### PR TITLE
db.collectionNames throws when options is null

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -400,7 +400,7 @@ Db.prototype.collectionNames = function(collectionName, options, callback) {
   var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
   collectionName = args.length ? args.shift() : null;
-  options = args.length ? args.shift() : {};
+  options = args.length ? args.shift() || {} : {};
 
   // Ensure no breaking behavior
   if(collectionName != null && typeof collectionName == 'object') {


### PR DESCRIPTION
If options is defined but null it isn't set to an empty object and the call to options.namesOnly causes an error.

Probably not the best fix here, but it gets the job done. You could probably remove the check for args.length, but I wasn't sure if it would have other side effects to just coerce to bool, so I made the smaller fix.
