### PR TITLE
Ensure MongoClient.connect closes connection if an error occurred

### DIFF
--- a/lib/mongodb/mongo_client.js
+++ b/lib/mongodb/mongo_client.js
@@ -100,7 +100,12 @@ MongoClient.connect = function(url, options, callback) {
   }
 
   Db.connect(url, options, function(err, db) {
-    if(err) return callback(err, null);
+    if(err) {
+      if (db) {
+        db.close();
+      }
+      return callback(err, null);
+    }
 
     if(db.options !== null && !db.options.safe && !db.options.journal 
       && !db.options.w && !db.options.fsync && typeof db.options.w != 'number'


### PR DESCRIPTION
Currently `MongoClient.connect` prevents Node from exiting if an authorization failure occurs.

It assumes that if `Db.connect` returned an error, that the database wasn’t open. But in fact, `Db.connect` can return _both_ and error and a `db` object.

So, in case of an error, check for a `db` object, and if it exists, close the connection.
