### PR TITLE
Change 'updateOne' into 'replaceOne' in e.g 54

### DIFF
--- a/test/functional/examples_tests.js
+++ b/test/functional/examples_tests.js
@@ -851,7 +851,7 @@ exports['update and replace'] = {
 
         var promise =
         // Start Example 54
-        db.collection('inventory').updateOne(
+        db.collection('inventory').replaceOne(
           { item: "paper" },
           { item: "paper", 
             instock: [


### PR DESCRIPTION
I got here from the tutorial, and the reference of this test in tutorial is 'https://docs.mongodb.com/manual/tutorial/update-documents/#replace-a-document' .
updateOne should contain atomic operators, while replaceOne needn't.
Thus according to the context, I infer the original purpose in that doc shall refers to 'replaceOne' instead of 'updateOne'