### PR TITLE
Don't only emit server close event once

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -168,7 +168,7 @@ var Db = function(databaseName, topology, options) {
   // Add listeners
   topology.once('error', createListener(self, 'error', self));
   topology.once('timeout', createListener(self, 'timeout', self));
-  topology.once('close', createListener(self, 'close', self));
+  topology.on('close', createListener(self, 'close', self));
   topology.once('parseError', createListener(self, 'parseError', self));
   topology.once('open', createListener(self, 'open', self));
   topology.once('fullsetup', createListener(self, 'fullsetup', self));

--- a/lib/server.js
+++ b/lib/server.js
@@ -260,7 +260,7 @@ Server.prototype.connect = function(db, _options, callback) {
     // Set up listeners
     self.s.server.once('timeout', errorHandler('timeout'));
     self.s.server.once('error', errorHandler('error'));
-    self.s.server.once('close', errorHandler('close'));
+    self.s.server.on('close', errorHandler('close'));
     // Only called on destroy
     self.s.server.once('destroy', destroyHandler);
 

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -331,9 +331,14 @@ exports['Should correctly reconnect and finish query operation'] = {
         test.equal(null, err);
         // Signal db reconnect
         var dbReconnect = 0;
+        var dbClose = 0;
 
         db.on('reconnect', function() {
           ++dbReconnect;
+        });
+
+        db.on('close', function() {
+          ++dbClose;
         });
 
         db.serverConfig.once('reconnect', function() {
@@ -343,6 +348,7 @@ exports['Should correctly reconnect and finish query operation'] = {
             test.equal(null, err);
             test.equal(1, doc.a);
             test.equal(1, dbReconnect);
+            test.equal(1, dbClose);
 
             // Attempt disconnect again
             db.serverConfig.connections()[0].destroy();
@@ -352,6 +358,7 @@ exports['Should correctly reconnect and finish query operation'] = {
               test.equal(null, err);
               test.equal(1, doc.a);
               test.equal(2, dbReconnect);
+              test.equal(2, dbClose);
 
               db.close();
               test.done();


### PR DESCRIPTION
Hi Christian,

This is analogous to #1265, but this time for the `close` event - the `close` event only gets fired once when connected to a single server, but never again. This manifests in mongoose because mongoose re-emits the `close` event as `disconnected`, see Automattic/mongoose#2865.