### PR TITLE
Added UnorderedBulkOperation.length property annotation

### DIFF
--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -203,6 +203,7 @@ var addToOperationsList = function(_self, docType, document) {
 /**
  * Create a new UnorderedBulkOperation instance (INTERNAL TYPE, do not instantiate directly)
  * @class
+ * @property {number} length Get the number of operations in the bulk.
  * @return {UnorderedBulkOperation} a UnorderedBulkOperation instance.
  */
 var UnorderedBulkOperation = function(topology, collection, options) {


### PR DESCRIPTION
The `UnorderedBulkOperation.length` property annotation was missing. This pr adds it