### PR TITLE
Force callbacks on toArray and each. Optional callbacks on `find`, `close` and `collectionsInfo` methods

### DIFF
--- a/integration/integration_tests.js
+++ b/integration/integration_tests.js
@@ -535,6 +535,33 @@ var all_tests = {
     });
   },
 
+  // Test a simple find chained
+  test_find_simple_chained : function() {
+    client.createCollection('test_find_simple_chained', function(err, r) {
+      var collection = client.collection('test_find_simple_chained', function(err, collection) {
+        var doc1 = null;
+        var doc2 = null;
+
+        // Insert some test documents
+        collection.insert([{a:2}, {b:3}], function(err, docs) {doc1 = docs[0]; doc2 = docs[1]});
+        // Ensure correct insertion testing via the cursor and the count function
+        collection.find().toArray(function(err, documents) {
+          test.equal(2, documents.length);
+        });
+        collection.count(function(err, count) {
+          test.equal(2, count);
+        });
+        // Fetch values by selection
+        collection.find({'a': doc1.a}).toArray(function(err, documents) {
+          test.equal(1, documents.length);
+          test.equal(doc1.a, documents[0].a);
+          // Let's close the db
+          finished_test({test_find_simple_chained:'ok'});
+        });
+      });
+    });
+  },
+
   // Test advanced find
   test_find_advanced : function() {
     client.createCollection('test_find_advanced', function(err, r) {

--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -347,37 +347,41 @@ Collection.prototype.findAndModify = function(query, sort, update, options, call
 
 /**
  * Various argument possibilities
- * 1 callback
- * 2 selector, callback,
- * 2 callback, options  // really?!
- * 3 selector, fields, callback
- * 3 selector, options, callback
- * 4,selector, fields, options, callback
- * 5 selector, fields, skip, limit, callback
- * 6 selector, fields, skip, limit, timeout, callback
+ * 1 callback?
+ * 2 selector, callback?,
+ * 2 callback?, options  // really?!
+ * 3 selector, fields, callback?
+ * 3 selector, options, callback?
+ * 4,selector, fields, options, callback?
+ * 5 selector, fields, skip, limit, callback?
+ * 6 selector, fields, skip, limit, timeout, callback?
  *
  * Available options:
  * limit, sort, fields, skip, hint, explain, snapshot, timeout, tailable, batchSize
  */
 Collection.prototype.find = function() {
   var options,
-      len = arguments.length,
-      selector = (len > 1) ? arguments[0] : {},
-      fields = (len > 2) ? arguments[1] : undefined,
-      callback = arguments[len-1];
+      args = Array.prototype.slice.call(arguments, 0);
+      has_callback = typeof args[args.length - 1] === 'function',
+      has_weird_callback = typeof args[0] === 'function',
+      callback = has_callback ? args.pop() : (has_weird_callback ? args.shift() : null),
+      len = args.length,
+      selector = (len >= 1) ? args[0] : {},
+      fields = (len >= 2) ? args[1] : undefined;
 
-  if(len == 2 && typeof arguments[0] == 'function') {
-    selector = {}; options = arguments[1]; callback = arguments[0];
+  if(len == 1 && has_weird_callback) { // backwards compat for callback?, options case
+    selector = {};
+    options = args[0];
   }
 
-  if(len == 3){ // backwards compat for options object
+  if(len == 2){ // backwards compat for options object
     var test = ['limit','sort','fields','skip','hint','explain','snapshot','timeout','tailable', 'batchSize'],
         idx = 0, l = test.length, is_option = false;
     while(!is_option && idx < l) if(test[idx] in fields ) is_option = true; else idx++;
     options = is_option ? fields : {};
     if(is_option) fields = undefined;
   }
-  if(len == 4) options = arguments[2];
+  if(len == 3) options = args[2];
 
   if(options && options.fields){
     fields = {};
@@ -389,13 +393,19 @@ Collection.prototype.find = function() {
   }
   if(!options) options = {};
 
-  options.skip = len > 4 ? arguments[2] : options.skip ? options.skip : 0;
-  options.limit = len > 4 ? arguments[3] : options.limit ? options.limit : 0;
+  options.skip = len > 3 ? args[2] : options.skip ? options.skip : 0;
+  options.limit = len > 3 ? args[3] : options.limit ? options.limit : 0;
   options.hint = options.hint != null ? this.normalizeHintField(options.hint) : this.internalHint;
-  options.timeout = len == 6 ? arguments[4] : options.timeout ? options.timeout : undefined;
+  options.timeout = len == 5 ? args[4] : options.timeout ? options.timeout : undefined;
 
   var o = options;
-  callback(null, new Cursor(this.db, this, selector, fields, o.skip, o.limit, o.sort, o.hint, o.explain, o.snapshot, o.timeout, o.tailable, o.batchSize));
+
+  // callback for backward compatibility
+  if (callback) {
+    callback(null, new Cursor(this.db, this, selector, fields, o.skip, o.limit, o.sort, o.hint, o.explain, o.snapshot, o.timeout, o.tailable, o.batchSize));
+  } else {
+    return new Cursor(this.db, this, selector, fields, o.skip, o.limit, o.sort, o.hint, o.explain, o.snapshot, o.timeout, o.tailable, o.batchSize);
+  }
 };
 
 Collection.prototype.normalizeHintField = function(hint) {

--- a/lib/mongodb/cursor.js
+++ b/lib/mongodb/cursor.js
@@ -624,14 +624,20 @@ Cursor.prototype.close = function(callback) {
   if(this.cursorId instanceof self.db.bson_serializer.Long && this.cursorId.greaterThan(self.db.bson_serializer.Long.fromInt(0))) {
     try {
       var command = new KillCursorCommand(this.db, [this.cursorId]);
-      this.db.executeCommand(command, null);      
+      this.db.executeCommand(command, null);
     } catch(err) {}
   }
 
   this.cursorId = self.db.bson_serializer.Long.fromInt(0);
   this.state    = Cursor.CLOSED;
-  if (callback) callback(null, this);
-  
+
+  // callback for backward compatibility
+  if (callback) {
+    callback(null, this);
+  } else {
+    return this;
+  }
+
   this.items = null;
 };
 

--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -193,8 +193,14 @@ Db.prototype.collectionsInfo = function(collection_name, callback) {
   var selector = {};
   // If we are limiting the access to a specific collection name
   if(collection_name != null) selector.name = this.databaseName + "." + collection_name;
+
   // Return Cursor
-  callback(null, new Cursor(this, new Collection(this, DbCommand.SYSTEM_NAMESPACE_COLLECTION), selector));
+  // callback for backward compatibility
+  if (callback) {
+    callback(null, new Cursor(this, new Collection(this, DbCommand.SYSTEM_NAMESPACE_COLLECTION), selector));
+  } else {
+    return new Cursor(this, new Collection(this, DbCommand.SYSTEM_NAMESPACE_COLLECTION), selector);
+  }
 };
 
 /**


### PR DESCRIPTION
Throw a meaningful error if you forget them.
Simplified the API by providing callbacks only when dealing with asynchronous calls, returns are used on synchronous ones instead.
