### PR TITLE
LearnBoost/mongoose#2229: emit close on parseError on db for single servers

### DIFF
--- a/lib/mongodb/connection/server.js
+++ b/lib/mongodb/connection/server.js
@@ -700,7 +700,7 @@ Server.prototype.connect = function(dbInstance, options, callback) {
       // Emit error
       server._emitAcrossAllDbInstances(server, eventReceiver, "parseError", server, null, true);
       // Emit close event
-      if(eventReceiver.listeners("close") && eventReceiver.listeners("close").length > 0) eventReceiver.emit("close", new Error("connection closed"), server); }
+      server._emitAcrossAllDbInstances(server, eventReceiver, "close", new Error("connection closed"), null, true);
   });
 
   // Boot up connection poole, pass in a locator of callbacks


### PR DESCRIPTION
Re: some of the work for https://jira.mongodb.org/browse/NODE-244 and LearnBoost/mongoose#2229. Right now the close event only gets bubbled up to the server instance, rather than the actual connection. IMO makes sense to emit on the connection if its a standalone.