### PR TITLE
Fixed 'finalize' function passed to mapReduce through options not being converted to string

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -852,6 +852,10 @@ Collection.prototype.mapReduce = function mapReduce (map, reduce, options, callb
     reduce = reduce.toString();
   }
 
+  if ('function' === typeof options.finalize) {
+    options.finalize = options.finalize.toString();
+  }
+
   var mapCommandHash = {
       mapreduce: this.collectionName
     , map: map
@@ -859,12 +863,7 @@ Collection.prototype.mapReduce = function mapReduce (map, reduce, options, callb
   };
 
   // Add any other options passed in
-  var keys = Object.keys(options)
-    , i = keys.length
-    , name;
-
-  while (i--) {
-    name = keys[i];
+  for (var name in options) {
     mapCommandHash[name] = options[name];
   }
 


### PR DESCRIPTION
Fixed 'finalize' function passed to mapReduce through options not being converted to string
