### PR TITLE
Fix passing the readConcern option to MongoClient.connect

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -121,7 +121,7 @@ function MongoClient() {
    * @param {object} [options.pkFactory=null] A primary key factory object for generation of custom _id keys.
    * @param {object} [options.promiseLibrary=null] A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible
    * @param {object} [options.readConcern=null] Specify a read concern for the collection. (only MongoDB 3.2 or higher supported)
-   * @param {object} [options.readConcern.level='local'] Specify a read concern level for the collection operations, one of [local|majority]. (only MongoDB 3.2 or higher supported)
+   * @param {string} [options.readConcern.level='local'] Specify a read concern level for the collection operations, one of [local|majority]. (only MongoDB 3.2 or higher supported)
    * @param {number} [options.maxStalenessSeconds=undefined] The max staleness to secondary reads (values under 10 seconds cannot be guaranteed);
    * @param {string} [options.loggerLevel=undefined] The logging level (error/warn/info/debug)
    * @param {object} [options.logger=undefined] Custom logger object
@@ -183,7 +183,7 @@ var define = MongoClient.define = new Define('MongoClient', MongoClient, false);
  * @param {object} [options.pkFactory=null] A primary key factory object for generation of custom _id keys.
  * @param {object} [options.promiseLibrary=null] A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible
  * @param {object} [options.readConcern=null] Specify a read concern for the collection. (only MongoDB 3.2 or higher supported)
- * @param {object} [options.readConcern.level='local'] Specify a read concern level for the collection operations, one of [local|majority]. (only MongoDB 3.2 or higher supported)
+ * @param {string} [options.readConcern.level='local'] Specify a read concern level for the collection operations, one of [local|majority]. (only MongoDB 3.2 or higher supported)
  * @param {number} [options.maxStalenessSeconds=undefined] The max staleness to secondary reads (values under 10 seconds cannot be guaranteed);
  * @param {string} [options.loggerLevel=undefined] The logging level (error/warn/info/debug)
  * @param {object} [options.logger=undefined] Custom logger object

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -245,7 +245,7 @@ var mergeOptions = function(target, source, flatten) {
 var createUnifiedOptions = function(finalOptions, options) {
   var childOptions = ['mongos', 'server', 'db'
     , 'replset', 'db_options', 'server_options', 'rs_options', 'mongos_options'];
-  var noMerge = [];
+  var noMerge = ['readconcern'];
 
   for(var name in options) {
     if(noMerge.indexOf(name.toLowerCase()) != -1) {


### PR DESCRIPTION
The documentation says that the connect function of MongoClient accepts a readConcern option, but the object was being flattened and passed to the db as `level` instead of `readConcern`. This change excludes the readConcern option from being merged which results in it being handled correctly.

I confirmed that the test fails on MongoDB 3.4 when run with the replicaset topology before the change, and passes after it has been applied.

This PR also includes a documentation fix for the type of the `readConcern.level` property.