### PR TITLE
fixed typo in double-colon test

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -41,7 +41,7 @@ module.exports = function(url, options) {
 
   if(result.query) {
     for(var name in result.query) {
-      if(name.indexOf(':') != -1) {
+      if(name.indexOf('::') != -1) {
         throw new Error('double colon in host identifier');
       }
 


### PR DESCRIPTION
Fixes test for a double-colon in line 44 of url_parser.js from one colon to two colons :-)