### PR TITLE
Memory leak fix?

### DIFF
--- a/external-libs/bson/bson.cc
+++ b/external-libs/bson/bson.cc
@@ -2079,7 +2079,6 @@ Handle<Value> BSON::SerializeWithBufferAndIndex(const Arguments &args) {
   } catch(char *err_msg) {
     // Free up serialized object space
     free(serialized_object);
-    V8::AdjustAmountOfExternalAllocatedMemory(-object_size);
     // Throw exception with the string
     Handle<Value> error = VException(err_msg);
     // free error message
@@ -2091,7 +2090,8 @@ Handle<Value> BSON::SerializeWithBufferAndIndex(const Arguments &args) {
   for(uint32_t i = 0; i < object_size; i++) {
     *(data + index + i) = *(serialized_object + i);
   }
-  
+  free(serialized_object);
+
   return scope.Close(Uint32::New(index + object_size - 1));
 }
 


### PR DESCRIPTION
Hi,  we had serious memory leak on our production servers and after some grinding with valgrind, it reported huge number of leaks from this piece of code. After this commit, the reported memory leaks vanished.

For some reason I couldn't get tests to run with 'make test' (reported missing libraries) so I've been unable to validate if this change would break something. Can someone check this if its really legit leak and if fix is correct?
