### PR TITLE
Do nothing on gfs read stream resume() if it wasn't paused

### DIFF
--- a/lib/mongodb/gridfs/readstream.js
+++ b/lib/mongodb/gridfs/readstream.js
@@ -148,6 +148,9 @@ ReadStream.prototype.destroy = function() {
  * @api public
  */
 ReadStream.prototype.resume = function() {
+  if (this.paused === false) {
+    return;
+  }
   this.paused = false;
   var self = this;
   if(self.pendingChunk != null) {


### PR DESCRIPTION
If resume() on GridFS readstream called twice or when stream not paused then stream will be immediate closed. It breaks resume() semantic a bit and confuse in some use cases: pumping gfs stream via util.pump() for example.
