### PR TITLE
Fix mongo driver to use passive nodes

### DIFF
--- a/lib/mongodb/connection/repl_set/repl_set.js
+++ b/lib/mongodb/connection/repl_set/repl_set.js
@@ -373,8 +373,16 @@ var _handler = function(event, self, server) {
 }
 
 var locateNewServers = function(self, state, candidateServers, ismaster) {
-  // Retrieve the host
-  var hosts = ismaster.hosts;
+  // Retrieve the hosts
+  var hosts = [];
+  if(Array.isArray(ismaster.hosts)) {
+    hosts = hosts.concat(ismaster.hosts);
+  }
+  // Include the passives
+  if(Array.isArray(ismaster.passives)) {
+    hosts = hosts.concat(ismaster.passives);
+  }
+
   // In candidate servers
   var inCandidateServers = function(name, candidateServers) {
     for(var i = 0; i < candidateServers.length; i++) {
@@ -386,14 +394,12 @@ var locateNewServers = function(self, state, candidateServers, ismaster) {
 
   // New servers
   var newServers = [];
-  if(Array.isArray(hosts)) {
-    // Let's go over all the hosts
-    for(var i = 0; i < hosts.length; i++) {
-      if(!state.contains(hosts[i]) 
-        && !inCandidateServers(hosts[i], candidateServers)) {
-          newServers.push(createServer(self, hosts[i], self.options));
-      }
-    }    
+  // Let's go over all the hosts
+  for(var i = 0; i < hosts.length; i++) {
+    if(!state.contains(hosts[i]) 
+      && !inCandidateServers(hosts[i], candidateServers)) {
+        newServers.push(createServer(self, hosts[i], self.options));
+    }
   }
 
   // Return list of possible new servers


### PR DESCRIPTION
The mongo connect response does not include passive hosts in the hosts array.  Instead, these hosts are included in the passives array.  The (BSON) response might look like:
```
{ setName: 'rs0',
 setVersion: 31,
 ismaster: true,
 secondary: false,
 hosts: 
  [ '10.72.100.80:8000',
    '10.72.229.66:8000',
    '10.72.102.196:8000',
    '10.72.101.200:8000' ],
 passives: [ '10.72.230.249:8000' ],
 primary: '10.72.100.80:8000',
 tags: { dc: 'west' },
 me: '10.72.100.80:8000',
 maxBsonObjectSize: 16777216,
 maxMessageSizeBytes: 48000000,
 maxWriteBatchSize: 1000,
 localTime: Wed Jun 24 2015 19:19:42 GMT+0000 (UTC),
 maxWireVersion: 2,
 minWireVersion: 0,
 ok: 1 }
```
We want to be able to read from these passive hosts.

I have manually verified all existing unit tests pass.
I am looking into adding a unit test corresponding to this change...
