### PR TITLE
Handle case where db_command is an array and an error occurs.

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1491,7 +1491,10 @@ var __executeQueryCommand = function(self, db_command, options, callback) {
     connection.write(db_command, function(err) {
       if(err != null) {
         // Call the handler with an error
-        self.serverConfig._callHandler(db_command.getRequestId(), null, err);
+        if(Array.isArray(db_command))
+          self.serverConfig._callHandler(db_command[0].getRequestId(), null, err);
+        else
+          self.serverConfig._callHandler(db_command.getRequestId(), null, err);
       }
     });
   } else if(typeof callback === 'function' && onAll) {


### PR DESCRIPTION
I'm not sure if this is best fix, but I found that I could trigger an exception with a findAndModify query:

```
../mongoose/lib/utils.js:409
        throw err;
              ^
TypeError: Object [object Object],[object Object] has no method 'getRequestId'
    at mongodb/lib/mongodb/db.js:1501:53
    at Connection.write (mongodb/lib/mongodb/connection/connection.js:218:40)
    at __executeQueryCommand (mongodb/lib/mongodb/db.js:1495:16)
    at Db._executeQueryCommand (mongodb/lib/mongodb/db.js:1711:3)
    at Collection.findAndModify (mongodb/lib/mongodb/collection.js:689:13)
    at NativeCollection.(anonymous function) [as findAndModify] (../mongoose/lib/drivers/node-mongodb-native/collection.js:130:21)
```

The commit converts this into a normal error by handling the case where db_command is an array (e.g. [findandmodify query, getlasterror query])
