### PR TITLE
Add cursor to reply of aggregate command

### DIFF
--- a/lib/apm.js
+++ b/lib/apm.js
@@ -484,16 +484,10 @@ var Instrumentation = function(core, options, callback) {
               // Emit the command
               self.emit('failed', command)
             } else {
-              // Do we have a getMore
-              if(commandName.toLowerCase() == 'getmore' && r == null) {
-                r = {
-                  cursor: {
-                    id: cursor.cursorState.cursorId,
-                    ns: cursor.ns,
-                    nextBatch: cursor.cursorState.documents
-                  }, ok:1
-                }
-              } else if(commandName.toLowerCase() == 'find' && r == null) {
+              // List commands containing cursor in reply
+              var cursorCommands = ['getmore', 'find', 'aggregate'];
+              
+              if (cursorCommands.indexOf(commandName.toLowerCase()) != -1 && r == null) {
                 r = {
                   cursor: {
                     id: cursor.cursorState.cursorId,


### PR DESCRIPTION
Only 'find' and 'getmore' had the cursor in their reply. But aggregate can also return a cursor. Unfortunately the reply field used to be null in that case.