### PR TITLE
Remove a weird new in code

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -82,7 +82,7 @@ function Db(databaseName, serverConfig, options) {
   try {
     this.native_parser = this.options.native_parser;
     // The bson lib
-    var bsonLib = this.bsonLib = this.options.native_parser ? require('bson').BSONNative : new require('bson').BSONPure;
+    var bsonLib = this.bsonLib = this.options.native_parser ? require('bson').BSONNative : require('bson').BSONPure;
     // Fetch the serializer object
     var BSON = bsonLib.BSON;
     // Create a new instance


### PR DESCRIPTION
This expression is really weird: `new require('bson').BSONPure`

I think it's incorrect and the `new` should be removed to: `require('bson').BSONPure`
