### PR TITLE
Use mongodb-version-manager for matrix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,8 @@ node_js:
   - 0.10
   - 0.11
 sudo: false
+env:
+  - MONGODB_VERSION=2.2.x
+  - MONGODB_VERSION=2.4.x
+  - MONGODB_VERSION=2.6.x
+  - MONGODB_VERSION=2.8.x

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "2.0.9",
   "description": "MongoDB legacy driver emulation layer on top of mongodb-core",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/christkv/mongodb-legacy.git"
@@ -27,6 +24,7 @@
     , "semver": "4.1.0"
     , "rimraf": "2.2.6"
     , "gleak": "0.5.0"
+    , "mongodb-version-manager": "^0.5.0"
   },
   "author": "Christian Kvalheim",
   "license": "Apache 2.0",

--- a/test/runner.js
+++ b/test/runner.js
@@ -15,6 +15,7 @@ var Runner = require('integra').Runner
   , path = require('path')
   , rimraf = require('rimraf')
   , fs = require('fs')
+  , m = require('mongodb-version-manager')
   , f = require('util').format;
 
 var detector = require('gleak')();
@@ -478,8 +479,19 @@ if(argv.t == 'functional') {
   } catch(err) {
   }
 
-  // Run the configuration
-  runner.run(config);
+  // Kill any running MongoDB processes and
+  // `install $MONGODB_VERSION` || `use existing installation` || `install stable`
+  m(function(err){
+    if(err) return console.error(err) && process.exit(1);
+
+    m.current(function(err, version){
+      if(err) return console.error(err) && process.exit(1);
+
+      console.log('Running tests against MongoDB version `%s`', version);
+      // Run the configuration
+      runner.run(config);
+    });
+  });
 }
 
 


### PR DESCRIPTION
Want to test against 2.6.6? `MONGODB_VERSION=2.6.6 npm test;`

Want to test against latest 2.8 rc? `MONGODB_VERSION=2.8.x npm test;`

2.2.x functional tests are currently broken through:

```
> MONGODB_VERSION=2.2.x npm test;
# …lots of logging output
error command line: unknown option setParameter
use --help for help
```

Perhaps we should collab more on things like
https://github.com/imlucas/mongodb-runner and
https://github.com/imlucas/mongodb-bridge :)
