### PR TITLE
fix: allow passing in an array of tags to ReadPreference constructor

### DIFF
--- a/lib/read_preference.js
+++ b/lib/read_preference.js
@@ -57,8 +57,9 @@ var ReadPreference = function(mode, tags, options) {
   this.options =  options;
 
   // If no tags were passed in
-  if(tags && typeof tags == 'object') {
-    this.options = tags, this.tags = null;
+  if(tags && typeof tags == 'object' && !Array.isArray(tags)) {
+    this.options = tags;
+    this.tags = null;
   }
 
   // Add the maxStalenessMS value to the read Preference


### PR DESCRIPTION
This should be the last fix necessary for mongoose to work with 2.2.x (https://github.com/Automattic/mongoose/pull/4363), all tests pass with 2.2.5 and this patch.

General problem is that `typeof [] === 'object'` and the `tags` param is an array, so the read preference constructor thinks that tags are never passed.