### PR TITLE
fix for server.js when connection is lost

### DIFF
--- a/lib/mongodb/connection/server.js
+++ b/lib/mongodb/connection/server.js
@@ -134,7 +134,7 @@ Server.prototype.connect = function(dbInstance, options, callback) {
     // console.dir(reply)
     
     // ensure no callbacks get called twice
-    var internalCallback = callback;
+    var internalCallback = callback ? callback : function() {};
     callback = null;
     // Internal callback
     if(err != null) return internalCallback(err, null);
@@ -267,7 +267,7 @@ Server.prototype.connect = function(dbInstance, options, callback) {
     // Emit timeout event
     if(typeof callback === 'function') {
       // ensure no callbacks get called twice
-      var internalCallback = callback;
+      var internalCallback = callback ? callback : function() {};
       callback = null;
       // Perform callback
       internalCallback(err, null);
@@ -299,7 +299,7 @@ Server.prototype.connect = function(dbInstance, options, callback) {
       // Set server state to connected
       server._serverState = 'disconnected';
       // ensure no callbacks get called twice
-      var internalCallback = callback;
+      var internalCallback = callback ? callback : function() {};
       callback = null;
       // Only do a callback if we have a valid callback function, on retries this might not be true
       internalCallback(new Error(message && message.err ? message.err : message));
@@ -326,7 +326,7 @@ Server.prototype.connect = function(dbInstance, options, callback) {
     // Emit timeout event
     if(typeof callback === 'function') {
       // ensure no callbacks get called twice
-      var internalCallback = callback;
+      var internalCallback = callback ? callback : function() {};
       callback = null;
       // Perform callback
       internalCallback(new Error("connection closed"), null);


### PR DESCRIPTION
Hi,

Here's a small fix for node-mongodb-native to prevent an exception from being thrown when the server connection is closed (i am using auto_reconnect:true) -- for some reason, it was trying to call a null function.

I don't know why the callback was null, (didn't dig into it that much) but my fix makes it work -- and it certainly never hurts to check for null before trying to call a callback :)

Joel
