### PR TITLE
Enable setting w:0 in .insert()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1993,10 +1993,10 @@ Collection.prototype.initializeOrderedBulkOp = function(options) {
 var writeConcern = function(target, db, col, options) {
   if(options.w != null || options.j != null || options.fsync != null) {
     var opts = {};
-    if(options.w) opts.w = options.w;
-    if(options.wtimeout) opts.wtimeout = options.wtimeout;
-    if(options.j) opts.j = options.j;
-    if(options.fsync) opts.fsync = options.fsync;
+    if(options.w != null) opts.w = options.w;
+    if(options.wtimeout != null) opts.wtimeout = options.wtimeout;
+    if(options.j != null) opts.j = options.j;
+    if(options.fsync != null) opts.fsync = options.fsync;
     target.writeConcern = opts;
   } else if(col.writeConcern.w != null || col.writeConcern.j != null || col.writeConcern.fsync != null) {      
     target.writeConcern = col.writeConcern;


### PR DESCRIPTION
Right now `{ w: 0 }` doesn't work when you specify it in arguments to insert, for instance `coll.insert({ x: 1 }, { w: 0}, callback)` because 0 is falsy. Thanks to some language quirks, however, `0 != null`, so if you use the same check you use in L1994 this works as expected.

Also, for posterity's sake, much to my surprise, using `==` is actually the [right choice here](http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3). My knee-jerk reaction was "fix to use `===`" but the ECMAScript spec clarifies that this gives the correct behavior, `x == null` iff x is null or undefined.