### PR TITLE
NODE-1072 Remove Cursor.nextObject and document changes

### DIFF
--- a/CHANGES_3.0.0.md
+++ b/CHANGES_3.0.0.md
@@ -15,6 +15,7 @@ We removed the following API methods.
 - Admin.prototype.profilingLevel
 - Admin.prototype.setProfilingLevel
 - Admin.prototype.profilingInfo
+- Cursor.prototype.nextObject
 
 We've added the following API methods.
 - MongoClient.prototype.logout

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -655,16 +655,7 @@ define.classMethod('skip', {callback: false, promise:false, returns: [Cursor]});
  * @return {null}
  */
 
-/**
- * Get the next available document from the cursor, returns null if no more documents are available.
- * @method
- * @param {Cursor~resultCallback} [callback] The result callback.
- * @throws {MongoError}
- * @deprecated
- * @return {Promise} returns Promise if no callback passed
- */
-Cursor.prototype.nextObject = Cursor.prototype.next;
-
+// Get the next available document from the cursor, returns null if no more documents are available.
 var nextObject = function(self, callback) {
   if(self.s.state == Cursor.CLOSED || self.isDead && self.isDead()) return handleCallback(callback, MongoError.create({message: "Cursor is closed", driver:true}));
   if(self.s.state == Cursor.INIT && self.s.cmd.sort) {
@@ -683,8 +674,6 @@ var nextObject = function(self, callback) {
   });
 }
 
