### PR TITLE
Keep numeric error code in query errors

### DIFF
--- a/lib/mongodb/cursor.js
+++ b/lib/mongodb/cursor.js
@@ -711,7 +711,7 @@ Cursor.prototype.nextObject = function(options, callback) {
       }
 
       if(err == null && result && result.documents[0] && result.documents[0]['$err']) {
-        return self.close(function() {callback(utils.toError(result.documents[0]['$err']), null);});
+        return self.close(function() {callback(utils.toError(result.documents[0]), null);});
       }
 
       if(err == null && result && result.documents[0] && result.documents[0]['errmsg']) {

--- a/lib/mongodb/utils.js
+++ b/lib/mongodb/utils.js
@@ -110,7 +110,7 @@ exports.isRegExp = function (arg) {
 var toError = function(error) {
   if (error instanceof Error) return error;
 
-  var msg = error.err || error.errmsg || error.errMessage || error;
+  var msg = error.err || error.errmsg || error.errMessage || error.$err || error;
   var e = new Error(msg);
   e.name = 'MongoError';
 

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -2207,6 +2207,7 @@ exports.shouldFailToTailANormalCollection = {
       collection.insert(docs, configuration.writeConcernMax(), function(err, ids) {
         collection.find({}, {tailable:true}).each(function(err, doc) {
           test.ok(err instanceof Error);
+          test.ok(typeof(err.code) === 'number');
           db.close();
           test.done();
         });


### PR DESCRIPTION
When query commands (specifically, nextObject) return an error as a
result document of the form {$err: "message", code: 1234}, we should
allow the application to see the code (and any other fields on the
error).  This is consistent with what we do if the error is returned in
the "errmsg" field on the next line.

Note: `node test/runner.js -t functional -f cursor` passes with the change (and fails with my test change only) but `node test/runner.js -t functional` fails for me on current master:

```
/Users/glasser/Projects/Meteor/node-mongodb-native/lib/mongodb/connection/base.js:246
        throw message;      
              ^
AssertionError: {} == null
    at equal (/Users/glasser/Projects/Meteor/node-mongodb-native/node_modules/integra/lib/schedulers/test_runner.js:62:14)
    at /Users/glasser/Projects/Meteor/node-mongodb-native/test/functional/gridfs_tests.js:1406:18
    at error (/Users/glasser/Projects/Meteor/node-mongodb-native/lib/mongodb/gridfs/gridstore.js:274:5)
    at /Users/glasser/Projects/Meteor/node-mongodb-native/lib/mongodb/gridfs/gridstore.js:200:16
    at /Users/glasser/Projects/Meteor/node-mongodb-native/lib/mongodb/collection/query.js:164:5
    at /Users/glasser/Projects/Meteor/node-mongodb-native/lib/mongodb/cursor.js:778:35
    at Cursor.close (/Users/glasser/Projects/Meteor/node-mongodb-native/lib/mongodb/cursor.js:1009:5)
    at Cursor.nextObject (/Users/glasser/Projects/Meteor/node-mongodb-native/lib/mongodb/cursor.js:778:17)
    at commandHandler (/Users/glasser/Projects/Meteor/node-mongodb-native/lib/mongodb/cursor.js:741:14)
    at /Users/glasser/Projects/Meteor/node-mongodb-native/lib/mongodb/db.js:1903:9
```