### PR TITLE
fix(db): bubble up `reconnectFailed` event from Server topology

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -173,6 +173,7 @@ var Db = function(databaseName, topology, options) {
   topology.once('fullsetup', createListener(self, 'fullsetup', self));
   topology.once('all', createListener(self, 'all', self));
   topology.on('reconnect', createListener(self, 'reconnect', self));
+  topology.on('reconnectFailed', createListener(self, 'reconnectFailed', self));
 }
 
 inherits(Db, EventEmitter);


### PR DESCRIPTION
Server has a 'reconnectFailed' event, but that doesn't end up getting emitted by the 'db'