### PR TITLE
Add kerberos as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "dependencies": {
       "mongodb-core": "1.2.25"
+    , "kerberos": "0.0.17"
     , "readable-stream": "1.0.31"
     , "es6-promise": "2.1.1"
   },


### PR DESCRIPTION
This meets the peerDependency need for `mongodb-core` when using `npm@3+`

This is what happens currently: ![dependency screenshot] (https://www.dropbox.com/s/i6stbxmeaeka50g/Screenshot%202015-11-27%2013.38.34.png?dl=1)