### PR TITLE
Handle index creation failure in a manner consistent with inserts

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -701,7 +701,7 @@ Db.prototype.createIndex = function(name, fieldOrSpec, options, callback) {
       if(callback == null) return;
       if(err) return handleCallback(callback, err);
       if(result == null) return handleCallback(callback, null, null);
-      if(result.result.writeErrors) return handleCallback(callback, MongoError.create(result.result), null);
+      if(result.result.writeErrors) return handleCallback(callback, MongoError.create(result.result.writeErrors[0]), null);
       handleCallback(callback, null, doc.name);
     });
   });


### PR DESCRIPTION
Right now index error string gives unhelpful "MongoError: n/a". With this change you get a more helpful error message.