### PR TITLE
Allow ismaster command to run on secondaries and arbiters, since it is a read-only command.

### DIFF
--- a/lib/mongodb/connection/repl_set.js
+++ b/lib/mongodb/connection/repl_set.js
@@ -1,4 +1,4 @@
-var Connection = require('./connection').Connection,  
+var Connection = require('./connection').Connection,
   ReadPreference = require('./read_preference').ReadPreference,
   DbCommand = require('../commands/db_command').DbCommand,
   MongoReply = require('../responses/mongo_reply').MongoReply,
@@ -111,8 +111,8 @@ var ReplSet = exports.ReplSet = function(servers, options) {
 
   // Ensure read_secondary is set correctly
   if(!this.readSecondary)
-    this.readSecondary = this._readPreference == ReadPreference.PRIMARY 
-        || this._readPreference == false  
+    this.readSecondary = this._readPreference == ReadPreference.PRIMARY
+        || this._readPreference == false
         || this._readPreference == null ? false : true;
 
   // Strategy for picking a secondary
@@ -343,7 +343,7 @@ ReplSet.prototype._enableHA = function () {
         // Create is master command
         var cmd = DbCommand.createIsMasterCommand(db);
         // Execute is master command
-        db._executeQueryCommand(cmd, {failFast:true, connection: _server.checkoutWriter()}, function(err, res) {
+        db._executeQueryCommand(cmd, {failFast:true, connection: _server.checkoutWriter(true)}, function(err, res) {
           // Close the connection used
           _server.close();
           // If error let's set perform another check
@@ -481,7 +481,7 @@ function connectToHost (host, auths, replset, cb) {
     var pendingAuthConn = connections.length;
     for(var x = 0; x <connections.length; x++) {
       var connection = connections[x];
-      var authDone = false; 
+      var authDone = false;
       for(var i = 0; i < auths.length; i++) {
         var auth = auths[i];
         var options = { authdb: auth.authdb, connection: connection };
@@ -494,7 +494,7 @@ function connectToHost (host, auths, replset, cb) {
             --pendingAuthConn;
             if(0 === pendingAuthConn) {
               return complete();
-            }  
+            }
           }
         });
       }
@@ -546,7 +546,7 @@ function createServer (host, replset) {
 }
 
 var _handler = function(event, self) {
-  return function(err, server) {    
+  return function(err, server) {
     // Remove from all lists
     delete self._state.secondaries[server.name];
     delete self._state.arbiters[server.name];
@@ -562,7 +562,7 @@ var _handler = function(event, self) {
     }
 
     // If it's the primary close all connections
-    if(self._state.master 
+    if(self._state.master
       && self._state.master.host == server.host
       && self._state.master.port == server.port) {
       // return self.close();


### PR DESCRIPTION
Currently, sending "{ismaster:1}" to any node other than the primary will fail.  This fixes this problem.
