### PR TITLE
refactor(topologies): extract common code into TopologyBase

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -1,9 +1,7 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter,
-  inherits = require('util').inherits,
-  f = require('util').format,
-  ServerCapabilities = require('./topology_base').ServerCapabilities,
+var ServerCapabilities = require('./topology_base').ServerCapabilities,
+  TopologyBase = require('./topology_base').TopologyBase,
   MongoError = require('mongodb-core').MongoError,
   CMongos = require('mongodb-core').Mongos,
   Cursor = require('../cursor'),
@@ -16,17 +14,7 @@ var EventEmitter = require('events').EventEmitter,
   translateOptions = require('../utils').translateOptions,
   filterOptions = require('../utils').filterOptions,
   mergeOptions = require('../utils').mergeOptions,
-  getReadPreference = require('../utils').getReadPreference,
-  os = require('os'),
   assign = require('../utils').assign;
-
-// Get package.json variable
-var driverVersion = require('../../package.json').version;
-var nodejsversion = f('Node.js %s, %s', process.version, os.endianness());
-var type = os.type();
-var name = process.platform;
-var architecture = process.arch;
-var release = os.release();
 
 /**
  * @fileOverview The **Mongos** class is a class that represents a Mongos Proxy topology and is
@@ -120,144 +108,234 @@ var legalOptionNames = [
  * @property {string} parserType the parser type used (c++ or js).
  * @return {Mongos} a Mongos instance.
  */
