### PR TITLE
Fix non-callback query command calls

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1600,7 +1600,7 @@ Db.prototype._executeQueryCommand = function(db_command, options, callback) {
   var self = this;
 
   // Unpack the parameters
-  if (typeof callback === 'undefined') {
+  if (typeof callback === 'undefined' && typeof options === 'function') {
     callback = options;
     options = {};
   }


### PR DESCRIPTION
`Cursor.prototype.close` was changed to execute the command without a callback parameter like this (9e4b0ceb2b800dfcb56ddeb5cc8cce69ff045c3d):

```
 this.db._executeQueryCommand(command, {read:self.read, raw:self.raw, connection:self.connection});
```

`Db.prototype._executeQueryCommand` assumes this 2 argument call to be `command, callback` and unpacks parameters according to that and looses the options object in process. I changed it to ensure that second parameter is actually a function.

I had continuous logging of `[conn822108] killcursors: found 0 of 1` messages on mongodb.log (related: LearnBoost/mongoose#1700) and this fix resolves the issue.
