### PR TITLE
Additional callback parameter for collection.mapReduce

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -494,7 +494,15 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
     if(err == null && result.documents[0].ok == 1) {
       // Create a collection object that wraps the result collection
       self.db.collection(result.documents[0].result, function(err, collection) {
-        callback(err, collection, { processtime: result.documents[0].timeMillis, counts: result.documents[0].counts });
+        if(options.include_statistics) {
+          var stats = {
+            processtime: result.documents[0].timeMillis,
+            counts: result.documents[0].counts
+          };
+          callback(err, collection, stats);
+        } else {
+          callback(err, collection);
+        }
       });
     } else {
       err != null ? callback(err, null, null) : callback(new Error("map-reduce failed: " + result.documents[0].errmsg), null, null);


### PR DESCRIPTION
Added new callback parameter to fetch mapReduce operation statistics. They can be requested using the new option 'include_statistics' and include the execution time and the counts object from mongodb.
