### PR TITLE
Added support for unavailable replica servers

### DIFF
--- a/lib/mongodb/connection/connection.js
+++ b/lib/mongodb/connection/connection.js
@@ -247,7 +247,7 @@ Connection.prototype.write = function(command, callback) {
         var binaryCommand = command.toBinary(this.maxBsonSettings)
         // Do we have a logger active log the event
         if(this.logger != null && this.logger.doDebug) 
-          this.logger.debug("writing command to mongodb", {binary: binaryCommand, json: command[i]});
+          this.logger.debug("writing command to mongodb", {binary: binaryCommand, json: command});
         // Write the binary command out to socket
         this.writeSteam.write(binaryCommand);
       } catch(err) {

--- a/lib/mongodb/connection/repl_set/strategies/ping_strategy.js
+++ b/lib/mongodb/connection/repl_set/strategies/ping_strategy.js
@@ -10,8 +10,8 @@ var PingStrategy = exports.PingStrategy = function(replicaset, secondaryAcceptab
   this.state = 'disconnected';
   // Interval of ping attempts
   this.pingInterval = replicaset.options.socketOptions.pingInterval || 5000;
-  // Timeout for ping response
-  this.pingTimeout = replicaset.options.socketOptions.pingTimeout || 5000;
+  // Timeout for ping response, default - no timeout
+  this.pingTimeout = replicaset.options.socketOptions.pingTimeout || null;
   // Class instance
   this.Db = require("../../../db").Db;
   // Active db connections
@@ -145,13 +145,12 @@ PingStrategy.prototype.checkoutConnection = function(tags, secondaryCandidates) 
     self.logger.debug("Ping strategy selection order for tags", tags);
     finalCandidates.forEach(function(c) {
       self.logger.debug(format("%s:%s = %s ms", c.host, c.port, c.runtimeStats['pingMs']), null);
-    })    
+    })
   }
 
   // If no candidates available return an error
   if(finalCandidates.length == 0)
     return new Error("No replica set members available for query");
-
   // Ensure no we don't overflow
   this.index = this.index % finalCandidates.length
   // Pick a random acceptable server  
@@ -207,14 +206,12 @@ PingStrategy.prototype._pingServer = function(callback) {
 
           // Execute ping command in own scope
           var _ping = function(__db, __serverInstance) {
-
-            // Server unavailable
-            var _failTimer = setTimeout(function () {
+            // Server unavailable. Checks only if pingTimeout defined & greater than 0
+            var _failTimer = self.pingTimeout ? setTimeout(function () {
               if(null != __serverInstance.runtimeStats && __serverInstance.isConnected()) {
-                __serverInstance.runtimeStats['pingMs'] = undefined;
-                //__serverInstance.emit('timeout');//.connectionPool.emit('timeout');
+                  __serverInstance.close();
               }
-            }, self.pingTimeout);
+            }, self.pingTimeout) : null;
 
             // Execute ping on this connection
             __db.executeDbCommand({ping:1}, {failFast:true}, function(err) {


### PR DESCRIPTION
3 fixes for a ping strategy.
1. Implemented support for unavailable replica servers
2. No more lowest.runtimeStats.pingMs = undefined
3. Configurable options for ping timeout/interval.
