### PR TITLE
Aggregation cursor flag 'allowDiskUse' correction

### DIFF
--- a/lib/mongodb/aggregation_cursor.js
+++ b/lib/mongodb/aggregation_cursor.js
@@ -38,9 +38,9 @@ var AggregationCursor = function(collection, serverCapabilities, options) {
 		, cursor: _cursor_options
 	}
 
-	// If allowDiskUsage is set
-	if(typeof options.allowDiskUsage == 'boolean') 
-		command.allowDiskUsage = options.allowDiskUsage;
+	// If allowDiskUse is set
+	if(typeof options.allowDiskUse == 'boolean') 
+		command.allowDiskUse = options.allowDiskUse;
 	
 	// Command cursor (if we support one)
 	var commandCursor = new CommandCursor(collection.db, collection, command);


### PR DESCRIPTION
The aggregation flag 'allowDiskUse' was incorrectly named 'allowDiskUsage' which was preventing this functionality from working.
