### PR TITLE
getMore doesn't work when reading from more than one secondary

### DIFF
--- a/lib/mongodb/cursor.js
+++ b/lib/mongodb/cursor.js
@@ -69,6 +69,7 @@ function Cursor(db, collection, selector, fields, skip, limit
   this.queryRun = false;
   this.getMoreTimer = false;
   this.collectionName = (this.db.databaseName ? this.db.databaseName + "." : '') + this.collection.collectionName;
+  this.connection = null;
 };
 
 /**
@@ -434,7 +435,8 @@ Cursor.prototype.nextObject = function(callback) {
       return callback(err, null);
     }
 
-    var commandHandler = function(err, result) {
+    var commandHandler = function(err, result, connection) {
+
       if(err != null && result == null) return callback(err, null);
 
       if(!err && result.documents[0] && result.documents[0]['$err']) {
@@ -445,6 +447,7 @@ Cursor.prototype.nextObject = function(callback) {
       self.state = Cursor.OPEN; // Adjust the state of the cursor
       self.cursorId = result.cursorId;
       self.totalNumberOfRecords = result.numberReturned;
+      self.connection = connection;
 
       // Add the new documents to the list of items, using forloop to avoid
       // new array allocations and copying
@@ -494,6 +497,10 @@ var getMore = function(self, callback) {
     );
 
     var options = { read: self.read, raw: self.raw };
+    
+    if (self.connection != null) {
+      options.connection = self.connection;
+    }
 
     // Execute the command
     self.db._executeQueryCommand(getMoreCommand, options, function(err, result) {


### PR DESCRIPTION
Fixed the cursor to remember which connection was used for a query, in order to issue getMore requests to the same server. Without this fix, cursors won't work when reading from slaves in replica sets with more than one secondary server.
