### PR TITLE
Pass promise library through to DB function

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -242,7 +242,7 @@ var connect = function(url, options, callback) {
 
     var connectFunction = function(__server) {
       // Attempt connect
-      new Db(object.dbName, __server, {w:1, native_parser:false}).open(function(err, db) {
+      new Db(object.dbName, __server, {w:1, native_parser:false, promiseLibrary:options.promiseLibrary}).open(function(err, db) {
         // Update number of servers
         totalNumberOfServers = totalNumberOfServers - 1;
         


### PR DESCRIPTION
If the library is not properly passed, the underlying function attempts to use es-6 promises instead.
As I am not using that particular package, it crashes my app.