### PR TITLE
Wrong ssl option description

### DIFF
--- a/docs/reference/content/reference/connecting/connection-settings.md
+++ b/docs/reference/content/reference/connecting/connection-settings.md
@@ -206,7 +206,7 @@ MongoClient.connect(f('mongodb://%s@server:27017/test'), {
 *  `secondaryAcceptableLatencyMS` {Number, default:15}, sets the range of servers to pick when using NEAREST (lowest ping ms + the latency fence, ex: range of 1 to (1 + 15) ms)
 *  `connectWithNoPrimary` {Boolean, default:false}, Sets if the driver should connect even if no primary is available.
 * `poolSize`, {Number, default: 5} Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
-* `ssl`, {Boolean, default: false} Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
+* `ssl`, {Boolean, default: false} Use ssl connection (needs to have a mongod server with ssl support).
 * `sslValidate`, {Boolean, default: true} Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher).
 * `sslCA`, {Buffer[]|string[], default: null} Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support, 2.4 or higher).
 * `sslCert`, {Buffer|string, default: null} String or buffer containing the certificate we wish to present (needs to have a mongod server with ssl support, 2.4 or higher).
@@ -241,7 +241,7 @@ MongoClient.connect(f('mongodb://%s@server:27017/test'), {
 *  `haInterval` {Number, default:5000}, time between each replicaset status check.
 *  `secondaryAcceptableLatencyMS` {Number, default:15}, sets the range of servers to pick when using NEAREST (lowest ping ms + the latency fence, ex: range of 1 to (1 + 15) ms)
 * `poolSize`, {Number, default: 5} Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
-* `ssl`, {Boolean, default: false} Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
+* `ssl`, {Boolean, default: false} Use ssl connection (needs to have a mongod server with ssl support).
 * `sslValidate`, {Boolean, default: true} Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher).
 * `sslCA`, {Buffer[]|string[], default: null} Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support, 2.4 or higher).
 * `sslCert`, {Buffer|string, default: null} String or buffer containing the certificate we wish to present (needs to have a mongod server with ssl support, 2.4 or higher).

--- a/docs/reference/content/reference/connecting/connection-settings.md
+++ b/docs/reference/content/reference/connecting/connection-settings.md
@@ -168,7 +168,7 @@ MongoClient.connect(f('mongodb://%s@server:27017/test'), {
 ## Individual Server Level Options
 
 * `poolSize`, {Number, default: 5} Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
-* `ssl`, {Boolean, default: false} Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
+* `ssl`, {Boolean, default: false} Use ssl connection (needs to have a mongod server with ssl support).
 * `sslValidate`, {Boolean, default: true} Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher).
 * `sslCA`, {Buffer[]|string[], default: null} Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support, 2.4 or higher).
 * `sslCert`, {Buffer|string, default: null} String or buffer containing the certificate we wish to present (needs to have a mongod server with ssl support, 2.4 or higher).


### PR DESCRIPTION
The description of the `ssl` option in Individual Server Level Options was a copy of the description of `poolSize`. Changed to the description found on the api reference in the class Server.