### PR TITLE
Allow replicaSet name to be omitted 

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -193,6 +193,8 @@ MongoClient.connect = function(url, options, callback) {
     var _server = object.servers[i].domain_socket 
         ? new Server(object.servers[i].domain_socket, _server_options)
         : new Server(object.servers[i].host, object.servers[i].port, _server_options);
+        
+    var setName;
 
     var connectFunction = function(__server) { 
       // Attempt connect


### PR DESCRIPTION
The replicaSet option (of ReplSet) now defaults to server's setName, if totalNumberOfMongodServers is 1. This provides a sensible default value for trivial cases, thus simplifying the connection boilerplate. 

Motivation:

I can connect to a mongo on heroku via:

mongo some_address -u UUU -p PPP  --eval "db.getCollectionNames()"

But I _cannot_ connect to it via mongodb 2.0.3:

require('mongodb').MongoClient.connect(
    'mongodb://UUU:PPP@some_address',
    function(err, db) { console.error(err); }
);

Output: 
"replicaSet parameter must be set"
