### PR TITLE
Remove unnecessary octal literal to allow the code to run in strict mode

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -304,7 +304,7 @@ var _open = function(self, callback) {
 GridStore.prototype.writeFile = function (file, callback) {
   var self = this;
   if (typeof file === 'string') {
-    fs.open(file, 'r', 0666, function (err, fd) {
+    fs.open(file, 'r', function (err, fd) {
       if(err) return callback(err);
       self.writeFile(fd, callback);
     });


### PR DESCRIPTION
Currently, attempting to run an application that depends upon this module in global strict mode (via the `--use-strict` flag) fails, due to the use of an octal literal.

Removing the octal literal fixes this issue, and does not cause any problems since the `0666` value being used is the default value according to the Node [file system documentation](http://nodejs.org/api/fs.html#fs_fs_open_path_flags_mode_callback) (this is true for all versions of Node supported by this module):

> **fs.open(path, flags, [mode], [callback])**
> ...
> `mode` defaults to `0666`
