### PR TITLE
Handle undefined document.me in mongo connection reply

### DIFF
--- a/lib/mongodb/connection/repl_set_servers.js
+++ b/lib/mongodb/connection/repl_set_servers.js
@@ -39,7 +39,7 @@ var ReplSetServers = exports.ReplSetServers = function(servers, options) {
   this.readSecondary = this.options["read_secondary"];
   this.slaveOk = true;
   this.closedConnectionCount = 0;
-  
+
   // Tells the driver if we need to restart Replicaset connections due to changes
   this.replicaSetCheckInterval = this.options["replicaSetCheckInterval"] != null ? this.options["replicaSetCheckInterval"] : 1000;
   this.replicaSetChanged = false;
@@ -58,26 +58,26 @@ var ReplSetServers = exports.ReplSetServers = function(servers, options) {
   this._readPreference = null;
   // Do we record server stats or not
   this.recordQueryStats = false;
-    
+
   // Get the readPreference
-  var readPreference = this.options['readPreference'];  
+  var readPreference = this.options['readPreference'];
   // Read preference setting
   if(readPreference != null) {
     if(readPreference != Server.READ_PRIMARY && readPreference != Server.READ_SECONDARY_ONLY
       && readPreference != Server.READ_SECONDARY) {
         throw new Error("Illegal readPreference mode specified, " + readPreference);
     }
-    
+
     // Set read Preference
     this._readPreference = readPreference;
   } else {
-    this._readPreference = null;        
+    this._readPreference = null;
   }
-  
+
   // Strategy for picking a secondary
-  this.strategy = this.options['strategy'] == null ? 'statistical' : this.options['strategy'];  
+  this.strategy = this.options['strategy'] == null ? 'statistical' : this.options['strategy'];
   // Make sure strategy is one of the two allowed
-  if(this.strategy != null && (this.strategy != 'ping' && this.strategy != 'statistical')) throw new Error("Only ping or statistical strategies allowed");  
+  if(this.strategy != null && (this.strategy != 'ping' && this.strategy != 'statistical')) throw new Error("Only ping or statistical strategies allowed");
   // Let's set up our strategy object for picking secodaries
   if(this.strategy == 'ping') {
     // Create a new instance
@@ -87,18 +87,18 @@ var ReplSetServers = exports.ReplSetServers = function(servers, options) {
     this.strategyInstance = new StatisticsStrategy(this);
     // Add enable query information
     this.enableRecordQueryStats(true);
-  }  
-  
+  }
+
   // Set default connection pool options
-  this.socketOptions = this.options.socketOptions != null ? this.options.socketOptions : {};  
+  this.socketOptions = this.options.socketOptions != null ? this.options.socketOptions : {};
 
   // Set up logger if any set
-  this.logger = this.options.logger != null 
-    && (typeof this.options.logger.debug == 'function') 
-    && (typeof this.options.logger.error == 'function') 
-    && (typeof this.options.logger.debug == 'function') 
+  this.logger = this.options.logger != null
+    && (typeof this.options.logger.debug == 'function')
+    && (typeof this.options.logger.error == 'function')
+    && (typeof this.options.logger.debug == 'function')
       ? this.options.logger : {error:function(message, object) {}, log:function(message, object) {}, debug:function(message, object) {}};
-  
+
   // Ensure all the instances are of type server and auto_reconnect is false
   if(!Array.isArray(servers) || servers.length == 0) {
     throw Error("The parameter must be an array of servers and contain at least one server");
@@ -115,8 +115,8 @@ var ReplSetServers = exports.ReplSetServers = function(servers, options) {
     } else {
       this.servers = servers;
     }
-  }  
-  
+  }
+
   // Auto Reconnect property
   Object.defineProperty(this, "autoReconnect", { enumerable: true
     , get: function () {
@@ -135,7 +135,7 @@ var ReplSetServers = exports.ReplSetServers = function(servers, options) {
           return this._readPreference;
         }
       }
-  });  
+  });
 
   // Db Instances
   Object.defineProperty(this, "dbInstances", {enumerable:true
@@ -166,7 +166,7 @@ var ReplSetServers = exports.ReplSetServers = function(servers, options) {
 
   // Get list of secondaries
   Object.defineProperty(this, "secondaries", {enumerable: true
-    , get: function() {              
+    , get: function() {
         var keys = Object.keys(this._state.secondaries);
         var array = new Array(keys.length);
         // Convert secondaries to array
@@ -179,7 +179,7 @@ var ReplSetServers = exports.ReplSetServers = function(servers, options) {
 
   // Get list of all secondaries including passives
   Object.defineProperty(this, "allSecondaries", {enumerable: true
-    , get: function() {              
+    , get: function() {
         return this.secondaries.concat(this.passives);
       }
   });
@@ -215,7 +215,7 @@ var ReplSetServers = exports.ReplSetServers = function(servers, options) {
     , get: function () {
         return this._state != null ? this._state.master : null;
       }
-  });  
+  });
 };
 
 inherits(ReplSetServers, SimpleEmitter);
@@ -225,7 +225,7 @@ ReplSetServers.prototype.setReadPreference = function(preference) {
   // Set read preference
   this._readPreference = preference;
   // Ensure slaveOk is correct for secodnaries read preference and tags
-  if((this._readPreference == Server.READ_SECONDARY || this._readPreference == Server.READ_SECONDARY_ONLY) 
+  if((this._readPreference == Server.READ_SECONDARY || this._readPreference == Server.READ_SECONDARY_ONLY)
     || (this._readPreference != null && typeof this._readPreference == 'object')) {
     this.slaveOk = true;
   }
@@ -266,7 +266,7 @@ var cleanupConnections = ReplSetServers.cleanupConnections = function(connection
         cleanupTags(server, byTags);
       }
     }
-  }  
+  }
 }
 
 var cleanupTags = ReplSetServers._cleanupTags = function(server, byTags) {
@@ -278,21 +278,21 @@ var cleanupTags = ReplSetServers._cleanupTags = function(server, byTags) {
     var value = server.tags[serverTagKeys[i]];
 
     // If we got an instance of the server
-    if(byTags[serverTagKeys[i]] != null 
-      && byTags[serverTagKeys[i]][value] != null  
+    if(byTags[serverTagKeys[i]] != null
+      && byTags[serverTagKeys[i]][value] != null
       && Array.isArray(byTags[serverTagKeys[i]][value])) {
       // List of clean servers
       var cleanInstances = [];
       // We got instances for the particular tag set
       var instances = byTags[serverTagKeys[i]][value];
       for(var j = 0; j < instances.length; j++) {
-        var serverInstance = instances[j];              
+        var serverInstance = instances[j];
         // If we did not find an instance add it to the clean instances
         if((serverInstance.host + ":" + serverInstance.port) !== (server.host + ":" + server.port)) {
           cleanInstances.push(serverInstance);
         }
       }
-      
+
       // Update the byTags list
       byTags[serverTagKeys[i]][value] = cleanInstances;
     }
@@ -344,10 +344,10 @@ var __executeAllCallbacksWithError = function(dbInstance, error) {
 ReplSetServers.prototype.connect = function(parent, options, callback) {
   var self = this;
   var dateStamp = new Date().getTime();
-  if('function' === typeof options) callback = options, options = {};  
+  if('function' === typeof options) callback = options, options = {};
   if(options == null) options = {};
   if(!('function' === typeof callback)) callback = null;
-  
+
   // Keep reference to parent
   this.db = parent;
   // Set server state to connecting
@@ -363,7 +363,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
     // If we have a valid master connection let's attempt to perform a query to get the status of
     // The replicaset server
     var connection = self.checkoutWriter();
-    
+
     // If we have a connection
     if(connection != null) {
       self.db.admin().command({replSetGetStatus:1}, {connection:connection}, function(err, result) {
@@ -376,31 +376,31 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
             // We have changed update replicaset object to restart connections
             self.replicaSetChanged = true;
           } else {
-            // We need to dig a bit deeper and check if the roles of different servers have changed            
+            // We need to dig a bit deeper and check if the roles of different servers have changed
             // Located members must have the same setup (being secondary etc) for it to be equivalent
             var numberOfFoundMembersWithSameSetup = 0;
-  
+
             // Check for the member to see if it's anywhere
-            for(var i = 0; i < members.length; i++) {              
+            for(var i = 0; i < members.length; i++) {
               // Get member
               var member = members[i];
               // If it's a primary check that is a primary in the current set aswell
               if(member.state == STATE_PRIMARY && self._state.master != null && (self._state.master.host + ":" + self._state.master.port) == member.name) {
                 numberOfFoundMembersWithSameSetup = numberOfFoundMembersWithSameSetup + 1;
               } else if(member.state == STATE_SECONDARY && (self._state.secondaries[member.name] != null || self._state.passives[member.name] != null)) {
-                numberOfFoundMembersWithSameSetup = numberOfFoundMembersWithSameSetup + 1;                
+                numberOfFoundMembersWithSameSetup = numberOfFoundMembersWithSameSetup + 1;
               } else if(member.state == STATE_ARBITER && self._state.arbiters[member.name] != null) {
-                numberOfFoundMembersWithSameSetup = numberOfFoundMembersWithSameSetup + 1;                
-              }              
+                numberOfFoundMembersWithSameSetup = numberOfFoundMembersWithSameSetup + 1;
+              }
             }
-                        
+
             if(numberOfFoundMembersWithSameSetup != members.length) {
               // We have changed update replicaset object to restart connections
               self.replicaSetChanged = true;
             } else {
               setTimeout(checkStateOfReplicasetFunction, replicasetCheckFrequencey);
             }
-          }                    
+          }
         } else {
           setTimeout(checkStateOfReplicasetFunction, replicasetCheckFrequencey);
         }
@@ -409,7 +409,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
       setTimeout(checkStateOfReplicasetFunction, replicasetCheckFrequencey);
     }
   }
-  
+
   // Start timeout
   setTimeout(checkStateOfReplicasetFunction, replicasetCheckFrequencey);
 
@@ -431,14 +431,14 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
     return function(err, result) {
       // console.log("--------------------------------------------- connectionHandler")
       // console.dir(err)
-      
+
       // Don't attempt to connect if we are done
       // if(replSetSelf._serverState === 'disconnected') return;
       // Remove a server from the list of intialized servers we need to perform
       numberOfServersLeftToInitialize = numberOfServersLeftToInitialize - 1;
       // Add enable query information
       instanceServer.enableRecordQueryStats(replSetSelf.recordQueryStats);
-      
+
       if(err == null && result.documents[0].hosts != null) {
         // Fetch the isMaster command result
         var document = result.documents[0];
@@ -453,8 +453,8 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
         var passives = Array.isArray(document.passives) ? document.passives : [];
         var tags = document.tags ? document.tags : {};
         var primary = document.primary;
-        var me = document.me;
-                
+        var me = document.me || (instanceServer.host + ":" + instanceServer.port);
+
         // Only add server to our internal list if it's a master, secondary or arbiter
         if(isMaster == true || secondary == true || arbiterOnly == true) {
           // Handle a closed connection
@@ -463,7 +463,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
             if(replSetSelf._serverState == 'connected') {
               // Shut down the replicaset for now and Fire off all the callbacks sitting with no reply
               replSetSelf.close(function() {
-                __executeAllCallbacksWithError(parent, new Error("connection closed"));        
+                __executeAllCallbacksWithError(parent, new Error("connection closed"));
                 // Ensure single callback only
                 if(callback != null) {
                   // Single callback only
@@ -477,7 +477,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
                     parent.emit("close", new Error("connection closed"));
                   }
                 }
-              });              
+              });
             }
           }
 
@@ -501,7 +501,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
                     parent.emit("timeout", new Error("connection timed out"));
                   }
                 }
-              });          
+              });
             }
           }
 
