### PR TITLE
Add missing unref implementations for replset, mongos

### DIFF
--- a/lib/mongos.js
+++ b/lib/mongos.js
@@ -397,6 +397,14 @@ Mongos.prototype.lastIsMaster = function() {
   return this.s.mongos.lastIsMaster();
 }
 
+/**
+ * Unref all sockets
+ * @method
+ */
+Mongos.prototype.unref = function () {
+  return this.s.mongos.unref();
+}
+
 Mongos.prototype.close = function(forceClosed) {
   this.s.mongos.destroy();
   // We need to wash out all stored processes

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -445,6 +445,14 @@ ReplSet.prototype.lastIsMaster = function() {
   return this.s.replset.lastIsMaster();
 }
 
+/**
+ * Unref all sockets
+ * @method
+ */
+ReplSet.prototype.unref = function() {
+  return this.s.replset.unref();
+}
+
 ReplSet.prototype.close = function(forceClosed) {
   var self = this;
   this.s.replset.destroy();


### PR DESCRIPTION
Fixes [NODE-728](https://jira.mongodb.org/browse/NODE-728) (`this.s.topology.unref is not a function` when calling `db.unref()`)