### PR TITLE
Make callbacks to be executed in right domain

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1770,6 +1770,7 @@ Db.prototype._executeQueryCommand = function(db_command, options, callback) {
     callback = options;
     options = {};
   }
+  callback = bindToCurrentDomain(callback);
 
   // fast fail option used for HA, no retry
   var failFast = options['failFast'] != null
@@ -1826,7 +1827,7 @@ Db.prototype._executeQueryCommand = function(db_command, options, callback) {
         {   type: 'query'
           , db_command: db_command
           , options: options
-          , callback: callback 
+          , callback: callback
           , db: self
           , executeQueryCommand: __executeQueryCommand
           , executeInsertCommand: __executeInsertCommand
@@ -1924,7 +1925,7 @@ Db.prototype._executeInsertCommand = function(db_command, options, callback) {
     callback = options;
     options = {};
   }
-
+  callback = bindToCurrentDomain(callback);
   // Ensure options are not null
   options = options == null ? {} : options;
 

--- a/test/runners/standalone_runner.js
+++ b/test/runners/standalone_runner.js
@@ -60,6 +60,7 @@ module.exports = function(configurations) {
         , '/test/tests/functional/connection_tests.js'
         , '/test/tests/functional/collection_tests.js'
         , '/test/tests/functional/db_tests.js'
+        , '/test/tests/functional/domain_tests.js'
         , '/test/tests/functional/read_preferences_tests.js'
         // , '/test/tests/functional/fluent_api/aggregation_tests.js'
         , '/test/tests/functional/maxtimems_tests.js'

--- a/test/tests/functional/domain_tests.js
+++ b/test/tests/functional/domain_tests.js
@@ -1,0 +1,131 @@
+/**
+ * @ignore
+ */
+exports.shouldStayInCorrectDomainForReadCommand = function(configuration, test) {
+  var Domain;
+
+  try {
+    Domain = require('domain');
+  } catch (e) {
+    //Old node versions. Nothing to test
+    test.done();
+    return;
+  }
+
+  var domainInstance = Domain.create();
+  var client = configuration.newDbInstance({w: 0}, {poolSize: 1, auto_reconnect: true});
+
+  client.open(function(err, client) {
+    test.ok(!err);
+    var collection = client.collection('test');
+    domainInstance.run(function() {
+      collection.count({}, function(err) {
+        test.ok(!err);
+        test.ok(domainInstance === process.domain);
+        test.done();
+      });
+    });
+  });
+}
+
+/**
+ * @ignore
+ */
+exports.shouldStayInCorrectDomainForWriteCommand = function(configuration, test) {
+  var Domain;
+
+  try {
+    Domain = require('domain');
+  } catch (e) {
+    //Old node versions. Nothing to test
+    test.done();
+    return;
+  }
+
+  var domainInstance = Domain.create();
+  var client = configuration.newDbInstance({w: 1}, {poolSize: 1, auto_reconnect: true});
+
+  client.open(function(err, client) {
+    test.ok(!err);
+    var collection = client.collection('test');
+    domainInstance.run(function() {
+      collection.insert({field: 123}, function(err) {
+        test.ok(!err);
+        test.ok(domainInstance === process.domain);
+        test.done();
+      });
+    });
+  });
+}
+
+
+/**
+ * @ignore
+ */
+exports.shouldStayInCorrectDomainForQueuedReadCommand = function(configuration, test) {
+  var Domain;
+
+  try {
+    Domain = require('domain');
+  } catch (e) {
+    //Old node versions. Nothing to test
+    test.done();
+    return;
+  }
+
+  var domainInstance = Domain.create();
+  var client = configuration.newDbInstance({w: 0}, {poolSize: 1, auto_reconnect: true});
+
+  client.open(function(err, client) {
+    var connection = client.serverConfig.connectionPool.openConnections[0];
+    var collection = client.collection('test');
+
+    //imitate connection error, to make commands queued into
+    //commandsStore
+    connection.emit('error', {err: 'fake disconnect'}, connection);
+
+    domainInstance.run(function() {
+      collection.count({}, function(err) {
+        test.ok(!err);
+        test.ok(process.domain === domainInstance);
+        test.done();
+      });
+    });
+  });
+}
+
+/**
+ * @ignore
+ */
+exports.shouldStayInCorrectDomainForQueuedWriteCommand = function(configuration, test) {
+  var Domain;
+
+  try {
+    Domain = require('domain');
+  } catch (e) {
+    //Old node versions. Nothing to test
+    test.done();
+    return;
+  }
+
+  var domainInstance = Domain.create();
+  var client = configuration.newDbInstance({w: 1}, {poolSize: 1, auto_reconnect: true});
+
+  client.open(function(err, client) {
+    test.ok(!err);
+    var connection = client.serverConfig.connectionPool.openConnections[0];
+    var collection = client.collection('test');
+
+    //imitate connection error, to make commands queued into
+    //commandsStore
+    connection.emit('error', {err: 'fake disconnect'}, connection);
+
+    domainInstance.run(function() {
+      collection.insert({field: 123}, function(err) {
+        test.ok(!err);
+        test.ok(process.domain === domainInstance);
+        test.done();
+      });
+    });
+  });
+}


### PR DESCRIPTION
Seems, that there are one more way to loose domain:  
If connection for some reason is not ready, command is queued in commandsStore.
When connection is finally ready, commands from commandsStore are executed, but not in the domain, they has been pushed in queue.
Example, that reproduces such situation: 
1. Break existing connection, imitating some kind of error (that makes next command to be queued in _commandsStore)
2. Try to execute count command. That's done in specially created domain. 
3. Command is executed when new connection is ready due to auto_reconnect = true option. 
4. debugDomain function is called (it is made in such way, that it tell's if it's called in wrong domain)

Pull request contains tests and fixes.  (see https://jira.mongodb.org/browse/NODE-110)
