### PR TITLE
replaced 'legacy' package keyword with 'official'

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "keywords": [
     "mongodb",
     "driver",
-    "legacy"
+    "official"
   ],
   "dependencies": {
     "es6-promise": "3.0.2",


### PR DESCRIPTION
This doesn't look legacy to me.