@@ -514,7 +514,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
             if(replSetSelf._serverState == 'connected') {
               replSetSelf.close(function() {
                 __executeAllCallbacksWithError(parent, err);
-                // console.log("--------------------------------- " + callback)                
+                // console.log("--------------------------------- " + callback)
                 // Ensure single callback only
                 if(callback != null) {
                   // Single callback only
@@ -531,7 +531,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
               });
             }
           }
-          
+
           // Ensure we don't have duplicate handlers
           instanceServer.removeAllListeners("close");
           instanceServer.removeAllListeners("error");
@@ -557,7 +557,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
               // For the value check if we have an array of server instances
               if(!Array.isArray(replSetSelf._state.byTags[tagKeys[i]][value])) replSetSelf._state.byTags[tagKeys[i]][value] = [];
               // Check that the instance is not already registered there
-              var valueArray = replSetSelf._state.byTags[tagKeys[i]][value];            
+              var valueArray = replSetSelf._state.byTags[tagKeys[i]][value];
               var found = false;
 
               // Iterate over all values
@@ -581,7 +581,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
 
           // Assign the set name
           if(replSetSelf.replicaSet == null) {
-            replSetSelf._state.setName = setName;          
+            replSetSelf._state.setName = setName;
           } else if(replSetSelf.replicaSet != setName && replSetSelf._serverState != 'disconnected') {
             replSetSelf._state.errorMessages.push(new Error("configured mongodb replicaset does not match provided replicaset [" + setName + "] != [" + replSetSelf.replicaSet + "]"));
             // Set done
@@ -607,14 +607,14 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
           }
 
           // Let's go throught all the "possible" servers in the replicaset
