### PR TITLE
Pings

### DIFF
--- a/lib/mongodb/connection/strategies/ping_strategy.js
+++ b/lib/mongodb/connection/strategies/ping_strategy.js
@@ -27,8 +27,9 @@ PingStrategy.prototype.start = function(callback) {
 PingStrategy.prototype.stop = function(callback) {
   // Stop the ping process
   this.state = 'disconnected';
-  // Call the callback
-  callback(null, null);
+
+  // optional callback
+  callback && callback(null, null);
 }
 
 PingStrategy.prototype.checkoutSecondary = function(tags, secondaryCandidates) {


### PR DESCRIPTION
protect against starting PingStrategy being called more than once
make PingStrategy interval configurable (was 1 second, relaxed to 5)
made PingStrategy api more consistant , callback to start/stop methods are optional
refactor _pingServer
