### PR TITLE
Fixed bug where collection.group keyf given as Code is processed as a regular object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test: build_native
 
 test_pure: build_native
 	@echo "\n == Run All tests minus replicaset tests=="
-	$(NODE) dev/tools/test_all.js --noreplicaset --boot --noactive
+	$(NODE) dev/tools/test_all.js --noreplicaset --boot --nonative
 
 test_junit: build_native
 	@echo "\n == Run All tests minus replicaset tests=="

--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -1189,7 +1189,7 @@ Collection.prototype.group = function group(keys, condition, initial, reduce, fi
     finalize = null;
   }
 
-  if (!Array.isArray(keys) && keys instanceof Object && typeof(keys) !== 'function') {
+  if (!Array.isArray(keys) && keys instanceof Object && typeof(keys) !== 'function' && !(keys instanceof Code)) {
     keys = Object.keys(keys);
   }
   
@@ -1223,7 +1223,7 @@ Collection.prototype.group = function group(keys, condition, initial, reduce, fi
     // if finalize is defined
     if(finalize != null) selector.group['finalize'] = finalize;
     // Set up group selector
-    if ('function' === typeof keys) {
+    if ('function' === typeof keys || keys instanceof Code) {
       selector.group.$keyf = keys instanceof Code
         ? keys
         : new Code(keys);

--- a/test/map_reduce_test.js
+++ b/test/map_reduce_test.js
@@ -140,14 +140,28 @@ exports.shouldCorrectlyExecuteGroupFunction = function(test) {
                             test.equal(1, results[1].a);
                             test.equal(1, results[1].value);
                             
-                            // Correctly handle illegal function when using the EVAL method
-                            collection.group([], {}, {}, "5 ++ 5", false, function(err, results) {
-                              test.ok(err instanceof Error);
-                              test.ok(err.message != null);
-
-                              db.close();
-                              test.done();
-                            });                          
+                            // Use a Code object to select the keys used to group by
+                            var keyf = new Code(function(doc) { return {a: doc.a}; });
+                            collection.group(keyf, {a: {$gt: 0}}, {"count": 0, "value": 0}
+                              , function(obj, prev) { prev.count++; prev.value += obj.a; }, true, function(err, results) {
+                              // Results                        
+                              results.sort(function(a, b) { return b.count - a.count; });
+                              test.equal(2, results[0].count);
+                              test.equal(2, results[0].a);
+                              test.equal(4, results[0].value);
+                              test.equal(1, results[1].count);
+                              test.equal(1, results[1].a);
+                              test.equal(1, results[1].value);
+                              
+                              // Correctly handle illegal function when using the EVAL method
+                              collection.group([], {}, {}, "5 ++ 5", false, function(err, results) {
+                                test.ok(err instanceof Error);
+                                test.ok(err.message != null);
+  
+                                db.close();
+                                test.done();
+                              });
+                            });
                           });
                         });
                       });


### PR DESCRIPTION
Although the reduce and finalize functions accept BSON.Code for the function, the keyf function did not. What was missing was a simple check at the beginning where if it isn't a function and is an object then you call Object.keys(keyf) which makes the new keyset into ['_bsontype','code','scope'] which are the instance variables of the Code object. I added the simple instanceof check in that line and then added the same instanceof check where you check if typeof(keyf) === 'function' which inside of that if statement you already have the valid code for handling either Code or function input.

I added an extra step to the test_map_reduce which takes you're already existing test for passing a keyf function and I copied it verbatim except that I wrapped the function in new Code(). The test fails without the changes and passes with them and now I can make functions from strings for keyf. 

The final change I made is that I couldn't get ANY tests to pass on the basic npm test. After investigation I saw in your Makefile that you run:

test_pure: build_native
    @echo "\n == Run All tests minus replicaset tests=="
    $(NODE) dev/tools/test_all.js --noreplicaset --boot --noactive

however in test_all.js I noticed --noactive is not an option and that it should be --nonative. When I made this final change all tests passed and keyf works with Code.