-          var candidateServers = hosts.concat(arbiters).concat(passives);        
+          var candidateServers = hosts.concat(arbiters).concat(passives);
 
           // If we have new servers let's add them
           for(var i = 0; i < candidateServers.length; i++) {
             // Fetch the server string
-            var candidateServerString = candidateServers[i];        
+            var candidateServerString = candidateServers[i];
             // Add the server if it's not defined
-            if(replSetSelf._state.addresses[candidateServerString] == null) {            
+            if(replSetSelf._state.addresses[candidateServerString] == null) {
               // Split the server string
               var parts = candidateServerString.split(/:/);
               if(parts.length == 1) {
@@ -637,7 +637,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
               var newServer = new Server(parts[0], parseInt(parts[1]), {auto_reconnect:false, 'socketOptions':socketOptions
                               , logger:replSetSelf.logger, ssl:replSetSelf.ssl, poolSize:replSetSelf.poolSize});
               // Set the replicaset instance
-              newServer.replicasetInstance = replSetSelf;              
+              newServer.replicasetInstance = replSetSelf;
 
               // Add handlers
               newServer.on("close", closeHandler);
@@ -653,15 +653,15 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
               // Let's set up a new server instance
               newServer.connect(parent, {returnIsMasterResults: true, eventReceiver:newServer}, connectionHandler(newServer));
             }
-          }          
+          }
         } else {
           // Remove the instance from out list of servers
           delete replSetSelf._state.addresses[me];
         }
       }
