### PR TITLE
GridFS stream support for cancelling upload streams and download streams

### DIFF
--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -128,7 +128,8 @@ GridFSBucketReadStream.prototype.end = function(end) {
 
 /**
  * Marks this stream as destroyed (will never push another `data` event)
- * and kills the underlying cursor. Will emit
+ * and kills the underlying cursor. Will emit the 'end' event, and then
+ * the 'close' event once the cursor is successfully killed.
  *
  * @method
  * @param {GridFSBucket~errorCallback} [callback] called when the cursor is successfully closed or an error occurred.

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -61,6 +61,27 @@ util.inherits(GridFSBucketReadStream, stream.Readable);
  */
 
 /**
+ * Emitted when a chunk of data is available to be consumed.
+ *
+ * @event GridFSBucketReadStream#data
+ * @type {object}
+ */
+
+/**
+ * Fired when the stream is exhausted and the underlying cursor is killed
+ *
+ * @event GridFSBucketReadStream#close
+ * @type {object}
+ */
+
+/**
+ * Fired when the stream is exhausted (no more data events).
+ *
+ * @event GridFSBucketReadStream#end
+ * @type {object}
+ */
+
+/**
  * Reads from the cursor and pushes to the stream.
  * @method
  */
@@ -107,10 +128,12 @@ GridFSBucketReadStream.prototype.end = function(end) {
 
 /**
  * Marks this stream as destroyed (will never push another `data` event)
- * and kills the underlying cursor.
+ * and kills the underlying cursor. Will emit
  *
  * @method
  * @param {GridFSBucket~errorCallback} [callback] called when the cursor is successfully closed or an error occurred.
+ * @fires GridFSBucketWriteStream#close
+ * @fires GridFSBucketWriteStream#end
  */
 
 GridFSBucketReadStream.prototype.destroy = function(callback) {
@@ -118,8 +141,16 @@ GridFSBucketReadStream.prototype.destroy = function(callback) {
   this.push(null);
   this.destroyed = true;
   if (this.s.cursor) {
-    this.s.cursor.close(callback);
+    this.s.cursor.close(function(error) {
+      _this.emit('close');
+      callback && callback(error);
+    });
   } else {
+    if (!this.s.init) {
+      // If not initialized, fire close event because we will never
+      // get a cursor
+      _this.emit('close');
+    }
     callback && callback();
   }
 };
@@ -152,7 +183,13 @@ function doRead(_this) {
       return __handleError(_this, error);
     }
     if (!doc) {
-      return _this.push(null);
+      _this.push(null);
+      return _this.s.cursor.close(function(error) {
+        if (error) {
+          return __handleError(_this, error);
+        }
+        _this.emit('close');
+      });
     }
 
     var bytesRemaining = _this.s.file.length - _this.s.bytesRead;
@@ -240,6 +277,10 @@ function init(self) {
     }
 
     if (self.destroyed) {
+      // If user destroys the stream before we have a cursor, wait
+      // until the query is done to say we're 'closed' because we can't
+      // cancel a query.
+      self.emit('close');
       return;
     }
 

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -68,16 +68,16 @@ util.inherits(GridFSBucketReadStream, stream.Readable);
  */
 
 /**
- * Fired when the stream is exhausted and the underlying cursor is killed
+ * Fired when the stream is exhausted (no more data events).
  *
- * @event GridFSBucketReadStream#close
+ * @event GridFSBucketReadStream#end
  * @type {object}
  */
 
 /**
- * Fired when the stream is exhausted (no more data events).
+ * Fired when the stream is exhausted and the underlying cursor is killed
  *
- * @event GridFSBucketReadStream#end
+ * @event GridFSBucketReadStream#close
  * @type {object}
  */
 

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -67,6 +67,9 @@ util.inherits(GridFSBucketReadStream, stream.Readable);
 
 GridFSBucketReadStream.prototype._read = function() {
   var _this = this;
+  if (this.destroyed) {
+    return;
+  }
   waitForFile(_this, function() {
     doRead(_this);
   });
@@ -103,6 +106,25 @@ GridFSBucketReadStream.prototype.end = function(end) {
 };
 
 /**
+ * Marks this stream as destroyed (will never push another `data` event)
+ * and kills the underlying cursor.
+ *
+ * @method
+ * @param {GridFSBucket~errorCallback} [callback] called when the cursor is successfully closed or an error occurred.
+ */
+
+GridFSBucketReadStream.prototype.destroy = function(callback) {
+  var _this = this;
+  this.push(null);
+  this.destroyed = true;
+  if (this.s.cursor) {
+    this.s.cursor.close(callback);
+  } else {
+    callback && callback();
+  }
+};
+
+/**
  * @ignore
  */
 
@@ -118,7 +140,14 @@ function throwIfInitialized(self) {
  */
 
 function doRead(_this) {
+  if (_this.destroyed) {
+    return;
+  }
+
   _this.s.cursor.next(function(error, doc) {
+    if (_this.destroyed) {
+      return;
+    }
     if (error) {
       return __handleError(_this, error);
     }
@@ -207,6 +236,10 @@ function init(self) {
     // execute any reads
     if (doc.length <= 0) {
       self.push(null);
+      return;
+    }
+
+    if (self.destroyed) {
       return;
     }
 

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -69,8 +69,8 @@ util.inherits(GridFSBucketWriteStream, stream.Writable);
  */
 
 /**
- * end() was called and the write stream successfully wrote all chunks to
- * MongoDB.
+ * `end()` was called and the write stream successfully wrote the file
+ * metadata and all the chunks to MongoDB.
  *
  * @event GridFSBucketWriteStream#finish
  * @type {object}

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -43,7 +43,9 @@ function GridFSBucketWriteStream(bucket, filename, options) {
   this.state = {
     streamEnd: false,
     outstandingRequests: 0,
-    errored: false
+    errored: false,
+    aborted: false,
+    promiseLibrary: this.bucket.s.promiseLibrary
   };
 
   if (!this.bucket.s.calledOpenUploadStream) {
@@ -92,6 +94,32 @@ GridFSBucketWriteStream.prototype.write = function(chunk, encoding, callback) {
 };
 
 /**
+ * Places this write stream into an aborted state (all future writes fail)
+ * and deletes all chunks that have already been written.
+ *
+ * @method
+ * @param {GridFSBucket~errorCallback} callback called when chunks are successfully removed or error occurred
+ * @return {Promise} if no callback specified
+ */
+
+GridFSBucketWriteStream.prototype.abort = function(callback) {
+  if (this.state.streamEnd) {
+    var error = new Error('Cannot abort a stream that has already completed');
+    if (callback) {
+      return callback(error);
+    }
+    return this.s.promiseLibrary.reject(error);
+  }
+  if (checkAborted(this, callback)) {
+    return;
+  }
+  this.state.aborted = true;
+  this.chunks.deleteMany({ files_id: this.id }, function(error) {
+    callback(error);
+  });
+};
+
+/**
  * Tells the stream that no more data will be coming in. The stream will
  * persist the remaining data to MongoDB, write the files document, and
  * then emit a 'finish' event.
@@ -103,6 +131,9 @@ GridFSBucketWriteStream.prototype.write = function(chunk, encoding, callback) {
  */
 
 GridFSBucketWriteStream.prototype.end = function(chunk, encoding, callback) {
+  if (checkAborted(this, callback)) {
+    return;
+  }
   var _this = this;
   this.state.streamEnd = true;
 
@@ -327,6 +358,10 @@ function createFilesDoc(_id, length, chunkSize, md5, filename, contentType,
  */
 
 function doWrite(_this, chunk, encoding, callback) {
+  if (checkAborted(_this, callback)) {
+    return;
+  }
+
   var inputBuf = (Buffer.isBuffer(chunk)) ?
     chunk : new Buffer(chunk, encoding);
 
@@ -446,4 +481,16 @@ function writeRemnant(_this, callback) {
     --_this.state.outstandingRequests;
     checkDone(_this);
   });
+}
+
+/**
+ * @ignore
+ */
+
+function checkAborted(_this, callback) {
+  if (_this.state.aborted) {
+    callback(new Error('this stream has been aborted'));
+    return true;
+  }
+  return false;
 }

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -108,10 +108,14 @@ GridFSBucketWriteStream.prototype.abort = function(callback) {
     if (callback) {
       return callback(error);
     }
-    return this.s.promiseLibrary.reject(error);
+    return this.state.promiseLibrary.reject(error);
   }
-  if (checkAborted(this, callback)) {
-    return;
+  if (this.state.aborted) {
+    var error = new Error('Cannot call abort() on a stream twice');
+    if (callback) {
+      return callback(error);
+    }
+    return this.state.promiseLibrary.reject(error);
   }
   this.state.aborted = true;
   this.chunks.deleteMany({ files_id: this.id }, function(error) {
@@ -359,7 +363,7 @@ function createFilesDoc(_id, length, chunkSize, md5, filename, contentType,
 
 function doWrite(_this, chunk, encoding, callback) {
   if (checkAborted(_this, callback)) {
-    return;
+    return false;
   }
 
   var inputBuf = (Buffer.isBuffer(chunk)) ?

--- a/test/functional/gridfs_stream_tests.js
+++ b/test/functional/gridfs_stream_tests.js
@@ -332,6 +332,71 @@ exports['Deleting a file'] = {
 };
 
 /**
+ * Aborting an upload
+ *
+ * @example-class GridFSBucketWriteStream
+ * @example-method abort
+ * @ignore
+ */
+exports['Aborting an upload'] = {
+  metadata: { requires: { topology: ['single'] } },
+
+  // The actual test we wish to run
+  test: function(configuration, test) {
+    var GridFSBucket = configuration.require.GridFSBucket;
+
+    var db = configuration.newDbInstance(configuration.writeConcernMax(),
+      { poolSize:1 });
+    db.open(function(error, db) {
+    // LINE var MongoClient = require('mongodb').MongoClient,
+    // LINE   test = require('assert');
+    // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+    // REPLACE configuration.writeConcernMax() WITH {w:1}
+    // REMOVE-LINE test.done();
+    // BEGIN
+      var bucket = new GridFSBucket(db,
+        { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
+      var CHUNKS_COLL = 'gridfsabort.chunks';
+      var FILES_COLL = 'gridfsabort.files';
+      var uploadStream = bucket.openUploadStream('test.dat');
+
+      var id = uploadStream.id;
+      var query = { files_id: id };
+      uploadStream.write('a', 'utf8', function(error) {
+        test.equal(error, null);
+        db.collection(CHUNKS_COLL).count(query, function(error, c) {
+          test.equal(error, null);
+          test.equal(c, 1);
+          uploadStream.abort(function(error) {
+            test.equal(error, null);
+            db.collection(CHUNKS_COLL).count(query, function(error, c) {
+              test.equal(error, null);
+              test.equal(c, 0);
+              uploadStream.write('b', 'utf8', function(error) {
+                test.equal(error.toString(),
+                  'Error: this stream has been aborted');
+                uploadStream.end('c', 'utf8', function(error) {
+                  test.equal(error.toString(),
+                    'Error: this stream has been aborted');
+                  // Fail if user tries to abort an aborted stream
+                  uploadStream.abort(function(error) {
+                    test.equal(error.toString(),
+                      'Error: this stream has been aborted');
+                    test.done();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+    // END
+  }
+};
+
+
+/**
  * Deleting a file from GridFS using promises
  *
  * @example-class GridFSBucket

--- a/test/functional/gridfs_stream_tests.js
+++ b/test/functional/gridfs_stream_tests.js
@@ -429,11 +429,24 @@ exports['Destroying a download stream'] = {
       uploadStream.once('finish', function() {
         var id = uploadStream.id;
         var downloadStream = bucket.openDownloadStream(id);
+        var done = {};
         downloadStream.on('data', function() {
           test.ok(false);
         });
+        downloadStream.on('error', function() {
+          test.ok(false);
+        });
         downloadStream.on('end', function() {
-          test.done();
+          if (done.close) {
+            return test.done();
+          }
+          done.end = true;
+        });
+        downloadStream.on('close', function() {
+          if (done.end) {
+            return test.done();
+          }
+          done.close = true;
         });
         downloadStream.destroy(function(error) {
           test.equal(error, null);

--- a/test/functional/gridfs_stream_tests.js
+++ b/test/functional/gridfs_stream_tests.js
@@ -379,9 +379,9 @@ exports['Aborting an upload'] = {
                   test.equal(error.toString(),
                     'Error: this stream has been aborted');
                   // Fail if user tries to abort an aborted stream
-                  uploadStream.abort(function(error) {
+                  uploadStream.abort().then(null, function(error) {
                     test.equal(error.toString(),
-                      'Error: this stream has been aborted');
+                      'Error: Cannot call abort() on a stream twice');
                     test.done();
                   });
                 });

--- a/test/functional/gridfs_stream_tests.js
+++ b/test/functional/gridfs_stream_tests.js
@@ -437,6 +437,7 @@ exports['Destroying a download stream'] = {
           test.ok(false);
         });
         downloadStream.on('end', function() {
+          test.equal(downloadStream.s.cursor, null);
           if (done.close) {
             return test.done();
           }


### PR DESCRIPTION
Re: https://jira.mongodb.org/browse/NODE-655 .

* `GridFSBucketUploadStream` now has an `abort()` method as described in [the GridFS stream spec](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#file-upload)
* `GridFSBucketDownloadStream` now has a `destroy()` method that is analogous to [node fs read stream's implementation](https://github.com/nodejs/node/blob/1124de2d76ad7118267d91a08485aa928a5f0865/lib/fs.js#L1849-L1854)