### PR TITLE
Remove options check on index creation

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -35,7 +35,6 @@ try {
 
 // Set processor, setImmediate if 0.10 otherwise nextTick
 var processor = require('./utils').processor();
-var indexOptions = ["unique", "sparse", "background", "dropDups", "min", "max", "v", "expireAfterSeconds", "bucketSize", "language_override"];
 
 /**
  * Create a new Db instance.
@@ -1333,10 +1332,10 @@ var createCreateIndexCommand = function(db, collectionName, fieldOrSpec, options
     : options;
 
   // Add all the options
-  var keys = Object.keys(options);
-  for(var i = 0; i < keys.length; i++) {
-    if(indexOptions.indexOf(keys[i]) != -1) {
-      selector[keys[i]] = options[keys[i]];
+  var keysToOmit = Object.keys(selector);
+  for(var optionName in options) {
+    if(keysToOmit.indexOf(optionName) == -1) {
+      selector[optionName] = options[optionName];
     }
   }
 
@@ -1363,9 +1362,10 @@ var createIndexUsingCreateIndexes = function(self, collectionName, fieldOrSpec, 
   }];
 
   // merge all the options
-  for(var name in options) {
-    if(indexOptions.indexOf(name) != -1) {
-      indexes[0][name] = options[name];      
+  var keysToOmit = Object.keys(indexes[0]);
+  for(var optionName in options) {
+    if(keysToOmit.indexOf(optionName) == -1) {
+      indexes[0][optionName] = options[optionName];
     }
   }
 


### PR DESCRIPTION
New index options added in MongoDB 2.6 were ignored by index creation methods, particularly those related to geospatial and full-text search.

I've spent some hours to understand why full-text search in french was so unefficient :)
