### PR TITLE
Properly remove listeners on timeout

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -203,7 +203,7 @@ Server.prototype.connect = function(db, _options, callback) {
       // Remove all event handlers
       var events = ['timeout', 'error', 'close'];
       events.forEach(function(e) {
-        self.removeListener(e, connectErrorHandler);
+        self.s.server.removeListener(e, connectHandlers[e]);
       });
 
       self.s.server.removeListener('connect', connectErrorHandler);
@@ -256,9 +256,14 @@ Server.prototype.connect = function(db, _options, callback) {
   }
 
   // Set up listeners
-  self.s.server.once('timeout', connectErrorHandler('timeout'));
-  self.s.server.once('error', connectErrorHandler('error'));
-  self.s.server.once('close', connectErrorHandler('close'));
+  var connectHandlers = {
+    timeout: connectErrorHandler('timeout'),
+    error: connectErrorHandler('error'),
+    close: connectErrorHandler('close')
+  };
+  self.s.server.once('timeout', connectHandlers.timeout);
+  self.s.server.once('error', connectHandlers.error);
+  self.s.server.once('close', connectHandlers.close);
   self.s.server.once('connect', connectHandler);
   // Reconnect server
   self.s.server.on('reconnect', reconnectHandler);

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -249,6 +249,8 @@ exports.testConnectBadUrl = {
   
   // The actual test we wish to run
   test: function(configuration, test) {
+    var connect = configuration.require;
+
     test.throws(function() {
       connect('mangodb://localhost:27017/test?safe=false', function(err, db) {
         test.ok(false, 'Bad URL!');
@@ -355,3 +357,4 @@ exports['Should correctly reconnect and finish query operation'] = {
     });
   }
 }
+


### PR DESCRIPTION
Standalone wasn't properly removing listeners when connection timed out - was causing one of the failures in mongoose's driver upgrade branch.