### PR TITLE
Confusing error with invalid partial index filter

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -21,6 +21,8 @@ var EventEmitter = require('events').EventEmitter
   , Collection = require('./collection')
   , crypto = require('crypto');
 
+var INVALID_PARTIAL_INDEX_EXPRESSION_CODE = 67;
+
 var debugFields = ['authSource', 'w', 'wtimeout', 'j', 'native_parser', 'forceServerObjectId'
   , 'serializeFunctions', 'raw', 'promoteLongs', 'bufferMaxEntries', 'numberOfRetries', 'retryMiliSeconds'
   , 'readPreference', 'pkFactory'];
@@ -994,6 +996,9 @@ var createIndex = function(self, name, fieldOrSpec, options, callback) {
   // Attempt to run using createIndexes command
   createIndexUsingCreateIndexes(self, name, fieldOrSpec, options, function(err, result) {
     if(err == null) return handleCallback(callback, err, result);
+    if(err.code === INVALID_PARTIAL_INDEX_EXPRESSION_CODE) {
+      return handleCallback(callback, err, result);
+    }
     // Create command
     var doc = createCreateIndexCommand(self, name, fieldOrSpec, options);
     // Set no key checking

--- a/lib/db.js
+++ b/lib/db.js
@@ -21,8 +21,6 @@ var EventEmitter = require('events').EventEmitter
   , Collection = require('./collection')
   , crypto = require('crypto');
 
-var INVALID_PARTIAL_INDEX_EXPRESSION_CODE = 67;
-
 var debugFields = ['authSource', 'w', 'wtimeout', 'j', 'native_parser', 'forceServerObjectId'
   , 'serializeFunctions', 'raw', 'promoteLongs', 'bufferMaxEntries', 'numberOfRetries', 'retryMiliSeconds'
   , 'readPreference', 'pkFactory'];
@@ -996,7 +994,10 @@ var createIndex = function(self, name, fieldOrSpec, options, callback) {
   // Attempt to run using createIndexes command
   createIndexUsingCreateIndexes(self, name, fieldOrSpec, options, function(err, result) {
     if(err == null) return handleCallback(callback, err, result);
-    if(err.code === INVALID_PARTIAL_INDEX_EXPRESSION_CODE) {
+    // 67 = 'CannotCreateIndex', means that the server recognized
+    // `createIndex` as a command and so we don't need to fallback to
+    // an insert.
+    if(err.code === 67) {
       return handleCallback(callback, err, result);
     }
     // Create command

--- a/test/functional/index_tests.js
+++ b/test/functional/index_tests.js
@@ -822,7 +822,10 @@ exports['should correctly pass partialIndexes through to createIndexCommand'] = 
  * @ignore
  */
 exports['should not retry partial index expression error'] = {
-  metadata: { requires: { topology: ['single'], mongodb: ">=3.1.8" } },
+  metadata: {
+    requires: { topology: ['single', 'replicaset', 'sharded'],
+    mongodb: ">=3.1.8" }
+  },
 
   // The actual test we wish to run
   test: function(configuration, test) {

--- a/test/functional/index_tests.js
+++ b/test/functional/index_tests.js
@@ -821,6 +821,33 @@ exports['should correctly pass partialIndexes through to createIndexCommand'] = 
 /**
  * @ignore
  */
+exports['should not retry partial index expression error'] = {
+  metadata: { requires: { topology: ['single'], mongodb: ">=3.1.8" } },
+
+  // The actual test we wish to run
+  test: function(configuration, test) {
+    var db = configuration.newDbInstance(configuration.writeConcernMax(), {poolSize:1});
+    db.open(function(error, db) {
+      test.equal(error, null);
+      // Can't use $exists: false in partial filter expression, see
+      // https://jira.mongodb.org/browse/SERVER-17853
+      var opts = { partialFilterExpression: { a: { $exists: false } } };
+      db.collection('partialIndexes').createIndex({a:1}, opts, function(err) {
+        test.ok(err);
+        test.equal(err.code, 67);
+        var msg = "key $exists must not start with '$'";
+        test.ok(err.toString().indexOf(msg) === -1);
+
+        db.close();
+        test.done();
+      });
+    });
+  }
+}
+
+/**
+ * @ignore
+ */
 exports['should correctly error out due to driver close'] = {
   metadata: { requires: { topology: ['single'] } },
 


### PR DESCRIPTION
Re: Automattic/mongoose#3864, if you try to use an invalid partial index filter, the `createIndex()` function falls back to trying to create the index using an insert, which then gives you a BSON serialization error because of query operators in the partial index filter: `Error: key $exists must not start with '$'`.

I added a test case to repro this error condition in a separate commit below, as well as a possible solution: if the mongodb server gives you an invalid partial index filter error, don't fall back to using insert. I'm not thrilled about this solution, you may be able to think of a better one, so I put it as a separate commit to make it easier.