### PR TITLE
Support for slaveOk bit in find queries

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -397,14 +397,15 @@ Collection.prototype.find = function() {
   options.limit = len > 3 ? args[3] : options.limit ? options.limit : 0;
   options.hint = options.hint != null ? this.normalizeHintField(options.hint) : this.internalHint;
   options.timeout = len == 5 ? args[4] : options.timeout ? options.timeout : undefined;
+  options.slaveOk = options.slaveOk != null ? options.slaveOk : false;
 
   var o = options;
 
   // callback for backward compatibility
   if (callback) {
-    callback(null, new Cursor(this.db, this, selector, fields, o.skip, o.limit, o.sort, o.hint, o.explain, o.snapshot, o.timeout, o.tailable, o.batchSize));
+    callback(null, new Cursor(this.db, this, selector, fields, o.skip, o.limit, o.sort, o.hint, o.explain, o.snapshot, o.timeout, o.tailable, o.batchSize, o.slaveOk));
   } else {
-    return new Cursor(this.db, this, selector, fields, o.skip, o.limit, o.sort, o.hint, o.explain, o.snapshot, o.timeout, o.tailable, o.batchSize);
+    return new Cursor(this.db, this, selector, fields, o.skip, o.limit, o.sort, o.hint, o.explain, o.snapshot, o.timeout, o.tailable, o.batchSize, o.slaveOk);
   }
 };
 

--- a/lib/mongodb/cursor.js
+++ b/lib/mongodb/cursor.js
@@ -39,7 +39,7 @@ var QueryCommand = require('./commands/query_command').QueryCommand,
  * @see Collection#find
  * @see Db#eval
  */
-var Cursor = exports.Cursor = function(db, collection, selector, fields, skip, limit, sort, hint, explain, snapshot, timeout, tailable, batchSize) {
+var Cursor = exports.Cursor = function(db, collection, selector, fields, skip, limit, sort, hint, explain, snapshot, timeout, tailable, batchSize, slaveOk) {
   this.db = db;
   this.collection = collection;
   this.selector = selector;
@@ -53,6 +53,7 @@ var Cursor = exports.Cursor = function(db, collection, selector, fields, skip, l
   this.timeout = timeout == null ? true : timeout;
   this.tailable = tailable;
   this.batchSizeValue = batchSize == null ? 0 : batchSize;
+  this.slaveOk = slaveOk == null ? false : slaveOk;
 
   this.totalNumberOfRecords = 0;
   this.items = [];
@@ -365,6 +366,10 @@ Cursor.prototype.generateQueryCommand = function() {
       queryOptions += QueryCommand.OPTS_TAILABLE_CURSOR;
       this.skipValue = this.limitValue = 0;
   }
+  if (this.slaveOk) {
+      queryOptions += QueryCommand.OPTS_SLAVE;
+  }
+
 
   // limitValue of -1 is a special case used by Db#eval
   var numberToReturn = this.limitValue == -1 ? -1 : this.limitRequest();


### PR DESCRIPTION
Hi,

I added a support for slaveOk option into the Cursor class which can be used with the collection.find() command.

We have ran it in our production cluster without problems.

Usage example: collection.find(query, {slaveOk : true}, function (error, cursor) { ... });
