### PR TITLE
ReplSetServers servers array validation

### DIFF
--- a/lib/mongodb/connections/repl_set_servers.js
+++ b/lib/mongodb/connections/repl_set_servers.js
@@ -32,9 +32,9 @@ var ReplSetServers = exports.ReplSetServers = function(servers, options) {
   this.slaveOk = this.readSecondary ? true : false;
   this.otherErrors = [];
 
-  if(servers.constructor != Array || servers.length == 0) {
+  if(!Array.isArray(servers) || servers.length == 0) {
     throw Error("The parameter must be an array of servers and contain at least one server");
-  } else if(servers.constructor == Array || servers.length > 0) {
+  } else if(Array.isArray(servers) || servers.length > 0) {
     var count = 0;
     servers.forEach(function(server) {
       if(server instanceof Server) count = count + 1;


### PR DESCRIPTION
Even though a valid array of Server objects was passed to ReplSetServers constructor, its type validation would fail. I changed the validation to use Array.isArray instead calling the "constructor". That solved the issue.
