### PR TITLE
docs on options are wrong, chunk_type is ignored, use content_type instead

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -27,7 +27,7 @@ var REFERENCE_BY_FILENAME = 0,
  *
  * Options
  *  - **root** {String}, root collection to use. Defaults to **{GridStore.DEFAULT_ROOT_COLLECTION}**.
- *  - **chunk_type** {String}, mime type of the file. Defaults to **{GridStore.DEFAULT_CONTENT_TYPE}**.
+ *  - **content_type** {String}, mime type of the file. Defaults to **{GridStore.DEFAULT_CONTENT_TYPE}**.
  *  - **chunk_size** {Number}, size for the chunk. Defaults to **{Chunk.DEFAULT_CHUNK_SIZE}**.
  *  - **metadata** {Object}, arbitrary data the user wants to store.
  *


### PR DESCRIPTION
Tried setting "content_type" as an option in my code instead and it now correctly saves it to my files doc
