### PR TITLE
Make callback type checks agnostic to V8 context boundaries

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -1164,11 +1164,11 @@ Collection.prototype.group = function group(keys, condition, initial, reduce, fi
     keys = Object.keys(keys);
   }
   
-  if(reduce instanceof Function) {
+  if(typeof reduce === 'function') {
     reduce = reduce.toString();
   }
   
-  if(finalize instanceof Function) {
+  if(typeof finalize === 'function') {
     finalize = finalize.toString();
   }
   

--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1240,7 +1240,7 @@ var __executeQueryCommand = function(self, db_command, options, callback) {
   var specifiedConnection = options['connection'] != null ? options['connection'] : null;
   
   // If we got a callback object
-  if(callback instanceof Function && !onAll) {
+  if(typeof callback === 'function' && !onAll) {
     // Fetch either a reader or writer dependent on the specified read option
     var connection = read == true || read === 'secondary' ? self.serverConfig.checkoutReader() : self.serverConfig.checkoutWriter(true);
     // Override connection if needed
@@ -1265,7 +1265,7 @@ var __executeQueryCommand = function(self, db_command, options, callback) {
         self._callHandler(db_command.getRequestId(), null, err);
       }
     });    
-  } else if(callback instanceof Function && onAll) {
+  } else if(typeof callback === 'function' && onAll) {
     var connections = self.serverConfig.allRawConnections();
     var numberOfEntries = connections.length;
     // Go through all the connections
@@ -1467,7 +1467,7 @@ var __executeInsertCommand = function(self, db_command, options, callback) {
   connection = specifiedConnection != null ? specifiedConnection : connection;
 
   // Ensure we have a valid connection  
-  if(callback instanceof Function) {
+  if(typeof callback === 'function') {
     // Ensure we have a valid connection
     if(connection == null) {
       return callback(new Error("no open connections"));
@@ -1494,12 +1494,12 @@ var __executeInsertCommand = function(self, db_command, options, callback) {
   // Write the message out
   connection.write(db_command, function(err) {
     // Return the callback if it's not a safe operation and the callback is defined
-    if(callback instanceof Function && (safe == null || safe == false)) {
+    if(typeof callback === 'function' && (safe == null || safe == false)) {
       // Perform reaping
       if(self.reaperEnabled) reaper(self, self.reaperInterval, self.reaperTimeout);
       // Perform the callback
       callback(err, null);
-    } else if(callback instanceof Function){      
+    } else if(typeof callback === 'function'){      
       // Call the handler with an error
       self._callHandler(db_command[1].getRequestId(), null, err);
     } else {


### PR DESCRIPTION
If a node.js application that uses MongoDB is executed with NODE_MODULE_CONTEXTS=1 environment variable (which causes each userland module to be loaded in its own V8 context), several checks for the type of the callback argument in MongoDB fail even though they should semantically pass. 

For detailed description of the root cause see http://tomasz.janczuk.org/2012/03/when-javascript-function-is-not.html. 

This fix addresses the issue by changing

```
callback instanceof Function
```

checks to 

```
typeof callback === 'function'
```

checks. 

Note that I have not verified whether similar issue exists in other locations where `instanceof` is used. In particular, one other suspectible use case is `err instanceof Error` which occurs a lot in the code base. The issue would only occur if the instance tested had been created in a different node.js module that the module performing the test. 
