### PR TITLE
Modified collection.geoNear to support a geoJSON point or legacy coordinate pair

### DIFF
--- a/lib/mongodb/collection/geo.js
+++ b/lib/mongodb/collection/geo.js
@@ -2,7 +2,9 @@ var shared = require('./shared')
   , utils = require('../utils');
 
 var geoNear = function geoNear(x, y, options, callback) {
-  var args = Array.prototype.slice.call(arguments, 2);
+  var point = typeof(x) == 'object' && x
+    , args = Array.prototype.slice.call(arguments, point?1:2);
+
   callback = args.pop();
   // Fetch all commands
   options = args.length ? args.shift() || {} : {};
@@ -10,7 +12,7 @@ var geoNear = function geoNear(x, y, options, callback) {
   // Build command object
   var commandObject = {
     geoNear:this.collectionName,
-    near: [x, y]
+    near: point || [x, y]
   }
 
   // Ensure we have the right read preference inheritance


### PR DESCRIPTION
Modified the collection.geoNear method to support a geoJSON point or legacy coordinate pair; currently only a legacy coordinate pair is supported.
