### PR TITLE
gridfs: add code attribute to file not found error

### DIFF
--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -267,7 +267,9 @@ function init(self) {
       var identifier = self.s.filter._id ?
         self.s.filter._id.toString() : self.s.filter.filename;
       var errmsg = 'FileNotFound: file ' + identifier + ' was not found';
-      return __handleError(self, new Error(errmsg));
+      var err = new Error(errmsg);
+      err.code = 'ENOENT';
+      return __handleError(self, err);
     }
 
     // If document is empty, kill the stream immediately and don't


### PR DESCRIPTION
This addition makes it much easier to handle file not found errors the users applications.