-var Mongos = function(servers, options) {
-  if (!(this instanceof Mongos)) return new Mongos(servers, options);
-  options = options || {};
-  var self = this;
+class Mongos extends TopologyBase {
+  constructor(servers, options) {
+    super();
 
-  // Filter the options
-  options = filterOptions(options, legalOptionNames);
+    options = options || {};
+    var self = this;
 
-  // Ensure all the instances are Server
-  for (var i = 0; i < servers.length; i++) {
-    if (!(servers[i] instanceof Server)) {
-      throw MongoError.create({
-        message: 'all seed list instances must be of the Server type',
-        driver: true
+    // Filter the options
+    options = filterOptions(options, legalOptionNames);
+
+    // Ensure all the instances are Server
+    for (var i = 0; i < servers.length; i++) {
+      if (!(servers[i] instanceof Server)) {
+        throw MongoError.create({
+          message: 'all seed list instances must be of the Server type',
+          driver: true
+        });
+      }
+    }
+
+    // Stored options
+    var storeOptions = {
+      force: false,
+      bufferMaxEntries:
+        typeof options.bufferMaxEntries === 'number' ? options.bufferMaxEntries : MAX_JS_INT
+    };
+
+    // Shared global store
+    var store = options.store || new Store(self, storeOptions);
+
+    // Build seed list
+    var seedlist = servers.map(function(x) {
+      return { host: x.host, port: x.port };
+    });
+
+    // Get the reconnect option
+    var reconnect = typeof options.auto_reconnect === 'boolean' ? options.auto_reconnect : true;
+    reconnect = typeof options.autoReconnect === 'boolean' ? options.autoReconnect : reconnect;
+
+    // Clone options
+    var clonedOptions = mergeOptions(
+      {},
+      {
+        disconnectHandler: store,
+        cursorFactory: Cursor,
+        reconnect: reconnect,
+        emitError: typeof options.emitError === 'boolean' ? options.emitError : true,
+        size: typeof options.poolSize === 'number' ? options.poolSize : 5
+      }
+    );
+
+    // Translate any SSL options and other connectivity options
+    clonedOptions = translateOptions(clonedOptions, options);
+
+    // Socket options
+    var socketOptions =
+      options.socketOptions && Object.keys(options.socketOptions).length > 0
+        ? options.socketOptions
+        : options;
+
+    // Translate all the options to the mongodb-core ones
+    clonedOptions = translateOptions(clonedOptions, socketOptions);
+    if (typeof clonedOptions.keepAlive === 'number') {
+      clonedOptions.keepAliveInitialDelay = clonedOptions.keepAlive;
+      clonedOptions.keepAlive = clonedOptions.keepAlive > 0;
+    }
+
+    // Build default client information
+    clonedOptions.clientInfo = this.clientInfo;
+    // Do we have an application specific string
+    if (options.appname) {
+      clonedOptions.clientInfo.application = { name: options.appname };
+    }
+
+    // Internal state
+    this.s = {
+      // Create the Mongos
+      coreTopology: new CMongos(seedlist, clonedOptions),
+      // Server capabilities
+      sCapabilities: null,
+      // Debug turned on
+      debug: clonedOptions.debug,
+      // Store option defaults
+      storeOptions: storeOptions,
+      // Cloned options
+      clonedOptions: clonedOptions,
+      // Actual store of callbacks
+      store: store,
+      // Options
+      options: options
+    };
+  }
+
+  // Connect
+  connect(db, _options, callback) {
+    var self = this;
+    if ('function' === typeof _options) (callback = _options), (_options = {});
+    if (_options == null) _options = {};
+    if (!('function' === typeof callback)) callback = null;
+    _options = assign({}, this.s.clonedOptions, _options);
+    self.s.options = _options;
+
+    // Update bufferMaxEntries
+    self.s.storeOptions.bufferMaxEntries = db.bufferMaxEntries;
+
+    // Error handler
+    var connectErrorHandler = function() {
+      return function(err) {
+        // Remove all event handlers
+        var events = ['timeout', 'error', 'close'];
+        events.forEach(function(e) {
+          self.removeListener(e, connectErrorHandler);
+        });
+
+        self.s.coreTopology.removeListener('connect', connectErrorHandler);
+        // Force close the topology
+        self.close(true);
+
+        // Try to callback
+        try {
+          callback(err);
+        } catch (err) {
+          process.nextTick(function() {
+            throw err;
+          });
+        }
+      };
+    };
+
+    // Actual handler
+    var errorHandler = function(event) {
+      return function(err) {
+        if (event !== 'error') {
+          self.emit(event, err);
+        }
+      };
+    };
+
+    // Error handler
+    var reconnectHandler = function() {
+      self.emit('reconnect');
+      self.s.store.execute();
+    };
+
+    // relay the event
+    var relay = function(event) {
+      return function(t, server) {
+        self.emit(event, t, server);
+      };
+    };
+
+    // Connect handler
+    var connectHandler = function() {
+      // Clear out all the current handlers left over
+      var events = ['timeout', 'error', 'close', 'fullsetup'];
+      events.forEach(function(e) {
+        self.s.coreTopology.removeAllListeners(e);
       });
-    }
+
+      // Set up listeners
+      self.s.coreTopology.once('timeout', errorHandler('timeout'));
+      self.s.coreTopology.once('error', errorHandler('error'));
+      self.s.coreTopology.once('close', errorHandler('close'));
+
+      // Set up serverConfig listeners
+      self.s.coreTopology.on('fullsetup', function() {
+        self.emit('fullsetup', self);
+      });
+
+      // Emit open event
+      self.emit('open', null, self);
+
+      // Return correctly
+      try {
+        callback(null, self);
+      } catch (err) {
+        process.nextTick(function() {
+          throw err;
+        });
+      }
+    };
+
+    // Clear out all the current handlers left over
+    var events = [
+      'timeout',
+      'error',
+      'close',
+      'serverOpening',
+      'serverDescriptionChanged',
+      'serverHeartbeatStarted',
+      'serverHeartbeatSucceeded',
+      'serverHeartbeatFailed',
+      'serverClosed',
+      'topologyOpening',
+      'topologyClosed',
+      'topologyDescriptionChanged'
+    ];
+    events.forEach(function(e) {
+      self.s.coreTopology.removeAllListeners(e);
+    });
+
+    // Set up SDAM listeners
+    self.s.coreTopology.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
+    self.s.coreTopology.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
+    self.s.coreTopology.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
+    self.s.coreTopology.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
+    self.s.coreTopology.on('serverOpening', relay('serverOpening'));
+    self.s.coreTopology.on('serverClosed', relay('serverClosed'));
+    self.s.coreTopology.on('topologyOpening', relay('topologyOpening'));
+    self.s.coreTopology.on('topologyClosed', relay('topologyClosed'));
+    self.s.coreTopology.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
+
+    // Set up listeners
+    self.s.coreTopology.once('timeout', connectErrorHandler('timeout'));
+    self.s.coreTopology.once('error', connectErrorHandler('error'));
+    self.s.coreTopology.once('close', connectErrorHandler('close'));
+    self.s.coreTopology.once('connect', connectHandler);
+    // Join and leave events
+    self.s.coreTopology.on('joined', relay('joined'));
+    self.s.coreTopology.on('left', relay('left'));
+
+    // Reconnect server
+    self.s.coreTopology.on('reconnect', reconnectHandler);
+
+    // Start connection
+    self.s.coreTopology.connect(_options);
   }
-
-  // Stored options
-  var storeOptions = {
-    force: false,
-    bufferMaxEntries:
-      typeof options.bufferMaxEntries === 'number' ? options.bufferMaxEntries : MAX_JS_INT
-  };
-
-  // Shared global store
-  var store = options.store || new Store(self, storeOptions);
-
-  // Set up event emitter
-  EventEmitter.call(this);
-
-  // Build seed list
-  var seedlist = servers.map(function(x) {
-    return { host: x.host, port: x.port };
-  });
-
-  // Get the reconnect option
-  var reconnect = typeof options.auto_reconnect === 'boolean' ? options.auto_reconnect : true;
-  reconnect = typeof options.autoReconnect === 'boolean' ? options.autoReconnect : reconnect;
-
-  // Clone options
-  var clonedOptions = mergeOptions(
-    {},
-    {
-      disconnectHandler: store,
-      cursorFactory: Cursor,
-      reconnect: reconnect,
-      emitError: typeof options.emitError === 'boolean' ? options.emitError : true,
-      size: typeof options.poolSize === 'number' ? options.poolSize : 5
-    }
-  );
-
-  // Translate any SSL options and other connectivity options
-  clonedOptions = translateOptions(clonedOptions, options);
-
-  // Socket options
-  var socketOptions =
-    options.socketOptions && Object.keys(options.socketOptions).length > 0
-      ? options.socketOptions
-      : options;
-
-  // Translate all the options to the mongodb-core ones
-  clonedOptions = translateOptions(clonedOptions, socketOptions);
-  if (typeof clonedOptions.keepAlive === 'number') {
-    clonedOptions.keepAliveInitialDelay = clonedOptions.keepAlive;
-    clonedOptions.keepAlive = clonedOptions.keepAlive > 0;
-  }
-
-  // Build default client information
-  this.clientInfo = {
-    driver: {
-      name: 'nodejs',
-      version: driverVersion
-    },
-    os: {
-      type: type,
-      name: name,
-      architecture: architecture,
-      version: release
-    },
-    platform: nodejsversion
-  };
-
-  // Build default client information
-  clonedOptions.clientInfo = this.clientInfo;
-  // Do we have an application specific string
-  if (options.appname) {
-    clonedOptions.clientInfo.application = { name: options.appname };
-  }
-
-  // Internal state
-  this.s = {
-    // Create the Mongos
-    coreTopology: new CMongos(seedlist, clonedOptions),
-    // Server capabilities
-    sCapabilities: null,
-    // Debug turned on
-    debug: clonedOptions.debug,
-    // Store option defaults
-    storeOptions: storeOptions,
-    // Cloned options
-    clonedOptions: clonedOptions,
-    // Actual store of callbacks
-    store: store,
-    // Options
-    options: options
-  };
-};
-
-var define = (Mongos.define = new Define('Mongos', Mongos, false));
-
-/**
- * @ignore
- */
-inherits(Mongos, EventEmitter);
-
-// Last ismaster
-Object.defineProperty(Mongos.prototype, 'isMasterDoc', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.lastIsMaster();
-  }
-});
-
-Object.defineProperty(Mongos.prototype, 'parserType', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.parserType;
-  }
-});
-
-// BSON property
-Object.defineProperty(Mongos.prototype, 'bson', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.s.bson;
-  }
-});
+}
 
 Object.defineProperty(Mongos.prototype, 'haInterval', {
   enumerable: true,
@@ -266,264 +344,28 @@ Object.defineProperty(Mongos.prototype, 'haInterval', {
   }
 });
 
-Object.defineProperty(Mongos.prototype, 'logicalSessionTimeoutMinutes', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.logicalSessionTimeoutMinutes;
-  }
-});
-
-// Connect
-Mongos.prototype.connect = function(db, _options, callback) {
-  var self = this;
-  if ('function' === typeof _options) (callback = _options), (_options = {});
-  if (_options == null) _options = {};
-  if (!('function' === typeof callback)) callback = null;
-  _options = assign({}, this.s.clonedOptions, _options);
-  self.s.options = _options;
-
-  // Update bufferMaxEntries
-  self.s.storeOptions.bufferMaxEntries = db.bufferMaxEntries;
-
-  // Error handler
-  var connectErrorHandler = function() {
-    return function(err) {
-      // Remove all event handlers
-      var events = ['timeout', 'error', 'close'];
-      events.forEach(function(e) {
-        self.removeListener(e, connectErrorHandler);
-      });
-
-      self.s.coreTopology.removeListener('connect', connectErrorHandler);
-      // Force close the topology
-      self.close(true);
-
-      // Try to callback
-      try {
-        callback(err);
-      } catch (err) {
-        process.nextTick(function() {
-          throw err;
-        });
-      }
-    };
-  };
-
-  // Actual handler
-  var errorHandler = function(event) {
-    return function(err) {
-      if (event !== 'error') {
-        self.emit(event, err);
-      }
-    };
-  };
-
-  // Error handler
-  var reconnectHandler = function() {
-    self.emit('reconnect');
-    self.s.store.execute();
-  };
-
-  // relay the event
-  var relay = function(event) {
-    return function(t, server) {
-      self.emit(event, t, server);
-    };
-  };
-
-  // Connect handler
-  var connectHandler = function() {
-    // Clear out all the current handlers left over
-    var events = ['timeout', 'error', 'close', 'fullsetup'];
-    events.forEach(function(e) {
-      self.s.coreTopology.removeAllListeners(e);
-    });
-
-    // Set up listeners
-    self.s.coreTopology.once('timeout', errorHandler('timeout'));
-    self.s.coreTopology.once('error', errorHandler('error'));
-    self.s.coreTopology.once('close', errorHandler('close'));
-
-    // Set up serverConfig listeners
-    self.s.coreTopology.on('fullsetup', function() {
-      self.emit('fullsetup', self);
-    });
-
-    // Emit open event
-    self.emit('open', null, self);
-
-    // Return correctly
-    try {
-      callback(null, self);
-    } catch (err) {
-      process.nextTick(function() {
-        throw err;
-      });
-    }
-  };
-
-  // Clear out all the current handlers left over
-  var events = [
-    'timeout',
-    'error',
-    'close',
-    'serverOpening',
-    'serverDescriptionChanged',
-    'serverHeartbeatStarted',
-    'serverHeartbeatSucceeded',
-    'serverHeartbeatFailed',
-    'serverClosed',
-    'topologyOpening',
-    'topologyClosed',
-    'topologyDescriptionChanged'
-  ];
-  events.forEach(function(e) {
-    self.s.coreTopology.removeAllListeners(e);
-  });
-
-  // Set up SDAM listeners
-  self.s.coreTopology.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
-  self.s.coreTopology.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
-  self.s.coreTopology.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
-  self.s.coreTopology.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
-  self.s.coreTopology.on('serverOpening', relay('serverOpening'));
-  self.s.coreTopology.on('serverClosed', relay('serverClosed'));
-  self.s.coreTopology.on('topologyOpening', relay('topologyOpening'));
-  self.s.coreTopology.on('topologyClosed', relay('topologyClosed'));
-  self.s.coreTopology.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
-
-  // Set up listeners
-  self.s.coreTopology.once('timeout', connectErrorHandler('timeout'));
-  self.s.coreTopology.once('error', connectErrorHandler('error'));
-  self.s.coreTopology.once('close', connectErrorHandler('close'));
-  self.s.coreTopology.once('connect', connectHandler);
-  // Join and leave events
-  self.s.coreTopology.on('joined', relay('joined'));
-  self.s.coreTopology.on('left', relay('left'));
-
-  // Reconnect server
-  self.s.coreTopology.on('reconnect', reconnectHandler);
-
-  // Start connection
-  self.s.coreTopology.connect(_options);
-};
-
-// Server capabilities
-Mongos.prototype.capabilities = function() {
-  if (this.s.sCapabilities) return this.s.sCapabilities;
-  if (this.s.coreTopology.lastIsMaster() == null) return null;
-  this.s.sCapabilities = new ServerCapabilities(this.s.coreTopology.lastIsMaster());
-  return this.s.sCapabilities;
-};
-
+const define = (Mongos.define = new Define('Mongos', Mongos, false));
 define.classMethod('capabilities', {
   callback: false,
   promise: false,
   returns: [ServerCapabilities]
 });
 
-// Command
-Mongos.prototype.command = function(ns, cmd, options, callback) {
-  this.s.coreTopology.command(ns, cmd, getReadPreference(options), callback);
-};
-
 define.classMethod('command', { callback: true, promise: false });
-
-// Insert
-Mongos.prototype.insert = function(ns, ops, options, callback) {
-  this.s.coreTopology.insert(ns, ops, options, function(e, m) {
-    callback(e, m);
-  });
-};
-
 define.classMethod('insert', { callback: true, promise: false });
