### PR TITLE
DB Environment and DBRef Fetch

### DIFF
--- a/lib/mongodb/bson/bson.js
+++ b/lib/mongodb/bson/bson.js
@@ -7,7 +7,8 @@ var BinaryParser = require('./binary_parser').BinaryParser
   , Binary = require('./binary').Binary
   , Timestamp = Long
   , debug = require('util').debug
-  , inspect = require('util').inspect;
+  , inspect = require('util').inspect
+  , env = require('../env');
 
 /**
  * BSON constructor.
@@ -913,6 +914,22 @@ DBRef.prototype.toJSON = function() {
     '$id':this.oid,
     '$db':this.db == null ? '' : this.db
   });
+}
+
+DBRef.prototype.fetch = function(callback) {
+  var database;
+  if (typeof this.db === "string") {
+    database = env[this.db];
+    if (database === null) {
+      throw Error("database '" + this.db + "' not registered in environment");
+    }
+  } else {
+    database = env.currentdb;
+    if (database === null) {
+      throw Error("no current database set in environment");
+    }
+  }
+  return database.dereference(this, callback);
 }
 
 /**

--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -14,7 +14,8 @@ var QueryCommand = require('./commands/query_command').QueryCommand,
   EventEmitter = require('events').EventEmitter,
   inherits = require('util').inherits,
   debug = require('util').debug,
-  inspect = require('util').inspect;
+  inspect = require('util').inspect,
+  env = require('./env');
 
 var Db = exports.Db = function(databaseName, serverConfig, options) {
   EventEmitter.call(this);
@@ -42,6 +43,10 @@ var Db = exports.Db = function(databaseName, serverConfig, options) {
   this.slaveOk = false;
   this.isInitializing = true;
   this.auths = [];
+
+  // Register database in db environment
+  env.databases[databaseName] = this;
+  env.currentdb = this;
 };
 
 inherits(Db, EventEmitter);

--- a/lib/mongodb/env.js
+++ b/lib/mongodb/env.js
@@ -1,0 +1,9 @@
+/* 
+ * Global database environment - shared across all databases
+ */
+
+// Cache of database instances by database name
+exports.databases = {};
+
+// Last database that was created
+exports.currentdb = null;


### PR DESCRIPTION
Hi Christian

I'm using dbref instances a lot so, I've created a patch that extends the bson/dbref object with a 'fetch' function that executes a db.dereference for the dbref instance.  

To do this I have also created a 'global database environment' where db instance 'register' themselves by db.databaseName such that this can be used by the dbref.fetch to resolve the $db member to a db instance.

For those dbref instances without the $db value, the 'currentdb' value from the database environment (which is the last database to have been registered/instantiated) is used.

Please take a look

Thanks
Stuart 