-      
+
       // console.log("================================================= numberOfServersLeftToInitialize :: " + numberOfServersLeftToInitialize);
-      
+
       // If done finish up
       if((numberOfServersLeftToInitialize == 0) && replSetSelf._serverState === 'connecting' && replSetSelf._state.errorMessages.length == 0) {
         // Set db as connected
@@ -708,7 +708,7 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
             // Perform callback
             internalCallback(null, parent);
           }
-        } else if(replSetSelf.readSecondary == true && Object.keys(replSetSelf._state.secondaries).length == 0) {          
+        } else if(replSetSelf.readSecondary == true && Object.keys(replSetSelf._state.secondaries).length == 0) {
           replSetSelf._serverState = 'disconnected';
           // ensure no callbacks get called twice
           var internalCallback = callback;
@@ -725,8 +725,8 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
           // Force close all server instances
           replSetSelf.close();
           // Perform callback
-          internalCallback(new Error("no primary server found"), null);            
-        }          
+          internalCallback(new Error("no primary server found"), null);
+        }
       } else if((numberOfServersLeftToInitialize == 0) && replSetSelf._state.errorMessages.length > 0 && replSetSelf._serverState != 'disconnected') {
         // Set done
         replSetSelf._serverState = 'disconnected';
@@ -736,18 +736,18 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
         // Force close all server instances
         replSetSelf.close();
         // Callback to signal we are done
-        internalCallback(replSetSelf._state.errorMessages[0], null);          
+        internalCallback(replSetSelf._state.errorMessages[0], null);
       }
     }
   }
-  
+
   // Ensure we have all registered servers in our set
