### PR TITLE
Connection (and Connection.DEFAULT_PORT) are no longer exposed. Better way?

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -10,7 +10,7 @@ The first thing to do in order to make queries to the database is to open one. T
     db_connector.open(callback);
     
   * `host` is a server hostname or IP
-  * `port` is a MongoDB port, use `mongodb.Connection.DEFAULT_PORT` for default (27017)
+  * `port` is a MongoDB port, use `null` for the default port (27017)
   * `server_options` see *Server options*
   * `name` is the databse name that needs to be opened, database will be created automatically if it doesn't yet exist
   * `db_options` see *DB options*

--- a/examples/admin.js
+++ b/examples/admin.js
@@ -10,9 +10,9 @@ var Db = require('../lib/mongodb').Db,
   Server = require('../lib/mongodb').Server;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 var db = new Db('node-mongo-examples', new Server(host, port, {}), {native_parser:true});
 db.open(function(err, db) {
   db.dropDatabase(function(err, result){

--- a/examples/blog.js
+++ b/examples/blog.js
@@ -8,11 +8,11 @@ var Db = require('../lib/mongodb').Db,
   Server = require('../lib/mongodb').Server;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
 var LINE_SIZE = 120;
 
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 var db = new Db('node-mongo-blog', new Server(host, port, {}), {native_parser:true});
 db.open(function(err, db) {
   db.dropDatabase(function(err, result) {

--- a/examples/capped.js
+++ b/examples/capped.js
@@ -8,9 +8,9 @@ var Db = require('../lib/mongodb').Db,
   Server = require('../lib/mongodb').Server;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 var db = new Db('node-mongo-examples', new Server(host, port, {}), {native_parser:true});
 db.open(function(err, db) {
   db.dropCollection('test', function(err, result) {

--- a/examples/cursor.js
+++ b/examples/cursor.js
@@ -8,9 +8,9 @@ var Db = require('../lib/mongodb').Db,
   Server = require('../lib/mongodb').Server;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 var db = new Db('node-mongo-examples', new Server(host, port, {}), {native_parser:true});
 db.open(function(err, db) {
   db.collection('test', function(err, collection) {

--- a/examples/gridfs.js
+++ b/examples/gridfs.js
@@ -9,9 +9,9 @@ var Db = require('../lib/mongodb').Db,
   GridStore = require('../lib/mongodb').GridStore;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
-sys.puts(">> Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 var db1 = new Db('node-mongo-examples', new Server(host, port, {}), {native_parser:true});
 db1.open(function(err, db) {
   // Write a new file

--- a/examples/index.js
+++ b/examples/index.js
@@ -9,9 +9,9 @@ var Db = require('../lib/mongodb').Db,
   mongo = require('../lib/mongodb');
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
-sys.puts(">> Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 var db = new Db('node-mongo-examples', new Server(host, port, {}), {native_parser:true});
 db.open(function(err, db) {
   sys.puts(">> Dropping collection test");

--- a/examples/info.js
+++ b/examples/info.js
@@ -8,9 +8,9 @@ var Db = require('../lib/mongodb').Db,
   Server = require('../lib/mongodb').Server;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 var db = new Db('node-mongo-examples', new Server(host, port, {}), {native_parser:true});
 db.open(function(err, db) {
   db.collection('test', function(err, collection) {

--- a/examples/oplog.js
+++ b/examples/oplog.js
@@ -9,7 +9,7 @@ var Db = require('../lib/mongodb').Db,
   Cursor = require('../lib/mongodb').Cursor;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
 Slave = function() {
   this.running = false;
@@ -17,7 +17,7 @@ Slave = function() {
   //no native_parser right now (because timestamps)
   //no strict mode (because system db signed with $  db.js line 189)
   //connect without dbName for querying not only "local" db
-  sys.puts("Connecting to " + host + ":" + port);
+  sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
   this.db = new Db('', new Server(host, port, {}), {});
 }
 

--- a/examples/queries.js
+++ b/examples/queries.js
@@ -8,9 +8,9 @@ var Db = require('../lib/mongodb').Db,
     Server = require('../lib/mongodb').Server;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 
 var db = new Db('node-mongo-examples', new Server(host, port, {}), {native_parser:true});
 db.open(function(err, db) {

--- a/examples/replSetServersQueries.js
+++ b/examples/replSetServersQueries.js
@@ -9,7 +9,7 @@ var Db = require('../lib/mongodb').Db,
   ReplSetServers = require('../lib/mongodb').ReplSetServers;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
 var port1 = 27018;
 var port2 = 27019;
@@ -22,7 +22,7 @@ servers[1] = server1;
 servers[2] = server;
 
 var replStat = new ReplSetServers(servers);
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 sys.puts("Connecting to " + host1 + ":" + port1);
 sys.puts("Connecting to " + host2 + ":" + port2);
 var db = new Db('node-mongo-examples', replStat, {native_parser:true});

--- a/examples/replSetServersSimple.js
+++ b/examples/replSetServersSimple.js
@@ -12,13 +12,13 @@ var Db = require('../lib/mongodb').Db,
   CheckMaster = require('../lib/mongodb').CheckMaster;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
 var port1 = 27018;
 var port2 = 27019;
 
 
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 sys.puts("Connecting to " + host + ":" + port1);
 sys.puts("Connecting to " + host + ":" + port2);
 

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -10,9 +10,9 @@ var Db = require('../lib/mongodb').Db,
   Server = require('../lib/mongodb').Server;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 var db = new Db('node-mongo-examples', new Server(host, port, {}), {native_parser:true});
 db.open(function(err, db) {
   db.dropDatabase(function(err, result) {

--- a/examples/strict.js
+++ b/examples/strict.js
@@ -8,9 +8,9 @@ var Db = require('../lib/mongodb').Db,
   Server = require('../lib/mongodb').Server;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 var db = new Db('node-mongo-examples', new Server(host, port, {}), {native_parser:true});
 db.open(function(err, db) {
   db.dropCollection('does-not-exist', function(err, result) {

--- a/examples/types.js
+++ b/examples/types.js
@@ -9,9 +9,9 @@ var Db = require('../lib/mongodb').Db,
   BSON = require('../lib/mongodb').BSONPure;
 
 var host = process.env['MONGO_NODE_DRIVER_HOST'] != null ? process.env['MONGO_NODE_DRIVER_HOST'] : 'localhost';
-var port = process.env['MONGO_NODE_DRIVER_PORT'] != null ? process.env['MONGO_NODE_DRIVER_PORT'] : Connection.DEFAULT_PORT;
+var port = process.env['MONGO_NODE_DRIVER_PORT'];
 
-sys.puts("Connecting to " + host + ":" + port);
+sys.puts("Connecting to " + host + (port != null ? ":" + port : ''));
 var db = new Db('node-mongo-examples', new Server(host, port, {}), {});
 db.open(function(err, db) {
   db.collection('test', function(err, collection) {        

--- a/lib/mongodb/connection/server.js
+++ b/lib/mongodb/connection/server.js
@@ -9,7 +9,7 @@ var Connection = require('./connection').Connection,
 var Server = exports.Server = function(host, port, options) {
   var self = this;
   this.host = host;
-  this.port = port;
+  this.port = port || Connection.DEFAULT_PORT;
   this.options = options == null ? {} : options;
   this.internalConnection;
   this.internalMaster = false;


### PR DESCRIPTION
Since `Connection` is no longer exposed, `Connection.DEFAULT_PORT` is no longer exposed, and there’s no good way to say, “Just use the default port”. This patch makes it possible to just pass `null` and updates the documentation and examples accordingly.
