### PR TITLE
typo in url_parser.js resulting in "replSetServerOptions is not defined" when connecting over ssl

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -247,7 +247,7 @@ module.exports = function(url, options) {
         break;
       case 'sslValidate':
         serverOptions.sslValidate = (value == 'true');
-        replSetServerOptions.sslValidate = (value == 'true');
+        replSetServersOptions.sslValidate = (value == 'true');
         break;
       case 'replicaSet':
       case 'rs_name':


### PR DESCRIPTION
see https://jira.mongodb.org/browse/NODE-661