### PR TITLE
improve toArray: using push instead of concat

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -58,6 +58,7 @@ var inherits = require('util').inherits
 // Flags allowed for cursor
 var flags = ['tailable', 'oplogReplay', 'noCursorTimeout', 'awaitData', 'exhaust', 'partial'];
 var fields = ['numberOfRetries', 'tailableRetryInterval'];
+var push = Array.prototype.push;
 
 /**
  * Creates a new Cursor instance (INTERNAL TYPE, do not instantiate directly)
@@ -863,7 +864,7 @@ var toArray = function(self, callback) {
           docs = docs.map(self.s.transforms.doc);
         }
 
-        items = items.concat(docs);
+        push.apply(items, docs);
       }
 
       // Attempt a fetch


### PR DESCRIPTION
Using concat and creating a new array each time a chunk of documents arrives has a huge performance drawback, especially when fetching large amount of documents. Using Array.prototype.push reuses the existing result array, and is a much faster.