### PR TITLE
MongoClient support for MongoS through Unix Socket

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -300,7 +300,10 @@ var connect = function(url, options, callback) {
                 return errorServers[serverObj.host + ":" + serverObj.port] == null;
               })
               .map(function(serverObj) {
-                return new Server(serverObj.host, serverObj.port, object.server_options);
+                var serverConfig = serverObj.domain_socket ?
+                  new Server(serverObj.domain_socket, 27017, object.server_options)
+                : new Server(serverObj.host, serverObj.port, object.server_options);
+                return serverObj;
               });
 
             // Clean out any error servers


### PR DESCRIPTION
MongoClient didn't use the domain_socket property for MongoS connections, so this couldn't connect through Unix Sockets.

Maybe this is because MongoS expects a port. I have included a dummy 27017 port in the new Server invocation for the domain_socket version.