### PR TITLE
cursorstream - streams2

### DIFF
--- a/lib/mongodb/cursorstream.js
+++ b/lib/mongodb/cursorstream.js
@@ -1,12 +1,10 @@
-var timers = require('timers');
-
 // Set processor, setImmediate if 0.10 otherwise nextTick
 var processor = require('./utils').processor();
 
 /**
  * Module dependecies.
  */
-var Stream = require('stream').Stream;
+var Readable = require('stream').Readable || require('readable-stream').Readable;
 
 /**
  * CursorStream
@@ -19,29 +17,26 @@ var Stream = require('stream').Stream;
  * Events
  *  - **data** {function(item) {}} the data event triggers when a document is ready.
  *  - **error** {function(err) {}} the error event triggers if an error happens.
- *  - **close** {function() {}} the end event triggers when there is no more documents available.
+ *  - **end** {function() {}} the end event triggers when there are no more documents available.
+ *  - **close** {function() {}} the close event triggers when the underlying cursor is closed.
  *
  * @class Represents a CursorStream.
  * @param {Cursor} cursor a cursor object that the stream wraps.
+ * @param {Options} an options object that is also passed to the readable stream.
  * @return {Stream}
  */
 function CursorStream(cursor, options) {
   if(!(this instanceof CursorStream)) return new CursorStream(cursor);
   options = options ? options : {};
+  // Documents are objects
+  options.objectMode = true;
 
-  Stream.call(this);
+  Readable.call(this, options);
 
-  this.readable = true;
-  this.paused = false;
   this._cursor = cursor;
-  this._destroyed = null;
+  this.destroyed = null;
+  this.transform = typeof options.transform === 'function' && options.transform;
   this.options = options;
-
-  // give time to hook up events
-  var self = this;
-  process.nextTick(function() {
-    self._init();      
-  });
 }
 
 /**
@@ -49,92 +44,34 @@ function CursorStream(cursor, options) {
  * @ignore
  * @api private
  */
-CursorStream.prototype.__proto__ = Stream.prototype;
+CursorStream.prototype.__proto__ = Readable.prototype;
 
 /**
- * Flag stating whether or not this stream is readable.
- */
-CursorStream.prototype.readable;
-
-/**
- * Flag stating whether or not this stream is paused.
- */
-CursorStream.prototype.paused;
-
-/**
- * Initialize the cursor.
+ * Implement the _read method for the readable stream.
  * @ignore
  * @api private
  */
-CursorStream.prototype._init = function () {
-  if (this._destroyed) return;
-  this._next();
-}
-
-/**
- * Pull the next document from the cursor.
- * @ignore
- * @api private
- */
-CursorStream.prototype._next = function () {
-  if(this.paused || this._destroyed) return;
+CursorStream.prototype._read = function (size) {
+  // We _may_ want to implement the `size` argument,
+  // but it is only advisory.
+  if (this.destroyed) return;
 
   var self = this;
-  // Get the next object
   processor(function() {
-    if(self.paused || self._destroyed) return;
-
     self._cursor.nextObject(function (err, doc) {
-      self._onNextObject(err, doc);
-    });    
+      if (err) {
+        this.destroy(err);
+      } else if (doc) {
+        // Continue reading if the stream wants more documents
+        if (self.transform) doc = self.transform(doc);
+        if (self.push(doc)) this._read();
+      } else {
+        // There are no more documents, so we've reached the end of the stream.
+        self.push(null);
+        self.destroy();
+      }
+    });
   });
-}
-
-/**
- * Handle each document as its returned from the cursor.
- * @ignore
- * @api private
- */
-CursorStream.prototype._onNextObject = function (err, doc) {
-  if(err) return this.destroy(err);
-
-  // when doc is null we hit the end of the cursor
-  if(!doc && (this._cursor.state == 1 || this._cursor.state == 2)) {
-    this.emit('end')
-    return this.destroy();
-  } else if(doc) {
-    var data = typeof this.options.transform == 'function' ? this.options.transform(doc) : doc;
-    this.emit('data', data);
-    this._next();
-  }
-}
-
-/**
- * Pauses the stream.
- *
- * @api public
- */
-CursorStream.prototype.pause = function () {
-  this.paused = true;
-}
-
-/**
- * Resumes the stream.
- *
- * @api public
- */
-CursorStream.prototype.resume = function () {
-  var self = this;
-
-  // Don't do anything if we are not paused
-  if(!this.paused) return;
-  if(!this._cursor.state == 3) return;
-
-  process.nextTick(function() {
-    self.paused = false;
-    // Only trigger more fetching if the cursor is open
-    self._next();
-  })
 }
 
 /**
@@ -144,15 +81,11 @@ CursorStream.prototype.resume = function () {
  * @api public
  */
 CursorStream.prototype.destroy = function (err) {
-  if (this._destroyed) return;
-  this._destroyed = true;
-  this.readable = false;
-
+  if (this.destroyed) return;
+  this.destroyed = true;
   this._cursor.close();
 
-  if(err) {
-    this.emit('error', err);
-  }
+  if (err) this.emit('error', err);
 
   this.emit('close');
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 	  , "async": "0.1.22"
     , "integra": "latest"
     , "optimist": "latest"
+    , "readable-stream": "1.1.9"
   }
 , "optionalDependencies": {
     "kerberos": "0.0.3"


### PR DESCRIPTION
#1071 upgrades cursorstream to a streams2 implementation. some notes:
- i no longer check the cursor state. you may want to handle that differently.
- uses `self.destroyed` vs `self._destroyed` just like node: https://github.com/joyent/node/blob/master/lib/fs.js#L1538
- i'm not sure if the tests work for me - they just pause among hundreds of `✔ Should handle uncaught error correctly`s. or perhaps you just need to `process.exit()`?

you may also want to add tests for the streams2 portions, such as:

``` js
stream.on('readable', function () {
  var doc = this.read(1);
})
```
