### PR TITLE
Allow db.open() to be called multiple times

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -228,35 +228,34 @@ inherits(Db, EventEmitter);
  * @api public
  */
 Db.prototype.open = function(callback) {
-  var self = this; 
-  
-  // Check that the user has not called this twice
-  if(this.openCalled) {
-    // Close db
-    this.close();
-    // Throw error
-    throw new Error("db object already connecting, open cannot be called multiple times");
+  if (this._state == 'connected' || this._openError) {
+    return callback(this._openError, self);
+  } 
+
+  if (this.openCalled) {
+    this._openPromise.on('ready', callback);
+    return;
   }
-  
-  // Set that db has been opened
+
+  this._state = 'connecting';
   this.openCalled = true;
-       
-  // Set the status of the server
-  self._state = 'connecting';
-  // Set up connections
-  if(self.serverConfig instanceof Server || self.serverConfig instanceof ReplSetServers) {
-    self.serverConfig.connect(self, {firstCall: true}, function(err, result) {
-      if(err != null) {
-        // Return error from connection
-        return callback(err, null);            
-      }
-      // Set the status of the server
-      self._state = 'connected';      
-      // Callback
-      return callback(null, self);
-    });
+  this._openPromise = new EventEmitter();
+  this._openPromise.on('ready', callback);
+  var self = this;
+
+  function cb (error) {
+    if (!error) {
+      self._state = 'connected';
+    }
+    self._openError = error;
+    self._openPromise.emit('ready', error, self);
+    self._openPromise = null;
+  }
+
+  if(this.serverConfig instanceof Server || this.serverConfig instanceof ReplSetServers) {
+    this.serverConfig.connect(this, {firstCall: true}, cb);
   } else {
-    return callback(Error("Server parameter must be of type Server or ReplSetServers"), null);
+    return cb(new Error("Server parameter must be of type Server or ReplSetServers"));
   }
 };
 


### PR DESCRIPTION
The use case is to allow multiple independent wrappers to share single Db instance, e.g. mongoose and something.
