### PR TITLE
Removed mention about default value for `out`

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -1171,7 +1171,7 @@ Collection.prototype.reIndex = function(callback) {
  * Run Map Reduce across a collection. Be aware that the inline option for out will return an array of results not a collection.
  *
  * Options
- *  - **out** {Object, default:*{inline:1}*}, sets the output target for the map reduce job. *{inline:1} | {replace:'collectionName'} | {merge:'collectionName'} | {reduce:'collectionName'}*
+ *  - **out** {Object}, sets the output target for the map reduce job. *{inline:1} | {replace:'collectionName'} | {merge:'collectionName'} | {reduce:'collectionName'}*
  *  - **query** {Object}, query filter object.
  *  - **sort** {Object}, sorts the input objects using this key. Useful for optimization, like sorting by the emit key for fewer reduces.
  *  - **limit** {Number}, number of objects to return from collection.


### PR DESCRIPTION
Default value for `out` is no more provided, see issue #911.
