### PR TITLE
Writing binary Buffers into GridStore

### DIFF
--- a/integration/integration_tests.js
+++ b/integration/integration_tests.js
@@ -2804,6 +2804,29 @@ var all_tests = {
     });
   },
   
+  // checks if 8 bit values will be preserved in gridstore
+  test_gs_check_high_bits : function() {
+      var gridStore = new GridStore(client, "test_gs_check_high_bits", "w");
+      var data = new Buffer(255);
+      for(var i=0; i<255; i++){
+          data[i] = i;
+      }
+    
+      gridStore.open(function(err, gridStore) {
+        gridStore.write(data, function(err, gridStore) {
+          gridStore.close(function(err, result) {
+            // Assert that we have overwriten the data
+            GridStore.read(client, 'test_gs_check_high_bits', function(err, fileData) {
+              // change testvalue into a string like "0,1,2,...,255"
+              test.equal(Array.prototype.join.call(data),
+                      Array.prototype.join.call(new Buffer(fileData, "binary")));
+              finished_test({test_gs_check_high_bits:'ok'});
+            });
+          });
+        });
+      });
+    },
+  
   test_change_chunk_size : function() {
     var gridStore = new GridStore(client, "test_change_chunk_size", "w");
     gridStore.open(function(err, gridStore) {

--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -139,7 +139,7 @@ GridStore.prototype.write = function(string, close, callback) {
   if(typeof close === "function") { callback = close; close = null; }
   var self = this;
   var finalClose = close == null ? false : close;
-  string = string instanceof Buffer ? string.toString() : string;
+  string = string instanceof Buffer ? string.toString("binary") : string;
 
   if(self.mode[0] != "w") {
     callback(new Error(self.filename + " not opened for writing"), null);


### PR DESCRIPTION
Hi, I updated the line 142 in gridstore.js as you suggested and it started working as it should. 

Added also a test "test_gs_check_high_bits" that creates a 255 byte long Buffer, fills it with every possible byte value (from 0..255) and saves it into GridStore. Then reads the value back and checks if the bytes are still correct.
