### PR TITLE
Fixes formattedOrderClause in collection.js to accept a plain hash as a parameter

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -52,6 +52,8 @@ function formattedOrderClause (sortValue) {
         orderBy[sortElement[0]] = formatSortValue(sortElement[1]);
       }
     });
+  } else if(Object.prototype.toString.call(sortValue) === '[object Object]') {
+    orderBy = sortValue;
   } else if (sortValue.constructor == String) {
     orderBy[sortValue] = 1;
   } else {


### PR DESCRIPTION
I'm attaching a simple commit to fix a behavior in the `findAndModify` method of a collection where it would not accept a simple hash as the second argument to specify desired sorting. Unfortunately I found that the offending function `formattedOrderClause` is (was, actually) an exact copy of a similarly named method on an instance of `Cursor`. Which isn't very _DRY_, to say the least. I'm guessing that this "twin function" simply was forgotten as the other one was changed and my attached commit simply puts it up to date.

If I'd be calling the shots I would probably move this function onto a `utils.js` file which is similar to how many other node projects have resolved the issue of sharing small functions across a library. I could do it myself but before I (possibly) waste my own and even other peoples time I figured that I would float it for discussion here.
