### PR TITLE
Add non-verbose inline mapReduce support

### DIFF
--- a/lib/mongodb/collection/aggregation.js
+++ b/lib/mongodb/collection/aggregation.js
@@ -92,6 +92,10 @@ var mapReduce = function mapReduce (map, reduce, options, callback) {
 
     // invoked with inline?
     if(result.documents[0].results) {
+      // If we wish for no verbosity
+      if(options['verbose'] == null || !options['verbose']) {
+        return callback(null, result.documents[0].results);
+      }
       return callback(null, result.documents[0].results, stats);
     }
 


### PR DESCRIPTION
Had some issues with `async.parallel` because the inline results were always returning stats.  Not sure if it's intentional or not, but it seems like a bug to me.
