### PR TITLE
Support using `null` as ObjectId for GridStore

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -40,7 +40,7 @@ var REFERENCE_BY_FILENAME = 0,
  *
  * @class Represents the GridStore.
  * @param {Db} db A database instance to interact with.
- * @param {Any} [id] optional unique id for this file
+ * @param {ObjectID} [id] optional unique id for this file
  * @param {String} [filename] optional filename for this file, no unique constrain on the field
  * @param {String} mode set the mode for this file.
  * @param {Object} options optional properties to specify.
@@ -76,14 +76,12 @@ var GridStore = function GridStore(db, id, filename, mode, options) {
     this.referenceBy = REFERENCE_BY_ID;
     this.fileId = id;
     this.filename = filename;
-  } else if(typeof filename == 'undefined') {
+  } else if (typeof filename == 'undefined') {
     this.referenceBy = REFERENCE_BY_FILENAME;
     this.filename = id;
-    if (mode.indexOf('w') != null) {
-      this.fileId = new ObjectID();
-    }
+    this.fileId = new ObjectID();
   } else {
-    this.referenceBy = REFERENCE_BY_ID;
+    this.referenceBy = ((id === null) ? REFERENCE_BY_FILENAME : REFERENCE_BY_ID);
     this.fileId = id;
     this.filename = filename;
   }
@@ -170,7 +168,7 @@ var _open = function(self, callback) {
 
     // Create the query
     var query = self.referenceBy == REFERENCE_BY_ID ? {_id:self.fileId} : {filename:self.filename};
-    query = null == self.fileId && this.filename == null ? null : query;
+    query = null == self.fileId && self.filename == null ? null : query;
 
     // Fetch the chunks
     if(query != null) {

--- a/test/tests/functional/gridstore/gridstore_tests.js
+++ b/test/tests/functional/gridstore/gridstore_tests.js
@@ -10,20 +10,24 @@ exports.shouldCreateNewGridStoreObject = function(configuration, test) {
     , ObjectID = configuration.getMongoPackage().ObjectID;
   var db = configuration.db();
 
-  var gs1
-    , gs2
+  var gs
     , id = new ObjectID()
     , filename = 'test_create_gridstore';
 
-  var gs = new GridStore(db, id, filename, "w");
+  gs = new GridStore(db, id, filename, "w");
   test.ok(gs instanceof GridStore);
   test.equal(id, gs.fileId);
   test.equal(filename, gs.filename);
 
-  var gs = GridStore(db, id, filename, "w");
+  gs = GridStore(db, id, filename, "w");
   test.ok(gs instanceof GridStore);
   test.equal(id, gs.fileId);
   test.equal(filename, gs.filename);
+
+  gs = GridStore(db, null, filename, "r");
+  test.ok(gs instanceof GridStore);
+  test.equal(filename, gs.filename);
+  test.equal(gs.referenceBy, 0); // 0 = REFERENCE_BY_FILENAME
 
   db.close();
   test.done();


### PR DESCRIPTION
Regarding the GridStore constructor:

When `null` is supplied as ObjectId and an extra filename is passed, the GridStore will not try to query by filename.

This patch fixes this. 
