### PR TITLE
ReplSetServers options parameter/class member

### DIFF
--- a/lib/mongodb/connections/repl_set_servers.js
+++ b/lib/mongodb/connections/repl_set_servers.js
@@ -20,15 +20,15 @@ var ReplSetServers = exports.ReplSetServers = function(servers, options) {
   this.master = null;
   this.target = null;
   this.options = options == null ? {} : options;
-  this.reconnectWait = options["reconnectWait"] != null ? options["reconnectWait"] : 1000;
-  this.retries = options["retries"] != null ? options["retries"] : 30;
+  this.reconnectWait = this.options["reconnectWait"] != null ? this.options["reconnectWait"] : 1000;
+  this.retries = this.options["retries"] != null ? this.options["retries"] : 30;
   // Set up internal state variables
-  this.replicaSet = options["rs_name"];
+  this.replicaSet = this.options["rs_name"];
   // Keep references to node types for caching purposes
   this.secondaries = [];
   this.arbiters = [];
   // Are we allowing reads from secondaries ?
-  this.readSecondary = options["read_secondary"];
+  this.readSecondary = this.options["read_secondary"];
   this.slaveOk = this.readSecondary;
   this.otherErrors = [];
   this.closedConnectionCount = 0;


### PR DESCRIPTION
if options parameter is null error occurs:  TypeError: Cannot read
property 'reconnectWait' of undefined     at new <anonymous>
(/var/www/node/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connections/repl_set_servers.js:23:31)
because in the following line the parameter is used and not the class
member. added 'this.' so that class member instead of parameter is used.
