### PR TITLE
Gracefully handle non-numeric pool sizes

### DIFF
--- a/lib/mongodb/connection/connection_pool.js
+++ b/lib/mongodb/connection/connection_pool.js
@@ -26,6 +26,12 @@ var ConnectionPool = exports.ConnectionPool = function(host, port, poolSize, bso
   this.socketOptions.domainSocket = false;
   this.bson = bson;
   // PoolSize is always + 1 for special reserved "measurment" socket (like ping, stats etc)
+  if (typeof poolSize !== 'number') {
+    poolSize = parseInt(poolSize.toString(), 10);
+    if (isNaN(poolSize)) {
+      throw new Error("poolSize must be a number!");
+    }
+  }
   this.poolSize = poolSize;
   this.minPoolSize = Math.floor(this.poolSize / 2) + 1;
 

--- a/test/functional/db_tests.js
+++ b/test/functional/db_tests.js
@@ -417,3 +417,21 @@ exports['should correctly list collection names with batchSize 1 for 2.8 or high
     });
   }
 }
+
+/**
+ * @ignore
+ */
+exports.shouldCrashOnBadPoolSize = {
+  metadata: { requires: { topology: 'single' } },
+
+  // The actual test we wish to run
+  test: function(configuration, test) {
+    var db = configuration.newDbInstance(configuration.writeConcernMax(), {poolSize:'bad!'});
+    test.throws(function() {
+      db.open(function() {
+        db.close();
+      });
+    });
+    test.done();
+  }
+}


### PR DESCRIPTION
Hi Christian,

Re: LearnBoost/mongoose#2682, looks like when you specify a non-numeric pool size the driver will hang forever because of the [=== check here](https://github.com/mongodb/node-mongodb-native/blob/0b9644bc89fe988c5cde04801dbac34d5b1ef9ec/lib/mongodb/connection/connection_pool.js#L117). I think we can improve how we handle that case.