### PR TITLE
Match poolSize defaults to main mongodb docs

### DIFF
--- a/docs/reference/content/reference/connecting/connection-settings.md
+++ b/docs/reference/content/reference/connecting/connection-settings.md
@@ -34,7 +34,7 @@ The table below shows all settings and what topology they affect.
 
 | Option | Affects | Type | Default | Description |
 | :----------| :------------------ | :------ | :------ |:------------- |
-| **poolSize** | Server, ReplicaSet, Mongos | integer | 5 | Set the maximum poolSize for each individual server or proxy connection.|
+| **poolSize** | Server, ReplicaSet, Mongos | integer | 100 | Set the maximum poolSize for each individual server or proxy connection.|
 | **ssl** | Server, ReplicaSet, Mongos | boolean | false | Use ssl connection (needs to have a mongod server with ssl support) |
 | **sslValidate** | Server, ReplicaSet, Mongos | boolean | true | Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher) |
 | **sslCA** | Server, ReplicaSet, Mongos | Array | null | Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support, 2.4 or higher) |

--- a/lib/mongos.js
+++ b/lib/mongos.js
@@ -63,7 +63,7 @@ var release = os.release();
  * @param {object} [options=null] Optional settings.
  * @param {booelan} [options.ha=true] Turn on high availability monitoring.
  * @param {number} [options.haInterval=5000] Time between each replicaset status check.
- * @param {number} [options.poolSize=5] Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
+ * @param {number} [options.poolSize=100] Number of connections in the connection pool for each server instance.
  * @param {number} [options.acceptableLatencyMS=15] Cutoff latency point in MS for MongoS proxy selection
  * @param {boolean} [options.ssl=false] Use ssl connection (needs to have a mongod server with ssl support)
  * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
@@ -132,7 +132,7 @@ var Mongos = function(servers, options) {
     cursorFactory: Cursor,
     reconnect: reconnect,
     emitError: typeof options.emitError == 'boolean' ? options.emitError : true,
-    size: typeof options.poolSize == 'number' ? options.poolSize : 5
+    size: typeof options.poolSize == 'number' ? options.poolSize : 100
   });
 
   // Translate any SSL options and other connectivity options

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -69,7 +69,7 @@ var release = os.release();
  * @param {string} [options.replicaSet] The name of the replicaset to connect to.
  * @param {number} [options.secondaryAcceptableLatencyMS=15] Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency fence, ex: range of 1 to (1 + 15) ms)
  * @param {boolean} [options.connectWithNoPrimary=false] Sets if the driver should connect even if no primary is available
- * @param {number} [options.poolSize=5] Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
+ * @param {number} [options.poolSize=100] Number of connections in the connection pool for each server instance.
  * @param {boolean} [options.ssl=false] Use ssl connection (needs to have a mongod server with ssl support)
  * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
  * @param {object} [options.sslValidate=true] Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher)
@@ -132,7 +132,7 @@ var ReplSet = function(servers, options) {
     cursorFactory: Cursor,
     reconnect: false,
     emitError: typeof options.emitError == 'boolean' ? options.emitError : true,
-    size: typeof options.poolSize == 'number' ? options.poolSize : 5
+    size: typeof options.poolSize == 'number' ? options.poolSize : 100
   });
 
   // Translate any SSL options and other connectivity options

--- a/lib/server.js
+++ b/lib/server.js
@@ -59,7 +59,7 @@ var release = os.release();
  * @param {string} host The host for the server, can be either an IP4, IP6 or domain socket style host.
  * @param {number} [port] The server port if IP4.
  * @param {object} [options=null] Optional settings.
- * @param {number} [options.poolSize=5] Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
+ * @param {number} [options.poolSize=100] Number of connections in the connection pool for each server instance.
  * @param {boolean} [options.ssl=false] Use ssl connection (needs to have a mongod server with ssl support)
  * @param {object} [options.sslValidate=true] Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher)
  * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
@@ -124,7 +124,7 @@ var Server = function(host, port, options) {
     cursorFactory: Cursor,
     reconnect: reconnect,
     emitError: typeof options.emitError == 'boolean' ? options.emitError : true,
-    size: typeof options.poolSize == 'number' ? options.poolSize : 5
+    size: typeof options.poolSize == 'number' ? options.poolSize : 100
   });
 
   // Translate any SSL options and other connectivity options


### PR DESCRIPTION
Updated docs & defaults to match the value given in https://docs.mongodb.com/manual/reference/connection-string/#urioption.maxPoolSize

If we have to retain the value of 5 for backwards compatibility, can you document the reasoning, and outline the situations where you may want to increase the value, and sensible levels?