### PR TITLE
Fix for reading a GridStore from arbitrary, non-chunk aligned offsets.

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -736,7 +736,7 @@ GridStore.prototype.read = function(length, buffer, callback) {
     // Else return data
     callback(null, finalBuffer);
   } else {
-    var slice = self.currentChunk.readSlice(self.currentChunk.length());
+    var slice = self.currentChunk.readSlice(self.currentChunk.length() - self.currentChunk.position);
     // Copy content to final buffer
     slice.copy(finalBuffer, finalBuffer._index);
     // Update index position


### PR DESCRIPTION
Hi!

I think there's a bug when reading from a GridStore after seeking to an arbitrary location in the file. I believe the fix is just one line - modifying the call to readSlice to account for the offset into the chunk.
- Albert
