### PR TITLE
Don't ignore Db-level authSource on log-in

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1450,9 +1450,10 @@ var authenticate = function(self, username, password, options, callback) {
 
   // the default db to authenticate against is 'self'
   // if authententicate is called from a retry context, it may be another one, like admin
-  var authdb = options.authdb ? options.authdb : options.dbName;
+  var authdb = options.dbName ? options.dbName : self.databaseName;
+  authdb = self.authSource ? self.authSource : authdb;
+  authdb = options.authdb ? options.authdb : authdb;
   authdb = options.authSource ? options.authSource : authdb;
-  authdb = authdb ? authdb : self.databaseName;
 
   // Callback
   var _callback = function(err, result) {


### PR DESCRIPTION
It seems like this property has been eliminated in 3.0 but it is definitely documented in 2.2:
http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html

and is used in `logout`(): https://github.com/mongodb/node-mongodb-native/blob/2.2/lib/db.js#L1579

furthermore, an `authSource` as an option to `authenticate()` is **NOT** documented:
http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html#authenticate