### PR TITLE
Replica set member status update when primary changes

### DIFF
--- a/lib/mongodb/connection/repl_set.js
+++ b/lib/mongodb/connection/repl_set.js
@@ -830,7 +830,7 @@ ReplSet.prototype.connect = function(parent, options, callback) {
   this.replicasetCheckFunction = function() {
     try {
       // Retrieve a reader connection
-      var con = self.checkoutReader();
+      var con = self.checkoutReader(true);
       // If we have a connection and we have a db object
       if(con != null && Array.isArray(self.dbInstances) && self.dbInstances.length > 0) {
         var dbInstance = self.dbInstances[0];
@@ -839,7 +839,9 @@ ReplSet.prototype.connect = function(parent, options, callback) {
           if(null == err && null != result && null != result["documents"] && result["documents"].length > 0) {
             // For each member we need to check if we have a new connection that needs to be established
             var members = result['documents'][0]['members'];
-            
+            if(self._state.master && self._state.master['name'] == undefined) {
+              self._state.master['name'] = self._state.master['host'] + ':' + self._state.master['port'];
+            }
             if(null != members) {
               // The total members we check
               var newServers = 0;
@@ -849,66 +851,85 @@ ReplSet.prototype.connect = function(parent, options, callback) {
                 var member = members[i];
                 // If the node is healthy and it does not exist in the current replicaset, add it to the
                 // current setup
-                if(null != self._state && 0 != member['health'] && null == self._state['addresses'][member['name']]) {                  
-                  // We need to add a server to the connection, this means going through the notions of establishing
-                  // A completely new connection
-                  // Found a new server
-                  newServers = newServers + 1;
+                if(null != self._state && 0 != member['health']) {
+                  if(null == self._state['addresses'][member['name']]) {                  
+                    // We need to add a server to the connection, this means going through the notions of establishing
+                    // A completely new connection
+                    // Found a new server
+                    newServers = newServers + 1;
 
-                  // Split the server string
-                  var parts = member.name.split(/:/);
-                  if(parts.length == 1) {
-                    parts = [parts[0], Connection.DEFAULT_PORT];
-                  }
-                  
-                  // Default empty socket options object
-                  var socketOptions = {};
-                  // If a socket option object exists clone it
-                  if(self.socketOptions != null) {
-                    var keys = Object.keys(self.socketOptions);
-                    for(var k = 0; k < keys.length;k++) socketOptions[keys[i]] = self.socketOptions[keys[i]];
-                  }
-                  
-                  // Add host information to socket options
-                  socketOptions['host'] = parts[0];
-                  socketOptions['port'] = parseInt(parts[1]);
-                  
-                  // Create a new server instance
-                  var newServer = new Server(parts[0], parseInt(parts[1]), {auto_reconnect:false, 'socketOptions':socketOptions
-                                  , logger:self.logger, ssl:self.ssl, poolSize:self.poolSize});
-                  // Set the replicaset instance
-                  newServer.replicasetInstance = self;              
-                  
-                  // Add handlers
-                  newServer.on("close", self.closeHandler);
-                  newServer.on("timeout", self.timeoutHandler);
-                  newServer.on("error", self.errorHandler);
-                  
-                  // Add a new server to the total number of servers that need to initialized before we are done
-                  var newServerCallback = self.connectionHandler(newServer);
-                  
-                  // Let's set up a new server instance
-                  newServer.connect(self.db, {returnIsMasterResults: true, eventReceiver:newServer}, function(err, result) {
-                    // Remove from number of newServers
-                    newServers = newServers - 1;
-                    // Call the setup
-                    newServerCallback(err, result);
-                    // If we have 0 new servers let's go back to rechecking
-                    if(newServers <= 0) {
-                      setTimeout(self.replicasetCheckFunction, self.replicasetStatusCheckInterval);                      
+                    // Split the server string
+                    var parts = member.name.split(/:/);
+                    if(parts.length == 1) {
+                      parts = [parts[0], Connection.DEFAULT_PORT];
                     }
-                  });
-                }
+                    
+                    // Default empty socket options object
+                    var socketOptions = {};
+                    // If a socket option object exists clone it
+                    if(self.socketOptions != null) {
+                      var keys = Object.keys(self.socketOptions);
+                      for(var k = 0; k < keys.length;k++) socketOptions[keys[i]] = self.socketOptions[keys[i]];
+                    }
+                    
+                    // Add host information to socket options
+                    socketOptions['host'] = parts[0];
+                    socketOptions['port'] = parseInt(parts[1]);
+                    
+                    // Create a new server instance
+                    var newServer = new Server(parts[0], parseInt(parts[1]), {auto_reconnect:false, 'socketOptions':socketOptions
+                                    , logger:self.logger, ssl:self.ssl, poolSize:self.poolSize});
+                    // Set the replicaset instance
+                    newServer.replicasetInstance = self;              
+                    
+                    // Add handlers
+                    newServer.on("close", self.closeHandler);
+                    newServer.on("timeout", self.timeoutHandler);
+                    newServer.on("error", self.errorHandler);
+                    
+                    // Add a new server to the total number of servers that need to initialized before we are done
+                    var newServerCallback = self.connectionHandler(newServer);
+                    // Let's set up a new server instance
+                    newServer.connect(self.db, {returnIsMasterResults: true, eventReceiver:newServer}, function(err, result) {
+                      // Remove from number of newServers
+                      newServers = newServers - 1;
+                      // Call the setup
+                      newServerCallback(err, result);
+                      // If we have 0 new servers let's go back to rechecking
+                      if(newServers <= 0) {
+                        //console.log( new Error().stack.split(' at ' )[1]);
+                        setTimeout(self.replicasetCheckFunction, self.replicasetStatusCheckInterval);                      
+                      }
+                    });
+                  //There has been a change in strcuture, we have a new primary
+                  } else if(member['stateStr'] == 'PRIMARY' && self._state.master['name'] != member['name']) { 
+                    // Delete master record so we can rediscover it
+                    delete self._state['addresses'][self._state.master['name']];
+                    // Update inormation on new primary
+                    var newMaster = self._state.secondaries[member['name']];
+                    newMaster.isMasterDoc.ismaster = true;
+                    newMaster.isMasterDoc.secondary = false;
+                    self._state.master = newMaster;
+                    con = newMaster;
+                    // Remove from secondaries
+                    delete self._state.secondaries[member['name']];
+                    newMaster = null;
+                  } 
+                } 
               }
               
               // If we have no new servers check status again
               if(newServers == 0) {
                 setTimeout(self.replicasetCheckFunction, self.replicasetStatusCheckInterval);
               }
-            }            
+            }
+          } else { 
+                setTimeout(self.replicasetCheckFunction, self.replicasetStatusCheckInterval);
           }
         });        
-      }      
+      } else {
+        setTimeout(self.replicasetCheckFunction, self.replicasetStatusCheckInterval);
+      }
     } catch(err) {
       setTimeout(self.replicasetCheckFunction, self.replicasetStatusCheckInterval);
     }
