### PR TITLE
Update read-method docs in GridStore

### DIFF
--- a/docs/gridfs.md
+++ b/docs/gridfs.md
@@ -79,12 +79,11 @@ where
 
 Reading from GridStore can be done with `read`
 
-    gs.read([size[, offset]], callback)
+    gs.read([size], callback)
     
 where
 
   * `size` is the length of the data to be read
-  * `offset` is the position to start reading
   * `callback` is a callback function with two parameters - error object (if an error occured) and data (binary string)
 
 ## Streaming from GridStore


### PR DESCRIPTION
Read does not take offset as second param as seen here:
https://github.com/christkv/node-mongodb-native/blob/fdc7d8cc421abafd43c07ca0cd697acbb88e579a/lib/mongodb/gridfs/gridstore.js#L678
