### PR TITLE
doc: close event is always emitted

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -336,7 +336,7 @@ Db.prototype.db = function(dbName) {
 };
 
 /**
- * Close the current db connection, including all the child db instances. Emits close event if no callback is provided.
+ * Close the current db connection, including all the child db instances. Emits close event and calls optional callback.
  *
  * @param {Boolean} [forceClose] connection can never be reused.
  * @param {Function} callback this will be called after executing this method. The first parameter will contain the Error object if an error occurred, or null otherwise. While the second parameter will contain the results or null if an error occurred.

--- a/lib/mongodb/mongo_client.js
+++ b/lib/mongodb/mongo_client.js
@@ -105,7 +105,7 @@ MongoClient.prototype.open = function(callback) {
 }
 
 /**
- * Close the current db connection, including all the child db instances. Emits close event if no callback is provided.
+ * Close the current db connection, including all the child db instances. Emits close event and calls optional callback.
  *
  * @param {Function} callback this will be called after executing this method. The first parameter will contain the Error object if an error occured, or null otherwise. While the second parameter will contain the results from the close method or null if an error occured.
  * @return {null}


### PR DESCRIPTION
Test case:

``` js
var mongodb = require('mongodb');

mongodb.MongoClient.connect('mongodb://localhost/test', function (err, db) {
  if(err) { throw err; }

  db.on('close', function () { console.log('CLOSE EVENT'); });
  db.close(function () { console.log('CLOSE CALLBACK'); });
});
```

Output:

``` text
CLOSE CALLBACK
CLOSE EVENT
```
