### PR TITLE
connection handling

### DIFF
--- a/lib/mongodb/connection.js
+++ b/lib/mongodb/connection.js
@@ -17,6 +17,7 @@ var Connection = exports.Connection = function(host, port, autoReconnect) {
   this.bytesRead = 0;
   this.buffer = '';
   this.stubBuffer = '';
+  this.disconnecting = false;
 };
 
 inherits(Connection, EventEmitter);
@@ -38,12 +39,24 @@ Connection.prototype.open = function() {
   });
   
   this.connection.addListener("error", function(err) {
+	console.log("NMN ERROR "+err);
     self.emit("error", err);
+	if(self.connection == null || self.connection.readyState != "open" && self.autoReconnect && !self.disconnecting) {
+		setTimeout(function() {
+			console.log("NMN RECONNECT AFTER ERROR");
+			self.open();
+		}, 500);
+	}    
   });
   
   // Add a close listener
   this.connection.addListener("end", function() {
+	console.log("NMN END ");
     self.emit("close");
+	if(self.connection.readyState != "open" && self.autoReconnect && !self.disconnecting) {
+		console.log("NMN RECONNECT AFTER END");
+		self.open();
+	}    
   });
   
   // Listener for receive data
@@ -92,9 +105,20 @@ Connection.prototype.open = function() {
 
   // Add a receieved data connection
   this.connection.addListener("data", this.receiveListener);
+
+  // send all pending messages
+  while(this.messages.length > 0) {
+    var msg = this.messages.shift();
+    if(msg.constructor == String) {
+      this.connection.write(msg, "binary");      
+    } else {
+      this.connection.write(msg.toBinary(), "binary");      
+    }    
+  }
 };
 
 Connection.prototype.close = function() {
+  this.disconnecting = true;
   if(this.connection) this.connection.end();
 };
 
@@ -103,16 +127,19 @@ Connection.prototype.send = function(command) {
   // Check if the connection is closed
   try {
     if(command.constructor == String) {
-      this.connection.write(command, "binary");      
+      this.connection.write(command, "binary"); 
     } else {
-      this.connection.write(command.toBinary(), "binary");      
+      this.connection.write(command.toBinary(), "binary");
     }    
   } catch(err) {
     // Check if the connection is closed
     if(this.connection.readyState != "open" && this.autoReconnect) {
       // Add the message to the queue of messages to send
       this.messages.push(command);
+		console.log("NMN AUTO RECONNECT");
+		return this.open();
       // Initiate reconnect if no current running
+/*
       if(this.connection.currently_reconnecting == null) {
         this.connection.currently_reconnecting = true;
         // Create the associated connection
@@ -140,6 +167,7 @@ Connection.prototype.send = function(command) {
           }
         });
       }
+*/
     } else {   
       throw err;   
     }


### PR DESCRIPTION
Hi Christian,

Did some connection handling fixes. Now this works correctly with auto_reconnect:true option against mongos (query router) 1.7.5 (and 1.6.5) in a replica set fail-over situation. Left some console.logs in there, feel free to remove them.

Jak
