### PR TITLE
GridStore doesn't share readPreference setting from connection string

### DIFF
--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -127,7 +127,7 @@ var GridStore = function GridStore(db, id, filename, mode, options) {
   // Set the root if overridden
   this.root = this.options['root'] == null ? GridStore.DEFAULT_ROOT_COLLECTION : this.options['root'];
   this.position = 0;
-  this.readPreference = this.options.readPreference || ReadPreference.PRIMARY;
+  this.readPreference = this.options.readPreference || db.options.readPreference || ReadPreference.PRIMARY;
   this.writeConcern = _getWriteConcern(db, this.options);
   // Set default chunk size
   this.internalChunkSize = this.options['chunkSize'] == null ? Chunk.DEFAULT_CHUNK_SIZE : this.options['chunkSize'];


### PR DESCRIPTION
JIRA issue [NODE-557](https://jira.mongodb.org/browse/NODE-557)