### PR TITLE
fix: don't rely on global toString() for checking if object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -230,7 +230,7 @@ var parseIndexOptions = function(fieldOrSpec) {
 }
 
 var isObject = exports.isObject = function (arg) {
-  return '[object Object]' == toString.call(arg)
+  return '[object Object]' == Object.prototype.toString.call(arg)
 }
 
 var debugOptions = function(debugFields, options) {


### PR DESCRIPTION
Re: tmpvar/jsdom#1752, Automattic/mongoose#5033

The origin of this issue was that using Facebook's "jest" testing library bugs out with mongoose indexes (Automattic/mongoose#5033). The issue traces down to jsdom overwriting `global.toString()`, which confuses the index `isObject` check and leaves us with an empty index getting sent to mongodb. `Object.prototype.toString` works though