### PR TITLE
Remove multi option from updateMany tests/docs

### DIFF
--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -2773,8 +2773,6 @@ exports.shouldCorrectlyUpdateMultipleDocuments = {
       collection.insertMany([{a:1, b:1}, {a:1, b:2}], configuration.writeConcernMax(), function(err, result) {
 
         var o = configuration.writeConcernMax();
-        o.multi = true
-        // Update multiple documents using the multi option
         collection.updateMany({a:1}, {$set:{b:0}}, o, function(err, r) {
           test.equal(null, err);
           test.equal(2, r.result.n);

--- a/test/functional/operation_generators_example_tests.js
+++ b/test/functional/operation_generators_example_tests.js
@@ -2385,9 +2385,6 @@ exports.shouldCorrectlyUpdateMultipleDocumentsWithGenerators = {
       yield collection.insertMany([{a:1, b:1}, {a:1, b:2}], configuration.writeConcernMax());
 
       var o = configuration.writeConcernMax();
-      o.multi = true
-
-      // Update multiple documents using the multi option
       var r = yield collection.updateMany({a:1}, {$set:{b:0}}, o);
       test.equal(2, r.result.n);
 

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -2278,8 +2278,6 @@ exports.shouldCorrectlyUpdateMultipleDocumentsWithPromises = {
       collection.insertMany([{a:1, b:1}, {a:1, b:2}], configuration.writeConcernMax()).then(function(result) {
 
         var o = configuration.writeConcernMax();
-        o.multi = true
-        // Update multiple documents using the multi option
         collection.updateMany({a:1}, {$set:{b:0}}, o).then(function(r) {
           test.equal(2, r.result.n);
 


### PR DESCRIPTION
Many of the tests of (and consequently the documentation for)
collections.updateMany(...) included the "multi" option, which was
used by collections.update(...), but is not a valid option for
updateMany.  These have been removed.

	modified:   test/functional/operation_example_tests.js
	modified:   test/functional/operation_generators_example_tests.js
	modified:   test/functional/operation_promises_example_tests.js