### PR TITLE
Check ReadPreference object on ReplSet.canRead

### DIFF
--- a/lib/mongodb/connection/repl_set/repl_set.js
+++ b/lib/mongodb/connection/repl_set/repl_set.js
@@ -138,6 +138,7 @@ ReplSet.prototype.canWrite = function() {
 
 ReplSet.prototype.canRead = function(read) {
   if((read == ReadPreference.PRIMARY 
+      || (typeof read == 'object' && read.mode == ReadPreference.PRIMARY)
       || read == null || read == false) && (this._state.master == null || !this._state.master.isConnected())) return false;
   return Object.keys(this._state.secondaries).length > 0;
 }


### PR DESCRIPTION
`ReplSet.prototype.canRead` can be called with a `ReadPreference` object instance (for example: https://github.com/mongodb/node-mongodb-native/blob/1.4/lib/mongodb/db.js#L1745)

This ensures that the object is checked correctly.
