### PR TITLE
Fix unpack error on _executeQueryCommand

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1705,7 +1705,7 @@ Db.prototype._executeQueryCommand = function(db_command, options, callback) {
   var self = this;
 
   // Unpack the parameters
-  if (typeof callback === 'undefined') {
+  if (typeof options === 'function') {
     callback = options;
     options = {};
   }


### PR DESCRIPTION
Similar of #1098 for 1.4. However that was closed without resolving the issue.
