### PR TITLE
fix DEFAULT authMechanism; don't throw error if explicitly set by user

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1485,11 +1485,12 @@ Db.prototype.authenticate = function(username, password, options, callback) {
   if(!options.authMechanism) {
     options.authMechanism = 'DEFAULT';
   } else if(options.authMechanism != 'GSSAPI'
+    && options.authMechanism != 'DEFAULT'
     && options.authMechanism != 'MONGODB-CR'
     && options.authMechanism != 'MONGODB-X509'
     && options.authMechanism != 'SCRAM-SHA-1'
     && options.authMechanism != 'PLAIN') {
-      return handleCallback(callback, MongoError.create({message: "only GSSAPI, PLAIN, MONGODB-X509, SCRAM-SHA-1 or MONGODB-CR is supported by authMechanism", driver:true}));
+      return handleCallback(callback, MongoError.create({message: "only DEFAULT, GSSAPI, PLAIN, MONGODB-X509, SCRAM-SHA-1 or MONGODB-CR is supported by authMechanism", driver:true}));
   }
 
   // If we have a callback fallback


### PR DESCRIPTION
If the `authMechanism` is omitted, it will be populated with `DEFAULT`. However, if the user has explicitly set `authMechanism` to `DEFAULT`, an error will be thrown because the code does not include `DEFAULT` in its sanity check of the `authMechanism` field. This is [contrary to the documented behaviour](https://mongodb.github.io/node-mongodb-native/2.1/reference/connecting/authenticating/).