### PR TITLE
Changed misleading parameter name

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -916,7 +916,7 @@ define.classMethod('updateOne', {callback: true, promise:true});
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-Collection.prototype.replaceOne = function(filter, update, options, callback) {
+Collection.prototype.replaceOne = function(filter, doc, options, callback) {
   var self = this;
   if(typeof options == 'function') callback = options, options = {};
   options = shallowClone(options)
@@ -928,22 +928,22 @@ Collection.prototype.replaceOne = function(filter, update, options, callback) {
   }
 
   // Execute using callback
-  if(typeof callback == 'function') return replaceOne(self, filter, update, options, callback);
+  if(typeof callback == 'function') return replaceOne(self, filter, doc, options, callback);
 
   // Return a Promise
   return new this.s.promiseLibrary(function(resolve, reject) {
-    replaceOne(self, filter, update, options, function(err, r) {
+    replaceOne(self, filter, doc, options, function(err, r) {
       if(err) return reject(err);
       resolve(r);
     });
   });
 }
 
-var replaceOne = function(self, filter, update, options, callback) {
+var replaceOne = function(self, filter, doc, options, callback) {
   // Set single document update
   options.multi = false;
   // Execute update
-  updateDocuments(self, filter, update, options, function(err, r) {
+  updateDocuments(self, filter, doc, options, function(err, r) {
     if(callback == null) return;
     if(err && callback) return callback(err);
     if(r == null) return callback(null, {result: {ok:1}});
@@ -951,7 +951,7 @@ var replaceOne = function(self, filter, update, options, callback) {
     r.modifiedCount = r.result.nModified != null ? r.result.nModified : r.result.n;
     r.upsertedId = Array.isArray(r.result.upserted) && r.result.upserted.length > 0 ? r.result.upserted[0] : null;
     r.upsertedCount = Array.isArray(r.result.upserted) && r.result.upserted.length ? r.result.upserted.length : 0;
-    r.ops = [update];
+    r.ops = [doc];
     if(callback) callback(null, r);
   });
 }


### PR DESCRIPTION
The documentation even states "doc" to be the parameter name. I think this happened due to copy & paste from the updateOne function.