### PR TITLE
Don't only emit reconnect event on db once

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -167,7 +167,7 @@ var Db = function(databaseName, topology, options) {
   topology.once('open', createListener(self, 'open', self));
   topology.once('fullsetup', createListener(self, 'fullsetup', self));
   topology.once('all', createListener(self, 'all', self));
-  topology.once('reconnect', createListener(self, 'reconnect', self));
+  topology.on('reconnect', createListener(self, 'reconnect', self));
 }
 
 inherits(Db, EventEmitter);

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -330,10 +330,10 @@ exports['Should correctly reconnect and finish query operation'] = {
       db.collection('test_reconnect').insert({a:1}, function(err, doc) {
         test.equal(null, err);
         // Signal db reconnect
-        var dbReconnect = false;
+        var dbReconnect = 0;
 
-        db.once('reconnect', function() {
-          dbReconnect = true;
+        db.on('reconnect', function() {
+          ++dbReconnect;
         });
 
         db.serverConfig.once('reconnect', function() {
@@ -342,6 +342,7 @@ exports['Should correctly reconnect and finish query operation'] = {
           db.collection('test_reconnect').findOne(function(err, doc) {
             test.equal(null, err);
             test.equal(1, doc.a);
+            test.equal(1, dbReconnect);
 
             // Attempt disconnect again
             db.serverConfig.connections()[0].destroy();
@@ -350,7 +351,7 @@ exports['Should correctly reconnect and finish query operation'] = {
             db.collection('test_reconnect').findOne(function(err, doc) {
               test.equal(null, err);
               test.equal(1, doc.a);
-              test.equal(true, dbReconnect);
+              test.equal(2, dbReconnect);
 
               db.close();
               test.done();


### PR DESCRIPTION
Currently won't re-emit 'reconnect' event on db after one reconnect because of `.once()`, see LearnBoost/mongoose#2656.

FWIW I think we should change the entire L163-L169 block to use `on()` instead of `once()` as well as 'reconnect'. Functional tests succeed with both on() and once() on my mint box