### PR TITLE
prevent build of native lib under solaris

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-if [ $number = `uname -o` = "Cygwin" ]
-then    
+if [ `uname -o` = "Cygwin" ]
+then
   echo "Not building native library for cygwin"
+elif [ `uname -o` = "Solaris" ]
+then
+  echo "Not building native library for solaris"
 else
-  echo "Not building native library for cygwin"
   make total
 fi


### PR DESCRIPTION
This fixes the installation over npm when module is installed on Solaris.

Tested on:
- Mac OS X
- Solaris
- Ubuntu
