### PR TITLE
Get all the fields according to the given data type 

### DIFF
--- a/lib/mongodb/commands/db_command.js
+++ b/lib/mongodb/commands/db_command.js
@@ -105,8 +105,8 @@ DbCommand.createCreateIndexCommand = function(db, collectionName, fieldOrSpec, u
         indexes.push(f + '_' + 1);
         fieldHash[f] = 1;
       } else if (f.constructor === Array) {             // [['location', '2d'],['type', 1]]
-        indexes.push(f[0] + '_' + f[1]);
-        fieldHash[f[0]] = f[1];
+        indexes.push(f[0] + '_' + (f[1] || 1));
+        fieldHash[f[0]] = f[1] || 1;
       } else if (f.constructor === Object) {            // [{location:'2d'}, {type:1}]
         keys = Object.keys(f);
         keys.forEach(function(k) {


### PR DESCRIPTION
This is crucial especially when you dealing with geospatial features of mongodb.
e.g.
db.geodata.ensureIndex({location: '2d'}, {min:-25, max:25}); 
