### PR TITLE
Ensures that errors from bulk unordered and ordered are instanceof Error

### DIFF
--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -402,7 +402,7 @@ var executeCommands = function(self, callback) {
     // If we are ordered and have errors and they are
     // not all replication errors terminate the operation
     if(self.s.bulkResult.writeErrors.length > 0) {
-      return callback(self.s.bulkResult.writeErrors[0], new BulkWriteResult(self.s.bulkResult));
+      return callback(toError(self.s.bulkResult.writeErrors[0]), new BulkWriteResult(self.s.bulkResult));
     }
 
     // Execute the next command in line

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -431,7 +431,7 @@ var executeBatches = function(self, callback) {
 
       // Execute
       if(numberOfCommandsToExecute == 0) {
-        var error = self.s.bulkResult.writeErrors.length > 0 ? self.s.bulkResult.writeErrors[0] : null;
+        var error = self.s.bulkResult.writeErrors.length > 0 ? toError(self.s.bulkResult.writeErrors[0]) : null;
         callback(error, new BulkWriteResult(self.s.bulkResult));
       }
     });

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -82,6 +82,7 @@ exports['Should correctly handle ordered multiple batch api write command error'
         // Execute the operations
         batch.execute(function(err, result) {
           // Basic properties check
+          test.equal(err instanceof Error, true);
           test.equal(1, result.nInserted);
           test.equal(true, result.hasWriteErrors());
           test.ok(1, result.getWriteErrorCount());
@@ -484,6 +485,7 @@ exports['Should correctly handle single unordered batch API'] = {
         // Execute the operations
         batch.execute(function(err, result) {
           // Basic properties check
+          test.equal(err instanceof Error, true);
           test.equal(2, result.nInserted);
           test.equal(0, result.nUpserted);
           test.equal(0, result.nMatched);


### PR DESCRIPTION
Previously writeErrors returned by ordered and unordered bulk operations were mongodb WriteErrors, this runs them through the toError pathway that way it plays nicer in user land where a lot of code depends on err instanceof Error.

JIRA: https://jira.mongodb.org/browse/NODE-506