### PR TITLE
Fixed errors on geoNear and geoSearch

### DIFF
--- a/lib/mongodb/collection.js
+++ b/lib/mongodb/collection.js
@@ -75,8 +75,8 @@ function Collection (db, collectionName, pkFactory, options) {
  *  - **continueOnError/keepGoing** {Boolean, default:false}, keep inserting documents even if one document has an error, *mongodb 1.9.1 >*.
  *  - **serializeFunctions** {Boolean, default:false}, serialize functions on the document.
  *  - **forceServerObjectId** {Boolean, default:false}, let server assign ObjectId instead of the driver
- * 
- * Deprecated Options 
+ *
+ * Deprecated Options
  *  - **safe** {true | {w:n, wtimeout:n} | {fsync:true}, default:false}, executes with a getLastError command returning the results of the command on MongoDB.
  *
  * @param {Array|Object} docs
@@ -125,8 +125,8 @@ var checkCollectionName = function checkCollectionName (collectionName) {
  *  - **fsync**, (Boolean, default:false) write waits for fsync before returning
  *  - **journal**, (Boolean, default:false) write waits for journal sync before returning
  *  - **single** {Boolean, default:false}, removes the first document found.
- * 
- * Deprecated Options 
+ *
+ * Deprecated Options
  *  - **safe** {true | {w:n, wtimeout:n} | {fsync:true}, default:false}, executes with a getLastError command returning the results of the command on MongoDB.
  *
  * @param {Object} [selector] optional select, no selector is equivalent to removing all documents.
@@ -299,8 +299,8 @@ var insertAll = function insertAll (self, docs, options, callback) {
     var doc = docs[index];
 
     // Add id to each document if it's not already defined
-    if (!(Buffer.isBuffer(doc)) 
-      && doc['_id'] == null 
+    if (!(Buffer.isBuffer(doc))
+      && doc['_id'] == null
       && self.db.forceServerObjectId != true
       && options.forceServerObjectId != true) {
         doc['_id'] = self.pkFactory.createPk();
@@ -368,8 +368,8 @@ var insertAll = function insertAll (self, docs, options, callback) {
  *  - **wtimeout**, {Number, 0} set the timeout for waiting for write concern to finish (combines with w option)
  *  - **fsync**, (Boolean, default:false) write waits for fsync before returning
  *  - **journal**, (Boolean, default:false) write waits for journal sync before returning
- * 
- * Deprecated Options 
+ *
+ * Deprecated Options
  *  - **safe** {true | {w:n, wtimeout:n} | {fsync:true}, default:false}, executes with a getLastError command returning the results of the command on MongoDB.
  *
  * @param {Object} [doc] the document to save
@@ -415,8 +415,8 @@ Collection.prototype.save = function save(doc, options, callback) {
  *  - **upsert** {Boolean, default:false}, perform an upsert operation.
  *  - **multi** {Boolean, default:false}, update all documents matching the selector.
  *  - **serializeFunctions** {Boolean, default:false}, serialize functions on the document.
- * 
- * Deprecated Options 
+ *
+ * Deprecated Options
  *  - **safe** {true | {w:n, wtimeout:n} | {fsync:true}, default:false}, executes with a getLastError command returning the results of the command on MongoDB.
  *
  * @param {Object} selector the query to select the document/documents to be updated
@@ -611,8 +611,8 @@ Collection.prototype.drop = function drop(callback) {
  *  - **remove** {Boolean, default:false}, set to true to remove the object before returning.
  *  - **upsert** {Boolean, default:false}, perform an upsert operation.
  *  - **new** {Boolean, default:false}, set to true if you want to return the modified object rather than the original. Ignored for remove.
- * 
- * Deprecated Options 
+ *
+ * Deprecated Options
  *  - **safe** {true | {w:n, wtimeout:n} | {fsync:true}, default:false}, executes with a getLastError command returning the results of the command on MongoDB.
  *
  * @param {Object} query query object to locate the object to modify
@@ -660,7 +660,7 @@ Collection.prototype.findAndModify = function findAndModify (query, sort, doc, o
   // Unpack the error options if any
   var errorOptions = _getWriteConcern(this, options, callback);
   // If we have j, w or something else do the getLast Error path
-  if(errorOptions != null 
+  if(errorOptions != null
     && typeof errorOptions == 'object'
     && (errorOptions.w != 0 && errorOptions.w != 1 && errorOptions.safe != false)) {
     // Commands to send
@@ -722,8 +722,8 @@ Collection.prototype.findAndModify = function findAndModify (query, sort, doc, o
  *  - **wtimeout**, {Number, 0} set the timeout for waiting for write concern to finish (combines with w option)
  *  - **fsync**, (Boolean, default:false) write waits for fsync before returning
  *  - **journal**, (Boolean, default:false) write waits for journal sync before returning
- * 
- * Deprecated Options 
+ *
+ * Deprecated Options
  *  - **safe** {true | {w:n, wtimeout:n} | {fsync:true}, default:false}, executes with a getLastError command returning the results of the command on MongoDB.
  *
  * @param {Object} query query object to locate the object to modify
@@ -932,12 +932,12 @@ var normalizeHintField = function normalizeHintField(hint) {
 
     hint.forEach(function(param) {
       finalHint[param] = 1;
-    });  
+    });
   } else if(hint != null && typeof hint == 'object') {
     finalHint = {};
     for (var name in hint) {
       finalHint[name] = hint[name];
-    }    
+    }
   }
 
   return finalHint;
@@ -1011,8 +1011,8 @@ Collection.prototype.findOne = function findOne () {
  *  - **v** {Number}, specify the format version of the indexes.
  *  - **expireAfterSeconds** {Number}, allows you to expire data on indexes applied to a data (MongoDB 2.2 or higher)
  *  - **name** {String}, override the autogenerated index name (useful if the resulting name is larger than 128 bytes)
- * 
- * Deprecated Options 
+ *
+ * Deprecated Options
  *  - **safe** {true | {w:n, wtimeout:n} | {fsync:true}, default:false}, executes with a getLastError command returning the results of the command on MongoDB.
  *
  * @param {Object} fieldOrSpec fieldOrSpec that defines the index.
@@ -1052,8 +1052,8 @@ Collection.prototype.createIndex = function createIndex (fieldOrSpec, options, c
  *  - **v** {Number}, specify the format version of the indexes.
  *  - **expireAfterSeconds** {Number}, allows you to expire data on indexes applied to a data (MongoDB 2.2 or higher)
  *  - **name** {String}, override the autogenerated index name (useful if the resulting name is larger than 128 bytes)
- * 
- * Deprecated Options 
+ *
+ * Deprecated Options
  *  - **safe** {true | {w:n, wtimeout:n} | {fsync:true}, default:false}, executes with a getLastError command returning the results of the command on MongoDB.
  *
  * @param {Object} fieldOrSpec fieldOrSpec that defines the index.
@@ -1537,7 +1537,17 @@ Collection.prototype.geoNear = function geoNear(x, y, options, callback) {
   options.readPreference = _getReadConcern(this, options);
 
   // Execute the command
-  this.db.command(commandObject, options, callback);
+  this.db.command(commandObject, options, function (err, res) {
+    if (err) {
+      callback(err);
+    } else if (res.err || res.errmsg) {
+      callback(utils.toError(res));
+    } else {
+      // should we only be returning res.results here? Not sure if the user
+      // should see the other return information
+      callback(null, res);
+    }
+  });
 }
 
 /**
@@ -1578,7 +1588,17 @@ Collection.prototype.geoHaystackSearch = function geoHaystackSearch(x, y, option
   options.readPreference = _getReadConcern(this, options);
 
   // Execute the command
-  this.db.command(commandObject, options, callback);
+  this.db.command(commandObject, options, function (err, res) {
+    if (err) {
+      callback(err);
+    } else if (res.err || res.errmsg) {
+      callback(utils.toError(res));
+    } else {
+      // should we only be returning res.results here? Not sure if the user
+      // should see the other return information
+      callback(null, res);
+    }
+  });
 }
 
 /**
@@ -1712,11 +1732,11 @@ var _hasWriteConcern = function(errorOptions) {
  */
 var _setWriteConcernHash = function(options) {
   var finalOptions = {};
-  if(options.w != null) finalOptions.w = options.w;  
+  if(options.w != null) finalOptions.w = options.w;
   if(options.journal == true) finalOptions.j = options.journal;
   if(options.j == true) finalOptions.j = options.j;
   if(options.fsync == true) finalOptions.fsync = options.fsync;
-  if(options.wtimeout != null) finalOptions.wtimeout = options.wtimeout;  
+  if(options.wtimeout != null) finalOptions.wtimeout = options.wtimeout;
   return finalOptions;
 }
 
@@ -1746,7 +1766,7 @@ var _getWriteConcern = function(self, options, callback) {
   }
 
   // Ensure we don't have an invalid combination of write concerns
-  if(finalOptions.w < 1 
+  if(finalOptions.w < 1
     && (finalOptions.journal == true || finalOptions.j == true || finalOptions.fsync == true)) throw new Error("No acknowlegement using w < 1 cannot be combined with journal:true or fsync:true");
 
   // Return the options


### PR DESCRIPTION
Previously, these commands would return the raw db command object, not
checking for errors or anything. This now checks to see if the command
succeeded, and if it did not, creates and returns an appropriate error
message. Fixes Issue #1023