-
-// Update
-Mongos.prototype.update = function(ns, ops, options, callback) {
-  this.s.coreTopology.update(ns, ops, options, callback);
-};
-
 define.classMethod('update', { callback: true, promise: false });
-
-// Remove
-Mongos.prototype.remove = function(ns, ops, options, callback) {
-  this.s.coreTopology.remove(ns, ops, options, callback);
-};
-
 define.classMethod('remove', { callback: true, promise: false });
-
-// Destroyed
-Mongos.prototype.isDestroyed = function() {
-  return this.s.coreTopology.isDestroyed();
-};
-
-// IsConnected
-Mongos.prototype.isConnected = function() {
-  return this.s.coreTopology.isConnected();
-};
-
 define.classMethod('isConnected', { callback: false, promise: false, returns: [Boolean] });
-
-// Insert
-Mongos.prototype.cursor = function(ns, cmd, options) {
-  options.disconnectHandler = this.s.store;
-  return this.s.coreTopology.cursor(ns, cmd, options);
-};
-
+define.classMethod('isDestroyed', { callback: false, promise: false, returns: [Boolean] });
 define.classMethod('cursor', {
   callback: false,
   promise: false,
   returns: [Cursor, AggregationCursor, CommandCursor]
 });
 
-Mongos.prototype.lastIsMaster = function() {
-  return this.s.coreTopology.lastIsMaster();
-};
-
-/**
- * Unref all sockets
- * @method
- */
-Mongos.prototype.unref = function() {
-  return this.s.coreTopology.unref();
-};
-
-Mongos.prototype.close = function(forceClosed) {
-  this.s.coreTopology.destroy({
-    force: typeof forceClosed === 'boolean' ? forceClosed : false
-  });
-  // We need to wash out all stored processes
-  if (forceClosed === true) {
-    this.s.storeOptions.force = forceClosed;
-    this.s.store.flush();
-  }
-};
-
 define.classMethod('close', { callback: false, promise: false });
-
-Mongos.prototype.auth = function() {
-  var args = Array.prototype.slice.call(arguments, 0);
-  this.s.coreTopology.auth.apply(this.s.coreTopology, args);
-};
-
 define.classMethod('auth', { callback: true, promise: false });
-
-Mongos.prototype.logout = function() {
-  var args = Array.prototype.slice.call(arguments, 0);
-  this.s.coreTopology.logout.apply(this.s.coreTopology, args);
-};
-
 define.classMethod('logout', { callback: true, promise: false });
-
-/**
- * All raw connections
- * @method
- * @return {array}
- */
-Mongos.prototype.connections = function() {
-  return this.s.coreTopology.connections();
-};
-
 define.classMethod('connections', { callback: false, promise: false, returns: [Array] });
 
 /**

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1,25 +1,19 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter,
-  inherits = require('util').inherits,
-  f = require('util').format,
-  Server = require('./server'),
+var Server = require('./server'),
   Cursor = require('../cursor'),
   AggregationCursor = require('../aggregation_cursor'),
   CommandCursor = require('../command_cursor'),
-  ReadPreference = require('../read_preference'),
   MongoError = require('mongodb-core').MongoError,
   ServerCapabilities = require('./topology_base').ServerCapabilities,
+  TopologyBase = require('./topology_base').TopologyBase,
   Store = require('./topology_base').Store,
   Define = require('../metadata'),
   CReplSet = require('mongodb-core').ReplSet,
-  CoreReadPreference = require('mongodb-core').ReadPreference,
   MAX_JS_INT = require('../utils').MAX_JS_INT,
   translateOptions = require('../utils').translateOptions,
   filterOptions = require('../utils').filterOptions,
-  getReadPreference = require('../utils').getReadPreference,
   mergeOptions = require('../utils').mergeOptions,
-  os = require('os'),
   assign = require('../utils').assign;
 
 /**
@@ -83,14 +77,6 @@ var legalOptionNames = [
   'maxStalenessSeconds'
 ];
 
-// Get package.json variable
-var driverVersion = require('../../package.json').version;
-var nodejsversion = f('Node.js %s, %s', process.version, os.endianness());
-var type = os.type();
-var name = process.platform;
-var architecture = process.arch;
-var release = os.release();
-
 /**
  * Creates a new ReplSet instance
  * @class
@@ -132,157 +118,281 @@ var release = os.release();
  * @property {string} parserType the parser type used (c++ or js).
  * @return {ReplSet} a ReplSet instance.
  */
