### PR TITLE
Remove superfluous connect object copying in index.js

### DIFF
--- a/lib/mongodb/index.js
+++ b/lib/mongodb/index.js
@@ -45,19 +45,12 @@ exports.Timestamp = require('bson').Timestamp;
 // Add BSON Parser
 exports.BSON = require('bson').BSONPure.BSON;
 
-// Get the Db object
-var Db = require('./db').Db;
 // Set up the connect function
-var connect = Db.connect;
-var obj = connect;
-// Map all values to the exports value
-for(var name in exports) {
-  obj[name] = exports[name];
-}
+var connect = exports.Db.connect;
 
 // Add the pure and native backward compatible functions
 exports.pure = exports.native = function() {
-  return obj;
+  return connect;
 }
 
 // Map all values to the exports value


### PR DESCRIPTION
The main export is a reference to Db.connect and a reference to all other exports is attached to the the Db.connect object on startup.

Previously this was done twice.

Note: if the intention of creating the "obj" object was so that the "pure" method does not return an object with a reference to itself then that's not how it works.
