### PR TITLE
GridFS off-by-one bug in lastChunkNumber() causes uncaught throw and data loss

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -633,7 +633,7 @@ GridStore.prototype._nthChunk = function(chunkNumber, callback) {
  * @api private
  */
 var lastChunkNumber = function(self) {
-  return Math.floor(self.length/self.chunkSize);
+  return Math.floor((self.length ? self.length - 1 : 0)/self.chunkSize);
 };
 
 /**

--- a/test/tests/manual_tests/lastChunkNumber_off_by_one.js
+++ b/test/tests/manual_tests/lastChunkNumber_off_by_one.js
@@ -1,0 +1,51 @@
+var Db = require('mongodb').Db;
+var GridStore = require('mongodb').GridStore;
+var Server = require('mongodb').Server;
+var ObjectID = require('mongodb').ObjectID;
+var assert = require('assert');
+
+var chunkSize = 256*1024;  // Standard 256KB chunks
+
+var db = new Db('test', new Server('127.0.0.1', 27017));
+// Establish connection to db
+db.open(function(err, db) {
+  // Our file ID
+  var fileId = new ObjectID();
+
+  // Open a new file
+  var gridStore = new GridStore(db, fileId, 'w', { chunkSize: chunkSize });
+
+  // Open the new file
+  gridStore.open(function(err, gridStore) {
+
+    // Create a chunkSize Buffer
+    var buffer = new Buffer(chunkSize); 
+
+    // Write the buffer
+    gridStore.write(buffer, function(err, gridStore) {
+
+      // Close the file
+      gridStore.close(function(err, result) {
+
+        // Open the same file, this time for appending data
+        // No need to specify chunkSize...
+        gridStore = new GridStore(db, fileId, 'w+');
+
+        // Open the file again
+        gridStore.open(function(err, gridStore) {
+
+          // Write the buffer again
+          gridStore.write(buffer, function(err, gridStore) {
+
+          // Close the file again
+          gridStore.close(function(err, result) {
+
+            db.close();
+
+          });
+        });
+      });
+    });
+  });
+});
+},{},{ w: 1 });


### PR DESCRIPTION
This is an extremely severe bug in that it causes an uncaught thrown error emanating from the mongodb core (during the md5 sum recalculation) due to a corruption of the chunk numbering following a write of appended data. The included test script `test/tests/manual_tests/lastChunkNumber_off_by_one.js` reproduces this bug, and results in an invalid file with two chunks each with `chunk.n === 0`. 

The bug occurs when appending (write mode: "w+") to an existing non-zero length gridFS file with file length exactly equal to a multiple of its chunkSize.  That is, when:

```
 (file.length > 0) && ( file.length % file.chunkSize === 0 )
```

In addition to the 1.4 branch, this bug also affects the currently released version 1.3.23 and probably other under-development branches as well.
