### PR TITLE
Fix LearnBoost/mongoose#2313: don't let user accidentally clobber geoNear params

### DIFF
--- a/lib/mongodb/collection/geo.js
+++ b/lib/mongodb/collection/geo.js
@@ -16,8 +16,14 @@ var geoNear = function geoNear(x, y, options, callback) {
   // Ensure we have the right read preference inheritance
   options.readPreference = shared._getReadConcern(this, options);
 
-  // Remove read preference from hash if it exists
-  commandObject = utils.decorateCommand(commandObject, options, {readPreference: true});
+  // Exclude readPreference and existing options to prevent user from
+  // shooting themselves in the foot
+  var exclude = {
+    readPreference: true,
+    geoNear: true,
+    near: true
+  };
+  commandObject = utils.decorateCommand(commandObject, options, exclude);
 
   // Execute the command
   this.db.command(commandObject, options, function (err, res) {

--- a/test/tests/functional/geo_tests.js
+++ b/test/tests/functional/geo_tests.js
@@ -33,6 +33,42 @@ exports.shouldCorrectlyPerformSimpleGeoNearCommand = function(configuration, tes
 }
 
 /**
+ * Make sure user can't clobber geoNear options
+ *
+ * @_class collection
+ * @_function geoNear
+ * @ignore
+ */
+exports.shouldNotAllowUserToClobberGeoNearWithOptions = function(configuration, test) {
+  var db = configuration.newDbInstance({w:0}, {poolSize:1});
+
+  // Establish connection to db
+  db.open(function(err, db) {
+   
+    // Fetch the collection
+    var collection = db.collection("simple_geo_near_command");
+
+    // Add a location based index
+    collection.ensureIndex({loc:"2d"}, function(err, result) {
+
+      // Save a new location tagged document
+      collection.insert([{a:1, loc:[50, 30]}, {a:1, loc:[30, 50]}], {w:1}, function(err, result) {
+        // Try to intentionally clobber the underlying geoNear option
+        var options = {query:{a:1}, num:1, geoNear: 'bacon', near: 'butter' };
+
+        // Use geoNear command to find document
+        collection.geoNear(50, 50, options, function(err, docs) {
+          test.equal(1, docs.results.length);
+
+          db.close();
+          test.done();
+        });
+      });
+    });
+  });
+};
+
+/**
  * Example of a simple geoHaystackSearch query across some documents
  *
  * @_class collection


### PR DESCRIPTION
Hi Christian,

A mongoose user ran into a fairly interesting issue - looks like you can clobber geoNear params by passing bad options to the `geoNear()` function. Obviously, specifying a `geoNear` option when calling `geoNear()` isn't necessary or useful, but would be nice to foolproof this a bit more. One user's been having some trouble with this, and you can easily imagine a case where somebody might want to do `if (options.geoNear) { collection.geoNear(x, y, options) }`
