### PR TITLE
Removed node_events.h includes

### DIFF
--- a/external-libs/bson/binary.cc
+++ b/external-libs/bson/binary.cc
@@ -4,7 +4,6 @@
 #include <v8.h>
 #include <node.h>
 #include <node_version.h>
-#include <node_events.h>
 #include <node_buffer.h>
 #include <cstring>
 #include <cmath>

--- a/external-libs/bson/code.cc
+++ b/external-libs/bson/code.cc
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
 #include <node_buffer.h>
 #include <cstring>
 #include <cmath>

--- a/external-libs/bson/dbref.cc
+++ b/external-libs/bson/dbref.cc
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
 #include <node_buffer.h>
 #include <cstring>
 #include <cmath>

--- a/external-libs/bson/long.cc
+++ b/external-libs/bson/long.cc
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
 #include <node_buffer.h>
 #include <cstring>
 #include <cmath>

--- a/external-libs/bson/objectid.cc
+++ b/external-libs/bson/objectid.cc
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
 #include <node_buffer.h>
 #include <cstring>
 #include <cmath>

--- a/external-libs/bson/timestamp.cc
+++ b/external-libs/bson/timestamp.cc
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
 #include <node_buffer.h>
 #include <cstring>
 #include <cmath>


### PR DESCRIPTION
removed unnecessary references to node_events.h as it's no longer available in node 0.5
