### PR TITLE
Improve some unclear descriptions in the docs

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -506,7 +506,7 @@ var createCollection = function(self, name, options, callback) {
 }
 
 /**
- * Creates a collection on a server pre-allocating space, need to create f.ex capped collections.
+ * Create a new collection on a server with the specified options. Use this to create capped collections.
  *
  * @method
  * @param {string} name the collection name we wish to access.
@@ -811,7 +811,7 @@ Db.prototype.dropCollection = function(name, callback) {
 define.classMethod('dropCollection', {callback: true, promise:true});
 
 /**
- * Drop a database.
+ * Drop a database, removing it permanently from the server.
  *
  * @method
  * @param {Db~resultCallback} [callback] The results callback


### PR DESCRIPTION
Couple small tweaks to the docs in db.js: improved the `createCollection()` description, and made the one for `dropDatabase()` more in line with the one for `dropCollection()`.