### PR TITLE
False option values should not trigger w:1.

### DIFF
--- a/lib/mongodb/mongo_client.js
+++ b/lib/mongodb/mongo_client.js
@@ -32,9 +32,9 @@ var Db = require('./db').Db
  */
 function MongoClient(serverConfig, options) {
   if(serverConfig != null) {
-    options = options == null ? {} : options;
+    options = options ? options : {};
     // If no write concern is set set the default to w:1
-    if(options != null && !options.journal && !options.w && !options.fsync) {
+    if('w' in options === false) {
       options.w = 1;
     }
     


### PR DESCRIPTION
I noticed while using `mongoose` that `{journal:false}` made my tests incredibly slow.  Not passing in any option object at all made the tests fast.  I then traced it down to this.

Please advise if you'd like me to write tests for this.
