### PR TITLE
Update cursor.js documentation

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -598,7 +598,6 @@ Cursor.prototype.toArray = function(callback) {
  * Get the count of documents for this cursor
  * @method
  * @param {boolean} applySkipLimit Should the count command apply limit and skip settings on the cursor or in the passed in options.
- * @param {(string|ReadPreference)} readPreference The new read preference for the cursor.
  * @param {object} [options=null] Optional settings.
  * @param {number} [options.skip=null] The number of documents to skip.
  * @param {number} [options.limit=null] The maximum amounts to count before aborting.


### PR DESCRIPTION
Remove nonexistent argument from Cursor.prototype.count documentation