### PR TITLE
Fix LearnBoost/mongoose#2627: don't hang callback when no selector specified

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -716,6 +716,11 @@ Collection.prototype.removeMany = Collection.prototype.deleteMany;
 
 var removeDocuments = function(self, selector, options, callback) {
   if(typeof options == 'function') callback = options, options = {};
+  else if (typeof selector === 'function') {
+    callback = selector;
+    options = {};
+    selector = {};
+  }
   options = options || {};
 
   // Get the write concern options


### PR DESCRIPTION
Not sure if the correct behavior is to throw an exception if no selector is specified (I seem to remember this being part of some spec that was floating around in early 2.6, but this behavior isn't really specified in the CRUD spec atm) or to accept it. Unfortunately, the current behavior is to silently accept it but never call the callback, which is definitely not right.