### PR TITLE
Auto-detect and resolve trying to use SCRAM-SHA-1 on pre-2.8 kernel.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1338,6 +1338,16 @@ var authenticate = function(self, username, password, options, callback) {
   var authMechanism = options.authMechanism || '';
   authMechanism = authMechanism.toUpperCase();
 
+  // If SCRAM-SHA-1 supplied as the authMechanism but the server
+  // is pre-2.8 and doesn't support it, automatically switch to
+  // MONGODB-CR. This will allow much easier upgrades as the
+  // customer's app config can be updated and deployed out of band and
+  // *before*  upgrading to 3.x vs. requiring simultaneous upgrades.
+  // @see https://jira.mongodb.org/browse/SERVER-15521
+  if(self.s.topology.capabilities().hasSCRAMSHA1 === false && authMechanism === 'SCRAM-SHA-1'){
+    authMechanism = 'MONGODB-CR';
+  }
+
   // If classic auth delegate to auth command
   if(authMechanism == 'MONGODB-CR') {
     self.s.topology.auth('mongocr', authdb, username, password, function(err, result) {

--- a/lib/topology_base.js
+++ b/lib/topology_base.js
@@ -107,6 +107,7 @@ var ServerCapabilities = function(ismaster) {
   var authCommands = false;
   var listCollections = false;
   var listIndexes = false;
+  var hasSCRAMSHA1 = true;
   var maxNumberOfDocsInBatch = ismaster.maxWriteBatchSize || 1000;
 
   if(ismaster.minWireVersion >= 0) {
@@ -136,6 +137,12 @@ var ServerCapabilities = function(ismaster) {
     ismaster.maxWireVersion = 0;
   }
 
+  // Use MONGODB-CR for v2.6 and earlier.
+  // @see https://jira.mongodb.org/browse/SERVER-15521
+  if (ismaster.maxWireVersion < 3) {
+    hasSCRAMSHA1 = false;
+  }
+
   // Map up read only parameters
   setup_get_property(this, "hasAggregationCursor", aggregationCursor);
   setup_get_property(this, "hasWriteCommands", writeCommands);
@@ -146,6 +153,7 @@ var ServerCapabilities = function(ismaster) {
   setup_get_property(this, "minWireVersion", ismaster.minWireVersion);
   setup_get_property(this, "maxWireVersion", ismaster.maxWireVersion);
   setup_get_property(this, "maxNumberOfDocsInBatch", maxNumberOfDocsInBatch);
+  setup_get_property(this, "hasSCRAMSHA1", hasSCRAMSHA1);
 }
 
 exports.Store = Store;


### PR DESCRIPTION
If SCRAM-SHA-1 supplied as the authMechanism but the server
is pre-2.8 and doesn't support it, automatically switch to
MONGODB-CR. This will allow much easier upgrades as the
customer's app config can be updated and deployed out of band and
*before*  upgrading to 3.x vs. requiring simultaneous upgrades.

@see https://jira.mongodb.org/browse/SERVER-15521

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongodb/node-mongodb-native/1299)
<!-- Reviewable:end -->
