### PR TITLE
Remove dead code path in Grid.put

### DIFF
--- a/lib/mongodb/gridfs/grid.js
+++ b/lib/mongodb/gridfs/grid.js
@@ -39,25 +39,14 @@ Grid.prototype.put = function(data, options, callback) {
   gridStore.open(function(err, gridStore) {
     if(err) return callback(err, null);
 
-    if(data instanceof Buffer) {
-      gridStore.writeBuffer(data, function(err, result) {
-        if(err) return callback(err, null);
+    gridStore.writeBuffer(data, function(err, result) {
+      if(err) return callback(err, null);
 
-        gridStore.close(function(err, result) {
-          if(err) return callback(err, null);
-          callback(null, result);
-        })
-      })            
-    } else {
-      gridStore.write(data, function(err, result) {
+      gridStore.close(function(err, result) {
         if(err) return callback(err, null);
-
-        gridStore.close(function(err, result) {
-          if(err) return callback(err, null);
-          callback(null, result);
-        })
-      })      
-    }    
+        callback(null, result);
+      })
+    })            
   })
 }
 


### PR DESCRIPTION
Since one returns if passing a non-Buffer object after:

``` javascript
if(!(data instanceof Buffer)) return callback(new Error("Data object must be a buffer object"), null);
```

The data instanceof buffer code path will never run. I've verified this by passing all tests.
