### PR TITLE
Make connect() support documented mongodb: syntax.

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -772,6 +772,9 @@ exports.connect = function(url, options, callback) {
   }
 
   var db = new Db(dbname, server, dbOptions);
+  if (options.noOpen)
+    return db;
+
   db.open(function(err, db){
     if(!err && authPart){
       db.authenticate(auth[0], auth[1], function(err, success){


### PR DESCRIPTION
Note that this includes ReplicaSet support, and options.

If you like this, I'll add some unit tests.

Seems like it'd be nice to rationalize constructor options some time - they're a mix of camelCase and under_score, some have funky names ('rs_name'), some options from Ruby mongodb driver don't exist.
