### PR TITLE
renaming `dbInstance` to match `db` of ReplSet and Mongos

### DIFF
--- a/lib/mongodb/connection/server.js
+++ b/lib/mongodb/connection/server.js
@@ -227,9 +227,8 @@ Server.prototype.connect = function(dbInstance, options, callback) {
   var server = this;
   // Let's us override the main receiver of events
   var eventReceiver = options.eventReceiver != null ? options.eventReceiver : this;
-  // Creating dbInstance
-  this.dbInstance = dbInstance;
   // Save reference to dbInstance
+  this.db = dbInstance;  // `db` property matches ReplSet and Mongos
   this.dbInstances = [dbInstance];
 
   // Force connection pool if there is one


### PR DESCRIPTION
Found the `dbInstance` property of Server to not be referenced anywhere in the code or documentation.  However, both ReplSet and Mongos have a `db` property which is expected in the Db.db() function when copying `auths` to the newDbInstance.
