### PR TITLE
NODE 1155 - ignoreUndefined is not working in unordered bulkWrite

### DIFF
--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -502,7 +502,7 @@ var executeCommands = function(self, callback) {
     finalOptions.serializeFunctions = true;
   }
 
-  // Serialize functions
+  // Ingore undefined
   if (self.s.options.ignoreUndefined) {
     finalOptions.ignoreUndefined = true;
   }

--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -502,7 +502,7 @@ var executeCommands = function(self, callback) {
     finalOptions.serializeFunctions = true;
   }
 
-  // Ingore undefined
+  // Ignore undefined
   if (self.s.options.ignoreUndefined) {
     finalOptions.ignoreUndefined = true;
   }

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -463,6 +463,11 @@ var executeBatch = function(self, batch, callback) {
     finalOptions.serializeFunctions = true;
   }
 
+  // Ingore undefined
+  if (self.s.options.ignoreUndefined) {
+    finalOptions.ignoreUndefined = true;
+  }
+
   // Is the bypassDocumentValidation options specific
   if (self.s.bypassDocumentValidation === true) {
     finalOptions.bypassDocumentValidation = true;

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -463,7 +463,7 @@ var executeBatch = function(self, batch, callback) {
     finalOptions.serializeFunctions = true;
   }
 
-  // Ingore undefined
+  // Ignore undefined
   if (self.s.options.ignoreUndefined) {
     finalOptions.ignoreUndefined = true;
   }

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -21,7 +21,7 @@ describe('Bulk', function() {
 
       client.connect(function(err, client) {
         var db = client.db(self.configuration.db);
-        var col = db.collection('batch_write_ordered_ops_2');
+        var col = db.collection('batch_write_ordered_ops_10');
 
         // Add unique index on b field causing all updates to fail
         col.ensureIndex({ a: 1 }, { unique: true, sparse: false }, function(err) {
@@ -129,7 +129,7 @@ describe('Bulk', function() {
     }
   });
 
-  it('should correctly handle ordered multiple batch api write command error', {
+  it('should correctly handle ordered multiple batch api write command errors', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
@@ -144,7 +144,7 @@ describe('Bulk', function() {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_ordered_ops_2');
 
-        // Add unique index on b field causing all updates to fail
+        // Add unique index on field `a` causing all updates to fail
         col.ensureIndex({ a: 1 }, { unique: true, sparse: false }, function(err) {
           test.equal(err, null);
 

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -21,7 +21,7 @@ describe('Bulk', function() {
 
       client.connect(function(err, client) {
         var db = client.db(self.configuration.db);
-        var col = db.collection('batch_write_ordered_ops_1');
+        var col = db.collection('batch_write_ordered_ops_2');
 
         // Add unique index on b field causing all updates to fail
         col.ensureIndex({ a: 1 }, { unique: true, sparse: false }, function(err) {
@@ -113,7 +113,7 @@ describe('Bulk', function() {
 
       return client.connect().then(client => {
         var db = client.db(this.configuration.db);
-        var col = db.collection('batch_write_ordered_ops_1');
+        var col = db.collection('batch_write_ordered_ops_3');
 
         return col
           .initializeOrderedBulkOp({ ignoreUndefined: true })


### PR DESCRIPTION
This adds the check into unordered bulk operations to see if the `ignoreUndefined` option has been set to `true`. 

Tests added for both ordered and unordered bulk operations. 

Fixes [NODE-1155](https://jira.mongodb.org/browse/NODE-1155) ✨ 