### PR TITLE
Better error message for slash in hostname

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -87,7 +87,13 @@ module.exports = function(url, options) {
   for(i = 0; i < hosts.length; i++) {
     var r = parser.parse(f('mongodb://%s', hosts[i].trim()));
     if(r.path && r.path.indexOf(':') != -1) {
-      throw new Error('double colon in host identifier');
+      // Not connecting to a socket so check for an extra slash in the hostname.
+      // Using String#split as perf is better than match.
+      if (r.path.split('/').length > 1) {
+        throw new Error('slash in host identifier');
+      } else {
+        throw new Error('double colon in host identifier');
+      }
     }
   }
 

--- a/test/functional/url_parser_tests.js
+++ b/test/functional/url_parser_tests.js
@@ -669,3 +669,15 @@ exports['Should use options passed into url parsing'] = {
     test.done();
   }
 }
+
+/**
+ * @ignore
+ */
+exports['Raises exceptions on invalid hostnames'] = {
+  metadata: { requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] } },
+  test: function(configure, test) {
+    test.throws(function() { parse("mongodb://invalid::host:27017/db") }, "double colon in host identifier");
+    test.throws(function() { parse("mongodb://invalid/host:27017/db") }, "slash in host identifier");
+    test.done();
+  }
+}


### PR DESCRIPTION
If a user enters a non-socket hostname with more than one "/" in it (such as `mongodb://invalid/127.0.0.1:27017/db`), the error message would previously state "double colon in host identifier" which was incorrect.