### PR TITLE
Add `options.connectArbiter` to decide connect arbiters or not. fixed #675

### DIFF
--- a/lib/mongodb/connection/repl_set.js
+++ b/lib/mongodb/connection/repl_set.js
@@ -498,7 +498,7 @@ var _connectHandler = function(self, candidateServers, instanceServer) {
       // Possible hosts
       var possibleHosts = Array.isArray(hosts) ? hosts.slice() : [];
       possibleHosts = Array.isArray(passives) ? possibleHosts.concat(passives) : possibleHosts;
-      if (this.connectArbiter) {
+      if (self.connectArbiter) {
         possibleHosts = Array.isArray(arbiters) ? possibleHosts.concat(arbiters) : possibleHosts;
       }
       

--- a/test/replicaset/connect_test.js
+++ b/test/replicaset/connect_test.js
@@ -205,9 +205,12 @@ exports.shouldCorrectlyConnectWithDefaultReplicaset = function(test) {
     ],
     {}
   );
+  test.equal(true, replSet.connectArbiter);
 
   var db = new Db('integration_test_', replSet);
+  test.equal(true, db.serverConfig.connectArbiter);
   db.open(function(err, p_db) {
+    test.equal(1, replSet.arbiters.length);
     test.equal(null, err);
     test.done();
     p_db.close();
@@ -235,6 +238,29 @@ exports.shouldCorrectlyConnectWithDefaultReplicasetAndSocketOptionsSet = functio
     p_db.close();
   })
 }
+
+/**
+ * @ignore
+ */
+exports.shouldCorrectlyConnectWithConnectArbiterFalse = function(test) {
+  // Replica configuration
+  var replSet = new ReplSetServers([
+      new Server( RS.host, RS.ports[0], { auto_reconnect: true } ),
+    ],
+    {connectArbiter:false}
+  );
+  test.equal(false, replSet.connectArbiter);
+
+  var db = new Db('integration_test_', replSet);
+  test.equal(false, db.serverConfig.connectArbiter);
+  db.open(function(err, p_db) {
+    test.equal(0, replSet.arbiters.length);
+    test.equal(null, err);
+    test.equal(false, db.serverConfig.connectArbiter);
+    test.done();
+    p_db.close();
+  });
+};
 
 /**
  * @ignore


### PR DESCRIPTION
I think application should not to know about `arbiters`.

In company network, application server cannot to connect `arbiters` by `ACL` control rules.

There should be an options to let mongodb users to decide connect arbiters or not.
