### PR TITLE
allow auth option

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -38,7 +38,7 @@ var validOptionNames = ['poolSize', 'ssl', 'sslValidate', 'sslCA', 'sslCert',
   'serializeFunctions', 'ignoreUndefined', 'raw', 'promoteLongs', 'bufferMaxEntries',
   'readPreference', 'pkFactory', 'promiseLibrary', 'readConcern', 'maxStalenessSeconds',
   'loggerLevel', 'logger', 'promoteValues', 'promoteBuffers', 'promoteLongs',
-  'domainsEnabled', 'keepAliveInitialDelay', 'checkServerIdentity', 'validateOptions', 'appname'];
+  'domainsEnabled', 'keepAliveInitialDelay', 'checkServerIdentity', 'validateOptions', 'appname', 'auth'];
 var ignoreOptionNames = ['native_parser'];
 var legacyOptionNames = ['server', 'replset', 'replSet', 'mongos', 'db'];
 
@@ -114,6 +114,8 @@ function MongoClient() {
    * @param {number} [options.acceptableLatencyMS=15] Cutoff latency point in MS for Mongos proxies selection.
    * @param {boolean} [options.connectWithNoPrimary=false] Sets if the driver should connect even if no primary is available
    * @param {string} [options.authSource=undefined] Define the database to authenticate against
+   * @param {string} [options.auth.user=undefined] The username for auth
+   * @param {string} [options.auth.password=undefined] The username for auth
    * @param {(number|string)} [options.w=null] The write concern.
    * @param {number} [options.wtimeout=null] The write concern timeout.
    * @param {boolean} [options.j=false] Specify a journal write concern.
@@ -183,6 +185,8 @@ var define = MongoClient.define = new Define('MongoClient', MongoClient, false);
  * @param {number} [options.acceptableLatencyMS=15] Cutoff latency point in MS for Mongos proxies selection.
  * @param {boolean} [options.connectWithNoPrimary=false] Sets if the driver should connect even if no primary is available
  * @param {string} [options.authSource=undefined] Define the database to authenticate against
+ * @param {string} [options.auth.user=undefined] The username for auth
+ * @param {string} [options.auth.password=undefined] The username for auth
  * @param {(number|string)} [options.w=null] The write concern.
  * @param {number} [options.wtimeout=null] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -496,8 +496,6 @@ var connect = function(self, url, options, callback) {
     delete _finalOptions.db_options.auth;
   }
 
-  console.log('_finalOptions', _finalOptions)
-
   // Failure modes
   if(object.servers.length == 0) {
     throw new Error("connection string must contain at least one seed host");

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -484,6 +484,7 @@ var connect = function(self, url, options, callback) {
 
   // Parse the string
   var object = parse(url, options);
+  console.log('Z', object)
   var _finalOptions = createUnifiedOptions({}, object);
   _finalOptions = mergeOptions(_finalOptions, object, false);
   _finalOptions = createUnifiedOptions(_finalOptions, options);
@@ -491,6 +492,8 @@ var connect = function(self, url, options, callback) {
   // Check if we have connection and socket timeout set
   if(_finalOptions.socketTimeoutMS == null) _finalOptions.socketTimeoutMS = 360000;
   if(_finalOptions.connectTimeoutMS == null) _finalOptions.connectTimeoutMS = 30000;
+
+  console.log('T', _finalOptions)
 
   // Failure modes
   if(object.servers.length == 0) {

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -484,7 +484,6 @@ var connect = function(self, url, options, callback) {
 
   // Parse the string
   var object = parse(url, options);
-  console.log('Z', object)
   var _finalOptions = createUnifiedOptions({}, object);
   _finalOptions = mergeOptions(_finalOptions, object, false);
   _finalOptions = createUnifiedOptions(_finalOptions, options);
@@ -493,7 +492,11 @@ var connect = function(self, url, options, callback) {
   if(_finalOptions.socketTimeoutMS == null) _finalOptions.socketTimeoutMS = 360000;
   if(_finalOptions.connectTimeoutMS == null) _finalOptions.connectTimeoutMS = 30000;
 
-  console.log('T', _finalOptions)
+  if (_finalOptions.db_options && _finalOptions.db_options.auth) {
+    delete _finalOptions.db_options.auth;
+  }
+
+  console.log('_finalOptions', _finalOptions)
 
   // Failure modes
   if(object.servers.length == 0) {

--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -145,6 +145,8 @@ module.exports = function(url, options) {
 
   // Add auth to final object if we have 2 elements
   if(auth.length == 2) object.auth = {user: auth[0], password: auth[1]};
+  // if user provided auth options, use that
+  if(options && options.auth != null) object.auth = options.auth;
 
   // Variables used for temporary storage
   var hostPart;

--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -144,7 +144,7 @@ module.exports = function(url, options) {
   }
 
   // if user provided auth, use that, but URL overrides
-  if(options.auth != null) object.auth = options.auth;
+  if(options && options.auth != null) object.auth = options.auth;
   // Add auth to final object if we have 2 elements
   if(auth.length == 2) object.auth = {user: auth[0], password: auth[1]};
 

--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -143,10 +143,10 @@ module.exports = function(url, options) {
     auth[1] = decodeURIComponent(auth[1]);
   }
 
-  // if user provided auth, use that, but URL overrides
-  if(options && options.auth != null) object.auth = options.auth;
   // Add auth to final object if we have 2 elements
   if(auth.length == 2) object.auth = {user: auth[0], password: auth[1]};
+  // if user provided auth options, use that
+  if(options && options.auth != null) object.auth = options.auth;
 
   // Variables used for temporary storage
   var hostPart;

--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -143,6 +143,8 @@ module.exports = function(url, options) {
     auth[1] = decodeURIComponent(auth[1]);
   }
 
+  // if user provided auth, use that, but URL overrides
+  if(options.auth != null) object.auth = options.auth;
   // Add auth to final object if we have 2 elements
   if(auth.length == 2) object.auth = {user: auth[0], password: auth[1]};
 

--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -145,8 +145,6 @@ module.exports = function(url, options) {
 
   // Add auth to final object if we have 2 elements
   if(auth.length == 2) object.auth = {user: auth[0], password: auth[1]};
-  // if user provided auth options, use that
-  if(options && options.auth != null) object.auth = options.auth;
 
   // Variables used for temporary storage
   var hostPart;

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -286,13 +286,36 @@ exports.testConnectGoodAuth = {
     function restOfTest() {
       connect(configuration.url(user, password), connectionTester(test, 'testConnectGoodAuth', function(db) {
         db.close();
-        asOption();
+        test.done();
       }));
     }
+  }
+}
 
-    function asOption() {
+/**
+ * @ignore
+ */
+exports.testConnectGoodAuthAsOption = {
+  metadata: { requires: { topology: 'single' } },
+
+  // The actual test we wish to run
+  test: function(configuration, test) {
+    var connect = configuration.require;
+    var user = 'testConnectGoodAuthAsOption', password = 'password';
+    // First add a user.
+    connect(configuration.url(), function(err, db) {
+      test.equal(err, null);
+
+      db.addUser(user, password, function(err, result) {
+        test.equal(err, null);
+        db.close();
+        restOfTest();
+      });
+    });
+
+    function restOfTest() {
       var opts = { auth: { user: user, password: password } };
-      connect(configuration.url('baduser', 'badpassword'), opts, connectionTester(test, 'testConnectGoodAuthOpts', function(db) {
+      connect(configuration.url('baduser', 'badpassword'), opts, connectionTester(test, 'testConnectGoodAuthAsOption', function(db) {
         db.close();
         test.done();
       }));

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -286,6 +286,14 @@ exports.testConnectGoodAuth = {
     function restOfTest() {
       connect(configuration.url(user, password), connectionTester(test, 'testConnectGoodAuth', function(db) {
         db.close();
+        asOption();
+      }));
+    }
+
+    function asOption() {
+      var opts = { auth: { user: user, password: password } };
+      connect(configuration.url(), opts, connectionTester(test, 'testConnectGoodAuth', function(db) {
+        db.close();
         test.done();
       }));
     }

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -292,7 +292,7 @@ exports.testConnectGoodAuth = {
 
     function asOption() {
       var opts = { auth: { user: user, password: password } };
-      connect(configuration.url(), opts, connectionTester(test, 'testConnectGoodAuth', function(db) {
+      connect(configuration.url('baduser', 'badpassword'), opts, connectionTester(test, 'testConnectGoodAuthOpts', function(db) {
         db.close();
         test.done();
       }));


### PR DESCRIPTION
Based on my reading of `url_parser.js` looks like there's no reason why `auth` isn't a supported option. Having support for this option would be very helpful for issues like https://github.com/Automattic/mongoose/issues/5419, otherwise we'd have to mutate the user-provided URI or ask users to not use those options anymore.