### PR TITLE
Don't treat ObjectId as object for mapReduce scope

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -3088,7 +3088,7 @@ define.classMethod('group', {callback: true, promise:true});
  * @ignore
  */
 function processScope (scope) {
-  if(!isObject(scope)) {
+  if(!isObject(scope) || scope instanceof ObjectID) {
     return scope;
   }
 


### PR DESCRIPTION
Hi Christian,

Still having some test failures on mongoose with 2.2.x, [this strange mapReduce issue showed up on node 0.10 and 0.12](https://travis-ci.org/Automattic/mongoose/jobs/155174111) . Not sure the exact reason why this started happening, but one fix for this issue would be to make it so that the `processScope` function treats ObjectIds as standalone values rather than cloning them into POJOs (which seems like the right behavior anyway).