### PR TITLE
NODE-376 Fixes issue - Unordered batch incorrectly tracks batch size when switching batch types

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -50,6 +50,7 @@ var Batch = function(batchType, originalZeroIndex) {
   this.batchType = batchType;
   this.operations = [];
   this.size = 0;
+  this.sizeBytes = 0;
 }
 
 /**

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -161,7 +161,7 @@ var addToOperationsList = function(_self, docType, document) {
 
   // Check if we need to create a new batch
   if(((_self.s.currentBatch.size + 1) >= _self.s.maxWriteBatchSize)
-    || ((_self.s.currentBatch.sizeBytes + _self.s.currentBatch.sizeBytes) >= _self.s.maxBatchSizeBytes)
+    || ((_self.s.currentBatch.sizeBytes + bsonSize) >= _self.s.maxBatchSizeBytes)
     || (_self.s.currentBatch.batchType != docType)) {
     // Save the batch to the execution stack
     _self.s.batches.push(_self.s.currentBatch);

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -159,35 +159,15 @@ var addToOperationsList = function(_self, docType, document) {
   // Create a new batch object if we don't have a current one
   if(_self.s.currentBatch == null) _self.s.currentBatch = new Batch(docType, _self.s.currentIndex);
 
-  // Check if we need to switch batch type
-  if(_self.s.currentBatch.batchType != docType) {
-    // Save current batch
-    _self.s.batches.push(_self.s.currentBatch);
-    // Create a new batch
-    _self.s.currentBatch = new Batch(docType, _self.s.currentIndex);
-
-    // Reset the current size trackers
-    _self.s.currentBatchSize = 0;
-    _self.s.currentBatchSizeBytes = 0;
-  }
-
   // Check if we need to create a new batch
-  if(((_self.s.currentBatchSize + 1) >= _self.s.maxWriteBatchSize)
-    || ((_self.s.currentBatchSizeBytes + _self.s.currentBatchSizeBytes) >= _self.s.maxBatchSizeBytes)
+  if(((_self.s.currentBatch.size + 1) >= _self.s.maxWriteBatchSize)
+    || ((_self.s.currentBatch.sizeBytes + _self.s.currentBatch.sizeBytes) >= _self.s.maxBatchSizeBytes)
     || (_self.s.currentBatch.batchType != docType)) {
     // Save the batch to the execution stack
     _self.s.batches.push(_self.s.currentBatch);
 
     // Create a new batch
     _self.s.currentBatch = new Batch(docType, _self.s.currentIndex);
-
-    // Reset the current size trackers
-    _self.s.currentBatchSize = 0;
-    _self.s.currentBatchSizeBytes = 0;
-  } else {
-    // Update current batch size
-    _self.s.currentBatchSize = _self.s.currentBatchSize + 1;
-    _self.s.currentBatchSizeBytes = _self.s.currentBatchSizeBytes + bsonSize;
   }
 
   // We have an array of documents
@@ -210,8 +190,8 @@ var addToOperationsList = function(_self, docType, document) {
   }
 
   // Update current batch size
-  _self.s.currentBatchSize = _self.s.currentBatchSize + 1;
-  _self.s.currentBatchSizeBytes = _self.s.currentBatchSizeBytes + bsonSize;
+  _self.s.currentBatch.size = _self.s.currentBatch.size + 1;
+  _self.s.currentBatch.sizeBytes = _self.s.currentBatch.sizeBytes + bsonSize;
 
   // Return self
   return _self;
@@ -236,8 +216,6 @@ var UnorderedBulkOperation = function(topology, collection, options) {
   // var currentBatch = null;
 	var currentOp = null;
 	var currentIndex = 0;
-  var currentBatchSize = 0;
-  var currentBatchSizeBytes = 0;
   var batches = [];
 
   // The current Batches for the different operations
@@ -282,8 +260,6 @@ var UnorderedBulkOperation = function(topology, collection, options) {
     , currentRemoveBatch: null
     , currentBatch: null
     , currentIndex: 0
-    , currentBatchSize: 0
-    , currentBatchSizeBytes: 0
     , batches: []
     // Write concern
     , writeConcern: writeConcern


### PR DESCRIPTION
There were few issues with in the unordered bulk operation implementation in addToOperationsList: 1) currentBatchSize is updated twice in the function so the batch size will be half of maxWriteBatchSize. 2) currentBatchSize and currentBatchSizeBytes are not reset when switching batches for batch types. As a result it's incorrectly creating a new batch because it thinks it's reached maxWriteBatchSize when it has not. This can result in an empty batch and an "insert must contain at least one document" error. 3) There is some redundant code in the addToOperation function.

This pull request fixes the above issues.