### PR TITLE
fix race condition in setting up connection pool

### DIFF
--- a/lib/mongodb/connection.js
+++ b/lib/mongodb/connection.js
@@ -172,6 +172,15 @@ var setupConnectionPool = function(self, poolSize, reconnect) {
   
   // Wait until we are done connected to all pool entries before emitting connect signal
   process.nextTick(waitForConnections);
+
+  self.addListener("connect", function() {
+    self.poolByReference = {};
+ 
+     // Save the connections by the fd reference
+    this.pool.forEach(function(con) {
+      self.poolByReference[con.connection.fd] = con;
+    });
+  });  
   
   // Return the pool
   return connectionPool;
@@ -182,12 +191,6 @@ Connection.prototype.open = function() {
   var self = this;
   // Create the pool with connections
   this.pool = setupConnectionPool(this, this.poolSize);
-  this.poolByReference = {};
-  
-  // Save the connections by the fd reference
-  this.pool.forEach(function(con) {
-    self.poolByReference[con.connection.fd] = con;
-  })
 }
 
 Connection.prototype.close = function() {


### PR DESCRIPTION
the loop which sets the poolByReference array is run before all connections are sure to be connected. this patch  moves this loop inside the connection's own "connect" event.

that's what is causing the hangups on cygwin - it is slow enough to make this bug show. on linux the process.nextTick are likely to be sufficient to let the connections complete (at least when connecting to localhost).
