### PR TITLE
Fix for streamRecords when limit specified

### DIFF
--- a/integration/integration_tests.js
+++ b/integration/integration_tests.js
@@ -1133,6 +1133,51 @@ var all_tests = {
     });
   },
   
+  test_stream_records_calls_data_the_right_number_of_times : function() {
+    client.createCollection('test_stream_records', function(err, collection) {
+      test.ok(collection instanceof Collection);
+      collection.insert([{'a':1}, {'b' : 2}, {'c' : 3}, {'d' : 4}, {'e' : 5}], function(err, ids) {
+        collection.find({}, {'limit' : 3}, function(err, cursor) {
+          var stream = cursor.streamRecords(function(er,item) {}); 
+          var callsToEnd = 0;
+          stream.addListener('end', function() { 
+            finished_test({test_stream_records_calls_data_the_right_number_of_times:'ok'});
+          });
+          
+          var callsToData = 0;
+          stream.addListener('data',function(data){ 
+            callsToData += 1;
+            test.ok(callsToData <= 3);
+          }); 
+        });
+      });
+    });    
+  },
+
+  test_stream_records_calls_end_the_right_number_of_times : function() {
+    client.createCollection('test_stream_records', function(err, collection) {
+      test.ok(collection instanceof Collection);
+      collection.insert([{'a':1}, {'b' : 2}, {'c' : 3}, {'d' : 4}, {'e' : 5}], function(err, ids) {
+        collection.find({}, {'limit' : 3}, function(err, cursor) {
+          var stream = cursor.streamRecords(function(er,item) {}); 
+          var callsToEnd = 0;
+          stream.addListener('end', function() { 
+            callsToEnd += 1;
+            test.equal(1, callsToEnd);
+            setTimeout(function() {
+              // Let's close the db
+              if (callsToEnd == 1) {
+                finished_test({test_stream_records_calls_end_the_right_number_of_times:'ok'});
+              }
+            }.bind(this), 1000);
+          });
+          
+          stream.addListener('data',function(data){ /* nothing here */ }); 
+        });
+      });
+    });    
+  },
+  
   test_where : function() {
     client.createCollection('test_where', function(err, collection) {
       test.ok(collection instanceof Collection);

--- a/lib/mongodb/cursor.js
+++ b/lib/mongodb/cursor.js
@@ -302,7 +302,7 @@ Cursor.prototype.streamRecords = function(callback) {
       if (result.documents && result.documents.length) {
         try {
           result.documents.forEach(function(doc){ 
-            if (recordLimitValue && emittedRecordCount>recordLimitValue) {
+            if (recordLimitValue && emittedRecordCount>=recordLimitValue) {
               throw("done");
             }
             emittedRecordCount++;


### PR DESCRIPTION
Hi Christian,

I believe I've found an issue in cursor behavior when using streamRecords.  When a limit is specified, the behavior of the existing code fails to break out of the forEach loop iterating over the record set (it's using return(null), which returns from the anonymous function passed to forEach but doesn't stop it).  This results in the 'end' event firing multiple times (500 - limit I believe).

I've modified the code to throw when the limit is exceeded and moved the post-limit behavior into a catch block. Let me know what you think.  I didn't see an obvious place for a test in the existing code, but it's fairly easy to verify - when passing a limit to find that's less than the default numberToReturn for a cursor, the 'end' event will fire multiple times.
