### PR TITLE
Use findOne instead of find followed by nextObject

### DIFF
--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -174,69 +174,64 @@ var _open = function(self, options, callback) {
 
   // Fetch the chunks
   if(query != null) {
-    collection.find(query, options, function(err, cursor) {
+    collection.findOne(query, options, function(err, doc) {
       if(err) return error(err);
 
-      // Fetch the file
-      cursor.nextObject(function(err, doc) {
-        if(err) return error(err);
+      // Check if the collection for the files exists otherwise prepare the new one
+      if(doc != null) {
+        self.fileId = doc._id;
+        // Prefer a new filename over the existing one if this is a write
+        self.filename = ((self.mode == 'r') || (self.filename == undefined)) ? doc.filename : self.filename;
+        self.contentType = doc.contentType;
+        self.internalChunkSize = doc.chunkSize;
+        self.uploadDate = doc.uploadDate;
+        self.aliases = doc.aliases;
+        self.length = doc.length;
+        self.metadata = doc.metadata;
+        self.internalMd5 = doc.md5;
+      } else if (self.mode != 'r') {
+        self.fileId = self.fileId == null ? new ObjectID() : self.fileId;
+        self.contentType = exports.GridStore.DEFAULT_CONTENT_TYPE;
+        self.internalChunkSize = self.internalChunkSize == null ? Chunk.DEFAULT_CHUNK_SIZE : self.internalChunkSize;
+        self.length = 0;
+      } else {
+        self.length = 0;
+        var txtId = self.fileId instanceof ObjectID ? self.fileId.toHexString() : self.fileId;
+        return error(new Error((self.referenceBy == REFERENCE_BY_ID ? txtId : self.filename) + " does not exist", self));
+      }
 
-        // Check if the collection for the files exists otherwise prepare the new one
-        if(doc != null) {
-          self.fileId = doc._id;
-          // Prefer a new filename over the existing one if this is a write
-          self.filename = ((self.mode == 'r') || (self.filename == undefined)) ? doc.filename : self.filename;
-          self.contentType = doc.contentType;
-          self.internalChunkSize = doc.chunkSize;
-          self.uploadDate = doc.uploadDate;
-          self.aliases = doc.aliases;
-          self.length = doc.length;
-          self.metadata = doc.metadata;
-          self.internalMd5 = doc.md5;
-        } else if (self.mode != 'r') {
-          self.fileId = self.fileId == null ? new ObjectID() : self.fileId;
-          self.contentType = exports.GridStore.DEFAULT_CONTENT_TYPE;
-          self.internalChunkSize = self.internalChunkSize == null ? Chunk.DEFAULT_CHUNK_SIZE : self.internalChunkSize;
-          self.length = 0;
-        } else {
-          self.length = 0;
-          var txtId = self.fileId instanceof ObjectID ? self.fileId.toHexString() : self.fileId;
-          return error(new Error((self.referenceBy == REFERENCE_BY_ID ? txtId : self.filename) + " does not exist", self));
-        }
-
-        // Process the mode of the object
-        if(self.mode == "r") {
-          nthChunk(self, 0, options, function(err, chunk) {
-            if(err) return error(err);
-            self.currentChunk = chunk;
-            self.position = 0;
-            callback(null, self);
-          });
-        } else if(self.mode == "w") {
-          // Delete any existing chunks
-          deleteChunks(self, options, function(err, result) {
-            if(err) return error(err);
-            self.currentChunk = new Chunk(self, {'n':0}, self.writeConcern);
-            self.contentType = self.options['content_type'] == null ? self.contentType : self.options['content_type'];
-            self.internalChunkSize = self.options['chunk_size'] == null ? self.internalChunkSize : self.options['chunk_size'];
-            self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
-            self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
-            self.position = 0;
-            callback(null, self);
-          });
-        } else if(self.mode == "w+") {
-          nthChunk(self, lastChunkNumber(self), options, function(err, chunk) {
-            if(err) return error(err);
-            // Set the current chunk
-            self.currentChunk = chunk == null ? new Chunk(self, {'n':0}, self.writeConcern) : chunk;
-            self.currentChunk.position = self.currentChunk.data.length();
-            self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
-            self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
-            self.position = self.length;
-            callback(null, self);
-          });
-        }
-      });
+      // Process the mode of the object
+      if(self.mode == "r") {
+        nthChunk(self, 0, options, function(err, chunk) {
+          if(err) return error(err);
+          self.currentChunk = chunk;
+          self.position = 0;
+          callback(null, self);
+        });
+      } else if(self.mode == "w") {
+        // Delete any existing chunks
+        deleteChunks(self, options, function(err, result) {
+          if(err) return error(err);
+          self.currentChunk = new Chunk(self, {'n':0}, self.writeConcern);
+          self.contentType = self.options['content_type'] == null ? self.contentType : self.options['content_type'];
+          self.internalChunkSize = self.options['chunk_size'] == null ? self.internalChunkSize : self.options['chunk_size'];
+          self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
+          self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
+          self.position = 0;
+          callback(null, self);
+        });
+      } else if(self.mode == "w+") {
+        nthChunk(self, lastChunkNumber(self), options, function(err, chunk) {
+          if(err) return error(err);
+          // Set the current chunk
+          self.currentChunk = chunk == null ? new Chunk(self, {'n':0}, self.writeConcern) : chunk;
+          self.currentChunk.position = self.currentChunk.data.length();
+          self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
+          self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
+          self.position = self.length;
+          callback(null, self);
+        });
+      }
     });
   } else {
     // Write only mode
@@ -415,7 +410,7 @@ var writeBuffer = function(self, buffer, close, callback) {
                 callback(err, self);
               });
             }
-            
+
             // Return normally
             return callback(null, self);
           }
@@ -584,15 +579,11 @@ var nthChunk = function(self, chunkNumber, options, callback) {
   options = options || self.writeConcern;
   options.readPreference = self.readPreference;
   // Get the nth chunk
-  self.chunkCollection().find({'files_id':self.fileId, 'n':chunkNumber}, options, function(err, cursor) {
+  self.chunkCollection().findOne({'files_id':self.fileId, 'n':chunkNumber}, options, function(err, chunk) {
     if(err) return callback(err);
 
-    cursor.nextObject(function(err, chunk) {
-      if(err) return callback(err);
-
-      var finalChunk = chunk == null ? {} : chunk;
-      callback(null, new Chunk(self, finalChunk, self.writeConcern));
-    });
+    var finalChunk = chunk == null ? {} : chunk;
+    callback(null, new Chunk(self, finalChunk, self.writeConcern));
   });
 };
 
@@ -1026,13 +1017,10 @@ GridStore.exist = function(db, fileIdObject, rootCollection, options, callback) 
       ? {'filename':fileIdObject}
       : {'_id':fileIdObject};    // Attempt to locate file
 
-    collection.find(query, {readPreference:readPreference}, function(err, cursor) {
+    collection.findOne(query, {readPreference:readPreference}, function(err, item) {
       if(err) return callback(err);
 
-      cursor.nextObject(function(err, item) {
-        if(err) return callback(err);
-        callback(null, item == null ? false : true);
-      });
+      callback(null, item == null ? false : true);
     });
   });
 };
@@ -1536,11 +1524,11 @@ var _hasWriteConcern = function(errorOptions) {
  */
 var _setWriteConcernHash = function(options) {
   var finalOptions = {};
-  if(options.w != null) finalOptions.w = options.w;  
+  if(options.w != null) finalOptions.w = options.w;
   if(options.journal == true) finalOptions.j = options.journal;
   if(options.j == true) finalOptions.j = options.j;
   if(options.fsync == true) finalOptions.fsync = options.fsync;
-  if(options.wtimeout != null) finalOptions.wtimeout = options.wtimeout;  
+  if(options.wtimeout != null) finalOptions.wtimeout = options.wtimeout;
   return finalOptions;
 }
 
@@ -1568,7 +1556,7 @@ var _getWriteConcern = function(self, options) {
   }
 
   // Ensure we don't have an invalid combination of write concerns
-  if(finalOptions.w < 1 
+  if(finalOptions.w < 1
     && (finalOptions.journal == true || finalOptions.j == true || finalOptions.fsync == true)) throw new Error("No acknowledgement using w < 1 cannot be combined with journal:true or fsync:true");
 
   // Return the options


### PR DESCRIPTION
GridFS code uses combination of find followed by nextObject to fetch things (file or chunk) known to exists in zero or ono instance. The problem is that after using nextObject cursor object remain opened, at least on driver logic level. Logic issue cause memory leak in NewRelic instrumentation module which keep tracer object linked to this specific object. However I believe that forgotten alive cursor can cause more serious issue.
The findOne actually does same thing (find + nextObject) but it sets batch size to 1, which makes cursor to close automatically. Anyway, I believe use of findOne is more appropriate for this code. 
