### PR TITLE
Don't modify user options object in createIndex

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1243,9 +1243,18 @@ Db.prototype.createIndex = function(collectionName, fieldOrSpec, options, callba
   var self = this;
   var args = Array.prototype.slice.call(arguments, 2);
   callback = args.pop();
-  options = args.length ? args.shift() || {} : {};
-  options = typeof callback === 'function' ? options : callback;
-  options = options == null ? {} : options;
+
+  var _options = options;
+  _options = args.length ? args.shift() || {} : {};
+  _options = typeof callback === 'function' ? _options : callback;
+  _options = _options == null ? {} : _options;
+
+  // Copy options so we don't mysteriously add a readPreference to user's
+  // options object
+  var options = {};
+  for (var key in _options) {
+    options[key] = _options[key];
+  }
 
   // Get the error options
   var writeConcern = _getWriteConcern(self, options);

--- a/test/tests/functional/index_tests.js
+++ b/test/tests/functional/index_tests.js
@@ -111,8 +111,13 @@ exports.shouldCreateComplexEnsureIndex = function(configuration, test) {
         test.equal(null, err);
 
         // Create an index on the a field
+        var options = {unique:true, background:true, dropDups:true, w:1};
         collection.ensureIndex({a:1, b:1}
-          , {unique:true, background:true, dropDups:true, w:1}, function(err, indexName) {
+          , options, function(err, indexName) {
+
+          // Make sure that we haven't modified the user's options
+          test.ok(!options.readPreference);
+
           // Show that duplicate records got dropped
           collection.find({}).toArray(function(err, items) {
             test.equal(null, err);


### PR DESCRIPTION
Hey Christian,

Minor issue that's causing mongoose tests to fail against 1.4.2 - `createIndex()` currently modifies the user's options object and adds a `readPreference` field, which isn't ideal. Version bump would be nice for this because its blocking mongoose from upgrading to 1.4.x .
