### PR TITLE
GridStore reference by filename not working

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -40,7 +40,7 @@ var REFERENCE_BY_FILENAME = 0,
  *
  * @class Represents the GridStore.
  * @param {Db} db A database instance to interact with.
- * @param {Any} [id] optional unique id for this file
+ * @param {ObjectID} [id] optional unique id for this file
  * @param {String} [filename] optional filename for this file, no unique constrain on the field
  * @param {String} mode set the mode for this file.
  * @param {Object} options optional properties to specify.
@@ -83,7 +83,7 @@ var GridStore = function GridStore(db, id, filename, mode, options) {
       this.fileId = new ObjectID();
     }
   } else {
-    this.referenceBy = REFERENCE_BY_ID;
+    this.referenceBy = ((id === null || id === undefined) ? REFERENCE_BY_FILENAME : REFERENCE_BY_ID);
     this.fileId = id;
     this.filename = filename;
   }
@@ -170,7 +170,7 @@ var _open = function(self, callback) {
 
     // Create the query
     var query = self.referenceBy == REFERENCE_BY_ID ? {_id:self.fileId} : {filename:self.filename};
-    query = null == self.fileId && this.filename == null ? null : query;
+    query = null == self.fileId && self.filename == null ? null : query;
 
     // Fetch the chunks
     if(query != null) {


### PR DESCRIPTION
The feature of the GridStore to lookup a file by it's name just didn't work. This patch should fix that.

As a side note: maybe this feature should be removed AT ALL. Since file names don't have to be unique, the behavior is a bit unpredictable. For a read operation you can't know for sure whether the requested file is correct, for a write operation it's not obvious if you are creating a new file, or appending / overwriting an existing one...
