### PR TITLE
Fix of DBRef resaving/deserialization weird behaviour

### DIFF
--- a/external-libs/bson/bson.cc
+++ b/external-libs/bson/bson.cc
@@ -1404,14 +1404,7 @@ Handle<Value> BSON::deserialize(char *data, bool is_array_item) {
   // Check if we have a db reference
   if(!is_array_item && return_data->Has(String::New("$ref")) && return_data->Has(String::New("$id"))) {
     Handle<Value> dbref_value;
-    
-    if(return_data->Has(String::New("$db"))) {
-      dbref_value = BSON::decodeDBref(return_data->Get(String::New("$ref")), return_data->Get(String::New("$id")), return_data->Get(String::New("$db")));
-      // return scope.Close(dbref_value);
-    } else {
-      dbref_value = BSON::decodeDBref(return_data->Get(String::New("$ref")), return_data->Get(String::New("$id")), String::New(""));
-    }
-
+    dbref_value = BSON::decodeDBref(return_data->Get(String::New("$ref")), return_data->Get(String::New("$id")), return_data->Get(String::New("$db")));
     return scope.Close(dbref_value);
   }
   


### PR DESCRIPTION
Using mongodb driver with native deserializer i've descovered strange bug: 
1 Object created and saved with DBRef field
2 Then loaded (deserilizer processed their fields) and saved again.
3 After saving DBRef field became corrupted! IMHO due to $db field value (empty string) in DBRef //see patch

I've created test case and fix.

PS.
  All test cases checked agains pure BSON serializer! Regardless of  'native_parser' option value!
**Due to small typo:**

``` javascript
var client = new Db(MONGODB, 
new Server("127.0.0.1", 27017, {auto_reconnect: true, poolSize: 4, 
 native_parser: (process.env['TEST_NATIVE'] != null) ? true : false}));
```

**But correct:**

``` javascript
var client = new Db(MONGODB, 
new Server("127.0.0.1", 27017, {auto_reconnect: true, poolSize: 4}), 
{native_parser: (process.env['TEST_NATIVE'] != null) ? true : false});
```
