### PR TITLE
Fixed bug that causes the BSON constructor to overwrite the native EventEmitter constructor

### DIFF
--- a/external-libs/bson/bson.cc
+++ b/external-libs/bson/bson.cc
@@ -54,6 +54,8 @@ static Handle<Value> VException(const char *msg) {
     return ThrowException(Exception::Error(String::New(msg)));
   };
 
+Persistent<FunctionTemplate> BSON::constructor_template;
+
 class MyExternal : public String::ExternalAsciiStringResource {
  public:
   MyExternal (char *d, size_t length) : ExternalAsciiStringResource() {

--- a/external-libs/bson/bson.h
+++ b/external-libs/bson/bson.h
@@ -22,6 +22,9 @@ class BSON : public EventEmitter {
     static Handle<Value> ToLong(const Arguments &args);
     static Handle<Value> ToInt(const Arguments &args);
   
+    // Constructor used for creating new BSON objects from C++
+    static Persistent<FunctionTemplate> constructor_template;
+
   private:
     static Handle<Value> New(const Arguments &args);
     static Handle<Value> deserialize(char *data, bool is_array_item);


### PR DESCRIPTION
To reproduce this bug:

```
var db = require('./node-mongodb-native');   // remove this line for tests to pass

var compress = require('./compress');   // node-compress library
var gzip = new compress.Gzip;
if (!gzip.addListener)
  console.log('error: gzip.addListener() is missing!');

/*
// Also occurs with other node libraries such as node-expat

var expat = require('./node-expat');    // node-expat library
var parser = new expat.Parser("UTF-8");
if (!parser.addListener)
  console.log('error: p.addListener() is missing!');

*/
```
