### PR TITLE
Previous change to findAndModify seems to break safe with findAndModify

### DIFF
--- a/test/find_test.js
+++ b/test/find_test.js
@@ -583,6 +583,15 @@ var tests = testCase({
         })
       });
         
+      // Test return new document on change with both operations being safe
+      collection.insert({'a':5, 'b':6}, {safe:true}, function(err, doc) {
+        // Let's modify the document in place
+        collection.findAndModify({'a':5}, [['a', 1]], {'$set':{'b':7}}, {'new': true, safe: true}, function(err, updated_doc) {
+          test.equal(5, updated_doc.a);
+          test.equal(7, updated_doc.b);
+        })
+      });
+        
       // Test return old document on change
       collection.insert({'a':2, 'b':2}, {safe:true}, function(err, doc) {
         // Let's modify the document in place


### PR DESCRIPTION
After updating to 0.9.6-14 my tests fail when using `safe` with `findAndModify`, I'm not sure if this behaviour is intended so I've attached a test that now breaks.
