### PR TITLE
findOne from primary

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -955,7 +955,7 @@ Collection.prototype.findOne = function findOne () {
   options.slaveOk = options.slaveOk != null ? options.slaveOk : this.db.slaveOk;
   // Create cursor instance
   var o = options;
-  var cursor = new Cursor(this.db, this, selector, fields, o.skip, 1, o.sort, o.hint, o.explain, o.snapshot, o.timeout, o.tailable, o.batchSize, o.slaveOk, o.raw);
+  var cursor = new Cursor(this.db, this, selector, fields, o.skip, 1, o.sort, o.hint, o.explain, o.snapshot, o.timeout, o.tailable, o.batchSize, o.slaveOk, o.raw, o.read);
   cursor.toArray(function(err, items) {
     if(err != null) return callback(err instanceof Error ? err : self.db.wrap(new Error(err)), null);
     if(items.length == 1) return callback(null, items[0]);    


### PR DESCRIPTION
Fix the following case:
1. Replicaset configured with multiple nodes, replicaset connection configured to read from secondary
2. Execute findOne query, attempt to force to read from primary

Previously the {read:'primary'} option was ignored for findOne (although not for find).
