### PR TITLE
Updates to documentation

### DIFF
--- a/docs/reference/content/index.md
+++ b/docs/reference/content/index.md
@@ -36,7 +36,7 @@ If you wish to use the MongoDB driver with the ES6 features such as Promises and
 
 After going over the basics of the driver use you might want to explore how authentication and the Grid FS implementation work.
 
-* [Authentication]({{< relref "reference/connecting/autjenticate.md" >}})
+* [Authentication]({{< relref "reference/connecting/authenticating.md" >}})
 * [Grid FS]({{< relref "reference/gridfs/streaming.md" >}})
 
 ## Advanced topics

--- a/docs/reference/content/reference/connecting/authenticating.md
+++ b/docs/reference/content/reference/connecting/authenticating.md
@@ -1,27 +1,30 @@
 +++
 date = "2015-03-19T14:27:51-04:00"
-title = "Authenticating"
+title = "Authentication"
 [menu.main]
-  parent = "Connecting"
-  identifier = "Authenticating"
-  weight = 20
+  parent = "Connect to MongoDB"
+  identifier = "Authentication"
+  weight = 30
   pre = "<i class='fa'></i>"
 +++
 
 # Authentication
 
-The Node.js driver supports all MongoDB [authentication mechanisms](http://docs.mongodb.org/manual/core/authentication/), including those
-only available in the MongoDB [Enterprise Edition](http://docs.mongodb.org/manual/administration/install-enterprise/).
+The Node.js driver supports all MongoDB [authentication mechanisms](http://docs.mongodb.org/manual/core/authentication/), including those only available in the MongoDB [Enterprise Edition](http://docs.mongodb.org/manual/administration/install-enterprise/).
 
-{{% note %}}
-MongoDB 3.0 changed the default authentication mechanism from
-[MONGODB-CR](http://docs.mongodb.org/manual/core/authentication/#mongodb-cr-authentication) to
-[SCRAM-SHA-1](http://docs.mongodb.org/manual/core/authentication/#scram-sha-1-authentication).
-{{% /note %}}
 
 ## DEFAULT
 
-If no authentication mechanism is specified or the mechanism DEFAULT is specified, the driver will attempt to authenticate using the SCRAM-SHA-1 authentication method if it is available on the MongoDB server. If the server does not support SCRAM-SHA-1 the driver will authenticate using MONGODB-CR.
+{{% note %}}
+Starting in MongoDB 3.0, MongoDB changed the default authentication mechanism from [MONGODB-CR](https://docs.mongodb.org/manual/core/security-mongodb-cr/) to [SCRAM-SHA-1](https://docs.mongodb.org/manual/core/security-scram-sha-1/).
+{{% /note %}}
+
+
+To use the default mechanism, either omit the authentication mechanism specification or specify `DEFAULT` as the mechanism in the [URI ConnectionString](https://docs.mongodb.org/manual/reference/connection-string/). The driver will attempt to authenticate using the [SCRAM-SHA-1 authentication] (https://docs.mongodb.org/manual/core/security-scram-sha-1/) method if it is available on the MongoDB server. If the server does not support SCRAM-SHA-1, the driver will authenticate using [MONGODB-CR](https://docs.mongodb.org/manual/core/security-mongodb-cr/).
+
+Include the name and password and the [authentication database] (https://docs.mongodb.org/manual/core/security-users/#user-authentication-database) (`authSource`) in the connection string.
+
+In the following example, the connection string specifies the user `dave`, password `abc123`, authentication mechanism `DEFAULT`, and authentication database `myproject`.
 
 ```js
 var MongoClient = require('mongodb').MongoClient,
@@ -29,7 +32,7 @@ var MongoClient = require('mongodb').MongoClient,
   assert = require('assert');
 
 // Connection URL
-var url = 'mongodb://dave:password@localhost:27017?authMechanism=DEFAULT&authSource=db';
+var url = 'mongodb://dave:abc123@localhost:27017?authMechanism=DEFAULT&authSource=myproject';
 // Use connect method to connect to the Server
 MongoClient.connect(url, function(err, db) {
   assert.equal(null, err);
@@ -41,7 +44,11 @@ MongoClient.connect(url, function(err, db) {
 
 ## SCRAM-SHA-1
 
-To explicitly connect to MongoDB using [SCRAM-SHA-1](http://docs.mongodb .org/manual/core/authentication/#scram-sha-1-authentication), we pass the following parameters to the driver over the connection URI.
+To explicitly connect to MongoDB using [SCRAM-SHA-1] (http://docs.mongodb.org/manual/core/authentication/#scram-sha-1-authentication), specify `SCRAM-SHA-1` as the mechanism in the [URI connection string](https://docs.mongodb.org/manual/reference/connection-string/).
+
+Include the name and password and the [authentication database](https://docs.mongodb.org/manual/core/security-users/#user-authentication-database) (`authSource`) in the connection string.
+
+In the following example, the connection string specifies the user `dave`, password `abc123`, authentication mechanism `SCRAM-SHA-1`, and authentication database `myproject`.
 
 ```js
 var MongoClient = require('mongodb').MongoClient,
@@ -49,7 +56,7 @@ var MongoClient = require('mongodb').MongoClient,
   assert = require('assert');
 
 // Connection URL
-var url = 'mongodb://dave:password@localhost:27017?authMechanism=SCRAM-SHA-1&authSource=db';
+var url = 'mongodb://dave:abc123@localhost:27017?authMechanism=SCRAM-SHA-1&authSource=myprojectdb';
 // Use connect method to connect to the Server
 MongoClient.connect(url, function(err, db) {
   assert.equal(null, err);
@@ -59,11 +66,14 @@ MongoClient.connect(url, function(err, db) {
 });
 ```
 
-The URI uses the authMechanism `SCRAM-SHA-1` with the user `dave` and password `password` against the database `db`.
 
 ## MONGODB-CR
 
-To explicitly create a credential of type [MONGODB-CR](http://docs.mongodb.org/manual/core/authentication/#mongodb-cr-authentication), we pass the following parameters to the driver over the connection URI.
+To explicitly connect to MongoDB using [MONGODB-CR](https://docs.mongodb.org/manual/core/security-mongodb-cr/), specify `MONGODB-CR` as the mechanism in the [URI connection string](https://docs.mongodb.org/manual/reference/connection-string/).
+
+Include the name and password and the [authentication database](https://docs.mongodb.org/manual/core/security-users/#user-authentication-database) (`authSource`) in the connection string.
+
+In the following example, the connection string specifies the user `dave`, password `abc123`, authentication mechanism `MONGODB-CR`, and authentication database `myproject`.
 
 ```js
 var MongoClient = require('mongodb').MongoClient,
@@ -71,7 +81,7 @@ var MongoClient = require('mongodb').MongoClient,
   assert = require('assert');
 
 // Connection URL
-var url = 'mongodb://dave:password@localhost:27017?authMechanism=MONGODB-CR&authSource=db';
+var url = 'mongodb://dave:abc123@localhost:27017?authMechanism=MONGODB-CR&authSource=myprojectdb';
 // Use connect method to connect to the Server
 MongoClient.connect(url, function(err, db) {
   assert.equal(null, err);
@@ -81,19 +91,23 @@ MongoClient.connect(url, function(err, db) {
 });
 ```
 
-The URI uses the authMechanism `MONGODB-CR` with the user `dave` and password `password` against the database `db`.
-
 {{% note class="important" %}}
-If you specify the `MONGODB-CR` authMechanism the authentication might fail once you upgrade MongoDB to 3.0 or higher due to new users only being created using the `SCRAM-SHA-1` mechanism.
+
+If you have [upgraded the authentication schema]
+(https://docs.mongodb.org/manual/release-notes/3.0-scram/) from `MONGODB-CR` to `SCRAM-SHA-1`, `MONGODB-CR` credentials will fail to authenticate.
+
 {{% /note %}}
 
 ## X509
 
-The [x.509](http://docs.mongodb.org/manual/core/authentication/#x-509-certificate-authentication) mechanism authenticates a user
-whose name is derived from the distinguished subject name of the X.509 certificate presented by the driver during SSL negotiation. This
-authentication method requires the use of SSL connections with certificate validation and is available in MongoDB 2.6 and newer.
+With  [X.509](http://docs.mongodb.org/manual/core/authentication/#x-509-certificate-authentication) mechanism, MongoDB uses the X.509 certificate presented during SSL negotiation to authenticate a user whose name is derived from the distinguished name of the X.509 certificate.
 
-The example below shows how you connect using a X509 certificate using `MongoClient`. We assume that the `client.pem` file here is a valid X509 certificate and that the MongoDB server is correctly configured.
+X.509 authentication requires the use of SSL connections with certificate validation and is available in MongoDB 2.6 and newer.
+
+To connect using the X.509 authentication mechanism, specify `MONGODB-X509` as the mechanism in the [URI connection string](https://docs.mongodb.org/manual/reference/connection-string/), `ssl=true`, and the username. Use `enodeURIComponent` to encode the username string.
+
+In addition to the connection string, pass to the `MongoClient.connect` method a connections options for the `server` with  the X.509 certificate and other [TLS/SSL connections]({{< relref "reference/connecting/ssl.md" >}}) options.
+
 
 ```js
 var MongoClient = require('mongodb').MongoClient,
@@ -122,16 +136,18 @@ MongoClient.connect(f('mongodb://%s@server:27017/test?authMechanism=MONGODB-X509
 });
 ```
 
-See the MongoDB server
-[x.509 tutorial](http://docs.mongodb.org/manual/tutorial/configure-x509-client-authentication/#add-x-509-certificate-subject-as-a-user) for
-more information about determining the subject name from the certificate.
-## Against The Specified Database
+For more information on connecting to MongoDB instance, replica set, and sharded cluster with TLS/SSL options, see [TLS/SSL connections options]({{< relref "reference/connecting/ssl.md" >}}).
+
+For more information, refer to the MongoDB manual
+[X.509 tutorial](http://docs.mongodb.org/manual/tutorial/configure-x509-client-authentication/#add-x-509-certificate-subject-as-a-user) for more information about determining the subject name from the certificate.
 
 ## Kerberos (GSSAPI/SSPI)
 
 [MongoDB Enterprise](http://www.mongodb.com/products/mongodb-enterprise) supports proxy authentication through a Kerberos service. The Node.js driver supports Kerberos on UNIX via the MIT Kerberos library and on Windows via the SSPI API.
 
-Below is an example on how to connect to MongoDB using Kerberos for UNIX.
+To connect using the X.509 authentication mechanism, specify ``authMechanism=GSSAPI`` as the mechanism in the [URI connection string](https://docs.mongodb.org/manual/reference/connection-string/). Specify the user principal and the service name in the connection string.  Use `enodeURIComponent` to encode the user principal string.
+
+The following example connects to MongoDB using Kerberos for UNIX.
 
 ```js
 var MongoClient = require('mongodb').MongoClient,
@@ -144,7 +160,7 @@ var principal = "drivers@KERBEROS.EXAMPLE.COM";
 var urlEncodedPrincipal = encodeURIComponent(principal);
 
 // Let's write the actual connection code
-MongoClient.connect(format("mongodb://%s@%s/kerberos?authMechanism=GSSAPI&gssapiServiceName=mongodb", urlEncodedPrincipal, server), function(err, db) {
+MongoClient.connect(f("mongodb://%s@%s/kerberos?authMechanism=GSSAPI&gssapiServiceName=mongodb", urlEncodedPrincipal, server), function(err, db) {
   assert.equal(null, err);
 
   db.close();
@@ -153,14 +169,15 @@ MongoClient.connect(format("mongodb://%s@%s/kerberos?authMechanism=GSSAPI&gssapi
 ```
 
 {{% note %}}
-The method refers to the `GSSAPI` authentication mechanism instead of `Kerberos` because technically the driver is authenticating via the 
-[GSSAPI](https://tools.ietf.org/html/rfc4752) SASL mechanism.
+The method refers to the `GSSAPI` authentication mechanism instead of `Kerberos` because technically the driver authenticates via the [GSSAPI](https://tools.ietf.org/html/rfc4752) SASL mechanism.
+
 {{% /note %}}
 
 ## LDAP (PLAIN)
 
-[MongoDB Enterprise](http://www.mongodb.com/products/mongodb-enterprise) supports proxy authentication through a Lightweight Directory
-Access Protocol (LDAP) service.
+[MongoDB Enterprise](http://www.mongodb.com/products/mongodb-enterprise) supports proxy authentication through a Lightweight Directory Access Protocol (LDAP) service.
+
+To connect using the LDAP authentication mechanism, specify ``authMechanism=PLAIN`` as the mechanism in the [URI connection string](https://docs.mongodb.org/manual/reference/connection-string/).
 
 ```js
 var MongoClient = require('mongodb').MongoClient,
@@ -173,7 +190,7 @@ var user = "ldap-user";
 var pass = "ldap-password";
 
 // Url
-var url = format("mongodb://%s:%s@%s/test?authMechanism=PLAIN&maxPoolSize=1", user, pass, server);
+var url = f("mongodb://%s:%s@%s/test?authMechanism=PLAIN&maxPoolSize=1", user, pass, server);
 
 // Let's write the actual connection code
 MongoClient.connect(url, function(err, db) {
@@ -185,5 +202,5 @@ MongoClient.connect(url, function(err, db) {
 ```
 
 {{% note %}}
-The method refers to the `plain` authentication mechanism instead of `LDAP` because technically the driver is authenticating via the [PLAIN](https://www.ietf.org/rfc/rfc4616.txt) SASL mechanism.
+The method refers to the `PLAIN` authentication mechanism instead of `LDAP` because technically the driver authenticates via the [PLAIN](https://www.ietf.org/rfc/rfc4616.txt) SASL mechanism.
 {{% /note %}}

--- a/docs/reference/content/reference/connecting/connection-settings.md
+++ b/docs/reference/content/reference/connecting/connection-settings.md
@@ -2,115 +2,15 @@
 date = "2015-03-19T12:53:30-04:00"
 title = "Connection Settings"
 [menu.main]
-  parent = "Connecting"
+  parent = "Connect to MongoDB"
   identifier = "Connection Settings"
-  weight = 10
+  weight = 40
   pre = "<i class='fa'></i>"
 +++
 
-# Connecting To MongoDB
+# URI Connection Settings
 
-{{% note %}}
-This reference applies to `2.1.11` or higher. For `2.1.10` or earlier please see the legacy connection settings. `2.1.11` is backward compatible with the legacy connection settings as well as the simplified settings.
-{{% /note %}}
-
-Connecting to MongoDB using the driver is primarily done using the `MongoClient.connect` method and a URI. Let's look at how we connect to a couple of different server topologies.
-
-## Single Server Connection
-
-We have a single MongoDB server instance running on the port *27017* Let's connect using the driver and *MongoClient.connect*
-
-```js
-var MongoClient = require('mongodb').MongoClient
-  , assert = require('assert');
-
-// Connection URL
-var url = 'mongodb://localhost:27017/myproject';
-// Use connect method to connect to the Server
-MongoClient.connect(url, function(err, db) {
-  assert.equal(null, err);
-  console.log("Connected correctly to server");
-
-  db.close();
-});
-```
-
-Let's break down the `URI` string we passed as the first argument to MongoClient.connect.
-
-| Parameter | Description |
-| :----------| :------------- |
-| `mongodb://` | is the protocol definition |
-| `localhost:27017` | is the server we are connecting to |
-| `/myproject` | is the database we wish to connect to |
-
-## Replicaset Server Connection
-
-We wish to connect to a ReplicaSet consisting of one primary and 1 or more secondaries. To Do this we need to supply the driver with a seedlist of servers and the name of the ReplicaSet we wish to connect to. Let's take a look at a code example.
-
-```js
-var MongoClient = require('mongodb').MongoClient
-  , assert = require('assert');
-
-// Connection URL
-var url = 'mongodb://localhost:27017,localhost:27018/myproject?replicaSet=foo';
-// Use connect method to connect to the Server
-MongoClient.connect(url, function(err, db) {
-  assert.equal(null, err);
-  console.log("Connected correctly to server");
-
-  db.close();
-});
-```
-
-Let's break down the `URI` string.
-
-| Parameter | Description |
-| :----------| :------------- |
-| `mongodb://` | is the protocol definition |
-| `localhost:27017,localhost:27018` | is the servers we are connecting to to discover the topology of the ReplicaSet. |
-| `/myproject` | is the database we wish to connect to |
-| `replicaSet=foo` | is the name of the ReplicaSet we are connecting to. This ensures we are connecting to the correct Replicaset. **This is a required parameter when using the 2.0 driver** |
-
-## Mongos Proxy Connection
-
-We wish to connect to a set of `mongos` proxies. Just as in the case of connecting to a ReplicaSet we can provide a seed list of `mongos` proxies. This allows the driver to perform failover between proxies automatically in case of a proxy process having been shut down. Let's look at an example of code connecting to a set of proxies.
-
-```js
-var MongoClient = require('mongodb').MongoClient
-  , assert = require('assert');
-
-// Connection URL
-var url = 'mongodb://localhost:50000,localhost:50001/myproject';
-// Use connect method to connect to the Server
-MongoClient.connect(url, function(err, db) {
-  assert.equal(null, err);
-  console.log("Connected correctly to server");
-
-  db.close();
-});
-```
-
-Let's break down the `URI` string.
-
-| Parameter | Description |
-| :----------| :------------- |
-| `mongodb://` | is the protocol definition |
-| `localhost:50000,localhost:50001` | is the *mongos* proxies we are connecting to. |
-| `/myproject` | is the database we wish to connect to |
-
-Let's break down the `URI` string.
-
-| Parameter | Description |
-| :----------| :------------- |
-| `mongodb://` | is the protocol definition |
-| `dave:password` | is the user name and password for the database |
-| `localhost:27017` | is the server we are connecting to |
-| `/myproject` | is the database we wish to connect to |
-| `authSource=admin` | is the database we wish to authenticate against |
-
-## Optional Connection Settings
-
-Optional connection settings are settings not covered by the MongoDB URI specification. These options are passed in the options parameter in the MongoClient.connect function.
+Optional connection settings are settings not covered by the [URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/). The following options are passed in the options parameter in the MongoClient.connect function.
 
 ```js
 var MongoClient = require('mongodb').MongoClient

--- a/docs/reference/content/reference/connecting/index.md
+++ b/docs/reference/content/reference/connecting/index.md
@@ -1,17 +1,149 @@
 +++
 date = "2015-03-19T12:53:30-04:00"
-title = "Connecting"
+title = "Connect to MongoDB"
 [menu.main]
   parent = "Reference"
-  identifier = "Connecting"
+  identifier = "Connect to MongoDB"
   weight = 30
   pre = "<i class='fa'></i>"
 +++
 
-## Connecting
+# Connect to MongoDB
 
-The reference documentation for connecting to a MongoDB server deployment is divided into three sections:   
+{{% note %}}
 
-- [Connection Settings]({{<relref "reference/connecting/connection-settings.md">}}): documentation of the various ways to specify the properties of a connection
-- [Authenticating]({{<relref "reference/connecting/authenticating.md">}}): detailed documentation of the various ways to specify authentication credentials
-- [SSL]({{<relref "reference/connecting/ssl.md">}}): Detailed documentation of the various ways to specify the properties of an SSL connection
+This reference applies to **2.1.11** or higher. For **2.1.10** or
+earlier, refer to the [legacy connection settings] ({{< relref
+"reference/connecting/legacy-connection-settings.md" >}}). **2.1.11**
+is backward compatible with the legacy settings as well as the
+simplified settings. {{% /note %}}
+
+Use the `MongoClient.connect` method to connect to a running MongoDB deployment.
+ 
+## Connect to a Single MongoDB Instance
+
+To connect to a single MongoDB instance, specify the URI of the MongoDB
+instance to connect to.
+
+In the following example, the
+[URI connection string](https://docs.mongodb.org/manual/reference/connection-string/)
+specifies connecting to a MongoDB instance that is running on
+`localhost` using port `27017`. The `myproject` indicates the database
+to use. If the database is omitted, the `MongoClient` uses the default `test` database:
+
+```js
+var MongoClient = require('mongodb').MongoClient
+  , assert = require('assert');
+
+// Connection URL
+var url = 'mongodb://localhost:27017/myproject';
+
+// Use connect method to connect to the Server
+MongoClient.connect(url, function(err, db) {
+  assert.equal(null, err);
+  console.log("Connected correctly to server");
+
+  db.close();
+});
+```
+
+For more information on the URI connection string, see
+[URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/).
+
+## Connect to a Replica Set
+
+To connect to a [replica set](https://docs.mongodb.org/manual/core/replication-introduction/),
+include a seedlist of replica set members and the name of the replica set in the
+[URI connection string](https://docs.mongodb.org/manual/reference/connection-string/).
+
+In the following example, the connection string specifies two of the replica set members running on `localhost:27017` and `localhost:27018`, the database to access (`myproject`), and the name of the replica set (`foo`). **When using the 2.0 driver, you must include the replica set name.**
+
+```js
+var MongoClient = require('mongodb').MongoClient
+  , assert = require('assert');
+
+// Connection URL
+var url = 'mongodb://localhost:27017,localhost:27018/myproject?replicaSet=foo';
+// Use connect method to connect to the Server
+MongoClient.connect(url, function(err, db) {
+  assert.equal(null, err);
+  console.log("Connected correctly to server");
+
+  db.close();
+});
+```
+
+For more information on the URI connection string, see
+[URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/).
+
+## Connect to Sharded Cluster
+
+To connect to a [sharded cluster] (https://docs.mongodb.org/manual/core/sharded-cluster-components/), specify the `mongos` instance or instances in the [URI connection string](https://docs.mongodb.org/manual/reference/connection-string/).
+
+In the following example, the connection string specifies the `mongos` instances running on `localhost:50000` and `localhost:50000` and the database to access (`myproject`).
+
+```js
+var MongoClient = require('mongodb').MongoClient
+  , assert = require('assert');
+
+// Connection URL
+var url = 'mongodb://localhost:50000,localhost:50001/myproject';
+// Use connect method to connect to the Server
+MongoClient.connect(url, function(err, db) {
+  assert.equal(null, err);
+  console.log("Connected correctly to server");
+
+  db.close();
+});
+```
+
+For more information on the URI connection string, see
+[URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/).
+
+## Connection Options
+
+You can specify various connection settings in the [URI Connection
+String ](https://docs.mongodb.org/manual/reference/connection-string/).
+
+For example, you can specify TLS/SSL and authentication setting.
+
+```js
+
+var MongoClient = require('mongodb').MongoClient,
+  f = require('util').format,
+  assert = require('assert'),
+  fs = require('fs');
+
+  // Read the certificate authority
+  var ca = [fs.readFileSync(__dirname + "/ssl/ca.pem")];
+  var cert = fs.readFileSync(__dirname + "/ssl/client.pem");
+  
+// Connection URL
+var url = 'mongodb://dave:password@localhost:27017?authMechanism=DEFAULT&authSource=db&ssl=true"';
+
+// Use connect method to connect to the Server passing in
+// additional options
+MongoClient.connect(url,  {
+  server: {
+      sslValidate:true
+    , sslCA:ca
+    , sslCert:cert
+  }
+}, function(err, db) {
+  assert.equal(null, err);
+  console.log("Connected correctly to server");
+
+  db.close();
+});
+
+```
+
+For more information on connecting with authentication and TSL/SSL, see:
+
+- [Authentication]({{<relref "reference/connecting/authenticating.md">}}): detailed documentation of the various ways to specify authentication credentials
+- [TLS/SSL]({{<relref "reference/connecting/ssl.md">}}): Detailed documentation of the various ways to specify the properties of an TLS/SSL connection
+
+For more information on the connection options: 
+
+- [URI Connection String](https://docs.mongodb.org/manual/reference/connection-string/): MongoDB connection string URI.
+- [Connection Settings]({{<relref "reference/connecting/connection-settings.md">}}): Reference on the driver-specific connection settings.

--- a/docs/reference/content/reference/connecting/legacy-connection-settings.md
+++ b/docs/reference/content/reference/connecting/legacy-connection-settings.md
@@ -2,13 +2,19 @@
 date = "2015-03-19T12:53:30-04:00"
 title = "Legacy Connection Settings"
 [menu.main]
-  parent = "Connecting"
+  parent = "Connect to MongoDB"
   identifier = "Legacy Connection Settings"
   weight = 40
   pre = "<i class='fa'></i>"
 +++
 
-# Connecting To MongoDB
+# Connect To MongoDB (Legacy)
+
+{{% note %}}
+
+For 2.1.10 or earlier. For newer versions, see [Connect to MongoDB]({{< relref
+"reference/connecting/index.md" >}})
+{{% /note %}}
 
 Connecting to MongoDB using the driver is primarily done using the `MongoClient.connect` method and a URI. Let's look at how we connect to a couple of different server topologies.
 

--- a/docs/reference/content/reference/index.md
+++ b/docs/reference/content/reference/index.md
@@ -11,7 +11,7 @@ title = "Reference"
 
 The reference documentation for the Node.js driver driver focuses on high-level documentation and use-cases.
 
-- [Connecting]({{< relref "reference/connecting/index.md" >}}): Documentation of the driver's support for connecting to MongoDB servers
+- [Connect to MongoDB]({{< relref "reference/connecting/index.md" >}}): Documentation of the driver's support for connecting to MongoDB servers
 - [CRUD]({{< relref "reference/crud/index.md" >}}): Documentation of the driver's support for CRUD operations
 - [ECMAScript 6]({{< relref "reference/ecmascript6/index.md" >}}): Using the driver with Javascript 6.
 - [Management]({{< relref "reference/management/index.md" >}}): Documentation of the driver's support for logging and monitoring of its


### PR DESCRIPTION
@christkv -- here are the edits to the connect and ssl and authentication pages.  

- I wasn't sure if we should blurb that some of the options can be specified in URL connection string vs options object since I didn't know what the preferred method was.  

- Also, I noticed that we don't specify external as the authentication database -- and wasn't sure if that was expected.

- I didn't separate yet into files for Tutorials section and Reference section.  However, I did move the connection settings into a separate page (which will be a reference page in the future) from the Connect to MongoDB page (which will go to the tutorials)