### PR TITLE
Added support for the language_override index option

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -35,7 +35,7 @@ try {
 
 // Set processor, setImmediate if 0.10 otherwise nextTick
 var processor = require('./utils').processor();
-var indexOptions = ["unique", "sparse", "background", "dropDups", "min", "max", "v", "expireAfterSeconds", "bucketSize"];
+var indexOptions = ["unique", "sparse", "background", "dropDups", "min", "max", "v", "expireAfterSeconds", "bucketSize", "language_override"];
 
 /**
  * Create a new Db instance.

--- a/test/tests/functional/index_tests.js
+++ b/test/tests/functional/index_tests.js
@@ -891,3 +891,29 @@ exports['should correctly apply hint to find'] = function(configuration, test) {
     });
   });
 }
+
+exports['should correctly set language_override option'] = function(configuration, test) {
+  var db = configuration.newDbInstance({w:1}, {poolSize:1});
+  db.open(function(err, db) {
+    var collection = db.collection("should_correctly_set_language_override");
+    collection.insert([{text:'Lorem ipsum dolor sit amet.', langua:'italian'}], function(err, result) {
+      test.equal(null, err);
+
+      collection.ensureIndex({text:'text'}, {language_override:'langua', name:'language_override_index'}, function(err, result) {
+        test.equal(null, err);
+
+        collection.indexInformation({full:true}, function(err, indexInformation) {
+          test.equal(null, err);
+          for (var i = 0; i < indexInformation.length; i++) {
+            if (indexInformation[i].name === 'language_override_index')
+              test.equal(indexInformation[i].language_override, 'langua')
+          }
+
+          db.close();
+          test.done();
+
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
Our tests over at CodeCombat failed because we couldn't set the `language_override` option in our indexes. Managed to track it down: it wasn't in the `indexOptions` list. Wrote a quick but rather trivial test to ascertain that setting the `language_override` option now works. 