@@ -928,11 +949,11 @@ ReplSet.prototype.checkoutWriter = function() {
 /**
  * @ignore
  */
-ReplSet.prototype.checkoutReader = function() {
+ReplSet.prototype.checkoutReader = function(readAnyForAdmin) {
   var connection = null;
   // If we have specified to read from a secondary server grab a random one and read
   // from it, otherwise just pass the primary connection
-  if((this.readSecondary == true || this._readPreference == Server.READ_SECONDARY || this._readPreference == Server.READ_SECONDARY_ONLY) && Object.keys(this._state.secondaries).length > 0) {
+  if((readAnyForAdmin || this.readSecondary == true || this._readPreference == Server.READ_SECONDARY || this._readPreference == Server.READ_SECONDARY_ONLY) && Object.keys(this._state.secondaries).length > 0) {
     // Checkout a secondary server from the passed in set of servers
     if(this.strategyInstance != null) {
       connection = this.strategyInstance.checkoutSecondary();


### PR DESCRIPTION
When the primary steps down the status was not properly updated. In replicaCheckFunction if the primary returned from rs.status() si different than the known one, the old master is deleted ( from "addresses" ) so it can be rediscovered with it's new role and the primary get's upgraded from it's place ( in secondaries ) to new master and deleted from secondaries ( the primary can only "evolve" from a secondary, right ? ). 
