### PR TITLE
Fix BSON parser on runtimes without TypedArrays.

### DIFF
--- a/lib/mongodb/bson/bson.js
+++ b/lib/mongodb/bson/bson.js
@@ -13,6 +13,13 @@ if(typeof window === 'undefined') {
     , readIEEE754 = require('./float_parser').readIEEE754;
 }
 
+var isUint8Array;
+if(typeof Uint8Array === 'undefined') {
+  isUint8Array = function(obj) { return false; }
+} else {
+  isUint8Array = function(obj) { return obj instanceof Uint8Array; }
+}
+
 /**
  * Create a new BSON instance
  *
@@ -405,13 +412,13 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
       // Encode String type
       buffer[index++] = BSON.BSON_DATA_STRING;
       // Number of written bytes
-      var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+      var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
       // Encode the name
       index = index + numberOfWrittenBytes + 1;
       buffer[index - 1] = 0;          
       
       // Calculate size
-      var size = buffer instanceof Uint8Array ? numberOfBytes(value) + 1 : Buffer.byteLength(value) + 1;
+      var size = isUint8Array(buffer) ? numberOfBytes(value) + 1 : Buffer.byteLength(value) + 1;
       // Write the size of the string to buffer
       buffer[index + 3] = (size >> 24) & 0xff;     
       buffer[index + 2] = (size >> 16) & 0xff;
@@ -420,7 +427,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
       // Ajust the index
       index = index + 4;
       // Write the string
-      buffer instanceof Uint8Array ? writeToTypedArray(buffer, value, index) : buffer.write(value, index, 'utf8');
+      isUint8Array(buffer) ? writeToTypedArray(buffer, value, index) : buffer.write(value, index, 'utf8');
       // Update index
       index = index + size - 1;
       // Write zero
@@ -436,7 +443,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
           // Set int type 32 bits or less
           buffer[index++] = BSON.BSON_DATA_INT;          
           // Number of written bytes
-          var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+          var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
           // Encode the name
           index = index + numberOfWrittenBytes + 1;
           buffer[index - 1] = 0;          
@@ -449,7 +456,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
           // Encode as double
           buffer[index++] = BSON.BSON_DATA_NUMBER;
           // Number of written bytes
-          var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+          var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
           // Encode the name
           index = index + numberOfWrittenBytes + 1;
           buffer[index - 1] = 0;          
@@ -461,7 +468,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
           // Set long type
           buffer[index++] = BSON.BSON_DATA_LONG;          
           // Number of written bytes
-          var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+          var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
           // Encode the name
           index = index + numberOfWrittenBytes + 1;
           buffer[index - 1] = 0;          
@@ -483,7 +490,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Encode as double
         buffer[index++] = BSON.BSON_DATA_NUMBER;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;          
@@ -498,7 +505,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
       // Set long type
       buffer[index++] = BSON.BSON_DATA_NULL;
       // Number of written bytes
-      var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+      var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
       // Encode the name
       index = index + numberOfWrittenBytes + 1;
       buffer[index - 1] = 0;
@@ -507,7 +514,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
       // Write the type
       buffer[index++] = BSON.BSON_DATA_BOOLEAN;
       // Number of written bytes
-      var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+      var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
       // Encode the name
       index = index + numberOfWrittenBytes + 1;
       buffer[index - 1] = 0;
@@ -527,7 +534,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         }
       
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
@@ -536,13 +543,13 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the type
         buffer[index++] = BSON.BSON_DATA_OID;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
 
         // Write objectid
-        buffer instanceof Uint8Array ? writeToTypedArray(buffer, value.id, index) : buffer.write(value.id, index, 'binary');
+        isUint8Array(buffer) ? writeToTypedArray(buffer, value.id, index) : buffer.write(value.id, index, 'binary');
         // Ajust index
         index = index + 12;
         return index;
@@ -550,7 +557,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the type
         buffer[index++] = BSON.BSON_DATA_DATE;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
@@ -574,7 +581,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the type
         buffer[index++] = BSON.BSON_DATA_BINARY;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
@@ -596,7 +603,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the type
         buffer[index++] = value instanceof Long ? BSON.BSON_DATA_LONG : BSON.BSON_DATA_TIMESTAMP;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
@@ -618,7 +625,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Encode as double
         buffer[index++] = BSON.BSON_DATA_NUMBER;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;          
@@ -632,16 +639,16 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
           // Write the type
           buffer[index++] = BSON.BSON_DATA_CODE_W_SCOPE;
           // Number of written bytes
-          var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+          var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
           // Encode the name
           index = index + numberOfWrittenBytes + 1;
           buffer[index - 1] = 0;
           // Calculate the scope size
-          var scopeSize = BSON.calculateObjectSize(value.scope, serializeFunctions, !(buffer instanceof Uint8Array));
+          var scopeSize = BSON.calculateObjectSize(value.scope, serializeFunctions, !isUint8Array(buffer));
           // Function string
           var functionString = value.code.toString();
           // Function Size
-          var codeSize = buffer instanceof Uint8Array ? numberOfBytes(functionString) + 1 : Buffer.byteLength(functionString) + 1;
+          var codeSize = isUint8Array(buffer) ? numberOfBytes(functionString) + 1 : Buffer.byteLength(functionString) + 1;
 
           // Calculate full size of the object
           var totalSize = 4 + codeSize + scopeSize + 4;
@@ -659,13 +666,13 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
           buffer[index++] = (codeSize >> 24) & 0xff;     
 
           // Write the string
-          buffer instanceof Uint8Array ? writeToTypedArray(buffer, functionString, index) : buffer.write(functionString, index, 'utf8');          
+          isUint8Array(buffer) ? writeToTypedArray(buffer, functionString, index) : buffer.write(functionString, index, 'utf8');          
           // Update index
           index = index + codeSize - 1;
           // Write zero
           buffer[index++] = 0;
           // Serialize the scope object          
-          var scopeObjectBuffer = buffer instanceof Uint8Array ? new Uint8Array(new ArrayBuffer(scopeSize)) : new Buffer(scopeSize);
+          var scopeObjectBuffer = isUint8Array(buffer) ? new Uint8Array(new ArrayBuffer(scopeSize)) : new Buffer(scopeSize);
           // Execute the serialization into a seperate buffer
           serializeObject(value.scope, checkKeys, scopeObjectBuffer, 0, serializeFunctions);
           
@@ -678,7 +685,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
           buffer[index++] = (scopeDocSize >> 24) & 0xff;     
           
           // Write the scopeObject into the buffer
-          buffer instanceof Uint8Array ? buffer.set(scopeObjectBuffer, index): scopeObjectBuffer.copy(buffer, index, 0, scopeSize);
+          isUint8Array(buffer) ? buffer.set(scopeObjectBuffer, index): scopeObjectBuffer.copy(buffer, index, 0, scopeSize);
           // Adjust index, removing the empty size of the doc (5 bytes 0000000005)
           index = index + scopeDocSize - 5;          
           // Write trailing zero
@@ -687,14 +694,14 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         } else {
           buffer[index++] = BSON.BSON_DATA_CODE;
           // Number of written bytes
-          var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+          var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
           // Encode the name
           index = index + numberOfWrittenBytes + 1;
           buffer[index - 1] = 0;
           // Function string
           var functionString = value.code.toString();
           // Function Size
-          var size = buffer instanceof Uint8Array ? numberOfBytes(functionString) + 1 : Buffer.byteLength(functionString) + 1;
+          var size = isUint8Array(buffer) ? numberOfBytes(functionString) + 1 : Buffer.byteLength(functionString) + 1;
           // Write the size of the string to buffer
           buffer[index++] = size & 0xff;
           buffer[index++] = (size >> 8) & 0xff;
@@ -712,7 +719,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the type
         buffer[index++] = BSON.BSON_DATA_BINARY;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
@@ -728,7 +735,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the subtype to the buffer
         buffer[index++] = value.sub_type;
         // Write the data to the object
-        buffer instanceof Uint8Array ? buffer.set(data, index): data.copy(buffer, index, 0, value.position);
+        isUint8Array(buffer) ? buffer.set(data, index): data.copy(buffer, index, 0, value.position);
         // Ajust index
         index = index + value.position;
         return index;
@@ -736,12 +743,12 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the type
         buffer[index++] = BSON.BSON_DATA_SYMBOL;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
         // Calculate size
-        var size = buffer instanceof Uint8Array ? numberOfBytes(value.value) + 1 : Buffer.byteLength(value.value) + 1;
+        var size = isUint8Array(buffer) ? numberOfBytes(value.value) + 1 : Buffer.byteLength(value.value) + 1;
         // Write the size of the string to buffer
         buffer[index++] = size & 0xff;
         buffer[index++] = (size >> 8) & 0xff;
@@ -758,7 +765,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the type
         buffer[index++] = BSON.BSON_DATA_OBJECT;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
@@ -774,7 +781,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         }
 
         // Message size
-        var size = BSON.calculateObjectSize(ordered_values, serializeFunctions, !(buffer instanceof Uint8Array));
+        var size = BSON.calculateObjectSize(ordered_values, serializeFunctions, !isUint8Array(buffer));
         // Serialize the object
         var endIndex = BSON.serializeWithBufferAndIndex(ordered_values, checkKeys, buffer, index, serializeFunctions);
         // Write the size of the string to buffer
@@ -790,15 +797,15 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the type
         buffer[index++] = BSON.BSON_DATA_REGEXP;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
 
         // Write the regular expression string
-        buffer instanceof Uint8Array ? writeToTypedArray(buffer, value.source, index) : buffer.write(value.source, index, 'utf8');
+        isUint8Array(buffer) ? writeToTypedArray(buffer, value.source, index) : buffer.write(value.source, index, 'utf8');
         // Adjust the index
-        index = index + (buffer instanceof Uint8Array ? numberOfBytes(value.source) : Buffer.byteLength(value.source));
+        index = index + (isUint8Array(buffer) ? numberOfBytes(value.source) : Buffer.byteLength(value.source));
         // Write zero
         buffer[index++] = 0x00;        
         // Write the parameters
@@ -812,7 +819,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the type
         buffer[index++] = Array.isArray(value) ? BSON.BSON_DATA_ARRAY : BSON.BSON_DATA_OBJECT;        
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Adjust the index
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
@@ -833,7 +840,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the type
         buffer[index++] = BSON.BSON_DATA_REGEXP;
         // Number of written bytes
-        var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+        var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
         // Encode the name
         index = index + numberOfWrittenBytes + 1;
         buffer[index - 1] = 0;
@@ -841,7 +848,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         // Write the regular expression string
         buffer.write(value.source, index, 'utf8');
         // Adjust the index
-        index = index + (buffer instanceof Uint8Array ? numberOfBytes(value.source) : Buffer.byteLength(value.source));
+        index = index + (isUint8Array(buffer) ? numberOfBytes(value.source) : Buffer.byteLength(value.source));
         // Write zero
         buffer[index++] = 0x00;        
         // Write the parameters
@@ -856,16 +863,16 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
           // Write the type
           buffer[index++] = BSON.BSON_DATA_CODE_W_SCOPE;
           // Number of written bytes
-          var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+          var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
           // Encode the name
           index = index + numberOfWrittenBytes + 1;
           buffer[index - 1] = 0;
           // Calculate the scope size
-          var scopeSize = BSON.calculateObjectSize(value.scope, serializeFunctions, !(buffer instanceof Uint8Array));
+          var scopeSize = BSON.calculateObjectSize(value.scope, serializeFunctions, !isUint8Array(buffer));
           // Function string
           var functionString = value.toString();
           // Function Size
-          var codeSize = buffer instanceof Uint8Array ? numberOfBytes(functionString) + 1 : Buffer.byteLength(functionString) + 1;
+          var codeSize = isUint8Array(buffer) ? numberOfBytes(functionString) + 1 : Buffer.byteLength(functionString) + 1;
 
           // Calculate full size of the object
           var totalSize = 4 + codeSize + scopeSize;
@@ -912,14 +919,14 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         } else if(serializeFunctions) {
           buffer[index++] = BSON.BSON_DATA_CODE;
           // Number of written bytes
-          var numberOfWrittenBytes = buffer instanceof Uint8Array ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
+          var numberOfWrittenBytes = isUint8Array(buffer) ? writeToTypedArray(buffer, name, index) : buffer.write(name, index, 'utf8');
           // Encode the name
           index = index + numberOfWrittenBytes + 1;
           buffer[index - 1] = 0;
           // Function string
           var functionString = value.toString();
           // Function Size
-          var size = buffer instanceof Uint8Array ? numberOfBytes(functionString) + 1 : Buffer.byteLength(functionString) + 1;
+          var size = isUint8Array(buffer) ? numberOfBytes(functionString) + 1 : Buffer.byteLength(functionString) + 1;
           // Write the size of the string to buffer
           buffer[index++] = size & 0xff;
           buffer[index++] = (size >> 8) & 0xff;
@@ -1123,7 +1130,7 @@ BSON.deserialize = function(buffer, options, isArray) {
     // Locate the end of the c string
     while(buffer[i] !== 0x00) { i++ }
     // Grab utf8 encoded string
-    var string = buffer instanceof Uint8Array ? convertUint8ArrayToUtf8String(buffer, index, i) : buffer.toString('utf8', index, i);
+    var string = isUint8Array(buffer) ? convertUint8ArrayToUtf8String(buffer, index, i) : buffer.toString('utf8', index, i);
     // Update index position
     index = i + 1;
     // Return string
@@ -1150,7 +1157,7 @@ BSON.deserialize = function(buffer, options, isArray) {
     // Switch on the type
     switch(elementType) {
       case BSON.BSON_DATA_OID:
-        var string = buffer instanceof Uint8Array ? convertArraytoUtf8BinaryString(buffer, index, index + 12) : buffer.toString('binary', index, index + 12);
+        var string = isUint8Array(buffer) ? convertArraytoUtf8BinaryString(buffer, index, index + 12) : buffer.toString('binary', index, index + 12);
         // Decode the oid
         object[name] = new ObjectID(string);
         // Update index
@@ -1160,7 +1167,7 @@ BSON.deserialize = function(buffer, options, isArray) {
         // Read the content of the field
         var stringSize = buffer[index++] | buffer[index++] << 8 | buffer[index++] << 16 | buffer[index++] << 24;
         // Add string to object
-        object[name] = buffer instanceof Uint8Array ? convertUint8ArrayToUtf8String(buffer, index, index + stringSize - 1) : buffer.toString('utf8', index, index + stringSize - 1);
+        object[name] = isUint8Array(buffer) ? convertUint8ArrayToUtf8String(buffer, index, index + stringSize - 1) : buffer.toString('utf8', index, index + stringSize - 1);
         // Update parse index position
         index = index + stringSize;
         break;
@@ -1277,7 +1284,7 @@ BSON.deserialize = function(buffer, options, isArray) {
         // Read the content of the field
         var stringSize = buffer[index++] | buffer[index++] << 8 | buffer[index++] << 16 | buffer[index++] << 24;
         // Function string
-        var functionString = buffer instanceof Uint8Array ? convertUint8ArrayToUtf8String(buffer, index, index + stringSize - 1) : buffer.toString('utf8', index, index + stringSize - 1);
+        var functionString = isUint8Array(buffer) ? convertUint8ArrayToUtf8String(buffer, index, index + stringSize - 1) : buffer.toString('utf8', index, index + stringSize - 1);
 
         // If we are evaluating the functions
         if(evalFunctions) {
@@ -1304,7 +1311,7 @@ BSON.deserialize = function(buffer, options, isArray) {
         var totalSize = buffer[index++] | buffer[index++] << 8 | buffer[index++] << 16 | buffer[index++] << 24;
         var stringSize = buffer[index++] | buffer[index++] << 8 | buffer[index++] << 16 | buffer[index++] << 24;
         // Javascript function
-        var functionString = buffer instanceof Uint8Array ? convertUint8ArrayToUtf8String(buffer, index, index + stringSize - 1) : buffer.toString('utf8', index, index + stringSize - 1);
+        var functionString = isUint8Array(buffer) ? convertUint8ArrayToUtf8String(buffer, index, index + stringSize - 1) : buffer.toString('utf8', index, index + stringSize - 1);
         // Update parse index position
         index = index + stringSize;
         // Parse the element


### PR DESCRIPTION
Node 0.4 has no TypedArrays at all. Accessing `Uint8Array`, even just for an `instanceof` check, throws a `ReferenceError`.
