### PR TITLE
Added error catching in bulkWrite function for bulk.raw

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -599,8 +599,12 @@ var bulkWrite = function(self, operations, options, callback) {
   var bulk = options.ordered == true || options.ordered == null ? self.initializeOrderedBulkOp(options) : self.initializeUnorderedBulkOp(options);
 
   // for each op go through and add to the bulk
-  for(var i = 0; i < operations.length; i++) {
-    bulk.raw(operations[i]);
+  try {
+    for(var i = 0; i < operations.length; i++) {
+      bulk.raw(operations[i]);
+    }
+  } catch(err) {
+    return callback(err, null);
   }
 
   // Final options for write concern


### PR DESCRIPTION
When an error is thrown from `OrderedBulkOperation#raw` or `UnorderedBulkOperation#raw` (such as the document greater than maximum size error), it was not caught properly, and therefore not propagated correctly through callbacks.

Test case:

```js
var MongoClient = require('mongodb').MongoClient;

// Connection URL
var url = 'mongodb://localhost/test';
// Use connect method to connect to the Server
MongoClient.connect(url, function(err, db) {
  console.log("Connected correctly to server");

  var col = db.collection('testcol');
  col.insert({
    blob: new Buffer(20 * 1024 * 1024)
  }, function (err) {
    console.log('callback');
    console.log(err);

    db.close();
  });
});
```

Before:

```
$ node test
Connected correctly to server

node_modules/mongodb/lib/mongo_client.js:465
          throw err
          ^
MongoError: document is larger than the maximum size 16777216
    at Function.MongoError.create (node_modules/mongodb-core/lib/error.js:31:11)
    at toError (node_modules/mongodb/lib/utils.js:114:22)
    at addToOperationsList (node_modules/mongodb/lib/bulk/ordered.js:154:51)
    at OrderedBulkOperation.raw (node_modules/mongodb/lib/bulk/ordered.js:342:7)
    at bulkWrite (node_modules/mongodb/lib/collection.js:591:10)
    at Collection.insertMany (node_modules/mongodb/lib/collection.js:490:44)
    at Collection.insert (node_modules/mongodb/lib/collection.js:773:15)
    at test.js:10:7
    at node_modules/mongodb/lib/mongo_client.js:462:11
    at nextTickCallbackWith0Args (node.js:419:9)
```

After:

```
$ node test
Connected correctly to server
callback
{ [MongoError: document is larger than the maximum size 16777216]
  name: 'MongoError',
  message: 'document is larger than the maximum size 16777216',
  driver: true }
```

System info:

```sh
$ node -p 'process.versions'
{ http_parser: '2.5.1',
  node: '4.3.0',
  v8: '4.5.103.35',
  uv: '1.8.0',
  zlib: '1.2.8',
  ares: '1.10.1-DEV',
  icu: '56.1',
  modules: '46',
  openssl: '1.0.2f' }
$ node -p 'require("mongodb/package").version'
2.1.6
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 12.04.5 LTS
Release:        12.04
Codename:       precise
$ mongod --version
db version v3.2.1
git version: a14d55980c2cdc565d4704a7e3ad37e4e535c1b2
OpenSSL version: OpenSSL 1.0.1 14 Mar 2012
allocator: tcmalloc
modules: none
build environment:
    distmod: ubuntu1204
    distarch: x86_64
    target_arch: x86_64
```