-  for(var i = 0; i < serverConnections.length; i++) {    
+  for(var i = 0; i < serverConnections.length; i++) {
     replSetSelf._state.addresses[serverConnections[i].host + ':' + serverConnections[i].port] = serverConnections[i];
   }
 
   // Initialize all the connections
-  for(var i = 0; i < serverConnections.length; i++) {    
+  for(var i = 0; i < serverConnections.length; i++) {
     // Set up the logger for the server connection
     serverConnections[i].logger = replSetSelf.logger;
     // Default empty socket options object
@@ -757,22 +757,22 @@ ReplSetServers.prototype.connect = function(parent, options, callback) {
       var keys = Object.keys(this.socketOptions);
       for(var j = 0; j < keys.length;j++) socketOptions[keys[j]] = this.socketOptions[keys[j]];
     }
-    
+
     // If ssl is specified
     if(replSetSelf.ssl) serverConnections[i].ssl = true;
 
     // Add host information to socket options
     socketOptions['host'] = serverConnections[i].host;
     socketOptions['port'] = serverConnections[i].port;
-    
+
     // Set the socket options
     serverConnections[i].socketOptions = socketOptions;
     // Set the replicaset instance
     serverConnections[i].replicasetInstance = replSetSelf;
     // Connect to server
     serverConnections[i].connect(parent, {returnIsMasterResults: true, eventReceiver:serverConnections[i]}, connectionHandler(serverConnections[i]));
-  }  
-  
+  }
+
   // Check if we have an error in the inital set of servers and callback with error
   if(replSetSelf._state.errorMessages.length > 0 && typeof callback === 'function') {
     // ensure no callbacks get called twice
@@ -798,8 +798,8 @@ ReplSetServers.prototype.checkoutReader = function() {
       // Pick a random key
       var keys = Object.keys(this._state.secondaries);
       var key = keys[Math.floor(Math.random() * keys.length)];
-      return this._state.secondaries[key].checkoutReader();      
-    }    
+      return this._state.secondaries[key].checkoutReader();
+    }
   } else if(this._readPreference == Server.READ_SECONDARY_ONLY && Object.keys(this._state.secondaries).length == 0) {
     return null;
   } else if(this._readPreference != null && typeof this._readPreference === 'object') {
@@ -809,11 +809,11 @@ ReplSetServers.prototype.checkoutReader = function() {
     var instanceServer = null;
     // for each key look for an avilable instance
     for(var i = 0; i < keys.length; i++) {
-      // Grab subkey value      
+      // Grab subkey value
       var value = this._readPreference[keys[i]];
 
       // Check if we have any servers for the tag, if we do pick a random one
-      if(this._state.byTags[keys[i]] != null 
+      if(this._state.byTags[keys[i]] != null
         && this._state.byTags[keys[i]][value] != null
         && Array.isArray(this._state.byTags[keys[i]][value])
         && this._state.byTags[keys[i]][value].length > 0) {
@@ -824,7 +824,7 @@ ReplSetServers.prototype.checkoutReader = function() {
         break;
       }
     }
-    
+
     // Return the instance of the server
     return instanceServer != null ? instanceServer.checkoutReader() : this.checkoutWriter();
   } else {
@@ -839,7 +839,7 @@ ReplSetServers.prototype.allRawConnections = function() {
   var allMasterConnections = this._state.master.connectionPool.getAllConnections();
   // Add all connections to list
   allConnections = allConnections.concat(allMasterConnections);
-  
+
   // If we have read secondary let's add all secondary servers
   if(this.readSecondary && Object.keys(this._state.secondaries).length > 0) {
     // Get all the keys
@@ -852,7 +852,7 @@ ReplSetServers.prototype.allRawConnections = function() {
       allConnections = allConnections.concat(secondaryPoolConnections);
     }
   }
-  
+
   // Return all the conections
   return allConnections;
 }
@@ -860,7 +860,7 @@ ReplSetServers.prototype.allRawConnections = function() {
 ReplSetServers.prototype.enableRecordQueryStats = function(enable) {
   // Set the global enable record query stats
   this.recordQueryStats = enable;
-  // Ensure all existing servers already have the flag set, even if the 
+  // Ensure all existing servers already have the flag set, even if the
   // connections are up already or we have not connected yet
   if(this._state != null && this._state.addresses != null) {
     var keys = Object.keys(this._state.addresses);
@@ -880,9 +880,9 @@ ReplSetServers.prototype.disconnect = function(callback) {
 }
 
 ReplSetServers.prototype.close = function(callback) {
-  var self = this;  
+  var self = this;
   // Set server status as disconnected
-  this._serverState = 'disconnected';  
+  this._serverState = 'disconnected';
   // Get all the server instances and close them
   var allServers = [];
   // Make sure we have servers
@@ -890,9 +890,9 @@ ReplSetServers.prototype.close = function(callback) {
     var keys = Object.keys(this._state.addresses);
     for(var i = 0; i < keys.length; i++) {
       allServers.push(this._state.addresses[keys[i]]);
-    }    
+    }
   }
-  
+
   // Let's process all the closing
   var numberOfServersToClose = allServers.length;
 
@@ -917,14 +917,14 @@ ReplSetServers.prototype.close = function(callback) {
 
         // If we are finished perform the call back
         if(numberOfServersToClose == 0 && typeof callback === 'function') {
-          callback(null);          
+          callback(null);
         }
-      })      
+      })
     } else {
-      numberOfServersToClose = numberOfServersToClose - 1;      
+      numberOfServersToClose = numberOfServersToClose - 1;
       // If we have no more servers perform the callback
       if(numberOfServersToClose == 0 && typeof callback === 'function') {
-        callback(null);          
+        callback(null);
       }
     }
   }


### PR DESCRIPTION
replicaSetChanged is always being set in checkStateOfReplicasetFunction (line 377) because self._state.addresses does not match the number of members in the server's replSetGetStatus reply. the root of the issue seems to be that the connection reply from mongo doesn't have a 'me' attribute. thus, when the instanceServer is assigned to the _state.addresses object we erroneously use 'undefined' as the key:

replSetSelf._state.addresses[me] = instanceServer; (line 580)
