### PR TITLE
allow Grid.get and Grid.delete to accept non ObjectID ids

### DIFF
--- a/lib/mongodb/gridfs/grid.js
+++ b/lib/mongodb/gridfs/grid.js
@@ -63,8 +63,6 @@ Grid.prototype.put = function(data, options, callback) {
  * @api public
  */
 Grid.prototype.get = function(id, callback) {
-  // Validate that we have a valid ObjectId
-  if(!(id instanceof ObjectID)) return callback(new Error("Not a valid ObjectID", null));
   // Create gridstore
   var gridStore = new GridStore(this.db, id, "r", {root:this.fsName});
   gridStore.open(function(err, gridStore) {
@@ -86,8 +84,6 @@ Grid.prototype.get = function(id, callback) {
  * @api public
  */
 Grid.prototype.delete = function(id, callback) {
-  // Validate that we have a valid ObjectId
-  if(!(id instanceof ObjectID)) return callback(new Error("Not a valid ObjectID", null));
   // Create gridstore
   GridStore.unlink(this.db, id, {root:this.fsName}, function(err, result) {
     if(err) return callback(err, false);


### PR DESCRIPTION
There is no need to limit users of Grid.get and Grid.delete to use only ObjectID identifiers. In any other places you can use object of any type as identifier (such as int, string, etc).
