### PR TITLE
feat(execute-operation): refactor codebase to isolate operation execution

### DIFF
--- a/CHANGES_3.0.0.md
+++ b/CHANGES_3.0.0.md
@@ -113,3 +113,11 @@ MongoClient.connect('mongodb://localhost', function(err, client) {
 Where the result of the failed operation is a `BulkWriteError` which has a child value `result` which
 is the original `BulkWriteResult`.  Similarly, the callback form no longer calls back with an
 `(Error, BulkWriteResult)`, but instead just a `(BulkWriteError)`.
+
+## mapReduce inlined results
+When `Collection.prototype.mapReduce` is invoked with a callback with `out: 'inline'`, it would
+diverge from the `Promise`-based variant by returning additional data as positional arguments to
+the callback (`(err, result, stats, ...)`).  This is no longer the case, both variants of the
+method will now return a single object for all results - a single value for the default case,
+and an object similar to the existing `Promise` form for cases where there is more data to pass
+to the user.

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -3,7 +3,8 @@
 var toError = require('./utils').toError,
   Define = require('./metadata'),
   shallowClone = require('./utils').shallowClone,
-  assign = require('./utils').assign;
+  assign = require('./utils').assign,
+  executeOperation = require('./utils').executeOperation;
 
 /**
  * @fileOverview The **Admin** class is an internal class that allows convenient access to
@@ -65,25 +66,20 @@ var define = (Admin.define = new Define('Admin', Admin, false));
  * @return {Promise} returns Promise if no callback passed
  */
 Admin.prototype.command = function(command, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   options = args.length ? args.shift() : {};
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return this.s.db.executeDbAdminCommand(command, options, function(err, doc) {
-      return callback != null ? callback(err, doc) : null;
-    });
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self.s.db.executeDbAdminCommand(command, options, function(err, doc) {
-      if (err) return reject(err);
-      resolve(doc);
-    });
-  });
+  return executeOperation(this, this.s.db.executeDbAdminCommand.bind(this.s.db), [
+    command,
+    options,
+    callback
+  ]);
 };
 
 define.classMethod('command', { callback: true, promise: true });
