### PR TITLE
Map reduce has incorrect expectations of 'inline' value for 'out' option

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -1210,7 +1210,7 @@ Collection.prototype.mapReduce = function mapReduce (map, reduce, options, callb
   var readPreference = _getReadConcern(this, options);
 
   // If we have a read preference and inline is not set as output fail hard
-  if((readPreference != false && readPreference != 'primary') && options['out'] != 'inline') {
+  if((readPreference != false && readPreference != 'primary') && options['out'].inline != 1) {
     throw new Error("a readPreference can only be provided when performing an inline mapReduce");
   }
 

--- a/test/tests/functional/read_preferences_tests.js
+++ b/test/tests/functional/read_preferences_tests.js
@@ -154,7 +154,7 @@ exports['Should correctly apply collection level read Preference to mapReduce'] 
     var reduce = function(k,vals) { return 1; };
 
     // Peform the map reduce
-    collection.mapReduce(map, reduce, {out: 'inline'}, function(err, collection) {
+    collection.mapReduce(map, reduce, {out: {inline:1}}, function(err, collection) {
       db.serverConfig.checkoutReader = checkout;
 
       db.close();


### PR DESCRIPTION
What looks to be a long standing but unnoticed bug was recently exposed by recent commit [bb3816f85526b053ae36966ccd21acc889217d19](https://github.com/rcotter/node-mongodb-native/commit/bb3816f85526b053ae36966ccd21acc889217d19#L0L1230)

As per docs (in [code](https://github.com/rcotter/node-mongodb-native/blob/b3649d2d8c66b4d7f13633b5c55cd653876dbf94/lib/mongodb/collection.js#L1157) and at [10gen](http://docs.mongodb.org/manual/reference/method/db.collection.mapReduce/#output-inline)) the 'out' option for mapreduce should be {inline:1}, not 'inline'.
