### PR TITLE
set pool refs without using an event listener

### DIFF
--- a/lib/mongodb/connection.js
+++ b/lib/mongodb/connection.js
@@ -152,6 +152,13 @@ var setupConnectionPool = function(self, poolSize, reconnect) {
     if(connectedTo == connectionPool.length) {
       if(reconnect == null || !reconnect) {
         self.connected = true;
+        self.poolByReference = {};
+     
+         // Save the connections by the fd reference
+        self.pool.forEach(function(con) {
+          self.poolByReference[con.connection.fd] = con;
+        });
+                
         self.emit("connect");
       } else {
         self.connected = false;
@@ -172,15 +179,6 @@ var setupConnectionPool = function(self, poolSize, reconnect) {
   
   // Wait until we are done connected to all pool entries before emitting connect signal
   process.nextTick(waitForConnections);
-
-  self.addListener("connect", function() {
-    self.poolByReference = {};
- 
-     // Save the connections by the fd reference
-    this.pool.forEach(function(con) {
-      self.poolByReference[con.connection.fd] = con;
-    });
-  });  
   
   // Return the pool
   return connectionPool;


### PR DESCRIPTION
small change to what i submitted to you yesterday. does the same thing without using events and risking leaks.