@@ -96,17 +92,7 @@ define.classMethod('command', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Admin.prototype.buildInfo = function(callback) {
-  var self = this;
-  // Execute using callback
-  if (typeof callback === 'function') return this.serverInfo(callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self.serverInfo(function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, this.serverInfo.bind(this), [callback]);
 };
 
 define.classMethod('buildInfo', { callback: true, promise: true });
@@ -119,21 +105,8 @@ define.classMethod('buildInfo', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Admin.prototype.serverInfo = function(callback) {
-  var self = this;
-  // Execute using callback
-  if (typeof callback === 'function')
-    return this.s.db.executeDbAdminCommand({ buildinfo: 1 }, function(err, doc) {
-      if (err != null) return callback(err, null);
-      callback(null, doc);
-    });
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self.s.db.executeDbAdminCommand({ buildinfo: 1 }, function(err, doc) {
-      if (err) return reject(err);
-      resolve(doc);
-    });
-  });
+  const cmd = { buildinfo: 1 };
+  return executeOperation(this, this.s.db.executeDbAdminCommand.bind(this.s.db), [cmd, callback]);
 };
 
 define.classMethod('serverInfo', { callback: true, promise: true });
@@ -145,18 +118,7 @@ define.classMethod('serverInfo', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Admin.prototype.serverStatus = function(callback) {
-  var self = this;
-
-  // Execute using callback
-  if (typeof callback === 'function') return serverStatus(self, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    serverStatus(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, serverStatus, [this, callback]);
 };
 
 var serverStatus = function(self, callback) {
@@ -179,21 +141,15 @@ define.classMethod('serverStatus', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Admin.prototype.ping = function(options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
 
-  // Execute using callback
-  if (typeof callback === 'function') return this.s.db.executeDbAdminCommand({ ping: 1 }, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self.s.db.executeDbAdminCommand({ ping: 1 }, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  const cmd = { ping: 1 };
+  return executeOperation(this, this.s.db.executeDbAdminCommand.bind(this.s.db), [cmd, callback]);
 };
 
 define.classMethod('ping', { callback: true, promise: true });
@@ -238,7 +194,11 @@ Admin.prototype.addUser = function(username, password, options, callback) {
   var self = this;
   var args = Array.prototype.slice.call(arguments, 2);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   options = args.length ? args.shift() : {};
   options = options || {};
   // Get the options
@@ -246,17 +206,12 @@ Admin.prototype.addUser = function(username, password, options, callback) {
   // Set the db name to admin
   options.dbName = 'admin';
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return self.s.db.addUser(username, password, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self.s.db.addUser(username, password, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, this.s.db.addUser.bind(this.s.db), [
+    username,
+    password,
+    options,
+    callback
+  ]);
 };
 
 define.classMethod('addUser', { callback: true, promise: true });
@@ -277,7 +232,11 @@ Admin.prototype.removeUser = function(username, options, callback) {
   var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   options = args.length ? args.shift() : {};
   options = options || {};
   // Get the options
@@ -285,16 +244,11 @@ Admin.prototype.removeUser = function(username, options, callback) {
   // Set the db name
   options.dbName = 'admin';
 
-  // Execute using callback
-  if (typeof callback === 'function') return self.s.db.removeUser(username, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self.s.db.removeUser(username, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, this.s.db.removeUser.bind(this.s.db), [
+    username,
+    options,
+    callback
+  ]);
 };
 
 define.classMethod('removeUser', { callback: true, promise: true });
@@ -308,24 +262,17 @@ define.classMethod('removeUser', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Admin.prototype.validateCollection = function(collectionName, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   options = args.length ? args.shift() : {};
   options = options || {};
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return validateCollection(self, collectionName, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    validateCollection(self, collectionName, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, validateCollection, [this, collectionName, options, callback]);
 };
 
 var validateCollection = function(self, collectionName, options, callback) {
@@ -378,16 +325,11 @@ Admin.prototype.listDatabases = function(options, callback) {
   // cast boolean to 1 or 0
   if (cmd.nameOnly) cmd.nameOnly = Number(cmd.nameOnly);
 
-  // Execute using callback
-  if (typeof callback === 'function') return self.s.db.executeDbAdminCommand(cmd, {}, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self.s.db.executeDbAdminCommand(cmd, {}, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, this.s.db.executeDbAdminCommand.bind(this.s.db), [
+    cmd,
+    {},
+    callback
+  ]);
 };
 
 define.classMethod('listDatabases', { callback: true, promise: true });
@@ -399,16 +341,7 @@ define.classMethod('listDatabases', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Admin.prototype.replSetGetStatus = function(callback) {
-  var self = this;
-  // Execute using callback
-  if (typeof callback === 'function') return replSetGetStatus(self, callback);
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    replSetGetStatus(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, replSetGetStatus, [this, callback]);
 };
 
 var replSetGetStatus = function(self, callback) {

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -67,12 +67,7 @@ var define = (Admin.define = new Define('Admin', Admin, false));
  */
 Admin.prototype.command = function(command, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() : {};
 
   return executeOperation(this, this.s.db.executeDbAdminCommand.bind(this.s.db), [
@@ -142,12 +137,7 @@ define.classMethod('serverStatus', { callback: true, promise: true });
  */
 Admin.prototype.ping = function(options, callback) {
   var args = Array.prototype.slice.call(arguments, 0);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   const cmd = { ping: 1 };
   return executeOperation(this, this.s.db.executeDbAdminCommand.bind(this.s.db), [cmd, callback]);
 };
@@ -193,11 +183,7 @@ var writeConcern = function(options, db) {
 Admin.prototype.addUser = function(username, password, options, callback) {
   var self = this;
   var args = Array.prototype.slice.call(arguments, 2);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
 
   options = args.length ? args.shift() : {};
   options = options || {};
@@ -231,11 +217,7 @@ define.classMethod('addUser', { callback: true, promise: true });
 Admin.prototype.removeUser = function(username, options, callback) {
   var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
 
   options = args.length ? args.shift() : {};
   options = options || {};
@@ -263,11 +245,7 @@ define.classMethod('removeUser', { callback: true, promise: true });
  */
 Admin.prototype.validateCollection = function(collectionName, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
 
   options = args.length ? args.shift() : {};
   options = options || {};

--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -10,7 +10,8 @@ var common = require('./common'),
   Define = require('../metadata'),
   BSON = require('mongodb-core').BSON,
   Batch = common.Batch,
-  mergeBatchResults = common.mergeBatchResults;
+  mergeBatchResults = common.mergeBatchResults,
+  executeOperation = require('../utils').executeOperation;
 
 var bson = new BSON([
   BSON.Binary,
@@ -565,18 +566,7 @@ OrderedBulkOperation.prototype.execute = function(_writeConcern, callback) {
       : this.s.promiseLibrary.reject(emptyBatchError);
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') {
-    return executeCommands(this, callback);
-  }
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    executeCommands(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, executeCommands, [this, callback]);
 };
 
 define.classMethod('execute', { callback: true, promise: false });

--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -541,7 +541,6 @@ var executeCommands = function(self, callback) {
  * @return {Promise} returns Promise if no callback passed
  */
 OrderedBulkOperation.prototype.execute = function(_writeConcern, callback) {
-  var self = this;
   if (this.s.executed) {
     var executedError = toError('batch cannot be re-executed');
     return typeof callback === 'function'

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -546,7 +546,6 @@ var executeBatches = function(self, callback) {
  * @return {Promise} returns Promise if no callback passed
  */
 UnorderedBulkOperation.prototype.execute = function(_writeConcern, callback) {
-  var self = this;
   if (this.s.executed) {
     var executedError = toError('batch cannot be re-executed');
     return typeof callback === 'function'

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -10,7 +10,8 @@ var common = require('./common'),
   BSON = require('mongodb-core').BSON,
   Define = require('../metadata'),
   Batch = common.Batch,
-  mergeBatchResults = common.mergeBatchResults;
+  mergeBatchResults = common.mergeBatchResults,
+  executeOperation = require('../utils').executeOperation;
 
 var bson = new BSON([
   BSON.Binary,
@@ -572,16 +573,7 @@ UnorderedBulkOperation.prototype.execute = function(_writeConcern, callback) {
       : this.s.promiseLibrary.reject(emptyBatchError);
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return executeBatches(this, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    executeBatches(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, executeBatches, [this, callback]);
 };
 
 define.classMethod('execute', { callback: true, promise: false });

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -431,6 +431,56 @@ Collection.prototype.find = function() {
 define.classMethod('find', { callback: false, promise: false, returns: [Cursor] });
 
 /**
+ *
+ * @param {*} self
+ * @param {*} operation
+ * @param {*} args
+ * @param {*} options
+ */
+const executeOperation = (self, operation, args, options) => {
+  options = options || {};
+  const Promise = self.s.promiseLibrary;
+  let resultMutator = options.resultMutator;
+  let callback = args[args.length - 1];
+
+  // Execute using callback
+  if (typeof callback === 'function') {
+    if (resultMutator) {
+      callback = args.pop();
+
+      if (options.resultCanBeError) {
+        args.push(
+          (err, result) => (err ? callback(err, result) : callback(null, resultMutator(result)))
+        );
+      } else {
+        args.push(
+          (err, result) => (err ? callback(err, null) : callback(null, resultMutator(result)))
+        );
+      }
+    }
+
+    return operation.apply(null, args);
+  }
+
+  // Return a Promise
+  return new Promise(function(resolve, reject) {
+    args[args.length - 1] = (err, r) => {
+      // NOTE: we check if `r == null` here explicitly because bulkWrite might have a bulkWriteError
+      if (options.resultCanBeError) {
+        if (err && r == null) return reject(err);
+      } else {
+        if (err) return reject(err);
+      }
+
+      if (resultMutator) return resolve(resultMutator(r));
+      resolve(r);
+    };
+
+    operation.apply(null, args);
+  });
+};
+
+/**
  * Inserts a single document into MongoDB. If documents passed in do not contain the **_id** field,
  * one will be added to each of the documents missing it by the driver, mutating the document. This behavior
  * can be overridden by setting the **forceServerObjectId** flag.
@@ -448,7 +498,6 @@ define.classMethod('find', { callback: false, promise: false, returns: [Cursor] 
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.insertOne = function(doc, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
   if (Array.isArray(doc) && typeof callback === 'function') {
@@ -467,16 +516,7 @@ Collection.prototype.insertOne = function(doc, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return insertOne(self, doc, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    insertOne(self, doc, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, insertOne, [this, doc, options, callback]);
 };
 
 var insertOne = function(self, doc, options, callback) {
@@ -582,19 +622,9 @@ Collection.prototype.insertMany = function(docs, options, callback) {
     }
   ];
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return bulkWrite(self, operations, options, function(err, r) {
-      if (err) return callback(err, r);
-      callback(null, mapInserManyResults(docs, r));
-    });
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    bulkWrite(self, operations, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(mapInserManyResults(docs, r));
-    });
+  return executeOperation(this, bulkWrite, [this, operations, options, callback], {
+    resultMutator: result => mapInserManyResults(docs, result),
+    resultCanBeError: true
   });
 };
 
@@ -653,7 +683,6 @@ define.classMethod('insertMany', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.bulkWrite = function(operations, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || { ordered: true };
 
@@ -661,15 +690,8 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
     throw MongoError.create({ message: 'operations must be an array of documents', driver: true });
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return bulkWrite(self, operations, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    bulkWrite(self, operations, options, function(err, r) {
-      if (err && r == null) return reject(err);
-      resolve(r);
-    });
+  return executeOperation(this, bulkWrite, [this, operations, options, callback], {
+    resultCanBeError: true
   });
 };
 
@@ -941,8 +963,6 @@ define.classMethod('insert', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.updateOne = function(filter, update, options, callback) {
-  var self = this;
-
   if (typeof options === 'function') (callback = options), (options = {});
 
   var err = checkForAtomicOperators(update);
@@ -959,16 +979,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return updateOne(self, filter, update, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    updateOne(self, filter, update, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, updateOne, [this, filter, update, options, callback]);
 };
 
 var checkForAtomicOperators = function(update) {
@@ -1022,7 +1033,6 @@ define.classMethod('updateOne', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.replaceOne = function(filter, doc, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = shallowClone(options);
 
@@ -1032,16 +1042,7 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return replaceOne(self, filter, doc, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    replaceOne(self, filter, doc, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, replaceOne, [this, filter, doc, options, callback]);
 };
 
 var replaceOne = function(self, filter, doc, options, callback) {
@@ -1084,7 +1085,6 @@ define.classMethod('replaceOne', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.updateMany = function(filter, update, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
 
   var err = checkForAtomicOperators(update);
@@ -1101,16 +1101,7 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return updateMany(self, filter, update, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    updateMany(self, filter, update, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, updateMany, [this, filter, update, options, callback]);
 };
 
 var updateMany = function(self, filter, update, options, callback) {
@@ -1200,25 +1191,13 @@ var updateDocuments = function(self, selector, document, options, callback) {
  * @deprecated use updateOne, updateMany or bulkWrite
  */
 Collection.prototype.update = function(selector, document, options, callback) {
-  var self = this;
-
   // Add ignoreUndfined
   if (this.s.options.ignoreUndefined) {
     options = shallowClone(options);
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return updateDocuments(self, selector, document, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    updateDocuments(self, selector, document, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, updateDocuments, [this, selector, document, options, callback]);
 };
 
 define.classMethod('update', { callback: true, promise: true });
@@ -1251,7 +1230,6 @@ define.classMethod('update', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.deleteOne = function(filter, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = shallowClone(options);
 
@@ -1261,16 +1239,7 @@ Collection.prototype.deleteOne = function(filter, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return deleteOne(self, filter, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    deleteOne(self, filter, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, deleteOne, [this, filter, options, callback]);
 };
 
 var deleteOne = function(self, filter, options, callback) {
@@ -1302,7 +1271,6 @@ define.classMethod('removeOne', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.deleteMany = function(filter, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = shallowClone(options);
 
@@ -1312,16 +1280,7 @@ Collection.prototype.deleteMany = function(filter, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return deleteMany(self, filter, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    deleteMany(self, filter, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, deleteMany, [this, filter, options, callback]);
 };
 
 var deleteMany = function(self, filter, options, callback) {
@@ -1394,24 +1353,13 @@ define.classMethod('removeMany', { callback: true, promise: true });
  * @deprecated use deleteOne, deleteMany or bulkWrite
  */
 Collection.prototype.remove = function(selector, options, callback) {
-  var self = this;
-
   // Add ignoreUndfined
   if (this.s.options.ignoreUndefined) {
     options = shallowClone(options);
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return removeDocuments(self, selector, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    removeDocuments(self, selector, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, removeDocuments, [this, selector, options, callback]);
 };
 
 define.classMethod('remove', { callback: true, promise: true });
@@ -1430,7 +1378,6 @@ define.classMethod('remove', { callback: true, promise: true });
  * @deprecated use insertOne, insertMany, updateOne or updateMany
  */
 Collection.prototype.save = function(doc, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
@@ -1440,16 +1387,7 @@ Collection.prototype.save = function(doc, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return save(self, doc, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    save(self, doc, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, save, [this, doc, options, callback]);
 };
 
 var save = function(self, doc, options, callback) {
@@ -1512,21 +1450,11 @@ define.classMethod('save', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.findOne = function() {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 0);
   var callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
 
-  // Execute using callback
-  if (typeof callback === 'function') return findOne(self, args, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    findOne(self, args, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, findOne, [this, args, callback]);
 };
 
 var findOne = function(self, args, callback) {
@@ -1561,20 +1489,10 @@ define.classMethod('findOne', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.rename = function(newName, opt, callback) {
-  var self = this;
   if (typeof opt === 'function') (callback = opt), (opt = {});
   opt = assign({}, opt, { readPreference: ReadPreference.PRIMARY });
 
-  // Execute using callback
-  if (typeof callback === 'function') return rename(self, newName, opt, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    rename(self, newName, opt, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, rename, [this, newName, opt, callback]);
 };
 
 var rename = function(self, newName, opt, callback) {
@@ -1624,20 +1542,14 @@ define.classMethod('rename', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.drop = function(options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return self.s.db.dropCollection(self.s.name, options, callback);
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self.s.db.dropCollection(self.s.name, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, this.s.db.dropCollection.bind(this.s.db), [
+    this.s.name,
+    options,
+    callback
+  ]);
 };
 
 define.classMethod('drop', { callback: true, promise: true });
@@ -1650,18 +1562,7 @@ define.classMethod('drop', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.options = function(callback) {
-  var self = this;
-
-  // Execute using callback
-  if (typeof callback === 'function') return options(self, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    options(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, options, [this, callback]);
 };
 
 var options = function(self, callback) {
@@ -1688,18 +1589,7 @@ define.classMethod('options', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.isCapped = function(callback) {
-  var self = this;
-
-  // Execute using callback
-  if (typeof callback === 'function') return isCapped(self, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    isCapped(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, isCapped, [this, callback]);
 };
 
 var isCapped = function(self, callback) {
@@ -1734,7 +1624,6 @@ define.classMethod('isCapped', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.createIndex = function(fieldOrSpec, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
@@ -1742,16 +1631,7 @@ Collection.prototype.createIndex = function(fieldOrSpec, options, callback) {
   options = typeof callback === 'function' ? options : callback;
   options = options == null ? {} : options;
 
-  // Execute using callback
-  if (typeof callback === 'function') return createIndex(self, fieldOrSpec, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    createIndex(self, fieldOrSpec, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, createIndex, [this, fieldOrSpec, options, callback]);
 };
 
 var createIndex = function(self, fieldOrSpec, options, callback) {
@@ -1770,18 +1650,7 @@ define.classMethod('createIndex', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.createIndexes = function(indexSpecs, callback) {
-  var self = this;
-
-  // Execute using callback
-  if (typeof callback === 'function') return createIndexes(self, indexSpecs, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    createIndexes(self, indexSpecs, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, createIndexes, [this, indexSpecs, callback]);
 };
 
 var createIndexes = function(self, indexSpecs, callback) {
@@ -1831,7 +1700,6 @@ define.classMethod('createIndexes', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.dropIndex = function(indexName, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
@@ -1839,16 +1707,7 @@ Collection.prototype.dropIndex = function(indexName, options, callback) {
   // Run only against primary
   options.readPreference = ReadPreference.PRIMARY;
 
-  // Execute using callback
-  if (typeof callback === 'function') return dropIndex(self, indexName, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    dropIndex(self, indexName, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, dropIndex, [this, indexName, options, callback]);
 };
 
 var dropIndex = function(self, indexName, options, callback) {
@@ -1875,22 +1734,10 @@ define.classMethod('dropIndex', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.dropIndexes = function(options, callback) {
-  var self = this;
-
-  // Do we have options
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  // Execute using callback
-  if (typeof callback === 'function') return dropIndexes(self, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    dropIndexes(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, dropIndexes, [this, options, callback]);
 };
 
 var dropIndexes = function(self, options, callback) {
@@ -1921,20 +1768,10 @@ define.classMethod('dropAllIndexes', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.reIndex = function(options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  // Execute using callback
-  if (typeof callback === 'function') return reIndex(self, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    reIndex(self, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, reIndex, [this, options, callback]);
 };
 
 var reIndex = function(self, options, callback) {
@@ -2026,20 +1863,10 @@ define.classMethod('listIndexes', { callback: false, promise: false, returns: [C
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.ensureIndex = function(fieldOrSpec, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  // Execute using callback
-  if (typeof callback === 'function') return ensureIndex(self, fieldOrSpec, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    ensureIndex(self, fieldOrSpec, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, ensureIndex, [this, fieldOrSpec, options, callback]);
 };
 
 var ensureIndex = function(self, fieldOrSpec, options, callback) {
@@ -2056,18 +1883,7 @@ define.classMethod('ensureIndex', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.indexExists = function(indexes, callback) {
-  var self = this;
-
-  // Execute using callback
-  if (typeof callback === 'function') return indexExists(self, indexes, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    indexExists(self, indexes, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, indexExists, [this, indexes, callback]);
 };
 
 var indexExists = function(self, indexes, callback) {
@@ -2100,23 +1916,12 @@ define.classMethod('indexExists', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.indexInformation = function(options, callback) {
-  var self = this;
-  // Unpack calls
   var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
   options = args.length ? args.shift() || {} : {};
 
-  // Execute using callback
-  if (typeof callback === 'function') return indexInformation(self, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    indexInformation(self, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, indexInformation, [this, options, callback]);
 };
 
 var indexInformation = function(self, options, callback) {
@@ -2146,27 +1951,13 @@ define.classMethod('indexInformation', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.count = function(query, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
   var queryOption = args.length ? args.shift() || {} : {};
   var optionsOption = args.length ? args.shift() || {} : {};
 
-  // Execute using callback
-  if (typeof callback === 'function') return count(self, queryOption, optionsOption, callback);
-
-  // Check if query is empty
-  query = query || {};
-  options = options || {};
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    count(self, query, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, count, [this, queryOption, optionsOption, callback]);
 };
 
 var count = function(self, query, options, callback) {
@@ -2220,28 +2011,13 @@ define.classMethod('count', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.distinct = function(key, query, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
   var queryOption = args.length ? args.shift() || {} : {};
   var optionsOption = args.length ? args.shift() || {} : {};
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return distinct(self, key, queryOption, optionsOption, callback);
-
-  // Ensure the query and options are set
-  query = query || {};
-  options = options || {};
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    distinct(self, key, query, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, distinct, [this, key, queryOption, optionsOption, callback]);
 };
 
 var distinct = function(self, key, query, options, callback) {
@@ -2286,17 +2062,7 @@ define.classMethod('distinct', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.indexes = function(callback) {
-  var self = this;
-  // Execute using callback
-  if (typeof callback === 'function') return indexes(self, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    indexes(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, indexes, [this, callback]);
 };
 
 var indexes = function(self, callback) {
@@ -2315,23 +2081,13 @@ define.classMethod('indexes', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.stats = function(options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
   // Fetch all commands
   options = args.length ? args.shift() || {} : {};
 
-  // Execute using callback
-  if (typeof callback === 'function') return stats(self, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    stats(self, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, stats, [this, options, callback]);
 };
 
 var stats = function(self, options, callback) {
@@ -2380,7 +2136,6 @@ define.classMethod('stats', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.findOneAndDelete = function(filter, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
@@ -2388,18 +2143,7 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
   if (filter == null || typeof filter !== 'object')
     throw toError('filter parameter must be an object');
 
-  // Execute using callback
-  if (typeof callback === 'function') return findOneAndDelete(self, filter, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    options = options || {};
-
-    findOneAndDelete(self, filter, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, findOneAndDelete, [this, filter, options, callback]);
 };
 
 var findOneAndDelete = function(self, filter, options, callback) {
@@ -2429,7 +2173,6 @@ define.classMethod('findOneAndDelete', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.findOneAndReplace = function(filter, replacement, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
@@ -2439,19 +2182,7 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
   if (replacement == null || typeof replacement !== 'object')
     throw toError('replacement parameter must be an object');
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return findOneAndReplace(self, filter, replacement, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    options = options || {};
-
-    findOneAndReplace(self, filter, replacement, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, findOneAndReplace, [this, filter, replacement, options, callback]);
 };
 
 var findOneAndReplace = function(self, filter, replacement, options, callback) {
@@ -2485,7 +2216,6 @@ define.classMethod('findOneAndReplace', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.findOneAndUpdate = function(filter, update, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
@@ -2495,19 +2225,7 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
   if (update == null || typeof update !== 'object')
     throw toError('update parameter must be an object');
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return findOneAndUpdate(self, filter, update, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    options = options || {};
-
-    findOneAndUpdate(self, filter, update, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, findOneAndUpdate, [this, filter, update, options, callback]);
 };
 
 var findOneAndUpdate = function(self, filter, update, options, callback) {
@@ -2544,7 +2262,6 @@ define.classMethod('findOneAndUpdate', { callback: true, promise: true });
  * @deprecated use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead
  */
 Collection.prototype.findAndModify = function(query, sort, doc, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
@@ -2557,19 +2274,7 @@ Collection.prototype.findAndModify = function(query, sort, doc, options, callbac
   // Force read preference primary
   options.readPreference = ReadPreference.PRIMARY;
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return findAndModify(self, query, sort, doc, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    options = options || {};
-
-    findAndModify(self, query, sort, doc, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, findAndModify, [this, query, sort, doc, options, callback]);
 };
 
 var findAndModify = function(self, query, sort, doc, options, callback) {
@@ -2653,23 +2358,13 @@ define.classMethod('findAndModify', { callback: true, promise: true });
  * @deprecated use findOneAndDelete instead
  */
 Collection.prototype.findAndRemove = function(query, sort, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
   sort = args.length ? args.shift() || [] : [];
   options = args.length ? args.shift() || {} : {};
 
-  // Execute using callback
-  if (typeof callback === 'function') return findAndRemove(self, query, sort, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    findAndRemove(self, query, sort, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, findAndRemove, [this, query, sort, options, callback]);
 };
 
 var findAndRemove = function(self, query, sort, options, callback) {
@@ -2910,7 +2605,6 @@ define.classMethod('watch', { callback: false, promise: false });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.parallelCollectionScan = function(options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = { numCursors: 1 });
   // Set number of cursors to 1
   options.numCursors = options.numCursors || 1;
@@ -2923,16 +2617,7 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
   // Add a promiseLibrary
   options.promiseLibrary = this.s.promiseLibrary;
 
-  // Execute using callback
-  if (typeof callback === 'function') return parallelCollectionScan(self, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    parallelCollectionScan(self, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, parallelCollectionScan, [this, options, callback]);
 };
 
 var parallelCollectionScan = function(self, options, callback) {
@@ -2999,7 +2684,6 @@ define.classMethod('parallelCollectionScan', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.geoNear = function(x, y, options, callback) {
-  var self = this;
   var point = typeof x === 'object' && x,
     args = Array.prototype.slice.call(arguments, point ? 1 : 2);
 
@@ -3008,16 +2692,7 @@ Collection.prototype.geoNear = function(x, y, options, callback) {
   // Fetch all commands
   options = args.length ? args.shift() || {} : {};
 
-  // Execute using callback
-  if (typeof callback === 'function') return geoNear(self, x, y, point, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    geoNear(self, x, y, point, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, geoNear, [this, x, y, point, options, callback]);
 };
 
 var geoNear = function(self, x, y, point, options, callback) {
@@ -3077,23 +2752,13 @@ define.classMethod('geoNear', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.geoHaystackSearch = function(x, y, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 2);
   callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
   // Fetch all commands
   options = args.length ? args.shift() || {} : {};
 
-  // Execute using callback
-  if (typeof callback === 'function') return geoHaystackSearch(self, x, y, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    geoHaystackSearch(self, x, y, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, geoHaystackSearch, [this, x, y, options, callback]);
 };
 
 var geoHaystackSearch = function(self, x, y, options, callback) {
@@ -3187,7 +2852,6 @@ Collection.prototype.group = function(
   options,
   callback
 ) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 3);
   callback = args.pop();
   if (typeof callback !== 'function') args.push(callback);
@@ -3223,16 +2887,17 @@ Collection.prototype.group = function(
   // Set up the command as default
   command = command == null ? true : command;
 
-  // Execute using callback
-  if (typeof callback === 'function')
-    return group(self, keys, condition, initial, reduce, finalize, command, options, callback);
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    group(self, keys, condition, initial, reduce, finalize, command, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, group, [
+    this,
+    keys,
+    condition,
+    initial,
+    reduce,
+    finalize,
+    command,
+    options,
+    callback
+  ]);
 };
 
 var group = function(self, keys, condition, initial, reduce, finalize, command, options, callback) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1396,12 +1396,7 @@ define.classMethod('save', { callback: true, promise: true });
  */
 Collection.prototype.findOne = function() {
   var args = Array.prototype.slice.call(arguments, 0);
-  var callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  var callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   return executeOperation(this, findOne, [this, args, callback]);
 };
 
@@ -1573,11 +1568,7 @@ define.classMethod('isCapped', { callback: true, promise: true });
  */
 Collection.prototype.createIndex = function(fieldOrSpec, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
 
   options = args.length ? args.shift() || {} : {};
   options = typeof callback === 'function' ? options : callback;
@@ -1653,11 +1644,7 @@ define.classMethod('createIndexes', { callback: true, promise: true });
  */
 Collection.prototype.dropIndex = function(indexName, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
 
   options = args.length ? args.shift() || {} : {};
   // Run only against primary
@@ -1873,12 +1860,7 @@ define.classMethod('indexExists', { callback: true, promise: true });
  */
 Collection.prototype.indexInformation = function(options, callback) {
   var args = Array.prototype.slice.call(arguments, 0);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() || {} : {};
 
   return executeOperation(this, indexInformation, [this, options, callback]);
@@ -1912,12 +1894,7 @@ define.classMethod('indexInformation', { callback: true, promise: true });
  */
 Collection.prototype.count = function(query, options, callback) {
   var args = Array.prototype.slice.call(arguments, 0);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   var queryOption = args.length ? args.shift() || {} : {};
   var optionsOption = args.length ? args.shift() || {} : {};
 
@@ -1976,12 +1953,7 @@ define.classMethod('count', { callback: true, promise: true });
  */
 Collection.prototype.distinct = function(key, query, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   var queryOption = args.length ? args.shift() || {} : {};
   var optionsOption = args.length ? args.shift() || {} : {};
 
@@ -2050,13 +2022,7 @@ define.classMethod('indexes', { callback: true, promise: true });
  */
 Collection.prototype.stats = function(options, callback) {
   var args = Array.prototype.slice.call(arguments, 0);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
-  // Fetch all commands
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() || {} : {};
 
   return executeOperation(this, stats, [this, options, callback]);
@@ -2235,12 +2201,7 @@ define.classMethod('findOneAndUpdate', { callback: true, promise: true });
  */
 Collection.prototype.findAndModify = function(query, sort, doc, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   sort = args.length ? args.shift() || [] : [];
   doc = args.length ? args.shift() : null;
   options = args.length ? args.shift() || {} : {};
@@ -2335,12 +2296,7 @@ define.classMethod('findAndModify', { callback: true, promise: true });
  */
 Collection.prototype.findAndRemove = function(query, sort, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   sort = args.length ? args.shift() || [] : [];
   options = args.length ? args.shift() || {} : {};
 
@@ -2666,14 +2622,7 @@ define.classMethod('parallelCollectionScan', { callback: true, promise: true });
 Collection.prototype.geoNear = function(x, y, options, callback) {
   var point = typeof x === 'object' && x,
     args = Array.prototype.slice.call(arguments, point ? 1 : 2);
-
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
-  // Fetch all commands
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() || {} : {};
 
   return executeOperation(this, geoNear, [this, x, y, point, options, callback]);
@@ -2737,13 +2686,7 @@ define.classMethod('geoNear', { callback: true, promise: true });
  */
 Collection.prototype.geoHaystackSearch = function(x, y, options, callback) {
   var args = Array.prototype.slice.call(arguments, 2);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
-  // Fetch all commands
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() || {} : {};
 
   return executeOperation(this, geoHaystackSearch, [this, x, y, options, callback]);
@@ -2841,13 +2784,7 @@ Collection.prototype.group = function(
   callback
 ) {
   var args = Array.prototype.slice.call(arguments, 3);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
-  // Fetch all commands
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   reduce = args.length ? args.shift() : null;
   finalize = args.length ? args.shift() : null;
   command = args.length ? args.shift() : null;

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -23,7 +23,8 @@ var checkCollectionName = require('./utils').checkCollectionName,
   ordered = require('./bulk/ordered'),
   assign = require('./utils').assign,
   ChangeStream = require('./change_stream'),
-  BulkWriteError = require('./bulk/common').BulkWriteError;
+  BulkWriteError = require('./bulk/common').BulkWriteError,
+  executeOperation = require('./utils').executeOperation;
 
 /**
  * @fileOverview The **Collection** class is an internal class that embodies a MongoDB collection
@@ -431,56 +432,6 @@ Collection.prototype.find = function() {
 define.classMethod('find', { callback: false, promise: false, returns: [Cursor] });
 
 /**
- *
- * @param {*} self
- * @param {*} operation
- * @param {*} args
- * @param {*} options
- */
-const executeOperation = (self, operation, args, options) => {
-  options = options || {};
-  const Promise = self.s.promiseLibrary;
-  let resultMutator = options.resultMutator;
-  let callback = args[args.length - 1];
-
-  // Execute using callback
-  if (typeof callback === 'function') {
-    if (resultMutator) {
-      callback = args.pop();
-
-      if (options.resultCanBeError) {
-        args.push(
-          (err, result) => (err ? callback(err, result) : callback(null, resultMutator(result)))
-        );
-      } else {
-        args.push(
-          (err, result) => (err ? callback(err, null) : callback(null, resultMutator(result)))
-        );
-      }
-    }
-
-    return operation.apply(null, args);
-  }
-
-  // Return a Promise
-  return new Promise(function(resolve, reject) {
-    args[args.length - 1] = (err, r) => {
-      // NOTE: we check if `r == null` here explicitly because bulkWrite might have a bulkWriteError
-      if (options.resultCanBeError) {
-        if (err && r == null) return reject(err);
-      } else {
-        if (err) return reject(err);
-      }
-
-      if (resultMutator) return resolve(resultMutator(r));
-      resolve(r);
-    };
-
-    operation.apply(null, args);
-  });
-};
-
-/**
  * Inserts a single document into MongoDB. If documents passed in do not contain the **_id** field,
  * one will be added to each of the documents missing it by the driver, mutating the document. This behavior
  * can be overridden by setting the **forceServerObjectId** flag.
@@ -500,15 +451,6 @@ const executeOperation = (self, operation, args, options) => {
 Collection.prototype.insertOne = function(doc, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
-  if (Array.isArray(doc) && typeof callback === 'function') {
-    return callback(
-      MongoError.create({ message: 'doc parameter must be an object', driver: true })
-    );
-  } else if (Array.isArray(doc)) {
-    return new this.s.promiseLibrary(function(resolve, reject) {
-      reject(MongoError.create({ message: 'doc parameter must be an object', driver: true }));
-    });
-  }
 
   // Add ignoreUndfined
   if (this.s.options.ignoreUndefined) {
@@ -520,6 +462,12 @@ Collection.prototype.insertOne = function(doc, options, callback) {
 };
 
 var insertOne = function(self, doc, options, callback) {
+  if (Array.isArray(doc)) {
+    return callback(
+      MongoError.create({ message: 'doc parameter must be an object', driver: true })
+    );
+  }
+
   insertDocuments(self, [doc], options, function(err, r) {
     if (callback == null) return;
     if (err && callback) return callback(err);
@@ -623,8 +571,7 @@ Collection.prototype.insertMany = function(docs, options, callback) {
   ];
 
   return executeOperation(this, bulkWrite, [this, operations, options, callback], {
-    resultMutator: result => mapInserManyResults(docs, result),
-    resultCanBeError: true
+    resultMutator: result => mapInserManyResults(docs, result)
   });
 };
 
@@ -690,9 +637,7 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
     throw MongoError.create({ message: 'operations must be an array of documents', driver: true });
   }
 
-  return executeOperation(this, bulkWrite, [this, operations, options, callback], {
-    resultCanBeError: true
-  });
+  return executeOperation(this, bulkWrite, [this, operations, options, callback]);
 };
 
 var bulkWrite = function(self, operations, options, callback) {
@@ -1452,7 +1397,10 @@ define.classMethod('save', { callback: true, promise: true });
 Collection.prototype.findOne = function() {
   var args = Array.prototype.slice.call(arguments, 0);
   var callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
 
   return executeOperation(this, findOne, [this, args, callback]);
 };
@@ -1626,7 +1574,11 @@ define.classMethod('isCapped', { callback: true, promise: true });
 Collection.prototype.createIndex = function(fieldOrSpec, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   options = args.length ? args.shift() || {} : {};
   options = typeof callback === 'function' ? options : callback;
   options = options == null ? {} : options;
@@ -1702,7 +1654,11 @@ define.classMethod('createIndexes', { callback: true, promise: true });
 Collection.prototype.dropIndex = function(indexName, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   options = args.length ? args.shift() || {} : {};
   // Run only against primary
   options.readPreference = ReadPreference.PRIMARY;
@@ -1918,7 +1874,11 @@ define.classMethod('indexExists', { callback: true, promise: true });
 Collection.prototype.indexInformation = function(options, callback) {
   var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   options = args.length ? args.shift() || {} : {};
 
   return executeOperation(this, indexInformation, [this, options, callback]);
@@ -1953,7 +1913,11 @@ define.classMethod('indexInformation', { callback: true, promise: true });
 Collection.prototype.count = function(query, options, callback) {
   var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   var queryOption = args.length ? args.shift() || {} : {};
   var optionsOption = args.length ? args.shift() || {} : {};
 
@@ -2013,7 +1977,11 @@ define.classMethod('count', { callback: true, promise: true });
 Collection.prototype.distinct = function(key, query, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   var queryOption = args.length ? args.shift() || {} : {};
   var optionsOption = args.length ? args.shift() || {} : {};
 
@@ -2083,7 +2051,11 @@ define.classMethod('indexes', { callback: true, promise: true });
 Collection.prototype.stats = function(options, callback) {
   var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   // Fetch all commands
   options = args.length ? args.shift() || {} : {};
 
@@ -2264,7 +2236,11 @@ define.classMethod('findOneAndUpdate', { callback: true, promise: true });
 Collection.prototype.findAndModify = function(query, sort, doc, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   sort = args.length ? args.shift() || [] : [];
   doc = args.length ? args.shift() : null;
   options = args.length ? args.shift() || {} : {};
@@ -2360,7 +2336,11 @@ define.classMethod('findAndModify', { callback: true, promise: true });
 Collection.prototype.findAndRemove = function(query, sort, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   sort = args.length ? args.shift() || [] : [];
   options = args.length ? args.shift() || {} : {};
 
@@ -2688,7 +2668,11 @@ Collection.prototype.geoNear = function(x, y, options, callback) {
     args = Array.prototype.slice.call(arguments, point ? 1 : 2);
 
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   // Fetch all commands
   options = args.length ? args.shift() || {} : {};
 
@@ -2754,7 +2738,11 @@ define.classMethod('geoNear', { callback: true, promise: true });
 Collection.prototype.geoHaystackSearch = function(x, y, options, callback) {
   var args = Array.prototype.slice.call(arguments, 2);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   // Fetch all commands
   options = args.length ? args.shift() || {} : {};
 
@@ -2854,7 +2842,11 @@ Collection.prototype.group = function(
 ) {
   var args = Array.prototype.slice.call(arguments, 3);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   // Fetch all commands
   reduce = args.length ? args.shift() : null;
   finalize = args.length ? args.shift() : null;
@@ -3016,7 +3008,6 @@ function processScope(scope) {
  * @return {Promise} returns Promise if no callback passed
  */
 Collection.prototype.mapReduce = function(map, reduce, options, callback) {
-  var self = this;
   if ('function' === typeof options) (callback = options), (options = {});
   // Out must allways be defined (make sure we don't break weirdly on pre 1.8+ servers)
   if (null == options.out) {
@@ -3037,17 +3028,7 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
     options.finalize = options.finalize.toString();
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return mapReduce(self, map, reduce, options, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    mapReduce(self, map, reduce, options, function(err, r, r1) {
-      if (err) return reject(err);
-      if (!r1) return resolve(r);
-      resolve({ results: r, stats: r1 });
-    });
-  });
+  return executeOperation(this, mapReduce, [this, map, reduce, options, callback]);
 };
 
 var mapReduce = function(self, map, reduce, options, callback) {
@@ -3124,7 +3105,7 @@ var mapReduce = function(self, map, reduce, options, callback) {
         return handleCallback(callback, null, result.results);
       }
 
-      return handleCallback(callback, null, result.results, stats);
+      return handleCallback(callback, null, { results: result.results, stats: stats });
     }
 
     // The returned collection
@@ -3150,7 +3131,7 @@ var mapReduce = function(self, map, reduce, options, callback) {
     }
 
     // Return stats as third set of values
-    handleCallback(callback, err, collection, stats);
+    handleCallback(callback, err, { collection: collection, stats: stats });
   });
 };
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -10,7 +10,8 @@ var inherits = require('util').inherits,
   Define = require('./metadata'),
   CoreCursor = require('mongodb-core').Cursor,
   Map = require('mongodb-core').BSON.Map,
-  CoreReadPreference = require('mongodb-core').ReadPreference;
+  CoreReadPreference = require('mongodb-core').ReadPreference,
+  executeOperation = require('./utils').executeOperation;
 
 /**
  * @fileOverview The **Cursor** class is an internal class that embodies a cursor on MongoDB
@@ -208,35 +209,20 @@ var define = (Cursor.define = new Define('Cursor', Cursor, true));
  * @return {Promise} returns Promise if no callback passed
  */
 Cursor.prototype.hasNext = function(callback) {
-  var self = this;
+  return executeOperation(this, hasNext, [this, callback]);
+};
 
-  // Execute using callback
-  if (typeof callback === 'function') {
-    if (self.s.currentDoc) {
-      return callback(null, true);
-    } else {
-      return nextObject(self, function(err, doc) {
-        if (err) return callback(err, null);
-        if (!doc) return callback(null, false);
-        self.s.currentDoc = doc;
-        callback(null, true);
-      });
-    }
+const hasNext = (self, callback) => {
+  if (self.s.currentDoc) {
+    return callback(null, true);
   }
 
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    if (self.s.currentDoc) {
-      resolve(true);
-    } else {
-      nextObject(self, function(err, doc) {
-        if (self.s.state === Cursor.CLOSED || self.isDead()) return resolve(false);
-        if (err) return reject(err);
-        if (!doc) return resolve(false);
-        self.s.currentDoc = doc;
-        resolve(true);
-      });
-    }
+  nextObject(self, function(err, doc) {
+    if (err) return callback(err, null);
+    if (self.s.state === Cursor.CLOSED || self.isDead()) return callback(null, false);
+    if (!doc) return callback(null, false);
+    self.s.currentDoc = doc;
+    callback(null, true);
   });
 };
 
@@ -250,35 +236,19 @@ define.classMethod('hasNext', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Cursor.prototype.next = function(callback) {
-  var self = this;
+  return executeOperation(this, next, [this, callback]);
+};
 
-  // Execute using callback
-  if (typeof callback === 'function') {
-    // Return the currentDoc if someone called hasNext first
-    if (self.s.currentDoc) {
-      var doc = self.s.currentDoc;
-      self.s.currentDoc = null;
-      return callback(null, doc);
-    }
-
-    // Return the next object
-    return nextObject(self, callback);
+const next = (self, callback) => {
+  // Return the currentDoc if someone called hasNext first
+  if (self.s.currentDoc) {
+    var doc = self.s.currentDoc;
+    self.s.currentDoc = null;
+    return callback(null, doc);
   }
 
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    // Return the currentDoc if someone called hasNext first
-    if (self.s.currentDoc) {
-      var doc = self.s.currentDoc;
-      self.s.currentDoc = null;
-      return resolve(doc);
-    }
-
-    nextObject(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  // Return the next object
+  nextObject(self, callback);
 };
 
 define.classMethod('next', { callback: true, promise: true });
@@ -290,8 +260,10 @@ define.classMethod('next', { callback: true, promise: true });
  * @return {Cursor}
  */
 Cursor.prototype.filter = function(filter) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.query = filter;
   return this;
 };
@@ -305,8 +277,10 @@ define.classMethod('filter', { callback: false, promise: false, returns: [Cursor
  * @return {Cursor}
  */
 Cursor.prototype.maxScan = function(maxScan) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.maxScan = maxScan;
   return this;
 };
@@ -320,8 +294,10 @@ define.classMethod('maxScan', { callback: false, promise: false, returns: [Curso
  * @return {Cursor}
  */
 Cursor.prototype.hint = function(hint) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.hint = hint;
   return this;
 };
@@ -350,8 +326,10 @@ define.classMethod('min', { callback: false, promise: false, returns: [Cursor] }
  * @return {Cursor}
  */
 Cursor.prototype.max = function(max) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.max = max;
   return this;
 };
@@ -365,8 +343,10 @@ define.classMethod('max', { callback: false, promise: false, returns: [Cursor] }
  * @return {Cursor}
  */
 Cursor.prototype.returnKey = function(value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.returnKey = value;
   return this;
 };
@@ -380,8 +360,10 @@ define.classMethod('returnKey', { callback: false, promise: false, returns: [Cur
  * @return {Cursor}
  */
 Cursor.prototype.showRecordId = function(value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.showDiskLoc = value;
   return this;
 };
@@ -395,8 +377,10 @@ define.classMethod('showRecordId', { callback: false, promise: false, returns: [
  * @return {Cursor}
  */
 Cursor.prototype.snapshot = function(value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.snapshot = value;
   return this;
 };
@@ -412,13 +396,17 @@ define.classMethod('snapshot', { callback: false, promise: false, returns: [Curs
  * @return {Cursor}
  */
 Cursor.prototype.setCursorOption = function(field, value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  if (fields.indexOf(field) === -1)
+  }
+
+  if (fields.indexOf(field) === -1) {
     throw MongoError.create({
       message: f('option %s not a supported option %s', field, fields),
       driver: true
     });
+  }
+
   this.s[field] = value;
   if (field === 'numberOfRetries') this.s.currentNumberOfRetries = value;
   return this;
@@ -435,15 +423,21 @@ define.classMethod('setCursorOption', { callback: false, promise: false, returns
  * @return {Cursor}
  */
 Cursor.prototype.addCursorFlag = function(flag, value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  if (flags.indexOf(flag) === -1)
+  }
+
+  if (flags.indexOf(flag) === -1) {
     throw MongoError.create({
       message: f('flag %s not a supported flag %s', flag, flags),
       driver: true
     });
-  if (typeof value !== 'boolean')
+  }
+
+  if (typeof value !== 'boolean') {
     throw MongoError.create({ message: f('flag %s must be a boolean value', flag), driver: true });
+  }
+
   this.s.cmd[flag] = value;
   return this;
 };
@@ -459,10 +453,14 @@ define.classMethod('addCursorFlag', { callback: false, promise: false, returns: 
  * @return {Cursor}
  */
 Cursor.prototype.addQueryModifier = function(name, value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  if (name[0] !== '$')
+  }
+
+  if (name[0] !== '$') {
     throw MongoError.create({ message: f('%s is not a valid query modifier'), driver: true });
+  }
+
   // Strip of the $
   var field = name.substr(1);
   // Set on the command
@@ -482,8 +480,10 @@ define.classMethod('addQueryModifier', { callback: false, promise: false, return
  * @return {Cursor}
  */
 Cursor.prototype.comment = function(value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.comment = value;
   return this;
 };
@@ -498,10 +498,14 @@ define.classMethod('comment', { callback: false, promise: false, returns: [Curso
  * @return {Cursor}
  */
 Cursor.prototype.maxAwaitTimeMS = function(value) {
-  if (typeof value !== 'number')
+  if (typeof value !== 'number') {
     throw MongoError.create({ message: 'maxAwaitTimeMS must be a number', driver: true });
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  }
+
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.maxAwaitTimeMS = value;
   return this;
 };
@@ -516,10 +520,14 @@ define.classMethod('maxAwaitTimeMS', { callback: false, promise: false, returns:
  * @return {Cursor}
  */
 Cursor.prototype.maxTimeMS = function(value) {
-  if (typeof value !== 'number')
+  if (typeof value !== 'number') {
     throw MongoError.create({ message: 'maxTimeMS must be a number', driver: true });
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  }
+
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.maxTimeMS = value;
   return this;
 };
@@ -538,8 +546,10 @@ define.classMethod('maxTimeMs', { callback: false, promise: false, returns: [Cur
  * @return {Cursor}
  */
 Cursor.prototype.project = function(value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   this.s.cmd.fields = value;
   return this;
 };
@@ -555,10 +565,14 @@ define.classMethod('project', { callback: false, promise: false, returns: [Curso
  * @return {Cursor}
  */
 Cursor.prototype.sort = function(keyOrList, direction) {
-  if (this.s.options.tailable)
+  if (this.s.options.tailable) {
     throw MongoError.create({ message: "Tailable cursor doesn't support sorting", driver: true });
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
+  }
+
+  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
+  }
+
   var order = keyOrList;
 
   // We have an array of arrays, we need to preserve the order of the sort
@@ -603,12 +617,18 @@ define.classMethod('sort', { callback: false, promise: false, returns: [Cursor] 
  * @return {Cursor}
  */
 Cursor.prototype.batchSize = function(value) {
-  if (this.s.options.tailable)
+  if (this.s.options.tailable) {
     throw MongoError.create({ message: "Tailable cursor doesn't support batchSize", driver: true });
-  if (this.s.state === Cursor.CLOSED || this.isDead())
+  }
+
+  if (this.s.state === Cursor.CLOSED || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  if (typeof value !== 'number')
+  }
+
+  if (typeof value !== 'number') {
     throw MongoError.create({ message: 'batchSize requires an integer', driver: true });
+  }
+
   this.s.cmd.batchSize = value;
   this.setCursorBatchSize(value);
   return this;
@@ -638,12 +658,18 @@ define.classMethod('collation', { callback: false, promise: false, returns: [Cur
  * @return {Cursor}
  */
 Cursor.prototype.limit = function(value) {
-  if (this.s.options.tailable)
+  if (this.s.options.tailable) {
     throw MongoError.create({ message: "Tailable cursor doesn't support limit", driver: true });
-  if (this.s.state === Cursor.OPEN || this.s.state === Cursor.CLOSED || this.isDead())
+  }
+
+  if (this.s.state === Cursor.OPEN || this.s.state === Cursor.CLOSED || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  if (typeof value !== 'number')
+  }
+
+  if (typeof value !== 'number') {
     throw MongoError.create({ message: 'limit requires an integer', driver: true });
+  }
+
   this.s.cmd.limit = value;
   // this.cursorLimit = value;
   this.setCursorLimit(value);
@@ -660,12 +686,18 @@ define.classMethod('limit', { callback: false, promise: false, returns: [Cursor]
  * @return {Cursor}
  */
 Cursor.prototype.skip = function(value) {
-  if (this.s.options.tailable)
+  if (this.s.options.tailable) {
     throw MongoError.create({ message: "Tailable cursor doesn't support skip", driver: true });
-  if (this.s.state === Cursor.OPEN || this.s.state === Cursor.CLOSED || this.isDead())
+  }
+
+  if (this.s.state === Cursor.OPEN || this.s.state === Cursor.CLOSED || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  if (typeof value !== 'number')
+  }
+
+  if (typeof value !== 'number') {
     throw MongoError.create({ message: 'skip requires an integer', driver: true });
+  }
+
   this.s.cmd.skip = value;
   this.setCursorSkip(value);
   return this;
@@ -877,16 +909,7 @@ Cursor.prototype.toArray = function(callback) {
       driver: true
     });
 
-  // Execute using callback
-  if (typeof callback === 'function') return toArray(self, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    toArray(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, toArray, [this, callback]);
 };
 
 var toArray = function(self, callback) {
@@ -951,22 +974,12 @@ define.classMethod('toArray', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Cursor.prototype.count = function(applySkipLimit, opts, callback) {
-  var self = this;
-  if (self.s.cmd.query == null)
+  if (this.s.cmd.query == null)
     throw MongoError.create({ message: 'count can only be used with find command', driver: true });
   if (typeof opts === 'function') (callback = opts), (opts = {});
   opts = opts || {};
 
-  // Execute using callback
-  if (typeof callback === 'function') return count(self, applySkipLimit, opts, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    count(self, applySkipLimit, opts, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, count, [this, applySkipLimit, opts, callback]);
 };
 
 var count = function(self, applySkipLimit, opts, callback) {
@@ -1037,6 +1050,7 @@ Cursor.prototype.close = function(callback) {
   this.kill();
   // Emit the close event for the cursor
   this.emit('close');
+
   // Callback if provided
   if (typeof callback === 'function') return handleCallback(callback, null, this);
   // Return a Promise
@@ -1107,7 +1121,6 @@ define.classMethod('stream', { callback: false, promise: false, returns: [Cursor
  * @return {Promise} returns Promise if no callback passed
  */
 Cursor.prototype.explain = function(callback) {
-  var self = this;
   this.s.cmd.explain = true;
 
   // Do we have a readConcern
@@ -1115,16 +1128,7 @@ Cursor.prototype.explain = function(callback) {
     delete this.s.cmd['readConcern'];
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') return this._next(callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self._next(function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, this._next.bind(this), [callback]);
 };
 
 define.classMethod('explain', { callback: true, promise: true });

--- a/lib/db.js
+++ b/lib/db.js
@@ -600,12 +600,7 @@ var createCollection = function(self, name, options, callback) {
  */
 Db.prototype.createCollection = function(name, options, callback) {
   var args = Array.prototype.slice.call(arguments, 0);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   name = args.length ? args.shift() : null;
   options = args.length ? args.shift() || {} : {};
 
@@ -804,12 +799,7 @@ var evaluate = function(self, code, parameters, options, callback) {
  */
 Db.prototype.eval = function(code, parameters, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   parameters = args.length ? args.shift() : parameters;
   options = args.length ? args.shift() || {} : {};
 
@@ -1026,12 +1016,7 @@ define.classMethod('executeDbAdminCommand', { callback: true, promise: true });
  */
 Db.prototype.createIndex = function(name, fieldOrSpec, options, callback) {
   var args = Array.prototype.slice.call(arguments, 2);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() || {} : {};
   options = typeof callback === 'function' ? options : callback;
   options = options == null ? {} : options;
@@ -1315,12 +1300,7 @@ var addUser = function(self, username, password, options, callback) {
 Db.prototype.addUser = function(username, password, options, callback) {
   // Unpack the parameters
   var args = Array.prototype.slice.call(arguments, 2);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() || {} : {};
 
   return executeOperation(this, addUser, [this, username, password, options, callback]);
@@ -1404,12 +1384,7 @@ define.classMethod('removeUser', { callback: true, promise: true });
  */
 Db.prototype.removeUser = function(username, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    args.push(callback);
-    callback = undefined;
-  }
-
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() || {} : {};
 
   return executeOperation(this, removeUser, [this, username, options, callback]);

--- a/lib/db.js
+++ b/lib/db.js
@@ -22,7 +22,8 @@ var EventEmitter = require('events').EventEmitter,
   Collection = require('./collection'),
   crypto = require('crypto'),
   mergeOptionsAndWriteConcern = require('./utils').mergeOptionsAndWriteConcern,
-  assign = require('./utils').assign;
+  assign = require('./utils').assign,
+  executeOperation = require('./utils').executeOperation;
 
 var debugFields = [
   'authSource',
@@ -343,21 +344,12 @@ var executeCommand = function(self, command, options, callback) {
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.command = function(command, options, callback) {
-  var self = this;
   // Change the callback
   if (typeof options === 'function') (callback = options), (options = {});
   // Clone the options
   options = shallowClone(options);
 
-  // Do we have a callback
-  if (typeof callback === 'function') return executeCommand(self, command, options, callback);
-  // Return a promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    executeCommand(self, command, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, executeCommand, [this, command, options, callback]);
 };
 
 define.classMethod('command', { callback: true, promise: true });
@@ -607,10 +599,13 @@ var createCollection = function(self, name, options, callback) {
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.createCollection = function(name, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   name = args.length ? args.shift() : null;
   options = args.length ? args.shift() || {} : {};
 
@@ -620,14 +615,7 @@ Db.prototype.createCollection = function(name, options, callback) {
   // Check if the callback is in fact a string
   if (typeof callback === 'string') name = callback;
 
-  // Execute the fallback callback
-  if (typeof callback === 'function') return createCollection(self, name, options, callback);
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    createCollection(self, name, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, createCollection, [this, name, options, callback]);
 };
 
 define.classMethod('createCollection', { callback: true, promise: true });
@@ -815,22 +803,17 @@ var evaluate = function(self, code, parameters, options, callback) {
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.eval = function(code, parameters, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   parameters = args.length ? args.shift() : parameters;
   options = args.length ? args.shift() || {} : {};
 
-  // Check if the callback is in fact a string
-  if (typeof callback === 'function') return evaluate(self, code, parameters, options, callback);
-  // Execute the command
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    evaluate(self, code, parameters, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, evaluate, [this, code, parameters, options, callback]);
 };
 
 define.classMethod('eval', { callback: true, promise: true });
@@ -847,24 +830,17 @@ define.classMethod('eval', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.renameCollection = function(fromCollection, toCollection, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
   // Add return new collection
   options.new_collection = true;
 
-  // Check if the callback is in fact a string
-  if (typeof callback === 'function') {
-    return this.collection(fromCollection).rename(toCollection, options, callback);
-  }
-
-  // Return a promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self.collection(fromCollection).rename(toCollection, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  const collection = this.collection(fromCollection);
+  return executeOperation(this, collection.rename.bind(collection), [
+    toCollection,
+    options,
+    callback
+  ]);
 };
 
 define.classMethod('renameCollection', { callback: true, promise: true });
@@ -878,7 +854,6 @@ define.classMethod('renameCollection', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.dropCollection = function(name, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
@@ -886,38 +861,24 @@ Db.prototype.dropCollection = function(name, options, callback) {
   var cmd = { drop: name };
 
   // Decorate with write concern
-  decorateWithWriteConcern(cmd, self, options);
+  decorateWithWriteConcern(cmd, this, options);
 
   // options
   options = assign({}, this.s.options, { readPreference: ReadPreference.PRIMARY });
 
-  // Check if the callback is in fact a string
-  if (typeof callback === 'function')
-    return this.command(cmd, options, function(err, result) {
-      // Did the user destroy the topology
-      if (self.serverConfig && self.serverConfig.isDestroyed())
-        return callback(new MongoError('topology was destroyed'));
-      if (err) return handleCallback(callback, err);
-      if (result.ok) return handleCallback(callback, null, true);
-      handleCallback(callback, null, false);
-    });
+  return executeOperation(this, dropCollection, [this, cmd, options, callback]);
+};
 
-  // Clone the options
-  options = shallowClone(self.s.options);
-  // Set readPreference PRIMARY
-  options.readPreference = ReadPreference.PRIMARY;
+const dropCollection = (self, cmd, options, callback) => {
+  return self.command(cmd, options, function(err, result) {
+    // Did the user destroy the topology
+    if (self.serverConfig && self.serverConfig.isDestroyed()) {
+      return callback(new MongoError('topology was destroyed'));
+    }
 
-  // Execute the command
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    // Execute command
-    self.command(cmd, options, function(err, result) {
-      // Did the user destroy the topology
-      if (self.serverConfig && self.serverConfig.isDestroyed())
-        return reject(new MongoError('topology was destroyed'));
-      if (err) return reject(err);
-      if (result.ok) return resolve(true);
-      resolve(false);
-    });
+    if (err) return handleCallback(callback, err);
+    if (result.ok) return handleCallback(callback, null, true);
+    handleCallback(callback, null, false);
   });
 };
 
@@ -931,40 +892,30 @@ define.classMethod('dropCollection', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.dropDatabase = function(options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
   // Drop database command
   var cmd = { dropDatabase: 1 };
 
   // Decorate with write concern
-  decorateWithWriteConcern(cmd, self, options);
+  decorateWithWriteConcern(cmd, this, options);
 
   // Ensure primary only
   options = assign({}, this.s.options, { readPreference: ReadPreference.PRIMARY });
 
-  // Check if the callback is in fact a string
-  if (typeof callback === 'function')
-    return this.command(cmd, options, function(err, result) {
-      // Did the user destroy the topology
-      if (self.serverConfig && self.serverConfig.isDestroyed())
-        return callback(new MongoError('topology was destroyed'));
-      if (callback == null) return;
-      if (err) return handleCallback(callback, err, null);
-      handleCallback(callback, null, result.ok ? true : false);
-    });
+  return executeOperation(this, dropDatabase, [this, cmd, options, callback]);
+};
 
-  // Execute the command
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    // Execute command
-    self.command(cmd, options, function(err, result) {
-      // Did the user destroy the topology
-      if (self.serverConfig && self.serverConfig.isDestroyed())
-        return reject(new MongoError('topology was destroyed'));
-      if (err) return reject(err);
-      if (result.ok) return resolve(true);
-      resolve(false);
-    });
+const dropDatabase = (self, cmd, options, callback) => {
+  self.command(cmd, options, function(err, result) {
+    // Did the user destroy the topology
+    if (self.serverConfig && self.serverConfig.isDestroyed()) {
+      return callback(new MongoError('topology was destroyed'));
+    }
+
+    if (callback == null) return;
+    if (err) return handleCallback(callback, err, null);
+    handleCallback(callback, null, result.ok ? true : false);
   });
 };
 
@@ -1011,17 +962,7 @@ var collections = function(self, callback) {
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.collections = function(callback) {
-  var self = this;
-
-  // Return the callback
-  if (typeof callback === 'function') return collections(self, callback);
-  // Return the promise
-  return new self.s.promiseLibrary(function(resolve, reject) {
-    collections(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, collections, [this, callback]);
 };
 
 define.classMethod('collections', { callback: true, promise: true });
@@ -1036,35 +977,26 @@ define.classMethod('collections', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.executeDbAdminCommand = function(selector, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  // Return the callback
-  if (typeof callback === 'function') {
-    // Convert read preference
-    if (options.readPreference) {
-      options.readPreference = convertReadPreference(options.readPreference);
-    }
-
-    return self.s.topology.command('admin.$cmd', selector, options, function(err, result) {
-      // Did the user destroy the topology
-      if (self.serverConfig && self.serverConfig.isDestroyed())
-        return callback(new MongoError('topology was destroyed'));
-      if (err) return handleCallback(callback, err);
-      handleCallback(callback, null, result.result);
-    });
+  // Convert read preference
+  if (options.readPreference) {
+    options.readPreference = convertReadPreference(options.readPreference);
   }
 
-  // Return promise
-  return new self.s.promiseLibrary(function(resolve, reject) {
-    self.s.topology.command('admin.$cmd', selector, options, function(err, result) {
-      // Did the user destroy the topology
-      if (self.serverConfig && self.serverConfig.isDestroyed())
-        return reject(new MongoError('topology was destroyed'));
-      if (err) return reject(err);
-      resolve(result.result);
-    });
+  return executeOperation(this, executeDbAdminCommand, [this, selector, options, callback]);
+};
+
+const executeDbAdminCommand = (self, selector, options, callback) => {
+  self.s.topology.command('admin.$cmd', selector, options, function(err, result) {
+    // Did the user destroy the topology
+    if (self.serverConfig && self.serverConfig.isDestroyed()) {
+      return callback(new MongoError('topology was destroyed'));
+    }
+
+    if (err) return handleCallback(callback, err);
+    handleCallback(callback, null, result.result);
   });
 };
 
@@ -1093,26 +1025,20 @@ define.classMethod('executeDbAdminCommand', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.createIndex = function(name, fieldOrSpec, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 2);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   options = args.length ? args.shift() || {} : {};
   options = typeof callback === 'function' ? options : callback;
   options = options == null ? {} : options;
   // Shallow clone the options
   options = shallowClone(options);
 
-  // If we have a callback fallback
-  if (typeof callback === 'function')
-    return createIndex(self, name, fieldOrSpec, options, callback);
-  // Return a promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    createIndex(self, name, fieldOrSpec, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, createIndex, [this, name, fieldOrSpec, options, callback]);
 };
 
 var createIndex = function(self, name, fieldOrSpec, options, callback) {
@@ -1193,21 +1119,10 @@ define.classMethod('createIndex', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.ensureIndex = function(name, fieldOrSpec, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  // If we have a callback fallback
-  if (typeof callback === 'function')
-    return ensureIndex(self, name, fieldOrSpec, options, callback);
-
-  // Return a promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    ensureIndex(self, name, fieldOrSpec, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, ensureIndex, [this, name, fieldOrSpec, options, callback]);
 };
 
 var ensureIndex = function(self, name, fieldOrSpec, options, callback) {
@@ -1399,22 +1314,16 @@ var addUser = function(self, username, password, options, callback) {
  */
 Db.prototype.addUser = function(username, password, options, callback) {
   // Unpack the parameters
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 2);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   options = args.length ? args.shift() || {} : {};
 
-  // If we have a callback fallback
-  if (typeof callback === 'function') return addUser(self, username, password, options, callback);
-
-  // Return a promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    addUser(self, username, password, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, addUser, [this, username, password, options, callback]);
 };
 
 define.classMethod('addUser', { callback: true, promise: true });
@@ -1494,23 +1403,16 @@ define.classMethod('removeUser', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.removeUser = function(username, options, callback) {
-  // Unpack the parameters
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  if (typeof callback !== 'function') {
+    args.push(callback);
+    callback = undefined;
+  }
+
   options = args.length ? args.shift() || {} : {};
 
-  // If we have a callback fallback
-  if (typeof callback === 'function') return removeUser(self, username, options, callback);
-
-  // Return a promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    removeUser(self, username, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, removeUser, [this, username, options, callback]);
 };
 
 /**
@@ -1521,18 +1423,7 @@ Db.prototype.removeUser = function(username, options, callback) {
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.setProfilingLevel = function(level, callback) {
-  var self = this;
-
-  // Execute using callback
-  if (typeof callback === 'function') return setProfilingLevel(self, level, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    setProfilingLevel(self, level, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, setProfilingLevel, [this, level, callback]);
 };
 
 var setProfilingLevel = function(self, level, callback) {
@@ -1570,18 +1461,7 @@ define.classMethod('setProfilingLevel', { callback: true, promise: true });
  * @deprecated Query the system.profile collection directly.
  */
 Db.prototype.profilingInfo = function(callback) {
-  var self = this;
-
-  // Execute using callback
-  if (typeof callback === 'function') return profilingInfo(self, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    profilingInfo(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, profilingInfo, [this, callback]);
 };
 
 var profilingInfo = function(self, callback) {
@@ -1604,18 +1484,7 @@ define.classMethod('profilingInfo', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.profilingLevel = function(callback) {
-  var self = this;
-
-  // Execute using callback
-  if (typeof callback === 'function') return profilingLevel(self, callback);
-
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    profilingLevel(self, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, profilingLevel, [this, callback]);
 };
 
 var profilingLevel = function(self, callback) {
@@ -1645,20 +1514,10 @@ define.classMethod('profilingLevel', { callback: true, promise: true });
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.indexInformation = function(name, options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  // If we have a callback fallback
-  if (typeof callback === 'function') return indexInformation(self, name, options, callback);
-
-  // Return a promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    indexInformation(self, name, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, indexInformation, [this, name, options, callback]);
 };
 
 var indexInformation = function(self, name, options, callback) {

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -6,6 +6,7 @@ var GridFSBucketWriteStream = require('./upload');
 var shallowClone = require('../utils').shallowClone;
 var toError = require('../utils').toError;
 var util = require('util');
+var executeOperation = require('../utils').executeOperation;
 
 var DEFAULT_GRIDFS_BUCKET_OPTIONS = {
   bucketName: 'fs',
@@ -159,20 +160,7 @@ GridFSBucket.prototype.openDownloadStream = function(id, options) {
  */
 
 GridFSBucket.prototype.delete = function(id, callback) {
-  if (typeof callback === 'function') {
-    return _delete(this, id, callback);
-  }
-
-  var _this = this;
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    _delete(_this, id, function(error, res) {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(res);
-      }
-    });
-  });
+  return executeOperation(this, _delete, [this, id, callback]);
 };
 
 /**
@@ -295,20 +283,7 @@ GridFSBucket.prototype.openDownloadStreamByName = function(filename, options) {
  */
 
 GridFSBucket.prototype.rename = function(id, filename, callback) {
-  if (typeof callback === 'function') {
-    return _rename(this, id, filename, callback);
-  }
-
-  var _this = this;
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    _rename(_this, id, filename, function(error, res) {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(res);
-      }
-    });
-  });
+  return executeOperation(this, _rename, [this, id, filename, callback]);
 };
 
 /**
@@ -336,20 +311,7 @@ function _rename(_this, id, filename, callback) {
  */
 
 GridFSBucket.prototype.drop = function(callback) {
-  if (typeof callback === 'function') {
-    return _drop(this, callback);
-  }
-
-  var _this = this;
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    _drop(_this, function(error, res) {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(res);
-      }
-    });
-  });
+  return executeOperation(this, _drop, [this, callback]);
 };
 
 /**

--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -46,7 +46,8 @@ var Chunk = require('./chunk'),
   MongoError = require('mongodb-core').MongoError,
   inherits = util.inherits,
   Duplex = require('stream').Duplex,
-  shallowClone = require('../utils').shallowClone;
+  shallowClone = require('../utils').shallowClone,
+  executeOperation = require('../utils').executeOperation;
 
 var REFERENCE_BY_FILENAME = 0,
   REFERENCE_BY_ID = 1;
@@ -658,23 +659,12 @@ define.classMethod('collection', { callback: true, promise: false, returns: [Col
  * @deprecated Use GridFSBucket API instead
  */
 GridStore.prototype.readlines = function(separator, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 0);
-  callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   separator = args.length ? args.shift() : '\n';
   separator = separator || '\n';
 
-  // We provided a callback leg
-  if (typeof callback === 'function') return readlines(self, separator, callback);
-
-  // Return promise
-  return new self.promiseLibrary(function(resolve, reject) {
-    readlines(self, separator, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, readlines, [this, separator, callback]);
 };
 
 var readlines = function(self, separator, callback) {
@@ -766,22 +756,12 @@ define.classMethod('rewind', { callback: true, promise: true });
  * @deprecated Use GridFSBucket API instead
  */
 GridStore.prototype.read = function(length, buffer, callback) {
-  var self = this;
-
   var args = Array.prototype.slice.call(arguments, 0);
-  callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   length = args.length ? args.shift() : null;
   buffer = args.length ? args.shift() : null;
-  // We provided a callback leg
-  if (typeof callback === 'function') return read(self, length, buffer, callback);
-  // Return promise
-  return new self.promiseLibrary(function(resolve, reject) {
-    read(self, length, buffer, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+
+  return executeOperation(this, read, [this, length, buffer, callback]);
 };
 
 var read = function(self, length, buffer, callback) {
@@ -890,22 +870,11 @@ define.classMethod('tell', { callback: true, promise: true });
  * @deprecated Use GridFSBucket API instead
  */
 GridStore.prototype.seek = function(position, seekLocation, callback) {
-  var self = this;
-
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   seekLocation = args.length ? args.shift() : null;
 
-  // We provided a callback leg
-  if (typeof callback === 'function') return seek(self, position, seekLocation, callback);
-  // Return promise
-  return new self.promiseLibrary(function(resolve, reject) {
-    seek(self, position, seekLocation, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  return executeOperation(this, seek, [this, position, seekLocation, callback]);
 };
 
 var seek = function(self, position, seekLocation, callback) {
@@ -1328,25 +1297,13 @@ GridStore.IO_SEEK_END = 2;
  */
 GridStore.exist = function(db, fileIdObject, rootCollection, options, callback) {
   var args = Array.prototype.slice.call(arguments, 2);
-  callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   rootCollection = args.length ? args.shift() : null;
   options = args.length ? args.shift() : {};
   options = options || {};
 
-  // Get the promiseLibrary
-  var promiseLibrary = options.promiseLibrary || Promise;
-
-  // We provided a callback leg
-  if (typeof callback === 'function')
-    return exists(db, fileIdObject, rootCollection, options, callback);
-  // Return promise
-  return new promiseLibrary(function(resolve, reject) {
-    exists(db, fileIdObject, rootCollection, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  const s = { promiseLibrary: options.promiseLibrary || Promise };
+  return executeOperation(s, exists, [db, fileIdObject, rootCollection, options, callback]);
 };
 
 var exists = function(db, fileIdObject, rootCollection, options, callback) {
@@ -1400,24 +1357,13 @@ define.staticMethod('exist', { callback: true, promise: true });
  */
 GridStore.list = function(db, rootCollection, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   rootCollection = args.length ? args.shift() : null;
   options = args.length ? args.shift() : {};
   options = options || {};
 
-  // Get the promiseLibrary
-  var promiseLibrary = options.promiseLibrary || Promise;
-
-  // We provided a callback leg
-  if (typeof callback === 'function') return list(db, rootCollection, options, callback);
-  // Return promise
-  return new promiseLibrary(function(resolve, reject) {
-    list(db, rootCollection, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  const s = { promiseLibrary: options.promiseLibrary || Promise };
+  return executeOperation(s, list, [db, rootCollection, options, callback]);
 };
 
 var list = function(db, rootCollection, options, callback) {
@@ -1479,26 +1425,14 @@ define.staticMethod('list', { callback: true, promise: true });
  */
 GridStore.read = function(db, name, length, offset, options, callback) {
   var args = Array.prototype.slice.call(arguments, 2);
-  callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   length = args.length ? args.shift() : null;
   offset = args.length ? args.shift() : null;
   options = args.length ? args.shift() : null;
   options = options || {};
 
-  // Get the promiseLibrary
-  var promiseLibrary = options.promiseLibrary || Promise;
-
-  // We provided a callback leg
-  if (typeof callback === 'function')
-    return readStatic(db, name, length, offset, options, callback);
-  // Return promise
-  return new promiseLibrary(function(resolve, reject) {
-    readStatic(db, name, length, offset, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  const s = { promiseLibrary: options.promiseLibrary || Promise };
+  return executeOperation(s, readStatic, [db, name, length, offset, options, callback]);
 };
 
 var readStatic = function(db, name, length, offset, options, callback) {
@@ -1542,25 +1476,13 @@ define.staticMethod('read', { callback: true, promise: true });
  */
 GridStore.readlines = function(db, name, separator, options, callback) {
   var args = Array.prototype.slice.call(arguments, 2);
-  callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   separator = args.length ? args.shift() : null;
   options = args.length ? args.shift() : null;
   options = options || {};
 
-  // Get the promiseLibrary
-  var promiseLibrary = options.promiseLibrary || Promise;
-
-  // We provided a callback leg
-  if (typeof callback === 'function')
-    return readlinesStatic(db, name, separator, options, callback);
-  // Return promise
-  return new promiseLibrary(function(resolve, reject) {
-    readlinesStatic(db, name, separator, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  const s = { promiseLibrary: options.promiseLibrary || Promise };
+  return executeOperation(s, readlinesStatic, [db, name, separator, options, callback]);
 };
 
 var readlinesStatic = function(db, name, separator, options, callback) {
@@ -1587,26 +1509,13 @@ define.staticMethod('readlines', { callback: true, promise: true });
  * @deprecated Use GridFSBucket API instead
  */
 GridStore.unlink = function(db, names, options, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments, 2);
-  callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() : {};
   options = options || {};
 
-  // Get the promiseLibrary
-  var promiseLibrary = options.promiseLibrary || Promise;
-
-  // We provided a callback leg
-  if (typeof callback === 'function') return unlinkStatic(self, db, names, options, callback);
-
-  // Return promise
-  return new promiseLibrary(function(resolve, reject) {
-    unlinkStatic(self, db, names, options, function(err, r) {
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
+  const s = { promiseLibrary: options.promiseLibrary || Promise };
+  return executeOperation(s, unlinkStatic, [this, db, names, options, callback]);
 };
 
 var unlinkStatic = function(self, db, names, options, callback) {
@@ -1845,8 +1754,7 @@ GridStoreStream.prototype.write = function(chunk) {
 GridStoreStream.prototype.end = function(chunk, encoding, callback) {
   var self = this;
   var args = Array.prototype.slice.call(arguments, 0);
-  callback = args.pop();
-  if (typeof callback !== 'function') args.push(callback);
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   chunk = args.length ? args.shift() : null;
   encoding = args.length ? args.shift() : null;
   self.endCalled = true;

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -17,7 +17,8 @@ var parse = require('./url_parser'),
   shallowClone = require('./utils').shallowClone,
   authenticate = require('./authenticate'),
   ServerSessionPool = require('mongodb-core').Sessions.ServerSessionPool,
-  ClientSession = require('mongodb-core').Sessions.ClientSession;
+  ClientSession = require('mongodb-core').Sessions.ClientSession,
+  executeOperation = require('./utils').executeOperation;
 
 /**
  * @fileOverview The **MongoClient** class is a class that allows for making Connections to MongoDB.
@@ -220,24 +221,17 @@ var define = (MongoClient.define = new Define('MongoClient', MongoClient, false)
  * @deprecated MongoClient.connect is deprecated, please use new MongoClient().connect() to connect.
  */
 MongoClient.prototype.connect = function(callback) {
-  var self = this;
-
   // Validate options object
-  var err = validOptions(self.s.options);
+  var err = validOptions(this.s.options);
 
-  // Return a promise
-  if (typeof callback !== 'function') {
-    return new this.s.promiseLibrary(function(resolve, reject) {
-      // Did we have a validation error
-      if (err) return reject(err);
-      // Attempt to connect
-      connect(self, self.s.url, self.s.options, function(err) {
-        if (err) return reject(err);
-        resolve(self);
-      });
-    });
+  if (typeof callback === 'string') {
+    throw new TypeError('`connect` only accepts a callback');
   }
 
+  return executeOperation(this, connectOp, [this, err, callback]);
+};
+
+const connectOp = (self, err, callback) => {
   // Did we have a validation error
   if (err) return callback(err);
   // Fallback to callback based connect
@@ -258,27 +252,19 @@ define.classMethod('close', { callback: true, promise: true, returns: [MongoClie
  * @return {Promise} returns Promise if no callback passed
  */
 MongoClient.prototype.logout = function(options, callback) {
-  var self = this;
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
   // Establish the correct database name
   var dbName = this.s.options.authSource ? this.s.options.authSource : this.s.options.dbName;
 
-  // If we have a callback
-  if (typeof callback === 'function') {
-    return self.topology.logout(dbName, function(err) {
-      if (err) return callback(err);
-      callback(null, true);
-    });
-  }
+  return executeOperation(this, logout, [this, dbName, callback]);
+};
 
-  // Return a promise
-  return new this.s.promiseLibrary(function(resolve, reject) {
-    self.topology.logout(dbName, function(err) {
-      if (err) return reject(err);
-      resolve(true);
-    });
+const logout = (self, dbName, callback) => {
+  self.topology.logout(dbName, function(err) {
+    if (err) return callback(err);
+    callback(null, true);
   });
 };
 
@@ -443,7 +429,7 @@ MongoClient.prototype.isConnected = function(options) {
  */
 MongoClient.connect = function(url, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
-  callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
+  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() : null;
   options = options || {};
 

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -15,7 +15,9 @@ var parse = require('./url_parser'),
   f = require('util').format,
   assign = require('./utils').assign,
   shallowClone = require('./utils').shallowClone,
-  authenticate = require('./authenticate');
+  authenticate = require('./authenticate'),
+  ServerSessionPool = require('mongodb-core').Sessions.ServerSessionPool,
+  ClientSession = require('mongodb-core').Sessions.ClientSession;
 
 /**
  * @fileOverview The **MongoClient** class is a class that allows for making Connections to MongoDB.
@@ -180,7 +182,8 @@ function MongoClient(url, options) {
     url: url,
     options: options || {},
     promiseLibrary: null,
-    dbCache: {}
+    dbCache: {},
+    sessionPool: null
   };
 
   // Get the promiseLibrary
@@ -228,9 +231,8 @@ MongoClient.prototype.connect = function(callback) {
       // Did we have a validation error
       if (err) return reject(err);
       // Attempt to connect
-      connect(self, self.s.url, self.s.options, function(err, topology) {
+      connect(self, self.s.url, self.s.options, function(err) {
         if (err) return reject(err);
-        self.topology = topology;
         resolve(self);
       });
     });
@@ -239,9 +241,8 @@ MongoClient.prototype.connect = function(callback) {
   // Did we have a validation error
   if (err) return callback(err);
   // Fallback to callback based connect
-  connect(self, self.s.url, self.s.options, function(err, topology) {
+  connect(self, self.s.url, self.s.options, function(err) {
     if (err) return callback(err);
-    self.topology = topology;
     callback(null, self);
   });
 };
@@ -454,6 +455,28 @@ MongoClient.connect = function(url, options, callback) {
 
 define.staticMethod('connect', { callback: true, promise: true });
 
+/**
+ * Starts a new session on the server
+ *
+ * @param {object} [options] optional settings for a driver session
+ * @param {MongoClient~sessionCallback} [callback] The callback called with a newly establish session, or an error if one occurred
+ * @return {Promise} if no callback is specified, a promise will be returned for the newly established session
+ */
+MongoClient.prototype.startSession = function(options) {
+  options = options || {};
+  if (!this.topology) {
+    throw new MongoError('Must connect to a server before calling this method');
+  }
+
+  const capabilities = this.topology.capabilities();
+  if (capabilities && !capabilities.hasSessionSupport) {
+    throw new MongoError('Current topology does not support sessions');
+  }
+
+  const session = new ClientSession(this.topology.s.coreTopology, this.s.sessionPool, options);
+  return session;
+};
+
 var mergeOptions = function(target, source, flatten) {
   for (var name in source) {
     if (source[name] && typeof source[name] === 'object' && flatten) {
@@ -611,6 +634,11 @@ function relayEvents(self, topology) {
   });
 }
 
+function assignTopology(client, topology) {
+  client.topology = topology;
+  client.s.sessionPool = new ServerSessionPool(topology.s.coreTopology);
+}
+
 function createServer(self, options, callback) {
   // Set default options
   var servers = translateOptions(options);
@@ -629,8 +657,9 @@ function createServer(self, options, callback) {
     addListeners(self, servers[0]);
     // Check if we are really speaking to a mongos
     var ismaster = topology.lastIsMaster();
+
     // Set the topology
-    self.topology = topology;
+    assignTopology(self, topology);
 
     // Do we actually have a mongos
     if (ismaster && ismaster.msg === 'isdbgrid') {
@@ -659,7 +688,8 @@ function createReplicaset(self, options, callback) {
   // Open the connection
   topology.connect(options, function(err, topology) {
     if (err) return callback(err);
-    self.topology = topology;
+
+    assignTopology(self, topology);
     callback(null, topology);
   });
 }
@@ -676,7 +706,8 @@ function createMongos(self, options, callback) {
   // Open the connection
   topology.connect(options, function(err, topology) {
     if (err) return callback(err);
-    self.topology = topology;
+
+    assignTopology(self, topology);
     callback(null, topology);
   });
 }
@@ -772,7 +803,8 @@ var connect = function(self, url, options, callback) {
   // Did we pass in a Server/ReplSet/Mongos
   if (url instanceof Server || url instanceof ReplSet || url instanceof Mongos) {
     // Set the topology
-    self.topology = url;
+    assignTopology(self, url);
+
     // Add listeners
     addListeners(self, url);
     // Connect

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -266,6 +266,13 @@ Object.defineProperty(Mongos.prototype, 'haInterval', {
   }
 });
 
+Object.defineProperty(Mongos.prototype, 'logicalSessionTimeoutMinutes', {
+  enumerable: true,
+  get: function() {
+    return this.s.coreTopology.logicalSessionTimeoutMinutes;
+  }
+});
+
 // Connect
 Mongos.prototype.connect = function(db, _options, callback) {
   var self = this;

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -210,17 +210,12 @@ var Mongos = function(servers, options) {
     clonedOptions.clientInfo.application = { name: options.appname };
   }
 
-  // Create the Mongos
-  var mongos = new CMongos(seedlist, clonedOptions);
-  // Server capabilities
-  var sCapabilities = null;
-
   // Internal state
   this.s = {
     // Create the Mongos
-    mongos: mongos,
+    coreTopology: new CMongos(seedlist, clonedOptions),
     // Server capabilities
-    sCapabilities: sCapabilities,
+    sCapabilities: null,
     // Debug turned on
     debug: clonedOptions.debug,
     // Store option defaults
@@ -245,14 +240,14 @@ inherits(Mongos, EventEmitter);
 Object.defineProperty(Mongos.prototype, 'isMasterDoc', {
   enumerable: true,
   get: function() {
-    return this.s.mongos.lastIsMaster();
+    return this.s.coreTopology.lastIsMaster();
   }
 });
 
 Object.defineProperty(Mongos.prototype, 'parserType', {
   enumerable: true,
   get: function() {
-    return this.s.mongos.parserType;
+    return this.s.coreTopology.parserType;
   }
 });
 
@@ -260,14 +255,14 @@ Object.defineProperty(Mongos.prototype, 'parserType', {
 Object.defineProperty(Mongos.prototype, 'bson', {
   enumerable: true,
   get: function() {
-    return this.s.mongos.s.bson;
+    return this.s.coreTopology.s.bson;
   }
 });
 
 Object.defineProperty(Mongos.prototype, 'haInterval', {
   enumerable: true,
   get: function() {
-    return this.s.mongos.s.haInterval;
+    return this.s.coreTopology.s.haInterval;
   }
 });
 
@@ -292,7 +287,7 @@ Mongos.prototype.connect = function(db, _options, callback) {
         self.removeListener(e, connectErrorHandler);
       });
 
-      self.s.mongos.removeListener('connect', connectErrorHandler);
+      self.s.coreTopology.removeListener('connect', connectErrorHandler);
       // Force close the topology
       self.close(true);
 
@@ -334,16 +329,16 @@ Mongos.prototype.connect = function(db, _options, callback) {
     // Clear out all the current handlers left over
     var events = ['timeout', 'error', 'close', 'fullsetup'];
     events.forEach(function(e) {
-      self.s.mongos.removeAllListeners(e);
+      self.s.coreTopology.removeAllListeners(e);
     });
 
     // Set up listeners
-    self.s.mongos.once('timeout', errorHandler('timeout'));
-    self.s.mongos.once('error', errorHandler('error'));
-    self.s.mongos.once('close', errorHandler('close'));
+    self.s.coreTopology.once('timeout', errorHandler('timeout'));
+    self.s.coreTopology.once('error', errorHandler('error'));
+    self.s.coreTopology.once('close', errorHandler('close'));
 
     // Set up serverConfig listeners
-    self.s.mongos.on('fullsetup', function() {
+    self.s.coreTopology.on('fullsetup', function() {
       self.emit('fullsetup', self);
     });
 
@@ -376,41 +371,41 @@ Mongos.prototype.connect = function(db, _options, callback) {
     'topologyDescriptionChanged'
   ];
   events.forEach(function(e) {
-    self.s.mongos.removeAllListeners(e);
+    self.s.coreTopology.removeAllListeners(e);
   });
 
   // Set up SDAM listeners
-  self.s.mongos.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
-  self.s.mongos.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
-  self.s.mongos.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
-  self.s.mongos.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
-  self.s.mongos.on('serverOpening', relay('serverOpening'));
-  self.s.mongos.on('serverClosed', relay('serverClosed'));
-  self.s.mongos.on('topologyOpening', relay('topologyOpening'));
-  self.s.mongos.on('topologyClosed', relay('topologyClosed'));
-  self.s.mongos.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
+  self.s.coreTopology.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
+  self.s.coreTopology.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
+  self.s.coreTopology.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
+  self.s.coreTopology.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
+  self.s.coreTopology.on('serverOpening', relay('serverOpening'));
+  self.s.coreTopology.on('serverClosed', relay('serverClosed'));
+  self.s.coreTopology.on('topologyOpening', relay('topologyOpening'));
+  self.s.coreTopology.on('topologyClosed', relay('topologyClosed'));
+  self.s.coreTopology.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
 
   // Set up listeners
-  self.s.mongos.once('timeout', connectErrorHandler('timeout'));
-  self.s.mongos.once('error', connectErrorHandler('error'));
-  self.s.mongos.once('close', connectErrorHandler('close'));
-  self.s.mongos.once('connect', connectHandler);
+  self.s.coreTopology.once('timeout', connectErrorHandler('timeout'));
+  self.s.coreTopology.once('error', connectErrorHandler('error'));
+  self.s.coreTopology.once('close', connectErrorHandler('close'));
+  self.s.coreTopology.once('connect', connectHandler);
   // Join and leave events
-  self.s.mongos.on('joined', relay('joined'));
-  self.s.mongos.on('left', relay('left'));
+  self.s.coreTopology.on('joined', relay('joined'));
+  self.s.coreTopology.on('left', relay('left'));
 
   // Reconnect server
-  self.s.mongos.on('reconnect', reconnectHandler);
+  self.s.coreTopology.on('reconnect', reconnectHandler);
 
   // Start connection
-  self.s.mongos.connect(_options);
+  self.s.coreTopology.connect(_options);
 };
 
 // Server capabilities
 Mongos.prototype.capabilities = function() {
   if (this.s.sCapabilities) return this.s.sCapabilities;
-  if (this.s.mongos.lastIsMaster() == null) return null;
-  this.s.sCapabilities = new ServerCapabilities(this.s.mongos.lastIsMaster());
+  if (this.s.coreTopology.lastIsMaster() == null) return null;
+  this.s.sCapabilities = new ServerCapabilities(this.s.coreTopology.lastIsMaster());
   return this.s.sCapabilities;
 };
 
@@ -422,14 +417,14 @@ define.classMethod('capabilities', {
 
 // Command
 Mongos.prototype.command = function(ns, cmd, options, callback) {
-  this.s.mongos.command(ns, cmd, getReadPreference(options), callback);
+  this.s.coreTopology.command(ns, cmd, getReadPreference(options), callback);
 };
 
 define.classMethod('command', { callback: true, promise: false });
 
 // Insert
 Mongos.prototype.insert = function(ns, ops, options, callback) {
-  this.s.mongos.insert(ns, ops, options, function(e, m) {
+  this.s.coreTopology.insert(ns, ops, options, function(e, m) {
     callback(e, m);
   });
 };
@@ -438,26 +433,26 @@ define.classMethod('insert', { callback: true, promise: false });
 
 // Update
 Mongos.prototype.update = function(ns, ops, options, callback) {
-  this.s.mongos.update(ns, ops, options, callback);
+  this.s.coreTopology.update(ns, ops, options, callback);
 };
 
 define.classMethod('update', { callback: true, promise: false });
 
 // Remove
 Mongos.prototype.remove = function(ns, ops, options, callback) {
-  this.s.mongos.remove(ns, ops, options, callback);
+  this.s.coreTopology.remove(ns, ops, options, callback);
 };
 
 define.classMethod('remove', { callback: true, promise: false });
 
 // Destroyed
 Mongos.prototype.isDestroyed = function() {
-  return this.s.mongos.isDestroyed();
+  return this.s.coreTopology.isDestroyed();
 };
 
 // IsConnected
 Mongos.prototype.isConnected = function() {
-  return this.s.mongos.isConnected();
+  return this.s.coreTopology.isConnected();
 };
 
 define.classMethod('isConnected', { callback: false, promise: false, returns: [Boolean] });
@@ -465,7 +460,7 @@ define.classMethod('isConnected', { callback: false, promise: false, returns: [B
 // Insert
 Mongos.prototype.cursor = function(ns, cmd, options) {
   options.disconnectHandler = this.s.store;
-  return this.s.mongos.cursor(ns, cmd, options);
+  return this.s.coreTopology.cursor(ns, cmd, options);
 };
 
 define.classMethod('cursor', {
@@ -475,7 +470,7 @@ define.classMethod('cursor', {
 });
 
 Mongos.prototype.lastIsMaster = function() {
-  return this.s.mongos.lastIsMaster();
+  return this.s.coreTopology.lastIsMaster();
 };
 
 /**
@@ -483,11 +478,11 @@ Mongos.prototype.lastIsMaster = function() {
  * @method
  */
 Mongos.prototype.unref = function() {
-  return this.s.mongos.unref();
+  return this.s.coreTopology.unref();
 };
 
 Mongos.prototype.close = function(forceClosed) {
-  this.s.mongos.destroy({
+  this.s.coreTopology.destroy({
     force: typeof forceClosed === 'boolean' ? forceClosed : false
   });
   // We need to wash out all stored processes
@@ -501,14 +496,14 @@ define.classMethod('close', { callback: false, promise: false });
 
 Mongos.prototype.auth = function() {
   var args = Array.prototype.slice.call(arguments, 0);
-  this.s.mongos.auth.apply(this.s.mongos, args);
+  this.s.coreTopology.auth.apply(this.s.coreTopology, args);
 };
 
 define.classMethod('auth', { callback: true, promise: false });
 
 Mongos.prototype.logout = function() {
   var args = Array.prototype.slice.call(arguments, 0);
-  this.s.mongos.logout.apply(this.s.mongos, args);
+  this.s.coreTopology.logout.apply(this.s.coreTopology, args);
 };
 
 define.classMethod('logout', { callback: true, promise: false });
@@ -519,7 +514,7 @@ define.classMethod('logout', { callback: true, promise: false });
  * @return {array}
  */
 Mongos.prototype.connections = function() {
-  return this.s.mongos.connections();
+  return this.s.coreTopology.connections();
 };
 
 define.classMethod('connections', { callback: false, promise: false, returns: [Array] });

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -291,6 +291,13 @@ Object.defineProperty(ReplSet.prototype, 'haInterval', {
   }
 });
 
+Object.defineProperty(ReplSet.prototype, 'logicalSessionTimeoutMinutes', {
+  enumerable: true,
+  get: function() {
+    return this.s.coreTopology.logicalSessionTimeoutMinutes;
+  }
+});
+
 var define = (ReplSet.define = new Define('ReplSet', ReplSet, false));
 
 // Ensure the right read Preference object

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -218,10 +218,10 @@ var ReplSet = function(servers, options) {
   }
 
   // Create the ReplSet
-  var replset = new CReplSet(seedlist, clonedOptions);
+  var coreTopology = new CReplSet(seedlist, clonedOptions);
 
   // Listen to reconnect event
-  replset.on('reconnect', function() {
+  coreTopology.on('reconnect', function() {
     self.emit('reconnect');
     store.execute();
   });
@@ -229,7 +229,7 @@ var ReplSet = function(servers, options) {
   // Internal state
   this.s = {
     // Replicaset
-    replset: replset,
+    coreTopology: coreTopology,
     // Server capabilities
     sCapabilities: null,
     // Debug tag
@@ -250,7 +250,7 @@ var ReplSet = function(servers, options) {
     Object.defineProperty(this, 'replset', {
       enumerable: true,
       get: function() {
-        return replset;
+        return coreTopology;
       }
     });
   }
@@ -265,14 +265,14 @@ inherits(ReplSet, EventEmitter);
 Object.defineProperty(ReplSet.prototype, 'isMasterDoc', {
   enumerable: true,
   get: function() {
-    return this.s.replset.lastIsMaster();
+    return this.s.coreTopology.lastIsMaster();
   }
 });
 
 Object.defineProperty(ReplSet.prototype, 'parserType', {
   enumerable: true,
   get: function() {
-    return this.s.replset.parserType;
+    return this.s.coreTopology.parserType;
   }
 });
 
@@ -280,14 +280,14 @@ Object.defineProperty(ReplSet.prototype, 'parserType', {
 Object.defineProperty(ReplSet.prototype, 'bson', {
   enumerable: true,
   get: function() {
-    return this.s.replset.s.bson;
+    return this.s.coreTopology.s.bson;
   }
 });
 
 Object.defineProperty(ReplSet.prototype, 'haInterval', {
   enumerable: true,
   get: function() {
-    return this.s.replset.s.haInterval;
+    return this.s.coreTopology.s.haInterval;
   }
 });
 
@@ -349,7 +349,7 @@ ReplSet.prototype.connect = function(db, _options, callback) {
     'ha'
   ];
   events.forEach(function(e) {
-    self.s.replset.removeAllListeners(e);
+    self.s.coreTopology.removeAllListeners(e);
   });
 
   // relay the event
@@ -378,36 +378,36 @@ ReplSet.prototype.connect = function(db, _options, callback) {
   };
 
   // Set up serverConfig listeners
-  self.s.replset.on('joined', replsetRelay('joined'));
-  self.s.replset.on('left', relay('left'));
-  self.s.replset.on('ping', relay('ping'));
-  self.s.replset.on('ha', relayHa);
+  self.s.coreTopology.on('joined', replsetRelay('joined'));
+  self.s.coreTopology.on('left', relay('left'));
+  self.s.coreTopology.on('ping', relay('ping'));
+  self.s.coreTopology.on('ha', relayHa);
 
   // Set up SDAM listeners
-  self.s.replset.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
-  self.s.replset.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
-  self.s.replset.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
-  self.s.replset.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
-  self.s.replset.on('serverOpening', relay('serverOpening'));
-  self.s.replset.on('serverClosed', relay('serverClosed'));
-  self.s.replset.on('topologyOpening', relay('topologyOpening'));
-  self.s.replset.on('topologyClosed', relay('topologyClosed'));
-  self.s.replset.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
+  self.s.coreTopology.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
+  self.s.coreTopology.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
+  self.s.coreTopology.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
+  self.s.coreTopology.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
+  self.s.coreTopology.on('serverOpening', relay('serverOpening'));
+  self.s.coreTopology.on('serverClosed', relay('serverClosed'));
+  self.s.coreTopology.on('topologyOpening', relay('topologyOpening'));
+  self.s.coreTopology.on('topologyClosed', relay('topologyClosed'));
+  self.s.coreTopology.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
 
-  self.s.replset.on('fullsetup', function() {
+  self.s.coreTopology.on('fullsetup', function() {
     self.emit('fullsetup', self, self);
   });
 
-  self.s.replset.on('all', function() {
+  self.s.coreTopology.on('all', function() {
     self.emit('all', null, self);
   });
 
   // Connect handler
   var connectHandler = function() {
     // Set up listeners
-    self.s.replset.once('timeout', errorHandler('timeout'));
-    self.s.replset.once('error', errorHandler('error'));
-    self.s.replset.once('close', errorHandler('close'));
+    self.s.coreTopology.once('timeout', errorHandler('timeout'));
+    self.s.coreTopology.once('error', errorHandler('error'));
+    self.s.coreTopology.once('close', errorHandler('close'));
 
     // Emit open event
     self.emit('open', null, self);
@@ -426,18 +426,18 @@ ReplSet.prototype.connect = function(db, _options, callback) {
   var connectErrorHandler = function() {
     return function(err) {
       ['timeout', 'error', 'close'].forEach(function(e) {
-        self.s.replset.removeListener(e, connectErrorHandler);
+        self.s.coreTopology.removeListener(e, connectErrorHandler);
       });
 
-      self.s.replset.removeListener('connect', connectErrorHandler);
+      self.s.coreTopology.removeListener('connect', connectErrorHandler);
       // Destroy the replset
-      self.s.replset.destroy();
+      self.s.coreTopology.destroy();
 
       // Try to callback
       try {
         callback(err);
       } catch (err) {
-        if (!self.s.replset.isConnected())
+        if (!self.s.coreTopology.isConnected())
           process.nextTick(function() {
             throw err;
           });
@@ -446,20 +446,20 @@ ReplSet.prototype.connect = function(db, _options, callback) {
   };
 
   // Set up listeners
-  self.s.replset.once('timeout', connectErrorHandler('timeout'));
-  self.s.replset.once('error', connectErrorHandler('error'));
-  self.s.replset.once('close', connectErrorHandler('close'));
-  self.s.replset.once('connect', connectHandler);
+  self.s.coreTopology.once('timeout', connectErrorHandler('timeout'));
+  self.s.coreTopology.once('error', connectErrorHandler('error'));
+  self.s.coreTopology.once('close', connectErrorHandler('close'));
+  self.s.coreTopology.once('connect', connectHandler);
 
   // Start connection
-  self.s.replset.connect(_options);
+  self.s.coreTopology.connect(_options);
 };
 
 // Server capabilities
 ReplSet.prototype.capabilities = function() {
   if (this.s.sCapabilities) return this.s.sCapabilities;
-  if (this.s.replset.lastIsMaster() == null) return null;
-  this.s.sCapabilities = new ServerCapabilities(this.s.replset.lastIsMaster());
+  if (this.s.coreTopology.lastIsMaster() == null) return null;
+  this.s.sCapabilities = new ServerCapabilities(this.s.coreTopology.lastIsMaster());
   return this.s.sCapabilities;
 };
 
@@ -471,35 +471,35 @@ define.classMethod('capabilities', {
 
 // Command
 ReplSet.prototype.command = function(ns, cmd, options, callback) {
-  this.s.replset.command(ns, cmd, getReadPreference(options), callback);
+  this.s.coreTopology.command(ns, cmd, getReadPreference(options), callback);
 };
 
 define.classMethod('command', { callback: true, promise: false });
 
 // Insert
 ReplSet.prototype.insert = function(ns, ops, options, callback) {
-  this.s.replset.insert(ns, ops, options, callback);
+  this.s.coreTopology.insert(ns, ops, options, callback);
 };
 
 define.classMethod('insert', { callback: true, promise: false });
 
 // Update
 ReplSet.prototype.update = function(ns, ops, options, callback) {
-  this.s.replset.update(ns, ops, options, callback);
+  this.s.coreTopology.update(ns, ops, options, callback);
 };
 
 define.classMethod('update', { callback: true, promise: false });
 
 // Remove
 ReplSet.prototype.remove = function(ns, ops, options, callback) {
-  this.s.replset.remove(ns, ops, options, callback);
+  this.s.coreTopology.remove(ns, ops, options, callback);
 };
 
 define.classMethod('remove', { callback: true, promise: false });
 
 // Destroyed
 ReplSet.prototype.isDestroyed = function() {
-  return this.s.replset.isDestroyed();
+  return this.s.coreTopology.isDestroyed();
 };
 
 // IsConnected
@@ -512,7 +512,7 @@ ReplSet.prototype.isConnected = function(options) {
     options.readPreference = translateReadPreference(options.readPreference);
   }
 
-  return this.s.replset.isConnected(options);
+  return this.s.coreTopology.isConnected(options);
 };
 
 define.classMethod('isConnected', { callback: false, promise: false, returns: [Boolean] });
@@ -521,7 +521,7 @@ define.classMethod('isConnected', { callback: false, promise: false, returns: [B
 ReplSet.prototype.cursor = function(ns, cmd, options) {
   options = translateReadPreference(options);
   options.disconnectHandler = this.s.store;
-  return this.s.replset.cursor(ns, cmd, options);
+  return this.s.coreTopology.cursor(ns, cmd, options);
 };
 
 define.classMethod('cursor', {
@@ -531,7 +531,7 @@ define.classMethod('cursor', {
 });
 
 ReplSet.prototype.lastIsMaster = function() {
-  return this.s.replset.lastIsMaster();
+  return this.s.coreTopology.lastIsMaster();
 };
 
 /**
@@ -539,13 +539,13 @@ ReplSet.prototype.lastIsMaster = function() {
  * @method
  */
 ReplSet.prototype.unref = function() {
-  return this.s.replset.unref();
+  return this.s.coreTopology.unref();
 };
 
 ReplSet.prototype.close = function(forceClosed) {
   var self = this;
   // Call destroy on the topology
-  this.s.replset.destroy({
+  this.s.coreTopology.destroy({
     force: typeof forceClosed === 'boolean' ? forceClosed : false
   });
   // We need to wash out all stored processes
@@ -564,14 +564,14 @@ define.classMethod('close', { callback: false, promise: false });
 
 ReplSet.prototype.auth = function() {
   var args = Array.prototype.slice.call(arguments, 0);
-  this.s.replset.auth.apply(this.s.replset, args);
+  this.s.coreTopology.auth.apply(this.s.coreTopology, args);
 };
 
 define.classMethod('auth', { callback: true, promise: false });
 
 ReplSet.prototype.logout = function() {
   var args = Array.prototype.slice.call(arguments, 0);
-  this.s.replset.logout.apply(this.s.replset, args);
+  this.s.coreTopology.logout.apply(this.s.coreTopology, args);
 };
 
 define.classMethod('logout', { callback: true, promise: false });
@@ -582,7 +582,7 @@ define.classMethod('logout', { callback: true, promise: false });
  * @return {array}
  */
 ReplSet.prototype.connections = function() {
-  return this.s.replset.connections();
+  return this.s.coreTopology.connections();
 };
 
 define.classMethod('connections', { callback: false, promise: false, returns: [Array] });

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -205,13 +205,10 @@ var Server = function(host, port, options) {
     clonedOptions.clientInfo.application = { name: options.appname };
   }
 
-  // Create an instance of a server instance from mongodb-core
-  var server = new CServer(clonedOptions);
-
   // Define the internal properties
   this.s = {
     // Create an instance of a server instance from mongodb-core
-    server: server,
+    coreTopology: new CServer(clonedOptions),
     // Server capabilities
     sCapabilities: null,
     // Cloned options
@@ -243,7 +240,7 @@ var define = (Server.define = new Define('Server', Server, false));
 Object.defineProperty(Server.prototype, 'bson', {
   enumerable: true,
   get: function() {
-    return this.s.server.s.bson;
+    return this.s.coreTopology.s.bson;
   }
 });
 
@@ -251,14 +248,14 @@ Object.defineProperty(Server.prototype, 'bson', {
 Object.defineProperty(Server.prototype, 'isMasterDoc', {
   enumerable: true,
   get: function() {
-    return this.s.server.lastIsMaster();
+    return this.s.coreTopology.lastIsMaster();
   }
 });
 
 Object.defineProperty(Server.prototype, 'parserType', {
   enumerable: true,
   get: function() {
-    return this.s.server.parserType;
+    return this.s.coreTopology.parserType;
   }
 });
 
@@ -266,7 +263,7 @@ Object.defineProperty(Server.prototype, 'parserType', {
 Object.defineProperty(Server.prototype, 'poolSize', {
   enumerable: true,
   get: function() {
-    return this.s.server.connections().length;
+    return this.s.coreTopology.connections().length;
   }
 });
 
@@ -311,10 +308,10 @@ Server.prototype.connect = function(_options, callback) {
       // Remove all event handlers
       var events = ['timeout', 'error', 'close'];
       events.forEach(function(e) {
-        self.s.server.removeListener(e, connectHandlers[e]);
+        self.s.coreTopology.removeListener(e, connectHandlers[e]);
       });
 
-      self.s.server.removeListener('connect', connectErrorHandler);
+      self.s.coreTopology.removeListener('connect', connectErrorHandler);
 
       // Try to callback
       try {
@@ -364,15 +361,15 @@ Server.prototype.connect = function(_options, callback) {
   var connectHandler = function() {
     // Clear out all the current handlers left over
     ['timeout', 'error', 'close', 'destroy'].forEach(function(e) {
-      self.s.server.removeAllListeners(e);
+      self.s.coreTopology.removeAllListeners(e);
     });
 
     // Set up listeners
-    self.s.server.on('timeout', errorHandler('timeout'));
-    self.s.server.once('error', errorHandler('error'));
-    self.s.server.on('close', errorHandler('close'));
+    self.s.coreTopology.on('timeout', errorHandler('timeout'));
+    self.s.coreTopology.once('error', errorHandler('error'));
+    self.s.coreTopology.on('close', errorHandler('close'));
     // Only called on destroy
-    self.s.server.on('destroy', destroyHandler);
+    self.s.coreTopology.on('destroy', destroyHandler);
 
     // Emit open event
     self.emit('open', null, self);
@@ -410,40 +407,40 @@ Server.prototype.connect = function(_options, callback) {
     'topologyClosed',
     'topologyDescriptionChanged'
   ].forEach(function(e) {
-    self.s.server.removeAllListeners(e);
+    self.s.coreTopology.removeAllListeners(e);
   });
 
   // Add the event handlers
-  self.s.server.once('timeout', connectHandlers.timeout);
-  self.s.server.once('error', connectHandlers.error);
-  self.s.server.once('close', connectHandlers.close);
-  self.s.server.once('connect', connectHandler);
+  self.s.coreTopology.once('timeout', connectHandlers.timeout);
+  self.s.coreTopology.once('error', connectHandlers.error);
+  self.s.coreTopology.once('close', connectHandlers.close);
+  self.s.coreTopology.once('connect', connectHandler);
   // Reconnect server
-  self.s.server.on('reconnect', reconnectHandler);
-  self.s.server.on('reconnectFailed', reconnectFailedHandler);
+  self.s.coreTopology.on('reconnect', reconnectHandler);
+  self.s.coreTopology.on('reconnectFailed', reconnectFailedHandler);
 
   // Set up SDAM listeners
-  self.s.server.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
-  self.s.server.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
-  self.s.server.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
-  self.s.server.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
-  self.s.server.on('serverOpening', relay('serverOpening'));
-  self.s.server.on('serverClosed', relay('serverClosed'));
-  self.s.server.on('topologyOpening', relay('topologyOpening'));
-  self.s.server.on('topologyClosed', relay('topologyClosed'));
-  self.s.server.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
-  self.s.server.on('attemptReconnect', relay('attemptReconnect'));
-  self.s.server.on('monitoring', relay('monitoring'));
+  self.s.coreTopology.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
+  self.s.coreTopology.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
+  self.s.coreTopology.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
+  self.s.coreTopology.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
+  self.s.coreTopology.on('serverOpening', relay('serverOpening'));
+  self.s.coreTopology.on('serverClosed', relay('serverClosed'));
+  self.s.coreTopology.on('topologyOpening', relay('topologyOpening'));
+  self.s.coreTopology.on('topologyClosed', relay('topologyClosed'));
+  self.s.coreTopology.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
+  self.s.coreTopology.on('attemptReconnect', relay('attemptReconnect'));
+  self.s.coreTopology.on('monitoring', relay('monitoring'));
 
   // Start connection
-  self.s.server.connect(_options);
+  self.s.coreTopology.connect(_options);
 };
 
 // Server capabilities
 Server.prototype.capabilities = function() {
   if (this.s.sCapabilities) return this.s.sCapabilities;
-  if (this.s.server.lastIsMaster() == null) return null;
-  this.s.sCapabilities = new ServerCapabilities(this.s.server.lastIsMaster());
+  if (this.s.coreTopology.lastIsMaster() == null) return null;
+  this.s.sCapabilities = new ServerCapabilities(this.s.coreTopology.lastIsMaster());
   return this.s.sCapabilities;
 };
 
@@ -455,39 +452,39 @@ define.classMethod('capabilities', {
 
 // Command
 Server.prototype.command = function(ns, cmd, options, callback) {
-  this.s.server.command(ns, cmd, getReadPreference(options), callback);
+  this.s.coreTopology.command(ns, cmd, getReadPreference(options), callback);
 };
 
 define.classMethod('command', { callback: true, promise: false });
 
 // Insert
 Server.prototype.insert = function(ns, ops, options, callback) {
-  this.s.server.insert(ns, ops, options, callback);
+  this.s.coreTopology.insert(ns, ops, options, callback);
 };
 
 define.classMethod('insert', { callback: true, promise: false });
 
 // Update
 Server.prototype.update = function(ns, ops, options, callback) {
-  this.s.server.update(ns, ops, options, callback);
+  this.s.coreTopology.update(ns, ops, options, callback);
 };
 
 define.classMethod('update', { callback: true, promise: false });
 
 // Remove
 Server.prototype.remove = function(ns, ops, options, callback) {
-  this.s.server.remove(ns, ops, options, callback);
+  this.s.coreTopology.remove(ns, ops, options, callback);
 };
 
 define.classMethod('remove', { callback: true, promise: false });
 
 // IsConnected
 Server.prototype.isConnected = function() {
-  return this.s.server.isConnected();
+  return this.s.coreTopology.isConnected();
 };
 
 Server.prototype.isDestroyed = function() {
-  return this.s.server.isDestroyed();
+  return this.s.coreTopology.isDestroyed();
 };
 
 define.classMethod('isConnected', { callback: false, promise: false, returns: [Boolean] });
@@ -495,7 +492,7 @@ define.classMethod('isConnected', { callback: false, promise: false, returns: [B
 // Insert
 Server.prototype.cursor = function(ns, cmd, options) {
   options.disconnectHandler = this.s.store;
-  return this.s.server.cursor(ns, cmd, options);
+  return this.s.coreTopology.cursor(ns, cmd, options);
 };
 
 define.classMethod('cursor', {
@@ -505,7 +502,7 @@ define.classMethod('cursor', {
 });
 
 Server.prototype.lastIsMaster = function() {
-  return this.s.server.lastIsMaster();
+  return this.s.coreTopology.lastIsMaster();
 };
 
 /**
@@ -513,11 +510,11 @@ Server.prototype.lastIsMaster = function() {
  * @method
  */
 Server.prototype.unref = function() {
-  this.s.server.unref();
+  this.s.coreTopology.unref();
 };
 
 Server.prototype.close = function(forceClosed) {
-  this.s.server.destroy();
+  this.s.coreTopology.destroy();
   // We need to wash out all stored processes
   if (forceClosed === true) {
     this.s.storeOptions.force = forceClosed;
@@ -529,14 +526,14 @@ define.classMethod('close', { callback: false, promise: false });
 
 Server.prototype.auth = function() {
   var args = Array.prototype.slice.call(arguments, 0);
-  this.s.server.auth.apply(this.s.server, args);
+  this.s.coreTopology.auth.apply(this.s.coreTopology, args);
 };
 
 define.classMethod('auth', { callback: true, promise: false });
 
 Server.prototype.logout = function() {
   var args = Array.prototype.slice.call(arguments, 0);
-  this.s.server.logout.apply(this.s.server, args);
+  this.s.coreTopology.logout.apply(this.s.coreTopology, args);
 };
 
 define.classMethod('logout', { callback: true, promise: false });
@@ -547,7 +544,7 @@ define.classMethod('logout', { callback: true, promise: false });
  * @return {array}
  */
 Server.prototype.connections = function() {
-  return this.s.server.connections();
+  return this.s.coreTopology.connections();
 };
 
 define.classMethod('connections', { callback: false, promise: false, returns: [Array] });

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -288,6 +288,13 @@ Object.defineProperty(Server.prototype, 'port', {
   }
 });
 
+Object.defineProperty(Server.prototype, 'logicalSessionTimeoutMinutes', {
+  enumerable: true,
+  get: function() {
+    return this.s.coreTopology.logicalSessionTimeoutMinutes;
+  }
+});
+
 // Connect
 // Server.prototype.connect = function(db, _options, callback) {
 Server.prototype.connect = function(_options, callback) {

--- a/lib/topologies/topology_base.js
+++ b/lib/topologies/topology_base.js
@@ -203,6 +203,7 @@ var ServerCapabilities = function(ismaster) {
   var maxNumberOfDocsInBatch = ismaster.maxWriteBatchSize || 1000;
   var commandsTakeWriteConcern = false;
   var commandsTakeCollation = false;
+  var sessionSupport = false;
 
   if (ismaster.minWireVersion >= 0) {
     textSearch = true;
@@ -236,6 +237,10 @@ var ServerCapabilities = function(ismaster) {
     ismaster.maxWireVersion = 0;
   }
 
+  if (typeof ismaster.logicalSessionTimeoutMinutes !== 'undefined') {
+    sessionSupport = true;
+  }
+
   // Map up read only parameters
   setup_get_property(this, 'hasAggregationCursor', aggregationCursor);
   setup_get_property(this, 'hasWriteCommands', writeCommands);
@@ -248,6 +253,7 @@ var ServerCapabilities = function(ismaster) {
   setup_get_property(this, 'maxNumberOfDocsInBatch', maxNumberOfDocsInBatch);
   setup_get_property(this, 'commandsTakeWriteConcern', commandsTakeWriteConcern);
   setup_get_property(this, 'commandsTakeCollation', commandsTakeCollation);
+  setup_get_property(this, 'hasSessionSupport', sessionSupport);
 };
 
 exports.Store = Store;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -376,6 +376,61 @@ var mergeOptionsAndWriteConcern = function(targetOptions, sourceOptions, keys, m
   return targetOptions;
 };
 
+/**
+ * Executes the given operation with provided arguments.
+ *
+ * This method reduces large amounts of duplication in the entire codebase by providing
+ * a single point for determining whether callbacks or promises should be used. Additionally
+ * it allows for a single point of entry to provide features such as implicit sessions, which
+ * are required by the Driver Sessions specification in the event that a ClientSession is
+ * not provided
+ *
+ * @param {object} self The originating class for operation execution, used primarily to find a refernce to the Promise library
+ * @param {function} operation The operation to execute
+ * @param {array} args Arguments to apply the provided operation
+ * @param {object} [options] Options that modify the behavior of the method
+ * @param {function]} [options.resultMutator] Allows for the result of the operation to be changed for custom return types
+ */
+const executeOperation = (self, operation, args, options) => {
+  if (!Array.isArray(args)) {
+    throw new TypeError('This method requires an array of arguments to apply');
+  }
+
+  options = options || {};
+  const Promise = self.s.promiseLibrary;
+  let resultMutator = options.resultMutator;
+  let callback = args[args.length - 1];
+
+  // Execute using callback
+  if (typeof callback === 'function') {
+    if (resultMutator) {
+      callback = args.pop();
+
+      args.push(
+        (err, result) => (err ? callback(err, null) : callback(null, resultMutator(result)))
+      );
+    }
+
+    return operation.apply(null, args);
+  }
+
+  // Return a Promise
+  if (args[args.length - 1] != null) {
+    console.dir(operation.name);
+    throw new TypeError('final argument to `executeOperation` must be a callback');
+  }
+
+  return new Promise(function(resolve, reject) {
+    args[args.length - 1] = (err, r) => {
+      if (err) return reject(err);
+      if (resultMutator) return resolve(resultMutator(r));
+      resolve(r);
+    };
+
+    operation.apply(null, args);
+  });
+};
+
 exports.filterOptions = filterOptions;
 exports.mergeOptions = mergeOptions;
 exports.translateOptions = translateOptions;
@@ -394,3 +449,4 @@ exports.MAX_JS_INT = 0x20000000000000;
 exports.assign = assign;
 exports.mergeOptionsAndWriteConcern = mergeOptionsAndWriteConcern;
 exports.getReadPreference = getReadPreference;
+exports.executeOperation = executeOperation;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -397,7 +397,7 @@ const executeOperation = (self, operation, args, options) => {
   }
 
   options = options || {};
-  const Promise = self.s.promiseLibrary;
+  const Promise = self.s ? self.s.promiseLibrary : self.promiseLibrary;
   let resultMutator = options.resultMutator;
   let callback = args[args.length - 1];
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "official"
   ],
   "dependencies": {
-    "mongodb-core": "mongodb-js/mongodb-core#3.0.0"
+    "mongodb-core": "mongodb-js/mongodb-core#driver-sessions"
   },
   "devDependencies": {
     "betterbenchmarks": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "official"
   ],
   "dependencies": {
-    "mongodb-core": "mongodb-js/mongodb-core#driver-sessions"
+    "mongodb-core": "mongodb-js/mongodb-core#3.0.0"
   },
   "devDependencies": {
     "betterbenchmarks": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "url": "https://github.com/mongodb/node-mongodb-native/issues"
   },
   "scripts": {
-    "test": "mongodb-test-runner -t 60000 test/functional",
+    "test": "mongodb-test-runner -t 60000 test/unit test/functional",
     "coverage": "node_modules/.bin/nyc node test/runner.js -t functional && node_modules/.bin/nyc report --reporter=text-lcov | node_modules/.bin/coveralls",
     "lint": "eslint lib test",
     "format": "prettier --print-width 100 --tab-width 2 --single-quote --write 'test/**/*.js' 'lib/**/*.js'"

--- a/test/functional/authentication_tests.js
+++ b/test/functional/authentication_tests.js
@@ -186,10 +186,7 @@ describe('Authentication', function() {
             });
 
             // Authenticate using the newly added user
-            client.connect('mongodb://admin15:admin15@localhost:27017/admin', function(
-              err,
-              client
-            ) {
+            client.connect(function(err, client) {
               test.equal(null, err);
               client.close();
             });

--- a/test/functional/collations_tests.js
+++ b/test/functional/collations_tests.js
@@ -34,7 +34,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
         singleServer.setMessageHandler(request => {
           var doc = request.document;
 
@@ -49,7 +49,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -85,7 +85,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
         singleServer.setMessageHandler(request => {
           var doc = request.document;
           if (doc.ismaster) {
@@ -99,7 +99,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -127,7 +127,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -143,7 +143,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -176,7 +176,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -192,7 +192,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -222,7 +222,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -238,7 +238,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -270,7 +270,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -286,7 +286,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -326,7 +326,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -342,7 +342,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -380,7 +380,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -396,7 +396,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -424,7 +424,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -440,7 +440,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -472,7 +472,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -488,7 +488,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -519,7 +519,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -535,7 +535,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -567,7 +567,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -583,7 +583,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -614,7 +614,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -639,7 +639,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -667,7 +667,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields, { maxWireVersion: 4 })];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -680,7 +680,7 @@ describe('Collation', function() {
         });
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -688,7 +688,7 @@ describe('Collation', function() {
           db
             .collection('test')
             .findOne({ a: 1 }, { collation: { caseLevel: true } }, function(err) {
-              test.equal('server localhost:32000 does not support collation', err.message);
+              test.equal(`server ${singleServer.uri()} does not support collation`, err.message);
               singleServer.destroy();
               client.close();
               done();
@@ -709,7 +709,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields, { maxWireVersion: 4 })];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -722,13 +722,13 @@ describe('Collation', function() {
         });
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
           // Simple findAndModify command returning the new document
           db.command({ count: 'test', query: {}, collation: { caseLevel: true } }, function(err) {
-            test.equal('server localhost:32000 does not support collation', err.message);
+            test.equal(`server ${singleServer.uri()} does not support collation`, err.message);
 
             client.close();
             done();
@@ -749,7 +749,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -767,7 +767,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -807,7 +807,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields, { maxWireVersion: 4 })];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -821,7 +821,7 @@ describe('Collation', function() {
         });
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -910,7 +910,7 @@ describe('Collation', function() {
       ];
 
       co(function*() {
-        const primaryServer = yield mock.createServer(32000, 'localhost');
+        const primaryServer = yield mock.createServer();
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
 
@@ -980,7 +980,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields)];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
         singleServer.setMessageHandler(request => {
           var doc = request.document;
           if (doc.ismaster) {
@@ -994,7 +994,7 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -1030,7 +1030,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields, { maxWireVersion: 4 })];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -1043,7 +1043,7 @@ describe('Collation', function() {
         });
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -1073,7 +1073,7 @@ describe('Collation', function() {
       var primary = [assign({}, defaultFields, { maxWireVersion: 4 })];
 
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         // Primary state machine
         singleServer.setMessageHandler(request => {
@@ -1086,7 +1086,7 @@ describe('Collation', function() {
         });
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 

--- a/test/functional/collations_tests.js
+++ b/test/functional/collations_tests.js
@@ -351,10 +351,13 @@ describe('Collation', function() {
           var reduce = new Code('function(k,vals) { return 1; }');
 
           // db.collection('test').mapReduce({
-          db.collection('test').mapReduce(map, reduce, {
+          db.collection('test').mapReduce(map,
+          reduce,
+          {
             out: { replace: 'tempCollection' },
             collation: { caseLevel: true }
-          }, function(err) {
+          },
+          function(err) {
             test.equal(null, err);
             test.deepEqual({ caseLevel: true }, commandResult.collation);
 
@@ -778,7 +781,9 @@ describe('Collation', function() {
               }
             },
             { deleteOne: { q: { c: 1 } } }
-          ], { ordered: true }, function(err) {
+          ],
+          { ordered: true },
+          function(err) {
             test.equal(null, err);
             test.ok(commandResult);
             test.deepEqual({ caseLevel: true }, commandResult.updates[0].collation);
@@ -830,7 +835,9 @@ describe('Collation', function() {
               }
             },
             { deleteOne: { q: { c: 1 } } }
-          ], { ordered: true }, function(err) {
+          ],
+          { ordered: true },
+          function(err) {
             test.ok(err);
             test.equal('server/primary/mongos does not support collation', err.message);
 
@@ -946,7 +953,9 @@ describe('Collation', function() {
                   }
                 },
                 { deleteOne: { q: { c: 1 } } }
-              ], { ordered: true }, function(err) {
+              ],
+              { ordered: true },
+              function(err) {
                 test.ok(err);
                 test.equal('server/primary/mongos does not support collation', err.message);
 

--- a/test/functional/command_write_concern_tests.js
+++ b/test/functional/command_write_concern_tests.js
@@ -345,11 +345,13 @@ describe('Command Write Concern', function() {
             test.equal(null, err);
             var db = client.db(configuration.db);
 
-            db.collection('indexOptionDefault').createIndex({ a: 1 }, {
+            db.collection('indexOptionDefault').createIndex({ a: 1 },
+            {
               indexOptionDefaults: true,
               w: 2,
               wtimeout: 1000
-            }, function(err) {
+            },
+            function(err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -459,7 +461,8 @@ describe('Command Write Concern', function() {
             db.collection('indexOptionDefault').drop({
               w: 2,
               wtimeout: 1000
-            }, function(err) {
+            },
+            function(err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -682,7 +685,8 @@ describe('Command Write Concern', function() {
             db.collection('test').dropIndexes({
               w: 2,
               wtimeout: 1000
-            }, function(err) {
+            },
+            function(err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -795,11 +799,14 @@ describe('Command Write Concern', function() {
             var reduce = new Code('function(k,vals) { return 1; }');
 
             // db.collection('test').mapReduce({
-            db.collection('test').mapReduce(map, reduce, {
+            db.collection('test').mapReduce(map,
+            reduce,
+            {
               out: { replace: 'tempCollection' },
               w: 2,
               wtimeout: 1000
-            }, function(err) {
+            },
+            function(err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -48,7 +48,7 @@ describe('Connection', function() {
 
       client.connect(function(err, client) {
         test.equal(null, err);
-        test.equal(false, client.topology.s.server.s.monitoring);
+        test.equal(false, client.topology.s.coreTopology.s.monitoring);
 
         client.close();
         done();
@@ -283,7 +283,7 @@ describe('Connection', function() {
         { auto_reconnect: true, poolSize: 4 },
         connectionTester(configuration, 'testConnectServerOptions', function(client) {
           test.equal(1, client.topology.poolSize);
-          test.equal(4, client.topology.s.server.s.pool.size);
+          test.equal(4, client.topology.s.coreTopology.s.pool.size);
           test.equal(true, client.topology.autoReconnect);
           client.close();
           done();
@@ -312,7 +312,7 @@ describe('Connection', function() {
         },
         connectionTester(configuration, 'testConnectAllOptions', function(client) {
           test.ok(client.topology.poolSize >= 1);
-          test.equal(4, client.topology.s.server.s.pool.size);
+          test.equal(4, client.topology.s.coreTopology.s.pool.size);
           test.equal(true, client.topology.autoReconnect);
           client.close();
           done();

--- a/test/functional/crud_api_tests.js
+++ b/test/functional/crud_api_tests.js
@@ -758,12 +758,15 @@ describe('CRUD API', function() {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
-            db.collection('t5_2').findOneAndReplace({ a: 1 }, { c: 1, b: 1 }, {
+            db.collection('t5_2').findOneAndReplace({ a: 1 },
+            { c: 1, b: 1 },
+            {
               projection: { b: 1, c: 1 },
               sort: { a: 1 },
               returnOriginal: false,
               upsert: true
-            }, function(err, r) {
+            },
+            function(err, r) {
               test.equal(null, err);
               test.equal(1, r.lastErrorObject.n);
               test.equal(1, r.value.b);
@@ -782,12 +785,15 @@ describe('CRUD API', function() {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
-            db.collection('t5_3').findOneAndUpdate({ a: 1 }, { $set: { d: 1 } }, {
+            db.collection('t5_3').findOneAndUpdate({ a: 1 },
+            { $set: { d: 1 } },
+            {
               projection: { b: 1, d: 1 },
               sort: { a: 1 },
               returnOriginal: false,
               upsert: true
-            }, function(err, r) {
+            },
+            function(err, r) {
               test.equal(null, err);
               test.equal(1, r.lastErrorObject.n);
               test.equal(1, r.value.b);

--- a/test/functional/crud_spec_tests.js
+++ b/test/functional/crud_spec_tests.js
@@ -290,13 +290,12 @@ describe('CRUD spec', function() {
 
     const errorHandler = err => {
       if (!err.message.match(/ns not found/)) throw err;
-    }
+    };
 
-    // Test setup
-    var setupPromises = [];
-    setupPromises.push(collection.drop().catch(errorHandler));
+    const dropPromises = [];
+    dropPromises.push(collection.drop().catch(errorHandler));
     if (scenarioTest.outcome.collection && scenarioTest.outcome.collection.name) {
-      setupPromises.push(
+      dropPromises.push(
         context.db
           .collection(scenarioTest.outcome.collection.name)
           .drop()
@@ -304,33 +303,31 @@ describe('CRUD spec', function() {
       );
     }
 
-    if (scenario.data) {
-      setupPromises.push(collection.insertMany(scenario.data));
-    }
-
-    return Promise.all(setupPromises).then(function() {
-      switch (scenarioTest.operation.name) {
-        case 'aggregate':
-          return executeAggregateTest(scenarioTest, context.db, collection);
-        case 'count':
-          return executeCountTest(scenarioTest, context.db, collection);
-        case 'distinct':
-          return executeDistinctTest(scenarioTest, context.db, collection);
-        case 'find':
-          return executeFindTest(scenarioTest, context.db, collection);
-        case 'deleteOne':
-        case 'deleteMany':
-          return executeDeleteTest(scenarioTest, context.db, collection);
-        case 'replaceOne':
-          return executeReplaceTest(scenarioTest, context.db, collection);
-        case 'updateOne':
-        case 'updateMany':
-          return executeUpdateTest(scenarioTest, context.db, collection);
-        case 'findOneAndReplace':
-        case 'findOneAndUpdate':
-        case 'findOneAndDelete':
-          return executeFindOneTest(scenarioTest, context.db, collection);
-      }
-    });
+    return Promise.all([dropPromises])
+      .then(() => (scenario.data ? collection.insertMany(scenario.data) : Promise.resolve()))
+      .then(() => {
+        switch (scenarioTest.operation.name) {
+          case 'aggregate':
+            return executeAggregateTest(scenarioTest, context.db, collection);
+          case 'count':
+            return executeCountTest(scenarioTest, context.db, collection);
+          case 'distinct':
+            return executeDistinctTest(scenarioTest, context.db, collection);
+          case 'find':
+            return executeFindTest(scenarioTest, context.db, collection);
+          case 'deleteOne':
+          case 'deleteMany':
+            return executeDeleteTest(scenarioTest, context.db, collection);
+          case 'replaceOne':
+            return executeReplaceTest(scenarioTest, context.db, collection);
+          case 'updateOne':
+          case 'updateMany':
+            return executeUpdateTest(scenarioTest, context.db, collection);
+          case 'findOneAndReplace':
+          case 'findOneAndUpdate':
+          case 'findOneAndDelete':
+            return executeFindOneTest(scenarioTest, context.db, collection);
+        }
+      });
   }
 });

--- a/test/functional/crud_spec_tests.js
+++ b/test/functional/crud_spec_tests.js
@@ -303,7 +303,7 @@ describe('CRUD spec', function() {
       );
     }
 
-    return Promise.all([dropPromises])
+    return Promise.all(dropPromises)
       .then(() => (scenario.data ? collection.insertMany(scenario.data) : Promise.resolve()))
       .then(() => {
         switch (scenarioTest.operation.name) {

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4140,12 +4140,14 @@ describe('Cursor', function() {
 
         db.collection('cursor_count_test1', { readConcern: { level: 'local' } }).count({
           project: '123'
-        }, {
+        },
+        {
           readConcern: { level: 'local' },
           limit: 5,
           skip: 5,
           hint: { project: 1 }
-        }, function(err) {
+        },
+        function(err) {
           test.equal(null, err);
           test.equal(1, started.length);
           if (started[0].command.readConcern)

--- a/test/functional/decimal128_tests.js
+++ b/test/functional/decimal128_tests.js
@@ -38,7 +38,8 @@ describe('Decimal128', function() {
 
           db.collection('decimal128').findOne({
             id: 1
-          }, function(err, doc) {
+          },
+          function(err, doc) {
             test.equal(null, err);
             test.ok(doc.value instanceof Decimal128);
             test.equal('1', doc.value.toString());

--- a/test/functional/insert_tests.js
+++ b/test/functional/insert_tests.js
@@ -2121,7 +2121,8 @@ describe('Insert', function() {
         db.collection('shouldCorrectlyHonorPromoteLong').insert({
           doc: Long.fromNumber(10),
           array: [[Long.fromNumber(10)]]
-        }, function(err, doc) {
+        },
+        function(err, doc) {
           test.equal(null, err);
           test.ok(doc);
 
@@ -2226,7 +2227,8 @@ describe('Insert', function() {
         db.collection('shouldCorrectlyHonorPromoteLongTrueNativeBSON').insert({
           doc: Long.fromNumber(10),
           array: [[Long.fromNumber(10)]]
-        }, function(err, doc) {
+        },
+        function(err, doc) {
           test.equal(null, err);
           test.ok(doc);
 
@@ -2266,7 +2268,8 @@ describe('Insert', function() {
         db.collection('shouldCorrectlyHonorPromoteLongFalseJSBSON').insert({
           doc: Long.fromNumber(10),
           array: [[Long.fromNumber(10)]]
-        }, function(err, doc) {
+        },
+        function(err, doc) {
           test.equal(null, err);
           test.ok(doc);
 
@@ -2301,7 +2304,8 @@ describe('Insert', function() {
         db.collection('shouldCorrectlyHonorPromoteLongTrueJSBSON').insert({
           doc: Long.fromNumber(10),
           array: [[Long.fromNumber(10)]]
-        }, function(err, doc) {
+        },
+        function(err, doc) {
           test.equal(null, err);
           test.ok(doc);
 
@@ -2334,7 +2338,10 @@ describe('Insert', function() {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyOverrideCheckKeysJSOnUpdate').update({
           'ps.op.t': 1
-        }, { $set: { b: 1 } }, { checkKeys: false }, function(err, doc) {
+        },
+        { $set: { b: 1 } },
+        { checkKeys: false },
+        function(err, doc) {
           test.equal(null, err);
           test.ok(doc);
 

--- a/test/functional/mongo_client_options_tests.js
+++ b/test/functional/mongo_client_options_tests.js
@@ -23,7 +23,7 @@ describe('MongoClient Options', function() {
         { autoReconnect: true, poolSize: 4 },
         connectionTester(configuration, 'testConnectServerOptions', function(client) {
           test.equal(1, client.topology.poolSize);
-          test.equal(4, client.topology.s.server.s.pool.size);
+          test.equal(4, client.topology.s.coreTopology.s.pool.size);
           test.equal(true, client.topology.autoReconnect);
           client.close();
           done();
@@ -48,7 +48,7 @@ describe('MongoClient Options', function() {
         { autoReconnect: true, poolSize: 4 },
         connectionTester(configuration, 'testConnectServerOptions', function(client) {
           test.equal(1, client.topology.poolSize);
-          test.equal(4, client.topology.s.server.s.pool.size);
+          test.equal(4, client.topology.s.coreTopology.s.pool.size);
           test.equal(true, client.topology.autoReconnect);
           client.close();
           done();

--- a/test/functional/mongo_client_tests.js
+++ b/test/functional/mongo_client_tests.js
@@ -318,7 +318,7 @@ describe('MongoClient', function() {
 
       MongoClient.connect(url, function(err, client) {
         test.equal(1, client.topology.connections().length);
-        test.equal(100, client.topology.s.server.s.pool.size);
+        test.equal(100, client.topology.s.coreTopology.s.pool.size);
 
         client.close();
         done();
@@ -705,8 +705,8 @@ describe('MongoClient', function() {
 
       MongoClient.connect(uri, {}, function(err, client) {
         test.equal(null, err);
-        test.equal(120000, client.topology.s.server.s.options.socketTimeout);
-        test.equal(15000, client.topology.s.server.s.options.connectionTimeout);
+        test.equal(120000, client.topology.s.coreTopology.s.options.socketTimeout);
+        test.equal(15000, client.topology.s.coreTopology.s.options.connectionTimeout);
 
         client.close();
         done();

--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -2172,18 +2172,17 @@ describe('Operation Examples', function() {
           // Execute map reduce and return results inline
           collection.mapReduce(map, reduce, { out: { inline: 1 }, verbose: true }, function(
             err,
-            results,
-            stats
+            result
           ) {
-            test.equal(2, results.length);
-            test.ok(stats != null);
+            test.equal(2, result.results.length);
+            test.ok(result.stats != null);
 
             collection.mapReduce(
               map,
               reduce,
               { out: { replace: 'mapreduce_integration_test' }, verbose: true },
-              function(err, results, stats) {
-                test.ok(stats != null);
+              function(err, result) {
+                test.ok(result.stats != null);
                 client.close();
                 done();
               }

--- a/test/functional/promote_buffers_tests.js
+++ b/test/functional/promote_buffers_tests.js
@@ -27,7 +27,8 @@ describe('Promote Buffers', function() {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteBuffer1').insert({
           doc: new Buffer(256)
-        }, function(err) {
+        },
+        function(err) {
           test.equal(null, err);
 
           db.collection('shouldCorrectlyHonorPromoteBuffer1').findOne(function(err, doc) {
@@ -64,7 +65,8 @@ describe('Promote Buffers', function() {
 
           db.collection('shouldCorrectlyHonorPromoteBuffer2').insert({
             doc: new Buffer(256)
-          }, function(err) {
+          },
+          function(err) {
             test.equal(null, err);
 
             db.collection('shouldCorrectlyHonorPromoteBuffer2').findOne(function(err, doc) {
@@ -102,7 +104,8 @@ describe('Promote Buffers', function() {
 
           db.collection('shouldCorrectlyHonorPromoteBuffer3').insert({
             doc: new Buffer(256)
-          }, function(err) {
+          },
+          function(err) {
             test.equal(null, err);
 
             db
@@ -137,7 +140,8 @@ describe('Promote Buffers', function() {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteBuffer4').insert({
           doc: new Buffer(256)
-        }, function(err) {
+        },
+        function(err) {
           test.equal(null, err);
 
           db
@@ -174,7 +178,8 @@ describe('Promote Buffers', function() {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteBuffer5').insert({
           doc: new Buffer(256)
-        }, function(err) {
+        },
+        function(err) {
           test.equal(null, err);
 
           db

--- a/test/functional/promote_values_tests.js
+++ b/test/functional/promote_values_tests.js
@@ -34,7 +34,8 @@ describe('Promote Values', function() {
           int: 10,
           double: 2.2222,
           array: [[Long.fromNumber(10)]]
-        }, function(err) {
+        },
+        function(err) {
           test.equal(null, err);
 
           db.collection('shouldCorrectlyHonorPromoteValues').findOne(function(err, doc) {
@@ -79,7 +80,8 @@ describe('Promote Values', function() {
             int: 10,
             double: 2.2222,
             array: [[Long.fromNumber(10)]]
-          }, function(err) {
+          },
+          function(err) {
             test.equal(null, err);
 
             db.collection('shouldCorrectlyHonorPromoteValues').findOne(function(err, doc) {
@@ -125,7 +127,8 @@ describe('Promote Values', function() {
             int: 10,
             double: 2.2222,
             array: [[Long.fromNumber(10)]]
-          }, function(err) {
+          },
+          function(err) {
             test.equal(null, err);
 
             db
@@ -169,7 +172,8 @@ describe('Promote Values', function() {
           int: 10,
           double: 2.2222,
           array: [[Long.fromNumber(10)]]
-        }, function(err) {
+        },
+        function(err) {
           test.equal(null, err);
 
           db
@@ -212,7 +216,8 @@ describe('Promote Values', function() {
           int: 10,
           double: 2.2222,
           array: [[Long.fromNumber(10)]]
-        }, function(err) {
+        },
+        function(err) {
           test.equal(null, err);
 
           db

--- a/test/functional/replicaset_mock_tests.js
+++ b/test/functional/replicaset_mock_tests.js
@@ -220,8 +220,8 @@ describe('ReplSet (mocks)', function() {
           'mongodb://localhost:12004,localhost:12005/test?socketTimeoutMS=120000&connectTimeoutMS=15000',
           function(err, client) {
             test.equal(null, err);
-            test.equal(15000, client.topology.s.mongos.s.options.connectionTimeout);
-            test.equal(120000, client.topology.s.mongos.s.options.socketTimeout);
+            test.equal(15000, client.topology.s.coreTopology.s.options.connectionTimeout);
+            test.equal(120000, client.topology.s.coreTopology.s.options.socketTimeout);
 
             client.close();
             done();

--- a/test/functional/replset_connection_tests.js
+++ b/test/functional/replset_connection_tests.js
@@ -1260,7 +1260,7 @@ describe('ReplSet (Connection)', function() {
         function(err, client) {
           test.equal(null, err);
 
-          var servers = client.topology.s.replset.s.replicaSetState.allServers();
+          var servers = client.topology.s.coreTopology.s.replicaSetState.allServers();
           for (var i = 0; i < servers.length; i++) {
             test.equal(10, servers[i].s.pool.options.reconnectTries);
           }

--- a/test/functional/sessions_tests.js
+++ b/test/functional/sessions_tests.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const MongoClient = require('../..').MongoClient;
+const expect = require('chai').expect;
+const assign = require('../../lib/utils').assign;
+const mock = require('../mock');
+
+const test = {};
+describe('Sessions', function() {
+  describe('unit', function() {
+    afterEach(() => mock.cleanup());
+    beforeEach(() => {
+      return mock.createServer().then(server => {
+        test.server = server;
+      });
+    });
+
+    it('should throw an exception if sessions are not supported', {
+      metadata: { requires: { topology: 'single' } },
+      test: function(done) {
+        test.server.setMessageHandler(request => {
+          var doc = request.document;
+          if (doc.ismaster) {
+            request.reply(assign({}, mock.DEFAULT_ISMASTER));
+          }
+        });
+
+        MongoClient.connect(`mongodb://${test.server.uri()}/test`, function(err, client) {
+          expect(err).to.not.exist;
+          expect(() => {
+            client.startSession();
+          }).to.throw(/Current topology does not support sessions/);
+
+          client.close();
+          done();
+        });
+      }
+    });
+
+    it('should return a client session when requested if the topology supports it', {
+      metadata: { requires: { topology: 'single' } },
+
+      test: function(done) {
+        test.server.setMessageHandler(request => {
+          var doc = request.document;
+          if (doc.ismaster) {
+            request.reply(
+              assign({}, mock.DEFAULT_ISMASTER, {
+                logicalSessionTimeoutMinutes: 10
+              })
+            );
+          }
+        });
+
+        MongoClient.connect(`mongodb://${test.server.uri()}/test`, function(err, client) {
+          expect(err).to.not.exist;
+          let session = client.startSession();
+          expect(session).to.exist;
+
+          client.close();
+          done();
+        });
+      }
+    });
+  });
+});

--- a/test/functional/sharding_connection_tests.js
+++ b/test/functional/sharding_connection_tests.js
@@ -157,7 +157,7 @@ describe('Sharding (Connection)', function() {
           test.equal(null, err);
           test.ok(client != null);
 
-          var servers = client.topology.s.mongos.connectedProxies;
+          var servers = client.topology.s.coreTopology.connectedProxies;
           for (var i = 0; i < servers.length; i++) {
             test.equal(10, servers[i].s.pool.options.reconnectTries);
           }

--- a/test/functional/sharding_read_preference_tests.js
+++ b/test/functional/sharding_read_preference_tests.js
@@ -427,7 +427,8 @@ describe('Sharding (Read Preference)', function() {
               client.db('admin').command({
                 shardCollection: 'integration_test_2.items',
                 key: { _id: 'hashed' }
-              }, function(err) {
+              },
+              function(err) {
                 test.equal(null, err);
 
                 var map = function() {

--- a/test/functional/ssl_mongoclient_tests.js
+++ b/test/functional/ssl_mongoclient_tests.js
@@ -1305,7 +1305,7 @@ describe.skip('SSL (MongoClient)', function() {
 
                   setTimeout(function() {
                     // Force a reconnect of a server
-                    var secondary = client.topology.s.replset.s.replicaSetState.secondaries[0];
+                    var secondary = client.topology.s.coreTopology.s.replicaSetState.secondaries[0];
                     secondary.destroy({ emitClose: true });
                     sets.push({});
 

--- a/test/functional/view_tests.js
+++ b/test/functional/view_tests.js
@@ -21,7 +21,7 @@ describe('Views', function() {
 
       // Boot the mock
       co(function*() {
-        const singleServer = yield mock.createServer(32000, 'localhost');
+        const singleServer = yield mock.createServer();
 
         singleServer.setMessageHandler(request => {
           var doc = request.document;
@@ -45,7 +45,7 @@ describe('Views', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect('mongodb://localhost:32000/test', function(err, client) {
+        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
           expect(err).to.not.exist;
           var db = client.db(self.configuration.db);
 

--- a/test/unit/sessions/client_tests.js
+++ b/test/unit/sessions/client_tests.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const MongoClient = require('../..').MongoClient;
+const MongoClient = require('../../..').MongoClient;
 const expect = require('chai').expect;
-const assign = require('../../lib/utils').assign;
-const mock = require('../mock');
+const assign = require('../../../lib/utils').assign;
+const mock = require('../../mock');
 
 const test = {};
 describe('Sessions', function() {
-  describe('unit', function() {
+  describe('Client', function() {
     afterEach(() => mock.cleanup());
     beforeEach(() => {
       return mock.createServer().then(server => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,7 +214,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.2.1, babel-core@^6.25.0, babel-core@^6.26.0:
+babel-core@^6.2.1, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -264,7 +264,7 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-polyfill@^6.2.0, babel-polyfill@^6.23.0:
+babel-polyfill@^6.2.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -2337,7 +2337,7 @@ moment@^2.10.6:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
-mongodb-core@2.1.15, mongodb-core@^2.1.12:
+mongodb-core@2.1.15:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-2.1.15.tgz#841f53b87ffff4c7458189c35c8ae827e1169764"
   dependencies:
@@ -2381,23 +2381,21 @@ mongodb-test-runner@mbroadst/mongodb-test-runner#master:
   resolved "https://codeload.github.com/mbroadst/mongodb-test-runner/tar.gz/f22e1a77d04e8225c01bade081fab7c9d5e370d5"
   dependencies:
     metamocha "^1.2.5"
-    mongodb-topology-manager "^1.0.13"
+    mongodb-topology-manager mongodb-js/mongodb-topology-manager#3.0.0
     mongodb-version-manager "^1.0.7"
     semver "^5.4.1"
     yargs "^8.0.2"
 
-mongodb-topology-manager@^1.0.13:
+mongodb-topology-manager@mongodb-js/mongodb-topology-manager#3.0.0:
   version "1.0.13"
-  resolved "https://registry.yarnpkg.com/mongodb-topology-manager/-/mongodb-topology-manager-1.0.13.tgz#053577386c587d2cfcc1cc45a0567b93b0f8710b"
+  resolved "https://codeload.github.com/mongodb-js/mongodb-topology-manager/tar.gz/719c142350017c934fec2944dc4fa516563937f5"
   dependencies:
-    babel-core "^6.25.0"
-    babel-polyfill "^6.23.0"
     bluebird "^3.5.0"
     co "^4.6.0"
     kerberos "^0.0.23"
     mkdirp "^0.5.1"
-    mongodb-core "^2.1.12"
-    rimraf "^2.6.1"
+    mongodb-core mongodb-js/mongodb-core#3.0.0
+    rimraf "^2.6.2"
 
 mongodb-version-list@^1.0.0:
   version "1.0.0"
@@ -2992,7 +2990,7 @@ rimraf@2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,7 +214,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.2.1, babel-core@^6.26.0:
+babel-core@^6.2.1, babel-core@^6.25.0, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -264,7 +264,7 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-polyfill@^6.2.0:
+babel-polyfill@^6.2.0, babel-polyfill@^6.23.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -2337,7 +2337,7 @@ moment@^2.10.6:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
-mongodb-core@2.1.15:
+mongodb-core@2.1.15, mongodb-core@^2.1.12:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-2.1.15.tgz#841f53b87ffff4c7458189c35c8ae827e1169764"
   dependencies:
@@ -2345,8 +2345,8 @@ mongodb-core@2.1.15:
     require_optional "~1.0.0"
 
 mongodb-core@mongodb-js/mongodb-core#3.0.0:
-  version "2.1.14"
-  resolved "https://codeload.github.com/mongodb-js/mongodb-core/tar.gz/9d63f5ab73d2c78e4f6a75f4d24c904bc7ae66c3"
+  version "2.1.90"
+  resolved "https://codeload.github.com/mongodb-js/mongodb-core/tar.gz/9c7e212a71ca7b1056ba51e235721c916f56ebb0"
   dependencies:
     bson "~1.0.4"
     require_optional "^1.0.1"
@@ -2381,21 +2381,23 @@ mongodb-test-runner@mbroadst/mongodb-test-runner#master:
   resolved "https://codeload.github.com/mbroadst/mongodb-test-runner/tar.gz/f22e1a77d04e8225c01bade081fab7c9d5e370d5"
   dependencies:
     metamocha "^1.2.5"
-    mongodb-topology-manager mongodb-js/mongodb-topology-manager#3.0.0
+    mongodb-topology-manager "^1.0.13"
     mongodb-version-manager "^1.0.7"
     semver "^5.4.1"
     yargs "^8.0.2"
 
-mongodb-topology-manager@mongodb-js/mongodb-topology-manager#3.0.0:
+mongodb-topology-manager@^1.0.13:
   version "1.0.13"
-  resolved "https://codeload.github.com/mongodb-js/mongodb-topology-manager/tar.gz/719c142350017c934fec2944dc4fa516563937f5"
+  resolved "https://registry.yarnpkg.com/mongodb-topology-manager/-/mongodb-topology-manager-1.0.13.tgz#053577386c587d2cfcc1cc45a0567b93b0f8710b"
   dependencies:
+    babel-core "^6.25.0"
+    babel-polyfill "^6.23.0"
     bluebird "^3.5.0"
     co "^4.6.0"
     kerberos "^0.0.23"
     mkdirp "^0.5.1"
-    mongodb-core mongodb-js/mongodb-core#3.0.0
-    rimraf "^2.6.2"
+    mongodb-core "^2.1.12"
+    rimraf "^2.6.1"
 
 mongodb-version-list@^1.0.0:
   version "1.0.0"
@@ -2990,7 +2992,7 @@ rimraf@2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
The gist of this change is that we were duplicating code _all over_ the codebase related to determining whether a callback or Promise was being used for most public facing API.  This PR addresses that, but also gains us the benefit of isolating the execution to a single point such that we can now introduce operation-wide changes very easily - most importantly the requirement set forth in the Driver Sessions spec that we use an implicit session if none is provided for _all_ public operations.

**NOTE:** This is rebased upon the `bulk-write-error` branch, so you might see some cross-pollination with the commits until that branch is merged (hopefully tomorrow).