### PR TITLE
Queue multiple open connection callbacks

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -232,12 +232,12 @@ inherits(Db, EventEmitter);
 Db.prototype.open = function(callback) {
   var self = this; 
   
+  if(self._state == 'connected') {
+    return callback(null, self);
+  }
   // Check that the user has not called this twice
   if(this.openCalled) {
-    // Close db
-    this.close();
-    // Throw error
-    throw new Error("db object already connecting, open cannot be called multiple times");
+    self._state = 'connecting';
   }
   
   // Set that db has been opened
@@ -247,15 +247,33 @@ Db.prototype.open = function(callback) {
   self._state = 'connecting';
   // Set up connections
   if(self.serverConfig instanceof Server || self.serverConfig instanceof ReplSet) {
+    if(!this._openCallbacks) {
+      this._openCallbacks = [];
+    }
+
+    if(callback) {
+      this._openCallbacks.push(callback);
+    }
+
     self.serverConfig.connect(self, {firstCall: true}, function(err, result) {
       if(err != null) {
         // Return error from connection
-        return callback(err, null);            
+        while(self._openCallbacks.length) {
+          self._openCallbacks.shift()(err, null);
+        }
+        return;
       }
       // Set the status of the server
       self._state = 'connected';      
-      // Callback
-      return callback(null, self);
+
+      // Notify that the connections is opened
+      self.emit('open', self);
+
+      // Callbacks
+      while(self._openCallbacks.length) {
+        self._openCallbacks.shift()(null, self);
+      }
+      return;
     });
   } else {
     return callback(Error("Server parameter must be of type Server or ReplSet"), null);


### PR DESCRIPTION
Hi!

Since the latest version of node-mongodb-native isn't allowing multiple opened connections, some third-party code might have broken.

This patch provides backwards compatibility. When someone tries to open a connection more than once, his callback will nevertheless be executed, even if the connection is remaining single.

Emission of `open` event is also included for convenient subscription.

Thanks!
