### PR TITLE
Fixes typo 'hash off'=> 'hash of'

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -1836,10 +1836,10 @@ Db.DEFAULT_URL = 'mongodb://localhost:27017/default';
  *
  * Options
  *  - **uri_decode_auth** {Boolean, default:false} uri decode the user name and password for authentication
- *  - **db** {Object, default: null} a hash off options to set on the db object, see **Db constructor**
- *  - **server** {Object, default: null} a hash off options to set on the server objects, see **Server** constructor**
- *  - **replSet** {Object, default: null} a hash off options to set on the replSet object, see **ReplSet** constructor**
- *  - **mongos** {Object, default: null} a hash off options to set on the mongos object, see **Mongos** constructor**
+ *  - **db** {Object, default: null} a hash of options to set on the db object, see **Db constructor**
+ *  - **server** {Object, default: null} a hash of options to set on the server objects, see **Server** constructor**
+ *  - **replSet** {Object, default: null} a hash of options to set on the replSet object, see **ReplSet** constructor**
+ *  - **mongos** {Object, default: null} a hash of options to set on the mongos object, see **Mongos** constructor**
  *
  * @param {String} url connection url for MongoDB.
  * @param {Object} [options] optional options for insert command

--- a/lib/mongodb/mongo_client.js
+++ b/lib/mongodb/mongo_client.js
@@ -57,10 +57,10 @@ inherits(MongoClient, EventEmitter);
  *
  * Options
  *  - **uri_decode_auth** {Boolean, default:false} uri decode the user name and password for authentication
- *  - **db** {Object, default: null} a hash off options to set on the db object, see **Db constructor**
- *  - **server** {Object, default: null} a hash off options to set on the server objects, see **Server** constructor**
- *  - **replSet** {Object, default: null} a hash off options to set on the replSet object, see **ReplSet** constructor**
- *  - **mongos** {Object, default: null} a hash off options to set on the mongos object, see **Mongos** constructor**
+ *  - **db** {Object, default: null} a hash of options to set on the db object, see **Db constructor**
+ *  - **server** {Object, default: null} a hash of options to set on the server objects, see **Server** constructor**
+ *  - **replSet** {Object, default: null} a hash of options to set on the replSet object, see **ReplSet** constructor**
+ *  - **mongos** {Object, default: null} a hash of options to set on the mongos object, see **Mongos** constructor**
  *
  * @param {String} url connection url for MongoDB.
  * @param {Object} [options] optional options for insert command
@@ -135,10 +135,10 @@ MongoClient.prototype.db = function(dbName) {
  *
  * Options
  *  - **uri_decode_auth** {Boolean, default:false} uri decode the user name and password for authentication
- *  - **db** {Object, default: null} a hash off options to set on the db object, see **Db constructor**
- *  - **server** {Object, default: null} a hash off options to set on the server objects, see **Server** constructor**
- *  - **replSet** {Object, default: null} a hash off options to set on the replSet object, see **ReplSet** constructor**
- *  - **mongos** {Object, default: null} a hash off options to set on the mongos object, see **Mongos** constructor**
+ *  - **db** {Object, default: null} a hash of options to set on the db object, see **Db constructor**
+ *  - **server** {Object, default: null} a hash of options to set on the server objects, see **Server** constructor**
+ *  - **replSet** {Object, default: null} a hash of options to set on the replSet object, see **ReplSet** constructor**
+ *  - **mongos** {Object, default: null} a hash of options to set on the mongos object, see **Mongos** constructor**
  *
  * @param {String} url connection url for MongoDB.
  * @param {Object} [options] optional options for insert command


### PR DESCRIPTION
Corrects English ... 

Correct: `Hash of options`
Incorrect:  `Hash off options`
