### PR TITLE
Enable setting connectTimeoutMS and socketTimeoutMS in URI

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -169,11 +169,13 @@ MongoClient.connect = function(url, options, callback) {
   // Connect to all servers and run ismaster
   for(var i = 0; i < object.servers.length; i++) {
     // Set up socket options
+    var providedSocketOptions = object.server_options.socketOptions || {};
+
     var _server_options = {
         poolSize:1
       , socketOptions: {
-          connectTimeoutMS:30000 
-        , socketTimeoutMS: 30000
+          connectTimeoutMS: providedSocketOptions.connectTimeoutMS || 30000
+        , socketTimeoutMS:  providedSocketOptions.socketTimeoutMS || 30000
       }
       , auto_reconnect:false};
 


### PR DESCRIPTION
Right now you can't set `connectTimeoutMS` in URI passed to MongoClient.connect(). For instance, [this connect-mongodb-session](https://github.com/vkarpov15/connect-mongodb-session/blob/master/test/examples.test.js#L153-162) test currently fails, because I'd expect connecting to `mongodb://bad.host:27000/connect_mongodb_session_test?connectTimeoutMS=10` to time out after 10ms rather than 30s.

With this patch, that test succeeds against 2.4, 2.6, and 2.8.