### PR TITLE
NODE-1034 Fix GridStore issue caused by Node 8.0.0 breaking backward compatible fs.read API

### DIFF
--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -427,20 +427,23 @@ var writeFile = function(self, file, callback) {
 
       // Write a chunk
       var writeChunk = function() {
-        fs.read(file, self.chunkSize, offset, 'binary', function(err, data, bytesRead) {
+        // Allocate the buffer
+        var _buffer = new Buffer(self.chunkSize);
+        // Read the file
+        fs.read(file, _buffer, 0, _buffer.length, offset, function(err, bytesRead, data) {
           if(err) return callback(err, self);
 
           offset = offset + bytesRead;
 
           // Create a new chunk for the data
           var chunk = new Chunk(self, {n:index++}, self.writeConcern);
-          chunk.write(data, function(err, chunk) {
+          chunk.write(data.slice(0, bytesRead), function(err, chunk) {
             if(err) return callback(err, self);
 
             chunk.save({}, function(err) {
               if(err) return callback(err, self);
 
-              self.position = self.position + data.length;
+              self.position = self.position + bytesRead;
 
               // Point to current chunk
               self.currentChunk = chunk;


### PR DESCRIPTION
This PR brings forward @christkv's commit 1298820dedaebc27fa0440b0da038441208dfa1f on the 2.2 branch. This commit fixed [NODE-1034](https://jira.mongodb.org/browse/NODE-1034), which fixed a GridStore on Node 8. This commit seems to have been made after the 3.0.0 branch was split off. This fix allows our tests to pass on Node 8.