### PR TITLE
made collection.insert() support keyed array

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -134,8 +134,8 @@ Collection.prototype.insertAll = function(docs, options, callback) {
     // Create an insert command
     var insertCommand = new InsertCommand(this.db, this.db.databaseName + "." + this.collectionName);
     // Add id to each document if it's not already defined
-    for(var index = 0; index < docs.length; index++) {
-      var doc = docs[index];
+    for (var key in docs) {
+      var doc = docs[key];
       // Add the id to the document
       var id = doc["_id"] == null ? this.pkFactory.createPk() : doc["_id"];
       doc['_id'] = id;


### PR DESCRIPTION
Hi,

I found collection.insert() did not work with a keyed array because it treated all coming docs were in a natural serial.

So instead of using:
    for (var index = 0; index < docs.length; index++) {...}
I use:
    for (var key in docs) {
        var doc = docs[key]
        ...
    }

thanks :)
