### PR TITLE
fixes 791. different -perhaps better- way to fix 791.  but it extends options in db.authenticate to allow the passing of a connection.

### DIFF
--- a/lib/mongodb/connection/repl_set.js
+++ b/lib/mongodb/connection/repl_set.js
@@ -463,17 +463,27 @@ function connectToHost (host, auths, replset, cb) {
 
     var pending = auths.length;
 
-    for(var i = 0; i < auths.length; i++) {
-      var auth = auths[i];
-      var options = { authdb: auth.authdb };
-      var username = auth.username;
-      var password = auth.password;
-      replset.db.authenticate(username, password, options, function() {
-        --pending;
-        if(0 === pending) {
-          return complete();
-        }
-      });
+    var connections = server.allRawConnections();
+    var pendingAuthConn = connections.length;
+    for(var x = 0; x <connections.length; x++) {
+      var connection = connections[x];
+      var authDone = false; 
+      for(var i = 0; i < auths.length; i++) {
+        var auth = auths[i];
+        var options = { authdb: auth.authdb, connection: connection };
+        var username = auth.username;
+        var password = auth.password;
+        replset.db.authenticate(username, password, options, function() {
+          --pending;
+          if(0 === pending) {
+            authDone = true;
+            --pendingAuthConn;
+            if(0 === pendingAuthConn) {
+              return complete();
+            }  
+          }
+        });
+      }
     }
   });
 }

--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -634,14 +634,22 @@ Db.prototype.authenticate = function(username, password, options, callback) {
   // the default db to authenticate against is 'this'
   // if authententicate is called from a retry context, it may be another one, like admin
   var authdb = options.authdb ? options.authdb : self.databaseName;
-
   // Push the new auth if we have no previous record
-  // Get the amount of connections in the pool to ensure we have authenticated all comments
-  var numberOfConnections = this.serverConfig.allRawConnections().length;
+  
+  var numberOfConnections = 0;
   var errorObject = null;
 
+  if (options['connection' != null]) {
+    //if a connection was explicitly passed on options, then we have only one...
+    numberOfConnections = 1;
+  } else {
+    // Get the amount of connections in the pool to ensure we have authenticated all comments
+    numberOfConnections = this.serverConfig.allRawConnections().length;
+    options['onAll'] = true;
+  }
+
   // Execute all four
-  this._executeQueryCommand(DbCommand.createGetNonceCommand(self), {onAll:true}, function(err, result, connection) {
+  this._executeQueryCommand(DbCommand.createGetNonceCommand(self), options, function(err, result, connection) {
     // Execute on all the connections
     if(err == null) {
       // Nonce used to make authentication request with md5 hash


### PR DESCRIPTION
I did this fix to show a different -better- way to fix 791.  I didn't originally provide this fix as I was hesitant to impact the db.authenticate contract (even as little as I did).  That said, this fix does the job without allowing the replset state to get updated unless we were able to successfully authenticate to the -potentially new- connections... while in the case of the other fix I provided, I allowed the replset state to get updated (in order to fix the bug) before calling authenticate.

At the very least the two fixes should help communicate the problem effectively.  And hopefully one of them is in line with the drivers direction.
