### PR TITLE
Do not return false when the connection buffer is still empty

### DIFF
--- a/lib/mongodb/connection/base.js
+++ b/lib/mongodb/connection/base.js
@@ -86,10 +86,13 @@ var NonExecutedOperationStore = function(config) {
       fireCallbacksWithError(error, commands.read);
       fireCallbacksWithError(error, commands.write_reads);
       fireCallbacksWithError(error, commands.write);
+
+      // Report back that the buffer has been filled
+      return false;
     }
 
-    // Return false
-    return false;
+    // There is still some room to go
+    return true;
   }
 
   this.execute_queries = function(executeInsertCommand) {


### PR DESCRIPTION
`CallbackStore.validateBufferLimit` returns `false` even though there is still room available. It should return `true` in case the supplied threshold has not been breached.
