### PR TITLE
allow saving doc with null `_id`

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -736,7 +736,7 @@ var insertDocuments = function(self, docs, options, callback) {
   // Add _id if not specified
   if(forceServerObjectId !== true){
     for(var i = 0; i < docs.length; i++) {
-      if(docs[i]._id == null) docs[i]._id = self.s.pkFactory.createPk();
+      if(docs[i]._id === void 0) docs[i]._id = self.s.pkFactory.createPk();
     }
   }
 


### PR DESCRIPTION
AFAIK saving a doc with null `_id` is perfectly valid, but this code makes that impossible. Re: Automattic/mongoose#5236