### PR TITLE
add currentDoc condition in hasNext function

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -183,29 +183,29 @@ Cursor.prototype.hasNext = function(callback) {
 
   // Execute using callback
   if(typeof callback == 'function') {
-      if(self.s.currentDoc){
-          return callback(null, true);
-      } else {
-          return nextObject(self, function(err, doc) {
-            if(!doc) return callback(null, false);
-            self.s.currentDoc = doc;
-            callback(null, true);
-          });
-      }
+    if(self.s.currentDoc){
+      return callback(null, true);
+    } else {
+      return nextObject(self, function(err, doc) {
+        if(!doc) return callback(null, false);
+        self.s.currentDoc = doc;
+        callback(null, true);
+      });
+    }
   }
 
   // Return a Promise
   return new this.s.promiseLibrary(function(resolve, reject) {
-      if(self.s.currentDoc){
-          resolve(true);
-      } else {
-        nextObject(self, function(err, doc) {
-          if(self.s.state == Cursor.CLOSED || self.isDead()) return resolve(false);
-          if(err) return reject(err);
-          if(!doc) return resolve(false);
-          self.s.currentDoc = doc;
-          resolve(true);
-        });
+    if(self.s.currentDoc){
+      resolve(true);
+    } else {
+      nextObject(self, function(err, doc) {
+        if(self.s.state == Cursor.CLOSED || self.isDead()) return resolve(false);
+        if(err) return reject(err);
+        if(!doc) return resolve(false);
+        self.s.currentDoc = doc;
+        resolve(true);
+      });
     }
   });
 }

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -182,21 +182,31 @@ Cursor.prototype.hasNext = function(callback) {
   var self = this;
 
   // Execute using callback
-  if(typeof callback == 'function') return nextObject(self, function(err, doc) {
-    if(!doc) return callback(null, false);
-    self.s.currentDoc = doc;
-    callback(null, true);
-  });
+  if(typeof callback == 'function') {
+      if(self.s.currentDoc){
+          return callback(null, true);
+      } else {
+          return nextObject(self, function(err, doc) {
+            if(!doc) return callback(null, false);
+            self.s.currentDoc = doc;
+            callback(null, true);
+          });
+      }
+  }
 
   // Return a Promise
   return new this.s.promiseLibrary(function(resolve, reject) {
-    nextObject(self, function(err, doc) {
-      if(self.s.state == Cursor.CLOSED || self.isDead()) return resolve(false);
-      if(err) return reject(err);
-      if(!doc) return resolve(false);
-      self.s.currentDoc = doc;
-      resolve(true);
-    });
+      if(self.s.currentDoc){
+          resolve(true);
+      } else {
+        nextObject(self, function(err, doc) {
+          if(self.s.state == Cursor.CLOSED || self.isDead()) return resolve(false);
+          if(err) return reject(err);
+          if(!doc) return resolve(false);
+          self.s.currentDoc = doc;
+          resolve(true);
+        });
+    }
   });
 }
 


### PR DESCRIPTION
Fix problem: run hasNext more than once will make cursor point move and miss document.

I don't find a way to report an issue. And this is a simple change. I hope you will take it.