### PR TITLE
Use handleCallback if result is an error for count queries

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -944,7 +944,9 @@ var count = function(self, applySkipLimit, opts, callback) {
     if(result.documents.length == 1
       && (result.documents[0].errmsg
       || result.documents[0].err
-      || result.documents[0]['$err'])) return callback(MongoError.create(result.documents[0]));
+      || result.documents[0]['$err'])) {
+      return handleCallback(callback, MongoError.create(result.documents[0]));
+    }
     handleCallback(callback, null, result.documents[0].n);
   });
 


### PR DESCRIPTION
Right now, if the result is a single document with error, the application callback is called directly. This means that if the application code throws an exception, it gets propagated to the driver code causing unexpected behavior (server topology being destroyed in my case).

Using `handleCallback` ensures that in this scenario, the exception does not get propagated to the driver code.