### PR TITLE
Insert should not modify arguments

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -464,7 +464,7 @@ Collection.prototype.insertMany = function(docs, options, callback) {
   if(forceServerObjectId !== true) {
     // Add _id if not specified
     for(var i = 0; i < docs.length; i++) {
-      if(docs[i]._id == null) docs[i]._id = self.s.pkFactory.createPk();
+      if(docs[i]._id == null) docs[i] = Object.assign({_id:self.s.pkFactory.createPk()}, docs[i]);
     }
   }
 

--- a/test/functional/insert_tests.js
+++ b/test/functional/insert_tests.js
@@ -78,7 +78,7 @@ exports.shouldCorrectlyHandleMultipleDocumentInsert = {
     var db = configuration.newDbInstance(configuration.writeConcernMax(), {poolSize:1});
     db.open(function(err, db) {
       var collection = db.collection('test_multiple_insert');
-      var docs = [{a:1}, {a:2}];
+      var docs = [{a:1}, {a:2}].map(Object.freeze);
 
       collection.insert(docs, configuration.writeConcernMax(), function(err, r) {
         r.ops.forEach(function(doc) {


### PR DESCRIPTION
It's considered best practice not to modify arguments. This could cause confusing behavior.

Multiple insert:

```js
var docs = [{a : 1}, {a : 2}];

collection.insertMany(docs)
    .then(function () {
        return collection.insertMany(docs);
    });
```
Expected: Inserted two copies of each document.
Actual: Duplicate _id error.

Frozen objects:

```js
var docs = [{a : 1}, {a : 2}].map(Object.freeze);

collection.insertMany(docs);
```

Expected: Documents inserted.
Actual: object is not extensible error