### PR TITLE
fix typo in serverHeartbeatFailed event name

### DIFF
--- a/lib/mongos.js
+++ b/lib/mongos.js
@@ -277,7 +277,7 @@ Mongos.prototype.connect = function(db, _options, callback) {
   var connectHandler = function() {
     // Clear out all the current handlers left over
     ["timeout", "error", "close", 'serverOpening', 'serverDescriptionChanged', 'serverHeartbeatStarted',
-      'serverHeartbeatSucceeded', 'serverHearbeatFailed', 'serverClosed', 'topologyOpening',
+      'serverHeartbeatSucceeded', 'serverHeartbeatFailed', 'serverClosed', 'topologyOpening',
       'topologyClosed', 'topologyDescriptionChanged'].forEach(function(e) {
       self.s.mongos.removeAllListeners(e);
     });
@@ -291,7 +291,7 @@ Mongos.prototype.connect = function(db, _options, callback) {
     self.s.mongos.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
     self.s.mongos.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
     self.s.mongos.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
-    self.s.mongos.on('serverHearbeatFailed', relay('serverHearbeatFailed'));
+    self.s.mongos.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
     self.s.mongos.on('serverOpening', relay('serverOpening'));
     self.s.mongos.on('serverClosed', relay('serverClosed'));
     self.s.mongos.on('topologyOpening', relay('topologyOpening'));

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -270,7 +270,7 @@ ReplSet.prototype.connect = function(db, _options, callback) {
   var connectHandler = function() {
     // Clear out all the current handlers left over
     ["timeout", "error", "close", 'serverOpening', 'serverDescriptionChanged', 'serverHeartbeatStarted',
-      'serverHeartbeatSucceeded', 'serverHearbeatFailed', 'serverClosed', 'topologyOpening',
+      'serverHeartbeatSucceeded', 'serverHeartbeatFailed', 'serverClosed', 'topologyOpening',
       'topologyClosed', 'topologyDescriptionChanged'].forEach(function(e) {
       self.s.replset.removeAllListeners(e);
     });
@@ -315,7 +315,7 @@ ReplSet.prototype.connect = function(db, _options, callback) {
     self.s.replset.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
     self.s.replset.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
     self.s.replset.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
-    self.s.replset.on('serverHearbeatFailed', relay('serverHearbeatFailed'));
+    self.s.replset.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
     self.s.replset.on('serverOpening', relay('serverOpening'));
     self.s.replset.on('serverClosed', relay('serverClosed'));
     self.s.replset.on('topologyOpening', relay('topologyOpening'));

--- a/lib/server.js
+++ b/lib/server.js
@@ -293,7 +293,7 @@ Server.prototype.connect = function(db, _options, callback) {
   var connectHandler = function() {
     // Clear out all the current handlers left over
     ["timeout", "error", "close", 'serverOpening', 'serverDescriptionChanged', 'serverHeartbeatStarted',
-      'serverHeartbeatSucceeded', 'serverHearbeatFailed', 'serverClosed', 'topologyOpening',
+      'serverHeartbeatSucceeded', 'serverHeartbeatFailed', 'serverClosed', 'topologyOpening',
       'topologyClosed', 'topologyDescriptionChanged'].forEach(function(e) {
       self.s.server.removeAllListeners(e);
     });
@@ -316,7 +316,7 @@ Server.prototype.connect = function(db, _options, callback) {
     self.s.server.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
     self.s.server.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
     self.s.server.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
-    self.s.server.on('serverHearbeatFailed', relay('serverHearbeatFailed'));
+    self.s.server.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
     self.s.server.on('serverOpening', relay('serverOpening'));
     self.s.server.on('serverClosed', relay('serverClosed'));
     self.s.server.on('topologyOpening', relay('topologyOpening'));


### PR DESCRIPTION
Fix a typo in the name of the serverHeartbeatFailed event. This should only be merged after https://github.com/christkv/mongodb-core/pull/143 is released.