### PR TITLE
global var leak fix

### DIFF
--- a/lib/mongodb/bson/binary_parser.js
+++ b/lib/mongodb/bson/binary_parser.js
@@ -178,7 +178,8 @@ p.encode_int64 = function(number) {
 p.decode_utf8 = function(a) {
   var string = "";
   var i = 0;
-  var c = c1 = c2 = 0;
+  var c, c1, c2;
+  c = c1 = c2 = 0;
 
   while ( i < a.length ) {
     c = a.charCodeAt(i);


### PR DESCRIPTION
There's a global var leak in binary_parser.js which this fixes.
