### PR TITLE
Process dropDatabase errors

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1126,13 +1126,30 @@ Db.prototype.indexInformation = function(collectionName, options, callback) {
 /**
  * Drop a database.
  *
- * @param {Function} callback returns the index information.
+ * @param {Function} callback returns whether the operation succeeded.
  * @return {null}
  * @api public
  */
 Db.prototype.dropDatabase = function(callback) {
   this._executeQueryCommand(DbCommand.createDropDatabaseCommand(this), function(err, result) {
-    callback(err, result);
+    // Handle any errors
+
+    if (err == null && result.documents[0].ok == 1) {
+      callback(null, true);
+    } else {
+      if (err) {
+        callback(err, false);
+      } else {
+        err = new Error(result.documents[0].errmsg);
+        for (var k in result.documents[0]) {
+          if (k !== "ok" && k !== "errmsg") {
+            err[k] = result.documents[0][k];
+          }
+        }
+
+        callback(err, false);
+      }
+    }
   });
 };
 


### PR DESCRIPTION
Adds handling of errors produced by `dropDatabase`. If additional error information is available (e.g. `assertion` and `assertionCode`), those will be copied to the error object provided to the callback.
