### PR TITLE
Correct message size validation (NODE-184)

### DIFF
--- a/lib/mongodb/connection/connection.js
+++ b/lib/mongodb/connection/connection.js
@@ -412,7 +412,7 @@ var createDataHandler = exports.Connection.createDataHandler = function(self) {
             }
 
             // Ensure that the size of message is larger than 0 and less than the max allowed
-            if(sizeOfMessage > 4 && sizeOfMessage < self.maxBsonSize && sizeOfMessage > data.length) {
+            if(sizeOfMessage > 4 && sizeOfMessage < self.maxMessageSizeBytes && sizeOfMessage > data.length) {
               self.buffer = new Buffer(sizeOfMessage);
               // Copy all the data into the buffer
               data.copy(self.buffer, 0);
@@ -425,7 +425,7 @@ var createDataHandler = exports.Connection.createDataHandler = function(self) {
               // Exit parsing loop
               data = new Buffer(0);
 
-            } else if(sizeOfMessage > 4 && sizeOfMessage < self.maxBsonSize && sizeOfMessage == data.length) {
+            } else if(sizeOfMessage > 4 && sizeOfMessage < self.maxMessageSizeBytes && sizeOfMessage == data.length) {
               try {
                 var emitBuffer = data;
                 // Reset state of buffer
@@ -446,7 +446,7 @@ var createDataHandler = exports.Connection.createDataHandler = function(self) {
                 // We got a parse Error fire it off then keep going
                 self.emit("parseError", errorObject, self);
               }
-            } else if(sizeOfMessage <= 4 || sizeOfMessage > self.maxBsonSize) {
+            } else if(sizeOfMessage <= 4 || sizeOfMessage > self.maxMessageSizeBytes) {
               var errorObject = {err:"socketHandler", trace:null, bin:data, parseState:{
                 sizeOfMessage:sizeOfMessage,
                 bytesRead:0,


### PR DESCRIPTION
Compares sizeOfMessage to maxMessageSizeBytes instead of maxBsonSize.

This resolves the issue where the response from mongo is greater then the max document size, but less than the max message size, and completes 5d3585c7795355fa1990968a9788ded25ebdcb13
