### PR TITLE
Close db on failed connect so node can exit.

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -267,10 +267,11 @@ Db.prototype.open = function(callback) {
     // Attempt to connect
     self.serverConfig.connect(self, connect_options, function(err, result) {
       if(err != null) {
-        // Set that db has been closed
-        self.openCalled = false;
-        // Return error from connection
-        return callback(err, null);
+        // Close db to reset connection
+        return self.close(function () {
+          // Return error from connection
+          return callback(err, null);
+        });
       }
       // Set the status of the server
       self._state = 'connected';


### PR DESCRIPTION
With mongod running on localhost:27017:

```
var MongoClient = require('mongodb').MongoClient;
MongoClient.connect('mongodb://localhost:27017', function (err, client) {
   if (err) console.error(err);
   else console.log('connect ok');
   if (client) client.close();
});

MongoClient.connect('mongodb://localhost:27018', function (err, client) {
   if (err) console.error(err);
   else console.log('connect ok');
   if (client) client.close();
});
```

Output is:

```
connect ok
[Error: failed to connect to [localhost:27018]]
```

...and the node process will not exit on its own.
