### PR TITLE
Fix Db not removing reconnect listener from serverConfig.

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -100,12 +100,12 @@ Db.prototype.open = function(callback) {
 };
 
 Db.prototype.close = function(callback) {
-  // Remove all listeners
-  this.removeAllListeners("reconnect");
+  // Remove all listeners and close the connection
+  this.serverConfig.removeAllListeners("reconnect");
+  this.serverConfig.close(callback);
+
   // Clear out state of the connection
   this.state = "notConnected"
-  // Close connection
-  this.serverConfig.close(callback);
 };
 
 Db.prototype.admin = function(callback) {


### PR DESCRIPTION
This fixes an issue where the reconnect event listener wasn't properly removed from serverConfig, previously it tried to remove it from itself which is incorrect.
