### PR TITLE
Error message when calling db.collection in strict mode without a callback isn't descriptive

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -537,6 +537,9 @@ Db.prototype.collection = function(collectionName, options, callback) {
   }
 
   // Strict mode
+  if ( !callback )
+      throw utils.toError(f("A callback is required in strict mode. While getting collection %s.", collectionName));
+
   self.listCollections(collectionName, function(err, collections) {
     if(err != null) return callback(err, null);
     if(collections.length == 0) return callback(utils.toError(f("Collection %s does not exist. Currently in strict mode.", collectionName)), null);


### PR DESCRIPTION
I'm doing this while trying to figure out mongo:

``` javascript
var collection = db.collection('someStuff', {strict:true});
if ( !collection ) {
    db.createCollection('someStuff', function ( e, r ) {
        db.close();
    });
};
```

I realize (now) that I'm not supposed to be assigning the return in strict mode. I'm flagging the way that the error is reported.

```
C:\TryMongo\node_modules\mongodb\lib\mongodb\connection\base.js:246
        throw message;
              ^
TypeError: undefined is not a function
    at C:\TryMongo\node_modules\mongodb\lib\mongodb\db.js:548:40
    at C:\TryMongo\node_modules\mongodb\lib\mongodb\db.js:456:7
    at C:\TryMongo\node_modules\mongodb\lib\mongodb\cursor.js:172:16
    at commandHandler (C:\TryMongo\node_modules\mongodb\lib\mongodb\cursor.js:720:16)
    at C:\TryMongo\node_modules\mongodb\lib\mongodb\db.js:1923:9
    at Server.Base._callHandler (C:\TryMongo\node_modules\mongodb\lib\mongodb\connection\base.js:448:41)
    at C:\TryMongo\node_modules\mongodb\lib\mongodb\connection\server.js:481:18
    at MongoReply.parseBody (C:\TryMongo\node_modules\mongodb\lib\mongodb\responses\mongo_reply.js:68:5)
    at null.<anonymous> (C:\TryMongo\node_modules\mongodb\lib\mongodb\connection\server.js:439:20)
    at emit (events.js:95:17)
```

The issue is that no callback is passed to Db.prototype.collection.
So the thrown error, in self.listCollection(,  is 'undefined is not a function' instead of something like 'callbacks are required in strict mode'

I've simply added a throw with a descriptive message if !callback.

Was:

``` javascript
  // Strict mode
  self.listCollections(collectionName, function(err, collections) {
```

Is

``` javascript
  // Strict mode
  if ( !callback )
      throw utils.toError(f("A callback is required in strict mode. While getting collection %s.", collectionName));

  self.listCollections(collectionName, function(err, collections) {
```