-define.classMethod('nextObject', {callback: true, promise:true});
-
 // Trampoline emptying the number of retrieved items
 // without incurring a nextTick operation
 var loop = function(self, callback) {
@@ -695,10 +684,6 @@ var loop = function(self, callback) {
   // Loop
   return loop;
 }
-
-Cursor.prototype.next = Cursor.prototype.nextObject;
-
-define.classMethod('next', {callback: true, promise:true});
 
 /**
  * Iterates over all the documents for this cursor. As with **{cursor.toArray}**,
@@ -1078,7 +1063,7 @@ Cursor.prototype._read = function() {
   }
 
   // Get the next item
-  self.nextObject(function(err, result) {
+  self.next(function(err, result) {
     if(err) {
       if(self.listeners('error') && self.listeners('error').length > 0) {
         self.emit('error', err);

--- a/test/functional/crud_api_tests.js
+++ b/test/functional/crud_api_tests.js
@@ -95,28 +95,6 @@ exports['should correctly execute find method using crud api'] = {
               clonedCursor.next(function(err, doc) {
                 test.equal(null, err);
                 test.equal(null, doc);
-                nextObjectMethod();
-              });
-            });
-          });
-        }
-
-        //
-        // Exercise nextObject legacy method
-        // -------------------------------------------------
-        var nextObjectMethod = function() {
-          var clonedCursor = cursor.clone();
-          clonedCursor.nextObject(function(err, doc) {
-            test.equal(null, err);
-            test.ok(doc != null);
-
-            clonedCursor.nextObject(function(err, doc) {
-              test.equal(null, err);
-              test.ok(doc != null);
-
-              clonedCursor.nextObject(function(err, doc) {
-                test.equal(null, err);
-                test.equal(null, doc);
                 streamMethod();
               });
             });

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -342,7 +342,7 @@ exports.shouldCorrectlyExecuteSortOnCursor = {
           test.deepEqual([['a', -1]], cursor.sortValue);finished();
 
           var cursor = collection.find();
-          cursor.nextObject(function(err, doc) {
+          cursor.next(function(err, doc) {
             try {
               cursor.sort(['a']);
             } catch(err) {
@@ -350,11 +350,11 @@ exports.shouldCorrectlyExecuteSortOnCursor = {
             }
           });
 
-          collection.find().sort('a', 25).nextObject(function(err, doc) {
+          collection.find().sort('a', 25).next(function(err, doc) {
             test.equal("Illegal sort clause, must be of the form [['field1', '(ascending|descending)'], ['field2', '(ascending|descending)']]", err.message);finished();
           });
 
-          collection.find().sort(25).nextObject(function(err, doc) {
+          collection.find().sort(25).next(function(err, doc) {
             test.equal("Illegal sort clause, must be of the form [['field1', '(ascending|descending)'], ['field2', '(ascending|descending)']]", err.message);finished();
           });
         }
@@ -584,7 +584,7 @@ exports.shouldCorrectlyReturnErrorsOnIllegalLimitValues = {
             }
 
             collection.find(function(err, cursor) {
-              cursor.nextObject(function(err, doc) {
+              cursor.next(function(err, doc) {
                 try {
                   cursor.limit(1);
                 } catch(err) {
@@ -705,7 +705,7 @@ exports.shouldCorrectlyReturnErrorsOnIllegalSkipValues = {
         }
 
         var cursor = collection.find()
-        cursor.nextObject(function(err, doc) {
+        cursor.next(function(err, doc) {
           try {
             cursor.skip(1);
           } catch(err) {
@@ -755,8 +755,8 @@ exports.shouldReturnErrorsOnIllegalBatchSizes = {
         }
 
         var cursor = collection.find();
-        cursor.nextObject(function(err, doc) {
-          cursor.nextObject(function(err, doc) {
+        cursor.next(function(err, doc) {
+          cursor.next(function(err, doc) {
             try {
               cursor.batchSize(1);
               test.ok(false);
@@ -808,13 +808,13 @@ exports.shouldCorrectlyHandleChangesInBatchSizes = {
         collection.insert(docs, configuration.writeConcernMax(), function() {
           collection.find({}, {batchSize : batchSize}, function(err, cursor) {
             //1st
-            cursor.nextObject(function(err, items) {
-              //cursor.items should contain 1 since nextObject already popped one
+            cursor.next(function(err, items) {
+              //cursor.items should contain 1 since next already popped one
               test.equal(1, cursor.bufferedCount());
               test.ok(items != null);
 
               //2nd
-              cursor.nextObject(function(err, items) {
+              cursor.next(function(err, items) {
                 test.equal(0, cursor.bufferedCount());
                 test.ok(items != null);
 
@@ -823,27 +823,27 @@ exports.shouldCorrectlyHandleChangesInBatchSizes = {
                 cursor.batchSize(batchSize);
 
                 //3rd
-                cursor.nextObject(function(err, items) {
+                cursor.next(function(err, items) {
                   test.equal(2, cursor.bufferedCount());
                   test.ok(items != null);
 
                   //4th
-                  cursor.nextObject(function(err, items) {
+                  cursor.next(function(err, items) {
                     test.equal(1, cursor.bufferedCount());
                     test.ok(items != null);
 
                     //5th
-                    cursor.nextObject(function(err, items) {
+                    cursor.next(function(err, items) {
                       test.equal(0, cursor.bufferedCount());
                       test.ok(items != null);
 
                       //6th
-                      cursor.nextObject(function(err, items) {
+                      cursor.next(function(err, items) {
                         test.equal(0, cursor.bufferedCount());
                         test.ok(items != null);
 
                         //No more
-                        cursor.nextObject(function(err, items) {
+                        cursor.next(function(err, items) {
                           test.ok(items == null);
                           test.ok(cursor.isClosed());
 
@@ -889,27 +889,27 @@ exports.shouldCorrectlyHandleBatchSize = {
         collection.insert(docs, configuration.writeConcernMax(), function() {
           collection.find({}, {batchSize : batchSize}, function(err, cursor) {
             //1st
-            cursor.nextObject(function(err, items) {
+            cursor.next(function(err, items) {
               test.equal(1, cursor.bufferedCount());
               test.ok(items != null);
 
               //2nd
-              cursor.nextObject(function(err, items) {
+              cursor.next(function(err, items) {
                 test.equal(0, cursor.bufferedCount());
                 test.ok(items != null);
 
                 //3rd
-                cursor.nextObject(function(err, items) {
+                cursor.next(function(err, items) {
                   test.equal(1, cursor.bufferedCount());
                   test.ok(items != null);
 
                   //4th
-                  cursor.nextObject(function(err, items) {
+                  cursor.next(function(err, items) {
                     test.equal(0, cursor.bufferedCount());
                     test.ok(items != null);
 
                     //No more
-                    cursor.nextObject(function(err, items) {
+                    cursor.next(function(err, items) {
                       test.ok(items == null);
                       test.ok(cursor.isClosed());
 
@@ -953,23 +953,23 @@ exports.shouldHandleWhenLimitBiggerThanBatchSize = {
         collection.insert(docs, configuration.writeConcernMax(), function() {
           var cursor = collection.find({}, {batchSize : batchSize, limit : limit});
           //1st
-          cursor.nextObject(function(err, items) {
+          cursor.next(function(err, items) {
             test.equal(2, cursor.bufferedCount());
 
             //2nd
-            cursor.nextObject(function(err, items) {
+            cursor.next(function(err, items) {
               test.equal(1, cursor.bufferedCount());
 
               //3rd
-              cursor.nextObject(function(err, items) {
+              cursor.next(function(err, items) {
                 test.equal(0, cursor.bufferedCount());
 
                 //4th
-                cursor.nextObject(function(err, items) {
+                cursor.next(function(err, items) {
                   test.equal(null, err);
 
                   //No more
-                  cursor.nextObject(function(err, items) {
+                  cursor.next(function(err, items) {
                     test.ok(items == null);
                     test.ok(cursor.isClosed());
 
@@ -1012,15 +1012,15 @@ exports.shouldHandleLimitLessThanBatchSize = {
         collection.insert(docs, configuration.writeConcernMax(), function() {
           var cursor = collection.find({}, {batchSize : batchSize, limit : limit});
           //1st
-          cursor.nextObject(function(err, items) {
+          cursor.next(function(err, items) {
             test.equal(1, cursor.bufferedCount());
 
             //2nd
-            cursor.nextObject(function(err, items) {
+            cursor.next(function(err, items) {
               test.equal(0, cursor.bufferedCount());
 
               //No more
-              cursor.nextObject(function(err, items) {
+              cursor.next(function(err, items) {
                 test.ok(items == null);
                 test.ok(cursor.isClosed());
 
@@ -1343,7 +1343,7 @@ exports.shouldCloseCursorAfterQueryHasBeenSent = {
       db.createCollection('test_close_after_query_sent', function(err, collection) {
         collection.insert({'a':1}, configuration.writeConcernMax(), function(err, r) {
           var cursor = collection.find({'a':1});
-          cursor.nextObject(function(err, item) {
+          cursor.next(function(err, item) {
             cursor.close(function(err, cursor) {
               test.equal(true, cursor.isClosed());
               // Let's close the db
@@ -2699,14 +2699,14 @@ exports['Should correctly handle batchSize of 2'] = {
         db.collection('should_correctly_handle_batchSize_2').find({}, {batchSize: 2}, function(error, cursor) {
           test.equal(null, err);
 
-          cursor.nextObject(function(err, obj) {
+          cursor.next(function(err, obj) {
             test.equal(null, err);
             client.close();
 
-            cursor.nextObject(function(err, obj) {
+            cursor.next(function(err, obj) {
               test.equal(null, err);
 
-              cursor.nextObject(function(err, obj) {
+              cursor.next(function(err, obj) {
                 test.ok(err != null);
                 test.done();
               });
@@ -2930,53 +2930,6 @@ exports['Should correctly apply map to next'] = {
           .batchSize(5)
           .limit(10);
         cursor.next(function(err, doc) {
-          test.equal(null, err);
-          test.equal(1, doc.a);
-
-          client.close();
-          test.done();
-        });
-      })
-    });
-  }
-}
-
-/**
- * @ignore
- * @api private
- */
-exports['Should correctly apply map to nextObject'] = {
-  // Add a tag that our runner can trigger on
-  // in this case we are setting that node needs to be higher than 0.10.X to run
-  metadata: { requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] } },
-
-  // The actual test we wish to run
-  test: function(configuration, test) {
-    var docs = [];
-
-    for(var i = 0; i < 1000; i++) {
-      var d = new Date().getTime() + i*1000;
-      docs[i] = {'a':i, createdAt:new Date(d)};
-    }
-
-    var client = configuration.newDbInstance(configuration.writeConcernMax(), {poolSize:1});
-    client.connect(function(err, client) {
-      var db = client.db(configuration.database);
-      test.equal(null, err);
-
-      var collection = db.collection('map_nextObject');
-
-      // insert all docs
-      collection.insert(docs, configuration.writeConcernMax(), function(err, result) {
-        test.equal(null, err);
-        var total = 0;
-
-        // Create a cursor for the content
-        var cursor = collection.find({})
-          .map(function(x) { return {a:1}; })
-          .batchSize(5)
-          .limit(10);
-        cursor.nextObject(function(err, doc) {
           test.equal(null, err);
           test.equal(1, doc.a);
 

--- a/test/functional/error_tests.js
+++ b/test/functional/error_tests.js
@@ -327,7 +327,7 @@ exports.shouldCorrectlyHandleExceptionsInCursorNext = {
       var db = client.db(configuration.database);
       var col = db.collection('shouldCorrectlyHandleExceptionsInCursorNext');
       col.insert({a:1}, function(err, result) {
-        col.find().nextObject(function(err, result) {
+        col.find().next(function(err, result) {
           boom
         });
       });

--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -4868,13 +4868,13 @@ exports['Should correctly rewind and restart cursor'] = {
         // Grab a cursor using the find
         var cursor = collection.find({});
         // Fetch the first object off the cursor
-        cursor.nextObject(function(err, item) {
+        cursor.next(function(err, item) {
           test.equal(0, item.a)
           // Rewind the cursor, resetting it to point to the start of the query
           cursor.rewind();
 
           // Grab the first object again
-          cursor.nextObject(function(err, item) {
+          cursor.next(function(err, item) {
             test.equal(0, item.a)
 
             client.close();
@@ -4968,12 +4968,12 @@ exports.shouldCorrectlyPerformSimpleSorts = {
         test.equal(null, err);
 
         // Do normal ascending sort
-        collection.find().sort({'a': 1}).nextObject(function(err, item) {
+        collection.find().sort({'a': 1}).next(function(err, item) {
           test.equal(null, err);
           test.equal(1, item.a);
 
           // Do normal descending sort, with new syntax that enforces ordering of sort keys
-          collection.find().sort([['a', -1]]).nextObject(function(err, item) {
+          collection.find().sort([['a', -1]]).next(function(err, item) {
             test.equal(null, err);
             test.equal(3, item.a);
 
@@ -5068,7 +5068,7 @@ exports.shouldCorrectlyPerformSkipOnCursor = {
         test.equal(null, err);
 
         // Skip one document
-        collection.find().skip(1).nextObject(function(err, item) {
+        collection.find().skip(1).next(function(err, item) {
           test.equal(null, err);
           test.equal(2, item.a);
 
@@ -5116,54 +5116,7 @@ exports.shouldCorrectlyPerformBatchSizeOnCursor = {
         test.equal(null, err);
 
         // Do normal ascending sort
-        collection.find().batchSize(1).nextObject(function(err, item) {
-          test.equal(null, err);
-          test.equal(1, item.a);
-
-          client.close();
-          test.done();
-        });
-      });
-    });
-    // END
-  }
-}
-
-/**
- * A simple example showing the use of nextObject.
- *
- * @example-class Cursor
- * @example-method nextObject
- * @ignore
- */
-exports.shouldCorrectlyPerformNextObjectOnCursor = {
-  // Add a tag that our runner can trigger on
-  // in this case we are setting that node needs to be higher than 0.10.X to run
-  metadata: { requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] } },
-
-  // The actual test we wish to run
-  test: function(configuration, test) {
-    var client = configuration.newDbInstance(configuration.writeConcernMax(), {poolSize:1});
-    client.connect(function(err, client) {
-    // LINE var MongoClient = require('mongodb').MongoClient,
-    // LINE   test = require('assert');
-    // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-    // LINE   var db = client.db('test);
-    // REPLACE configuration.writeConcernMax() WITH {w:1}
-    // REMOVE-LINE restartAndDone
-    // REMOVE-LINE test.done();
-    // REMOVE-LINE var db = client.db(configuration.database);
-    // BEGIN
-      var db = client.db(configuration.database);
-      // Create a collection
-      var collection = db.collection('simple_next_object_collection');
-
-      // Insert some documents we can sort on
-      collection.insertMany([{a:1}, {a:2}, {a:3}], configuration.writeConcernMax(), function(err, docs) {
-        test.equal(null, err);
-
-        // Do normal ascending sort
-        collection.find().nextObject(function(err, item) {
+        collection.find().batchSize(1).next(function(err, item) {
           test.equal(null, err);
           test.equal(1, item.a);
 
@@ -5397,7 +5350,7 @@ exports.shouldStreamDocumentsUsingTheIsCloseFunction = {
         var cursor = collection.find();
 
         // Fetch the first object
-        cursor.nextObject(function(err, object) {
+        cursor.next(function(err, object) {
           test.equal(null, err);
 
           // Close the cursor, this is the same as reseting the query
@@ -5456,7 +5409,7 @@ exports.shouldStreamDocumentsUsingTheCloseFunction = {
         var cursor = collection.find();
 
         // Fetch the first object
-        cursor.nextObject(function(err, object) {
+        cursor.next(function(err, object) {
           test.equal(null, err);
 
           // Close the cursor, this is the same as reseting the query

--- a/test/functional/operation_generators_example_tests.js
+++ b/test/functional/operation_generators_example_tests.js
@@ -4085,54 +4085,6 @@ exports.shouldCorrectlyUseCursorCountFunctionWithGenerators = {
 }
 
 /**
- * A simple example showing the use of nextObject using a Generator and the co module.
- *
- * @example-class Cursor
- * @example-method nextObject
- * @ignore
- */
-exports.shouldCorrectlyPerformNextObjectOnCursorWithGenerators = {
-  // Add a tag that our runner can trigger on
-  // in this case we are setting that node needs to be higher than 0.10.X to run
-  metadata: { requires: { generators:true, topology: ['single'] } },
-
-  // The actual test we wish to run
-  test: function(configuration, test) {
-    var co = require('co');
-
-    co(function*() {
-      // Connect
-      var client = yield configuration.newDbInstance(configuration.writeConcernMax(), {poolSize:1}).connect();
-      var db = client.db(configuration.database);
-    // LINE var MongoClient = require('mongodb').MongoClient,
-    // LINE   co = require('co');
-    // LINE   test = require('assert');
-    // LINE
-    // LINE co(function*() {
-    // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
-    // LINE   var db = client.db('test');
-    // REPLACE configuration.writeConcernMax() WITH {w:1}
-    // REMOVE-LINE test.done();
-    // BEGIN
-
-      // Create a collection
-      var collection = db.collection('simple_next_object_collection_with_generators');
-
-      // Insert some documents we can sort on
-      yield collection.insertMany([{a:1}, {a:2}, {a:3}], configuration.writeConcernMax());
-
-      // Do normal ascending sort
-      var item = yield collection.find().nextObject();
-      test.equal(1, item.a);
-
-      client.close();
-      test.done();
-    });
-    // END
-  }
-}
-
-/**
  * A simple example showing the use of next and co module to iterate over cursor
  *
  * @example-class Cursor
@@ -4282,7 +4234,7 @@ exports.shouldStreamDocumentsUsingTheCloseFunctionWithGenerators = {
       var cursor = collection.find();
 
       // Fetch the first object
-      yield cursor.nextObject();
+      yield cursor.next();
 
       // Close the cursor, this is the same as reseting the query
       yield cursor.close();

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -4104,13 +4104,13 @@ exports.shouldCorrectlyUseCursorCountFunctionWithPromises = {
 }
 
 /**
- * A simple example showing the use of nextObject using a Promise.
+ * A simple example showing the use of next using a Promise.
  *
  * @example-class Cursor
- * @example-method nextObject
+ * @example-method next
  * @ignore
  */
-exports.shouldCorrectlyPerformNextObjectOnCursorWithPromises = {
+exports.shouldCorrectlyPerformNextOnCursorWithPromises = {
   // Add a tag that our runner can trigger on
   // in this case we are setting that node needs to be higher than 0.10.X to run
   metadata: { requires: { promises:true, topology: ['single'] } },
@@ -4137,7 +4137,7 @@ exports.shouldCorrectlyPerformNextObjectOnCursorWithPromises = {
       collection.insertMany([{a:1}, {a:2}, {a:3}], configuration.writeConcernMax()).then(function(docs) {
 
         // Do normal ascending sort
-        collection.find().nextObject().then(function(item) {
+        collection.find().next().then(function(item) {
           test.equal(1, item.a);
 
           client.close();
@@ -4235,7 +4235,7 @@ exports.shouldStreamDocumentsUsingTheCloseFunctionWithPromises = {
         var cursor = collection.find();
 
         // Fetch the first object
-        cursor.nextObject().then(function(object) {
+        cursor.next().then(function(object) {
 
           // Close the cursor, this is the same as reseting the query
           cursor.close().then(function(result) {


### PR DESCRIPTION
The `Cursor.nextObject()` method was deprecated with the release of v2.0 of the driver. This PR entirely removes support for it and updates the documentation.