### PR TITLE
Make shallow clone of options to auth() before modifying

### DIFF
--- a/lib/mongodb/db.js
+++ b/lib/mongodb/db.js
@@ -686,6 +686,8 @@ Db.prototype.authenticate = function(username, password, options, callback) {
   if(typeof options == 'function') {
     callback = options;
     options = {};
+  } else {
+    options = utils.shallowObjectCopy(options);
   }
 
   // Set default mechanism


### PR DESCRIPTION
See LearnBoost/mongoose#2619. Basically if you reuse `.authenticate()`, your options object gets authMechanism set to "DEFAULT" and subsequent authenticate() calls with the same options incorrectly throw an error.