### PR TITLE
Fix async callback handling issue

### DIFF
--- a/lib/mongodb/cursor.js
+++ b/lib/mongodb/cursor.js
@@ -697,14 +697,16 @@ var getMore = function(self, options, callback) {
 
     // Execute the command
     self.db._executeQueryCommand(getMoreCommand, command_options, function(err, result) {
+      var cbValue;
+
       // Get more done
       self.state = Cursor.OPEN;
 
-      try {
-        if(err != null) {
-          return callback(utils.toError(err), null);
-        }
+      if(err != null) {
+        return callback(utils.toError(err), null);
+      }
 
+      try {
         var isDead = 1 === result.responseFlag && result.cursorId.isZero();
 
         self.cursorId = result.cursorId;
@@ -729,10 +731,9 @@ var getMore = function(self, options, callback) {
 
           // Don's shift a document out as we need it for toArray
           if(options.noReturn) {
-            return callback(null, true);
-            callback(null, true);  
+            cbValue = true;
           } else {
-            callback(null, self.items.shift());
+            cbValue = self.items.shift();
           }          
         } else if(self.tailable && !isDead && self.awaitdata) {
           // Excute the tailable cursor once more, will timeout after ~4 sec if awaitdata used
@@ -754,6 +755,7 @@ var getMore = function(self, options, callback) {
       } catch(err) {
         callback(utils.toError(err), null);
       }
+      if (cbValue != null) callback(null, cbValue);
     });
 
     getMoreCommand = null;


### PR DESCRIPTION
Inner Logic of `_executeQueryCommand` result looks as:

``` javascript
var getMore = function(self, options, callback) {
  // ...
  self.db._executeQueryCommand(a, b, function(err, result) {
    // ...
    try {
      // ...
      callback(null, value);
      // ...
    } catch (e) {
      // ...
      callback(err);
      // ...
    }
  });
  // ...
};
```

It means that eventual error thrown within callback is propagated back to same callback. That's unexpected, additionally in that case async function callback is called twice, which should never happen.

This patch fixes that to:

``` javascript
self.db._executeQueryCommand(a, b, function(err, result) {
  var cbValue;
  // ...
  try {
      // ...
    cbValue = value;
      // ...
  } catch (e) {
    // ...
    callback(err);
    // ...
  }
  if (cbValue != null) callback(null, cbValue);
});
```

Callback is not called with it's own error, and error is freely thrown as it should in such case.
