### PR TITLE
convert the err to a real error.

### DIFF
--- a/lib/mongodb/connection/base.js
+++ b/lib/mongodb/connection/base.js
@@ -381,6 +381,10 @@ Base.prototype._callHandler = function(id, document, err) {
       // Execute the callback if one was provided
       if(typeof callback == 'function') callback(err, document, info.connection);
     } catch(err) {
+      if (Object.prototype.toString.call(err) !== "[object Error]") {
+        err = new Error(err)
+      }
+      
       self._emitAcrossAllDbInstances(self, null, "error", err, self, true, true);
     }
   }


### PR DESCRIPTION
I had a minor bug that was

``` js
UsersCol.findOne({ name: "foo" }, function (err, record) {
  async.map(record.friends, function (friend, callback) {
    FriendsCol.findOne({ name: friend.name }, function (err, res) {
      if (err) return callback(err)
      callback(res); // OOPS NOT ERROR FIRST
    })
  }, function (err, results) {
    if (err) throw err
  })
})
```

I would get a cryptic error out of mongodb because it emitted an object as an `"error"` instead of an `Error` instance.

The error would look like this:

```
Error: [object Object]
    at normalizeError (/home/raynos/Documents/colingo-one-on-one/node_modules/trycatch/lib/formatError.js:33:11)
    at formatError (/home/raynos/Documents/colingo-one-on-one/node_modules/trycatch/lib/formatError.js:17:9)
    at Domain.EventEmitter.emit (events.js:95:17)
    at Db.EventEmitter.emit (events.js:70:21)
    at /home/raynos/Documents/colingo-one-on-one/node_modules/continuable-mongo/node_modules/mongodb/lib/mongodb/connection/base.js:223:19
    at process._tickDomainCallback (node.js:459:13)
```

Basically saying it came out of base.js and giving me no more information. And since it wasn't an `Error` instance I lost the long stacktraces tracing.
