### PR TITLE
Fix URL parsing problem.

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -87,7 +87,7 @@ module.exports = function(url, options) {
 
   for(var i = 0; i < hosts.length; i++) {
     var r = parser.parse(f('mongodb://%s', hosts[i].trim()));
-    if(r.path && r.path.indexOf(':') != -1) {
+    if(r.path && r.path.indexOf('::') != -1) {
       throw new Error('double colon in host identifier');
     }
   }


### PR DESCRIPTION
When I input mongodb port, url parsing has problem.
It shows "double colon in host identifier".
I think the ":" must be exchanged to "::".