### PR TITLE
Add param to documentation for BulkWriteResult.getWriteError

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -151,6 +151,7 @@ var BulkWriteResult = function(bulkResult) {
   /**
    * Returns a specific write error object
    *
+   * @param {number} index of the write error to return, returns null if there is no result for passed in index
    * @return {WriteError}
    */
   this.getWriteErrorAt = function(index) {


### PR DESCRIPTION
`index` wasn't documented before, I've added in the @param comment to the docs