### PR TITLE
Remove sort if it`s not set. It fixes very slow queries with findAndModify and sort

### DIFF
--- a/lib/mongodb/collection/core.js
+++ b/lib/mongodb/collection/core.js
@@ -701,10 +701,14 @@ var findAndModify = function findAndModify (query, sort, doc, options, callback)
   var self = this;
 
   var queryObject = {
-      'findandmodify': this.collectionName
-    , 'query': query
-    , 'sort': utils.formattedOrderClause(sort)
+     'findandmodify': this.collectionName
+   , 'query': query
   };
+
+  sort = utils.formattedOrderClause(sort);
+  if (sort) {
+    queryObject.sort = sort;
+  }
 
   queryObject.new = options.new ? 1 : 0;
   queryObject.remove = options.remove ? 1 : 0;

--- a/lib/mongodb/utils.js
+++ b/lib/mongodb/utils.js
@@ -26,6 +26,9 @@ var formattedOrderClause = exports.formattedOrderClause = function(sortValue) {
   var orderBy = {};
 
   if (Array.isArray(sortValue)) {
+    if(sortValue.length === 0) {
+      return null;
+    }
     for(var i = 0; i < sortValue.length; i++) {
       if(sortValue[i].constructor == String) {
         orderBy[sortValue[i]] = 1;


### PR DESCRIPTION
I have a collection with 500K + documents.

``` javascript

PixelSchema = mongoose.Schema({
    num: Number,
    r: Number,
    g: Number,
    b: Number,
    a: Number,
    random: {type: Number, index: true},
    used: {type: Boolean, index: true},
    loc: {type: [Number], index: {type: '2d', min: 0, max: 2000}}
});

Pixel = mongoose.model('Pixel', PixelSchema);
```

When I update some document in this collection using findAndModify it takes very long time (>1 sec)

```
2014-04-17T14:50:45.077+0300 [conn133] update noobjs_dev.pixels query: { _id: ObjectId('534fbe0b7698e90ad258142f'), used: false, loc: { $near: [ 600, 500 ] } } update: { $set: { used: false } } nscanned:1 nscannedObjects:1 nMatched:1 nModified:0 keyUpdates:0 numYields:0  1388ms
```

mongodb driver adds to the query empty sort object and if i remove it - query executed much faster (0,01 sec)
