### PR TITLE
Make readPreference variable local, not global

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1165,7 +1165,7 @@ Db.prototype.indexInformation = function(name, options, callback) {
     var selector = name != null ? {ns: (self.s.databaseName + "." + name)} : {};
 
     // Get read preference if we set one
-    readPreference = ReadPreference.PRIMARY;
+    var readPreference = ReadPreference.PRIMARY;
 
     // Iterate through all the fields of the index
     var collection = self.collection(Db.SYSTEM_INDEX_COLLECTION);


### PR DESCRIPTION
Make `readPreference` variable local, not global, to prevent a global memory leak.
