### PR TITLE
allow gridfs objects to use non ObjectID ids

### DIFF
--- a/lib/mongodb/gridfs/grid.js
+++ b/lib/mongodb/gridfs/grid.js
@@ -20,6 +20,13 @@ function Grid(db, fsName) {
 /**
  * Puts binary data to the grid
  *
+ * Options
+ *  - **_id** {Any}, unique id for this file
+ *  - **root** {String}, root collection to use. Defaults to **{GridStore.DEFAULT_ROOT_COLLECTION}**.
+ *  - **content_type** {String}, mime type of the file. Defaults to **{GridStore.DEFAULT_CONTENT_TYPE}**.
+ *  - **chunk_size** {Number}, size for the chunk. Defaults to **{Chunk.DEFAULT_CHUNK_SIZE}**.
+ *  - **metadata** {Object}, arbitrary data the user wants to store.
+ *
  * @param {Buffer} data buffer with Binary Data.
  * @param {Object} [options] the options for the files.
  * @param {Function} callback this will be called after this method is executed. The first parameter will contain an Error object if an error occured or null otherwise. The second parameter will contain a reference to this object.
@@ -37,9 +44,11 @@ Grid.prototype.put = function(data, options, callback) {
   // Return if we don't have a buffer object as data
   if(!(Buffer.isBuffer(data))) return callback(new Error("Data object must be a buffer object"), null);
   // Get filename if we are using it
-  var filename = options['filename'];
+  var filename = options['filename'] || null;
+  // Get id if we are using it
+  var id = options['_id'] || null;
   // Create gridstore
-  var gridStore = new GridStore(this.db, filename, "w", options);
+  var gridStore = new GridStore(this.db, id, filename, "w", options);
   gridStore.open(function(err, gridStore) {
     if(err) return callback(err, null);
 
@@ -57,16 +66,14 @@ Grid.prototype.put = function(data, options, callback) {
 /**
  * Get binary data to the grid
  *
- * @param {ObjectID} id ObjectID for file.
+ * @param {Any} id for file.
  * @param {Function} callback this will be called after this method is executed. The first parameter will contain an Error object if an error occured or null otherwise. The second parameter will contain a reference to this object.
  * @return {null}
  * @api public
  */
 Grid.prototype.get = function(id, callback) {
-  // Validate that we have a valid ObjectId
-  if(!(id instanceof ObjectID)) return callback(new Error("Not a valid ObjectID", null));
   // Create gridstore
-  var gridStore = new GridStore(this.db, id, "r", {root:this.fsName});
+  var gridStore = new GridStore(this.db, id, null, "r", {root:this.fsName});
   gridStore.open(function(err, gridStore) {
     if(err) return callback(err, null);
 
@@ -80,14 +87,12 @@ Grid.prototype.get = function(id, callback) {
 /**
  * Delete file from grid
  *
- * @param {ObjectID} id ObjectID for file.
+ * @param {Any} id for file.
  * @param {Function} callback this will be called after this method is executed. The first parameter will contain an Error object if an error occured or null otherwise. The second parameter will contain a reference to this object.
  * @return {null}
  * @api public
  */
 Grid.prototype.delete = function(id, callback) {
-  // Validate that we have a valid ObjectId
-  if(!(id instanceof ObjectID)) return callback(new Error("Not a valid ObjectID", null));
   // Create gridstore
   GridStore.unlink(this.db, id, {root:this.fsName}, function(err, result) {
     if(err) return callback(err, false);

--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -35,8 +35,8 @@ var REFERENCE_BY_FILENAME = 0,
  *
  * @class Represents the GridStore.
  * @param {Db} db A database instance to interact with.
- * @param {ObjectID} id an unique ObjectID for this file
- * @param {String} [filename] optional a filename for this file, no unique constrain on the field
+ * @param {Any} [id] optional unique id for this file
+ * @param {String} [filename] optional filename for this file, no unique constrain on the field
  * @param {String} mode set the mode for this file.
  * @param {Object} options optional properties to specify.
  * @return {GridStore}
@@ -56,34 +56,52 @@ var GridStore = function GridStore(db, id, filename, mode, options) {
   }
 
   // Handle options
-  if(options == null) options = {};
+  if(typeof options === 'undefined') options = {};
   // Handle mode
-  if(mode == null) {
+  if(typeof mode === 'undefined') {
     mode = filename;
-    filename = null;
+    filename = undefined;
   } else if(typeof mode == 'object') {
     options = mode;
     mode = filename;
-    filename = null;
+    filename = undefined;
   }
 
+  if(id instanceof ObjectID) {
+    this.referenceBy = REFERENCE_BY_ID;
+    this.fileId = id;
+    this.filename = filename;
+  } else if(typeof filename == 'undefined') {
+    this.referenceBy = REFERENCE_BY_FILENAME;
+    this.filename = id;
+    if (mode.indexOf('w') != null) {
+      this.fileId = new ObjectID();
+    }
+  } else {
+    this.referenceBy = REFERENCE_BY_ID;
+    this.fileId = id;
+    this.filename = filename;
+  }
+
+  /*
   // Handle id
   if(id instanceof ObjectID && (typeof filename == 'string' || filename == null)) {
-    this.referenceBy = 1;
+    this.referenceBy = REFERENCE_BY_ID;
     this.fileId = id;
     this.filename = filename;
   } else if(!(id instanceof ObjectID) && typeof id == 'string' && mode.indexOf("w") != null) {
-    this.referenceBy = 0;
+    this.referenceBy = REFERENCE_BY_FILENAME;
     this.fileId = new ObjectID();
     this.filename = id;
   } else if(!(id instanceof ObjectID) && typeof id == 'string' && mode.indexOf("r") != null) {
-    this.referenceBy = 0;
-    this.filename = filename;
+    this.referenceBy = REFERENCE_BY_FILENAME;
+    this.filename = id;
   } else {
-    this.referenceBy = 1;
+    this.referenceBy = REFERENCE_BY_ID;
     this.fileId = id;
     this.filename = filename;
   }
+  */
 
   // Set up the rest
   this.mode = mode == null ? "r" : mode;
@@ -196,7 +214,8 @@ var _open = function(self, callback) {
             self.length = 0;
           } else {
             self.length = 0;
-            return error(new Error((self.referenceBy == REFERENCE_BY_ID ? self.fileId.toHexString() : self.filename) + " does not exist", self));
+            var txtId = self.fileId instanceof ObjectID ? self.fileId.toHexString() : self.fileId;
+            return error(new Error((self.referenceBy == REFERENCE_BY_ID ? txtId : self.filename) + " does not exist", self));
           }
 
           // Process the mode of the object

--- a/test/gridstore/grid_store_file_test.js
+++ b/test/gridstore/grid_store_file_test.js
@@ -1087,7 +1087,7 @@ exports.shouldCorrectlySafeFileUsingIntAsIdKey = function(test) {
                     test.equal(null, err);
                     test.equal('hello world!', data.toString('ascii'));
 
-                    GridStore.read(client, 500, function(err, data) {
+                    GridStore.read(client, "test_gs_small_write", function(err, data) {
                       test.equal(null, err);
                       test.equal('hello world!', data.toString('ascii'));
                       test.done();

--- a/test/gridstore/grid_store_test.js
+++ b/test/gridstore/grid_store_test.js
@@ -88,6 +88,72 @@ exports.shouldCreateNewGridStoreObject = function(test) {
 };
 
 /**
+ * @ignore
+ */
+exports.shouldCreateNewGridStoreObjectWithIntId = function(test) {
+  var db = new Db('integration_tests', new Server("127.0.0.1", 27017,
+   {auto_reconnect: false, poolSize: 1, ssl:useSSL}), {w:0, native_parser: native_parser});
+
+  var gs1
+    , gs2
+    , id = 123
+    , filename = 'test_create_gridstore';
+  try {
+    var gs = new GridStore(db, id, filename, "w");
+    test.ok(gs instanceof GridStore);
+    test.equals(id, gs.fileId);
+    test.equals(filename, gs.filename);
+  } catch(e) {
+    test.ok(false, "Failed to create GridStore with new");
+  }
+
+  try {
+    var gs = GridStore(db, id, filename, "w");
+    test.ok(gs instanceof GridStore);
+    test.equals(id, gs.fileId);
+    test.equals(filename, gs.filename);
+  } catch(e) {
+    test.ok(false, "Failed to create GridStore without new");
+  }
+
+   db.close();
+   test.done();
+};
+
+/**
+ * @ignore
+ */
+exports.shouldCreateNewGridStoreObjectWithStringId = function(test) {
+  var db = new Db('integration_tests', new Server("127.0.0.1", 27017,
+   {auto_reconnect: false, poolSize: 1, ssl:useSSL}), {w:0, native_parser: native_parser});
+
+  var gs1
+    , gs2
+    , id = 'test'
+    , filename = 'test_create_gridstore';
+  try {
+    var gs = new GridStore(db, id, filename, "w");
+    test.ok(gs instanceof GridStore);
+    test.equals(id, gs.fileId);
+    test.equals(filename, gs.filename);
+  } catch(e) {
+    test.ok(false, "Failed to create GridStore with new");
+  }
+
+  try {
+    var gs = GridStore(db, id, filename, "w");
+    test.ok(gs instanceof GridStore);
+    test.equals(id, gs.fileId);
+    test.equals(filename, gs.filename);
+  } catch(e) {
+    test.ok(false, "Failed to create GridStore without new");
+  }
+
+   db.close();
+   test.done();
+};
+
+/**
  * A simple example showing the usage of the Gridstore.exist method.
  *
  * @_class gridstore
@@ -638,7 +704,7 @@ exports.shouldCorrectlyPerformWorkingFiledRead = function(test) {
  */
 exports.shouldCorrectlyPerformWorkingFiledReadWithChunkSizeLessThanFileSize = function(test) {
   // Create a new file
-  var gridStore = new GridStore(client, "test.txt", null, "w");
+  var gridStore = new GridStore(client, "test.txt", "w");
 
   // This shouldnt have to be set higher than the file...
   gridStore.chunkSize = 40960;

--- a/test/gridstore/grid_test.js
+++ b/test/gridstore/grid_test.js
@@ -83,6 +83,70 @@ exports.shouldPutFileCorrectlyToGridUsingObjectId = function(test) {
 }
 
 /**
+ * A simple example showing the usage of the put method.
+ *
+ * @_class grid
+ * @_function put
+ * @ignore
+ */
+exports.shouldPutFileCorrectlyToGridUsingIntId = function(test) {
+  var db = new Db('integration_tests', new Server("127.0.0.1", 27017,
+   {auto_reconnect: false, poolSize: 1, ssl:useSSL}), {w:0, native_parser: native_parser});
+
+  // Establish connection to db
+  db.open(function(err, db) {
+    // Create a new grid instance
+    var grid = new Grid(db, 'fs');
+    // Some data to write
+    var originalData = new Buffer('Hello world');
+    // Write data to grid
+    var id = 123;
+    grid.put(originalData, {_id: id}, function(err, result) {
+      // Fetch the content
+      grid.get(id, function(err, data) {
+        test.deepEqual(originalData.toString('base64'), data.toString('base64'));
+
+        db.close();
+        test.done();
+      });
+    });
+  });
+}
+
+/**
+ * A simple example showing the usage of the put method.
+ *
+ * @_class grid
+ * @_function put
+ * @ignore
+ */
+exports.shouldPutFileCorrectlyToGridUsingStringId = function(test) {
+  var db = new Db('integration_tests', new Server("127.0.0.1", 27017,
+   {auto_reconnect: false, poolSize: 1, ssl:useSSL}), {w:0, native_parser: native_parser});
+
+  // Establish connection to db
+  db.open(function(err, db) {
+    // Create a new grid instance
+    var grid = new Grid(db, 'fs');
+    // Some data to write
+    var originalData = new Buffer('Hello world');
+    // Write data to grid
+    var id = 'test';
+    grid.put(originalData, {_id: id}, function(err, result) {
+      test.equal(result._id, id);
+
+      // Fetch the content
+      grid.get(id, function(err, data) {
+        test.deepEqual(originalData.toString('base64'), data.toString('base64'));
+
+        db.close();
+        test.done();
+      });
+    });
+  });
+}
+
+/**
  * A simple example showing the usage of the get method.
  *
  * @_class grid


### PR DESCRIPTION
There is no need to limit users of Grid.get and Grid.delete to use only ObjectID identifiers. In any other places you can use object of any type as identifier (such as int, string, etc).
