### PR TITLE
Fix for GridStoreStream.pipe() to be able to chain correctly.

### DIFF
--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -1367,6 +1367,7 @@ GridStoreStream.prototype.pipe = function(destination) {
     self.totalBytesToRead = self.gs.length - self.gs.position;
     self._pipe.apply(self, [destination]);    
   }
+  return destination;
 }
 
 // Called by stream


### PR DESCRIPTION
Fixed bug where GridStoreStream.prototype.pipe(dst) is not returning dst. This breaks pipe chaining