### PR TITLE
[NODE-379][2.0] Fixes bug in cursor.count() that causes the result to always be zero for dotted collection names.

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -625,7 +625,7 @@ Cursor.prototype.count = function(applySkipLimit, opts, callback) {
 
   // Command
 
-  var delimiter = self.s.ns.indexOf('.')
+  var delimiter = self.s.ns.indexOf('.');
 
   var command = {
     'count': self.s.ns.substr(delimiter+1), 'query': self.s.cmd.query

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -624,8 +624,11 @@ Cursor.prototype.count = function(applySkipLimit, opts, callback) {
   }
 
   // Command
+
+  var delimiter = self.s.ns.indexOf('.')
+
   var command = {
-    'count': self.s.ns.split('.').pop(), 'query': self.s.cmd.query
+    'count': self.s.ns.substr(delimiter+1), 'query': self.s.cmd.query
   }
 
   // If maxTimeMS set
@@ -646,7 +649,7 @@ Cursor.prototype.count = function(applySkipLimit, opts, callback) {
   if(self.s.options.hint) command.hint = self.s.options.hint;
 
   // Build Query object
-  var query = new Query(self.s.bson, f("%s.$cmd", self.s.ns.split('.').shift()), command, {
+  var query = new Query(self.s.bson, f("%s.$cmd", self.s.ns.substr(0, delimiter)), command, {
       numberToSkip: 0, numberToReturn: -1
     , checkKeys: false
   });


### PR DESCRIPTION
Fixes bug in `cursor.count()` that causes the result to always be zero when called against a collection with a dot ('.') in the collection name (e.g. "fs.files").

This bug occurs in v2.0.x (I haven't investigated v3.0, it may happen there as well...)

This fixes the bug I reported here:  https://jira.mongodb.org/browse/NODE-379