### PR TITLE
NODE-913 Don't throw error with unsupported connection string options

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -3,7 +3,8 @@
 var ReadPreference = require('./read_preference'),
   parser = require('url'),
   f = require('util').format,
-  assign = require('./utils').assign;
+  assign = require('./utils').assign,
+  Logger = require('mongodb-core').Logger;
 
 module.exports = function(url, options) {
   // Variables
@@ -265,16 +266,6 @@ module.exports = function(url, options) {
       case 'auto_reconnect':
         serverOptions.auto_reconnect = value === 'true';
         break;
-      case 'minPoolSize':
-        throw new Error('minPoolSize not supported');
-      case 'maxIdleTimeMS':
-        throw new Error('maxIdleTimeMS not supported');
-      case 'waitQueueMultiple':
-        throw new Error('waitQueueMultiple not supported');
-      case 'waitQueueTimeoutMS':
-        throw new Error('waitQueueTimeoutMS not supported');
-      case 'uuidRepresentation':
-        throw new Error('uuidRepresentation not supported');
       case 'ssl':
         if (value === 'prefer') {
           serverOptions.ssl = value;
@@ -448,6 +439,8 @@ module.exports = function(url, options) {
         serverOptions.compression = compression;
         break;
       default:
+        var logger = Logger('URL Parser');
+        logger.info(`${name} is not supported`);
         break;
     }
   });

--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -440,7 +440,7 @@ module.exports = function(url, options) {
         break;
       default:
         var logger = Logger('URL Parser');
-        logger.info(`${name} is not supported`);
+        logger.warn(`${name} is not supported as a connection string option`);
         break;
     }
   });

--- a/test/functional/url_parser_tests.js
+++ b/test/functional/url_parser_tests.js
@@ -563,12 +563,12 @@ describe('Url Parser', function() {
       Logger.setCurrentLogger(function(msg, context) {
         expect(msg).to.exist;
         expect(msg).to.contain('not supported');
-        expect(context.type).to.equal('info');
+        expect(context.type).to.equal('warn');
         expect(context.className).to.equal('URL Parser');
         logged = true;
       });
 
-      Logger.setLevel('info');
+      Logger.setLevel('warn');
 
       parse('mongodb://localhost/db?minPoolSize=100');
       expect(logged).to.be.true;

--- a/test/functional/url_parser_tests.js
+++ b/test/functional/url_parser_tests.js
@@ -550,7 +550,7 @@ describe('Url Parser', function() {
   /**
    * @ignore
    */
-  it.only('should log when unsuported options are used in url', {
+  it('should log when unsuported options are used in url', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },

--- a/test/functional/url_parser_tests.js
+++ b/test/functional/url_parser_tests.js
@@ -550,31 +550,38 @@ describe('Url Parser', function() {
   /**
    * @ignore
    */
-  it('should throw on unsuported options', {
+  it.only('should log when unsuported options are used in url', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
     test: function() {
-      expect(function() {
-        parse('mongodb://localhost/db?minPoolSize=100');
-      }).to.throw(/minPoolSize not supported/);
+      var self = this,
+        Logger = self.configuration.require.Logger,
+        logged = false;
 
-      expect(function() {
-        parse('mongodb://localhost/db?maxIdleTimeMS=100');
-      }).to.throw(/maxIdleTimeMS not supported/);
+      Logger.setCurrentLogger(function(msg, context) {
+        expect(msg).to.exist;
+        expect(msg).to.contain('not supported');
+        expect(context.type).to.equal('info');
+        expect(context.className).to.equal('URL Parser');
+        logged = true;
+      });
 
-      expect(function() {
-        parse('mongodb://localhost/db?waitQueueMultiple=100');
-      }).to.throw(/waitQueueMultiple not supported/);
+      Logger.setLevel('info');
 
-      expect(function() {
-        parse('mongodb://localhost/db?waitQueueTimeoutMS=100');
-      }).to.throw(/waitQueueTimeoutMS not supported/);
+      parse('mongodb://localhost/db?minPoolSize=100');
+      expect(logged).to.be.true;
+      parse('mongodb://localhost/db?maxIdleTimeMS=100');
+      expect(logged).to.be.true;
+      parse('mongodb://localhost/db?waitQueueMultiple=100');
+      expect(logged).to.be.true;
+      parse('mongodb://localhost/db?waitQueueTimeoutMS=100');
+      expect(logged).to.be.true;
+      parse('mongodb://localhost/db?uuidRepresentation=1');
+      expect(logged).to.be.true;
 
-      expect(function() {
-        parse('mongodb://localhost/db?uuidRepresentation=1');
-      }).to.throw(/uuidRepresentation not supported/);
+      Logger.reset();
     }
   });
 


### PR DESCRIPTION
This changes the url parser so that unsupported connection string options don't throw an error and prevent the connection, instead they're ignored and a warning is issued 🍍 

Fixes [NODE-913](https://jira.mongodb.org/browse/NODE-913)