### PR TITLE
Forward unref to mongodb-core server class

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -374,6 +374,14 @@ Server.prototype.lastIsMaster = function() {
   return this.s.server.lastIsMaster();
 }
 
+/**
+ * Unref all sockets
+ * @method
+ */
+Server.prototype.unref = function() {
+  this.s.server.unref();
+}
+
 Server.prototype.close = function(forceClosed) {
   this.s.server.destroy();
   // We need to wash out all stored processes


### PR DESCRIPTION
Last time, we forgot to forward the unref request to the mongodb-core server class.