### PR TITLE
typo in db.authenticate caused a check (for provided connection) to return false, causing a connection AND onAll=true to be passed into __executeQueryCommand downstream.

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -312,7 +312,7 @@ Db.prototype.close = function(forceClose, callback) {
       var server = allServerInstances[0];
       // For all db instances signal all db instances
       if(Array.isArray(server.dbInstances) && server.dbInstances.length > 1) {
-    	  for(var i = 0; i < server.dbInstances.length; i++) {
+        for(var i = 0; i < server.dbInstances.length; i++) {
           var dbInstance = server.dbInstances[i];
           // Check if it's our current db instance and skip if it is
           if(dbInstance.databaseName !== self.databaseName && dbInstance.tag !== self.tag) {
@@ -639,7 +639,7 @@ Db.prototype.authenticate = function(username, password, options, callback) {
   var numberOfConnections = 0;
   var errorObject = null;
 
-  if(options['connection' != null]) {
+  if(options['connection'] != null) {
     //if a connection was explicitly passed on options, then we have only one...
     numberOfConnections = 1;
   } else {
@@ -1585,8 +1585,7 @@ var __executeQueryCommand = function(self, db_command, options, callback) {
     for(var i = 0; i < connections.length; i++) {
       // Fetch a connection
       var connection = connections[i];
-      // Override connection if needed
-      connection = specifiedConnection != null ? specifiedConnection : connection;
+
       // Ensure we have a valid connection
       if(connection == null) {
         return callback(new Error("no open connections"));


### PR DESCRIPTION
The typo (introduced by me... ugh... sorry) in authenticate caused the __executeQueryCommand to run with both options of onAll (connections) and with a connection specified. This caused the same connection to be used repeatedly (equal to the number returned from replset.getAllRawConnections). I can't see any reason for the "override" to exist, so I removed it, as it seems to only cause the same connection to be used again and again. In any case, this issue shows up during the _validateReplicaset...

Possibly related to 827.
