### PR TITLE
fix sort compare function in strategies 

### DIFF
--- a/lib/mongodb/connection/repl_set/strategies/ping_strategy.js
+++ b/lib/mongodb/connection/repl_set/strategies/ping_strategy.js
@@ -112,7 +112,7 @@ PingStrategy.prototype.checkoutConnection = function(tags, secondaryCandidates) 
 
   // Sort by ping time
   finalCandidates.sort(function(a, b) {
-    return a.runtimeStats['pingMs'] > b.runtimeStats['pingMs'];
+    return a.runtimeStats['pingMs'] - b.runtimeStats['pingMs'];
   });
 
   if(0 === finalCandidates.length)
@@ -129,7 +129,7 @@ PingStrategy.prototype.checkoutConnection = function(tags, secondaryCandidates) 
 
   // convert to integer
   var lowestPing = lowest.runtimeStats.pingMs | 0;
-  
+
   // determine acceptable latency
   var acceptable = lowestPing + this.secondaryAcceptableLatencyMS;
 
@@ -141,11 +141,11 @@ PingStrategy.prototype.checkoutConnection = function(tags, secondaryCandidates) 
     }
   }
 
-  if(self.logger && self.logger.debug) {    
+  if(self.logger && self.logger.debug) {
     self.logger.debug("Ping strategy selection order for tags", tags);
     finalCandidates.forEach(function(c) {
       self.logger.debug(format("%s:%s = %s ms", c.host, c.port, c.runtimeStats['pingMs']), null);
-    })    
+    })
   }
 
   // If no candidates available return an error
@@ -154,12 +154,12 @@ PingStrategy.prototype.checkoutConnection = function(tags, secondaryCandidates) 
 
   // Ensure no we don't overflow
   this.index = this.index % finalCandidates.length
-  // Pick a random acceptable server  
+  // Pick a random acceptable server
   var connection = finalCandidates[this.index].checkoutReader();
   // Point to next candidate (round robin style)
   this.index = this.index + 1;
 
-  if(self.logger && self.logger.debug) {    
+  if(self.logger && self.logger.debug) {
     if(connection)
       self.logger.debug("picked server %s:%s", connection.socketOptions.host, connection.socketOptions.port);
   }
@@ -252,12 +252,12 @@ PingStrategy.prototype._pingServer = function(callback) {
                 // Done with the pinging
                 done();
               });
-            });            
+            });
           };
           // Ping
           _ping(_db, serverInstance);
         } else {
-          var connectTimeoutMS = self.replicaset.options.socketOptions 
+          var connectTimeoutMS = self.replicaset.options.socketOptions
             ? self.replicaset.options.socketOptions.connectTimeoutMS : 0
 
           // Create a new master connection
@@ -275,7 +275,7 @@ PingStrategy.prototype._pingServer = function(callback) {
             sslPass: self.replicaset.options.sslPass
           });
 
-          // Create Db instance        
+          // Create Db instance
           var _db = new self.Db('local', _server, { safe: true });
           _db.on("close", function() {
             delete self.dbs[this.serverConfig.host + ":" + this.serverConfig.port];
@@ -287,7 +287,7 @@ PingStrategy.prototype._pingServer = function(callback) {
               return;
             }
 
-            __db.open(function(err, db) {  
+            __db.open(function(err, db) {
               // Emit ping connect
               self.replicaset.emit("ping_connect", err, __serverInstance);
 
@@ -310,7 +310,7 @@ PingStrategy.prototype._pingServer = function(callback) {
               // Execute ping on this connection
               __db.executeDbCommand({ping:1}, {failFast:true}, function(err) {
                 self.replicaset.emit("ping", err, __serverInstance);
-                
+
                 if(err) {
                   delete self.dbs[__db.serverConfig.host + ":" + __db.serverConfig.port];
                   __db.close();
@@ -329,7 +329,7 @@ PingStrategy.prototype._pingServer = function(callback) {
                     __db.close();
                     return done();
                   }
-    
+
                   // Process the ismaster for the server
                   if(result && result.documents && self.replicaset.processIsMaster) {
                     self.replicaset.processIsMaster(__serverInstance, result.documents[0]);
@@ -339,7 +339,7 @@ PingStrategy.prototype._pingServer = function(callback) {
                   done();
                 });
               });
-            });            
+            });
           };
 
           // Ping the server

--- a/lib/mongodb/connection/repl_set/strategies/statistics_strategy.js
+++ b/lib/mongodb/connection/repl_set/strategies/statistics_strategy.js
@@ -4,7 +4,7 @@
 var StatisticsStrategy = exports.StatisticsStrategy = function(replicaset) {
   this.replicaset = replicaset;
   // Logger api
-  this.Logger = null;  
+  this.Logger = null;
 }
 
 // Starts any needed code
@@ -74,7 +74,7 @@ StatisticsStrategy.prototype.checkoutConnection = function(tags, secondaryCandid
   }
 
   finalCandidates.sort(function(a, b) {
-    return a.runtimeStats.queryStats.sScore > b.runtimeStats.queryStats.sScore;
+    return a.runtimeStats.queryStats.sScore - b.runtimeStats.queryStats.sScore;
   });
 
   // If no candidates available return an error


### PR DESCRIPTION
i am use mongoose 3.8.23 (a old version) the related mongodb native is "1.4.28".  
we have 10host replset mongodb, whatever strategy we use the load is extremely un-balance.

after we dig in, we find the sort compare function return a boolean not a number so it will result in unsorted after call sort

e.g 

```
b= [1,2,10,3,78,8,90,11,3,20,7,4,2]
b.sort(function(x,y){return x>y})
// b = [ 90,1,11,2,2,3,3,4,7,8,10,20,78]
```

after fix that the load is balanced to DBs.

But i can not found the 1.x.x related branch, and there is no  strategies in 2.x.x  
so i do PR in this branch. 

if there are some proper place to do the PR just let me know.


