### PR TITLE
docs; still show .sort({a: 1}) syntax in docs

### DIFF
--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -5145,11 +5145,11 @@ exports.shouldCorrectlyPeformSimpleSorts = {
         test.equal(null, err);
 
         // Do normal ascending sort
-        collection.find().sort([['a', 1]]).nextObject(function(err, item) {
+        collection.find().sort({'a': 1}).nextObject(function(err, item) {
           test.equal(null, err);
           test.equal(1, item.a);
 
-          // Do normal descending sort
+          // Do normal descending sort, with new syntax that enforces ordering of sort keys
           collection.find().sort([['a', -1]]).nextObject(function(err, item) {
             test.equal(null, err);
             test.equal(3, item.a);


### PR DESCRIPTION
Hey Christian,

The EdX course still uses an older version of the driver (and still will because otherwise we're gonna have to re-record) that doesn't support the `[['a', 1]]` syntax for sorting, so students are getting confused when we link to the docs. Can the examples highlight both syntaxes and explain why you might want to use the array syntax?

Thanks,
Val