### PR TITLE
Advanced part of GridFS spec

### DIFF
--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -13,16 +13,18 @@ module.exports = GridFSBucketReadStream;
  * @param {Collection} chunks Handle for chunks collection
  * @param {Collection} files Handle for files collection
  * @param {Object} readPreference The read preference to use
- * @param {ObjectId} id The id of the file in the files collection
+ * @param {Object} filter The query to use to find the file document
+ * @param {Object} [sort] Optional sort for the file find query
+ * @param {Number} [skip] Optional skip for the file find query
  * @fires GridFSBucketReadStream#error
  * @fires GridFSBucketReadStream#file
  * @return {GridFSBucketReadStream} a GridFSBucketReadStream instance.
  */
 
-function GridFSBucketReadStream(chunks, files, readPreference, id) {
+function GridFSBucketReadStream(chunks, files, readPreference, filter, sort, skip) {
   var _this = this;
   this.s = {
-    cursor: chunks.find({ files_id: id }).sort({ n: 1 }),
+    cursor: null,
     expected: 0,
     file: null
   };
@@ -31,16 +33,22 @@ function GridFSBucketReadStream(chunks, files, readPreference, id) {
 
   var findOneOptions = {};
   if (readPreference) {
-    this.s.cursor.setReadPreference(readPreference);
     findOneOptions.readPreference = readPreference;
   }
+  if (sort) {
+    findOneOptions.sort = sort;
+  }
+  if (skip) {
+    findOneOptions.skip = skip;
+  }
 
-  files.findOne({ _id: id }, findOneOptions, function(error, doc) {
+  files.findOne(filter, findOneOptions, function(error, doc) {
     if (error) {
       return __handleError(_this, error);
     }
     if (!doc) {
-      var errmsg = 'FileNotFound: file ' + id.toString() + ' was not found';
+      var identifier = filter._id ? filter._id.toString() : filter.filename;
+      var errmsg = 'FileNotFound: file ' + identifier + ' was not found';
       return __handleError(_this, new Error(errmsg));
     }
 
@@ -49,6 +57,11 @@ function GridFSBucketReadStream(chunks, files, readPreference, id) {
     if (doc.length <= 0) {
       _this.push(null);
       return;
+    }
+
+    _this.s.cursor = chunks.find({ files_id: doc._id }).sort({ n: 1 });
+    if (readPreference) {
+      _this.s.cursor.setReadPreference(readPreference);
     }
     _this.s.file = doc;
     _this.s.bytesRemaining = doc.length;

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -23,7 +23,8 @@ function GridFSBucketReadStream(chunks, files, readPreference, id) {
   var _this = this;
   this.s = {
     cursor: chunks.find({ files_id: id }).sort({ n: 1 }),
-    expected: 0
+    expected: 0,
+    file: null
   };
 
   stream.Readable.call(this);
@@ -41,6 +42,13 @@ function GridFSBucketReadStream(chunks, files, readPreference, id) {
     if (!doc) {
       var errmsg = 'FileNotFound: file ' + id.toString() + ' was not found';
       return __handleError(_this, new Error(errmsg));
+    }
+
+    // If document is empty, kill the stream immediately and don't
+    // execute any reads
+    if (doc.length <= 0) {
+      _this.push(null);
+      return;
     }
     _this.s.file = doc;
     _this.s.bytesRemaining = doc.length;

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -14,18 +14,23 @@ module.exports = GridFSBucketReadStream;
  * @param {Collection} files Handle for files collection
  * @param {Object} readPreference The read preference to use
  * @param {Object} filter The query to use to find the file document
- * @param {Object} [sort] Optional sort for the file find query
- * @param {Number} [skip] Optional skip for the file find query
+ * @param {Object} [options=null] Optional settings.
+ * @param {Number} [options.sort=null] Optional sort for the file find query
+ * @param {Number} [options.skip=null] Optional skip for the file find query
+ * @param {Number} [options.start=null] Optional 0-based offset in bytes to start streaming from
+ * @param {Number} [options.end=null] Optional 0-based offset in bytes to stop streaming before
  * @fires GridFSBucketReadStream#error
  * @fires GridFSBucketReadStream#file
  * @return {GridFSBucketReadStream} a GridFSBucketReadStream instance.
  */
 
-function GridFSBucketReadStream(chunks, files, readPreference, filter, sort, skip) {
+function GridFSBucketReadStream(chunks, files, readPreference, filter, options) {
   var _this = this;
   this.s = {
+    bytesRead: 0,
     cursor: null,
     expected: 0,
+    expectedEnd: 0,
     file: null
   };
 
@@ -35,11 +40,11 @@ function GridFSBucketReadStream(chunks, files, readPreference, filter, sort, ski
   if (readPreference) {
     findOneOptions.readPreference = readPreference;
   }
-  if (sort) {
-    findOneOptions.sort = sort;
+  if (options && options.sort) {
+    findOneOptions.sort = options.sort;
   }
-  if (skip) {
-    findOneOptions.skip = skip;
+  if (options && options.skip) {
+    findOneOptions.skip = options.skip;
   }
 
   files.findOne(filter, findOneOptions, function(error, doc) {
@@ -63,8 +68,12 @@ function GridFSBucketReadStream(chunks, files, readPreference, filter, sort, ski
     if (readPreference) {
       _this.s.cursor.setReadPreference(readPreference);
     }
+
+    _this.s.expectedEnd = Math.ceil(doc.length / doc.chunkSize);
     _this.s.file = doc;
-    _this.s.bytesRemaining = doc.length;
+    _this.s.bytesToSkip = handleStartOption(_this, doc, _this.s.cursor,
+      options);
+    _this.s.bytesToTrim = handleEndOption(_this, doc, _this.s.cursor, options);
     _this.emit('file', doc);
   });
 }
@@ -111,9 +120,10 @@ function doRead(_this) {
       return _this.push(null);
     }
 
+    var bytesRemaining = _this.s.file.length - _this.s.bytesRead;
     var expectedN = _this.s.expected++;
     var expectedLength = Math.min(_this.s.file.chunkSize,
-      _this.s.bytesRemaining);
+      bytesRemaining);
     if (doc.n > expectedN) {
       var errmsg = 'ChunkIsMissing: Got unexpected n: ' + doc.n +
         ', expected: ' + expectedN;
@@ -125,7 +135,7 @@ function doRead(_this) {
       return __handleError(_this, new Error(errmsg));
     }
     if (doc.data.length() !== expectedLength) {
-      if (_this.s.bytesRemaining <= 0) {
+      if (bytesRemaining <= 0) {
         var errmsg = 'ExtraChunk: Got unexpected n: ' + doc.n;
         return __handleError(_this, new Error(errmsg));
       }
@@ -134,12 +144,29 @@ function doRead(_this) {
       return __handleError(_this, new Error(errmsg));
     }
 
-    _this.s.bytesRemaining -= doc.data.length();
+    _this.s.bytesRead += doc.data.length();
 
     if (doc.data.buffer.length === 0) {
       return _this.push(null);
     }
-    _this.push(doc.data.buffer);
+
+    var sliceStart = null;
+    var sliceEnd = null;
+    var buf = doc.data.buffer;
+    if (_this.s.bytesToSkip != null) {
+      sliceStart = _this.s.bytesToSkip;
+      _this.s.bytesToSkip = 0;
+    }
+
+    if (expectedN === _this.s.expectedEnd && _this.s.bytesToTrim != null) {
+      sliceEnd = _this.s.bytesToTrim;
+    }
+
+    if (sliceStart != null || sliceEnd != null) {
+      buf = buf.slice(sliceStart || 0, sliceEnd || buf.length);
+    }
+
+    _this.push(buf);
   });
 };
 
@@ -155,6 +182,64 @@ function waitForFile(_this, callback) {
     callback();
   });
 };
+
+/**
+ * @ignore
+ */
+
+function handleStartOption(stream, doc, cursor, options) {
+  if (options && options.start != null) {
+    if (options.start > doc.length) {
+      throw new Error('Stream start (' + options.start + ') must not be ' +
+        'more than the length of the file (' + doc.length +')')
+    }
+    if (options.start < 0) {
+      throw new Error('Stream start (' + options.start + ') must not be ' +
+        'negative');
+    }
+    if (options.end != null && options.end < options.start) {
+      throw new Error('Stream start (' + options.start + ') must not be ' +
+        'greater than stream end (' + options.end + ')');
+    }
+
+    cursor.skip(Math.floor(options.start / doc.chunkSize));
+
+    stream.s.bytesRead = Math.floor(options.start / doc.chunkSize) *
+      doc.chunkSize;
+    stream.s.expected = Math.floor(options.start / doc.chunkSize);
+
+    return options.start - stream.s.bytesRead;
+  }
+}
+
+/**
+ * @ignore
+ */
+
+function handleEndOption(stream, doc, cursor, options) {
+  if (options && options.end != null) {
+    if (options.end > doc.length) {
+      throw new Error('Stream end (' + options.end + ') must not be ' +
+        'more than the length of the file (' + doc.length +')')
+    }
+    if (options.start < 0) {
+      throw new Error('Stream end (' + options.end + ') must not be ' +
+        'negative');
+    }
+
+    var start = options.start != null ?
+      Math.floor(options.start / doc.chunkSize) :
+      0;
+
+    console.log('limit', options.end, doc.chunkSize, start);
+    cursor.limit(Math.ceil(options.end / doc.chunkSize) - start);
+
+    stream.s.expectedEnd = Math.ceil(options.end / doc.chunkSize);
+
+    return (Math.ceil(options.end / doc.chunkSize) * doc.chunkSize) -
+      options.end;
+  }
+}
 
 /**
  * @ignore

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -28,54 +28,19 @@ function GridFSBucketReadStream(chunks, files, readPreference, filter, options) 
   var _this = this;
   this.s = {
     bytesRead: 0,
+    chunks: chunks,
     cursor: null,
     expected: 0,
+    files: files,
+    filter: filter,
+    init: false,
     expectedEnd: 0,
-    file: null
+    file: null,
+    options: options,
+    readPreference: readPreference
   };
 
   stream.Readable.call(this);
-
-  var findOneOptions = {};
-  if (readPreference) {
-    findOneOptions.readPreference = readPreference;
-  }
-  if (options && options.sort) {
-    findOneOptions.sort = options.sort;
-  }
-  if (options && options.skip) {
-    findOneOptions.skip = options.skip;
-  }
-
-  files.findOne(filter, findOneOptions, function(error, doc) {
-    if (error) {
-      return __handleError(_this, error);
-    }
-    if (!doc) {
-      var identifier = filter._id ? filter._id.toString() : filter.filename;
-      var errmsg = 'FileNotFound: file ' + identifier + ' was not found';
-      return __handleError(_this, new Error(errmsg));
-    }
-
-    // If document is empty, kill the stream immediately and don't
-    // execute any reads
-    if (doc.length <= 0) {
-      _this.push(null);
-      return;
-    }
-
-    _this.s.cursor = chunks.find({ files_id: doc._id }).sort({ n: 1 });
-    if (readPreference) {
-      _this.s.cursor.setReadPreference(readPreference);
-    }
-
-    _this.s.expectedEnd = Math.ceil(doc.length / doc.chunkSize);
-    _this.s.file = doc;
-    _this.s.bytesToSkip = handleStartOption(_this, doc, _this.s.cursor,
-      options);
-    _this.s.bytesToTrim = handleEndOption(_this, doc, _this.s.cursor, options);
-    _this.emit('file', doc);
-  });
 }
 
 util.inherits(GridFSBucketReadStream, stream.Readable);
@@ -106,6 +71,47 @@ GridFSBucketReadStream.prototype._read = function() {
     doRead(_this);
   });
 };
+
+/**
+ * Sets the 0-based offset in bytes to start streaming from. Throws
+ * an error if this stream has entered flowing mode
+ * (e.g. if you've already called `on('data')`)
+ * @method
+ * @param {Number} start Offset in bytes to start reading at
+ * @return {GridFSBucketReadStream}
+ */
+
+GridFSBucketReadStream.prototype.start = function(start) {
+  throwIfInitialized(this);
+  this.s.options.start = start;
+  return this;
+};
+
+/**
+ * Sets the 0-based offset in bytes to start streaming from. Throws
+ * an error if this stream has entered flowing mode
+ * (e.g. if you've already called `on('data')`)
+ * @method
+ * @param {Number} end Offset in bytes to stop reading at
+ * @return {GridFSBucketReadStream}
+ */
+
+GridFSBucketReadStream.prototype.end = function(end) {
+  throwIfInitialized(this);
+  this.s.options.end = end;
+  return this;
+};
+
+/**
+ * @ignore
+ */
+
+function throwIfInitialized(self) {
+  if (self.s.init) {
+    throw new Error('You cannot change options after the stream has entered' +
+      'flowing mode!');
+  }
+}
 
 /**
  * @ignore
@@ -174,10 +180,65 @@ function doRead(_this) {
  * @ignore
  */
 
+function init(self) {
+  var findOneOptions = {};
+  if (self.s.readPreference) {
+    findOneOptions.readPreference = self.s.readPreference;
+  }
+  if (self.s.options && self.s.options.sort) {
+    findOneOptions.sort = self.s.options.sort;
+  }
+  if (self.s.options && self.s.options.skip) {
+    findOneOptions.skip = self.s.options.skip;
+  }
+
+  self.s.files.findOne(self.s.filter, findOneOptions, function(error, doc) {
+    if (error) {
+      return __handleError(self, error);
+    }
+    if (!doc) {
+      var identifier = self.s.filter._id ?
+        self.s.filter._id.toString() : self.s.filter.filename;
+      var errmsg = 'FileNotFound: file ' + identifier + ' was not found';
+      return __handleError(self, new Error(errmsg));
+    }
+
+    // If document is empty, kill the stream immediately and don't
+    // execute any reads
+    if (doc.length <= 0) {
+      self.push(null);
+      return;
+    }
+
+    self.s.cursor = self.s.chunks.find({ files_id: doc._id }).sort({ n: 1 });
+    if (self.s.readPreference) {
+      self.s.cursor.setReadPreference(self.s.readPreference);
+    }
+
+    self.s.expectedEnd = Math.ceil(doc.length / doc.chunkSize);
+    self.s.file = doc;
+    self.s.bytesToSkip = handleStartOption(self, doc, self.s.cursor,
+      self.s.options);
+    self.s.bytesToTrim = handleEndOption(self, doc, self.s.cursor,
+      self.s.options);
+    self.emit('file', doc);
+  });
+}
+
+/**
+ * @ignore
+ */
+
 function waitForFile(_this, callback) {
   if (_this.s.file) {
     return callback();
   }
+
+  if (!_this.s.init) {
+    init(_this);
+    _this.s.init = true;
+  }
+
   _this.once('file', function() {
     callback();
   });

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -231,7 +231,6 @@ function handleEndOption(stream, doc, cursor, options) {
       Math.floor(options.start / doc.chunkSize) :
       0;
 
-    console.log('limit', options.end, doc.chunkSize, start);
     cursor.limit(Math.ceil(options.end / doc.chunkSize) - start);
 
     stream.s.expectedEnd = Math.ceil(options.end / doc.chunkSize);

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -94,12 +94,20 @@ GridFSBucket.prototype.openUploadStream = function(filename, options) {
  * data from GridFS.
  * @method
  * @param {ObjectId} id The id of the file doc
+ * @param {Object} [options=null] Optional settings.
+ * @param {Number} [options.start=null] Optional 0-based offset in bytes to start streaming from
+ * @param {Number} [options.end=null] Optional 0-based offset in bytes to stop streaming before
  * @return {GridFSBucketReadStream}
  */
 
-GridFSBucket.prototype.openDownloadStream = function(id) {
+GridFSBucket.prototype.openDownloadStream = function(id, options) {
+  var filter = { _id: id };
+  var options = {
+    start: options && options.start,
+    end: options && options.end
+  };
   return new GridFSBucketReadStream(this.s._chunksCollection,
-    this.s._filesCollection, this.s.options.readPreference, { _id: id });
+    this.s._filesCollection, this.s.options.readPreference, filter, options);
 };
 
 /**
@@ -184,6 +192,8 @@ GridFSBucket.prototype.find = function(filter, options) {
  * @param {String} filename The name of the file to stream
  * @param {Object} [options=null] Optional settings
  * @param {number} [options.revision=-1] The revision number relative to the oldest file with the given filename. 0 gets you the oldest file, 1 gets you the 2nd oldest, -1 gets you the newest.
+ * @param {Number} [options.start=null] Optional 0-based offset in bytes to start streaming from
+ * @param {Number} [options.end=null] Optional 0-based offset in bytes to stop streaming before
  * @return {GridFSBucketReadStream}
  */
 
@@ -198,7 +208,14 @@ GridFSBucket.prototype.openDownloadStreamByName = function(filename, options) {
       skip = -options.revision - 1;
     }
   }
+
+  var filter = { filename: filename };
+  var options = {
+    sort: sort,
+    skip: skip,
+    start: options && options.start,
+    end: options && options.end
+  };
   return new GridFSBucketReadStream(this.s._chunksCollection,
-    this.s._filesCollection, this.s.options.readPreference,
-    { filename: filename }, sort, skip);
+    this.s._filesCollection, this.s.options.readPreference, filter, options);
 };

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -99,7 +99,7 @@ GridFSBucket.prototype.openUploadStream = function(filename, options) {
 
 GridFSBucket.prototype.openDownloadStream = function(id) {
   return new GridFSBucketReadStream(this.s._chunksCollection,
-    this.s._filesCollection, this.s.options.readPreference, id);
+    this.s._filesCollection, this.s.options.readPreference, { _id: id });
 };
 
 /**
@@ -172,4 +172,33 @@ GridFSBucket.prototype.find = function(filter, options) {
   }
 
   return cursor;
+};
+
+/**
+ * Returns a readable stream (GridFSBucketReadStream) for streaming the
+ * file with the given name from GridFS. If there are multiple files with
+ * the same name, this will stream the most recent file with the given name
+ * (as determined by the `uploadedDate` field). You can set the `revision`
+ * option to change this behavior.
+ * @method
+ * @param {String} filename The name of the file to stream
+ * @param {Object} [options=null] Optional settings
+ * @param {number} [options.revision=-1] The revision number relative to the oldest file with the given filename. 0 gets you the oldest file, 1 gets you the 2nd oldest, -1 gets you the newest.
+ * @return {GridFSBucketReadStream}
+ */
+
+GridFSBucket.prototype.openDownloadStreamByName = function(filename, options) {
+  var sort = { uploadedDate: -1 };
+  var skip = null;
+  if (options && options.revision != null) {
+    if (options.revision >= 0) {
+      sort = { uploadedDate: 1 };
+      skip = options.revision;
+    } else {
+      skip = -options.revision - 1;
+    }
+  }
+  return new GridFSBucketReadStream(this.s._chunksCollection,
+    this.s._filesCollection, this.s.options.readPreference,
+    { filename: filename }, sort, skip);
 };

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -2,6 +2,7 @@ var Emitter = require('events').EventEmitter;
 var GridFSBucketReadStream = require('./download');
 var GridFSBucketWriteStream = require('./upload');
 var shallowClone = require('../utils').shallowClone;
+var toError = require('../utils').toError;
 var util = require('util');
 
 var DEFAULT_GRIDFS_BUCKET_OPTIONS = {
@@ -219,3 +220,53 @@ GridFSBucket.prototype.openDownloadStreamByName = function(filename, options) {
   return new GridFSBucketReadStream(this.s._chunksCollection,
     this.s._filesCollection, this.s.options.readPreference, filter, options);
 };
+
+/**
+ * Renames the file with the given _id to the given string
+ * @method
+ * @param {ObjectId} id the id of the file to rename
+ * @param {String} filename new name for the file
+ * @param {GridFSBucket~errorCallback} callback
+ */
+
+GridFSBucket.prototype.rename = function(id, filename, callback) {
+  var filter = { _id: id };
+  var update = { $set: { filename: filename} };
+  this.s._filesCollection.updateOne(filter, update, function(error, res) {
+    if (error) {
+      return callback(error);
+    }
+    if (!res.result.n) {
+      return callback(toError('File with id ' + id + ' not found'));
+    }
+    callback();
+  });
+};
+
+/**
+ * Removes this bucket's files collection, followed by its chunks collection.
+ * @method
+ * @param {GridFSBucket~errorCallback} callback
+ */
+
+GridFSBucket.prototype.drop = function(callback) {
+  var _this = this;
+  this.s._filesCollection.drop(function(error) {
+    if (error) {
+      return callback(error);
+    }
+    _this.s._chunksCollection.drop(function(error) {
+      if (error) {
+        return callback(error);
+      }
+
+      return callback();
+    });
+  });
+};
+
+/**
+ * Callback format for all GridFSBucket methods that can accept a callback.
+ * @callback GridFSBucket~errorCallback
+ * @param {MongoError} error An error instance representing any errors that occurred
+ */

--- a/test/functional/gridfs_stream_tests.js
+++ b/test/functional/gridfs_stream_tests.js
@@ -213,7 +213,11 @@ exports['start/end options for openDownloadStream'] = {
         });
 
         downloadStream.on('end', function() {
-          test.equal(gotData, 3);
+          // Depending on different versions of node, we may get
+          // different amounts of 'data' events. node 0.10 gives 2,
+          // node >= 0.12 gives 3. Either is correct, but we just
+          // care that we got between 1 and 3, and got the right result
+          test.ok(gotData >= 1 && gotData <= 3);
           test.equal(str, 'pache');
           test.done();
         });

--- a/test/functional/gridfs_stream_tests.js
+++ b/test/functional/gridfs_stream_tests.js
@@ -199,7 +199,7 @@ exports['start/end options for openDownloadStream'] = {
 
       uploadStream.once('finish', function() {
         var downloadStream = bucket.openDownloadStreamByName('teststart.dat',
-          { start: 1, end: 6 });
+          { start: 1 }).end(6);
 
         downloadStream.on('error', function(error) {
           test.equal(error, null);


### PR DESCRIPTION
As specified in https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#id24. Includes:

* `openDownloadStreamByName()`
* start/end options (partial file retrieval) for `openDownloadStream()` and `openDownloadStreamByName()`
* `rename()`
* `drop()`

Also https://github.com/mongodb/node-mongodb-native/commit/fa10f88888e168e31975911bc51da6d931cae042 addresses a minor clarification added in between the original implementation.

This should put us in full conformance with the streaming gridfs spec's basic and advanced API sections.