### PR TITLE
ConnectionPool bug with a port is specified

### DIFF
--- a/lib/mongodb/connection/connection_pool.js
+++ b/lib/mongodb/connection/connection_pool.js
@@ -7,7 +7,7 @@ var utils = require('./connection_utils'),
   Connection = require("./connection").Connection;
 
 var ConnectionPool = exports.ConnectionPool = function(host, port, poolSize, bson, socketOptions) {
-  if(typeof host !== 'string' || typeof port !== 'number') throw "host and port must be specified [" + host + ":"  + port + "]";
+  if(typeof host !== 'string' || typeof port == undefined) throw "host and port must be specified [" + host + ":"  + port + "]";
   // Set up event emitter
   EventEmitter.call(this);  
   // Keep all options for the socket in a specific collection allowing the user to specify the 


### PR DESCRIPTION
When specifying a port number while using the driver, I always get this:

```
.../mongodb/lib/mongodb/connection/connection_pool.js:10
number') throw "host and port must be specified [" + host + ":"  + port + "]";
```

But I pass the port number as a number and not a string, there must be something else converting the port number to a string in the code.

So I guess it's a good way to accept a string as a port number since it changes nothing anywhere else in the code. So now it just checks if a port is defined.
