### PR TITLE
Fix spelling errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ http://jira.mongodb.org/browse/NODE
 
 QuickStart
 ==========
-The quick start guide will show you how to set up a simple application using node.js and MongoDB. It scope is only how to set up the driver and perform the simple crud operations. For more inn depth coverage we encourage reading the tutorials.
+The quick start guide will show you how to setup a simple application using node.js and MongoDB. It scope is only how to set up the driver and perform the simple crud operations. For more in depth coverage we encourage reading the tutorials.
 
 Create the package.json file
 ----------------------------


### PR DESCRIPTION
While reading the documentation I noticed a few trivial spelling errors:

1) 'set up' should be 'setup'
2) 'inn' should be 'in'

 This pull request contains the fixes for the listed discrepancies.

Have a good day!