### PR TITLE
correcting unlink

### DIFF
--- a/docs/gridfs.md
+++ b/docs/gridfs.md
@@ -116,7 +116,7 @@ The function returns [read stream](http://nodejs.org/docs/v0.4.12/api/streams.ht
 GridStore files can be unlinked with `unlink`
 
 ```javascript
-  mongodb.GridStore.unlink(db, name, callback)
+  gs.unlink(callback)
 ```
 
 Where


### PR DESCRIPTION
There is no db.GridStore.unlink. Its a call on a GridStore instance like all the rest.