### PR TITLE
Improve documentation for ObjectID.isValid()

### DIFF
--- a/2.1/api/ObjectID.html
+++ b/2.1/api/ObjectID.html
@@ -2269,7 +2269,7 @@ the created ObjectID
     <div class="nameContainer">
         <h4 class="name" id=".isValid">
             
-            <span class="type-signature static">static</span>ObjectID.isValid<span class="signature">()</span><span class="glyphicon glyphicon-circle-arrow-right"></span><span class="type-signature returnType">{boolean}</span>
+            <span class="type-signature static">static</span>ObjectID.isValid<span class="signature">(someID)</span><span class="glyphicon glyphicon-circle-arrow-right"></span><span class="type-signature returnType">{boolean}</span>
         </h4>
     
         


### PR DESCRIPTION
Hi,

I've noticed what appears to be a small mistake in the documentation for `ObjectID.isValid()`.

The method is a static, but the documentation omits (unlike the other statics before) to specify that an `ObjectId` should be passed as a parameter.

PS: I did not find any guidelines on how to contribute to the documentation, so I hope this is the right way.