### PR TITLE
count() fails against replica set with 'not master'

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -474,10 +474,15 @@ Collection.prototype.count = function count (query, callback) {
     , fields: null
   };
 
+  var queryOptions = QueryCommand.OPTS_NO_CURSOR_TIMEOUT;
+  if (this.slaveOk || this.db.slaveOk) {
+    queryOptions |= QueryCommand.OPTS_SLAVE;
+  }
+
   var queryCommand = new QueryCommand(
       this.db
     , this.db.databaseName + ".$cmd"
-    , QueryCommand.OPTS_NO_CURSOR_TIMEOUT
+    , queryOptions
     , 0
     , -1
     , final_query


### PR DESCRIPTION
In my setup I've got a replica set and read_secondary is enabled. Whether I get a cursor or call count() directly on the collection I get an error with the message 'not master'.

Looked at the source and saw that the slave option isn't being set in the count() method when creating the QueryCommand.
