### PR TITLE
should pass uri_decode_auth flag to parser in connect

### DIFF
--- a/lib/mongodb/mongo_client.js
+++ b/lib/mongodb/mongo_client.js
@@ -134,7 +134,7 @@ MongoClient.connect = function(url, options, callback) {
   if(callback == null) throw new Error("no callback function provided");
 
   // Parse the string
-  var object = parse(url);
+  var object = parse(url, options);
   // Merge in any options for db in options object
   if(dbOptions) {
     for(var name in dbOptions) object.db_options[name] = dbOptions[name];

--- a/test/tests/functional/uri_tests.js
+++ b/test/tests/functional/uri_tests.js
@@ -206,3 +206,22 @@ exports['Should correctly connect via normal url setting up poolsize of 1'] = fu
     test.done();
   });
 }
+
+exports['Should correctly connect using uri encoded username and password'] = function(configuration, test) {
+  var MongoClient = configuration.getMongoPackage().MongoClient;
+  MongoClient.connect("mongodb://localhost:27017/integration_tests", {native_parser:true}, function(err, db) {
+    test.equal(null, err);
+    var user = 'u$ser'
+      , pass = '$specialch@rs'
+      ;
+
+    db.addUser(user, pass, function(err) {
+      test.equal(null, err);
+      var uri = "mongodb://" + encodeURIComponent(user) + ":" + encodeURIComponent(pass) + "@localhost:27017/integration_tests";
+      MongoClient.connect(uri, {uri_decode_auth: true, native_parser:true}, function(err, authenticatedDb) {
+        test.equal(null, err);
+        test.done();
+      });
+    });
+  });
+}


### PR DESCRIPTION
With the current driver, the flag "uri_decode_auth" isn't doing anything. It just needs to be passed into the parser function as an option (it expects it), but the MongoClient connect function is just calling `parse(uri)` without options.
