### PR TITLE
Don't fall back to insert if 'IndexOptionsConflict' error

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1046,10 +1046,12 @@ var createIndex = function(self, name, fieldOrSpec, options, callback) {
   createIndexUsingCreateIndexes(self, name, fieldOrSpec, options, function(err, result) {
     if(err == null) return handleCallback(callback, err, result);
 
-    // 67 = 'CannotCreateIndex', means that the server recognized
-    // `createIndex` as a command and so we don't need to fallback to
-    // an insert.
-    if(err.code === 67 || err.code == 11000) {
+    // 67 = 'CannotCreateIndex' (malformed index options)
+    // 85 = 'IndexOptionsConflict' (index already exists with different options)
+    // 11000 = 'DuplicateKey' (couldn't build unique index because of dupes)
+    // These errors mean that the server recognized `createIndex` as a command
+    // and so we don't need to fallback to an insert.
+    if(err.code === 67 || err.code == 11000 || err.code === 85) {
       return handleCallback(callback, err, result);
     }
 


### PR DESCRIPTION
Hi Christian,

Automattic/mongoose#4459 pointed out another potential condition where `createIndex` incorrectly falls back to using inserts. This PR fixes that particular problem, but I think it might be better to explicitly check for the server returning a 'bad cmd' key (1) or error code 61 (2) rather than falling back to insert by default, because this is the second time we've had this bug.

(1)
```
{ MongoError: no such cmd: createIndexes
    at Function.MongoError.create (/home/val/Workspace/10gen/mongoose/node_modules/mongodb-core/lib/error.js:31:11)
    at commandCallback (/home/val/Workspace/10gen/mongoose/node_modules/mongodb-core/lib/topologies/server.js:1187:66)
    at Callbacks.emit (/home/val/Workspace/10gen/mongoose/node_modules/mongodb-core/lib/topologies/server.js:119:3)
    at .messageHandler (/home/val/Workspace/10gen/mongoose/node_modules/mongodb-core/lib/topologies/server.js:358:23)
    at Socket.<anonymous> (/home/val/Workspace/10gen/mongoose/node_modules/mongodb-core/lib/connection/connection.js:292:22)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:172:18)
    at Socket.Readable.push (_stream_readable.js:130:10)
    at TCP.onread (net.js:542:20)
  name: 'MongoError',
  message: 'no such cmd: createIndexes',
  ok: 0,
  errmsg: 'no such cmd: createIndexes',
  'bad cmd': 
   { createIndexes: 'people',
     indexes: [ [Object] ],
     writeConcern: { w: 1 } } }
```

2) https://github.com/mongodb/mongo/blob/2374ef1a3ac05e3fca39485ef4824f559b1c082c/src/mongo/base/error_codes.err#L61