### PR TITLE
Replica server availability check

### DIFF
--- a/lib/mongodb/connection/repl_set/strategies/ping_strategy.js
+++ b/lib/mongodb/connection/repl_set/strategies/ping_strategy.js
@@ -8,7 +8,10 @@ var PingStrategy = exports.PingStrategy = function(replicaset, secondaryAcceptab
   this.replicaset = replicaset;
   this.secondaryAcceptableLatencyMS = secondaryAcceptableLatencyMS;
   this.state = 'disconnected';
-  this.pingInterval = 5000;
+  // Interval of ping attempts
+  this.pingInterval = replicaset.options.socketOptions.pingInterval || 5000;
+  // Timeout for ping response, default - no timeout
+  this.pingTimeout = replicaset.options.socketOptions.pingTimeout || null;
   // Class instance
   this.Db = require("../../../db").Db;
   // Active db connections
@@ -204,8 +207,20 @@ PingStrategy.prototype._pingServer = function(callback) {
 
           // Execute ping command in own scope
           var _ping = function(__db, __serverInstance) {
+
+            // Server unavailable. Checks only if pingTimeout defined & greater than 0
+            var _failTimer = self.pingTimeout ? setTimeout(function () {
+              if(null != __serverInstance.runtimeStats && __serverInstance.isConnected()) {
+                __serverInstance.close();
+              }
+            }, self.pingTimeout) : null;
+
             // Execute ping on this connection
             __db.executeDbCommand({ping:1}, {failFast:true}, function(err) {
+
+              // Server available
+              clearTimeout(_failTimer);
+
               // Emit the ping
               self.replicaset.emit("ping", err, serverInstance);
 


### PR DESCRIPTION
2 improvements for a ping strategy.
1. Implemented support for unavailable replica servers
2. Configurable options for ping timeout/interval.
