### PR TITLE
collection.update does not check for null value in options

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -333,7 +333,7 @@ Collection.prototype.update = function update (selector, document, options, call
 
   // If safe, we need to check for successful execution
   if (options && options.safe || this.db.strict || this.opts.safe) {
-    var errorOptions = options.safe != null ? options.safe : null;    
+    var errorOptions = (options && options.safe != null) ? options.safe : null;    
     errorOptions = errorOptions == null && this.opts.safe != null ? this.opts.safe : errorOptions;
     this.db.error(errorOptions, function (err, error) {
       // FIXME: handle err


### PR DESCRIPTION
Function throws an exception if db is in strict mode but no options object passed.
