### PR TITLE
Fatal error: Cannot read property 'info' of null

### DIFF
--- a/lib/mongodb/connection/server.js
+++ b/lib/mongodb/connection/server.js
@@ -333,7 +333,7 @@ Server.prototype.connect = function(dbInstance, options, callback) {
         }
 
         // The command executed another request, log the handler again under that request id
-        if(mongoReply.requestId > 0 && mongoReply.cursorId.toString() != "0" && callbackInfo.info && callbackInfo.info.exhaust) {
+        if(mongoReply.requestId > 0 && mongoReply.cursorId.toString() != "0" && callbackInfo && callbackInfo.info && callbackInfo.info.exhaust) {
           dbInstance._reRegisterHandler(mongoReply.requestId, callbackInfo);
         }
 


### PR DESCRIPTION
When piping a CursorStream, I get the following error after about 10K documents:

```
/home/deploy/test/node-EmailBlast/node_modules/mongodb/lib/mongodb/connection/server.js:484
        throw err;
              ^
TypeError: Cannot read property 'info' of null
    at [object Object].<anonymous> (/home/deploy/test/node-EmailBlast/node_modules/mongodb/lib/mongodb/connection/server.js:336:93)
    at [object Object].emit (events.js:67:17)
    at [object Object].<anonymous> (/home/deploy/test/node-EmailBlast/node_modules/mongodb/lib/mongodb/connection/connection_pool.js:140:13)
    at [object Object].emit (events.js:70:17)
    at Socket.<anonymous> (/home/deploy/test/node-EmailBlast/node_modules/mongodb/lib/mongodb/connection/connection.js:238:18)
    at Socket.emit (events.js:67:17)
    at TCP.onread (net.js:367:14)
```

This is the offending block of code in server.js starting @ line 318:

```
        // Callback instance
        var callbackInfo = null;
        var dbInstanceObject = null;

        // Locate a callback instance and remove any additional ones
        for(var i = 0; i < server.dbInstances.length; i++) {
          var dbInstanceObjectTemp = server.dbInstances[i];
          var hasHandler = dbInstanceObjectTemp._hasHandler(mongoReply.responseTo.toString());
          // Assign the first one we find and remove any duplicate ones
          if(hasHandler && callbackInfo == null) {
            callbackInfo = dbInstanceObjectTemp._findHandler(mongoReply.responseTo.toString());
            dbInstanceObject = dbInstanceObjectTemp;
          } else if(hasHandler) {
            dbInstanceObjectTemp._removeHandler(mongoReply.responseTo.toString());
          }
        }

        // The command executed another request, log the handler again under that request id
// HEY LOOK HERE ** HEY LOOK HERE ** HEY LOOK HERE ** HEY LOOK HERE ** 
        if(mongoReply.requestId > 0 && mongoReply.cursorId.toString() != "0" && callbackInfo.info && callbackInfo.info.exhaust) {
// HEY LOOK HERE ** HEY LOOK HERE ** HEY LOOK HERE ** HEY LOOK HERE ** 
          dbInstance._reRegisterHandler(mongoReply.requestId, callbackInfo);
        }
```

Notice that callbackInfo could be null.
