### PR TITLE
Make an unique index files_id_1_n_1 on chunk collection

### DIFF
--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -46,7 +46,8 @@ var Chunk = require('./chunk'),
   Define = require('../metadata'),
   MongoError = require('mongodb-core').MongoError,
   inherits = util.inherits,
-  Duplex = require('stream').Duplex || require('readable-stream').Duplex;
+  Duplex = require('stream').Duplex || require('readable-stream').Duplex,
+  shallowClone = require('../utils').shallowClone;
 
 var REFERENCE_BY_FILENAME = 0,
   REFERENCE_BY_ID = 1;
@@ -216,8 +217,11 @@ var open = function(self, callback) {
     collection.ensureIndex([['filename', 1]], writeConcern, function(err, index) {
       // Get chunk collection
       var chunkCollection = self.chunkCollection();
+      // Make an unique index for compatibility with mongo-cxx-driver:legacy
+      var chunkIndexOptions = shallowClone(writeConcern);
+      chunkIndexOptions.unique = true;
       // Ensure index on chunk collection
-      chunkCollection.ensureIndex([['files_id', 1], ['n', 1]], writeConcern, function(err, index) {
+      chunkCollection.ensureIndex([['files_id', 1], ['n', 1]], chunkIndexOptions, function(err, index) {
         // Open the connection
         _open(self, writeConcern, function(err, r) {
           if(err) return callback(err);


### PR DESCRIPTION
Make an unique index files_id_1_n_1 on chunk collection for compatiblity with [mongo-cxx-driver:legacy](https://github.com/mongodb/mongo-cxx-driver/blob/legacy/src%2Fmongo%2Fclient%2Fgridfs.cpp)

fragment of mongo/client/gridfs.cpp:65
```cpp
GridFS::GridFS(DBClientBase& client, const string& dbName, const string& prefix)
    : _client(client), _dbName(dbName), _prefix(prefix) {
    _filesNS = dbName + "." + prefix + ".files";
    _chunksNS = dbName + "." + prefix + ".chunks";
    _chunkSize = DEFAULT_CHUNK_SIZE;

    client.createIndex(_filesNS, BSON("filename" << 1));
    client.createIndex(_chunksNS, IndexSpec().addKeys(BSON("files_id" << 1 << "n" << 1)).unique());
}
```
during the execution of the last line throw an exception "Index with name: files_id_1_n_1 already exists with different options"