### PR TITLE
passing the callback function onto _executeInsertCommand

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -318,7 +318,7 @@ var insertAll = function insertAll (self, docs, options, callback) {
       }
     });
   } else {
-    var result = self.db._executeInsertCommand(insertCommand, commandOptions);
+    var result = self.db._executeInsertCommand(insertCommand, commandOptions, callback);
     // If no callback just return
     if(!callback) return;
     // If error return error


### PR DESCRIPTION
From what I could see, not passing a callback function at this line implies :
- the options argument does not get used as it replaces the callback and is in turn replaced by {}
- breaks at line 1825, in case there is no open connections, because callback is not a function and cannot be called. This causes a Object.CALL_NON_FUNCTION (native) error.
