### PR TITLE
fixed issue when connecting to a mongodb cluster, and one or more of the servers is not accessible

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -105,17 +105,33 @@ Db.prototype.open = function(callback) {
     self.serverConfig.connection.open();            
   } else if(self.serverConfig instanceof ServerPair || self.serverConfig instanceof ServerCluster) {
     var serverConnections = self.serverConfig instanceof ServerPair ? [self.serverConfig.leftServer, self.serverConfig.rightServer] : self.serverConfig.servers;
-    var numberOfConnectedServers = 0; 
+    var numberOfCheckedServers = 0; 
+    
     serverConnections.forEach(function(server) {
       server.connection = new Connection(server.host, server.port, server.autoReconnect);
       self.connections.push(server.connection);
+      
+      var handleServerConnection = function() {
+        numberOfCheckedServers+=1;
+        
+        if(numberOfCheckedServers == serverConnections.length) {
+            if(self.masterConnection) {
+                // emit a message saying we got a master and are ready to go and change state to reflect it
+                self.state = 'connected';
+                callback(null, self);
+            } else {
+                // emit error only when all servers are checked and connecting to them failed.
+                self.state = "notConnected"
+                callback(new Error("Failed connecting to any of the servers in the cluster"), null);
+            }
+        }
+      }
 
       server.connection.addListener("connect", function() {
         // Create a callback function for a given connection
 
         var connectCallback = function(err, reply) {
-
-                  if(err != null) {
+          if(err != null) {
             callback(err, null);          
           } else {
             if(reply.documents[0].ismaster == 1) {
@@ -126,12 +142,8 @@ Db.prototype.open = function(callback) {
             } else {
               server.master = false;
             }
-
-            // emit a message saying we got a master and are ready to go and change state to reflect it
-            if(++numberOfConnectedServers == serverConnections.length && self.state == 'notConnected') {
-              self.state = 'connected';
-              callback(null, self);
-            }            
+            
+            handleServerConnection();
           }
         };
         // Create db command and Add the callback to the list of callbacks by the request id (mapping outgoing messages to correct callbacks)
@@ -154,12 +166,8 @@ Db.prototype.open = function(callback) {
       });
       
       server.connection.addListener("error", function(err) {
-        if(self.listeners("error") != null && self.listeners("error").length > 0) 
-        self.state = "notConnected"
-        return callback(err, null);
-      });      
-      
-      
+         handleServerConnection();
+      });
 
       // Emit timeout and close events so the client using db can figure do proper error handling (emit contains the connection that triggered the event)
       server.connection.addListener("timeout", function() { self.emit("timeout", this); });


### PR DESCRIPTION
Hi there,

I've been testing node-mongodb-native working in cluster mode and found that there is a broken logic of the driver when trying to connect to mongodb cluster which contains one or more failed nodes.

Please note:
I've fixed that and manually tested the solution so that it fits our needs for working with cluster replicaset, however didn't have any time to run the unit tests yet.
