### PR TITLE
Execute all stored command on master server switch.

### DIFF
--- a/lib/mongodb/connection/repl_set/ha.js
+++ b/lib/mongodb/connection/repl_set/ha.js
@@ -167,7 +167,8 @@ var _timeoutHandle = function(self) {
                 state.master.isMasterDoc.secondary = false;                
               }
 
-              // Execute any waiting writes
+              // Execute any waiting commands (queries or writes)
+              self.replset._commandsStore.execute_queries();
               self.replset._commandsStore.execute_writes();   
             }
           }


### PR DESCRIPTION
Execute all stored commands, both queries and writes (currently on stored writes are executed), when the master server is switched.

The application we were performing high availability testing was hanging on a query when we killed the primary mongo server of a replicaset.  The hang was intermittent.  Sometimes we would get an error return from the query, sometimes we would get a correct response from the query after a pause, but sometimes it would just hang and never return.

Adding the execute_queries() call in ha.js when the new master server was found addressed the issue. A call to execute_writes() already existed at this location.
