### PR TITLE
NODE-636: Multiple database names ignored without a warning

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -110,9 +110,23 @@ module.exports = function(url, options) {
   if(connection_part.indexOf(".sock") != -1) {
     if(connection_part.indexOf(".sock/") != -1) {
       dbName = connection_part.split(".sock/")[1];
+      // Check if multiple database names provided, or just an illegal trailing backslash
+      if (dbName.indexOf("/") != -1) {
+        if (dbName.split("/").length == 2 && dbName.split("/")[1].length == 0) {
+          throw new Error('Illegal trailing backslash after database name');
+        }
+        throw new Error('More than 1 database name in URL');
+      }
       connection_part = connection_part.split("/", connection_part.indexOf(".sock") + ".sock".length);
     }
   } else if(connection_part.indexOf("/") != -1) {
+    // Check if multiple database names provided, or just an illegal trailing backslash
+    if (connection_part.split("/").length > 2) {
+      if (connection_part.split("/")[2].length == 0) {
+        throw new Error('Illegal trailing backslash after database name');
+      }
+      throw new Error('More than 1 database name in URL');
+    }
     dbName = connection_part.split("/")[1];
     connection_part = connection_part.split("/")[0];
   }

--- a/test/functional/connection-string/invalid-uris.json
+++ b/test/functional/connection-string/invalid-uris.json
@@ -206,6 +206,42 @@
             "uri": "mongodb://alice@foo:bar@127.0.0.1", 
             "valid": false, 
             "warning": null
+        },  
+        {
+            "auth": null, 
+            "description": "Illegal backslash at the end", 
+            "hosts": null, 
+            "options": null, 
+            "uri": "mongodb://localhost:27107/admin/", 
+            "valid": false, 
+            "warning": null
+        }, 
+        {
+            "auth": null, 
+            "description": "More than 1 database name in URL", 
+            "hosts": null, 
+            "options": null, 
+            "uri": "mongodb://localhost:27107/admin/admin2", 
+            "valid": false, 
+            "warning": null
+        }, 
+        {
+            "auth": null, 
+            "description": "Illegal backslash at the end (Unix socket)", 
+            "hosts": null, 
+            "options": null, 
+            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock/admin/", 
+            "valid": false, 
+            "warning": null
+        }, 
+        {
+            "auth": null, 
+            "description": "More than 1 database name in URL (Unix socket)", 
+            "hosts": null, 
+            "options": null, 
+            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock/admin/admin2", 
+            "valid": false, 
+            "warning": null
         }
     ]
 }

--- a/test/functional/connection-string/invalid-uris.yml
+++ b/test/functional/connection-string/invalid-uris.yml
@@ -191,3 +191,35 @@ tests:
         hosts: ~
         auth: ~
         options: ~
+    -
+        description: "Illegal backslash at the end"
+        uri: "mongodb://localhost:27107/admin/"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+    -
+        description: "More than 1 database name in URL"
+        uri: "mongodb://localhost:27107/admin/admin2"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+    -
+        description: "Illegal backslash at the end (Unix socket)"
+        uri: "mongodb://%2Ftmp%2Fmongodb-27017.sock/admin/"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+    -
+        description: "More than 1 database name in URL (Unix socket)"
+        uri: "mongodb://%2Ftmp%2Fmongodb-27017.sock/admin/admin2"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~


### PR DESCRIPTION
Throw an error if more than database name provided with backslash separating
them, also throw an error if a trailing backslash found after the database
name.

link to ticket: https://jira.mongodb.org/browse/NODE-636