### PR TITLE
Changing r.result.n to r.length

### DIFF
--- a/docs/content/tutorials/aggregation.md
+++ b/docs/content/tutorials/aggregation.md
@@ -30,7 +30,7 @@ MongoClient.connect(url, function(err, db) {
   // Insert a single document
   col.insert([{a:1}, {a:1}, {a:1}], function(err, r) {
     assert.equal(null, err);
-    assert.equal(3, r.result.n);
+    assert.equal(3, r.length);
 
     // Get first two documents that match the query
     col.aggregate([
@@ -68,7 +68,7 @@ MongoClient.connect(url, function(err, db) {
   // Insert a single document
   col.insert([{a:1}, {a:1}, {a:1}], function(err, r) {
     assert.equal(null, err);
-    assert.equal(3, r.result.n);
+    assert.equal(3, r.length);
 
     // Get first two documents that match the query
     col.aggregate([
@@ -102,7 +102,7 @@ MongoClient.connect(url, function(err, db) {
   // Insert a single document
   col.insert([{a:1}, {a:1}, {a:1}], function(err, r) {
     assert.equal(null, err);
-    assert.equal(3, r.result.n);
+    assert.equal(3, r.length);
 
     // Get first two documents that match the query
     col.aggregate([


### PR DESCRIPTION
Hi Christian, can you verify I'm right in my thinking that the example code should be r.length rather than r.result.n when asserting the object's length?
