### PR TITLE
[Bug] self missing in findAndModify() method.

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -532,7 +532,8 @@ Collection.prototype.findAndModify = function findAndModify (query, sort, doc, o
   callback = args.pop();
   sort = args.length ? args.shift() : [];
   doc = args.length ? args.shift() : null;
-  options = args.length ? args.shift() : {};
+  options = args.length ? args.shift() : {},
+  self = this;
 
   var queryObject = {
       'findandmodify': this.collectionName


### PR DESCRIPTION
Bug: This bug occurred when an exception is raised during a findAndModify() operation.
Fix: self is now declared and set equal to this.
