### PR TITLE
Also ignore tests and build directories in external-libs

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,10 +2,10 @@
 .gitignore
 .buildinfo
 .mongodb
+.DS_Store
 
 HISTORY
 Readme.md
-Makefile
 TODO
 
 docs/
@@ -14,4 +14,7 @@ data/
 dev/
 examples/
 test/
-.DS_Store
+
+external-libs/bson/build/
+external-libs/bson/build/.wafpickle-7
+external-libs/bson/test/


### PR DESCRIPTION
There was a rather large mistake in my earlier pull request. It ignored the Makefile which is needed to build the native bson parser, sorry about that :(
