### PR TITLE
add `options.connectArbiter` check on _validateReplicaset()

### DIFF
--- a/lib/mongodb/connection/repl_set.js
+++ b/lib/mongodb/connection/repl_set.js
@@ -321,6 +321,9 @@ ReplSet.prototype._validateReplicaset = function(result, auths) {
     if(member['health'] != 0
       && null == self._state['addresses'][member['name']]
       && null == serversToConnectList[member['name']]) {
+      if (member['stateStr'] == 'ARBITER' && self.connectArbiter != true) {
+        continue;
+      }
       // Split the server string
       var parts = member.name.split(/:/);
       if(parts.length == 1) {


### PR DESCRIPTION
In #677 pull request, I forget to change _validateReplicaset() logic when `HA` enable.

If `connectArbiter` options not enable, we should not to check arbiter connection state.
