### PR TITLE
Allow URL encoded passwords with db.connect()

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1674,7 +1674,7 @@ Db.connect = function(url, options, callback) {
 
   db.open(function(err, db){
     if(err == null && authPart){
-      db.authenticate(auth[0], auth[1], function(err, success){
+      db.authenticate(decodeURIComponent(auth[0]), decodeURIComponent(auth[1]), function(err, success){
         if(success){
           callback(null, db);
         } else {


### PR DESCRIPTION
This is just a small change that URL decodes usernames and passwords in connection URLs.

I'd like make that function use the built in URL parsing in Node, would that be ok with you? Regex's give me hives. :)
