### PR TITLE
Fixing issue that prevented mapReduce stats from being resolved

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -3039,7 +3039,7 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
   return new this.s.promiseLibrary(function(resolve, reject) {
     mapReduce(self, map, reduce, options, function(err, r, r1) {
       if(err) return reject(err);
-      if(r instanceof Collection) return resolve(r);
+      if(!r1) return resolve(r);
       resolve({results: r, stats: r1});
     });
   });


### PR DESCRIPTION
Currently when you set `verbose:true` you wont get the stats of the mapReduce operation unless you specify inline results - this is when using Promises. In callback mode stats are returned regardless of the output settings.

cc: @christkv 