### PR TITLE
NODE-1168 promoteBuffers + GridFS = TypeError: doc.data.length is not a function

### DIFF
--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -209,26 +209,27 @@ function doRead(_this) {
       return __handleError(_this, new Error(errmsg));
     }
 
-    if (doc.data.length() !== expectedLength) {
+    var buf = Buffer.isBuffer(doc.data) ? doc.data : doc.data.buffer;
+
+    if (buf.length !== expectedLength) {
       if (bytesRemaining <= 0) {
         errmsg = 'ExtraChunk: Got unexpected n: ' + doc.n;
         return __handleError(_this, new Error(errmsg));
       }
 
       errmsg = 'ChunkIsWrongSize: Got unexpected length: ' +
-        doc.data.length() + ', expected: ' + expectedLength;
+        buf.length + ', expected: ' + expectedLength;
       return __handleError(_this, new Error(errmsg));
     }
 
-    _this.s.bytesRead += doc.data.length();
+    _this.s.bytesRead += buf.length;
 
-    if (doc.data.buffer.length === 0) {
+    if (buf.length === 0) {
       return _this.push(null);
     }
 
     var sliceStart = null;
     var sliceEnd = null;
-    var buf = doc.data.buffer;
 
     if (_this.s.bytesToSkip != null) {
       sliceStart = _this.s.bytesToSkip;
@@ -241,7 +242,7 @@ function doRead(_this) {
 
     // If the remaining amount of data left is < chunkSize read the right amount of data
     if (_this.s.options.end && (
-      (_this.s.options.end - _this.s.bytesToSkip) < doc.data.length()
+      (_this.s.options.end - _this.s.bytesToSkip) < buf.length
     )) {
       sliceEnd = (_this.s.options.end - _this.s.bytesToSkip);
     }


### PR DESCRIPTION
BUG: https://jira.mongodb.org/browse/NODE-1168

When using the promoteBuffers connect option, `doc.data` is already a node.js Buffer.
So trying to call `length()` like for `BSON.Binary` fails.
Fixed simply by checking `Buffer.isBuffer(doc.data)` type.

Would love to get your review, and fix whatever is needed.

Thanks