### PR TITLE
Expose MongoError from mongodb-core

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ var core = require('mongodb-core');
 // Set up the connect function
 var connect = require('./lib/mongo_client').connect;
 
+// Expose error class
+connect.MongoError = core.MongoError;
+
 // Actual driver classes exported
 connect.MongoClient = require('./lib/mongo_client');
 connect.Db = require('./lib/db');


### PR DESCRIPTION
This is useful when promisifying the API and trying to catch operational errors like:

```js
var Promise = require('bluebird');
var mongodb = Promise.promisifyAll(require('mongodb'));

var db = mongodb.connectAsync(mongoUri)
	.catch(mongodb.MongoError, function( e ){
		throw new Error('Unable to connect to database: "' + mongoUri + '"');
	});
```