### PR TITLE
When parsing the request fails, let the user know why so they can fix the error. 

### DIFF
--- a/lib/mongodb/connection/server.js
+++ b/lib/mongodb/connection/server.js
@@ -456,17 +456,17 @@ Server.prototype.connect = function(dbInstance, options, callback) {
               var internalCallback = callback;
               callback = null;
               // Perform callback
-              internalCallback(new Error("connection closed due to parseError"), null, server);
+              internalCallback(new Error("connection closed due to parseError: "+err), null, server);
             } else if(server.isSetMember()) {
-              if(server.listeners("parseError") && server.listeners("parseError").length > 0) server.emit("parseError", new Error("connection closed due to parseError"), server);
+              if(server.listeners("parseError") && server.listeners("parseError").length > 0) server.emit("parseError", new Error("connection closed due to parseError: "+err), server);
             } else {
-              if(eventReceiver.listeners("parseError") && eventReceiver.listeners("parseError").length > 0) eventReceiver.emit("parseError", new Error("connection closed due to parseError"), server);
+              if(eventReceiver.listeners("parseError") && eventReceiver.listeners("parseError").length > 0) eventReceiver.emit("parseError", new Error("connection closed due to parseError: "+err), server);
             }
 
             // If we are a single server connection fire errors correctly
             if(!server.isSetMember()) {
               // Fire all callback errors
-              server.__executeAllCallbacksWithError(new Error("connection closed due to parseError"));
+              server.__executeAllCallbacksWithError(new Error("connection closed due to parseError: "+err));
               // Emit error
               server._emitAcrossAllDbInstances(server, eventReceiver, "parseError", server, null, true);
             }


### PR DESCRIPTION
Right now, a parse error can be swallowed under some conditions. That is, an error will be returned that "connection has been closed to parseError", without details being given. 

This patch passes through the error messages, given, the developer valuable information to understand what the problem in their code might be so they can fix it. 

The issue persists in the 2.x branch, but I thought I would see how the patch was received here first. 
