### PR TITLE
Emit error events from topology to db

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1732,13 +1732,10 @@ var writeConcern = function(target, db, options) {
 // Add listeners to topology
 var createListener = function(self, e, object) {
   var listener = function(err) {
-    if(e != 'error') {
-      object.emit(e, err, self);
-
-      // Emit on all associated db's if available
-      for(var i = 0; i < self.s.children.length; i++) {
-        self.s.children[i].emit(e, err, self.s.children[i]);
-      }
+    object.emit(e, err, self);
+    // Emit on all associated db's if available
+    for(var i = 0; i < self.s.children.length; i++) {
+      self.s.children[i].emit(e, err, self.s.children[i]);
     }
   }
   return listener;

--- a/lib/server.js
+++ b/lib/server.js
@@ -247,9 +247,7 @@ Server.prototype.connect = function(db, _options, callback) {
   // Actual handler
   var errorHandler = function(event) {
     return function(err) {
-      if(event != 'error') {
-        self.emit(event, err);
-      }
+      self.emit(event, err);
     }
   }
 


### PR DESCRIPTION
This PR makes changes to propagate error events from topology to the db instance.

I am not sure why the error events were masked in the first place, there may have been some good reasons that i am aware of. But IMHO it is not a good option at all to filter the error events out.