### PR TITLE
return the destination stream in GridStore.pipe

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -1392,7 +1392,8 @@ GridStore.prototype.pipe = function(destination, options) {
     self.emit('open');
     // Read from the stream
     _read(self);
-  })
+  });
+  return destination;
 }
 
 /**

--- a/test/tests/functional/gridstore/gridstore_direct_streaming_tests.js
+++ b/test/tests/functional/gridstore/gridstore_direct_streaming_tests.js
@@ -51,7 +51,8 @@ exports.shouldCorrectlyStreamReadFromGridStoreObject = function(configuration, t
         test.done();			
       })
       // Pipe out the data
-      gridStore.pipe(fileStream);
+      var pipeResult = gridStore.pipe(fileStream);
+      test.equal(fileStream, pipeResult);
     });
   });
 }


### PR DESCRIPTION
Follow the [node convention](http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options) and return the destination stream in `GridStore.pipe` so one can chain multiple pipes.
