### PR TITLE
tags shouldn't default to [] in url_parser

### DIFF
--- a/lib/mongodb/connection/url_parser.js
+++ b/lib/mongodb/connection/url_parser.js
@@ -206,6 +206,11 @@ exports.parse = function(url, options) {
     }
   });
 
+  // No tags: should be null (not [])
+  if(dbOptions.read_preference_tags.length === 0) {
+    dbOptions.read_preference_tags = null;
+  }
+
   // Validate if there are an invalid write concern combinations
   if((dbOptions.w == -1 || dbOptions.w == 0) && (
       dbOptions.journal == true

--- a/test/url_parser_test.js
+++ b/test/url_parser_test.js
@@ -371,6 +371,9 @@ exports['Read preferences parsing'] = function(test) {
  * @ignore
  */
 exports['Read preferences tag parsing'] = function(test) {
+  var object = parse("mongodb://localhost/db");
+  test.equal(null, object.db_options.read_preference_tags);
+
   var object = parse("mongodb://localhost/db?readPreferenceTags=dc:ny");
   test.deepEqual([{dc:"ny"}], object.db_options.read_preference_tags);
 


### PR DESCRIPTION
Creating a connecting via mongo URL should yield null readPreference tags (not []).  Creating an empty list triggers an error when querying against a replica set server:

https://github.com/mongodb/node-mongodb-native/blob/master/lib/mongodb/connection/repl_set.js#L939

The attached pull request updates the `url_parser` (test included).  It may also be desirable (preferable?) to update the `repl_set` code to be more permissive...
