### PR TITLE
Ignore undefined fields in Collection.find()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -172,7 +172,7 @@ Collection.prototype.find = function() {
     options = args[0];
   }
 
-  if(len === 2 && !Array.isArray(fields)) {
+  if(len === 2 && fields !== undefined && !Array.isArray(fields)) {
     var fieldKeys = Object.keys(fields);
     var is_option = false;
 


### PR DESCRIPTION
I noticed when calling the `find(selector, fields)` method on a collection with fields set to `undefined`, I get a `TypeError: Object.keys called on non-object`. When checking out the problem, I found that the `collection.js` module checks if `argument.length >= 2` which evaluates to `true` even if `argument[1]` is not explicitly set. I.e. the code is trying to use the `fields` argument as if it's set, throwing the error eventually.

Fixed it by comparing `fields !== undefined` instead of using the argument count.

In our application, we basically do something like this:
```js
// fields is optional
function getRecords(arg1, arg2, fields) {
    // validate arg1, arg2 etc...

     // build the query with arg1, arg2
    var query = {};

    return collection.find(query, fields);
}
```

I changed `fields` to `fields || {}` as a quick work-around for now, but I'm pretty sure `undefined` should be just ignored in the module.