### PR TITLE
refactor(bulk-write): standarize how we treat bulk operation errors

### DIFF
--- a/CHANGES_3.0.0.md
+++ b/CHANGES_3.0.0.md
@@ -90,8 +90,9 @@ MongoClient.connect('mongodb://localhost', function(err, client) {
 
   collection
     .insert({ id: 1 })
-    .then(() => collection.insert({ id: 1 }))
-    .then(result => /* deal with errors in `result */);
+    .then(() => collection.insertMany([ { id: 1 }, { id: 1 } ]))
+    .then(result => /* deal with errors in `result */)
+    .catch(err => /* no error is thrown for bulk errors */);
 });
 ```
 
@@ -103,8 +104,9 @@ MongoClient.connect('mongodb://localhost', function(err, client) {
 
   collection
     .insert({ id: 1 })
-    .then(() => collection.insert({ id: 1 }))
-    .catch(err => /* deal with errors in `err */);
+    .then(() => collection.insertMany([ { id: 1 }, { id: 1 } ]))
+    .then(() => /* this will not be called in the event of a bulk write error */)
+    .catch(err => /* deal with errors in `err` */);
 });
 ```
 

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var Long = require('mongodb-core').BSON.Long;
+var Long = require('mongodb-core').BSON.Long,
+  MongoError = require('mongodb-core').MongoError,
+  util = require('util');
 
 // Error codes
 var UNKNOWN_ERROR = 8;
@@ -421,7 +423,31 @@ var cloneOptions = function(options) {
   return clone;
 };
 
+/**
+ * Creates a new BulkWriteError
+ *
+ * @class
+ * @param {Error|string|object} message The error message
+ * @param {BulkWriteResult} result The result of the bulk write operation
+ * @return {MongoNetworkError} A MongoNetworkError instance
+ * @extends {MongoError}
+ */
+const BulkWriteError = function(error, result) {
+  var message = error.err || error.errmsg || error.errMessage || error;
+  MongoError.call(this, message);
+
+  var keys = typeof error === 'object' ? Object.keys(error) : [];
+  for (var i = 0; i < keys.length; i++) {
+    this[keys[i]] = error[keys[i]];
+  }
+
+  this.name = 'BulkWriteError';
+  this.result = result;
+};
+util.inherits(BulkWriteError, MongoError);
+
 // Exports symbols
+exports.BulkWriteError = BulkWriteError;
 exports.BulkWriteResult = BulkWriteResult;
 exports.WriteError = WriteError;
 exports.Batch = Batch;

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -429,7 +429,7 @@ var cloneOptions = function(options) {
  * @class
  * @param {Error|string|object} message The error message
  * @param {BulkWriteResult} result The result of the bulk write operation
- * @return {MongoNetworkError} A MongoNetworkError instance
+ * @return {BulkWriteError} A BulkWriteError instance
  * @extends {MongoError}
  */
 const BulkWriteError = function(error, result) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -22,7 +22,8 @@ var checkCollectionName = require('./utils').checkCollectionName,
   unordered = require('./bulk/unordered'),
   ordered = require('./bulk/ordered'),
   assign = require('./utils').assign,
-  ChangeStream = require('./change_stream');
+  ChangeStream = require('./change_stream'),
+  BulkWriteError = require('./bulk/common').BulkWriteError;
 
 /**
  * @fileOverview The **Collection** class is an internal class that embodies a MongoDB collection
@@ -614,7 +615,7 @@ define.classMethod('insertMany', { callback: true, promise: true });
 /**
  * The callback format for inserts
  * @callback Collection~bulkWriteOpCallback
- * @param {MongoError} error An error instance representing the error during the execution.
+ * @param {BulkWriteError} error An error instance representing the error during the execution.
  * @param {Collection~BulkWriteOpResult} result The result object if the command was executed successfully.
  */
 
@@ -721,7 +722,7 @@ var bulkWrite = function(self, operations, options, callback) {
     if (!r && err) return callback(err, null);
     // We have single error
     if (r && r.hasWriteErrors() && r.getWriteErrorCount() === 1) {
-      return callback(toError(r.getWriteErrorAt(0)), r);
+      return callback(new BulkWriteError(toError(r.getWriteErrorAt(0)), r), null);
     }
 
     r.insertedCount = r.nInserted;
@@ -755,19 +756,22 @@ var bulkWrite = function(self, operations, options, callback) {
       var errors = r.getWriteErrors();
       // Return the MongoError object
       return callback(
-        toError({
-          message: 'write operation failed',
-          code: errors[0].code,
-          writeErrors: errors
-        }),
-        r
+        new BulkWriteError(
+          toError({
+            message: 'write operation failed',
+            code: errors[0].code,
+            writeErrors: errors
+          }),
+          r
+        ),
+        null
       );
     }
 
     // Check if we have a writeConcern error
     if (r.getWriteConcernError()) {
       // Return the MongoError object
-      return callback(toError(r.getWriteConcernError()), r);
+      return callback(new BulkWriteError(toError(r.getWriteConcernError()), r), null);
     }
 
     // Return the results

--- a/test/functional/insert_tests.js
+++ b/test/functional/insert_tests.js
@@ -1371,9 +1371,10 @@ describe('Insert', function() {
           test.ok(result);
 
           // Update two fields
-          collection.insert({ _id: 1 }, configuration.writeConcernMax(), function(err, result) {
+          collection.insert({ _id: 1 }, configuration.writeConcernMax(), function(err, r) {
+            test.equal(r, null);
             test.ok(err != null);
-            test.ok(result);
+            test.ok(err.result);
 
             client.close();
             done();
@@ -2508,9 +2509,10 @@ describe('Insert', function() {
               [{ a: 1 }, { a: 2 }, { a: 1 }, { a: 3 }, { a: 1 }],
               { ordered: false },
               function(err, r) {
+                test.equal(r, null);
                 test.ok(err != null);
                 test.ok(err.writeErrors.length === 2);
-                test.ok(r);
+                test.ok(err.result);
 
                 client.close();
                 done();
@@ -2547,9 +2549,10 @@ describe('Insert', function() {
               [{ a: 1 }, { a: 2 }, { a: 1 }, { a: 3 }, { a: 1 }],
               { ordered: false },
               function(err, r) {
+                test.equal(r, null);
                 test.ok(err != null);
                 test.ok(err.writeErrors.length === 2);
-                test.ok(r);
+                test.ok(err.result);
 
                 client.close();
                 done();
@@ -2588,8 +2591,9 @@ describe('Insert', function() {
               [{ a: 1 }, { a: 2 }, { a: 1 }, { a: 3 }, { a: 1 }],
               { ordered: true },
               function(err, r) {
+                test.equal(r, null);
                 test.ok(err != null);
-                test.ok(r);
+                test.ok(err.result);
 
                 client.close();
                 done();
@@ -2628,8 +2632,9 @@ describe('Insert', function() {
               [{ a: 1 }, { a: 2 }, { a: 1 }, { a: 3 }, { a: 1 }],
               { ordered: true },
               function(err, r) {
+                test.equal(r, null);
                 test.ok(err != null);
-                test.ok(r);
+                test.ok(err.result);
 
                 client.close();
                 done();

--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -2863,8 +2863,9 @@ describe('Operation Examples', function() {
                 ],
                 { w: 1, keepGoing: true },
                 function(err, result) {
-                  test.ok(result);
+                  test.equal(result, null);
                   test.ok(err);
+                  test.ok(err.result);
 
                   // Count the number of documents left (should not include the duplicates)
                   collection.count(function(err, count) {

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -7033,8 +7033,8 @@ describe('Operation (Promises)', function() {
             [{ insertOne: { document: { _id: 1 } } }, { insertOne: { document: { _id: 1 } } }],
             { ordered: true, w: 1 }
           )
-          .then(function(r) {
-            test.equal(true, r.hasWriteErrors());
+          .catch(function(err) {
+            test.equal(true, err.result.hasWriteErrors());
             // Ordered bulk operation
             client.close();
           });


### PR DESCRIPTION
Bulk operation failures used to be presented to users in a non
idiomatic fashion, calling the async callback with (Error,
BulkWriteResult), assuming the user remembered to check the second
value.  Instead we now create a new BulkWriteError type which wraps
the result, and only callback with a single value in the error
case

NODE-1088