### PR TITLE
Allow to configure the number of jobs when compiling bson

### DIFF
--- a/external-libs/bson/Makefile
+++ b/external-libs/bson/Makefile
@@ -2,9 +2,12 @@
 NODE = node
 name = all
 
+# To allow building on platforms with ridiculously little memory.
+JOBS ?= 16
+
 all:
 	rm -rf build .lock-wscript bson.node
-	node-waf configure build
+	node-waf -j$(JOBS) configure build
 	@$(NODE) test_bson.js
 	@$(NODE) test_full_bson.js
 


### PR DESCRIPTION
Joyend node smartmachines have only 128MB RAM, compiling with 16 parallel jobs does not work.
