### PR TITLE
typo in db.authenticate caused a check (for provided connection) to return false, causing a connection AND onAll=true to be passed into __executeQueryCommand downstream.

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1585,8 +1585,7 @@ var __executeQueryCommand = function(self, db_command, options, callback) {
     for(var i = 0; i < connections.length; i++) {
       // Fetch a connection
       var connection = connections[i];
-      // Override connection if needed
-      connection = specifiedConnection != null ? specifiedConnection : connection;
+
       // Ensure we have a valid connection
       if(connection == null) {
         return callback(new Error("no open connections"));


### PR DESCRIPTION
The typo (introduced by me... ugh... sorry) in authenticate caused the __executeQueryCommand to run with both options of onAll (connections) and with a connection specified.  This caused the same connection to be used repeatedly (equal to the number returned from replset.getAllRawConnections).  I can't see any reason for the "override" to exist, so I removed it, as it seems to only cause the same connection to be used again and again.  In any case, this issue shows up during the _validateReplicaset... which is why it can be avoided by turning off the haInterval checks.
I couldn't think of a good way to write a failing test for this one... but perhaps I can come up with something this weekend.  I just wanted to get a fix in (to at least communicate the issue - to Aaron) even if not accepted.
