### PR TITLE
fixed always connecting bug

### DIFF
--- a/lib/mongodb/connection/repl_set.js
+++ b/lib/mongodb/connection/repl_set.js
@@ -364,7 +364,7 @@ ReplSet.prototype.connect = function(parent, options, callback) {
         // dns name and the driver is using ip's                
         // Rename the connection so we are keying on the name used by mongod
         var userProvidedServerString = instanceServer.host + ":" + instanceServer.port;                        
-        var me = document.me;
+        var me = document.me || userProvidedServerString;
         
         // If we have user provided entries already, switch them to avoid additional
         // open connections


### PR DESCRIPTION
fixed always connecting bug when `replSet.connect` return `document.me === undefined` .

My test mongod server version is: v2.0.5

ReplSet: 1 primary, 1 secondary, 1 arbiter

[http://www.mongodb.org/display/DOCS/Replica+Sets+-+Basics](http://www.mongodb.org/display/DOCS/Replica+Sets+-+Basics)
