### PR TITLE
NODE-124 use a shallow copy of options in find()

### DIFF
--- a/lib/mongodb/collection/query.js
+++ b/lib/mongodb/collection/query.js
@@ -110,16 +110,23 @@ var find = function find () {
   }
 
   if (!options) options = {};
-  options.skip = len > 3 ? args[2] : options.skip ? options.skip : 0;
-  options.limit = len > 3 ? args[3] : options.limit ? options.limit : 0;
-  options.raw = options.raw != null && typeof options.raw === 'boolean' ? options.raw : this.raw;
-  options.hint = options.hint != null ? shared.normalizeHintField(options.hint) : this.internalHint;
-  options.timeout = len == 5 ? args[4] : typeof options.timeout === 'undefined' ? undefined : options.timeout;
+  
+  var newOptions = {};
+  for (key in options) {
+    // Make a shallow copy of options
+    newOptions[key] = options[key];
+  }
+
+  newOptions.skip = len > 3 ? args[2] : options.skip ? options.skip : 0;
+  newOptions.limit = len > 3 ? args[3] : options.limit ? options.limit : 0;
+  newOptions.raw = options.raw != null && typeof options.raw === 'boolean' ? options.raw : this.raw;
+  newOptions.hint = options.hint != null ? shared.normalizeHintField(options.hint) : this.internalHint;
+  newOptions.timeout = len == 5 ? args[4] : typeof options.timeout === 'undefined' ? undefined : options.timeout;
   // If we have overridden slaveOk otherwise use the default db setting
-  options.slaveOk = options.slaveOk != null ? options.slaveOk : this.db.slaveOk;
+  newOptions.slaveOk = options.slaveOk != null ? options.slaveOk : this.db.slaveOk;
 
   // Set option
-  var o = options;
+  var o = newOptions;
   // Support read/readPreference
   if(o["read"] != null) o["readPreference"] = o["read"];
   // Set the read preference

--- a/test/tests/functional/find_tests.js
+++ b/test/tests/functional/find_tests.js
@@ -2340,3 +2340,19 @@ exports['Should correctly sort using text search on 2.6 or higher in find'] = {
     });
   }
 }
+
+exports.shouldNotMutateUserOptions = function(configuration, test) {
+  var db = configuration.newDbInstance({w:1}, {poolSize:1});
+  db.open(function(err, db) {
+    
+    var collection = db.collection('shouldNotMutateUserOptions');
+    var options = { raw : "TEST" };
+    collection.find({}, {}, options, function(error, docs) {
+      test.equal(undefined, options.skip);
+      test.equal(undefined, options.limit);
+      test.equal("TEST", options.raw);
+      db.close();
+      test.done();
+    });
+  });
+}


### PR DESCRIPTION
This should fix that particular ticket, since it looks like `find()` only mutates the top level of the options object.
