### PR TITLE
Enable maxTimeMS in count, distinct, findAndModify

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1965,6 +1965,7 @@ define.classMethod('indexInformation', {callback: true, promise:true});
  * @param {boolean} [options.skip=null] The number of documents to skip for the count.
  * @param {string} [options.hint=null] An index name hint for the query.
  * @param {(ReadPreference|string)} [options.readPreference=null] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
+ * @param {number} [options.maxTimeMS=null] Number of miliseconds to wait before aborting the query.
  * @param {Collection~countCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
@@ -2003,9 +2004,10 @@ var count = function(self, query, options, callback) {
     'count': self.s.name, 'query': query
   };
 
-  // Add limit and skip if defined
+  // Add limit, skip and maxTimeMS if defined
   if(typeof skip == 'number') cmd.skip = skip;
   if(typeof limit == 'number') cmd.limit = limit;
+  if(typeof maxTimeMS == 'number') cmd.maxTimeMS = maxTimeMS;
   if(hint) options.hint = hint;
 
   options = shallowClone(options);
@@ -2036,6 +2038,7 @@ define.classMethod('count', {callback: true, promise:true});
  * @param {object} query The query for filtering the set of documents to which we apply the distinct filter.
  * @param {object} [options=null] Optional settings.
  * @param {(ReadPreference|string)} [options.readPreference=null] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
+ * @param {number} [options.maxTimeMS=null] Number of miliseconds to wait before aborting the query.
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
@@ -2075,6 +2078,10 @@ var distinct = function(self, key, query, options, callback) {
   options = shallowClone(options);
   // Ensure we have the right read preference inheritance
   options = getReadPreference(self, options, self.s.db, self);
+
+  // Add maxTimeMS if defined
+  if(typeof maxTimeMS == 'number')
+    cmd.maxTimeMS = maxTimeMS;
 
   // Do we have a readConcern specified
   if(self.s.readConcern) {
@@ -2417,6 +2424,9 @@ var findAndModify = function(self, query, sort, doc, options, callback) {
   if(doc && !options.remove) {
     queryObject.update = doc;
   }
+
+  if(options.maxTimeMS)
+    queryObject.maxTimeMS = options.maxTimeMS;
 
   // Either use override on the function, or go back to default on either the collection
   // level or db

--- a/lib/db.js
+++ b/lib/db.js
@@ -948,7 +948,6 @@ define.classMethod('collections', {callback: true, promise:true});
  * @param {object} command The command hash
  * @param {object} [options=null] Optional settings.
  * @param {(ReadPreference|string)} [options.readPreference=null] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
- * @param {number} [options.maxTimeMS=null] Number of milliseconds to wait before aborting the query.
  * @param {Db~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */


### PR DESCRIPTION
The `Collection.findAndModify` and `Collection.findOneAnd*` methods take an optional `maxTimeMS` parameter, but do not actually apply it when present. Fix by adding `options.maxTimeMS` to the command object in `findAndModify`, which all the `findOneAnd*` methods resolve to. Also apply the specified `maxTimeMS` in `Collection.count` and `Collection.distinct`, which previously ignored it.