### PR TITLE
Prevent callback from executing more than once in getMore function

### DIFF
--- a/lib/mongodb/cursor.js
+++ b/lib/mongodb/cursor.js
@@ -498,7 +498,9 @@ var getMore = function(self, callback) {
     // Execute the command
     self.db._executeQueryCommand(getMoreCommand, options, function(err, result) {
       try {
-        if(err != null) callback(err, null);
+        if(err != null) {
+          return callback(err, null);
+        }
 
         var isDead = 1 === result.responseFlag && result.cursorId.isZero();
 


### PR DESCRIPTION
If there is error in executing query command, return immediately after executing callback with the error. So that, callback would not be excuted for the second time in the try-catch because of trying to read property of null.
