### PR TITLE
Regressed new Binary(buffer) constructor

### DIFF
--- a/lib/mongodb/bson/binary.js
+++ b/lib/mongodb/bson/binary.js
@@ -21,7 +21,7 @@ function Binary (buffer, subType) {
     this.sub_type = subType == null ? bson.BSON.BSON_BINARY_SUBTYPE_DEFAULT : subType;
   }
 
-  if (buffer != null && (buffer instanceof Number)) {
+  if (buffer != null && !(buffer instanceof Number)) {
     this.buffer = buffer;
     this.position = buffer.length;
   } else {


### PR DESCRIPTION
Creating a new BSONPure.Binary object with a predefined Buffer results in an empty Binary object.
