### PR TITLE
Test case for $gt operator on 64-bit integers

### DIFF
--- a/test/find_test.js
+++ b/test/find_test.js
@@ -904,6 +904,36 @@ var tests = testCase({
       });
     });
   },
+
+  'Should correctly return record with 64-bit id' : function(test) {
+    client.createCollection('should_correctly_return_record_with_64bit_id', function(err, collection) {
+      var _lowerId = new client.bson_serializer.ObjectID();
+      var _higherId = new client.bson_serializer.ObjectID();
+
+      var lowerId = new client.bson_serializer.Long('133118461172916224');
+      var higherId = new client.bson_serializer.Long('133118461172916225');
+
+      var lowerDoc = {_id:_lowerId, id: lowerId};
+      var higherDoc = {_id:_higherId, id: higherId};
+
+      collection.insert([lowerDoc, higherDoc], {safe:true}, function(err, result) {
+
+        test.ok(err == null);
+
+        // Select record with id of 133118461172916225 using $gt directive
+        collection.find({id: {$gt: lowerId}}, {}, function(err, cur) {
+            test.ok(err == null);
+            cur.toArray(function(err, arr) {
+                test.ok(err == null);
+                test.equal(arr.length, 1, 'Selecting record via $gt directive on 64-bit integer should return a record with higher Id')
+                //console.log(arr)
+                //test.equal(arr[0].id.toString(), '133118461172916225', 'Returned Id should be equal to 133118461172916225')
+                test.done()
+            });
+        });
+      });
+    });
+  },
   
   // Should correctly execute findAndModify that is breaking in prod
   // shouldCorrectlyExecuteFindAndModify : function(test) {


### PR DESCRIPTION
As discussed in https://github.com/christkv/node-mongodb-native/issues/393#issuecomment-2644766 I added a test case for 64-bit integers being used in greater-than clause, passed to .find function. 
