### PR TITLE
removed the double wrap, by not passing an Error object to the wrap function.

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -970,7 +970,7 @@ Collection.prototype.findOne = function findOne () {
   var cursor = this.find.apply(this, args).limit(-1).batchSize(1);
   // Return the item
   cursor.toArray(function(err, items) {
-    if(err != null) return callback(err instanceof Error ? err : self.db.wrap(new Error(err)), null);
+    if(err != null) return callback(err instanceof Error ? err : self.db.wrap(err), null);
     if(items.length == 1) return callback(null, items[0]);
     callback(null, null);
   });


### PR DESCRIPTION
wrap was being passed an Error object containing the MongoError, but wrap expects a MongoError document alone which it will wrap in an Error object.  In this case, findOne was putting the MongoError document into an Error object and then also handing that Error object to wrap, which would then new up another Error object and use the input Error as the message.

I couldn't find any other instances of this issue other than this one (in findOne).

Possibly could check for instanceOf Error within wrap to double check and then unwrap (i.e. pull the message) and rewrap.
