### PR TITLE
Added "connectionTimeout" option in the "legalOptionNames" array (src/db.js)

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -47,7 +47,7 @@ var debugFields = ['authSource', 'w', 'wtimeout', 'j', 'native_parser', 'forceSe
 var legalOptionNames = ['w', 'wtimeout', 'fsync', 'j', 'readPreference', 'readPreferenceTags', 'native_parser'
   , 'forceServerObjectId', 'pkFactory', 'serializeFunctions', 'raw', 'bufferMaxEntries', 'authSource'
   , 'ignoreUndefined', 'promoteLongs', 'promiseLibrary', 'readConcern', 'retryMiliSeconds', 'numberOfRetries'
-  , 'parentDb', 'noListener', 'loggerLevel', 'logger', 'promoteBuffers', 'promoteLongs', 'promoteValues'];
+  , 'parentDb', 'noListener', 'loggerLevel', 'logger', 'promoteBuffers', 'promoteLongs', 'promoteValues', 'connectionTimeout'];
 
 /**
  * Creates a new Db instance


### PR DESCRIPTION
Need "connectionTimeout" more then 30 seconds.
Problem:
app.middleware('session', session({
  <other options>,
  store: new MongoStore({
    url: 'mongodb://...'
    ttl: 14*86400, // = 14 days. Default
    collection: 'Sessions',
    mongoOptions: {
      connectionTimeout: 60000 // <- NOT WORKING, no overwrite default 30000 ms
    }
  })
}));

Because "connectionTimeout" option isn't in the "legalOptionNames" array.