### PR TITLE
createCollection doc: autoIndexId defaults to true

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -802,7 +802,7 @@ Db.prototype.removeUser = function(username, options, callback) {
  *  - **capped** {Boolean, default:false}, create a capped collection.
  *  - **size** {Number}, the size of the capped collection in bytes.
  *  - **max** {Number}, the maximum number of documents in the capped collection.
- *  - **autoIndexId** {Boolean, default:false}, create an index on the _id field of the document, not created automatically on capped collections.
+ *  - **autoIndexId** {Boolean, default:true}, create an index on the _id field of the document.
  *  - **readPreference** {String}, the prefered read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  *  - **strict**, (Boolean, default:false) throws and error if collection already exists
  * 


### PR DESCRIPTION
Fix documentation since autoIndexId defaults to true, also on
capped collections.
