### PR TITLE
Fix Cursor.prototype.map return annotation

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -979,7 +979,7 @@ define.classMethod('close', {callback: true, promise:true});
  * Map all documents using the provided function
  * @method
  * @param {function} [transform] The mapping transformation method.
- * @return {null}
+ * @return {Cursor}
  */
 Cursor.prototype.map = function(transform) {
   this.cursorState.transforms = { doc: transform };


### PR DESCRIPTION
The `Cursor.prototype.map` function is annotated with a `null` return type, while it actually returns a `Cursor` instance (or, more precisely, `this`).