### PR TITLE
allow readPreference as objects for db commands

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -116,7 +116,7 @@ var Db = function(databaseName, topology, options) {
     // Authsource if any
     , authSource: options.authSource
     // Unpack read preference
-    , readPreference: options.readPreference
+    , readPreference: convertReadPreference(options.readPreference)
     // Set buffermaxEntries
     , bufferMaxEntries: typeof options.bufferMaxEntries == 'number' ? options.bufferMaxEntries : -1
     // Parent db (if chained)
@@ -250,6 +250,25 @@ Db.prototype.open = function(callback) {
 define.classMethod('open', {callback: true, promise:true});
 
 /**
+ * Converts provided read preference to CoreReadPreference
+ * @param {(ReadPreference|string|object)} readPreference the user provided read preference
+ * @return {CoreReadPreference}
+ */
+var convertReadPreference = function(readPreference) {
+  if(readPreference && typeof readPreference == 'string') {
+    return new CoreReadPreference(readPreference);
+  } else if(readPreference instanceof ReadPreference) {
+    return new CoreReadPreference(readPreference.mode, readPreference.tags);
+  } else if(readPreference && typeof readPreference == 'object') {
+    var mode = readPreference.mode || readPreference.preference;
+    if (mode && typeof mode == 'string') {
+      readPreference = new CoreReadPreference(mode, readPreference.tags);
+    }
+  }
+  return readPreference;
+}
+
+/**
  * The callback format for results
  * @callback Db~resultCallback
  * @param {MongoError} error An error instance representing the error during the execution.
@@ -267,11 +286,8 @@ var executeCommand = function(self, command, options, callback) {
   }
 
   // Convert the readPreference
-  if(options.readPreference && typeof options.readPreference == 'string') {
-    options.readPreference = new CoreReadPreference(options.readPreference);
-  } else if(options.readPreference instanceof ReadPreference) {
-    options.readPreference = new CoreReadPreference(options.readPreference.mode
-      , options.readPreference.tags);
+  if(options.readPreference) {
+    options.readPreference = convertReadPreference(options.readPreference);
   }
 
   // Debug information
@@ -606,7 +622,7 @@ Db.prototype.listCollections = function(filter, options) {
     // Create the cursor
     var cursor = this.s.topology.cursor(f('%s.$cmd', this.s.databaseName), command, options);
     // Do we have a readPreference, apply it
-    if(options.readPeference) cursor.setReadPreference(options.readPeference);
+    if(options.readPreference) cursor.setReadPreference(convertReadPreference(options.readPreference));
     // Return the cursor
     return cursor;
   }
@@ -637,7 +653,7 @@ Db.prototype.listCollections = function(filter, options) {
   // Get the cursor
   var cursor = this.collection(Db.SYSTEM_NAMESPACE_COLLECTION).find(filter, _options);
   // Do we have a readPreference, apply it
-  if(options.readPeference) cursor.setReadPreference(options.readPeference);
+  if(options.readPreference) cursor.setReadPreference(convertReadPreference(options.readPreference));
   // Set the passed in batch size if one was provided
   if(options.batchSize) cursor = cursor.batchSize(options.batchSize);
   // We have a fallback mode using legacy systems collections
@@ -883,7 +899,7 @@ Db.prototype.executeDbAdminCommand = function(selector, options, callback) {
   options = options || {};
 
   if(options.readPreference) {
-    options.readPreference = options.readPreference;
+    options.readPreference = convertReadPreference(options.readPreference);
   }
 
   // Return the callback

--- a/test/functional/readpreference_tests.js
+++ b/test/functional/readpreference_tests.js
@@ -424,3 +424,27 @@ exports['Should correctly honor the readPreferences at DB and individual command
     });
   }
 }
+
+/**
+ * @ignore
+ */
+exports['Should correctly apply readPreferences specified as objects'] = {
+  metadata: { requires: { mongodb: ">=2.6.0", topology: ['single', 'ssl'] } },
+
+  // The actual test we wish to run
+  test: function(configuration, test) {
+    var mongo = configuration.require
+      , ReadPreference = mongo.ReadPreference;
+
+    configuration.newDbInstance({w:1}, {poolSize:1}).open(function(err, db) {
+      test.equal(null, err);
+      // Create read preference object.
+      var mySecondaryPreferred = {mode:'secondaryPreferred', tags:[]};
+      db.command({dbStats:true}, {readPreference:mySecondaryPreferred}, function(err, result) {
+        test.equal(null, err);
+        db.close();
+        test.done();
+      });
+    });
+  }
+}


### PR DESCRIPTION
This converts readPreference-like objects handed to db commands into CoreReadPreference objects.