### PR TITLE
fixes #791

### DIFF
--- a/lib/mongodb/connection/repl_set.js
+++ b/lib/mongodb/connection/repl_set.js
@@ -450,17 +450,11 @@ function connectToHost (host, auths, replset, cb) {
     }
 
     // create handler for successful connections
-    var handleConnect = _connectHandler(replset, null, server);
-    function complete () {
-      handleConnect(err, result);
-      cb();
-    }
+    _connectHandler(replset, null, server)(err, result);
 
-    // authenticate if necessary
     if(!(Array.isArray(auths) && auths.length > 0)) {
-      return complete();
+      return cb();
     }
-
     var pending = auths.length;
 
     for(var i = 0; i < auths.length; i++) {
@@ -468,10 +462,11 @@ function connectToHost (host, auths, replset, cb) {
       var options = { authdb: auth.authdb };
       var username = auth.username;
       var password = auth.password;
+
       replset.db.authenticate(username, password, options, function() {
         --pending;
         if(0 === pending) {
-          return complete();
+          return cb();
         }
       });
     }


### PR DESCRIPTION
Let connectHandler run before authenticate when _validateReplicaSet fires. connectHandler fires with newly identified server in order to update secondaries state prior to running db.authenticate, so that when db.authenticate does run the replset state is correct (as db.authenticate has dependency on replset state to get allrawconnections - and we must authenticate against all of them) so we don't get authorization errors against new secondaries connections.

791 fix and test now separate.
