### PR TITLE
polyfill for Object.assign()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -20,7 +20,8 @@ var checkCollectionName = require('./utils').checkCollectionName
   , Define = require('./metadata')
   , Cursor = require('./cursor')
   , unordered = require('./bulk/unordered')
-  , ordered = require('./bulk/ordered');
+  , ordered = require('./bulk/ordered')
+  , assign = require('./utils').assign;
 
 /**
  * @fileOverview The **Collection** class is an internal class that embodies a MongoDB collection
@@ -1386,7 +1387,7 @@ define.classMethod('findOne', {callback: true, promise:true});
 Collection.prototype.rename = function(newName, opt, callback) {
   var self = this;
   if(typeof opt == 'function') callback = opt, opt = {};
-  opt = Object.assign({}, opt, {readPreference: ReadPreference.PRIMARY});
+  opt = assign({}, opt, {readPreference: ReadPreference.PRIMARY});
 
   // Execute using callback
   if(typeof callback == 'function') return rename(self, newName, opt, callback);

--- a/lib/db.js
+++ b/lib/db.js
@@ -20,7 +20,8 @@ var EventEmitter = require('events').EventEmitter
   , Define = require('./metadata')
   , Logger = require('mongodb-core').Logger
   , Collection = require('./collection')
-  , crypto = require('crypto');
+  , crypto = require('crypto')
+  , assign = require('./utils').assign;
 
 var debugFields = ['authSource', 'w', 'wtimeout', 'j', 'native_parser', 'forceServerObjectId'
   , 'serializeFunctions', 'raw', 'promoteLongs', 'bufferMaxEntries', 'numberOfRetries', 'retryMiliSeconds'
@@ -804,7 +805,7 @@ Db.prototype.dropCollection = function(name, options, callback) {
   var cmd = {'drop':name}
 
   // options
-  options = Object.assign({}, this.s.options, {readPreference: ReadPreference.PRIMARY});
+  options = assign({}, this.s.options, {readPreference: ReadPreference.PRIMARY});
 
   // Check if the callback is in fact a string
   if(typeof callback == 'function') return this.command(cmd, options, function(err, result) {
@@ -847,7 +848,7 @@ Db.prototype.dropDatabase = function(callback) {
   // Drop database command
   var cmd = {'dropDatabase':1};
   // Ensure primary only
-  var options = Object.assign({}, this.s.options, {readPreference: ReadPreference.PRIMARY});
+  var options = assign({}, this.s.options, {readPreference: ReadPreference.PRIMARY});
 
   // Check if the callback is in fact a string
   if(typeof callback == 'function') return this.command(cmd, options, function(err, result) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -269,6 +269,31 @@ var filterOptions = function(options, names) {
   return filterOptions;
 }
 
+// Object.assign method or polyfille
+var assign = Object.assign ? Object.assign : function assign(target, firstSource) {
+  if (target === undefined || target === null) {
+    throw new TypeError('Cannot convert first argument to object');
+  }
+
+  var to = Object(target);
+  for (var i = 1; i < arguments.length; i++) {
+    var nextSource = arguments[i];
+    if (nextSource === undefined || nextSource === null) {
+      continue;
+    }
+
+    var keysArray = Object.keys(Object(nextSource));
+    for (var nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex++) {
+      var nextKey = keysArray[nextIndex];
+      var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
+      if (desc !== undefined && desc.enumerable) {
+        to[nextKey] = nextSource[nextKey];
+      }
+    }
+  }
+  return to;
+}
+
 exports.filterOptions = filterOptions;
 exports.mergeOptions = mergeOptions;
 exports.translateOptions = translateOptions;
@@ -284,3 +309,4 @@ exports.decorateCommand = decorateCommand;
 exports.isObject = isObject;
 exports.debugOptions = debugOptions;
 exports.MAX_JS_INT = 0x20000000000000;
+exports.assign = assign;


### PR DESCRIPTION
Same fix as in mongodb-core.  The Db.dropCollection(), Db.dropDatabase(), and Collection.rename() were using Object.assign() directly.