### PR TITLE
fixed; domain sockets shouldn't require a port arg

### DIFF
--- a/lib/mongodb/connection/connection.js
+++ b/lib/mongodb/connection/connection.js
@@ -89,10 +89,10 @@ Connection.prototype.start = function() {
     }
   } else {
     // Create new connection instance
-    if(!this.domainSocket) {
-      this.connection = net.createConnection(this.socketOptions.port, this.socketOptions.host);      
+    if(this.domainSocket) {
+      this.connection = net.createConnection(this.socketOptions.host);
     } else {
-      this.connection = net.createConnection(this.socketOptions.host);            
+      this.connection = net.createConnection(this.socketOptions.port, this.socketOptions.host);
     }
     if(this.logger != null && this.logger.doDebug){
       this.logger.debug("opened connection", this.socketOptions);

--- a/lib/mongodb/connection/connection_pool.js
+++ b/lib/mongodb/connection/connection_pool.js
@@ -7,9 +7,13 @@ var utils = require('./connection_utils'),
   Connection = require("./connection").Connection;
 
 var ConnectionPool = exports.ConnectionPool = function(host, port, poolSize, bson, socketOptions) {
-  if(typeof host !== 'string' || typeof port !== 'number') throw "host and port must be specified [" + host + ":"  + port + "]";
+  if(typeof host !== 'string') {
+    throw new Error("host must be specified [" + host + "]");
+  }
+
   // Set up event emitter
   EventEmitter.call(this);
+
   // Keep all options for the socket in a specific collection allowing the user to specify the
   // Wished upon socket connection parameters
   this.socketOptions = typeof socketOptions === 'object' ? socketOptions : {};
@@ -22,7 +26,11 @@ var ConnectionPool = exports.ConnectionPool = function(host, port, poolSize, bso
   this.minPoolSize = Math.floor(this.poolSize / 2) + 1;
 
   // Check if the host is a socket
-  if(host.match(/^\//)) this.socketOptions.domainSocket = true;
+  if(host.match(/^\//)) {
+    this.socketOptions.domainSocket = true;
+  } else if(typeof port !== 'number') {
+    throw new Error("port must be specified ["  + port + "]");
+  }
 
   // Set default settings for the socket options
   utils.setIntegerParameter(this.socketOptions, 'timeout', 0);

--- a/test/domain_socket_test.js
+++ b/test/domain_socket_test.js
@@ -50,14 +50,13 @@ exports.tearDown = function(callback) {
 }
 
 /**
- * Test the authentication method for the user
- *
  * @ignore
  */
 exports['Should correctly connect to server using domain socket'] = function(test) {
 
-  var db = new Db(MONGODB, new Server("/tmp/mongodb-27017.sock", {w:0, auto_reconnect: true, poolSize: 4, ssl:useSSL}), {w:0, native_parser: (process.env['TEST_NATIVE'] != null)});  
+  var db = new Db(MONGODB, new Server("/tmp/mongodb-27017.sock", {w:0, auto_reconnect: true, poolSize: 4, ssl:useSSL}), {w:0, native_parser: (process.env['TEST_NATIVE'] != null)});
   db.open(function(err, db) {
+    test.equal(null, err);
 
     db.collection("domainSocketCollection").insert({a:1}, {w:1}, function(err, item) {
       test.equal(null, err);
@@ -65,12 +64,54 @@ exports['Should correctly connect to server using domain socket'] = function(tes
       db.collection("domainSocketCollection").find({a:1}).toArray(function(err, items) {
         test.equal(null, err);
         test.equal(1, items.length);
-  
+
         db.close();
         test.done();
       });
     });
   });
+}
+
+/**
+ * @ignore
+ */
+exports['Should connect to server using domain socket with undefined port'] = function(test) {
+
+  var db = new Db(MONGODB, new Server("/tmp/mongodb-27017.sock", undefined, {w:0, auto_reconnect: true, poolSize: 4, ssl:useSSL}), {w:0, native_parser: (process.env['TEST_NATIVE'] != null)});
+  db.open(function(err, db) {
+    test.equal(null, err);
+
+    db.collection("domainSocketCollection").insert({x:1}, {w:1}, function(err, item) {
+      test.equal(null, err);
+
+      db.collection("domainSocketCollection").find({x:1}).toArray(function(err, items) {
+        test.equal(null, err);
+        test.equal(1, items.length);
+
+        db.close();
+        test.done();
+      });
+    });
+  });
+}
+
+/**
+ * @ignore
+ */
+exports['Should fail to connect using non-domain socket with undefined port'] = function(test) {
+
+  var db = new Db(MONGODB, new Server("localhost", undefined, {w:0, auto_reconnect: true, poolSize: 4, ssl:useSSL}), {w:0, native_parser: (process.env['TEST_NATIVE'] != null)});
+
+  var error;
+  try {
+    db.open(function(){});
+  } catch (err){
+    error = err;
+  }
+
+  test.ok(error instanceof Error);
+  test.ok(/port must be specified/.test(error));
+  test.done();
 }
 
 // /**


### PR DESCRIPTION
An undefined port is now accepted which makes using domain sockets simpler for libraries that wrap the driver.

``` js
var host = userSpecifiedHost;
var port = userSpecifiedPort;
var options = someOptions;
new Sever(host, port, options) // no need to dig in the driver codebase to figure out how to get domain sockets working anymore :)
```

previous behavior:

``` js
new Db(MONGODB, new Server("/tmp/mongodb-27017.sock", undefined, {})).open(callback)

// host and port must be specified [/tmp/mongodb-27017.sock:undefined]
```

now it "just works".

Also stopped throwing strings around and `instanceof Error === true`.
