### PR TITLE
GridStore drops passed `aliases` option, always results in `null` value in GridFS files

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -232,6 +232,7 @@ var _open = function(self, callback) {
               self.contentType = self.options['content_type'] == null ? self.contentType : self.options['content_type'];
               self.internalChunkSize = self.options['chunk_size'] == null ? self.internalChunkSize : self.options['chunk_size'];
               self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
+              self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
               self.position = 0;
               callback(null, self);
             });
@@ -242,6 +243,7 @@ var _open = function(self, callback) {
               self.currentChunk = chunk == null ? new Chunk(self, {'n':0}, self.writeConcern) : chunk;
               self.currentChunk.position = self.currentChunk.data.length();
               self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
+              self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
               self.position = self.length;
               callback(null, self);
             });
@@ -267,6 +269,7 @@ var _open = function(self, callback) {
             self.contentType = self.options['content_type'] == null ? self.contentType : self.options['content_type'];
             self.internalChunkSize = self.options['chunk_size'] == null ? self.internalChunkSize : self.options['chunk_size'];
             self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
+            self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
             self.position = 0;
             callback(null, self);
           });
@@ -277,6 +280,7 @@ var _open = function(self, callback) {
             self.currentChunk = chunk == null ? new Chunk(self, {'n':0}, self.writeConcern) : chunk;
             self.currentChunk.position = self.currentChunk.data.length();
             self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
+            self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
             self.position = self.length;
             callback(null, self);
           });


### PR DESCRIPTION
The GridFS data model allows for an [array of strings containing alternate names](http://docs.mongodb.org/manual/reference/gridfs/#the-files-collection) called `aliases` to be attached to each file. GridStore already contains code to properly create this field in the `buildMongoObject()` [function](https://github.com/mongodb/node-mongodb-native/blob/1.3.20/lib/mongodb/gridfs/gridstore.js#L471). 

However, unlike the `metadata` field, which is correctly copied from `options` to `self` in preparation for calling `buildMongoObject()`, `aliases` is not copied over and this results in `aliases` always being `null` in GridStore created files, regardless of the value provided in the `options` object. 

This pull request fixes this issue by treating `aliases` identically to how `metadata` is treated.

This issue also exists in the 1.4 branch, I'd be happy to send a pull request for that branch as well (the fixes are identical).
