### PR TITLE
Use findOne instead of find followed by nextObject

### DIFF
--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -20,7 +20,7 @@
  *   gridStore.open(function(err, gridStore) {
  *     gridStore.write("hello world!", function(err, gridStore) {
  *       gridStore.close(function(err, result) {
- * 
+ *
  *         // Let's read the file using object Id
  *         GridStore.read(db, result._id, function(err, data) {
  *           test.equal('hello world!', data);
@@ -279,7 +279,7 @@ var GridStore = function GridStore(db, id, filename, mode, options) {
 
   /**
    * Handles the destroy part of a stream
-   *  
+   *
    * @method
    * @result {null}
    */
@@ -440,7 +440,7 @@ var GridStore = function GridStore(db, id, filename, mode, options) {
       if(typeof callback == 'function')
         callback(new MongoError(f("Illegal mode %s", self.mode), null));
     }
-  };    
+  };
 
   /**
    * The collection callback format.
@@ -744,69 +744,64 @@ var _open = function(self, options, callback) {
 
   // Fetch the chunks
   if(query != null) {
-    collection.find(query, options, function(err, cursor) {
+    collection.findOne(query, options, function(err, doc) {
       if(err) return error(err);
 
-      // Fetch the file
-      cursor.nextObject(function(err, doc) {
-        if(err) return error(err);
+      // Check if the collection for the files exists otherwise prepare the new one
+      if(doc != null) {
+        self.fileId = doc._id;
+        // Prefer a new filename over the existing one if this is a write
+        self.filename = ((self.mode == 'r') || (self.filename == undefined)) ? doc.filename : self.filename;
+        self.contentType = doc.contentType;
+        self.internalChunkSize = doc.chunkSize;
+        self.uploadDate = doc.uploadDate;
+        self.aliases = doc.aliases;
+        self.length = doc.length;
+        self.metadata = doc.metadata;
+        self.internalMd5 = doc.md5;
+      } else if (self.mode != 'r') {
+        self.fileId = self.fileId == null ? new ObjectID() : self.fileId;
+        self.contentType = GridStore.DEFAULT_CONTENT_TYPE;
+        self.internalChunkSize = self.internalChunkSize == null ? Chunk.DEFAULT_CHUNK_SIZE : self.internalChunkSize;
+        self.length = 0;
+      } else {
+         self.length = 0;
+         var txtId = self.fileId instanceof ObjectID ? self.fileId.toHexString() : self.fileId;
+         return error(new MongoError(f("file with id %s not opened for writing", (self.referenceBy == REFERENCE_BY_ID ? txtId : self.filename))), self);
+      }
 
-        // Check if the collection for the files exists otherwise prepare the new one
-        if(doc != null) {
-          self.fileId = doc._id;
-          // Prefer a new filename over the existing one if this is a write
-          self.filename = ((self.mode == 'r') || (self.filename == undefined)) ? doc.filename : self.filename;
-          self.contentType = doc.contentType;
-          self.internalChunkSize = doc.chunkSize;
-          self.uploadDate = doc.uploadDate;
-          self.aliases = doc.aliases;
-          self.length = doc.length;
-          self.metadata = doc.metadata;
-          self.internalMd5 = doc.md5;
-        } else if (self.mode != 'r') {
-          self.fileId = self.fileId == null ? new ObjectID() : self.fileId;
-          self.contentType = GridStore.DEFAULT_CONTENT_TYPE;
-          self.internalChunkSize = self.internalChunkSize == null ? Chunk.DEFAULT_CHUNK_SIZE : self.internalChunkSize;
-          self.length = 0;
-        } else {
-          self.length = 0;
-          var txtId = self.fileId instanceof ObjectID ? self.fileId.toHexString() : self.fileId;
-          return error(new MongoError(f("file with id %s not opened for writing", (self.referenceBy == REFERENCE_BY_ID ? txtId : self.filename))), self);
-        }
-
-        // Process the mode of the object
-        if(self.mode == "r") {
-          nthChunk(self, 0, options, function(err, chunk) {
-            if(err) return error(err);
-            self.currentChunk = chunk;
-            self.position = 0;
-            callback(null, self);
-          });
-        } else if(self.mode == "w") {
-          // Delete any existing chunks
-          deleteChunks(self, options, function(err, result) {
-            if(err) return error(err);
-            self.currentChunk = new Chunk(self, {'n':0}, self.writeConcern);
-            self.contentType = self.options['content_type'] == null ? self.contentType : self.options['content_type'];
-            self.internalChunkSize = self.options['chunk_size'] == null ? self.internalChunkSize : self.options['chunk_size'];
-            self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
-            self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
-            self.position = 0;
-            callback(null, self);
-          });
-        } else if(self.mode == "w+") {
-          nthChunk(self, lastChunkNumber(self), options, function(err, chunk) {
-            if(err) return error(err);
-            // Set the current chunk
-            self.currentChunk = chunk == null ? new Chunk(self, {'n':0}, self.writeConcern) : chunk;
-            self.currentChunk.position = self.currentChunk.data.length();
-            self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
-            self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
-            self.position = self.length;
-            callback(null, self);
-          });
-        }
-      });
+      // Process the mode of the object
+      if(self.mode == "r") {
+        nthChunk(self, 0, options, function(err, chunk) {
+          if(err) return error(err);
+          self.currentChunk = chunk;
+          self.position = 0;
+          callback(null, self);
+        });
+      } else if(self.mode == "w") {
+        // Delete any existing chunks
+        deleteChunks(self, options, function(err, result) {
+          if(err) return error(err);
+          self.currentChunk = new Chunk(self, {'n':0}, self.writeConcern);
+          self.contentType = self.options['content_type'] == null ? self.contentType : self.options['content_type'];
+          self.internalChunkSize = self.options['chunk_size'] == null ? self.internalChunkSize : self.options['chunk_size'];
+          self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
+          self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
+          self.position = 0;
+          callback(null, self);
+        });
+      } else if(self.mode == "w+") {
+        nthChunk(self, lastChunkNumber(self), options, function(err, chunk) {
+          if(err) return error(err);
+          // Set the current chunk
+          self.currentChunk = chunk == null ? new Chunk(self, {'n':0}, self.writeConcern) : chunk;
+          self.currentChunk.position = self.currentChunk.data.length();
+          self.metadata = self.options['metadata'] == null ? self.metadata : self.options['metadata'];
+          self.aliases = self.options['aliases'] == null ? self.aliases : self.options['aliases'];
+          self.position = self.length;
+          callback(null, self);
+        });
+      }
     });
   } else {
     // Write only mode
@@ -906,7 +901,7 @@ var writeBuffer = function(self, buffer, close, callback) {
                 callback(err, self);
               });
             }
-            
+
             // Return normally
             return callback(null, self);
           }
@@ -982,15 +977,11 @@ var nthChunk = function(self, chunkNumber, options, callback) {
   options = options || self.writeConcern;
   options.readPreference = self.readPreference;
   // Get the nth chunk
-  self.chunkCollection().find({'files_id':self.fileId, 'n':chunkNumber}, options, function(err, cursor) {
+  self.chunkCollection().findOne({'files_id':self.fileId, 'n':chunkNumber}, options, function(err, chunk) {
     if(err) return callback(err);
 
-    cursor.nextObject(function(err, chunk) {
-      if(err) return callback(err);
-
-      var finalChunk = chunk == null ? {} : chunk;
-      callback(null, new Chunk(self, finalChunk, self.writeConcern));
-    });
+    var finalChunk = chunk == null ? {} : chunk;
+    callback(null, new Chunk(self, finalChunk, self.writeConcern));
   });
 };
 
@@ -1090,13 +1081,9 @@ GridStore.exist = function(db, fileIdObject, rootCollection, options, callback) 
       ? {'filename':fileIdObject}
       : {'_id':fileIdObject};    // Attempt to locate file
 
-    collection.find(query, {readPreference:readPreference}, function(err, cursor) {
+    collection.findOne(query, {readPreference:readPreference}, function(err, item) {
       if(err) return callback(err);
-
-      cursor.nextObject(function(err, item) {
-        if(err) return callback(err);
-        callback(null, item == null ? false : true);
-      });
+      callback(null, item == null ? false : true);
     });
   });
 };
@@ -1286,11 +1273,11 @@ var _writeNormal = function(self, data, close, callback) {
  */
 var _setWriteConcernHash = function(options) {
   var finalOptions = {};
-  if(options.w != null) finalOptions.w = options.w;  
+  if(options.w != null) finalOptions.w = options.w;
   if(options.journal == true) finalOptions.j = options.journal;
   if(options.j == true) finalOptions.j = options.j;
   if(options.fsync == true) finalOptions.fsync = options.fsync;
-  if(options.wtimeout != null) finalOptions.wtimeout = options.wtimeout;  
+  if(options.wtimeout != null) finalOptions.wtimeout = options.wtimeout;
   return finalOptions;
 }
 
@@ -1318,7 +1305,7 @@ var _getWriteConcern = function(self, options) {
   }
 
   // Ensure we don't have an invalid combination of write concerns
-  if(finalOptions.w < 1 
+  if(finalOptions.w < 1
     && (finalOptions.journal == true || finalOptions.j == true || finalOptions.fsync == true)) throw new MongoError("No acknowledgement using w < 1 cannot be combined with journal:true or fsync:true");
 
   // Return the options
@@ -1335,7 +1322,7 @@ var _getWriteConcern = function(self, options) {
 var GridStoreStream = function(gs) {
   var self = this;
   // Initialize the duplex stream
-  Duplex.call(this);  
+  Duplex.call(this);
 
   // Save current pipe function
   var _pipe = this.pipe;
@@ -1362,7 +1349,7 @@ var GridStoreStream = function(gs) {
     var length = gs.length < gs.chunkSize ? gs.length - seekPosition : gs.chunkSize;
     // Read data
     gs.read(length, function(err, buffer) {
-      // Stream is closed      
+      // Stream is closed
       if(endCalled || buffer == null) return self.push(null);
       // Remove bytes read
       if(buffer.length <= totalBytesToRead) {
@@ -1395,7 +1382,7 @@ var GridStoreStream = function(gs) {
         gs.isOpen = true;
         gs.write(chunk, function() {
           self.emit('drain');
-        });        
+        });
       });
     } else {
       gs.write(chunk, function() {
@@ -1419,44 +1406,44 @@ var GridStoreStream = function(gs) {
           if(typeof callback == 'function') callback();
           self.emit('end')
         });
-      });      
+      });
     }
 
     gs.close(function() {
-      if(typeof callback == 'function') callback();      
+      if(typeof callback == 'function') callback();
       self.emit('end')
-    });    
+    });
   }
 
   /**
    * The read() method pulls some data out of the internal buffer and returns it. If there is no data available, then it will return null.
-   * @function external:Duplex#read 
+   * @function external:Duplex#read
    * @param {number} size Optional argument to specify how much data to read.
    * @return {(String | Buffer | null)}
    */
 
   /**
    * Call this function to cause the stream to return strings of the specified encoding instead of Buffer objects.
-   * @function external:Duplex#setEncoding 
+   * @function external:Duplex#setEncoding
    * @param {string} encoding The encoding to use.
    * @return {null}
    */
 
   /**
    * This method will cause the readable stream to resume emitting data events.
-   * @function external:Duplex#resume 
+   * @function external:Duplex#resume
    * @return {null}
    */
 
   /**
    * This method will cause a stream in flowing-mode to stop emitting data events. Any data that becomes available will remain in the internal buffer.
-   * @function external:Duplex#pause 
+   * @function external:Duplex#pause
    * @return {null}
    */
 
   /**
    * This method pulls all the data out of a readable stream, and writes it to the supplied destination, automatically managing the flow so that the destination is not overwhelmed by a fast readable stream.
-   * @function external:Duplex#pipe 
+   * @function external:Duplex#pipe
    * @param {Writable} destination The destination for writing data
    * @param {object} [options] Pipe options
    * @return {null}
@@ -1464,42 +1451,42 @@ var GridStoreStream = function(gs) {
 
   /**
    * This method will remove the hooks set up for a previous pipe() call.
-   * @function external:Duplex#unpipe 
+   * @function external:Duplex#unpipe
    * @param {Writable} [destination] The destination for writing data
    * @return {null}
    */
 
   /**
    * This is useful in certain cases where a stream is being consumed by a parser, which needs to "un-consume" some data that it has optimistically pulled out of the source, so that the stream can be passed on to some other party.
-   * @function external:Duplex#unshift 
+   * @function external:Duplex#unshift
    * @param {(Buffer|string)} chunk Chunk of data to unshift onto the read queue.
    * @return {null}
    */
 
   /**
    * Versions of Node prior to v0.10 had streams that did not implement the entire Streams API as it is today. (See "Compatibility" below for more information.)
-   * @function external:Duplex#wrap 
+   * @function external:Duplex#wrap
    * @param {Stream} stream An "old style" readable stream.
    * @return {null}
-   */  
+   */
 
   /**
    * This method writes some data to the underlying system, and calls the supplied callback once the data has been fully handled.
-   * @function external:Duplex#write 
+   * @function external:Duplex#write
    * @param {(string|Buffer)} chunk The data to write
    * @param {string} encoding The encoding, if chunk is a String
    * @param {function} callback Callback for when this chunk of data is flushed
    * @return {boolean}
-   */  
+   */
 
   /**
    * Call this method when no more data will be written to the stream. If supplied, the callback is attached as a listener on the finish event.
-   * @function external:Duplex#end 
+   * @function external:Duplex#end
    * @param {(string|Buffer)} chunk The data to write
    * @param {string} encoding The encoding, if chunk is a String
    * @param {function} callback Callback for when this chunk of data is flushed
    * @return {null}
-   */  
+   */
 }
 
 /**


### PR DESCRIPTION
GridFS code uses combination of find followed by nextObject to fetch things (file or chunk) know to exists in zero or on instance. The problem is that after using nextObject cursor object remain opened, at least on driver logic level. Logic issue cause memory leak in NewRelic instrumentation module which keep tracer object linked to this specific object. However I believe that forgotten alive cursor can cause more serious issue.
The findOne actually does same thing (find + nextObject) but it sets batch size to 1, which makes cursor to close automatically. Anyway, I believe use of findOne is more appropriate for this code. 
