### PR TITLE
ReplSetServer bug fixes

### DIFF
--- a/lib/mongodb/connections/repl_set_servers.js
+++ b/lib/mongodb/connections/repl_set_servers.js
@@ -201,7 +201,7 @@ ReplSetServers.prototype.connect = function(parent, callback) {
             // Add replica address to our internal address array
             replSetSelf.addresses[replica] = 1;
             var ipAndPort = replica.split(":");
-            var newServer = new Server(ipAndPort[0], parseInt( ipAndPort[1]), { auto_reconnect: true});
+            var newServer = new Server(ipAndPort[0], parseInt( ipAndPort[1]), { auto_reconnect: false});
 
             // Add to connection list
             serverConnections.push(newServer);


### PR DESCRIPTION
1) Handle the case where ReplSetServer() is called without an options parameter.  Currently, if you don't pass an options parameter, an error is thrown.

2) Newly discovered servers that the driver has not explicitly added should be created with auto_reconnect set to false.  Otherwise, if these servers ever become the primary and then go down, failover does not work properly since the driver will keep trying to reconnect to the failed server rather than re-connecting to a different secondary.  To reproduce:

```
1. Create a replica set with 3 servers (A, B, C)
2. Using the driver, construct a ReplicaSetServers instance by passing in only server A for the servers parameter
3. Create a new Db instance by passing in this ReplicaSetServers instance as the serverConfig parameter
4. Kill server A.  The Db instance should now reconnect automatically to either B or C (assume B for now) when you execute a query.
5. Bring server A back up.
5. Now, if you kill server B, the Db instance should re-connect to C when you execute a query, but instead it hangs since its trying to re-connect to B over and over again.
```
