### PR TITLE
Add cursor to reply of aggregate command

### DIFF
--- a/lib/apm.js
+++ b/lib/apm.js
@@ -493,7 +493,7 @@ var Instrumentation = function(core, options, callback) {
                     nextBatch: cursor.cursorState.documents
                   }, ok:1
                 }
-              } else if(commandName.toLowerCase() == 'find' && r == null) {
+              } else if((commandName.toLowerCase() == 'find' || commandName.toLowerCase() == 'aggregate') && r == null) {
                 r = {
                   cursor: {
                     id: cursor.cursorState.cursorId,


### PR DESCRIPTION
Only 'find' and 'getmore' had the cursor in their reply. But aggregate can also return a cursor. Unfortunately the reply field used to be null in that case.