### PR TITLE
Emit error before closing stream

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -2,12 +2,8 @@
 
 var inherits = require('util').inherits
   , f = require('util').format
-  , toError = require('./utils').toError
-  , getSingleProperty = require('./utils').getSingleProperty
   , formattedOrderClause = require('./utils').formattedOrderClause
   , handleCallback = require('./utils').handleCallback
-  , Logger = require('mongodb-core').Logger
-  , EventEmitter = require('events').EventEmitter
   , ReadPreference = require('./read_preference')
   , MongoError = require('mongodb-core').MongoError
   , Readable = require('stream').Readable || require('readable-stream').Readable
@@ -1021,9 +1017,9 @@ Cursor.prototype.isClosed = function() {
 define.classMethod('isClosed', {callback: false, promise:false, returns: [Boolean]});
 
 Cursor.prototype.destroy = function(err) {
+  if(err) this.emit('error', err);
   this.pause();
   this.close();
-  if(err) this.emit('error', err);
 }
 
 define.classMethod('destroy', {callback: false, promise:false});
@@ -1080,10 +1076,10 @@ Cursor.prototype._read = function(n) {
   // Get the next item
   self.nextObject(function(err, result) {
     if(err) {
-      if(!self.isDead()) self.close();
       if(self.listeners('error') && self.listeners('error').length > 0) {
         self.emit('error', err);
       }
+      if(!self.isDead()) self.close();
 
       // Emit end event
       self.emit('end');

--- a/test/functional/cursorstream_tests.js
+++ b/test/functional/cursorstream_tests.js
@@ -226,8 +226,6 @@ exports['should correctly error out stream'] = {
 
   // The actual test we wish to run
   test: function(configuration, test) {
-    var ObjectID = configuration.require.ObjectID
-      , Binary = configuration.require.Binary;
 
     // Should cause error
     configuration.newDbInstance({w:1}, {poolSize:1}).open(function(err, db) {
@@ -235,18 +233,23 @@ exports['should correctly error out stream'] = {
         timestamp: { $ltx: '1111' } // Error in query.
       });
 
-      var error;
+      var error, streamIsClosed;
 
       cursor.on('error', function(err) {
         error = err;
       });
+      
+      cursor.on('close', function() {
+        test.ok(error !== undefined && error !== null);
+        streamIsClosed = true;
+      });
 
       cursor.on('end', function() {
         test.ok(error !== undefined && error !== null);
-
+        test.ok(streamIsClosed === true);
         db.close();
         test.done();
-      })
+      });
 
       cursor.pipe(process.stdout);
     });


### PR DESCRIPTION
When using standard source.pipe(dest) source will not be destroyed if dest emits close or an error. You are also not able to provide a callback to tell when then pipe has finished.
[https://www.npmjs.com/package/pump](pump) does these two things for you, so you don't need to listen all the error events from all streams
So for handling all the errors correctly with pump it make sense to emit error first before closing stream. Example of code can be found here: https://github.com/mafintosh/pump/pull/2

Also, should it be PR to the 2.2 or 2.1?