### PR TITLE
Always use readPreference = primary for findAndModify command

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -24,7 +24,7 @@ var checkCollectionName = require('./utils').checkCollectionName
 /**
  * @fileOverview The **Collection** class is an internal class that embodies a MongoDB collection
  * allowing for insert/update/remove/find and other command operation on that MongoDB collection.
- * 
+ *
  * **COLLECTION Cannot directly be instantiated**
  * @example
  * var MongoClient = require('mongodb').MongoClient,
@@ -53,7 +53,7 @@ var checkCollectionName = require('./utils').checkCollectionName
  * @property {object} hint Get current index hint for collection.
  * @return {Collection} a Collection instance.
  */
-var Collection = function(db, topology, dbName, name, pkFactory, options) {  
+var Collection = function(db, topology, dbName, name, pkFactory, options) {
   checkCollectionName(name);
   var self = this;
   // Unpack variables
@@ -119,7 +119,7 @@ Object.defineProperty(Collection.prototype, 'namespace', {
 
 Object.defineProperty(Collection.prototype, 'writeConcern', {
   enumerable:true,
-  get: function() { 
+  get: function() {
     var ops = {};
     if(this.s.options.w != null) ops.w = this.s.options.w;
     if(this.s.options.j != null) ops.j = this.s.options.j;
@@ -281,7 +281,7 @@ Collection.prototype.find = function() {
   if(typeof newOptions.awaitdata == 'boolean')  {
     newOptions.awaitData = newOptions.awaitdata
   };
-  
+
   // Translate to new command option noCursorTimeout
   if(typeof newOptions.timeout == 'boolean') newOptions.noCursorTimeout = newOptions.timeout;
 
@@ -318,7 +318,7 @@ Collection.prototype.find = function() {
   if(newOptions.raw == null && this.s.raw) newOptions.raw = this.s.raw;
 
   // Sort options
-  if(findCommand.sort) 
+  if(findCommand.sort)
     findCommand.sort = formattedOrderClause(findCommand.sort);
 
   // Create the cursor
@@ -336,7 +336,7 @@ Collection.prototype.find = function() {
  * @param {boolean} [options.j=false] Specify a journal write concern.
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
- * @param {Collection~writeOpCallback} callback The command result callback   
+ * @param {Collection~writeOpCallback} callback The command result callback
  * @return {null}
  */
 Collection.prototype.insertOne = function(doc, options, callback) {
@@ -360,12 +360,12 @@ Collection.prototype.insertOne = function(doc, options, callback) {
  * @param {boolean} [options.j=false] Specify a journal write concern.
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
- * @param {Collection~writeOpCallback} callback The command result callback   
+ * @param {Collection~writeOpCallback} callback The command result callback
  * @return {null}
  */
 Collection.prototype.insertMany = function(docs, options, callback) {
   if(typeof options == 'function') callback = options, options = {};
-  if(!Array.isArray(docs)) return callback(new MongoError('docs parameter must be an array of documents'));    
+  if(!Array.isArray(docs)) return callback(new MongoError('docs parameter must be an array of documents'));
   insertDocuments(this, docs, options, function(err, r) {
     if(err) return callback(err);
     r.insertedCount = r.result.n;
@@ -408,7 +408,7 @@ Collection.prototype.insertMany = function(docs, options, callback) {
  *  { deleteOne: { filter: {c:1} } }
  *  { deleteMany: { filter: {c:1} } }
  *  { replaceOne: { filter: {c:3}, replacement: {c:4}, upsert:true}}]
- * 
+ *
  *
  * @method
  * @param {object[]} operations Bulk operations to perform.
@@ -417,7 +417,7 @@ Collection.prototype.insertMany = function(docs, options, callback) {
  * @param {number} [options.wtimeout=null] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
- * @param {Collection~bulkWriteOpCallback} callback The command result callback   
+ * @param {Collection~bulkWriteOpCallback} callback The command result callback
  * @return {null}
  */
 Collection.prototype.bulkWrite = function(operations, options, callback) {
@@ -425,7 +425,7 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
   if(typeof callback != 'function') throw new MongoError("bulkWrite must have a callback function specified");
   if(!Array.isArray(operations)) throw new MongoError("operations must be an array of documents");
   var bulk = options.ordered == true || options.ordered == null ? this.initializeOrderedBulkOp() : this.initializeUnorderedBulkOp();
-  
+
   // for each op go through and add to the bulk
   for(var i = 0; i < operations.length; i++) {
     bulk.raw(operations[i]);
@@ -457,7 +457,7 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
     // Map upserted ids
     for(var i = 0; i < upserted.length; i++) {
       r.upsertedIds[upserted[i].index] = upserted[i]._id;
-    }    
+    }
 
     // Return the results
     callback(null, r);
@@ -493,8 +493,8 @@ var insertDocuments = function(self, docs, options, callback) {
     // Add docs to the list
     result.ops = docs;
     // Return the results
-    handleCallback(callback, null, result);   
-  });  
+    handleCallback(callback, null, result);
+  });
 }
 
 /**
@@ -521,7 +521,7 @@ var insertDocuments = function(self, docs, options, callback) {
  * @param {boolean} [options.j=false] Specify a journal write concern.
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
- * @param {Collection~writeOpCallback} callback The command result callback   
+ * @param {Collection~writeOpCallback} callback The command result callback
  * @return {null}
  * @deprecated
  */
@@ -539,7 +539,7 @@ Collection.prototype.insert = function(docs, options, callback) {
  * @param {(number|string)} [options.w=null] The write concern.
  * @param {number} [options.wtimeout=null] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {Collection~writeOpCallback} callback The command result callback   
+ * @param {Collection~writeOpCallback} callback The command result callback
  * @return {null}
  */
 Collection.prototype.updateOne = function(filter, update, options, callback) {
@@ -554,7 +554,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
     r.modifiedCount = r.result.nModified != null ? r.result.nModified : r.result.n;
     r.upsertedId = Array.isArray(r.result.upserted) && r.result.upserted.length > 0 ? r.result.upserted[0] : null;
     r.upsertedCount = Array.isArray(r.result.upserted) && r.result.upserted.length ? r.result.upserted.length : 0;
-    callback(null, r);      
+    callback(null, r);
   });
 }
 
@@ -568,7 +568,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
  * @param {(number|string)} [options.w=null] The write concern.
  * @param {number} [options.wtimeout=null] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {Collection~writeOpCallback} callback The command result callback   
+ * @param {Collection~writeOpCallback} callback The command result callback
  * @return {null}
  */
 Collection.prototype.replaceOne = function(filter, update, options, callback) {
@@ -583,7 +583,7 @@ Collection.prototype.replaceOne = function(filter, update, options, callback) {
     r.modifiedCount = r.result.nModified != null ? r.result.nModified : r.result.n;
     r.upsertedId = Array.isArray(r.result.upserted) && r.result.upserted.length > 0 ? r.result.upserted[0] : null;
     r.upsertedCount = Array.isArray(r.result.upserted) && r.result.upserted.length ? r.result.upserted.length : 0;
-    callback(null, r);      
+    callback(null, r);
   });
 }
 
@@ -597,7 +597,7 @@ Collection.prototype.replaceOne = function(filter, update, options, callback) {
  * @param {(number|string)} [options.w=null] The write concern.
  * @param {number} [options.wtimeout=null] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {Collection~writeOpCallback} callback The command result callback   
+ * @param {Collection~writeOpCallback} callback The command result callback
  * @return {null}
  */
 Collection.prototype.updateMany = function(filter, update, options, callback) {
@@ -612,7 +612,7 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
     r.modifiedCount = r.result.nModified != null ? r.result.nModified : r.result.n;
     r.upsertedId = Array.isArray(r.result.upserted) && r.result.upserted.length > 0 ? r.result.upserted[0] : null;
     r.upsertedCount = Array.isArray(r.result.upserted) && r.result.upserted.length ? r.result.upserted.length : 0;
-    callback(null, r);      
+    callback(null, r);
   });
 }
 
@@ -646,8 +646,8 @@ var updateDocuments = function(self, selector, document, options, callback) {
     if(result.result.code) return handleCallback(callback, toError(result.result));
     if(result.result.writeErrors) return handleCallback(callback, toError(result.result.writeErrors[0]));
     // Return the results
-    handleCallback(callback, null, result);   
-  });  
+    handleCallback(callback, null, result);
+  });
 }
 
 /**
@@ -678,12 +678,12 @@ Collection.prototype.update = function(selector, document, options, callback) {
  * @param {(number|string)} [options.w=null] The write concern.
  * @param {number} [options.wtimeout=null] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {Collection~writeOpCallback} callback The command result callback   
+ * @param {Collection~writeOpCallback} callback The command result callback
  * @return {null}
  */
 Collection.prototype.deleteOne = function(filter, options, callback) {
   if(typeof options == 'function') callback = options, options = {};
-  var options = shallowClone(options);    
+  var options = shallowClone(options);
   options.single = true;
   removeDocuments(this, filter, options, function(err, r) {
     if(err) return callback(err);
@@ -702,12 +702,12 @@ Collection.prototype.removeOne = Collection.prototype.deleteOne;
  * @param {(number|string)} [options.w=null] The write concern.
  * @param {number} [options.wtimeout=null] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {Collection~writeOpCallback} callback The command result callback   
+ * @param {Collection~writeOpCallback} callback The command result callback
  * @return {null}
  */
 Collection.prototype.deleteMany = function(filter, options, callback) {
   if(typeof options == 'function') callback = options, options = {};
-  var options = shallowClone(options);    
+  var options = shallowClone(options);
   options.single = false;
   removeDocuments(this, filter, options, function(err, r) {
     if(err) return callback(err);
@@ -748,8 +748,8 @@ var removeDocuments = function(self, selector, options, callback) {
     if(result.result.code) return handleCallback(callback, toError(result.result));
     if(result.result.writeErrors) return handleCallback(callback, toError(result.result.writeErrors[0]));
     // Return the results
-    handleCallback(callback, null, result);   
-  });  
+    handleCallback(callback, null, result);
+  });
 }
 
 /**
@@ -816,7 +816,7 @@ Collection.prototype.save = function(doc, options, callback) {
  * @param {object} [options=null] Optional settings.
  * @param {number} [options.limit=0] Sets the limit of documents returned in the query.
  * @param {(array|object)} [options.sort=null] Set to sort the documents coming back from the query. Array of indexes, [['a', 1]] etc.
- * @param {object} [options.fields=null] The fields to return in the query. Object of fields to include or exclude (not both), {'a':1} 
+ * @param {object} [options.fields=null] The fields to return in the query. Object of fields to include or exclude (not both), {'a':1}
  * @param {number} [options.skip=0] Set to skip N documents ahead in your query (useful for pagination).
  * @param {Object} [options.hint=null] Tell the query to use specific indexes in the query. Object of indexes to use, {'_id':1}
  * @param {boolean} [options.explain=false] Explain the query instead of returning the data.
@@ -825,7 +825,7 @@ Collection.prototype.save = function(doc, options, callback) {
  * @param {boolean} [options.tailable=false] Specify if the cursor is tailable.
  * @param {number} [options.batchSize=0] Set the batchSize for the getMoreCommand when iterating over the query results.
  * @param {boolean} [options.returnKey=false] Only return the index key.
- * @param {number} [options.maxScan=null] Limit the number of items to scan. 
+ * @param {number} [options.maxScan=null] Limit the number of items to scan.
  * @param {number} [options.min=null] Set index bounds.
  * @param {number} [options.max=null] Set index bounds.
  * @param {boolean} [options.showDiskLoc=false] Show disk location of results.
@@ -837,7 +837,7 @@ Collection.prototype.save = function(doc, options, callback) {
  * @param {Collection~resultCallback} callback The command result callback
  * @return {null}
  */
-Collection.prototype.findOne = function() {    
+Collection.prototype.findOne = function() {
   var self = this;
   var args = Array.prototype.slice.call(arguments, 0);
   var callback = args.pop();
@@ -914,9 +914,9 @@ Collection.prototype.options = function(callback) {
   this.s.db.listCollections({name: this.s.name}).toArray(function(err, collections) {
     if(err) return handleCallback(callback, err);
     if(collections.length == 0) return handleCallback(callback, new MongoError(f("collection %s not found", self.s.namespace)));
-    handleCallback(callback, err, collections[0].options || null);      
+    handleCallback(callback, err, collections[0].options || null);
   });
-}  
+}
 
 /**
  * Returns if the collection is a capped collection
@@ -929,7 +929,7 @@ Collection.prototype.isCapped = function(callback) {
   this.options(function(err, document) {
     if(err) return handleCallback(callback, err);
     handleCallback(callback, null, document && document.capped);
-  });    
+  });
 }
 
 /**
@@ -967,7 +967,7 @@ Collection.prototype.createIndex = function(fieldOrSpec, options, callback) {
  * MongoDB 2.6 or higher. Earlier version of MongoDB will throw a command not supported
  * error. Index specifications are defined at http://docs.mongodb.org/manual/reference/command/createIndexes/.
  * @method
- * @param {array} indexSpecs An array of index specifications to be created 
+ * @param {array} indexSpecs An array of index specifications to be created
  * @param {Collection~resultCallback} callback The command result callback
  * @return {null}
  */
@@ -987,7 +987,7 @@ Collection.prototype.createIndexes = function(indexSpecs, callback) {
   }
 
   // Execute the index
-  this.s.db.command({ 
+  this.s.db.command({
     createIndexes: this.s.name, indexes: indexSpecs
   }, callback);
 }
@@ -1009,7 +1009,7 @@ Collection.prototype.dropIndex = function(indexName, options, callback) {
   options = args.length ? args.shift() || {} : {};
 
   // Delete index command
-  var cmd = {'deleteIndexes':this.s.name, 'index':indexName};  
+  var cmd = {'deleteIndexes':this.s.name, 'index':indexName};
 
   // Execute command
   this.s.db.command(cmd, options, function(err, result) {
@@ -1029,7 +1029,7 @@ Collection.prototype.dropIndexes = function(callback) {
   this.dropIndex('*', function (err, result) {
     if(err) return handleCallback(callback, err, false);
     handleCallback(callback, null, true);
-  });  
+  });
 }
 
 /**
@@ -1051,7 +1051,7 @@ Collection.prototype.dropAllIndexes = Collection.prototype.dropIndexes;
 Collection.prototype.reIndex = function(options, callback) {
   if(typeof options == 'function') callback = options, options = {};
   options = options || {};
-  
+
   // Reindex
   var cmd = {'reIndex':this.s.name};
 
@@ -1143,7 +1143,7 @@ Collection.prototype.indexExists = function(indexes, callback) {
 
     // All keys found return true
     return handleCallback(callback, null, true);
-  });    
+  });
 }
 
 /**
@@ -1160,7 +1160,7 @@ Collection.prototype.indexInformation = function(options, callback) {
   callback = args.pop();
   options = args.length ? args.shift() || {} : {};
   // Call the index information
-  this.s.db.indexInformation(this.s.name, options, callback);    
+  this.s.db.indexInformation(this.s.name, options, callback);
 }
 
 /**
@@ -1254,7 +1254,7 @@ Collection.prototype.distinct = function(key, query, options, callback) {
  * @return {null}
  */
 Collection.prototype.indexes = function(callback) {
-  this.s.db.indexInformation(this.s.name, {full:true}, callback);    
+  this.s.db.indexInformation(this.s.name, {full:true}, callback);
 }
 
 /**
@@ -1391,14 +1391,21 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
  * @param {object} [options.fields=null] Object containing the field projection for the result returned from the operation.
  * @param {Collection~resultCallback} callback The command result callback
  * @return {null}
- * @deprecated 
+ * @deprecated
  */
 Collection.prototype.findAndModify = function(query, sort, doc, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
+  var opts = {};
   callback = args.pop();
   sort = args.length ? args.shift() || [] : [];
   doc = args.length ? args.shift() : null;
   options = args.length ? args.shift() || {} : {};
+
+  for (var key in options) {
+    opts[key] = options[key];
+  }
+
+  opts.readPreference = ReadPreference.PRIMARY;
 
   var queryObject = {
      'findandmodify': this.s.name
@@ -1424,18 +1431,18 @@ Collection.prototype.findAndModify = function(query, sort, doc, options, callbac
 
   // Either use override on the function, or go back to default on either the collection
   // level or db
-  if(options['serializeFunctions'] != null) {
-    options['serializeFunctions'] = options['serializeFunctions'];
+  if(opts['serializeFunctions'] != null) {
+    opts['serializeFunctions'] = opts['serializeFunctions'];
   } else {
-    options['serializeFunctions'] = this.s.serializeFunctions;
+    opts['serializeFunctions'] = this.s.serializeFunctions;
   }
 
   // No check on the documents
-  options.checkKeys = false;
+  opts.checkKeys = false;
 
   // Execute the command
   this.s.db.command(queryObject
-    , options, function(err, result) {
+    , opts, function(err, result) {
       if(err) return handleCallback(callback, err, null);
       return handleCallback(callback, null, result);
   });
@@ -1491,7 +1498,7 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
     // a cursor based aggregation
     if(options == null && callback == null) {
       options = {};
-    }      
+    }
   } else {
     // Aggregation pipeline passed as arguments on the method
     var args = Array.prototype.slice.call(arguments, 0);
@@ -1500,7 +1507,7 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
     // Get the possible options object
     var opts = args[args.length - 1];
     // If it contains any of the admissible options pop it of the args
-    options = opts && (opts.readPreference 
+    options = opts && (opts.readPreference
       || opts.explain || opts.cursor || opts.out
       || opts.maxTimeMS || opts.allowDiskUse) ? args.pop() : {};
       // Left over arguments is the pipeline
@@ -1534,7 +1541,7 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
   if(typeof callback != 'function') {
     if(this.s.topology.capabilities().hasAggregationCursor) {
       options.cursor = options.cursor || { batchSize : 1000 };
-      command.cursor = options.cursor;        
+      command.cursor = options.cursor;
     }
 
     // Allow disk usage command
@@ -1595,7 +1602,7 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
 
   // Ensure we have the right read preference inheritance
   options = getReadPreference(this, options, this.s.db, this);
-  
+
   // Create command object
   var commandObject = {
       parallelCollectionScan: this.s.name
@@ -1632,7 +1639,7 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
 /**
  * Execute the geoNear command to search for items in the collection
  *
- * @method   
+ * @method
  * @param {number} x Point to search on the x axis, ensure the indexes are ordered in the same order.
  * @param {number} y Point to search on the y axis, ensure the indexes are ordered in the same order.
  * @param {object} [options=null] Optional settings.
@@ -1644,7 +1651,7 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
  * @param {object} [options.query=null] Filter the results by a query.
  * @param {boolean} [options.spherical=false] Perform query using a spherical model.
  * @param {boolean} [options.uniqueDocs=false] The closest location in a document to the center of the search region will always be returned MongoDB > 2.X.
- * @param {boolean} [options.includeLocs=false] Include the location data fields in the top level of the results MongoDB > 2.X. 
+ * @param {boolean} [options.includeLocs=false] Include the location data fields in the top level of the results MongoDB > 2.X.
  * @param {Collection~resultCallback} callback The command result callback
  * @return {null}
  */
@@ -1668,9 +1675,9 @@ Collection.prototype.geoNear = function(x, y, options, callback) {
   // Exclude readPreference and existing options to prevent user from
   // shooting themselves in the foot
   var exclude = {
-    readPreference: true, 
+    readPreference: true,
     geoNear: true,
-    near: true  
+    near: true
   };
 
   // Filter out any excluded objects
@@ -1689,7 +1696,7 @@ Collection.prototype.geoNear = function(x, y, options, callback) {
 /**
  * Execute a geo search using a geo haystack index on a collection.
  *
- * @method   
+ * @method
  * @param {number} x Point to search on the x axis, ensure the indexes are ordered in the same order.
  * @param {number} y Point to search on the y axis, ensure the indexes are ordered in the same order.
  * @param {object} [options=null] Optional settings.
@@ -1763,7 +1770,7 @@ var groupFunction = function () {
 /**
  * Run a group command across a collection
  *
- * @method   
+ * @method
  * @param {(object|array|function|code)} keys An object, array or function expressing the keys to group by.
  * @param {object} condition An optional condition that must be true for a row to be considered.
  * @param {object} initial Initial value of the aggregation counter object.
@@ -1894,7 +1901,7 @@ function processScope (scope) {
 /**
  * Run Map Reduce across a collection. Be aware that the inline option for out will return an array of results not a collection.
  *
- * @method   
+ * @method
  * @param {(function|string)} map The mapping function.
  * @param {(function|string)} reduce The reduce function.
  * @param {object} [options=null] Optional settings.
@@ -1951,9 +1958,9 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
   options = getReadPreference(this, options, this.s.db, this);
 
   // If we have a read preference and inline is not set as output fail hard
-  if((options.readPreference != false && options.readPreference != 'primary') 
+  if((options.readPreference != false && options.readPreference != 'primary')
     && options['out'] && (options['out'].inline != 1 && options['out'] != 'inline')) {
-      options.readPreference = 'primary';    
+      options.readPreference = 'primary';
   }
 
   // Execute command
@@ -1976,7 +1983,7 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
       if(options['verbose'] == null || !options['verbose']) {
         return handleCallback(callback, null, result.results);
       }
-      
+
       return handleCallback(callback, null, result.results, stats);
     }
 
@@ -2005,7 +2012,7 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
 /**
  * Initiate a Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order.
  *
- * @method   
+ * @method
  * @param {object} [options=null] Optional settings.
  * @param {(number|string)} [options.w=null] The write concern.
  * @param {number} [options.wtimeout=null] The write concern timeout.
@@ -2020,7 +2027,7 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
 /**
  * Initiate an In order bulk write operation, operations will be serially executed in the order they are added, creating a new operation for each switch in types.
  *
- * @method   
+ * @method
  * @param {object} [options=null] Optional settings.
  * @param {(number|string)} [options.w=null] The write concern.
  * @param {number} [options.wtimeout=null] The write concern timeout.
@@ -2041,7 +2048,7 @@ var writeConcern = function(target, db, col, options) {
     if(options.j != null) opts.j = options.j;
     if(options.fsync != null) opts.fsync = options.fsync;
     target.writeConcern = opts;
-  } else if(col.writeConcern.w != null || col.writeConcern.j != null || col.writeConcern.fsync != null) {      
+  } else if(col.writeConcern.w != null || col.writeConcern.j != null || col.writeConcern.fsync != null) {
     target.writeConcern = col.writeConcern;
   } else if(db.writeConcern.w != null || db.writeConcern.j != null || db.writeConcern.fsync != null) {
     target.writeConcern = db.writeConcern;
@@ -2061,7 +2068,7 @@ var getReadPreference = function(self, options, db, coll) {
     r = db.readPreference;
   }
 
-  if(r instanceof ReadPreference) {      
+  if(r instanceof ReadPreference) {
     options.readPreference = new CoreReadPreference(r.mode, r.tags);
   } else if(typeof r == 'string') {
     options.readPreference = new CoreReadPreference(r);

--- a/test/functional/replset_read_preference_tests.js
+++ b/test/functional/replset_read_preference_tests.js
@@ -21,7 +21,7 @@ exports.beforeTests = function(configuration, callback) {
 
 exports['Should Correctly Pick lowest ping time'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -87,7 +87,7 @@ exports['Should Correctly Pick lowest ping time'] = {
 
         // Attempt to perform a read
         db.collection('somecollection').findOne({}, {readPreference: new ReadPreference(ReadPreference.NEAREST)}, function(err, doc) {
-          test.equal(null, err);          
+          test.equal(null, err);
 
           // Pick the server
           db.serverConfig.replset.once('pickedServer', function(readPreference, server) {
@@ -96,7 +96,7 @@ exports['Should Correctly Pick lowest ping time'] = {
 
           // Attempt to perform a read
           db.collection('somecollection').findOne({}, {readPreference: new ReadPreference(ReadPreference.SECONDARY)}, function(err, doc) {
-            test.equal(null, err);          
+            test.equal(null, err);
 
             // Pick the server
             db.serverConfig.replset.once('pickedServer', function(readPreference, server) {
@@ -106,7 +106,7 @@ exports['Should Correctly Pick lowest ping time'] = {
 
             // Attempt to perform a read
             db.collection('somecollection').findOne({}, {readPreference: new ReadPreference(ReadPreference.SECONDARY_PREFERRED)}, function(err, doc) {
-              test.equal(null, err);          
+              test.equal(null, err);
 
               // Pick the server
               db.serverConfig.replset.once('pickedServer', function(readPreference, server) {
@@ -115,12 +115,12 @@ exports['Should Correctly Pick lowest ping time'] = {
 
               // Attempt to perform a read
               db.collection('somecollection').findOne({}, {readPreference: new ReadPreference(ReadPreference.PRIMARY)}, function(err, doc) {
-                test.equal(null, err);          
+                test.equal(null, err);
 
                 // Close db
                 db.close();
-                restartAndDone(configuration, test);           
-              });                
+                restartAndDone(configuration, test);
+              });
             });
           });
         });
@@ -135,7 +135,7 @@ exports['Should Correctly Pick lowest ping time'] = {
 
 exports['Should Correctly vary read server when using readpreference NEAREST'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -207,7 +207,7 @@ exports['Should Correctly vary read server when using readpreference NEAREST'] =
  */
 exports.shouldCorrectlyReadFromGridstoreWithSecondaryReadPreference = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var GridStore = configuration.require.GridStore
@@ -253,7 +253,7 @@ exports.shouldCorrectlyReadFromGridstoreWithSecondaryReadPreference = {
           // Write the file using write
           gridStore.write(data, function(err, doc) {
             test.equal(null, err);
-        
+
             gridStore.close(function(err, doc) {
               test.equal(null, err);
 
@@ -293,7 +293,7 @@ exports.shouldCorrectlyReadFromGridstoreWithSecondaryReadPreference = {
  */
 exports['shouldStillQuerySecondaryWhenNoPrimaryAvailable'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -305,7 +305,7 @@ exports['shouldStillQuerySecondaryWhenNoPrimaryAvailable'] = {
       , configuration.port, configuration.port + 1, configuration.port + 1, configuration.replicasetName);
 
     // Connect using the MongoClient
-    MongoClient.connect(url, { 
+    MongoClient.connect(url, {
         replSet: {
           //set replset check interval to be much smaller than our querying interval
           haInterval: 50,
@@ -319,7 +319,7 @@ exports['shouldStillQuerySecondaryWhenNoPrimaryAvailable'] = {
 
         db.collection("replicaset_readpref_test").insert({testfield:123}, function(err, result) {
           test.equal(null, err);
-          
+
           db.collection("replicaset_readpref_test").findOne({}, function(err, result){
             test.equal(null, err);
             test.equal(result.testfield, 123);
@@ -361,7 +361,7 @@ exports['shouldStillQuerySecondaryWhenNoPrimaryAvailable'] = {
  */
 exports['Connection to replicaset with primary read preference'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -417,7 +417,7 @@ exports['Connection to replicaset with primary read preference'] = {
  */
 exports['Should Set read preference at collection level using collection method'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -479,7 +479,7 @@ exports['Should Set read preference at collection level using collection method'
  */
 exports['Should Set read preference at collection level using createCollection method'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -512,13 +512,13 @@ exports['Should Set read preference at collection level using createCollection m
 
         // Grab the collection
         db.createCollection("read_preferences_all_levels_0", {readPreference:ReadPreference.SECONDARY}, function(err, collection) {
-          test.equal(null, err);    
+          test.equal(null, err);
 
           // Pick the server
           db.serverConfig.replset.once('pickedServer', function(readPreference, server) {
             test.ok(secondaries[server.name] != null);
           });
-          
+
           var cursor = collection.find();
           // Attempt to read (should fail due to the server not being a primary);
           cursor.toArray(function(err, items) {
@@ -543,7 +543,7 @@ exports['Should Set read preference at collection level using createCollection m
  */
 exports['Should Set read preference at cursor level'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -604,7 +604,7 @@ exports['Should Set read preference at cursor level'] = {
  */
 exports['Attempt to change read preference at cursor level after object read legacy'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -659,7 +659,7 @@ exports['Attempt to change read preference at cursor level after object read leg
  */
 exports['Set read preference at db level'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -723,7 +723,7 @@ exports['Set read preference at db level'] = {
  */
 exports['Set read preference at collection level using collection method'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -783,7 +783,7 @@ exports['Set read preference at collection level using collection method'] = {
  */
 exports['Ensure tag read goes only to the correct server'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -828,7 +828,7 @@ exports['Ensure tag read goes only to the correct server'] = {
  */
 exports['Ensure tag read goes only to the correct servers using nearest'] = {
   metadata: { requires: { topology: 'replicaset' } },
-  
+
   // The actual test we wish to run
   test: function(configuration, test) {
     var mongo = configuration.require
@@ -860,6 +860,93 @@ exports['Ensure tag read goes only to the correct servers using nearest'] = {
 
       db.db('local').collection('system.replset').find().toArray(function(err, doc) {
         test.ok(success);
+        db.close();
+        restartAndDone(configuration, test);
+      });
+    });
+
+    db.open(function(err, p_db) {
+      db = p_db;
+    });
+  }
+}
+
+/**
+ * @ignore
+ */
+exports['Ensure tag read goes only to the correct server'] = {
+  metadata: { requires: { topology: 'replicaset' } },
+
+  // The actual test we wish to run
+  test: function(configuration, test) {
+    var mongo = configuration.require
+      , MongoClient = mongo.MongoClient
+      , ReadPreference = mongo.ReadPreference
+      , ReplSet = mongo.ReplSet
+      , Server = mongo.Server
+      , Db = mongo.Db;
+
+    // Replica configuration
+    var replSet = new ReplSet( [
+        new Server(configuration.host, configuration.port),
+        new Server(configuration.host, configuration.port + 1),
+        new Server(configuration.host, configuration.port + 2)
+      ],
+      {rs_name:configuration.replicasetName, debug:true}
+    );
+
+    // Open the database
+    var db = new Db('local', replSet, {w:0, readPreference: new ReadPreference(ReadPreference.SECONDARY, {"loc":"ny"})});
+    // Trigger test once whole set is up
+    db.on("fullsetup", function() {
+      db.serverConfig.replset.once('pickedServer', function(readPreference, server) {
+        test.equal('secondary', readPreference.preference);
+        test.equal('ny', readPreference.tags['loc']);
+      });
+
+      db.db('local').collection('system.replset').find().toArray(function(err, doc) {
+        db.close();
+        restartAndDone(configuration, test);
+      });
+    });
+
+    db.open(function(err, p_db) {
+      db = p_db;
+    });
+  }
+}
+
+/**
+ * @ignore
+ */
+exports['Always uses primary readPreference for findAndModify'] = {
+  metadata: { requires: { topology: 'replicaset' } },
+
+  // The actual test we wish to run
+  test: function(configuration, test) {
+    var mongo = configuration.require
+      , MongoClient = mongo.MongoClient
+      , ReadPreference = mongo.ReadPreference
+      , ReplSet = mongo.ReplSet
+      , Server = mongo.Server
+      , Db = mongo.Db;
+
+    // Replica configuration
+    var replSet = new ReplSet( [
+        new Server(configuration.host, configuration.port),
+        new Server(configuration.host, configuration.port + 1),
+        new Server(configuration.host, configuration.port + 2)
+      ],
+      {rs_name:configuration.replicasetName, debug:true}
+    );
+
+    // Open the database
+    var db = new Db('test', replSet, {w:0, readPreference: new ReadPreference(ReadPreference.SECONDARY_PREFERRED)});
+    var success = false;
+    // Trigger test once whole set is up
+    db.on("fullsetup", function() {
+      db.collection('test').findAndModify({}, {}, { upsert: false }, function(err) {
+        test.equal(null, err);
         db.close();
         restartAndDone(configuration, test);
       });

--- a/test/functional/replset_read_preference_tests.js
+++ b/test/functional/replset_read_preference_tests.js
@@ -874,51 +874,6 @@ exports['Ensure tag read goes only to the correct servers using nearest'] = {
 /**
  * @ignore
  */
-exports['Ensure tag read goes only to the correct server'] = {
-  metadata: { requires: { topology: 'replicaset' } },
-
-  // The actual test we wish to run
-  test: function(configuration, test) {
-    var mongo = configuration.require
-      , MongoClient = mongo.MongoClient
-      , ReadPreference = mongo.ReadPreference
-      , ReplSet = mongo.ReplSet
-      , Server = mongo.Server
-      , Db = mongo.Db;
-
-    // Replica configuration
-    var replSet = new ReplSet( [
-        new Server(configuration.host, configuration.port),
-        new Server(configuration.host, configuration.port + 1),
-        new Server(configuration.host, configuration.port + 2)
-      ],
-      {rs_name:configuration.replicasetName, debug:true}
-    );
-
-    // Open the database
-    var db = new Db('local', replSet, {w:0, readPreference: new ReadPreference(ReadPreference.SECONDARY, {"loc":"ny"})});
-    // Trigger test once whole set is up
-    db.on("fullsetup", function() {
-      db.serverConfig.replset.once('pickedServer', function(readPreference, server) {
-        test.equal('secondary', readPreference.preference);
-        test.equal('ny', readPreference.tags['loc']);
-      });
-
-      db.db('local').collection('system.replset').find().toArray(function(err, doc) {
-        db.close();
-        restartAndDone(configuration, test);
-      });
-    });
-
-    db.open(function(err, p_db) {
-      db = p_db;
-    });
-  }
-}
-
-/**
- * @ignore
- */
 exports['Always uses primary readPreference for findAndModify'] = {
   metadata: { requires: { topology: 'replicaset' } },
 


### PR DESCRIPTION
As discussed this morning, see Automattic/mongoose#2823, Automattic/mongoose#2899 . Makes sense for `findAndModify` to ensure primary read pref.