### PR TITLE
Add missing `var`.

### DIFF
--- a/lib/mongodb/collection/query.js
+++ b/lib/mongodb/collection/query.js
@@ -113,7 +113,7 @@ var find = function find () {
 
   var newOptions = {};
   // Make a shallow copy of options
-  for (key in options) {
+  for (var key in options) {
     newOptions[key] = options[key];
   }
 


### PR DESCRIPTION
`key` is leaked to the global namespace. Detected the issue thanks to Mocha reporting `Error: global leak detected: key`. This pull request fixes this.
