### PR TITLE
Allow calling `findOne(id)` with a string

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -970,6 +970,9 @@ var normalizeHintField = function normalizeHintField(hint) {
 
 /**
  * Finds a single document based on the query
+ * 
+ * Selector can either be a query object or a string. If it's a string
+ *    then it will default to { _id: ObjectID(selector) }
  *
  * Various argument possibilities
  *  - callback?
@@ -1001,9 +1004,10 @@ var normalizeHintField = function normalizeHintField(hint) {
  *  - **readPreference** {String}, the preferred read preference (Server.PRIMARY, Server.PRIMARY_PREFERRED, Server.SECONDARY, Server.SECONDARY_PREFERRED, Server.NEAREST).
  *  - **partial** {Boolean, default:false}, specify if the cursor should return partial results when querying against a sharded system
  *
- * @param {Object} query query object to locate the object to modify
+ * @param {Object | String} query query object to locate the object to modify
  * @param {Object} [options] additional options during update.
- * @param {Function} callback this will be called after executing this method. The first parameter will contain the Error object if an error occured, or null otherwise. While the second parameter will contain the results from the findOne method or null if an error occured.
+ * @param {Function} callback this will be called after executing this method. The first parameter will contain the Error object if an error occured, or null otherwise. While the second parameter will contain the results from the 
+ * method or null if an error occured.
  * @return {Cursor} returns a cursor to the query
  * @api public
  */
@@ -1011,6 +1015,11 @@ Collection.prototype.findOne = function findOne () {
   var self = this;
   var args = Array.prototype.slice.call(arguments, 0);
   var callback = args.pop();
+  
+  if (typeof args[0] === "string") {
+    args[0] = { _id: new ObjectID(args[0]) }
+  }
+  
   var cursor = this.find.apply(this, args).limit(-1).batchSize(1);
   // Return the item
   cursor.nextObject(function(err, item) {


### PR DESCRIPTION
Rational: 
- Having the pay attention to whether an id variable contains a string
    or an ObjectID instance is a source of common bugs / confusion.
- Having a way to call `findOne(string)` will get rid of 95% of the 
    usage of the ObjectID constructor in common code and thus
    reduce exposure of the mongo _id implementation detail.

Down-sides: 
- probably not compatible with the js mongo console
- `find(id)` doesn't work (also doesn't make sense), may cause confusion.

In general I think this is worthwhile mainly because it avoids the confusion of "why does findOne({ _id: id }) not work?!?!?" and allows me to not litter my application code with references to `ObjectID` which is very specific to the mongo database and not specific to my application.
