### PR TITLE
Fix for NODE-1026

### DIFF
--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -298,15 +298,27 @@ function init(self) {
       return;
     }
 
-    self.s.cursor = self.s.chunks.find({ files_id: doc._id }).sort({ n: 1 });
+    self.s.bytesToSkip = handleStartOption(self, doc, self.s.options);
+
+    var filter = { files_id: doc._id };
+
+    // Currently (MongoDB 3.4.4) skip function does not support the index,
+    // it needs to retrieve all the documents first and then skip them. (CS-25811)
+    // As work around we use $gte on the "n" field.
+    if (self.s.options && self.s.options.start != null){
+      var skip = Math.floor(self.s.options.start / doc.chunkSize);
+      if (skip > 0){
+        filter["n"] = {"$gte": skip};
+      }
+    }
+    self.s.cursor = self.s.chunks.find(filter).sort({ n: 1 });
+
     if (self.s.readPreference) {
       self.s.cursor.setReadPreference(self.s.readPreference);
     }
 
     self.s.expectedEnd = Math.ceil(doc.length / doc.chunkSize);
     self.s.file = doc;
-    self.s.bytesToSkip = handleStartOption(self, doc, self.s.cursor,
-      self.s.options);
     self.s.bytesToTrim = handleEndOption(self, doc, self.s.cursor,
       self.s.options);
     self.emit('file', doc);
@@ -336,11 +348,11 @@ function waitForFile(_this, callback) {
  * @ignore
  */
 
-function handleStartOption(stream, doc, cursor, options) {
+function handleStartOption(stream, doc, options) {
   if (options && options.start != null) {
     if (options.start > doc.length) {
       throw new Error('Stream start (' + options.start + ') must not be ' +
-        'more than the length of the file (' + doc.length +')')
+        'more than the length of the file (' + doc.length +')');
     }
     if (options.start < 0) {
       throw new Error('Stream start (' + options.start + ') must not be ' +
@@ -350,8 +362,6 @@ function handleStartOption(stream, doc, cursor, options) {
       throw new Error('Stream start (' + options.start + ') must not be ' +
         'greater than stream end (' + options.end + ')');
     }
-
-    cursor.skip(Math.floor(options.start / doc.chunkSize));
 
     stream.s.bytesRead = Math.floor(options.start / doc.chunkSize) *
       doc.chunkSize;


### PR DESCRIPTION
Currently skip function does not use the index, replace it with $gte over "n" field