### PR TITLE
add connectionTimeout, socketTimeout to Db allowed parameters

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -52,7 +52,8 @@ var illegalCommandFields = ['w', 'wtimeout', 'j', 'fsync', 'autoIndexId'
 var legalOptionNames = ['w', 'wtimeout', 'fsync', 'j', 'readPreference', 'readPreferenceTags', 'native_parser'
   , 'forceServerObjectId', 'pkFactory', 'serializeFunctions', 'raw', 'bufferMaxEntries', 'authSource'
   , 'ignoreUndefined', 'promoteLongs', 'promiseLibrary', 'readConcern', 'retryMiliSeconds', 'numberOfRetries'
-  , 'parentDb', 'noListener', 'loggerLevel', 'logger', 'promoteBuffers', 'promoteLongs', 'promoteValues'];
+  , 'parentDb', 'noListener', 'loggerLevel', 'logger', 'promoteBuffers', 'promoteLongs', 'promoteValues',
+  , 'connectionTimeout', 'socketTimeout'];
 
 /**
  * Creates a new Db instance


### PR DESCRIPTION
`connectionTimeout`, `socketTimeout` can't change by options configure.