### PR TITLE
If we switch connections on reconnect, copy that into the cursor.

### DIFF
--- a/lib/mongodb/cursor.js
+++ b/lib/mongodb/cursor.js
@@ -617,8 +617,12 @@ Cursor.prototype.nextObject = function(options, callback) {
       return callback(err, null);
     }
 
+    var queryOptions = {exhaust: self.exhaust, raw:self.raw, read:self.read, connection:self.connection};
     // Execute command
     var commandHandler = function(err, result) {
+      // If on reconnect, the command got given a different connection, switch
+      // the whole cursor to it.
+      self.connection = queryOptions.connection;
       self.state = Cursor.OPEN;
       if(err != null && result == null) return callback(utils.toError(err), null);
 
@@ -666,7 +670,7 @@ Cursor.prototype.nextObject = function(options, callback) {
     }
 
     // Execute the command
-    self.db._executeQueryCommand(cmd, {exhaust: self.exhaust, raw:self.raw, read:self.read, connection:self.connection}, commandHandler);
+    self.db._executeQueryCommand(cmd, queryOptions, commandHandler);
     // Set the command handler to null
     commandHandler = null;
   } else if(self.items.length) {


### PR DESCRIPTION
This addresses #981. It's not super convincing --- eg, it depends on some internal implementation details about how a particular `options` object is passed around. But it does fix the issue I was seeing where starting a tailable cursor while disconnected would hang on the first getMore (after a successful Query) after disconnect.
