### PR TITLE
Fixed connection leaks

### DIFF
--- a/lib/mongodb/connection/repl_set.js
+++ b/lib/mongodb/connection/repl_set.js
@@ -475,6 +475,10 @@ var _connectHandler = function(self, candidateServers, instanceServer) {
       }
 
       // Make sure we have the right reference
+      if (self._state.addresses[instanceServer.host + ":" + instanceServer.port] != instanceServer) {
+        // Close the connection before deleting
+        self._state.addresses[instanceServer.host + ":" + instanceServer.port].close();
+      }
       delete self._state.addresses[instanceServer.host + ":" + instanceServer.port];
       self._state.addresses[me] = instanceServer;
 
@@ -556,6 +560,13 @@ var _connectHandler = function(self, candidateServers, instanceServer) {
       server.enableRecordQueryStats(self.recordQueryStats);
 
       // Set the server
+      if (addresses[server.host + ":" + server.port] != server) {
+        if (addresses[server.host + ":" + server.port]) {
+          // Close the connection before deleting
+          addresses[server.host + ":" + server.port].close();
+        }
+        delete addresses[server.host + ":" + server.port];
+      }
       addresses[server.host + ":" + server.port] = server;
       // Connect
       server.connect(self.db, {returnIsMasterResults: true, eventReceiver:server}, _connectHandler(self, candidateServers, server));
@@ -659,8 +670,9 @@ ReplSet.prototype.connect = function(parent, options, callback) {
 
   // Get the list of servers that is deduplicated and start connecting
   var candidateServers = [];
-  for(var key in addresses) {
-    candidateServers.push(addresses[key]);
+  var keys = Object.keys(addresses);
+  for(var i = 0; i < keys.length; i++) {
+    candidateServers.push(addresses[keys[i]]);
   }
   // Let's connect to the first one on the list
   server = candidateServers.pop();
@@ -942,8 +954,10 @@ ReplSet.prototype.close = function(callback) {
   this._serverState = 'disconnected';
   // Close all servers
   if(this._state && this._state.addresses) {
-    for(var key in this._state.addresses) {
-      this._state.addresses[key].close();
+    var keys = Object.keys(this._state.addresses);
+    // Iterate over all server instances
+    for(var i = 0; i < keys.length; i++) {
+      this._state.addresses[keys[i]].close();
     }
   }
 


### PR DESCRIPTION
I was seeing the number of connections between my client and mongodb replica set grow continuously over time even though I was closing the db connections after using them.  Eventually, this was causing crashes on both the client and mongodb servers.

After investigating, I made the following changes to the driver, which seems to have fixed the issue:
- Close existing connection (if any) before reassigning server reference
- Fix how servers are iterated over when closing
