### PR TITLE
Fix Admin.serverStatus

### DIFF
--- a/lib/mongodb/admin.js
+++ b/lib/mongodb/admin.js
@@ -57,7 +57,7 @@ Admin.prototype.serverInfo = function(callback) {
 Admin.prototype.serverStatus = function(callback) {
   var self = this;
 
-  this._executeQueryCommand(DbCommand.createServerStatusCommand(this), function(err, result) {
+  this.db._executeQueryCommand(DbCommand.createServerStatusCommand(this.db), function(err, result) {
     if (err == null && result.documents[0].ok == 1) {
       callback(null, result.documents[0]);
     } else {


### PR DESCRIPTION
christkv/node-mongodb-native@b381b161008f35a0b84b18077ece9a12628445f9 broke `serverStatus`, as `Admin` doesn't have `_executeQueryCommand` (the patch was originally written for `Db`).
