### PR TITLE
upgrade mongodb-core to 1.2.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "es6-promise": "3.0.2",
-    "mongodb-core": "1.2.31",
+    "mongodb-core": "1.2.32",
     "readable-stream": "1.0.31"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey Christian, can I get this upgrade for the fix in https://github.com/mongodb/js-bson/commit/b2058977c7bd8de5e508e9ebfce4169791dd6b57 ? Eager to close out Automattic/mongoose#3713