### PR TITLE
Check _bsonType for Binary

### DIFF
--- a/lib/mongodb/gridfs/chunk.js
+++ b/lib/mongodb/gridfs/chunk.js
@@ -36,7 +36,7 @@ var Chunk = exports.Chunk = function(file, mongoObject, writeConcern) {
     var buffer = new Buffer(mongoObjectFinal.data.length);
     buffer.write(mongoObjectFinal.data.join(''), 'binary', 0);
     this.data = new Binary(buffer);
-  } else if(mongoObjectFinal.data instanceof Binary || Object.prototype.toString.call(mongoObjectFinal.data) == "[object Binary]") {
+  } else if(mongoObjectFinal.data instanceof Binary || mongoObjectFinal.data._bsontype === 'Binary' || Object.prototype.toString.call(mongoObjectFinal.data) == "[object Binary]") {
     this.data = mongoObjectFinal.data;
   } else if(Buffer.isBuffer(mongoObjectFinal.data)) {
   } else {


### PR DESCRIPTION
This fixes a problem that I had which was very similar to http://stackoverflow.com/questions/11529458/mongodb-gridfs-illegal-chunk-format-exception?lq=1 except that I could not find any duplication.  

Unfortunately I couldn't get the tests to work (Error: ENOENT, no such file or directory '/home/mark/Projects/node-mongodb-native/data/data-27017/mongod.lock') even before I made the edit.
