### PR TITLE
NODE-643 fix memory leak in GridFSBucketWriteStream

### DIFF
--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -327,7 +327,6 @@ function createFilesDoc(_id, length, chunkSize, md5, filename, contentType,
  */
 
 function doWrite(_this, chunk, encoding, callback) {
-
   var inputBuf = (Buffer.isBuffer(chunk)) ?
     chunk : new Buffer(chunk, encoding);
 
@@ -411,7 +410,7 @@ function getWriteOptions(_this) {
 
 function waitForIndexes(_this, callback) {
   if (_this.bucket.s.checkedIndexes) {
-    callback(false);
+    return callback(false);
   }
 
   _this.bucket.once('index', function() {


### PR DESCRIPTION
Using the second script from JIRA. After fix:

```
---> { rss: 188477440, heapTotal: 46725152, heapUsed: 11759800 }
Completed 10000
```

Before:

```
---> { rss: 2214129664, heapTotal: 109673248, heapUsed: 65545536 }
Completed 10000
```

The issue is that, because I missed the return statement, every new GridFSBucketWriteStream registers a listener for the GridFSBucket's 'index' event, and so the GridFSBucketWriteStream never gets GC-ed until the whole GridFSBucket is.