### PR TITLE
Fix: GridFS always returns the oldest version due to incorrect field name

### DIFF
--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -209,7 +209,7 @@ GridFSBucket.prototype.find = function(filter, options) {
  * Returns a readable stream (GridFSBucketReadStream) for streaming the
  * file with the given name from GridFS. If there are multiple files with
  * the same name, this will stream the most recent file with the given name
- * (as determined by the `uploadedDate` field). You can set the `revision`
+ * (as determined by the `uploadDate` field). You can set the `revision`
  * option to change this behavior.
  * @method
  * @param {String} filename The name of the file to stream
@@ -221,11 +221,11 @@ GridFSBucket.prototype.find = function(filter, options) {
  */
 
 GridFSBucket.prototype.openDownloadStreamByName = function(filename, options) {
-  var sort = { uploadedDate: -1 };
+  var sort = { uploadDate: -1 };
   var skip = null;
   if (options && options.revision != null) {
     if (options.revision >= 0) {
-      sort = { uploadedDate: 1 };
+      sort = { uploadDate: 1 };
       skip = options.revision;
     } else {
       skip = -options.revision - 1;


### PR DESCRIPTION
GridFS always returns the oldest version due to incorrect field name in lib/gridfs-stream/index.js

uploadedDate -> uploadDate
