### PR TITLE
Minor typo fix in documentation

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -438,7 +438,7 @@ Db.prototype.collectionNames = function(collectionName, options, callback) {
  *  - **raw** {Boolean, default:false}, perform all operations using raw bson objects.
  *  - **pkFactory** {Object}, object overriding the basic ObjectID primary key generation.
  *  - **readPreference** {String}, the prefered read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
- *  - **strict**, (Boolean, default:false) throws and error if the collection does not exist
+ *  - **strict**, (Boolean, default:false) throws an error if the collection does not exist
  * 
  * Deprecated Options 
  *  - **safe** {true | {w:n, wtimeout:n} | {fsync:true}, default:false}, executes with a getLastError command returning the results of the command on MongoDB.
@@ -822,7 +822,7 @@ Db.prototype.removeUser = function(username, options, callback) {
  *  - **max** {Number}, the maximum number of documents in the capped collection.
  *  - **autoIndexId** {Boolean, default:true}, create an index on the _id field of the document, True by default on MongoDB 2.2 or higher off for version < 2.2.
  *  - **readPreference** {String}, the prefered read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
- *  - **strict**, (Boolean, default:false) throws and error if collection already exists
+ *  - **strict**, (Boolean, default:false) throws an error if collection already exists
  * 
  * Deprecated Options 
  *  - **safe** {true | {w:n, wtimeout:n} | {fsync:true}, default:false}, executes with a getLastError command returning the results of the command on MongoDB.


### PR DESCRIPTION
This is really minor typo that I noticed. It says "throws and error" instead of "throws an error". This commit fixes that.
