### PR TITLE
loading GridStore.filename when opening by id only

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -142,6 +142,7 @@ var _open = function(self, callback) {
           // Check if the collection for the files exists otherwise prepare the new one
           if(doc != null) {
             self.fileId = doc._id;
+            self.filename = doc.filename;
             self.contentType = doc.contentType;
             self.internalChunkSize = doc.chunkSize;
             self.uploadDate = doc.uploadDate;


### PR DESCRIPTION
I found that the filename was not being loaded when queried using id.  If queried via filename, replacing it should be not be a problem since it should be identical.
