### PR TITLE
emit end correctly

### DIFF
--- a/lib/mongodb/cursorstream.js
+++ b/lib/mongodb/cursorstream.js
@@ -89,7 +89,10 @@ CursorStream.prototype._onNextObject = function (err, doc) {
   if (err) return this.destroy(err);
 
   // when doc is null we hit the end of the cursor
-  if (!doc) return this.destroy();
+  if (!doc) {
+    this.emit('end')
+    return this.destroy();
+  }
 
   this.emit('data', doc);
   this._next();


### PR DESCRIPTION
A readable stream should emit an `"end"` event when there is no more data. 

[informal stream-spec reference](https://github.com/dominictarr/stream-spec/blob/master/stream_spec.md#emitend)

> Emitting `'close'` without `'end'` indicates a broken pipe - `Stream#pipe` will call `dest.destroy()`

This is unexpected behaviour as the cursor stream is not broken, it ended cleanly.
