### PR TITLE
NODE-1154 - Calling an asynchronous function without callback

### DIFF
--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -454,10 +454,11 @@ var writeFile = function(self, file, callback) {
               if (offset >= stats.size) {
                 fs.close(file, function(err) {
                   if (err) return callback(err);
-                });
-                self.close(function(err) {
-                  if (err) return callback(err, self);
-                  return callback(null, self);
+
+                  self.close(function(err) {
+                    if (err) return callback(err, self);
+                    return callback(null, self);
+                  });
                 });
               } else {
                 return process.nextTick(writeChunk);

--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -452,7 +452,9 @@ var writeFile = function(self, file, callback) {
               self.currentChunk = chunk;
 
               if (offset >= stats.size) {
-                fs.close(file);
+                fs.close(file, function(err) {
+                  if (err) return callback(err);
+                });
                 self.close(function(err) {
                   if (err) return callback(err, self);
                   return callback(null, self);


### PR DESCRIPTION
This adds the missing callback to `fs.close` in `grid_store.js` 🍕 

Fixes [NODE-1154](https://jira.mongodb.org/browse/NODE-1154)