### PR TITLE
Cursor.each should work in batches

### DIFF
--- a/lib/mongodb/cursor.js
+++ b/lib/mongodb/cursor.js
@@ -145,20 +145,26 @@ Cursor.prototype.toArray = function(callback) {
     callback(new Error("Tailable cursor cannot be converted to array"), null);
   } else if(this.state != Cursor.CLOSED) {
     var items = [];
+    getNext();
 
-    this.each(function(err, item) {
-      if(err != null) return callback(err, null);
-
-      if(item != null && Array.isArray(items)) {
-        items.push(item);
-      } else {
-        var resultItems = items;
-        items = null;
-        self.items = [];
-        // Returns items
-        callback(err, resultItems);
+    function getNext() {
+      for (var i = 0; i < self.items.length; i++) {
+        items.push(self.items[i]);
       }
-    });
+      self.items = [];
+      nextBatch(self, function(err, newitems) {
+        if(err != null) return callback(err, null);
+        if(!newitems || !newitems.length) {
+          self.state = Cursor.CLOSED;
+          var resultItems = items;
+          items = null;
+          self.items = [];
+          // Returns items
+          return callback(err, resultItems);
+        }
+        getNext();
+      });
+    }
   } else {
     callback(new Error("Cursor is closed"), null);
   }
@@ -520,10 +526,14 @@ var nextBatch = function(self, callback) {
       self.cursorId = result.cursorId;
       self.totalNumberOfRecords = result.numberReturned;
 
-      // Add the new documents to the list of items, using forloop to avoid
-      // new array allocations and copying
-      for(var i = 0; i < result.documents.length; i++) {
-        self.items.push(result.documents[i]);
+      if(!self.items.length) {
+        self.items = result.documents;
+      } else {
+        // Add the new documents to the list of items, using forloop to avoid
+        // new array allocations and copying
+        for(var i = 0; i < result.documents.length; i++) {
+          self.items.push(result.documents[i]);
+        }
       }
 
       // Ignore callbacks until the cursor is dead for exhausted
@@ -610,8 +620,12 @@ var getMore = function(self, callback) {
           // Reset the tries for awaitdata if we are using it
           self.currentNumberOfRetries = self.numberOfRetries;
           // Get the documents
-          for(var i = 0; i < result.documents.length; i++) {
-            self.items.push(result.documents[i]);
+          if(!self.items.length) {
+            self.items = result.documents;
+          } else {
+            for(var i = 0; i < result.documents.length; i++) {
+              self.items.push(result.documents[i]);
+            }
           }
 
           // result = null;
@@ -879,3 +893,5 @@ Cursor.CLOSED = 2;
  * @api private
  */
 exports.Cursor =  Cursor;
+
+/* vim: set sw=2 ts=2 et tw=80 : */


### PR DESCRIPTION
Currently, Cursor.each uses a really inefficient process.nextTick -> nextObject() -> recurse to self
loop.

This patch avoids this behavior and rather loops over a batch directly, providing a nice speedup up to 2x depending on workload.
I’ve run `make test` and its passing without issues.

The benchmarks I have done are available at Swatinem/mongobench. I can observe the following speedups:
![line](https://f.cloud.github.com/assets/580492/13140/697bf214-45e5-11e2-9b3c-f7dc95453bf8.png)
(jitter graph is in log scale)
![jitter](https://f.cloud.github.com/assets/580492/13141/6e0355de-45e5-11e2-948a-036a9ace1976.png)

The patched version however uses more memory:
![heap-total](https://f.cloud.github.com/assets/580492/13147/961e740e-45e5-11e2-8f33-c9f5115c78fc.png)

I might need some help fixing that.
