### PR TITLE
there was a : missing on the skip example

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -250,7 +250,7 @@ Paging can be achieved with option parameters `limit` and `skip`
 ```javascript
   {
     "limit": 20,
-    "skip" 10
+    "skip": 10
   }
 ```
 


### PR DESCRIPTION
Added : to the skip example under Paging
