### PR TITLE
Fixed bug with different md5sums of original file and the one in gridfs

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -112,7 +112,7 @@ GridStore.prototype.write = function(string, close, callback) {
       var previousChunkNumber = self.currentChunk.chunkNumber;
       var leftOverDataSize = self.chunkSize - self.currentChunk.position;
       var previousChunkData = string.substr(0, leftOverDataSize);
-      var leftOverData = string.substr(leftOverData, (string.length - leftOverDataSize));
+      var leftOverData = string.substr(leftOverDataSize, (string.length - leftOverDataSize));
       // Let's finish the current chunk and then call write again for the remaining data
       self.currentChunk.write(previousChunkData, function(err, chunk) {
         chunk.save(function(err, result) {


### PR DESCRIPTION
Hello, Christian

The strange behavior was caused by the fact the driver writes the first chunk every time it needs to write next chunk. I believe it's just a typo. The correction is overly simple.

Thanks.
