### PR TITLE
NODE-426 handle writes to GridStoreStream instances properly

### DIFF
--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -1405,16 +1405,18 @@ GridStoreStream.prototype.write = function(chunk, encoding, callback) {
     self.gs.open(function() {
       self.gs.isOpen = true;
       self.gs.write(chunk, function() {
-        self.emit('drain');
+        process.nextTick(function() {
+          self.emit('drain');
+        });
       });
     });
+    return false;
   } else {
     self.gs.write(chunk, function() {
       self.emit('drain');
     });
+    return true;
   }
-
-  return false;
 }
 
 GridStoreStream.prototype.end = function(chunk, encoding, callback) {


### PR DESCRIPTION
fixes stream.pipe compatibility for writable GridStoreStream objects