### PR TITLE
Documented third parameter on the update callback

### DIFF
--- a/docs/insert.md
+++ b/docs/insert.md
@@ -63,7 +63,7 @@ Where
   * `criteria` is a query object to find records that need to be updated (see [Queries](queries.md))
   * `update` is the replacement object
   * `options` is an options object (see below)
-  * `callback` is the callback to be run after the records are updated. Has two parameters, the first is an error object (if error occured), the second is the count of records that were modified.
+  * `callback` is the callback to be run after the records are updated. Has three parameters, the first is an error object (if error occured), the second is the count of records that were modified, the third is an object with the status of the operation.
   
 ### Update options
 


### PR DESCRIPTION
The documentation was missing the third callback passed to the update callback. The callback actually receives the error object, the result of the operation and a detailed status.
