### PR TITLE
Small fix on hanging problem

### DIFF
--- a/external-libs/bson/long.cc
+++ b/external-libs/bson/long.cc
@@ -622,7 +622,7 @@ Handle<Value> Long::GreatherThan(const Arguments &args) {
   Long *long_obj = Long::Unwrap<Long>(obj);
   // Compare the longs
   bool comparision_result = current_long_obj->greaterThan(long_obj);
-  scope.Close(Boolean::New(comparision_result));
+  return scope.Close(Boolean::New(comparision_result));
 }
 
 Handle<Value> Long::Equals(const Arguments &args) {
@@ -637,7 +637,7 @@ Handle<Value> Long::Equals(const Arguments &args) {
   Long *long_obj = Long::Unwrap<Long>(obj);
   // Compare the longs
   bool comparision_result = (current_long_obj->compare(long_obj) == 0);
-  scope.Close(Boolean::New(comparision_result));
+  return scope.Close(Boolean::New(comparision_result));
 }
 
 bool Long::greaterThan(Long *other) {

--- a/external-libs/bson/timestamp.cc
+++ b/external-libs/bson/timestamp.cc
@@ -619,7 +619,7 @@ Handle<Value> Timestamp::GreatherThan(const Arguments &args) {
   Timestamp *long_obj = Timestamp::Unwrap<Timestamp>(obj);
   // Compare the longs
   bool comparision_result = current_long_obj->greaterThan(long_obj);
-  scope.Close(Boolean::New(comparision_result));
+  return scope.Close(Boolean::New(comparision_result));
 }
 
 Handle<Value> Timestamp::Equals(const Arguments &args) {
@@ -634,7 +634,7 @@ Handle<Value> Timestamp::Equals(const Arguments &args) {
   Timestamp *long_obj = Timestamp::Unwrap<Timestamp>(obj);
   // Compare the longs
   bool comparision_result = (current_long_obj->compare(long_obj) == 0);
-  scope.Close(Boolean::New(comparision_result));
+  return scope.Close(Boolean::New(comparision_result));
 }
 
 bool Timestamp::greaterThan(Timestamp *other) {


### PR DESCRIPTION
This patch passes the integration test on both pure and native.

Commit message:

Fixed hanging problem when using the native parser.
Caused by:
Lack of return statements, causing the affected methods to return garbage values.

Fixed by:
Adding return statements.
