### PR TITLE
Provides fullResult even in an error state which is useful in Bulk inser...

### DIFF
--- a/lib/mongodb/collection/core.js
+++ b/lib/mongodb/collection/core.js
@@ -114,6 +114,8 @@ var insertWithWriteCommands = function(self, docs, options, callback) {
           var error = utils.toError(result.writeErrors[0].errmsg);
           error.code = result.writeErrors[0].code;
           error.err = result.writeErrors[0].errmsg;
+          
+          if (fullResult) return callback(error, result.getRawResponse());
           // Return the error
           return callback(error, null);
         }
@@ -141,6 +143,8 @@ var insertWithWriteCommands = function(self, docs, options, callback) {
           var error = result.getWriteErrors()[0];
           error.code = result.getWriteErrors()[0].code;
           error.err = result.getWriteErrors()[0].errmsg;        
+          
+          if (fullResult) return callback(error, result.getRawResponse());
           // Return the error
           return callback(error, null);
         }


### PR DESCRIPTION
This pull ensures that fullResult is respected and the `writeResult` is available even in the case that an error state has been encountered.

Take the following example for why this matters:

``` js
collection.insert([
    { foo : "foo1" },
    { foo : "foo2" },
    { _id : duplicateId, foo : "foo3" },
    { _id : duplicateId2, foo : "foo4" },
    { foo : "foo4" }
], { fullResult : true, keepGoing : true }, function(err, result) {
    // do something
});
```

In that case, documents 1,2,5 were successfully inserted into the DB. Documents 3,4 failed. Using the `err` alone I can't glean this information. But with the `writeResult` available, I can iterate through the `result.writeErrors` and reconcile the differences.

In non-keepGoing calls I can use the `err.index` to figure out which docs inserted and which didn't (since it halts at first failure), but I figure that providing the `writeResult` in all cases of `fullResult : true` will make a more consistent API.
