### PR TITLE
Throw error when file is not found in read mode

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -191,11 +191,14 @@ var _open = function(self, callback) {
             self.length = doc.length;
             self.metadata = doc.metadata;
             self.internalMd5 = doc.md5;
-          } else {
+          } else if (self.mode != 'r') {
             self.fileId = self.fileId == null ? new ObjectID() : self.fileId;
             self.contentType = exports.GridStore.DEFAULT_CONTENT_TYPE;
             self.internalChunkSize = self.internalChunkSize == null ? Chunk.DEFAULT_CHUNK_SIZE : self.internalChunkSize;
             self.length = 0;
+          } else {
+              self.length = 0;
+              return error(new Error((self.referenceBy == REFERENCE_BY_ID ? self.toHexString() : self.filename) + " does not exist", self));
           }
 
           // Process the mode of the object


### PR DESCRIPTION
Fix ensures that the file exists in the store and if not throws an error and marks the size as 0
