### PR TITLE
NODE-460 fix; don't set authMechanism for user in db.authenticate()

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1021,10 +1021,9 @@ Db.prototype.removeUser = function(username, options, callback) {
 Db.prototype.authenticate = function(username, password, options, callback) {
   if(typeof options == 'function') callback = options, options = {};
   var self = this;
-  // Set default mechanism
-  if(!options.authMechanism) {
-    options.authMechanism = 'DEFAULT';
-  } else if(options.authMechanism != 'GSSAPI'
+  // If authMechanism is set to an invalid value, error out
+  if(options.authMechanism
+    && options.authMechanism != 'GSSAPI'
     && options.authMechanism != 'MONGODB-CR'
     && options.authMechanism != 'MONGODB-X509'
     && options.authMechanism != 'SCRAM-SHA-1'
@@ -1085,7 +1084,7 @@ Db.prototype.authenticate = function(username, password, options, callback) {
         _callback(null, true);
       });
     }
-  } else if(authMechanism == 'DEFAULT') {
+  } else if(authMechanism === '') {
     this.s.topology.auth('default', authdb, username, password, function(err, result) {
       if(err) return handleCallback(callback, err, false);
       _callback(null, true);


### PR DESCRIPTION
Hi Christian,

I made an analogous fix for 1.4.x in #1246. The issue is that if you call `.authenticate()` with the same `options` object twice, you'll get an error because when you don't specify an `authMechanism`, `db.authenticate()` sets it to 'DEFAULT'. This breaks mongoose's `createConnection()` function if you reuse the options object like the user in Automattic/mongoose#2926 pointed out.