### PR TITLE
fix(collection): allow passing `noCursorTimeout` as an option to `find()`

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -3371,6 +3371,7 @@ var testForFields = {
   , numberOfRetries: 1, awaitdata: 1, awaitData: 1, exhaust: 1, batchSize: 1, returnKey: 1, maxScan: 1, min: 1, max: 1, showDiskLoc: 1
   , comment: 1, raw: 1, readPreference: 1, partial: 1, read: 1, dbName: 1, oplogReplay: 1, connection: 1, maxTimeMS: 1, transforms: 1
   , collation: 1
+  , noCursorTimeout: 1
 }
 
 module.exports = Collection;


### PR DESCRIPTION
[The porcelain layer cursor already supports `noCursorTimeout` as an option](https://github.com/mongodb/node-mongodb-native/blob/129d5400e46340f929eba32d5fb10b63145448e7/lib/cursor.js#L152-L154) and we got bit by this internally recently where `.find({}, { noCursorTimeout: true })` gets treated as a projection.