### PR TITLE
Db.dropDatabase() is missing self

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1131,6 +1131,8 @@ Db.prototype.indexInformation = function(collectionName, options, callback) {
  * @api public
  */
 Db.prototype.dropDatabase = function(callback) {
+  var self = this;
+
   this._executeQueryCommand(DbCommand.createDropDatabaseCommand(this), function(err, result) {
     if (err == null && result.documents[0].ok == 1) {
       callback(null, true);


### PR DESCRIPTION
Defines `self` so errors will be wrapped properly.
