### PR TITLE
Refactor use of Arguments object to gain performance

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -47,7 +47,7 @@ function Collection (db, collectionName, pkFactory, options) {
 
   this.db = db;
   this.collectionName = collectionName;
-  this.internalHint;
+  this.internalHint = null;
   this.opts = options != null && ('object' === typeof options) ? options : {};
   this.slaveOk = options == null || options.slaveOk == null ? db.slaveOk : options.slaveOk;
   this.serializeFunctions = options == null || options.serializeFunctions == null ? db.serializeFunctions : options.serializeFunctions;
@@ -56,7 +56,7 @@ function Collection (db, collectionName, pkFactory, options) {
     ? ObjectID
     : pkFactory;
     
-  var self = this
+  var self = this;
   Object.defineProperty(this, "hint", {
       enumerable: true
     , get: function () {
@@ -66,7 +66,7 @@ function Collection (db, collectionName, pkFactory, options) {
         this.internalHint = normalizeHintField(v);
       }
   });
-};
+}
 
 /**
  * Inserts a single document or a an array of documents into MongoDB.
@@ -947,11 +947,14 @@ Collection.prototype.createIndex = function createIndex (fieldOrSpec, options, c
  */
 Collection.prototype.ensureIndex = function ensureIndex (fieldOrSpec, options, callback) {
   // Clean up call
-  var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  options = args.length ? args.shift() : {};
-  options = typeof callback === 'function' ? options : callback;
-  options = options == null ? {} : options;
+  if (typeof callback === 'undefined' && typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  if (options == null) {
+    options = {};
+  }
   
   // Collect errorOptions
   var errorOptions = options.safe != null ? options.safe : null;

--- a/lib/mongodb/commands/db_command.js
+++ b/lib/mongodb/commands/db_command.js
@@ -92,9 +92,11 @@ DbCommand.createRenameCollectionCommand = function(db, fromCollectionName, toCol
 };
 
 DbCommand.createGetLastErrorCommand = function(options, db) {
-  var args = Array.prototype.slice.call(arguments, 0);
-  db = args.pop();
-  options = args.length ? args.shift() : {};
+
+  if (typeof db === 'undefined') {
+    db =  options;
+    options = {};
+  }
   // Final command 
   var command = {'getlasterror':1};
   // If we have an options Object let's merge in the fields (fsync/wtimeout/w)

--- a/lib/mongodb/commands/query_command.js
+++ b/lib/mongodb/commands/query_command.js
@@ -8,20 +8,21 @@ var QueryCommand = exports.QueryCommand = function(db, collectionName, queryOpti
   BaseCommand.call(this);
 
   // Validate correctness off the selector
-  var object = query;
+  var object = query,
+    object_size;
   if(Buffer.isBuffer(object)) {
-    var object_size = object[0] | object[1] << 8 | object[2] << 16 | object[3] << 24;    
-    if(object_size != object.length)  {
+    object_size = object[0] | object[1] << 8 | object[2] << 16 | object[3] << 24;
+    if(object_size != object.length) {
       var error = new Error("query selector raw message size does not match message header size [" + object.length + "] != [" + object_size + "]");
       error.name = 'MongoError';
       throw error;
     }
   }
 
-  var object = returnFieldSelector;
+  object = returnFieldSelector;
   if(Buffer.isBuffer(object)) {
-    var object_size = object[0] | object[1] << 8 | object[2] << 16 | object[3] << 24;    
-    if(object_size != object.length)  {
+    object_size = object[0] | object[1] << 8 | object[2] << 16 | object[3] << 24;
+    if(object_size != object.length) {
       var error = new Error("query fields raw message size does not match message header size [" + object.length + "] != [" + object_size + "]");
       error.name = 'MongoError';
       throw error;
@@ -42,7 +43,7 @@ var QueryCommand = exports.QueryCommand = function(db, collectionName, queryOpti
   // Let us defined on a command basis if we want functions to be serialized or not
   if(options['serializeFunctions'] != null && options['serializeFunctions']) {
     this.serializeFunctions = true;
-  }  
+  }
 };
 
 inherits(QueryCommand, BaseCommand);

--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1040,11 +1040,15 @@ Db.prototype.createIndex = function(collectionName, fieldOrSpec, options, callba
  */
 Db.prototype.ensureIndex = function(collectionName, fieldOrSpec, options, callback) {
   var self = this;
-  var args = Array.prototype.slice.call(arguments, 2);
-  callback = args.pop();
-  options = args.length ? args.shift() : {};
-  options = typeof callback === 'function' ? options : callback;
-  options = options == null ? {} : options;
+
+  if (typeof callback === 'undefined' && typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  if (options == null) {
+    options = {};
+  }
   
   // Collect errorOptions
   var errorOptions = options.safe != null ? options.safe : null;
@@ -1172,10 +1176,22 @@ Db.prototype.reIndex = function(collectionName, callback) {
  */
 Db.prototype.indexInformation = function(collectionName, options, callback) {
   // Unpack calls
-  var args = Array.prototype.slice.call(arguments, 0);
+  /*var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
   collectionName = args.length ? args.shift() : null;
-  options = args.length ? args.shift() : {};
+  options = args.length ? args.shift() : {};*/
+
+  if (typeof callback === 'undefined') {
+
+    if (typeof options === 'undefined') {
+      callback = collectionName;
+      collectionName = null;
+    } else {
+      callback = options;
+    }
+
+    options = {};
+  }
 
   // If we specified full information
   var full = options['full'] == null ? false : options['full'];  
@@ -1509,12 +1525,14 @@ var __retryCommandOnFailure = function(self, retryInMilliseconds, numberOfTimes,
  * @api private
  */
 Db.prototype._executeQueryCommand = function(db_command, options, callback) {
-  var self = this;  
+  var self = this;
+
   // Unpack the parameters
-  var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  options = args.length ? args.shift() : {};
-  
+  if (typeof callback === 'undefined') {
+    callback = options;
+    options = {};
+  }
+
   // Check if the user force closed the command
   if(this._applicationClosed) {
     if(typeof callback == 'function') {
@@ -1600,10 +1618,12 @@ var __executeInsertCommand = function(self, db_command, options, callback) {
  */
 Db.prototype._executeInsertCommand = function(db_command, options, callback) {  
   var self = this;
+
   // Unpack the parameters
-  var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  options = args.length ? args.shift() : {};
+  if (typeof callback === 'undefined') {
+    callback = options;
+    options = {};
+  }
 
   // Check if the user force closed the command
   if(this._applicationClosed) {

--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -93,7 +93,7 @@ function GridStore(db, id, filename, mode, options) {
          this.internalChunkSize = value;
        }
      }
-  });  
+  });
 
   /**
    * The md5 checksum for this file.
@@ -108,8 +108,8 @@ function GridStore(db, id, filename, mode, options) {
    , get: function () {
        return this.internalMd5;
      }
-  });  
-};
+  });
+}
 
 /**
  * Opens the file from the database and initialize this object. Also creates a
@@ -140,11 +140,11 @@ GridStore.prototype.open = function(callback) {
     });
   } else {
     _open(self, callback);
-  }  
-}
+  }
+};
 
 /**
- * Hidding the _open function 
+ * Hidding the _open function
  * @ignore
  * @api private
  */
@@ -164,8 +164,8 @@ var _open = function(self, callback) {
       collection.find(query, function(err, cursor) {
         // Fetch the file
         cursor.nextObject(function(err, doc) {
-          // Chek if the collection for the files exists otherwise prepare the new one
-          if(doc != null) {              
+          // Check if the collection for the files exists otherwise prepare the new one
+          if(doc != null) {
             self.fileId = doc._id;
             self.contentType = doc.contentType;
             self.internalChunkSize = doc.chunkSize;
@@ -175,7 +175,7 @@ var _open = function(self, callback) {
             self.metadata = doc.metadata;
             self.internalMd5 = doc.md5;
           } else {
-            // self.fileId = 
+            // self.fileId =
             // self.fileId = self.fileId instanceof ObjectID ? self.fileId : new ObjectID();
             self.fileId = self.fileId == null ? new ObjectID() : self.fileId;
             self.contentType = exports.GridStore.DEFAULT_CONTENT_TYPE;
@@ -208,16 +208,16 @@ var _open = function(self, callback) {
               self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
               self.position = self.length;
               callback(null, self);
-            });                
+            });
           }
         });
-      });              
+      });
     } else {
       // Write only mode
       self.fileId = null == self.fileId ? new ObjectID() : self.fileId;
       self.contentType = exports.GridStore.DEFAULT_CONTENT_TYPE;
       self.internalChunkSize = self.internalChunkSize == null ? Chunk.DEFAULT_CHUNK_SIZE : self.internalChunkSize;
-      self.length = 0;        
+      self.length = 0;
       
       self.chunkCollection(function(err, collection2) {
         // No file exists set up write mode
@@ -240,9 +240,9 @@ var _open = function(self, callback) {
             self.position = self.length;
             callback(null, self);
           });
-        }            
+        }
       });
-    };
+    }
   });
 };
 
@@ -618,9 +618,7 @@ GridStore.prototype.unlink = function(callback) {
  * @api public
  */
 GridStore.prototype.collection = function(callback) {
-  this.db.collection(this.root + ".files", function(err, collection) {
-    callback(err, collection);
-  });
+  this.db.collection(this.root + ".files", callback);
 };
 
 /**


### PR DESCRIPTION
I used node's profiler and the gridfs_benchmark.js to identify unoptimized code. It was mostly the use of the arguments object.

**Performance before (average of three runs):**
total time ms :: 1904.33
ms pr operation :: 1.9043
operations pr second :: 525.11
bytes pr second :: 39070348
MB pr second :: 37.26

**Performance after (average of three runs):**
total time ms :: 1579.33
ms pr operation :: 1.5793
operations pr second :: 633.17
bytes pr second :: 46880172
MB pr second :: 44.70
