### PR TITLE
Fix the explanation text.

### DIFF
--- a/docs/reference/content/tutorials/create-indexes.md
+++ b/docs/reference/content/tutorials/create-indexes.md
@@ -24,7 +24,7 @@ document to the `createIndex()` method:
 For an ascending index type, specify ``1`` for ``<type>``.
 
 The following example creates an ascending index key for the
-``quantity`` field:
+``dateOfBirth`` field:
 
 ```js
 


### PR DESCRIPTION
Ascending Index is created for the `dateOfBirth` field in the source example, not the `quantity` field as the explanation text says.

Fixes #NODE-814