### PR TITLE
Fix check of process.platfom for default socketOptions.keepAlive

### DIFF
--- a/lib/mongodb/connection/connection.js
+++ b/lib/mongodb/connection/connection.js
@@ -13,7 +13,7 @@ var Connection = exports.Connection = function(id, socketOptions) {
   // Store all socket options
   this.socketOptions = socketOptions ? socketOptions : {host:'localhost', port:27017, domainSocket:false};
   // Set keep alive default if not overriden
-  if(this.socketOptions.keepAlive == null && (process.platform !== "sunos" || process.platform !== "win32")) this.socketOptions.keepAlive = 100;
+  if(this.socketOptions.keepAlive == null && !(process.platform == "sunos" || process.platform == "win32")) this.socketOptions.keepAlive = 100;
   // Id for the connection
   this.id = id;
   // State of the connection


### PR DESCRIPTION
The previous logic would always evaluate as true since process.platform will always be either not `sunos` or `win32`.