### PR TITLE
Force the projection argument for find/findOne

### DIFF
--- a/lib/mongodb/collection/query.js
+++ b/lib/mongodb/collection/query.js
@@ -6,48 +6,23 @@ var ObjectID = require('bson').ObjectID
   , shared = require('./shared')
   , utils = require('../utils');
 
-var testForFields = {
-    limit: 1, sort: 1, fields:1, skip: 1, hint: 1, explain: 1, snapshot: 1, timeout: 1, tailable: 1, tailableRetryInterval: 1
-  , numberOfRetries: 1, awaitdata: 1, exhaust: 1, batchSize: 1, returnKey: 1, maxScan: 1, min: 1, max: 1, showDiskLoc: 1
-  , comment: 1, raw: 1, readPreference: 1, partial: 1, read: 1, dbName: 1, oplogReplay: 1, connection: 1
-};
-
 //
 // Find method
 //
 var find = function find () {
-  var options
-    , args = Array.prototype.slice.call(arguments, 0)
+  var args = Array.prototype.slice.call(arguments, 0)
     , has_callback = typeof args[args.length - 1] === 'function'
     , has_weird_callback = typeof args[0] === 'function'
     , callback = has_callback ? args.pop() : (has_weird_callback ? args.shift() : null)
     , len = args.length
     , selector = len >= 1 ? args[0] : {}
-    , fields = len >= 2 ? args[1] : undefined;
+    , fields = len >= 2 ? args[1] : undefined
+    , options = len >= 3 ? args[2] : undefined;
 
   if(len === 1 && has_weird_callback) {
     // backwards compat for callback?, options case
     selector = {};
     options = args[0];
-  }
-
-  if(len === 2 && !Array.isArray(fields)) {
-    var fieldKeys = Object.getOwnPropertyNames(fields);
-    var is_option = false;
-
-    for(var i = 0; i < fieldKeys.length; i++) {
-      if(testForFields[fieldKeys[i]] != null) {
-        is_option = true;
-        break;
-      }
-    }
-
-    if(is_option) {
-      options = fields;
-      fields = undefined;
-    } else {
-      options = {};
-    }
   } else if(len === 2 && Array.isArray(fields) && !Array.isArray(fields[0])) {
     var newFields = {};
     // Rewrite the array
@@ -56,10 +31,6 @@ var find = function find () {
     }
     // Set the fields
     fields = newFields;
-  }
-
-  if(3 === len) {
-    options = args[2];
   }
 
   // Ensure selector is not null

--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -174,7 +174,7 @@ var _open = function(self, options, callback) {
 
   // Fetch the chunks
   if(query != null) {
-    collection.find(query, options, function(err, cursor) {
+    collection.find(query, {}, options, function(err, cursor) {
       if(err) return error(err);
 
       // Fetch the file
@@ -584,7 +584,7 @@ var nthChunk = function(self, chunkNumber, options, callback) {
   options = options || self.writeConcern;
   options.readPreference = self.readPreference;
   // Get the nth chunk
-  self.chunkCollection().find({'files_id':self.fileId, 'n':chunkNumber}, options, function(err, cursor) {
+  self.chunkCollection().find({'files_id':self.fileId, 'n':chunkNumber}, {}, options, function(err, cursor) {
     if(err) return callback(err);
 
     cursor.nextObject(function(err, chunk) {
@@ -1026,7 +1026,7 @@ GridStore.exist = function(db, fileIdObject, rootCollection, options, callback) 
       ? {'filename':fileIdObject}
       : {'_id':fileIdObject};    // Attempt to locate file
 
-    collection.find(query, {readPreference:readPreference}, function(err, cursor) {
+    collection.find(query, {}, {readPreference:readPreference}, function(err, cursor) {
       if(err) return callback(err);
 
       cursor.nextObject(function(err, item) {
@@ -1068,7 +1068,7 @@ GridStore.list = function(db, rootCollection, options, callback) {
   db.collection((rootCollectionFinal + ".files"), function(err, collection) {
     if(err) return callback(err);
 
-    collection.find({}, {readPreference:readPreference}, function(err, cursor) {
+    collection.find({}, {}, {readPreference:readPreference}, function(err, cursor) {
       if(err) return callback(err);
 
       cursor.each(function(err, item) {

--- a/test/tests/functional/cursor_tests.js
+++ b/test/tests/functional/cursor_tests.js
@@ -160,11 +160,11 @@ exports.shouldCorrectlyExecuteCursorCount = function(configuration, test) {
               test.ok(count.constructor == Number);
             });
 
-            collection.find({}, {'limit':5}).count(function(err, count) {
+            collection.find({}, {}, {'limit':5}).count(function(err, count) {
               test.equal(10, count);
             });
 
-            collection.find({}, {'skip':5}).count(function(err, count) {
+            collection.find({}, {}, {'skip':5}).count(function(err, count) {
               test.equal(10, count);
             });
 
@@ -647,7 +647,7 @@ exports.shouldCorrectlyHandleChangesInBatchSizes = function(configuration, test)
       }
 
       collection.insert(docs, {w:1}, function() {
-        collection.find({}, {batchSize : batchSize}, function(err, cursor) {
+        collection.find({}, {}, {batchSize : batchSize}, function(err, cursor) {
           //1st
           cursor.nextObject(function(err, items) {
             //cursor.items should contain 1 since nextObject already popped one
@@ -720,7 +720,7 @@ exports.shouldCorrectlyHandleBatchSize = function(configuration, test) {
       }
 
       collection.insert(docs, {w:1}, function() {
-        collection.find({}, {batchSize : batchSize}, function(err, cursor) {
+        collection.find({}, {}, {batchSize : batchSize}, function(err, cursor) {
           //1st
           cursor.nextObject(function(err, items) {
             test.equal(1, cursor.items.length);
@@ -776,7 +776,7 @@ exports.shouldHandleWhenLimitBiggerThanBatchSize = function(configuration, test)
       }
 
       collection.insert(docs, {w:1}, function() {
-        var cursor = collection.find({}, {batchSize : batchSize, limit : limit});
+        var cursor = collection.find({}, {}, {batchSize : batchSize, limit : limit});
         //1st
         cursor.nextObject(function(err, items) {
           test.equal(2, cursor.items.length);
@@ -827,7 +827,7 @@ exports.shouldHandleLimitLessThanBatchSize = function(configuration, test) {
       }
 
       collection.insert(docs, {w:1}, function() {
-        var cursor = collection.find({}, {batchSize : batchSize, limit : limit});
+        var cursor = collection.find({}, {}, {batchSize : batchSize, limit : limit});
         //1st
         cursor.nextObject(function(err, items) {
           test.equal(1, cursor.items.length);
@@ -983,7 +983,7 @@ exports.shouldCorrectlyRefillViaGetMoreCommand = function(configuration, test) {
 
           var total = 0;
           var i = 0;
-          var cursor = collection.find({}, {}).each(function(err, item) {
+          var cursor = collection.find({}, {}, {}).each(function(err, item) {
           if(item != null) {
             total = total + item.a;
           } else {
@@ -1114,13 +1114,13 @@ exports.shouldCorrectlyExecuteCursorCountWithFields = function(configuration, te
   db.open(function(err, db) {
     db.createCollection('test_count_with_fields', function(err, collection) {
       collection.save({'x':1, 'a':2}, {w:1}, function(err, doc) {
-        collection.find({}, {'fields':['a']}).toArray(function(err, items) {
+        collection.find({}, {}, {'fields':['a']}).toArray(function(err, items) {
           test.equal(1, items.length);
           test.equal(2, items[0].a);
           test.equal(null, items[0].x);
         });
 
-        collection.findOne({}, {'fields':['a']}, function(err, item) {
+        collection.findOne({}, {}, {'fields':['a']}, function(err, item) {
           test.equal(2, item.a);
           test.equal(null, item.x);
           db.close();
@@ -1140,7 +1140,7 @@ exports.shouldCorrectlyCountWithFieldsUsingExclude = function(configuration, tes
   db.open(function(err, db) {
     db.createCollection('test_count_with_fields_using_exclude', function(err, collection) {
       collection.save({'x':1, 'a':2}, {w:1}, function(err, doc) {
-        collection.find({}, {'fields':{'x':0}}).toArray(function(err, items) {
+        collection.find({}, {}, {'fields':{'x':0}}).toArray(function(err, items) {
           test.equal(1, items.length);
           test.equal(2, items[0].a);
           test.equal(null, items[0].x);
@@ -1524,7 +1524,7 @@ exports['cursor stream errors'] = {
             , closed = 0
             , i = 0
 
-          var stream = collection.find({}, { batchSize: 5 }).stream();
+          var stream = collection.find({}, {}, { batchSize: 5 }).stream();
 
           stream.on('data', function (doc) {
             if (++i === 5) {
@@ -2005,7 +2005,7 @@ exports.shouldCloseDeadTailableCursors = function(configuration, test) {
 
       insert(function query () {
         var conditions = { id: { $gte: lastId }};
-        var stream = collection.find(conditions, { tailable: true }).stream();
+        var stream = collection.find(conditions, {}, { tailable: true }).stream();
 
         stream.on('data', function (doc) {
           lastId = doc.id;
@@ -2049,7 +2049,7 @@ exports.shouldAwaitData = function(configuration, test) {
     db.createCollection('should_await_data', options, function(err, collection) {
       collection.insert({a:1}, {w:1}, function(err, result) {
         // Create cursor with awaitdata, and timeout after the period specified
-        collection.find({}, {tailable:true, awaitdata:true, numberOfRetries:1}).each(function(err, result) {
+        collection.find({}, {}, {tailable:true, awaitdata:true, numberOfRetries:1}).each(function(err, result) {
           if(err != null) {
             db.close();
             test.done();
@@ -2072,7 +2072,7 @@ exports.shouldNotAwaitDataWhenFalse = function(configuration, test) {
     db.createCollection('should_not_await_data_when_false', options, function(err, collection) {
       collection.insert({a:1}, {w:1}, function(err, result) {
         // should not timeout
-        collection.find({}, {tailable:true, awaitdata:false}).each(function(err, result) {
+        collection.find({}, {}, {tailable:true, awaitdata:false}).each(function(err, result) {
           if(err != null) {
 	    test.equal("Error: Connection was destroyed by application", err);
           }
@@ -2320,7 +2320,7 @@ exports.shouldFailToTailANormalCollection = function(configuration, test) {
     for(var i = 0; i < 100; i++) docs.push({a:i, OrderNumber:i});
 
     collection.insert(docs, {w:1}, function(err, ids) {
-      collection.find({}, {tailable:true}).each(function(err, doc) {
+      collection.find({}, {}, {tailable:true}).each(function(err, doc) {
         test.ok(err instanceof Error);
         db.close();
         test.done();
@@ -2442,25 +2442,25 @@ exports['should correctly apply hint to count command for cursor'] = {
         col.ensureIndex({i:1}, function(err, r) {
           test.equal(null, err);
 
-          col.find({i:1}, {hint: "_id_"}).count(function(err, count) {
+          col.find({i:1}, {}, {hint: "_id_"}).count(function(err, count) {
             test.equal(null, err);
             test.equal(1, count);
 
-            col.find({}, {hint: "_id_"}).count(function(err, count) {
+            col.find({}, {}, {hint: "_id_"}).count(function(err, count) {
               test.equal(null, err);
               test.equal(2, count);
 
-              col.find({i:1}, {hint: "BAD HINT"}).count(function(err, count) {
+              col.find({i:1}, {}, {hint: "BAD HINT"}).count(function(err, count) {
                 test.ok(err != null);
 
                 col.ensureIndex({x:1}, {sparse:true}, function(err, r) {
                   test.equal(null, err);
 
-                  col.find({i:1}, {hint: "x_1"}).count(function(err, count) {
+                  col.find({i:1}, {}, {hint: "x_1"}).count(function(err, count) {
                     test.equal(null, err);
                     test.equal(0, count);
 
-                    col.find({}, {hint: "x_1"}).count(function(err, count) {
+                    col.find({}, {}, {hint: "x_1"}).count(function(err, count) {
                       test.equal(null, err);
                       test.equal(2, count);
 

--- a/test/tests/functional/find_tests.js
+++ b/test/tests/functional/find_tests.js
@@ -191,7 +191,7 @@ exports.shouldCorrectlyPerformFindWithSort = function(configuration, test) {
             doc4 = docs[3]
 
             // Test sorting (ascending)
-            collection.find({'a': {'$lt':10}}, {'sort': [['a', 1]]}).toArray(function(err, documents) {
+            collection.find({'a': {'$lt':10}}, {}, {'sort': [['a', 1]]}).toArray(function(err, documents) {
               test.equal(4, documents.length);
               test.equal(1, documents[0].a);
               test.equal(2, documents[1].a);
@@ -199,7 +199,7 @@ exports.shouldCorrectlyPerformFindWithSort = function(configuration, test) {
               test.equal(4, documents[3].a);
 
               // Test sorting (descending)
-              collection.find({'a': {'$lt':10}}, {'sort': [['a', -1]]}).toArray(function(err, documents) {
+              collection.find({'a': {'$lt':10}}, {}, {'sort': [['a', -1]]}).toArray(function(err, documents) {
                 test.equal(4, documents.length);
                 test.equal(4, documents[0].a);
                 test.equal(3, documents[1].a);
@@ -207,7 +207,7 @@ exports.shouldCorrectlyPerformFindWithSort = function(configuration, test) {
                 test.equal(1, documents[3].a);
 
                 // Test sorting (descending), sort is hash
-                collection.find({'a': {'$lt':10}}, {sort: {a: -1}}).toArray(function(err, documents) {
+                collection.find({'a': {'$lt':10}}, {}, {sort: {a: -1}}).toArray(function(err, documents) {
                   test.equal(4, documents.length);
                   test.equal(4, documents[0].a);
                   test.equal(3, documents[1].a);
@@ -215,7 +215,7 @@ exports.shouldCorrectlyPerformFindWithSort = function(configuration, test) {
                   test.equal(1, documents[3].a);
 
                   // Sorting using array of names, assumes ascending order
-                  collection.find({'a': {'$lt':10}}, {'sort': ['a']}).toArray(function(err, documents) {
+                  collection.find({'a': {'$lt':10}}, {}, {'sort': ['a']}).toArray(function(err, documents) {
                     test.equal(4, documents.length);
                     test.equal(1, documents[0].a);
                     test.equal(2, documents[1].a);
@@ -223,7 +223,7 @@ exports.shouldCorrectlyPerformFindWithSort = function(configuration, test) {
                     test.equal(4, documents[3].a);
 
                     // Sorting using single name, assumes ascending order
-                    collection.find({'a': {'$lt':10}}, {'sort': 'a'}).toArray(function(err, documents) {
+                    collection.find({'a': {'$lt':10}}, {}, {'sort': 'a'}).toArray(function(err, documents) {
                       test.equal(4, documents.length);
                       test.equal(1, documents[0].a);
                       test.equal(2, documents[1].a);
@@ -231,14 +231,14 @@ exports.shouldCorrectlyPerformFindWithSort = function(configuration, test) {
                       test.equal(4, documents[3].a);
 
                       // Sorting using single name, assumes ascending order, sort is hash
-                      collection.find({'a': {'$lt':10}}, {sort: {'a':1}}).toArray(function(err, documents) {
+                      collection.find({'a': {'$lt':10}}, {}, {sort: {'a':1}}).toArray(function(err, documents) {
                         test.equal(4, documents.length);
                         test.equal(1, documents[0].a);
                         test.equal(2, documents[1].a);
                         test.equal(3, documents[2].a);
                         test.equal(4, documents[3].a);
 
-                        collection.find({'a': {'$lt':10}}, {'sort': ['b', 'a']}).toArray(function(err, documents) {
+                        collection.find({'a': {'$lt':10}}, {}, {'sort': ['b', 'a']}).toArray(function(err, documents) {
                           test.equal(4, documents.length);
                           test.equal(2, documents[0].a);
                           test.equal(4, documents[1].a);
@@ -246,12 +246,12 @@ exports.shouldCorrectlyPerformFindWithSort = function(configuration, test) {
                           test.equal(3, documents[3].a);
 
                           // Sorting using empty array, no order guarantee should not blow up
-                          collection.find({'a': {'$lt':10}}, {'sort': []}).toArray(function(err, documents) {
+                          collection.find({'a': {'$lt':10}}, {}, {'sort': []}).toArray(function(err, documents) {
                             test.equal(4, documents.length);
 
                             /* NONACTUAL */
                             // Sorting using ordered hash
-                            collection.find({'a': {'$lt':10}}, {'sort': {a:-1}}).toArray(function(err, documents) {
+                            collection.find({'a': {'$lt':10}}, {}, {'sort': {a:-1}}).toArray(function(err, documents) {
                               // Fail test if not an error
                               test.equal(4, documents.length);
                               // Let's close the db
@@ -295,27 +295,27 @@ exports.shouldCorrectlyPerformFindWithLimit = function(configuration, test) {
             doc4 = docs[3]
 
             // Test limits
-            collection.find({}, {'limit': 1}).toArray(function(err, documents) {
+            collection.find({}, {}, {'limit': 1}).toArray(function(err, documents) {
               test.equal(1, documents.length);
             });
 
-            collection.find({}, {'limit': 2}).toArray(function(err, documents) {
+            collection.find({}, {}, {'limit': 2}).toArray(function(err, documents) {
               test.equal(2, documents.length);
             });
 
-            collection.find({}, {'limit': 3}).toArray(function(err, documents) {
+            collection.find({}, {}, {'limit': 3}).toArray(function(err, documents) {
               test.equal(3, documents.length);
             });
 
-            collection.find({}, {'limit': 4}).toArray(function(err, documents) {
+            collection.find({}, {}, {'limit': 4}).toArray(function(err, documents) {
               test.equal(4, documents.length);
             });
 
-            collection.find({}, {}).toArray(function(err, documents) {
+            collection.find({}, {}, {}).toArray(function(err, documents) {
               test.equal(4, documents.length);
             });
 
-            collection.find({}, {'limit':99}).toArray(function(err, documents) {
+            collection.find({}, {}, {'limit':99}).toArray(function(err, documents) {
               test.equal(4, documents.length);
               // Let's close the db
               db.close();
@@ -394,7 +394,7 @@ exports.shouldCorrectlyFindNoRecords = function(configuration, test) {
   db.open(function(err, db) {
     db.createCollection('test_find_one_no_records', function(err, r) {
       db.collection('test_find_one_no_records', function(err, collection) {
-        collection.find({'a':1}, {}).toArray(function(err, documents) {
+        collection.find({'a':1}, {}, {}).toArray(function(err, documents) {
           test.equal(0, documents.length);
           // Let's close the db
           db.close();
@@ -445,15 +445,15 @@ exports.shouldCorrectlyPerformFindsWithHintTurnedOn = function(configuration, te
     db.createCollection('test_hint', function(err, collection) {
       collection.insert({'a':1}, {w:1}, function(err, ids) {
         db.createIndex(collection.collectionName, "a", {w:1}, function(err, indexName) {
-          collection.find({'a':1}, {'hint':'a'}).toArray(function(err, items) {
+          collection.find({'a':1}, {}, {'hint':'a'}).toArray(function(err, items) {
             test.equal(1, items.length);
           });
 
-          collection.find({'a':1}, {'hint':['a']}).toArray(function(err, items) {
+          collection.find({'a':1}, {}, {'hint':['a']}).toArray(function(err, items) {
             test.equal(1, items.length);
           });
 
-          collection.find({'a':1}, {'hint':{'a':1}}).toArray(function(err, items) {
+          collection.find({'a':1}, {}, {'hint':{'a':1}}).toArray(function(err, items) {
             test.equal(1, items.length);
           });
 
@@ -536,7 +536,7 @@ exports.shouldCorrectlyReturnDocumentWithOriginalStructure= function(configurati
       };
 
       collection.insert(doc, {w:1}, function(err, docs) {
-        collection.findOne({'_id':doc._id}, {w:1,fields: undefined}, function(err, doc) {
+        collection.findOne({'_id':doc._id}, {}, {w:1,fields: undefined}, function(err, doc) {
           if (err) console.error('error', err);
           test.equal(2, doc.comments.length);
           test.equal('number 1', doc.comments[0].title);
@@ -960,10 +960,10 @@ exports['Should correctly pass timeout options to cursor'] = function(configurat
   var db = configuration.newDbInstance({w:1}, {poolSize:1});
   db.open(function(err, db) {
     db.createCollection('timeoutFalse', function(err, collection) {
-      collection.find({},{timeout:false},function(err, cursor) {
+      collection.find({},{},{timeout:false},function(err, cursor) {
         test.equal(false, cursor.timeout);
       });
-      collection.find({},{timeout:true},function(err, cursor) {
+      collection.find({},{},{timeout:true},function(err, cursor) {
         test.equal(true, cursor.timeout);
       });
       collection.find({},{},function(err, cursor) {
@@ -1127,12 +1127,12 @@ exports['Should Correctly find a Document using findOne excluding _id field'] = 
       // insert doc
       collection.insert(doc, {w:1}, function(err, result) {
         // Get one document, excluding the _id field
-        collection.findOne({a:1}, {fields:{'_id': 0}}, function(err, item) {
+        collection.findOne({a:1}, {}, {fields:{'_id': 0}}, function(err, item) {
           test.equal(null, item._id);
           test.equal(1, item.a);
           test.equal(2, item.c);
 
-          collection.find({a:1}, {fields:{'_id':0}}).toArray(function(err, items) {
+          collection.find({a:1}, {}, {fields:{'_id':0}}).toArray(function(err, items) {
             var item = items[0]
             test.equal(null, item._id);
             test.equal(1, item.a);
@@ -1617,7 +1617,7 @@ exports.shouldPeformASimpleExplainQuery = function(configuration, test) {
         test.equal(null, err);
 
         // Peform a simple find and return all the documents
-        collection.find({}, {explain:true}).toArray(function(err, docs) {
+        collection.find({}, {}, {explain:true}).toArray(function(err, docs) {
           test.equal(null, err);
           test.equal(1, docs.length);
 
@@ -1653,7 +1653,7 @@ exports.shouldPeformASimpleLimitSkipQuery = function(configuration, test) {
         test.equal(null, err);
 
         // Peform a simple find and return all the documents
-        collection.find({}, {skip:1, limit:1, fields:{b:1}}).toArray(function(err, docs) {
+        collection.find({}, {}, {skip:1, limit:1, fields:{b:1}}).toArray(function(err, docs) {
           test.equal(null, err);
           test.equal(1, docs.length);
           test.equal(null, docs[0].a);
@@ -1710,7 +1710,7 @@ exports.shouldPeformASimpleLimitSkipFindOneQuery = function(configuration, test)
         test.equal(null, err);
 
         // Peform a simple find and return all the documents
-        collection.findOne({a:2}, {fields:{b:1}}, function(err, doc) {
+        collection.findOne({a:2}, {}, {fields:{b:1}}, function(err, doc) {
           test.equal(null, err);
           test.equal(null, doc.a);
           test.equal(2, doc.b);
@@ -1782,7 +1782,7 @@ exports.shouldPeformASimpleLimitSkipFindWithFields2 = function(configuration, te
         test.equal(null, err);
 
         // Peform a simple find and return all the documents
-        collection.find({a:2}, {fields: ['b']}).toArray(function(err, docs) {
+        collection.find({a:2}, {}, {fields: ['b']}).toArray(function(err, docs) {
           test.equal(null, err);
           test.equal(1, docs.length);
           test.equal(null, docs[0].a);
@@ -2031,7 +2031,7 @@ exports.shouldCorrectlyDoFindMinMax = function(configuration, test) {
           test.equal(null, err);
           test.equal(10, docs[0].max)
 
-          collection.find({"_id": {$in:['some', 'value', 123]}}, {fields: {"_id":1, "max":1}}).toArray(function(err, docs) {        
+          collection.find({"_id": {$in:['some', 'value', 123]}}, {}, {fields: {"_id":1, "max":1}}).toArray(function(err, docs) {        
             test.equal(null, err);
             test.equal(10, docs[0].max)
 
@@ -2346,6 +2346,7 @@ exports['Should correctly sort using text search on 2.6 or higher in find'] = {
 
             collection.find(
                 {$text: {$search: 'spam'}}
+              , {}
               , {fields: {_id: false, s: true, score: {$meta: 'textScore'}}}
             ).sort({score: {$meta: 'textScore'}}).toArray(function(err, items) {
               test.equal(null, err);

--- a/test/tests/functional/index_tests.js
+++ b/test/tests/functional/index_tests.js
@@ -25,7 +25,7 @@ exports.shouldCreateASimpleIndexOnASingleField = function(configuration, test) {
           test.equal("a_1", indexName);
 
           // Peform a query, with explain to show we hit the query
-          collection.find({a:2}, {explain:true}).toArray(function(err, explanation) {
+          collection.find({a:2}, {}, {explain:true}).toArray(function(err, explanation) {
             test.equal(null, err);
             test.ok(explanation != null);
 
@@ -770,7 +770,7 @@ exports['should correctly apply hint to find'] = function(configuration, test) {
         collection.indexInformation({full:false}, function(err, indexInformation) {
           test.equal(null, err);
 
-          collection.find({}, {hint:"a_1"}).toArray(function(err, docs) {
+          collection.find({}, {}, {hint:"a_1"}).toArray(function(err, docs) {
             test.equal(null, err);
             test.equal(1, docs[0].a);
             db.close();

--- a/test/tests/functional/insert_tests.js
+++ b/test/tests/functional/insert_tests.js
@@ -1578,7 +1578,7 @@ exports.shouldCorrectlyInsertSimpleRegExpDocument = function(configuration, test
   db.open(function(err, db) {
     db.createCollection('test_regex', function(err, collection) {
       collection.insert({'b':regexp}, {w:1}, function(err, ids) {
-        collection.find({}, {'fields': ['b']}).toArray(function(err, items) {
+        collection.find({}, {}, {'fields': ['b']}).toArray(function(err, items) {
           test.equal(("" + regexp), ("" + items[0].b));
           // Let's close the db
           db.close();
@@ -1599,7 +1599,7 @@ exports.shouldCorrectlyInsertSimpleUTF8Regexp = function(configuration, test) {
     collection.insert({'b':regexp}, {w:1}, function(err, ids) {
       test.equal(null, err)
 
-      collection.find({}, {'fields': ['b']}).toArray(function(err, items) {
+      collection.find({}, {}, {'fields': ['b']}).toArray(function(err, items) {
         test.equal(null, err)
         test.equal(("" + regexp), ("" + items[0].b));
         // Let's close the db

--- a/test/tests/functional/raw_tests.js
+++ b/test/tests/functional/raw_tests.js
@@ -20,7 +20,7 @@ exports.shouldCorrectlySaveDocumentsAndReturnAsRaw = function(configuration, tes
           test.equal(2.3, objects[2].c);
           
           // Execute findOne
-          collection.findOne({a:1}, {raw:true}, function(err, item) {
+          collection.findOne({a:1}, {}, {raw:true}, function(err, item) {
             test.ok(Buffer.isBuffer(item));
             var object = db.bson.deserialize(item);
             test.equal(1, object.a)            

--- a/test/tests/functional/unicode_tests.js
+++ b/test/tests/functional/unicode_tests.js
@@ -121,7 +121,7 @@ exports.shouldCorrectlyHandleUT8KeyNames = function(configuration, test) {
     db.createCollection('test_utf8_key_name', function(err, collection) { 
       collection.insert({'šđžčćŠĐŽČĆ':1}, {w:1}, function(err, ids) { 
             // finished_test({test_utf8_key_name:'ok'}); 
-        collection.find({}, {'fields': ['šđžčćŠĐŽČĆ']}).toArray(function(err, items) { 
+        collection.find({}, {}, {'fields': ['šđžčćŠĐŽČĆ']}).toArray(function(err, items) { 
           test.equal(1, items[0]['šđžčćŠĐŽČĆ']); 
           // Let's close the db 
           db.close();


### PR DESCRIPTION
This pull request requires that the optional options argument should always be the 3rd argument. This means that if you do not want to specify any fields (aka projection), you will have to provide an empty hash:

Before:

``` javascript
collection.find(query, options, callback);
```

Now:

``` javascript
collection.find(query, {}, options, callback);
```

Ok, I'll admit that this is an opinionated and breaking change. But first let me demonstrate the problem I encountered that let me to propose this change:

I had a collection with a set of documents that each looked roughly like so:

``` javascript
{ _id: 1, name: "foo", max: 1000, min: 50, foo: "...", bar: "..." }
```

Now I did a query to get all `name`, `max` and `min` for each document:

``` javascript
collection.find({}, { _id: 0, name: 1, max: 1, min: 1 }, callback);
```

Instead of getting an array of documents in the callback, the mongo driver (v1.4.10) instead threw an error:

```
MongoError: Can't canonicalize query: BadValue $max must be a BSONObj
    at Object.toError (/tmp/node_modules/mongodb/lib/mongodb/utils.js:114:11)
    at /tmp/node_modules/mongodb/lib/mongodb/cursor.js:703:54
    at Cursor.close (/tmp/node_modules/mongodb/lib/mongodb/cursor.js:986:5)
    at commandHandler (/tmp/node_modules/mongodb/lib/mongodb/cursor.js:703:21)
    at /tmp/node_modules/mongodb/lib/mongodb/db.js:1847:9
    at Server.Base._callHandler (/tmp/node_modules/mongodb/lib/mongodb/connection/base.js:445:41)
    at /tmp/node_modules/mongodb/lib/mongodb/connection/server.js:478:18
    at MongoReply.parseBody (/tmp/node_modules/mongodb/lib/mongodb/responses/mongo_reply.js:68:5)
    at null.<anonymous> (/tmp/node_modules/mongodb/lib/mongodb/connection/server.js:436:20)
    at emit (events.js:95:17)
```

Researching it, I found that there exists [a secret list of magic property names](https://github.com/mongodb/node-mongodb-native/blob/927692e43c90d16832f8b1b3789c472b5df4ddfd/lib/mongodb/collection/query.js#L10-L12) that if used in a projection will treat that projection as an options argument instead. And of cause if you treat `{ _id: 0, name: 1, max: 1, min: 1 }` as options, weird things are bound to happen.

This behaviour is both undocumented (as far as I can see) and works differently than how the same command would work if entered into the mongo console.

A solution to this is easy, just change the above command to the following (notice the extra `{}`):

``` javascript
collection.find({}, { _id: 0, name: 1, max: 1, min: 1 }, {}, callback);
```

By explicitly giving `find` an empty options hash you overwrite the magic behaviour - but this took quite some digging and I would expect this to be the source of a lot of frustration out there.

I know this might not make it into master, but hopefully we can at least have a discussion about the issue and how this confusion can be avoided in other ways. I apologies in advance if this have already been discussed elsewhere, but I couldn't find any mention of it.
