### PR TITLE
Re: LearnBoost/mongoose#2652, add ability to get collection name from cursor

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var inherits = require('util').inherits
+  , ns = require('mongodb-ns')
   , f = require('util').format
   , toError = require('./utils').toError
   , getSingleProperty = require('./utils').getSingleProperty
@@ -119,6 +120,10 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
   this.sortValue = self.s.cmd.sort;
   this.readPreference = self.s.options.readPreference;
 }
+
+Object.defineProperty(Cursor.prototype, 'ns', {
+  enumerable: true, get: function() { return ns(this.s.ns); }
+});
 
 /**
  * Cursor stream data event, fired for each document in the cursor.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "dependencies": {
       "mongodb-core": "1.1.11"
+    , "mongodb-ns": "1.0.0"
     , "readable-stream": "1.0.31"
   },
   "devDependencies": {


### PR DESCRIPTION
Offending New Relic code is [here](https://github.com/newrelic/node-newrelic/blob/18440da8bf8409a187a0faea3583a59da7024a7e/lib/instrumentation/mongodb.js#L126). As far as I can tell, there's no good way to get around their need to get collection name from cursor unless we tell them to dig in to the `.s` internal state and ask them to parse namespaces themselves. IMO better solution would be to give them a supported way to access namespace info on a cursor. I also pulled in Lucas' namespace parsing module for this purpose, but I wouldn't be opposed to doing a simple split on '.' either.