### PR TITLE
bug in unlink mulit filename

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -1151,7 +1151,7 @@ GridStore.unlink = function(db, names, options, callback) {
     var tc = 0;
     for(var i = 0; i < names.length; i++) {
       ++tc;
-      self.unlink(db, names[i], function(result) {
+      self.unlink(db, names[i], options, function(result) {
         if(--tc == 0) {
             callback(null, self);
         }


### PR DESCRIPTION
there have a bug when i want unlink mulit filename, must have {root:} in options
