### PR TITLE
Fix parsing of new errored results from mongod

### DIFF
--- a/lib/mongodb/collection/core.js
+++ b/lib/mongodb/collection/core.js
@@ -110,10 +110,19 @@ var insertWithWriteCommands = function(self, docs, options, callback) {
         }
 
         // Result has an error
-        if(!result.ok || Array.isArray(result.writeErrors) && result.writeErrors.length > 0) {
-          var error = utils.toError(result.writeErrors[0].errmsg);
-          error.code = result.writeErrors[0].code;
-          error.err = result.writeErrors[0].errmsg;
+        if(!result.ok && 
+            (Array.isArray(result.writeErrors) && result.writeErrors.length > 0)  ||
+            (result.errCode && result.errMsg)
+        ) {
+          // Extract error code and error message, supporting both response formats
+          var errMsg = result.errMsg || result.writeErrors[0].errmsg;
+          var errCode = result.errCode || result.writeErrors[0].code;
+
+          // Build error object
+          var error = utils.toError(errMsg);
+          error.code = errCode;
+          error.err = errMsg;
+
           // Return the error
           return callback(error, null);
         }


### PR DESCRIPTION
In mongod `v2.5.3` (other versions likely affected).

It returns errors through the `errMsg` and `errCode` result attributes rather than through the `writeErrors` attribute array.

This adds support for that new format.

Dump of unsupported response object https://gist.github.com/AaronO/32543578369df276a5ac