-var ReplSet = function(servers, options) {
-  if (!(this instanceof ReplSet)) return new ReplSet(servers, options);
-  options = options || {};
-  var self = this;
-  // Set up event emitter
-  EventEmitter.call(this);
+class ReplSet extends TopologyBase {
+  constructor(servers, options) {
+    super();
 
-  // Filter the options
-  options = filterOptions(options, legalOptionNames);
+    options = options || {};
+    var self = this;
 
-  // Ensure all the instances are Server
-  for (var i = 0; i < servers.length; i++) {
-    if (!(servers[i] instanceof Server)) {
-      throw MongoError.create({
-        message: 'all seed list instances must be of the Server type',
-        driver: true
+    // Filter the options
+    options = filterOptions(options, legalOptionNames);
+
+    // Ensure all the instances are Server
+    for (var i = 0; i < servers.length; i++) {
+      if (!(servers[i] instanceof Server)) {
+        throw MongoError.create({
+          message: 'all seed list instances must be of the Server type',
+          driver: true
+        });
+      }
+    }
+
+    // Stored options
+    var storeOptions = {
+      force: false,
+      bufferMaxEntries:
+        typeof options.bufferMaxEntries === 'number' ? options.bufferMaxEntries : MAX_JS_INT
+    };
+
+    // Shared global store
+    var store = options.store || new Store(self, storeOptions);
+
+    // Build seed list
+    var seedlist = servers.map(function(x) {
+      return { host: x.host, port: x.port };
+    });
+
+    // Clone options
+    var clonedOptions = mergeOptions(
+      {},
+      {
+        disconnectHandler: store,
+        cursorFactory: Cursor,
+        reconnect: false,
+        emitError: typeof options.emitError === 'boolean' ? options.emitError : true,
+        size: typeof options.poolSize === 'number' ? options.poolSize : 5
+      }
+    );
+
+    // Translate any SSL options and other connectivity options
+    clonedOptions = translateOptions(clonedOptions, options);
+
+    // Socket options
+    var socketOptions =
+      options.socketOptions && Object.keys(options.socketOptions).length > 0
+        ? options.socketOptions
+        : options;
+
+    // Translate all the options to the mongodb-core ones
+    clonedOptions = translateOptions(clonedOptions, socketOptions);
+    if (typeof clonedOptions.keepAlive === 'number') {
+      clonedOptions.keepAliveInitialDelay = clonedOptions.keepAlive;
+      clonedOptions.keepAlive = clonedOptions.keepAlive > 0;
+    }
+
+    // Build default client information
+    clonedOptions.clientInfo = this.clientInfo;
+    // Do we have an application specific string
+    if (options.appname) {
+      clonedOptions.clientInfo.application = { name: options.appname };
+    }
+
+    // Create the ReplSet
+    var coreTopology = new CReplSet(seedlist, clonedOptions);
+
+    // Listen to reconnect event
+    coreTopology.on('reconnect', function() {
+      self.emit('reconnect');
+      store.execute();
+    });
+
+    // Internal state
+    this.s = {
+      // Replicaset
+      coreTopology: coreTopology,
+      // Server capabilities
+      sCapabilities: null,
+      // Debug tag
+      tag: options.tag,
+      // Store options
+      storeOptions: storeOptions,
+      // Cloned options
+      clonedOptions: clonedOptions,
+      // Store
+      store: store,
+      // Options
+      options: options
+    };
+
+    // Debug
+    if (clonedOptions.debug) {
+      // Last ismaster
+      Object.defineProperty(this, 'replset', {
+        enumerable: true,
+        get: function() {
+          return coreTopology;
+        }
       });
     }
   }
 
-  // Stored options
-  var storeOptions = {
-    force: false,
-    bufferMaxEntries:
-      typeof options.bufferMaxEntries === 'number' ? options.bufferMaxEntries : MAX_JS_INT
-  };
+  // Connect method
+  connect(db, _options, callback) {
+    var self = this;
+    if ('function' === typeof _options) (callback = _options), (_options = {});
+    if (_options == null) _options = {};
+    if (!('function' === typeof callback)) callback = null;
+    _options = assign({}, this.s.clonedOptions, _options);
+    self.s.options = _options;
 
-  // Shared global store
-  var store = options.store || new Store(self, storeOptions);
+    // Update bufferMaxEntries
+    self.s.storeOptions.bufferMaxEntries = db.bufferMaxEntries;
 
-  // Build seed list
-  var seedlist = servers.map(function(x) {
-    return { host: x.host, port: x.port };
-  });
+    // Actual handler
+    var errorHandler = function(event) {
+      return function(err) {
+        if (event !== 'error') {
+          self.emit(event, err);
+        }
+      };
+    };
 
-  // Clone options
-  var clonedOptions = mergeOptions(
-    {},
-    {
-      disconnectHandler: store,
-      cursorFactory: Cursor,
-      reconnect: false,
-      emitError: typeof options.emitError === 'boolean' ? options.emitError : true,
-      size: typeof options.poolSize === 'number' ? options.poolSize : 5
-    }
-  );
+    // Clear out all the current handlers left over
+    var events = [
+      'timeout',
+      'error',
+      'close',
+      'serverOpening',
+      'serverDescriptionChanged',
+      'serverHeartbeatStarted',
+      'serverHeartbeatSucceeded',
+      'serverHeartbeatFailed',
+      'serverClosed',
+      'topologyOpening',
+      'topologyClosed',
+      'topologyDescriptionChanged',
+      'joined',
+      'left',
+      'ping',
+      'ha'
+    ];
+    events.forEach(function(e) {
+      self.s.coreTopology.removeAllListeners(e);
+    });
 
-  // Translate any SSL options and other connectivity options
-  clonedOptions = translateOptions(clonedOptions, options);
+    // relay the event
+    var relay = function(event) {
+      return function(t, server) {
+        self.emit(event, t, server);
+      };
+    };
 
-  // Socket options
-  var socketOptions =
-    options.socketOptions && Object.keys(options.socketOptions).length > 0
-      ? options.socketOptions
-      : options;
+    // Replset events relay
+    var replsetRelay = function(event) {
+      return function(t, server) {
+        self.emit(event, t, server.lastIsMaster(), server);
+      };
+    };
 
-  // Translate all the options to the mongodb-core ones
-  clonedOptions = translateOptions(clonedOptions, socketOptions);
-  if (typeof clonedOptions.keepAlive === 'number') {
-    clonedOptions.keepAliveInitialDelay = clonedOptions.keepAlive;
-    clonedOptions.keepAlive = clonedOptions.keepAlive > 0;
-  }
+    // Relay ha
+    var relayHa = function(t, state) {
+      self.emit('ha', t, state);
 
-  // Client info
-  this.clientInfo = {
-    driver: {
-      name: 'nodejs',
-      version: driverVersion
-    },
-    os: {
-      type: type,
-      name: name,
-      architecture: architecture,
-      version: release
-    },
-    platform: nodejsversion
-  };
-
-  // Build default client information
-  clonedOptions.clientInfo = this.clientInfo;
-  // Do we have an application specific string
-  if (options.appname) {
-    clonedOptions.clientInfo.application = { name: options.appname };
-  }
-
-  // Create the ReplSet
-  var coreTopology = new CReplSet(seedlist, clonedOptions);
-
-  // Listen to reconnect event
-  coreTopology.on('reconnect', function() {
-    self.emit('reconnect');
-    store.execute();
-  });
-
-  // Internal state
-  this.s = {
-    // Replicaset
-    coreTopology: coreTopology,
-    // Server capabilities
-    sCapabilities: null,
-    // Debug tag
-    tag: options.tag,
-    // Store options
-    storeOptions: storeOptions,
-    // Cloned options
-    clonedOptions: clonedOptions,
-    // Store
-    store: store,
-    // Options
-    options: options
-  };
-
-  // Debug
-  if (clonedOptions.debug) {
-    // Last ismaster
-    Object.defineProperty(this, 'replset', {
-      enumerable: true,
-      get: function() {
-        return coreTopology;
+      if (t === 'start') {
+        self.emit('ha_connect', t, state);
+      } else if (t === 'end') {
+        self.emit('ha_ismaster', t, state);
       }
+    };
+
+    // Set up serverConfig listeners
+    self.s.coreTopology.on('joined', replsetRelay('joined'));
+    self.s.coreTopology.on('left', relay('left'));
+    self.s.coreTopology.on('ping', relay('ping'));
+    self.s.coreTopology.on('ha', relayHa);
+
+    // Set up SDAM listeners
+    self.s.coreTopology.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
+    self.s.coreTopology.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
+    self.s.coreTopology.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
+    self.s.coreTopology.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
+    self.s.coreTopology.on('serverOpening', relay('serverOpening'));
+    self.s.coreTopology.on('serverClosed', relay('serverClosed'));
+    self.s.coreTopology.on('topologyOpening', relay('topologyOpening'));
+    self.s.coreTopology.on('topologyClosed', relay('topologyClosed'));
+    self.s.coreTopology.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
+
+    self.s.coreTopology.on('fullsetup', function() {
+      self.emit('fullsetup', self, self);
+    });
+
+    self.s.coreTopology.on('all', function() {
+      self.emit('all', null, self);
+    });
+
+    // Connect handler
+    var connectHandler = function() {
+      // Set up listeners
+      self.s.coreTopology.once('timeout', errorHandler('timeout'));
+      self.s.coreTopology.once('error', errorHandler('error'));
+      self.s.coreTopology.once('close', errorHandler('close'));
+
+      // Emit open event
+      self.emit('open', null, self);
+
+      // Return correctly
+      try {
+        callback(null, self);
+      } catch (err) {
+        process.nextTick(function() {
+          throw err;
+        });
+      }
+    };
+
+    // Error handler
+    var connectErrorHandler = function() {
+      return function(err) {
+        ['timeout', 'error', 'close'].forEach(function(e) {
+          self.s.coreTopology.removeListener(e, connectErrorHandler);
+        });
+
+        self.s.coreTopology.removeListener('connect', connectErrorHandler);
+        // Destroy the replset
+        self.s.coreTopology.destroy();
+
+        // Try to callback
+        try {
+          callback(err);
+        } catch (err) {
+          if (!self.s.coreTopology.isConnected())
+            process.nextTick(function() {
+              throw err;
+            });
+        }
+      };
+    };
+
+    // Set up listeners
+    self.s.coreTopology.once('timeout', connectErrorHandler('timeout'));
+    self.s.coreTopology.once('error', connectErrorHandler('error'));
+    self.s.coreTopology.once('close', connectErrorHandler('close'));
+    self.s.coreTopology.once('connect', connectHandler);
+
+    // Start connection
+    self.s.coreTopology.connect(_options);
+  }
+
+  close(forceClosed) {
+    var self = this;
+    // Call destroy on the topology
+    this.s.coreTopology.destroy({
+      force: typeof forceClosed === 'boolean' ? forceClosed : false
+    });
+
+    // We need to wash out all stored processes
+    if (forceClosed === true) {
+      this.s.storeOptions.force = forceClosed;
+      this.s.store.flush();
+    }
+
+    var events = ['timeout', 'error', 'close', 'joined', 'left'];
+    events.forEach(function(e) {
+      self.removeAllListeners(e);
     });
   }
-};
-
-/**
- * @ignore
- */
-inherits(ReplSet, EventEmitter);
-
-// Last ismaster
-Object.defineProperty(ReplSet.prototype, 'isMasterDoc', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.lastIsMaster();
-  }
-});
-
-Object.defineProperty(ReplSet.prototype, 'parserType', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.parserType;
-  }
-});
-
-// BSON property
-Object.defineProperty(ReplSet.prototype, 'bson', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.s.bson;
-  }
-});
+}
 
 Object.defineProperty(ReplSet.prototype, 'haInterval', {
   enumerable: true,
@@ -291,307 +401,27 @@ Object.defineProperty(ReplSet.prototype, 'haInterval', {
   }
 });
 
-Object.defineProperty(ReplSet.prototype, 'logicalSessionTimeoutMinutes', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.logicalSessionTimeoutMinutes;
-  }
-});
-
-var define = (ReplSet.define = new Define('ReplSet', ReplSet, false));
-
-// Ensure the right read Preference object
-var translateReadPreference = function(options) {
-  if (typeof options.readPreference === 'string') {
-    options.readPreference = new CoreReadPreference(options.readPreference);
-  } else if (options.readPreference instanceof ReadPreference) {
-    options.readPreference = new CoreReadPreference(
-      options.readPreference.mode,
-      options.readPreference.tags,
-      { maxStalenessSeconds: options.readPreference.maxStalenessSeconds }
-    );
-  }
-
-  return options;
-};
-
-// Connect method
-ReplSet.prototype.connect = function(db, _options, callback) {
-  var self = this;
-  if ('function' === typeof _options) (callback = _options), (_options = {});
-  if (_options == null) _options = {};
-  if (!('function' === typeof callback)) callback = null;
-  _options = assign({}, this.s.clonedOptions, _options);
-  self.s.options = _options;
-
-  // Update bufferMaxEntries
-  self.s.storeOptions.bufferMaxEntries = db.bufferMaxEntries;
-
-  // Actual handler
-  var errorHandler = function(event) {
-    return function(err) {
-      if (event !== 'error') {
-        self.emit(event, err);
-      }
-    };
-  };
-
-  // Clear out all the current handlers left over
-  var events = [
-    'timeout',
-    'error',
-    'close',
-    'serverOpening',
-    'serverDescriptionChanged',
-    'serverHeartbeatStarted',
-    'serverHeartbeatSucceeded',
-    'serverHeartbeatFailed',
-    'serverClosed',
-    'topologyOpening',
-    'topologyClosed',
-    'topologyDescriptionChanged',
-    'joined',
-    'left',
-    'ping',
-    'ha'
-  ];
-  events.forEach(function(e) {
-    self.s.coreTopology.removeAllListeners(e);
-  });
-
-  // relay the event
-  var relay = function(event) {
-    return function(t, server) {
-      self.emit(event, t, server);
-    };
-  };
-
-  // Replset events relay
-  var replsetRelay = function(event) {
-    return function(t, server) {
-      self.emit(event, t, server.lastIsMaster(), server);
-    };
-  };
-
-  // Relay ha
-  var relayHa = function(t, state) {
-    self.emit('ha', t, state);
-
-    if (t === 'start') {
-      self.emit('ha_connect', t, state);
-    } else if (t === 'end') {
-      self.emit('ha_ismaster', t, state);
-    }
-  };
-
-  // Set up serverConfig listeners
-  self.s.coreTopology.on('joined', replsetRelay('joined'));
-  self.s.coreTopology.on('left', relay('left'));
-  self.s.coreTopology.on('ping', relay('ping'));
-  self.s.coreTopology.on('ha', relayHa);
-
-  // Set up SDAM listeners
-  self.s.coreTopology.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
-  self.s.coreTopology.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
-  self.s.coreTopology.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
-  self.s.coreTopology.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
-  self.s.coreTopology.on('serverOpening', relay('serverOpening'));
-  self.s.coreTopology.on('serverClosed', relay('serverClosed'));
-  self.s.coreTopology.on('topologyOpening', relay('topologyOpening'));
-  self.s.coreTopology.on('topologyClosed', relay('topologyClosed'));
-  self.s.coreTopology.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
-
-  self.s.coreTopology.on('fullsetup', function() {
-    self.emit('fullsetup', self, self);
-  });
-
-  self.s.coreTopology.on('all', function() {
-    self.emit('all', null, self);
-  });
-
-  // Connect handler
-  var connectHandler = function() {
-    // Set up listeners
-    self.s.coreTopology.once('timeout', errorHandler('timeout'));
-    self.s.coreTopology.once('error', errorHandler('error'));
-    self.s.coreTopology.once('close', errorHandler('close'));
-
-    // Emit open event
-    self.emit('open', null, self);
-
-    // Return correctly
-    try {
-      callback(null, self);
-    } catch (err) {
-      process.nextTick(function() {
-        throw err;
-      });
-    }
-  };
-
-  // Error handler
-  var connectErrorHandler = function() {
-    return function(err) {
-      ['timeout', 'error', 'close'].forEach(function(e) {
-        self.s.coreTopology.removeListener(e, connectErrorHandler);
-      });
-
-      self.s.coreTopology.removeListener('connect', connectErrorHandler);
-      // Destroy the replset
-      self.s.coreTopology.destroy();
-
-      // Try to callback
-      try {
-        callback(err);
-      } catch (err) {
-        if (!self.s.coreTopology.isConnected())
-          process.nextTick(function() {
-            throw err;
-          });
-      }
-    };
-  };
-
-  // Set up listeners
-  self.s.coreTopology.once('timeout', connectErrorHandler('timeout'));
-  self.s.coreTopology.once('error', connectErrorHandler('error'));
-  self.s.coreTopology.once('close', connectErrorHandler('close'));
-  self.s.coreTopology.once('connect', connectHandler);
-
-  // Start connection
-  self.s.coreTopology.connect(_options);
-};
-
-// Server capabilities
-ReplSet.prototype.capabilities = function() {
-  if (this.s.sCapabilities) return this.s.sCapabilities;
-  if (this.s.coreTopology.lastIsMaster() == null) return null;
-  this.s.sCapabilities = new ServerCapabilities(this.s.coreTopology.lastIsMaster());
-  return this.s.sCapabilities;
-};
-
+const define = (ReplSet.define = new Define('ReplSet', ReplSet, false));
 define.classMethod('capabilities', {
   callback: false,
   promise: false,
   returns: [ServerCapabilities]
 });
 
-// Command
-ReplSet.prototype.command = function(ns, cmd, options, callback) {
-  this.s.coreTopology.command(ns, cmd, getReadPreference(options), callback);
-};
-
 define.classMethod('command', { callback: true, promise: false });
-
-// Insert
-ReplSet.prototype.insert = function(ns, ops, options, callback) {
-  this.s.coreTopology.insert(ns, ops, options, callback);
-};
-
 define.classMethod('insert', { callback: true, promise: false });
-
-// Update
-ReplSet.prototype.update = function(ns, ops, options, callback) {
-  this.s.coreTopology.update(ns, ops, options, callback);
-};
-
 define.classMethod('update', { callback: true, promise: false });
-
-// Remove
-ReplSet.prototype.remove = function(ns, ops, options, callback) {
-  this.s.coreTopology.remove(ns, ops, options, callback);
-};
-
 define.classMethod('remove', { callback: true, promise: false });
-
-// Destroyed
-ReplSet.prototype.isDestroyed = function() {
-  return this.s.coreTopology.isDestroyed();
-};
-
-// IsConnected
-ReplSet.prototype.isConnected = function(options) {
-  options = options || {};
-
-  // If we passed in a readPreference, translate to
-  // a CoreReadPreference instance
-  if (options.readPreference) {
-    options.readPreference = translateReadPreference(options.readPreference);
-  }
-
-  return this.s.coreTopology.isConnected(options);
-};
-
 define.classMethod('isConnected', { callback: false, promise: false, returns: [Boolean] });
-
-// Insert
-ReplSet.prototype.cursor = function(ns, cmd, options) {
-  options = translateReadPreference(options);
-  options.disconnectHandler = this.s.store;
-  return this.s.coreTopology.cursor(ns, cmd, options);
-};
-
 define.classMethod('cursor', {
   callback: false,
   promise: false,
   returns: [Cursor, AggregationCursor, CommandCursor]
 });
 
-ReplSet.prototype.lastIsMaster = function() {
-  return this.s.coreTopology.lastIsMaster();
-};
-
-/**
- * Unref all sockets
- * @method
- */
-ReplSet.prototype.unref = function() {
-  return this.s.coreTopology.unref();
-};
-
-ReplSet.prototype.close = function(forceClosed) {
-  var self = this;
-  // Call destroy on the topology
-  this.s.coreTopology.destroy({
-    force: typeof forceClosed === 'boolean' ? forceClosed : false
-  });
-  // We need to wash out all stored processes
-  if (forceClosed === true) {
-    this.s.storeOptions.force = forceClosed;
-    this.s.store.flush();
-  }
-
-  var events = ['timeout', 'error', 'close', 'joined', 'left'];
-  events.forEach(function(e) {
-    self.removeAllListeners(e);
-  });
-};
-
 define.classMethod('close', { callback: false, promise: false });
-
-ReplSet.prototype.auth = function() {
-  var args = Array.prototype.slice.call(arguments, 0);
-  this.s.coreTopology.auth.apply(this.s.coreTopology, args);
-};
-
 define.classMethod('auth', { callback: true, promise: false });
-
-ReplSet.prototype.logout = function() {
-  var args = Array.prototype.slice.call(arguments, 0);
-  this.s.coreTopology.logout.apply(this.s.coreTopology, args);
-};
-
 define.classMethod('logout', { callback: true, promise: false });
-
-/**
- * All raw connections
- * @method
- * @return {array}
- */
-ReplSet.prototype.connections = function() {
-  return this.s.coreTopology.connections();
-};
-
 define.classMethod('connections', { callback: false, promise: false, returns: [Array] });
 
 /**

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter,
-  inherits = require('util').inherits,
-  CServer = require('mongodb-core').Server,
+var CServer = require('mongodb-core').Server,
   Cursor = require('../cursor'),
   AggregationCursor = require('../aggregation_cursor'),
   CommandCursor = require('../command_cursor'),
-  f = require('util').format,
   ServerCapabilities = require('./topology_base').ServerCapabilities,
+  TopologyBase = require('./topology_base').TopologyBase,
   Store = require('./topology_base').Store,
   Define = require('../metadata'),
   MongoError = require('mongodb-core').MongoError,
@@ -15,17 +13,7 @@ var EventEmitter = require('events').EventEmitter,
   translateOptions = require('../utils').translateOptions,
   filterOptions = require('../utils').filterOptions,
   mergeOptions = require('../utils').mergeOptions,
-  getReadPreference = require('../utils').getReadPreference,
-  os = require('os'),
   assign = require('../utils').assign;
-
-// Get package.json variable
-var driverVersion = require('../../package.json').version;
-var nodejsversion = f('Node.js %s, %s', process.version, os.endianness());
-var type = os.type();
-var name = process.platform;
-var architecture = process.arch;
-var release = os.release();
 
 /**
  * @fileOverview The **Server** class is a class that represents a single server topology and is
@@ -120,146 +108,250 @@ var legalOptionNames = [
  * @property {string} parserType the parser type used (c++ or js).
  * @return {Server} a Server instance.
  */
-var Server = function(host, port, options) {
-  options = options || {};
-  if (!(this instanceof Server)) return new Server(host, port, options);
-  EventEmitter.call(this);
-  var self = this;
+class Server extends TopologyBase {
+  constructor(host, port, options) {
+    super();
+    var self = this;
 
-  // Filter the options
-  options = filterOptions(options, legalOptionNames);
+    // Filter the options
+    options = filterOptions(options, legalOptionNames);
 
-  // Stored options
-  var storeOptions = {
-    force: false,
-    bufferMaxEntries:
-      typeof options.bufferMaxEntries === 'number' ? options.bufferMaxEntries : MAX_JS_INT
-  };
+    // Stored options
+    var storeOptions = {
+      force: false,
+      bufferMaxEntries:
+        typeof options.bufferMaxEntries === 'number' ? options.bufferMaxEntries : MAX_JS_INT
+    };
 
-  // Shared global store
-  var store = options.store || new Store(self, storeOptions);
+    // Shared global store
+    var store = options.store || new Store(self, storeOptions);
 
-  // Detect if we have a socket connection
-  if (host.indexOf('/') !== -1) {
-    if (port != null && typeof port === 'object') {
-      options = port;
-      port = null;
+    // Detect if we have a socket connection
+    if (host.indexOf('/') !== -1) {
+      if (port != null && typeof port === 'object') {
+        options = port;
+        port = null;
+      }
+    } else if (port == null) {
+      throw MongoError.create({ message: 'port must be specified', driver: true });
     }
-  } else if (port == null) {
-    throw MongoError.create({ message: 'port must be specified', driver: true });
-  }
 
-  // Get the reconnect option
-  var reconnect = typeof options.auto_reconnect === 'boolean' ? options.auto_reconnect : true;
-  reconnect = typeof options.autoReconnect === 'boolean' ? options.autoReconnect : reconnect;
+    // Get the reconnect option
+    var reconnect = typeof options.auto_reconnect === 'boolean' ? options.auto_reconnect : true;
+    reconnect = typeof options.autoReconnect === 'boolean' ? options.autoReconnect : reconnect;
 
-  // Clone options
-  var clonedOptions = mergeOptions(
-    {},
-    {
+    // Clone options
+    var clonedOptions = mergeOptions(
+      {},
+      {
+        host: host,
+        port: port,
+        disconnectHandler: store,
+        cursorFactory: Cursor,
+        reconnect: reconnect,
+        emitError: typeof options.emitError === 'boolean' ? options.emitError : true,
+        size: typeof options.poolSize === 'number' ? options.poolSize : 5
+      }
+    );
+
+    // Translate any SSL options and other connectivity options
+    clonedOptions = translateOptions(clonedOptions, options);
+
+    // Socket options
+    var socketOptions =
+      options.socketOptions && Object.keys(options.socketOptions).length > 0
+        ? options.socketOptions
+        : options;
+
+    // Translate all the options to the mongodb-core ones
+    clonedOptions = translateOptions(clonedOptions, socketOptions);
+    if (typeof clonedOptions.keepAlive === 'number') {
+      clonedOptions.keepAliveInitialDelay = clonedOptions.keepAlive;
+      clonedOptions.keepAlive = clonedOptions.keepAlive > 0;
+    }
+
+    // Build default client information
+    clonedOptions.clientInfo = this.clientInfo;
+    // Do we have an application specific string
+    if (options.appname) {
+      clonedOptions.clientInfo.application = { name: options.appname };
+    }
+
+    // Define the internal properties
+    this.s = {
+      // Create an instance of a server instance from mongodb-core
+      coreTopology: new CServer(clonedOptions),
+      // Server capabilities
+      sCapabilities: null,
+      // Cloned options
+      clonedOptions: clonedOptions,
+      // Reconnect
+      reconnect: clonedOptions.reconnect,
+      // Emit error
+      emitError: clonedOptions.emitError,
+      // Pool size
+      poolSize: clonedOptions.size,
+      // Store Options
+      storeOptions: storeOptions,
+      // Store
+      store: store,
+      // Host
       host: host,
+      // Port
       port: port,
-      disconnectHandler: store,
-      cursorFactory: Cursor,
-      reconnect: reconnect,
-      emitError: typeof options.emitError === 'boolean' ? options.emitError : true,
-      size: typeof options.poolSize === 'number' ? options.poolSize : 5
-    }
-  );
-
-  // Translate any SSL options and other connectivity options
-  clonedOptions = translateOptions(clonedOptions, options);
-
-  // Socket options
-  var socketOptions =
-    options.socketOptions && Object.keys(options.socketOptions).length > 0
-      ? options.socketOptions
-      : options;
-
-  // Translate all the options to the mongodb-core ones
-  clonedOptions = translateOptions(clonedOptions, socketOptions);
-  if (typeof clonedOptions.keepAlive === 'number') {
-    clonedOptions.keepAliveInitialDelay = clonedOptions.keepAlive;
-    clonedOptions.keepAlive = clonedOptions.keepAlive > 0;
+      // Options
+      options: options
+    };
   }
 
-  // Build default client information
-  this.clientInfo = {
-    driver: {
-      name: 'nodejs',
-      version: driverVersion
-    },
-    os: {
-      type: type,
-      name: name,
-      architecture: architecture,
-      version: release
-    },
-    platform: nodejsversion
-  };
+  // Connect
+  connect(_options, callback) {
+    var self = this;
+    if ('function' === typeof _options) (callback = _options), (_options = {});
+    if (_options == null) _options = this.s.clonedOptions;
+    if (!('function' === typeof callback)) callback = null;
+    _options = assign({}, this.s.clonedOptions, _options);
+    self.s.options = _options;
 
-  // Build default client information
-  clonedOptions.clientInfo = this.clientInfo;
-  // Do we have an application specific string
-  if (options.appname) {
-    clonedOptions.clientInfo.application = { name: options.appname };
+    // Update bufferMaxEntries
+    self.s.storeOptions.bufferMaxEntries =
+      typeof _options.bufferMaxEntries === 'number' ? _options.bufferMaxEntries : -1;
+
+    // Error handler
+    var connectErrorHandler = function() {
+      return function(err) {
+        // Remove all event handlers
+        var events = ['timeout', 'error', 'close'];
+        events.forEach(function(e) {
+          self.s.coreTopology.removeListener(e, connectHandlers[e]);
+        });
+
+        self.s.coreTopology.removeListener('connect', connectErrorHandler);
+
+        // Try to callback
+        try {
+          callback(err);
+        } catch (err) {
+          process.nextTick(function() {
+            throw err;
+          });
+        }
+      };
+    };
+
+    // Actual handler
+    var errorHandler = function(event) {
+      return function(err) {
+        if (event !== 'error') {
+          self.emit(event, err);
+        }
+      };
+    };
+
+    // Error handler
+    var reconnectHandler = function() {
+      self.emit('reconnect', self);
+      self.s.store.execute();
+    };
+
+    // Reconnect failed
+    var reconnectFailedHandler = function(err) {
+      self.emit('reconnectFailed', err);
+      self.s.store.flush(err);
+    };
+
+    // Destroy called on topology, perform cleanup
+    var destroyHandler = function() {
+      self.s.store.flush();
+    };
+
+    // relay the event
+    var relay = function(event) {
+      return function(t, server) {
+        self.emit(event, t, server);
+      };
+    };
+
+    // Connect handler
+    var connectHandler = function() {
+      // Clear out all the current handlers left over
+      ['timeout', 'error', 'close', 'destroy'].forEach(function(e) {
+        self.s.coreTopology.removeAllListeners(e);
+      });
+
+      // Set up listeners
+      self.s.coreTopology.on('timeout', errorHandler('timeout'));
+      self.s.coreTopology.once('error', errorHandler('error'));
+      self.s.coreTopology.on('close', errorHandler('close'));
+      // Only called on destroy
+      self.s.coreTopology.on('destroy', destroyHandler);
+
+      // Emit open event
+      self.emit('open', null, self);
+
+      // Return correctly
+      try {
+        callback(null, self);
+      } catch (err) {
+        console.log(err.stack);
+        process.nextTick(function() {
+          throw err;
+        });
+      }
+    };
+
+    // Set up listeners
+    var connectHandlers = {
+      timeout: connectErrorHandler('timeout'),
+      error: connectErrorHandler('error'),
+      close: connectErrorHandler('close')
+    };
+
+    // Clear out all the current handlers left over
+    [
+      'timeout',
+      'error',
+      'close',
+      'serverOpening',
+      'serverDescriptionChanged',
+      'serverHeartbeatStarted',
+      'serverHeartbeatSucceeded',
+      'serverHeartbeatFailed',
+      'serverClosed',
+      'topologyOpening',
+      'topologyClosed',
+      'topologyDescriptionChanged'
+    ].forEach(function(e) {
+      self.s.coreTopology.removeAllListeners(e);
+    });
+
+    // Add the event handlers
+    self.s.coreTopology.once('timeout', connectHandlers.timeout);
+    self.s.coreTopology.once('error', connectHandlers.error);
+    self.s.coreTopology.once('close', connectHandlers.close);
+    self.s.coreTopology.once('connect', connectHandler);
+    // Reconnect server
+    self.s.coreTopology.on('reconnect', reconnectHandler);
+    self.s.coreTopology.on('reconnectFailed', reconnectFailedHandler);
+
+    // Set up SDAM listeners
+    self.s.coreTopology.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
+    self.s.coreTopology.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
+    self.s.coreTopology.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
+    self.s.coreTopology.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
+    self.s.coreTopology.on('serverOpening', relay('serverOpening'));
+    self.s.coreTopology.on('serverClosed', relay('serverClosed'));
+    self.s.coreTopology.on('topologyOpening', relay('topologyOpening'));
+    self.s.coreTopology.on('topologyClosed', relay('topologyClosed'));
+    self.s.coreTopology.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
+    self.s.coreTopology.on('attemptReconnect', relay('attemptReconnect'));
+    self.s.coreTopology.on('monitoring', relay('monitoring'));
+
+    // Start connection
+    self.s.coreTopology.connect(_options);
   }
+}
 
-  // Define the internal properties
-  this.s = {
-    // Create an instance of a server instance from mongodb-core
-    coreTopology: new CServer(clonedOptions),
-    // Server capabilities
-    sCapabilities: null,
-    // Cloned options
-    clonedOptions: clonedOptions,
-    // Reconnect
-    reconnect: clonedOptions.reconnect,
-    // Emit error
-    emitError: clonedOptions.emitError,
-    // Pool size
-    poolSize: clonedOptions.size,
-    // Store Options
-    storeOptions: storeOptions,
-    // Store
-    store: store,
-    // Host
-    host: host,
-    // Port
-    port: port,
-    // Options
-    options: options
-  };
-};
-
-inherits(Server, EventEmitter);
-
-var define = (Server.define = new Define('Server', Server, false));
-
-// BSON property
-Object.defineProperty(Server.prototype, 'bson', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.s.bson;
-  }
-});
-
-// Last ismaster
-Object.defineProperty(Server.prototype, 'isMasterDoc', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.lastIsMaster();
-  }
-});
-
-Object.defineProperty(Server.prototype, 'parserType', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.parserType;
-  }
-});
-
-// Last ismaster
 Object.defineProperty(Server.prototype, 'poolSize', {
   enumerable: true,
   get: function() {
@@ -288,272 +380,28 @@ Object.defineProperty(Server.prototype, 'port', {
   }
 });
 
-Object.defineProperty(Server.prototype, 'logicalSessionTimeoutMinutes', {
-  enumerable: true,
-  get: function() {
-    return this.s.coreTopology.logicalSessionTimeoutMinutes;
-  }
-});
-
-// Connect
-// Server.prototype.connect = function(db, _options, callback) {
-Server.prototype.connect = function(_options, callback) {
-  var self = this;
-  if ('function' === typeof _options) (callback = _options), (_options = {});
-  if (_options == null) _options = this.s.clonedOptions;
-  if (!('function' === typeof callback)) callback = null;
-  _options = assign({}, this.s.clonedOptions, _options);
-  self.s.options = _options;
-
-  // Update bufferMaxEntries
-  self.s.storeOptions.bufferMaxEntries =
-    typeof _options.bufferMaxEntries === 'number' ? _options.bufferMaxEntries : -1;
-
-  // Error handler
-  var connectErrorHandler = function() {
-    return function(err) {
-      // Remove all event handlers
-      var events = ['timeout', 'error', 'close'];
-      events.forEach(function(e) {
-        self.s.coreTopology.removeListener(e, connectHandlers[e]);
-      });
-
-      self.s.coreTopology.removeListener('connect', connectErrorHandler);
-
-      // Try to callback
-      try {
-        callback(err);
-      } catch (err) {
-        process.nextTick(function() {
-          throw err;
-        });
-      }
-    };
-  };
-
-  // Actual handler
-  var errorHandler = function(event) {
-    return function(err) {
-      if (event !== 'error') {
-        self.emit(event, err);
-      }
-    };
-  };
-
-  // Error handler
-  var reconnectHandler = function() {
-    self.emit('reconnect', self);
-    self.s.store.execute();
-  };
-
-  // Reconnect failed
-  var reconnectFailedHandler = function(err) {
-    self.emit('reconnectFailed', err);
-    self.s.store.flush(err);
-  };
-
-  // Destroy called on topology, perform cleanup
-  var destroyHandler = function() {
-    self.s.store.flush();
-  };
-
-  // relay the event
-  var relay = function(event) {
-    return function(t, server) {
-      self.emit(event, t, server);
-    };
-  };
-
-  // Connect handler
-  var connectHandler = function() {
-    // Clear out all the current handlers left over
-    ['timeout', 'error', 'close', 'destroy'].forEach(function(e) {
-      self.s.coreTopology.removeAllListeners(e);
-    });
-
-    // Set up listeners
-    self.s.coreTopology.on('timeout', errorHandler('timeout'));
-    self.s.coreTopology.once('error', errorHandler('error'));
-    self.s.coreTopology.on('close', errorHandler('close'));
-    // Only called on destroy
-    self.s.coreTopology.on('destroy', destroyHandler);
-
-    // Emit open event
-    self.emit('open', null, self);
-
-    // Return correctly
-    try {
-      callback(null, self);
-    } catch (err) {
-      console.log(err.stack);
-      process.nextTick(function() {
-        throw err;
-      });
-    }
-  };
-
-  // Set up listeners
-  var connectHandlers = {
-    timeout: connectErrorHandler('timeout'),
-    error: connectErrorHandler('error'),
-    close: connectErrorHandler('close')
-  };
-
-  // Clear out all the current handlers left over
-  [
-    'timeout',
-    'error',
-    'close',
-    'serverOpening',
-    'serverDescriptionChanged',
-    'serverHeartbeatStarted',
-    'serverHeartbeatSucceeded',
-    'serverHeartbeatFailed',
-    'serverClosed',
-    'topologyOpening',
-    'topologyClosed',
-    'topologyDescriptionChanged'
-  ].forEach(function(e) {
-    self.s.coreTopology.removeAllListeners(e);
-  });
-
-  // Add the event handlers
-  self.s.coreTopology.once('timeout', connectHandlers.timeout);
-  self.s.coreTopology.once('error', connectHandlers.error);
-  self.s.coreTopology.once('close', connectHandlers.close);
-  self.s.coreTopology.once('connect', connectHandler);
-  // Reconnect server
-  self.s.coreTopology.on('reconnect', reconnectHandler);
-  self.s.coreTopology.on('reconnectFailed', reconnectFailedHandler);
-
-  // Set up SDAM listeners
-  self.s.coreTopology.on('serverDescriptionChanged', relay('serverDescriptionChanged'));
-  self.s.coreTopology.on('serverHeartbeatStarted', relay('serverHeartbeatStarted'));
-  self.s.coreTopology.on('serverHeartbeatSucceeded', relay('serverHeartbeatSucceeded'));
-  self.s.coreTopology.on('serverHeartbeatFailed', relay('serverHeartbeatFailed'));
-  self.s.coreTopology.on('serverOpening', relay('serverOpening'));
-  self.s.coreTopology.on('serverClosed', relay('serverClosed'));
-  self.s.coreTopology.on('topologyOpening', relay('topologyOpening'));
-  self.s.coreTopology.on('topologyClosed', relay('topologyClosed'));
-  self.s.coreTopology.on('topologyDescriptionChanged', relay('topologyDescriptionChanged'));
-  self.s.coreTopology.on('attemptReconnect', relay('attemptReconnect'));
-  self.s.coreTopology.on('monitoring', relay('monitoring'));
-
-  // Start connection
-  self.s.coreTopology.connect(_options);
-};
-
-// Server capabilities
-Server.prototype.capabilities = function() {
-  if (this.s.sCapabilities) return this.s.sCapabilities;
-  if (this.s.coreTopology.lastIsMaster() == null) return null;
-  this.s.sCapabilities = new ServerCapabilities(this.s.coreTopology.lastIsMaster());
-  return this.s.sCapabilities;
-};
-
+const define = (Server.define = new Define('Server', Server, false));
 define.classMethod('capabilities', {
   callback: false,
   promise: false,
   returns: [ServerCapabilities]
 });
 
-// Command
-Server.prototype.command = function(ns, cmd, options, callback) {
-  this.s.coreTopology.command(ns, cmd, getReadPreference(options), callback);
-};
-
 define.classMethod('command', { callback: true, promise: false });
-
-// Insert
-Server.prototype.insert = function(ns, ops, options, callback) {
-  this.s.coreTopology.insert(ns, ops, options, callback);
-};
-
 define.classMethod('insert', { callback: true, promise: false });
-
-// Update
-Server.prototype.update = function(ns, ops, options, callback) {
-  this.s.coreTopology.update(ns, ops, options, callback);
-};
-
 define.classMethod('update', { callback: true, promise: false });
-
-// Remove
-Server.prototype.remove = function(ns, ops, options, callback) {
-  this.s.coreTopology.remove(ns, ops, options, callback);
-};
-
 define.classMethod('remove', { callback: true, promise: false });
-
-// IsConnected
-Server.prototype.isConnected = function() {
-  return this.s.coreTopology.isConnected();
-};
-
-Server.prototype.isDestroyed = function() {
-  return this.s.coreTopology.isDestroyed();
-};
-
 define.classMethod('isConnected', { callback: false, promise: false, returns: [Boolean] });
-
-// Insert
-Server.prototype.cursor = function(ns, cmd, options) {
-  options.disconnectHandler = this.s.store;
-  return this.s.coreTopology.cursor(ns, cmd, options);
-};
-
+define.classMethod('isDestroyed', { callback: false, promise: false, returns: [Boolean] });
 define.classMethod('cursor', {
   callback: false,
   promise: false,
   returns: [Cursor, AggregationCursor, CommandCursor]
 });
 
-Server.prototype.lastIsMaster = function() {
-  return this.s.coreTopology.lastIsMaster();
-};
-
-/**
- * Unref all sockets
- * @method
- */
-Server.prototype.unref = function() {
-  this.s.coreTopology.unref();
-};
-
-Server.prototype.close = function(forceClosed) {
-  this.s.coreTopology.destroy();
-  // We need to wash out all stored processes
-  if (forceClosed === true) {
-    this.s.storeOptions.force = forceClosed;
-    this.s.store.flush();
-  }
-};
-
 define.classMethod('close', { callback: false, promise: false });
-
-Server.prototype.auth = function() {
-  var args = Array.prototype.slice.call(arguments, 0);
-  this.s.coreTopology.auth.apply(this.s.coreTopology, args);
-};
-
 define.classMethod('auth', { callback: true, promise: false });
-
-Server.prototype.logout = function() {
-  var args = Array.prototype.slice.call(arguments, 0);
-  this.s.coreTopology.logout.apply(this.s.coreTopology, args);
-};
-
 define.classMethod('logout', { callback: true, promise: false });
-
-/**
- * All raw connections
- * @method
- * @return {array}
- */
-Server.prototype.connections = function() {
-  return this.s.coreTopology.connections();
-};
-
 define.classMethod('connections', { callback: false, promise: false, returns: [Array] });
 
 /**

--- a/lib/topologies/topology_base.js
+++ b/lib/topologies/topology_base.js
@@ -1,7 +1,12 @@
 'use strict';
 
-var MongoError = require('mongodb-core').MongoError,
-  f = require('util').format;
+const EventEmitter = require('events'),
+  MongoError = require('mongodb-core').MongoError,
+  f = require('util').format,
+  os = require('os'),
+  getReadPreference = require('../utils').getReadPreference,
+  ReadPreference = require('../read_preference'),
+  CoreReadPreference = require('mongodb-core').ReadPreference;
 
 // The store of ops
 var Store = function(topology, storeOptions) {
@@ -256,5 +261,172 @@ var ServerCapabilities = function(ismaster) {
   setup_get_property(this, 'hasSessionSupport', sessionSupport);
 };
 
+// Get package.json variable
+const driverVersion = require('../../package.json').version,
+  nodejsversion = f('Node.js %s, %s', process.version, os.endianness()),
+  type = os.type(),
+  name = process.platform,
+  architecture = process.arch,
+  release = os.release();
+
+// Ensure the right read Preference object
+const translateReadPreference = function(options) {
+  if (typeof options.readPreference === 'string') {
+    options.readPreference = new CoreReadPreference(options.readPreference);
+  } else if (options.readPreference instanceof ReadPreference) {
+    options.readPreference = new CoreReadPreference(
+      options.readPreference.mode,
+      options.readPreference.tags,
+      { maxStalenessSeconds: options.readPreference.maxStalenessSeconds }
+    );
+  }
+
+  return options;
+};
+
+class TopologyBase extends EventEmitter {
+  constructor() {
+    super();
+
+    // Build default client information
+    this.clientInfo = {
+      driver: {
+        name: 'nodejs',
+        version: driverVersion
+      },
+      os: {
+        type: type,
+        name: name,
+        architecture: architecture,
+        version: release
+      },
+      platform: nodejsversion
+    };
+  }
+
+  // Server capabilities
+  capabilities() {
+    if (this.s.sCapabilities) return this.s.sCapabilities;
+    if (this.s.coreTopology.lastIsMaster() == null) return null;
+    this.s.sCapabilities = new ServerCapabilities(this.s.coreTopology.lastIsMaster());
+    return this.s.sCapabilities;
+  }
+
+  // Command
+  command(ns, cmd, options, callback) {
+    this.s.coreTopology.command(ns, cmd, getReadPreference(options), callback);
+  }
+
+  // Insert
+  insert(ns, ops, options, callback) {
+    this.s.coreTopology.insert(ns, ops, options, callback);
+  }
+
+  // Update
+  update(ns, ops, options, callback) {
+    this.s.coreTopology.update(ns, ops, options, callback);
+  }
+
+  // Remove
+  remove(ns, ops, options, callback) {
+    this.s.coreTopology.remove(ns, ops, options, callback);
+  }
+
+  // IsConnected
+  isConnected(options) {
+    options = options || {};
+    options = translateReadPreference(options);
+
+    return this.s.coreTopology.isConnected(options);
+  }
+
+  // IsDestroyed
+  isDestroyed() {
+    return this.s.coreTopology.isDestroyed();
+  }
+
+  // Cursor
+  cursor(ns, cmd, options) {
+    options = options || {};
+    options = translateReadPreference(options);
+    options.disconnectHandler = this.s.store;
+
+    return this.s.coreTopology.cursor(ns, cmd, options);
+  }
+
+  lastIsMaster() {
+    return this.s.coreTopology.lastIsMaster();
+  }
+
+  /**
+   * Unref all sockets
+   * @method
+   */
+  unref() {
+    return this.s.coreTopology.unref();
+  }
+
+  auth() {
+    var args = Array.prototype.slice.call(arguments, 0);
+    this.s.coreTopology.auth.apply(this.s.coreTopology, args);
+  }
+
+  logout() {
+    var args = Array.prototype.slice.call(arguments, 0);
+    this.s.coreTopology.logout.apply(this.s.coreTopology, args);
+  }
+
+  /**
+   * All raw connections
+   * @method
+   * @return {array}
+   */
+  connections() {
+    return this.s.coreTopology.connections();
+  }
+
+  close(forceClosed) {
+    this.s.coreTopology.destroy({
+      force: typeof forceClosed === 'boolean' ? forceClosed : false
+    });
+
+    // We need to wash out all stored processes
+    if (forceClosed === true) {
+      this.s.storeOptions.force = forceClosed;
+      this.s.store.flush();
+    }
+  }
+}
+
+// Properties
+Object.defineProperty(TopologyBase.prototype, 'isMasterDoc', {
+  enumerable: true,
+  get: function() {
+    return this.s.coreTopology.lastIsMaster();
+  }
+});
+
+Object.defineProperty(TopologyBase.prototype, 'bson', {
+  enumerable: true,
+  get: function() {
+    return this.s.coreTopology.s.bson;
+  }
+});
+
+Object.defineProperty(TopologyBase.prototype, 'parserType', {
+  enumerable: true,
+  get: function() {
+    return this.s.coreTopology.parserType;
+  }
+});
+
+Object.defineProperty(TopologyBase.prototype, 'logicalSessionTimeoutMinutes', {
+  enumerable: true,
+  get: function() {
+    return this.s.coreTopology.logicalSessionTimeoutMinutes;
+  }
+});
+
 exports.Store = Store;
 exports.ServerCapabilities = ServerCapabilities;
+exports.TopologyBase = TopologyBase;


### PR DESCRIPTION
All three topology types were duplicating code across three files
needlessly.  This reduces duplication, while also making it easier
to maintain and modify in the future by providing a common
TopologyBase class that they all extend.