### PR TITLE
Fix cursor issues with driver sessions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       env: MONGODB_VERSION=3.4.x
     - stage: tests
       node_js: 4
-      env: MONGODB_VERSION=3.5.x
+      env: MONGODB_VERSION=3.6.0-rc2
 
     - stage: tests
       node_js: 6

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2628,7 +2628,9 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
   // Add a promiseLibrary
   options.promiseLibrary = this.s.promiseLibrary;
 
-  return executeOperation(this.s.topology, parallelCollectionScan, [this, options, callback]);
+  return executeOperation(this.s.topology, parallelCollectionScan, [this, options, callback], {
+    returnsCursor: true
+  });
 };
 
 var parallelCollectionScan = function(self, options, callback) {

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -141,7 +141,7 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
     // Current doc
     currentDoc: null,
     // Optional ClientSession
-    session: options.session || null
+    session: options.session
   };
 
   // Translate correctly

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -808,8 +808,7 @@ var _each = function(self, callback) {
     self.next(function(err, item) {
       if (err) return handleCallback(callback, err);
       if (item == null) {
-        self.s.state = Cursor.CLOSED;
-        return handleCallback(callback, null, null);
+        return self.close({ skipKillCursors: true }, () => handleCallback(callback, null, null));
       }
 
       if (handleCallback(callback, null, item) === false) return;
@@ -930,8 +929,7 @@ var toArray = function(self, callback) {
     self._next(function(err, doc) {
       if (err) return handleCallback(callback, err);
       if (doc == null) {
-        self.s.state = Cursor.CLOSED;
-        return handleCallback(callback, null, items);
+        return self.close({ skipKillCursors: true }, () => handleCallback(callback, null, items));
       }
 
       // Add doc to items
@@ -1049,13 +1047,21 @@ define.classMethod('count', { callback: true, promise: true });
 /**
  * Close the cursor, sending a KillCursor command and emitting close.
  * @method
+ * @param {object} [options] Optional settings.
+ * @param {boolean} [options.skipKillCursors] Bypass calling killCursors when closing the cursor.
  * @param {Cursor~resultCallback} [callback] The result callback.
  * @return {Promise} returns Promise if no callback passed
  */
-Cursor.prototype.close = function(callback) {
+Cursor.prototype.close = function(options, callback) {
+  if (typeof options === 'function') (callback = options), (options = {});
+  options = Object.assign({}, { skipKillCursors: false }, options);
+
   this.s.state = Cursor.CLOSED;
-  // Kill the cursor
-  this.kill();
+  if (!options.skipKillCursors) {
+    // Kill the cursor
+    this.kill();
+  }
+
   // Emit the close event for the cursor
   this.emit('close');
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -139,7 +139,9 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
     // Promise library
     promiseLibrary: promiseLibrary,
     // Current doc
-    currentDoc: null
+    currentDoc: null,
+    // Optional ClientSession
+    session: options.session || null
   };
 
   // Translate correctly
@@ -1062,15 +1064,23 @@ Cursor.prototype.close = function(options, callback) {
     this.kill();
   }
 
-  // Emit the close event for the cursor
-  this.emit('close');
+  const completeClose = () => {
+    // Emit the close event for the cursor
+    this.emit('close');
 
-  // Callback if provided
-  if (typeof callback === 'function') return handleCallback(callback, null, this);
-  // Return a Promise
-  return new this.s.promiseLibrary(function(resolve) {
-    resolve();
-  });
+    // Callback if provided
+    if (typeof callback === 'function') return handleCallback(callback, null, this);
+    // Return a Promise
+    return new this.s.promiseLibrary(function(resolve) {
+      resolve();
+    });
+  };
+
+  if (this.s.session) {
+    return this.s.session.endSession(() => completeClose());
+  }
+
+  completeClose();
 };
 
 define.classMethod('close', { callback: true, promise: true });

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -1069,7 +1069,10 @@ Cursor.prototype.close = function(options, callback) {
     this.emit('close');
 
     // Callback if provided
-    if (typeof callback === 'function') return handleCallback(callback, null, this);
+    if (typeof callback === 'function') {
+      return handleCallback(callback, null, this);
+    }
+
     // Return a Promise
     return new this.s.promiseLibrary(function(resolve) {
       resolve();
@@ -1080,7 +1083,7 @@ Cursor.prototype.close = function(options, callback) {
     return this.s.session.endSession(() => completeClose());
   }
 
-  completeClose();
+  return completeClose();
 };
 
 define.classMethod('close', { callback: true, promise: true });

--- a/lib/db.js
+++ b/lib/db.js
@@ -604,16 +604,9 @@ var createCollection = function(self, name, options, callback) {
  * @return {Promise} returns Promise if no callback passed
  */
 Db.prototype.createCollection = function(name, options, callback) {
-  var args = Array.prototype.slice.call(arguments, 0);
-  callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
-  name = args.length ? args.shift() : null;
-  options = args.length ? args.shift() || {} : {};
-
-  // Do we have a promisesLibrary
+  if (typeof options === 'function') (callback = options), (options = {});
+  options = options || {};
   options.promiseLibrary = options.promiseLibrary || this.s.promiseLibrary;
-
-  // Check if the callback is in fact a string
-  if (typeof callback === 'string') name = callback;
 
   return executeOperation(this.s.topology, createCollection, [this, name, options, callback]);
 };

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -160,7 +160,9 @@ GridFSBucket.prototype.openDownloadStream = function(id, options) {
  */
 
 GridFSBucket.prototype.delete = function(id, callback) {
-  return executeOperation(this.s.db.s.topology, _delete, [this, id, callback]);
+  return executeOperation(this.s.db.s.topology, _delete, [this, id, callback], {
+    skipSessions: true
+  });
 };
 
 /**
@@ -283,7 +285,9 @@ GridFSBucket.prototype.openDownloadStreamByName = function(filename, options) {
  */
 
 GridFSBucket.prototype.rename = function(id, filename, callback) {
-  return executeOperation(this.s.db.s.topology, _rename, [this, id, filename, callback]);
+  return executeOperation(this.s.db.s.topology, _rename, [this, id, filename, callback], {
+    skipSessions: true
+  });
 };
 
 /**
@@ -311,7 +315,9 @@ function _rename(_this, id, filename, callback) {
  */
 
 GridFSBucket.prototype.drop = function(callback) {
-  return executeOperation(this.s.db.s.topology, _drop, [this, callback]);
+  return executeOperation(this.s.db.s.topology, _drop, [this, callback], {
+    skipSessions: true
+  });
 };
 
 /**

--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -201,7 +201,9 @@ GridStore.prototype.open = function(options, callback) {
     throw MongoError.create({ message: 'Illegal mode ' + this.mode, driver: true });
   }
 
-  return executeOperation(this.db.s.topology, open, [this, options, callback]);
+  return executeOperation(this.db.s.topology, open, [this, options, callback], {
+    skipSessions: true
+  });
 };
 
 var open = function(self, options, callback) {
@@ -276,7 +278,9 @@ GridStore.prototype.getc = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  return executeOperation(this.db.s.topology, getc, [this, options, callback]);
+  return executeOperation(this.db.s.topology, getc, [this, options, callback], {
+    skipSessions: true
+  });
 };
 
 var getc = function(self, options, callback) {
@@ -313,11 +317,12 @@ GridStore.prototype.puts = function(string, options, callback) {
   options = options || {};
 
   var finalString = string.match(/\n$/) == null ? string + '\n' : string;
-  return executeOperation(this.db.s.topology, this.write.bind(this), [
-    finalString,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.db.s.topology,
+    this.write.bind(this),
+    [finalString, options, callback],
+    { skipSessions: true }
+  );
 };
 
 define.classMethod('puts', { callback: true, promise: true });
@@ -351,7 +356,12 @@ GridStore.prototype.write = function write(data, close, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  return executeOperation(this.db.s.topology, _writeNormal, [this, data, close, options, callback]);
+  return executeOperation(
+    this.db.s.topology,
+    _writeNormal,
+    [this, data, close, options, callback],
+    { skipSessions: true }
+  );
 };
 
 define.classMethod('write', { callback: true, promise: true });
@@ -391,7 +401,9 @@ GridStore.prototype.writeFile = function(file, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  return executeOperation(this.db.s.topology, writeFile, [this, file, options, callback]);
+  return executeOperation(this.db.s.topology, writeFile, [this, file, options, callback], {
+    skipSessions: true
+  });
 };
 
 var writeFile = function(self, file, options, callback) {
@@ -476,7 +488,9 @@ GridStore.prototype.close = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  return executeOperation(this.db.s.topology, close, [this, options, callback]);
+  return executeOperation(this.db.s.topology, close, [this, options, callback], {
+    skipSessions: true
+  });
 };
 
 var close = function(self, options, callback) {
@@ -581,7 +595,9 @@ GridStore.prototype.unlink = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  return executeOperation(this.db.s.topology, unlink, [this, options, callback]);
+  return executeOperation(this.db.s.topology, unlink, [this, options, callback], {
+    skipSessions: true
+  });
 };
 
 var unlink = function(self, options, callback) {
@@ -646,7 +662,9 @@ GridStore.prototype.readlines = function(separator, options, callback) {
   separator = separator || '\n';
   options = args.length ? args.shift() : {};
 
-  return executeOperation(this.db.s.topology, readlines, [this, separator, options, callback]);
+  return executeOperation(this.db.s.topology, readlines, [this, separator, options, callback], {
+    skipSessions: true
+  });
 };
 
 var readlines = function(self, separator, options, callback) {
@@ -680,7 +698,9 @@ GridStore.prototype.rewind = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  return executeOperation(this.db.s.topology, rewind, [this, options, callback]);
+  return executeOperation(this.db.s.topology, rewind, [this, options, callback], {
+    skipSessions: true
+  });
 };
 
 var rewind = function(self, options, callback) {
@@ -742,7 +762,9 @@ GridStore.prototype.read = function(length, buffer, options, callback) {
   buffer = args.length ? args.shift() : null;
   options = args.length ? args.shift() : {};
 
-  return executeOperation(this.db.s.topology, read, [this, length, buffer, options, callback]);
+  return executeOperation(this.db.s.topology, read, [this, length, buffer, options, callback], {
+    skipSessions: true
+  });
 };
 
 var read = function(self, length, buffer, options, callback) {
@@ -860,13 +882,12 @@ GridStore.prototype.seek = function(position, seekLocation, options, callback) {
   seekLocation = args.length ? args.shift() : null;
   options = args.length ? args.shift() : {};
 
-  return executeOperation(this.db.s.topology, seek, [
-    this,
-    position,
-    seekLocation,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.db.s.topology,
+    seek,
+    [this, position, seekLocation, options, callback],
+    { skipSessions: true }
+  );
 };
 
 var seek = function(self, position, seekLocation, options, callback) {
@@ -924,7 +945,9 @@ var _open = function(self, options, callback) {
   // Fetch the chunks
   if (query != null) {
     collection.findOne(query, options, function(err, doc) {
-      if (err) return error(err);
+      if (err) {
+        return error(err);
+      }
 
       // Check if the collection for the files exists otherwise prepare the new one
       if (doc != null) {
@@ -1238,38 +1261,38 @@ var deleteChunks = function(self, options, callback) {
 };
 
 /**
-* The collection to be used for holding the files and chunks collection.
-*
-* @classconstant DEFAULT_ROOT_COLLECTION
-**/
+ * The collection to be used for holding the files and chunks collection.
+ *
+ * @classconstant DEFAULT_ROOT_COLLECTION
+ */
 GridStore.DEFAULT_ROOT_COLLECTION = 'fs';
 
 /**
-* Default file mime type
-*
-* @classconstant DEFAULT_CONTENT_TYPE
-**/
+ * Default file mime type
+ *
+ * @classconstant DEFAULT_CONTENT_TYPE
+ */
 GridStore.DEFAULT_CONTENT_TYPE = 'binary/octet-stream';
 
 /**
-* Seek mode where the given length is absolute.
-*
-* @classconstant IO_SEEK_SET
-**/
+ * Seek mode where the given length is absolute.
+ *
+ * @classconstant IO_SEEK_SET
+ */
 GridStore.IO_SEEK_SET = 0;
 
 /**
-* Seek mode where the given length is an offset to the current read/write head.
-*
-* @classconstant IO_SEEK_CUR
-**/
+ * Seek mode where the given length is an offset to the current read/write head.
+ *
+ * @classconstant IO_SEEK_CUR
+ */
 GridStore.IO_SEEK_CUR = 1;
 
 /**
-* Seek mode where the given length is an offset to the end of the file.
-*
-* @classconstant IO_SEEK_END
-**/
+ * Seek mode where the given length is an offset to the end of the file.
+ *
+ * @classconstant IO_SEEK_END
+ */
 GridStore.IO_SEEK_END = 2;
 
 /**
@@ -1295,13 +1318,12 @@ GridStore.exist = function(db, fileIdObject, rootCollection, options, callback) 
   options = args.length ? args.shift() : {};
   options = options || {};
 
-  return executeOperation(db.s.topology, exists, [
-    db,
-    fileIdObject,
-    rootCollection,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    db.s.topology,
+    exists,
+    [db, fileIdObject, rootCollection, options, callback],
+    { skipSessions: true }
+  );
 };
 
 var exists = function(db, fileIdObject, rootCollection, options, callback) {
@@ -1361,7 +1383,9 @@ GridStore.list = function(db, rootCollection, options, callback) {
   options = args.length ? args.shift() : {};
   options = options || {};
 
-  return executeOperation(db.s.topology, list, [db, rootCollection, options, callback]);
+  return executeOperation(db.s.topology, list, [db, rootCollection, options, callback], {
+    skipSessions: true
+  });
 };
 
 var list = function(db, rootCollection, options, callback) {
@@ -1430,7 +1454,12 @@ GridStore.read = function(db, name, length, offset, options, callback) {
   options = args.length ? args.shift() : null;
   options = options || {};
 
-  return executeOperation(db.s.topology, readStatic, [db, name, length, offset, options, callback]);
+  return executeOperation(
+    db.s.topology,
+    readStatic,
+    [db, name, length, offset, options, callback],
+    { skipSessions: true }
+  );
 };
 
 var readStatic = function(db, name, length, offset, options, callback) {
@@ -1480,7 +1509,12 @@ GridStore.readlines = function(db, name, separator, options, callback) {
   options = args.length ? args.shift() : null;
   options = options || {};
 
-  return executeOperation(db.s.topology, readlinesStatic, [db, name, separator, options, callback]);
+  return executeOperation(
+    db.s.topology,
+    readlinesStatic,
+    [db, name, separator, options, callback],
+    { skipSessions: true }
+  );
 };
 
 var readlinesStatic = function(db, name, separator, options, callback) {
@@ -1513,7 +1547,9 @@ GridStore.unlink = function(db, names, options, callback) {
   options = args.length ? args.shift() : {};
   options = options || {};
 
-  return executeOperation(db.s.topology, unlinkStatic, [this, db, names, options, callback]);
+  return executeOperation(db.s.topology, unlinkStatic, [this, db, names, options, callback], {
+    skipSessions: true
+  });
 };
 
 var unlinkStatic = function(self, db, names, options, callback) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -425,7 +425,7 @@ const executeOperation = (topology, operation, args, options) => {
     args.push((err, result) => {
       if (session && !options.returnsCursor) {
         session.endSession(() => {
-          opOptions.session = undefined;
+          delete opOptions.session;
           if (err) return callback(err, null);
           return resultMutator ? callback(null, resultMutator(result)) : callback(null, result);
         });
@@ -447,7 +447,7 @@ const executeOperation = (topology, operation, args, options) => {
     args[args.length - 1] = (err, r) => {
       if (session && !options.returnsCursor) {
         session.endSession(() => {
-          opOptions.session = undefined;
+          delete opOptions.session;
           if (err) return reject(err);
           if (resultMutator) return resolve(resultMutator(r));
           resolve(r);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -408,13 +408,14 @@ const executeOperation = (topology, operation, args, options) => {
 
   // The driver sessions spec mandates that we implicitly create sessions for operations
   // that are not explicitly provided with a session.
-
-  let session;
+  let session, opOptions;
   if (!options.skipSessions && topology.capabilities().hasSessionSupport) {
-    const opOptions = args[args.length - 2];
+    opOptions = args[args.length - 2];
     if (opOptions == null || opOptions.session == null) {
       session = topology.startSession();
       assign(args[args.length - 2], { session: session });
+    } else if (opOptions.session && opOptions.session.hasEnded) {
+      throw new MongoError('Use of expired sessions is not permitted');
     }
   }
 
@@ -422,8 +423,9 @@ const executeOperation = (topology, operation, args, options) => {
   if (typeof callback === 'function') {
     callback = args.pop();
     args.push((err, result) => {
-      if (session) {
+      if (session && !options.returnsCursor) {
         session.endSession(() => {
+          opOptions.session = undefined;
           if (err) return callback(err, null);
           return resultMutator ? callback(null, resultMutator(result)) : callback(null, result);
         });
@@ -438,14 +440,14 @@ const executeOperation = (topology, operation, args, options) => {
 
   // Return a Promise
   if (args[args.length - 1] != null) {
-    console.dir(operation.name);
     throw new TypeError('final argument to `executeOperation` must be a callback');
   }
 
   return new Promise(function(resolve, reject) {
     args[args.length - 1] = (err, r) => {
-      if (session) {
+      if (session && !options.returnsCursor) {
         session.endSession(() => {
+          opOptions.session = undefined;
           if (err) return reject(err);
           if (resultMutator) return resolve(resultMutator(r));
           resolve(r);

--- a/test/functional/db_tests.js
+++ b/test/functional/db_tests.js
@@ -304,7 +304,7 @@ describe('Db', function() {
                   test.equal(null, err);
 
                   // Force a reindex of the collection
-                  collection.reIndex('create_and_drop_all_indexes', function(err, result) {
+                  collection.reIndex(function(err, result) {
                     test.equal(null, err);
                     test.equal(true, result);
 

--- a/test/functional/gridfs_tests.js
+++ b/test/functional/gridfs_tests.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var test = require('./shared').assert;
-var setupDatabase = require('./shared').setupDatabase;
-var fs = require('fs');
-var format = require('util').format;
-var child_process = require('child_process');
+const test = require('./shared').assert,
+  setupDatabase = require('./shared').setupDatabase,
+  fs = require('fs'),
+  format = require('util').format,
+  child_process = require('child_process'),
+  expect = require('chai').expect;
 
 describe('GridFS', function() {
   before(function() {
@@ -26,6 +27,7 @@ describe('GridFS', function() {
         ObjectID = configuration.require.ObjectID;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var id = new ObjectID(),
           filename = 'test_create_gridstore';
@@ -59,6 +61,8 @@ describe('GridFS', function() {
       var GridStore = configuration.require.GridStore;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var id = 123,
           filename = 'test_create_gridstore';
@@ -93,6 +97,7 @@ describe('GridFS', function() {
       var GridStore = configuration.require.GridStore;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var id = 'test',
           filename = 'test_create_gridstore';
@@ -128,13 +133,18 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, null, 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err, result) {
+              expect(err).to.not.exist;
               // Let's read the file using object Id
               GridStore.read(db, result._id, function(err, data) {
+                expect(err).to.not.exist;
                 test.equal('hello world!', data.toString());
                 client.close();
                 done();
@@ -161,21 +171,27 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'foobar', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
               GridStore.exist(db, 'foobar', function(err, result) {
+                expect(err).to.not.exist;
                 test.equal(true, result);
               });
 
               GridStore.exist(db, 'does_not_exist', function(err, result) {
+                expect(err).to.not.exist;
                 test.equal(false, result);
               });
 
               GridStore.exist(db, 'foobar', 'another_root', function(err, result) {
+                expect(err).to.not.exist;
                 test.equal(false, result);
                 client.close();
                 done();
@@ -202,15 +218,19 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_read_length', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Assert that we have overwriten the data
               GridStore.read(db, 'test_gs_read_length', 5, function(err, data) {
+                expect(err).to.not.exist;
                 test.equal('hello', data.toString());
                 client.close();
                 done();
@@ -237,19 +257,24 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_read_with_offset', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello, world!', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Assert that we have overwriten the data
               GridStore.read(db, 'test_gs_read_with_offset', 5, 7, function(err, data) {
+                expect(err).to.not.exist;
                 test.equal('world', data.toString());
               });
 
               GridStore.read(db, 'test_gs_read_with_offset', null, 7, function(err, data) {
+                expect(err).to.not.exist;
                 test.equal('world!', data.toString());
                 client.close();
                 done();
@@ -276,15 +301,17 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var gridStore = new GridStore(db, 'test_gs_multi_chunk', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           test.equal(null, err);
 
           gridStore.chunkCollection().deleteMany({}, function(err) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
             gridStore.chunkSize = 512;
             var file1 = '';
             var file2 = '';
@@ -302,24 +329,26 @@ describe('GridFS', function() {
             }
 
             gridStore.write(file1, function(err, gridStore) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               gridStore.write(file2, function(err, gridStore) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 gridStore.write(file3, function(err, gridStore) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   gridStore.close(function(err) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     db.collection('fs.chunks', function(err, collection) {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
 
                       collection.count(function(err, count) {
+                        expect(err).to.not.exist;
                         test.equal(3, count);
 
                         GridStore.read(db, 'test_gs_multi_chunk', function(err, data) {
+                          expect(err).to.not.exist;
                           test.equal(512 * 3, data.length);
                           client.close();
 
@@ -352,25 +381,32 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
 
         var gridStore = new GridStore(db, '9476700.937375426_1271170118964-clipped.png', 'w', {
           root: 'articles'
         });
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           db.collection('articles.files').deleteMany({}, function() {
             db.collection('articles.chunks').deleteMany({}, function() {
               gridStore.write('hello, world!', function(err, gridStore) {
+                expect(err).to.not.exist;
                 gridStore.close(function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
                   db.collection('articles.files', function(err, collection) {
+                    expect(err).to.not.exist;
                     collection.count(function(err, count) {
+                      expect(err).to.not.exist;
                       test.equal(1, count);
                     });
                   });
 
                   db.collection('articles.chunks', function(err, collection) {
+                    expect(err).to.not.exist;
                     collection.count(function(err, count) {
+                      expect(err).to.not.exist;
                       test.equal(1, count);
 
                       // Unlink the file
@@ -379,15 +415,19 @@ describe('GridFS', function() {
                         '9476700.937375426_1271170118964-clipped.png',
                         { root: 'articles' },
                         function(err) {
-                          test.equal(null, err);
+                          expect(err).to.not.exist;
                           db.collection('articles.files', function(err, collection) {
+                            expect(err).to.not.exist;
                             collection.count(function(err, count) {
+                              expect(err).to.not.exist;
                               test.equal(0, count);
                             });
                           });
 
                           db.collection('articles.chunks', function(err, collection) {
+                            expect(err).to.not.exist;
                             collection.count(function(err, count) {
+                              expect(err).to.not.exist;
                               test.equal(0, count);
 
                               client.close();
@@ -422,34 +462,45 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
 
         var gridStore = new GridStore(db, 'test_gs_unlink_as_array', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           db.collection('fs.files').deleteMany({}, function() {
             db.collection('fs.chunks').deleteMany({}, function() {
               gridStore.write('hello, world!', function(err, gridStore) {
+                expect(err).to.not.exist;
                 gridStore.close(function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
                   db.collection('fs.files', function(err, collection) {
+                    expect(err).to.not.exist;
                     collection.count(function(err, count) {
+                      expect(err).to.not.exist;
                       test.equal(1, count);
                     });
                   });
 
                   db.collection('fs.chunks', function(err, collection) {
+                    expect(err).to.not.exist;
                     collection.count(function(err, count) {
+                      expect(err).to.not.exist;
                       test.equal(1, count);
 
                       // Unlink the file
                       GridStore.unlink(db, ['test_gs_unlink_as_array'], function(err) {
-                        test.equal(null, err);
+                        expect(err).to.not.exist;
                         db.collection('fs.files', function(err, collection) {
+                          expect(err).to.not.exist;
                           collection.count(function(err, count) {
+                            expect(err).to.not.exist;
                             test.equal(0, count);
 
                             db.collection('fs.chunks', function(err, collection) {
+                              expect(err).to.not.exist;
                               collection.count(function(err, count) {
+                                expect(err).to.not.exist;
                                 test.equal(0, count);
                                 client.close();
 
@@ -485,21 +536,25 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_writing_file', 'w');
         var fileSize = fs.statSync('./test/functional/data/test_gs_weird_bug.png').size;
         var data = fs.readFileSync('./test/functional/data/test_gs_weird_bug.png');
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.writeFile('./test/functional/data/test_gs_weird_bug.png', function(err) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
             GridStore.read(db, 'test_gs_writing_file', function(err, fileData) {
+              expect(err).to.not.exist;
               test.equal(data.toString('base64'), fileData.toString('base64'));
               test.equal(fileSize, fileData.length);
 
               // Ensure we have a md5
               var gridStore2 = new GridStore(db, 'test_gs_writing_file', 'r');
               gridStore2.open(function(err, gridStore2) {
+                expect(err).to.not.exist;
                 test.ok(gridStore2.md5 != null);
                 client.close();
                 done();
@@ -526,20 +581,25 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, null, 'w');
         var fileSize = fs.statSync('./test/functional/data/test_gs_weird_bug.png').size;
         var data = fs.readFileSync('./test/functional/data/test_gs_weird_bug.png');
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.writeFile('./test/functional/data/test_gs_weird_bug.png', function(err, doc) {
+            expect(err).to.not.exist;
             GridStore.read(db, doc.fileId, function(err, fileData) {
+              expect(err).to.not.exist;
               test.equal(data.toString('base64'), fileData.toString('base64'));
               test.equal(fileSize, fileData.length);
 
               // Ensure we have a md5
               var gridStore2 = new GridStore(db, doc.fileId, 'r');
               gridStore2.open(function(err, gridStore2) {
+                expect(err).to.not.exist;
                 test.ok(gridStore2.md5 != null);
                 client.close();
                 done();
@@ -566,6 +626,7 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_working_field_read', 'w');
         var data = fs.readFileSync(
@@ -574,11 +635,14 @@ describe('GridFS', function() {
         );
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write(data, function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
               // Assert that we have overwriten the data
               GridStore.read(db, 'test_gs_working_field_read', function(err, fileData) {
+                expect(err).to.not.exist;
                 test.equal(data.length, fileData.length);
                 client.close();
                 done();
@@ -605,6 +669,7 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         // Create a new file
         var gridStore = new GridStore(db, 'test.txt', 'w');
@@ -614,22 +679,23 @@ describe('GridFS', function() {
 
         // Open the file
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           var file = fs.createReadStream('./test/functional/data/test_gs_working_field_read.pdf');
 
           // Write the binary file data to GridFS
           file.on('data', function(chunk) {
             gridStore.write(chunk, function(err) {
-              if (err) {
-                test.ok(false);
-              }
+              expect(err).to.not.exist;
             });
           });
 
           file.on('close', function() {
             // Flush the remaining data to GridFS
             gridStore.close(function(err, result) {
+              expect(err).to.not.exist;
               // Read in the whole file and check that it's the same content
               GridStore.read(db, result._id, function(err, fileData) {
+                expect(err).to.not.exist;
                 var data = fs.readFileSync('./test/functional/data/test_gs_working_field_read.pdf');
                 test.equal(data.toString('base64'), fileData.toString('base64'));
                 client.close();
@@ -659,6 +725,7 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         // Prepare fake big file
         var data = fs.readFileSync(
@@ -683,24 +750,24 @@ describe('GridFS', function() {
 
         // Open the file
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           var file = fs.createReadStream('./test_gs_working_field_read.tmp');
 
           // Write the binary file data to GridFS
           file.on('data', function(chunk) {
             gridStore.write(chunk, function(err) {
-              if (err) {
-                test.ok(false);
-              }
+              expect(err).to.not.exist;
             });
           });
 
           file.on('close', function() {
             // Flush the remaining data to GridFS
             gridStore.close(function(err, result) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Read in the whole file and check that it's the same content
               GridStore.read(db, result._id, function(err, fileData) {
+                expect(err).to.not.exist;
                 var data = fs.readFileSync('./test_gs_working_field_read.tmp');
                 test.deepEqual(data, fileData);
                 client.close();
@@ -728,6 +795,7 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         // Prepare fake big file
         var data = fs.readFileSync(
@@ -755,25 +823,25 @@ describe('GridFS', function() {
 
           // Open the file
           gridStore.open(function(err, gridStore) {
+            expect(err).to.not.exist;
             var file = fs.createReadStream('./test_gs_working_field_read.tmp');
 
             // Write the binary file data to GridFS
             file.on('data', function(chunk) {
               gridStore.write(chunk, function(err) {
-                if (err) {
-                  test.ok(false);
-                }
+                expect(err).to.not.exist;
               });
             });
 
             file.on('end', function() {
               // Flush the remaining data to GridFS
               gridStore.close(function(err, result) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 test.ok(result != null);
 
                 // Read in the whole file and check that it's the same content
                 GridStore.read(db, result._id, function(err, fileData) {
+                  expect(err).to.not.exist;
                   var data = fs.readFileSync('./test_gs_working_field_read.tmp');
                   test.deepEqual(data, fileData);
                   callback(null, null);
@@ -785,13 +853,13 @@ describe('GridFS', function() {
 
         // Execute big chunk size
         executeTest(80960, test, function(err) {
-          test.equal(null, err);
+          expect(err).to.not.exist;
           // Execute small chunk size
           executeTest(5000, test, function(err) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
             // Execute chunksize larger than file
             executeTest(fileSize + 100, test, function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
               client.close();
               done();
             });
@@ -816,17 +884,21 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_weird_bug', 'w');
         var data = fs.readFileSync('./test/functional/data/test_gs_weird_bug.png', 'binary');
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write(data, function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Assert that we have overwriten the data
               GridStore.read(db, 'test_gs_weird_bug', function(err, fileData) {
+                expect(err).to.not.exist;
                 test.equal(data.length, fileData.length);
                 client.close();
                 done();
@@ -853,6 +925,8 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, null, 'w');
         // Force multiple chunks to be stored
@@ -860,14 +934,21 @@ describe('GridFS', function() {
         var data = fs.readFileSync('./test/functional/data/test_gs_weird_bug.png');
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           // Write the file using write
           gridStore.write(data, function(err) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             gridStore.close(function(err, doc) {
+              expect(err).to.not.exist;
+
               // Read the file using readBuffer
               new GridStore(db, doc._id, 'r').open(function(err, gridStore) {
+                expect(err).to.not.exist;
+
                 gridStore.read(function(err, data2) {
+                  expect(err).to.not.exist;
                   test.equal(data.toString('base64'), data2.toString('base64'));
                   client.close();
                   done();
@@ -895,20 +976,29 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, null, 'w');
         // Force multiple chunks to be stored
         var data = fs.readFileSync('./test/functional/data/test_gs_weird_bug.png');
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           // Write the file using writeBuffer
           gridStore.write(data, function(err) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             gridStore.close(function(err, doc) {
+              expect(err).to.not.exist;
+
               // Read the file using readBuffer
               new GridStore(db, doc._id, 'r').open(function(err, gridStore) {
+                expect(err).to.not.exist;
+
                 gridStore.read(function(err, data2) {
+                  expect(err).to.not.exist;
                   test.equal(data.toString('base64'), data2.toString('base64'));
                   client.close();
                   done();
@@ -936,6 +1026,8 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, null, 'w');
         // Force multiple chunks to be stored
@@ -943,14 +1035,21 @@ describe('GridFS', function() {
         var data = fs.readFileSync('./test/functional/data/test_gs_weird_bug.png');
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           // Write the buffer using the .write method that should use writeBuffer correctly
           gridStore.write(data, function(err) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             gridStore.close(function(err, doc) {
+              expect(err).to.not.exist;
+
               // Read the file using readBuffer
               new GridStore(db, doc._id, 'r').open(function(err, gridStore) {
+                expect(err).to.not.exist;
+
                 gridStore.read(function(err, data2) {
+                  expect(err).to.not.exist;
                   test.equal(data.toString('base64'), data2.toString('base64'));
                   client.close();
                   done();
@@ -978,20 +1077,25 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, null, 'w');
         // Force multiple chunks to be stored
         var data = fs.readFileSync('./test/functional/data/test_gs_weird_bug.png');
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           // Write the file using writeBuffer
           gridStore.write(data, function(err) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             gridStore.close(function(err, doc) {
+              expect(err).to.not.exist;
               // Read the file using readBuffer
               GridStore.exist(db, doc._id, function(err, result) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 test.equal(true, result);
 
                 client.close();
@@ -1020,17 +1124,23 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var id = new ObjectID();
         var gridStore = new GridStore(db, id, 'w');
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('bar', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               GridStore.exist(db, id, function(err, result) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 test.equal(true, result);
 
                 client.close();
@@ -1058,16 +1168,22 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'shouldCheckExistsByUsingRegexp.txt', 'w');
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('bar', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               GridStore.exist(db, /shouldCheck/, function(err, result) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 test.equal(true, result);
 
                 client.close();
@@ -1097,13 +1213,15 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var store = new GridStore(db, new ObjectID(asset.source.toString()), 'w', {
           root: 'store'
         });
 
         store.open(function(err) {
-          test.equal(null, err);
+          expect(err).to.not.exist;
 
           client.close();
           done();
@@ -1128,18 +1246,24 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var id = new ObjectID();
         var gridStore = new GridStore(db, id, 'test_gs_read_length', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Open the gridstore
               gridStore = new GridStore(db, id, 'r');
               gridStore.open(function(err, gridStore) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 test.equal('test_gs_read_length', gridStore.filename);
                 client.close();
                 done();
@@ -1167,28 +1291,36 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var id = new ObjectID();
         var gridStore = new GridStore(db, id, 'test_gs_read_length', 'w', {
           content_type: 'image/jpeg'
         });
+
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Open the gridstore
               new GridStore(db, id, 'w+').open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 gridStore.contentType = 'html/text';
                 gridStore.close(function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   new GridStore(db, id, 'r').open(function(err, gridStore) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
                     test.equal('html/text', gridStore.contentType);
 
                     gridStore.read(function(err, data) {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
                       test.equal('hello world!', data.toString('utf8'));
                       client.close();
                       done();
@@ -1219,27 +1351,37 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var id = new ObjectID();
         var gridStore = new GridStore(db, id, 'w', { content_type: 'image/jpeg' });
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Open the gridstore
               new GridStore(db, id, 'test_gs_filename', 'w').open(function(err, gridStore) {
+                expect(err).to.not.exist;
+
                 gridStore.contentType = 'html/text';
                 gridStore.write('<h1>hello world!</h1>', function(err, gridStore) {
+                  expect(err).to.not.exist;
+
                   gridStore.close(function(err) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     new GridStore(db, id, 'r').open(function(err, gridStore) {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
                       test.equal('test_gs_filename', gridStore.filename);
 
                       gridStore.read(function(err, data) {
-                        test.equal(null, err);
+                        expect(err).to.not.exist;
                         test.equal('<h1>hello world!</h1>', data.toString('utf8'));
                         client.close();
                         done();
@@ -1271,29 +1413,39 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var id = new ObjectID();
         var gridStore = new GridStore(db, id, 'test_gs_filename3', 'w', {
           content_type: 'image/jpeg'
         });
+
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Open the gridstore
               new GridStore(db, id, 'test_gs_filename4', 'w').open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 gridStore.contentType = 'html/text';
                 gridStore.write('<h1>hello world!</h1>', function(err, gridStore) {
+                  expect(err).to.not.exist;
+
                   gridStore.close(function(err) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     new GridStore(db, id, 'r').open(function(err, gridStore) {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
                       test.equal('test_gs_filename4', gridStore.filename);
 
                       gridStore.read(function(err, data) {
-                        test.equal(null, err);
+                        expect(err).to.not.exist;
                         test.equal('<h1>hello world!</h1>', data.toString('utf8'));
                         client.close();
                         done();
@@ -1325,28 +1477,36 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var id = new ObjectID();
         var gridStore = new GridStore(db, id, 'test_gs_filename1', 'w', {
           content_type: 'image/jpeg'
         });
+
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Open the gridstore
               new GridStore(db, id, 'test_gs_filename2', 'w+').open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 gridStore.contentType = 'html/text';
                 gridStore.close(function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   new GridStore(db, id, 'r').open(function(err, gridStore) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
                     test.equal('test_gs_filename2', gridStore.filename);
 
                     gridStore.read(function(err, data) {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
                       test.equal('hello world!', data.toString('utf8'));
                       client.close();
                       done();
@@ -1377,22 +1537,29 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var id = new ObjectID();
         var gridStore = new GridStore(db, id, 'test_gs_read_length', 'w', {
           content_type: 'image/jpeg'
         });
+
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Open the gridstore
               new GridStore(db, id, 'r').open(function(err, gridStore) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 gridStore.seek(2, function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   var stream = gridStore.stream(true);
 
@@ -1430,23 +1597,30 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var id = new ObjectID();
         var gridStore = new GridStore(db, id, 'test_gs_read_length', 'w', {
           content_type: 'image/jpeg',
           chunk_size: 5
         });
+
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Open the gridstore
               new GridStore(db, id, 'r').open(function(err, gridStore) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 gridStore.seek(7, function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   var stream = gridStore.stream(true);
                   var data = '';
@@ -1484,22 +1658,37 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_seek_with_buffer', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write(new Buffer('012345678901234567890', 'utf8'), function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function() {
               var gridStore2 = new GridStore(db, 'test_gs_seek_with_buffer', 'r');
               gridStore2.open(function(err, gridStore2) {
+                expect(err).to.not.exist;
+
                 gridStore2.read(5, function(err, data) {
+                  expect(err).to.not.exist;
                   test.equal('01234', data.toString());
 
                   gridStore2.seek(-2, GridStore.IO_SEEK_CUR, function(err, gridStore2) {
+                    expect(err).to.not.exist;
+
                     gridStore2.read(5, function(err, data) {
+                      expect(err).to.not.exist;
                       test.equal('34567', data.toString());
 
                       gridStore2.seek(-2, GridStore.IO_SEEK_CUR, function(err, gridStore2) {
+                        expect(err).to.not.exist;
+
                         gridStore2.read(5, function(err, data) {
+                          expect(err).to.not.exist;
                           test.equal('67890', data.toString());
                           client.close();
                           done();
@@ -1531,22 +1720,36 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_seek_with_buffer', 'w', { chunk_size: 4 });
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write(new Buffer('012345678901234567890', 'utf8'), function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function() {
               var gridStore2 = new GridStore(db, 'test_gs_seek_with_buffer', 'r');
               gridStore2.open(function(err, gridStore2) {
+                expect(err).to.not.exist;
+
                 gridStore2.read(5, function(err, data) {
+                  expect(err).to.not.exist;
                   test.equal('01234', data.toString());
 
                   gridStore2.seek(-2, GridStore.IO_SEEK_CUR, function(err, gridStore2) {
+                    expect(err).to.not.exist;
                     gridStore2.read(5, function(err, data) {
+                      expect(err).to.not.exist;
                       test.equal('34567', data.toString());
 
                       gridStore2.seek(-2, GridStore.IO_SEEK_CUR, function(err, gridStore2) {
+                        expect(err).to.not.exist;
+
                         gridStore2.read(5, function(err, data) {
+                          expect(err).to.not.exist;
                           test.equal('67890', data.toString());
                           client.close();
                           done();
@@ -1576,6 +1779,7 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
 
         // Execute function
@@ -1597,10 +1801,10 @@ describe('GridFS', function() {
             // Load the file using MongoDB
             var gridStore = new GridStore(db, __dirname + '/data/iya_logo_final_bw.jpg', 'r', {});
             gridStore.open(function(err, gridStore) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               gridStore.read(function(err, data) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 test.deepEqual(originalData, data);
                 client.close();
                 done();
@@ -1628,6 +1832,8 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         test.equal(null, err);
         var chunkSize = 256 * 1024; // Standard 256KB chunks
@@ -1642,14 +1848,14 @@ describe('GridFS', function() {
 
         // Open the new file
         gridStore.open(function(err, gridStore) {
-          test.equal(null, err);
+          expect(err).to.not.exist;
 
           // Create a chunkSize Buffer
           var buffer = new Buffer(chunkSize);
 
           // Write the buffer
           gridStore.write(buffer, function(err, gridStore) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             // Close the file
             gridStore.close(function(err) {
@@ -1661,7 +1867,7 @@ describe('GridFS', function() {
 
               // Open the file again
               gridStore.open(function(err, gridStore) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 // Write the buffer again
                 gridStore.write(buffer, function(err) {
@@ -1693,6 +1899,8 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         // Set up gridStore
         var gridStore = new GridStore(db, 'test_stream_write_2', 'w');
@@ -1736,6 +1944,8 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         // Set up gridStore
         var gridStore = new GridStore(db, 'test_stream_write_2', 'w');
@@ -1777,6 +1987,8 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var filename = 'test_stream_write_2';
         var filepath = './test/functional/data/test_gs_working_field_read.pdf';
@@ -1788,7 +2000,7 @@ describe('GridFS', function() {
         storeStream.on('end', function() {
           // Just read the content and compare to the raw binary
           GridStore.read(db, filename, function(err, gridData) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
             var fileData = fs.readFileSync(filepath);
             test.equal(fileData.toString('hex'), gridData.toString('hex'));
             client.close();
@@ -1818,12 +2030,16 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var fileId = new ObjectID();
         var gridStore = new GridStore(db, fileId, 'w', { root: 'fs' });
         gridStore.chunkSize = 5000;
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           var d = '';
           for (var j = 0; j < 5000; j++) {
             d = d + '+';
@@ -1842,6 +2058,7 @@ describe('GridFS', function() {
                   var endLen = 0;
                   var gridStore = new GridStore(db, fileId, 'r');
                   gridStore.open(function(err, gridStore) {
+                    expect(err).to.not.exist;
                     var stream = gridStore.stream();
 
                     stream.on('data', function(chunk) {
@@ -1883,12 +2100,15 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var fileId = new ObjectID();
         var gridStore = new GridStore(db, fileId, 'w', { root: 'fs' });
         gridStore.chunkSize = 5000;
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           var d = new Buffer(5000);
           for (var j = 0; j < 5000; j++) {
             d[j] = 43;
@@ -1907,6 +2127,7 @@ describe('GridFS', function() {
                   var endLen = 0;
                   var gridStore = new GridStore(db, fileId, 'r');
                   gridStore.open(function(err, gridStore) {
+                    expect(err).to.not.exist;
                     var stream = gridStore.stream();
 
                     stream.on('data', function(chunk) {
@@ -1947,6 +2168,8 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStoreR = new GridStore(db, 'test_gs_read_stream', 'r');
         var gridStoreW = new GridStore(db, 'test_gs_read_stream', 'w', { chunkSize: 56 });
@@ -1959,12 +2182,16 @@ describe('GridFS', function() {
         var readLen = 0;
 
         gridStoreW.open(function(err, gs) {
-          gs.write(data, function(err, gs) {
-            gs.close(function(err) {
-              test.equal(null, err);
-              gridStoreR.open(function(err, gs) {
-                var chunks = [];
+          expect(err).to.not.exist;
 
+          gs.write(data, function(err, gs) {
+            expect(err).to.not.exist;
+
+            gs.close(function(err) {
+              expect(err).to.not.exist;
+              gridStoreR.open(function(err, gs) {
+                expect(err).to.not.exist;
+                var chunks = [];
                 var stream = gs.stream();
                 stream.on('data', function(chunk) {
                   readLen += chunk.length;
@@ -1980,6 +2207,8 @@ describe('GridFS', function() {
                     test.equal(null, err);
 
                     gridStoreRead.read(function(err, data2) {
+                      expect(err).to.not.exist;
+
                       // Put together all the chunks
                       var streamData = new Buffer(data.length);
                       var index = 0;
@@ -2023,9 +2252,13 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var FILE = 'empty.test.file';
         db.collection('fs.files', function(err, collection) {
+          expect(err).to.not.exist;
+
           collection.insert(
             {
               filename: FILE,
@@ -2041,6 +2274,8 @@ describe('GridFS', function() {
               test.equal(null, err);
 
               new GridStore(db, FILE, 'r').open(function(err, gs) {
+                expect(err).to.not.exist;
+
                 gs.read(function(err) {
                   test.ok(err != null);
                   gs.close(function() {});
@@ -2071,15 +2306,24 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_small_write4', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
               test.equal(null, err);
 
               db.collection('fs.files', function(err, collection) {
+                expect(err).to.not.exist;
+
                 collection.find({ filename: 'test_gs_small_write4' }).toArray(function(err, items) {
+                  expect(err).to.not.exist;
                   test.equal(1, items.length);
                   var item = items[0];
                   test.ok(
@@ -2088,9 +2332,12 @@ describe('GridFS', function() {
                   );
 
                   db.collection('fs.chunks', function(err, collection) {
+                    expect(err).to.not.exist;
+
                     var id = ObjectID.createFromHexString(item._id.toHexString());
 
                     collection.find({ files_id: id }).toArray(function(err, items) {
+                      expect(err).to.not.exist;
                       test.equal(1, items.length);
                       client.close();
                       done();
@@ -2120,24 +2367,37 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_small_write_with_buffer', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           var data = new Buffer('hello world', 'utf8');
 
           gridStore.write(data, function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
               test.equal(null, err);
 
               db.collection('fs.files', function(err, collection) {
+                expect(err).to.not.exist;
+
                 collection
                   .find({ filename: 'test_gs_small_write_with_buffer' })
                   .toArray(function(err, items) {
+                    expect(err).to.not.exist;
+
                     test.equal(1, items.length);
                     var item = items[0];
 
                     db.collection('fs.chunks', function(err, collection) {
+                      expect(err).to.not.exist;
+
                       collection.find({ files_id: item._id }).toArray(function(err, items) {
+                        expect(err).to.not.exist;
                         test.equal(1, items.length);
                         client.close();
                         done();
@@ -2167,19 +2427,28 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_small_file', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
+
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               db.collection('fs.files', function(err, collection) {
+                expect(err).to.not.exist;
                 collection.find({ filename: 'test_gs_small_file' }).toArray(function(err, items) {
+                  expect(err).to.not.exist;
                   test.equal(1, items.length);
 
                   // Read test of the file
                   GridStore.read(db, 'test_gs_small_file', function(err, data) {
+                    expect(err).to.not.exist;
                     test.equal('hello world!', data.toString());
                     client.close();
                     done();
@@ -2208,25 +2477,31 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_overwrite', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
+
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore2 = new GridStore(db, 'test_gs_overwrite', 'w');
               gridStore2.open(function(err) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 gridStore2.write('overwrite', function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   gridStore2.close(function(err) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     // Assert that we have overwriten the data
                     GridStore.read(db, 'test_gs_overwrite', function(err, data) {
+                      expect(err).to.not.exist;
                       test.equal('overwrite', data.toString());
                       client.close();
                       done();
@@ -2256,78 +2531,105 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_seek', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello, world!', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function() {
               var gridStore2 = new GridStore(db, 'test_gs_seek', 'r');
               gridStore2.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 gridStore.seek(0, function(err, gridStore) {
+                  expect(err).to.not.exist;
                   gridStore.getc(function(err, chr) {
+                    expect(err).to.not.exist;
                     test.equal('h', chr.toString());
 
                     var gridStore3 = new GridStore(db, 'test_gs_seek', 'r');
                     gridStore3.open(function(err, gridStore) {
+                      expect(err).to.not.exist;
                       gridStore.seek(7, function(err, gridStore) {
+                        expect(err).to.not.exist;
                         gridStore.getc(function(err, chr) {
+                          expect(err).to.not.exist;
                           test.equal('w', chr.toString());
 
                           var gridStore4 = new GridStore(db, 'test_gs_seek', 'r');
                           gridStore4.open(function(err, gridStore) {
+                            expect(err).to.not.exist;
                             gridStore.seek(4, function(err, gridStore) {
+                              expect(err).to.not.exist;
                               gridStore.getc(function(err, chr) {
+                                expect(err).to.not.exist;
                                 test.equal('o', chr.toString());
 
                                 var gridStore5 = new GridStore(db, 'test_gs_seek', 'r');
                                 gridStore5.open(function(err, gridStore) {
+                                  expect(err).to.not.exist;
                                   gridStore.seek(-1, GridStore.IO_SEEK_END, function(
                                     err,
                                     gridStore
                                   ) {
+                                    expect(err).to.not.exist;
                                     gridStore.getc(function(err, chr) {
+                                      expect(err).to.not.exist;
                                       test.equal('!', chr.toString());
 
                                       var gridStore6 = new GridStore(db, 'test_gs_seek', 'r');
                                       gridStore6.open(function(err, gridStore) {
+                                        expect(err).to.not.exist;
                                         gridStore.seek(-6, GridStore.IO_SEEK_END, function(
                                           err,
                                           gridStore
                                         ) {
+                                          expect(err).to.not.exist;
                                           gridStore.getc(function(err, chr) {
+                                            expect(err).to.not.exist;
                                             test.equal('w', chr.toString());
 
                                             var gridStore7 = new GridStore(db, 'test_gs_seek', 'r');
                                             gridStore7.open(function(err, gridStore) {
+                                              expect(err).to.not.exist;
                                               gridStore.seek(7, GridStore.IO_SEEK_CUR, function(
                                                 err,
                                                 gridStore
                                               ) {
+                                                expect(err).to.not.exist;
                                                 gridStore.getc(function(err, chr) {
+                                                  expect(err).to.not.exist;
                                                   test.equal('w', chr.toString());
 
                                                   gridStore.seek(
                                                     -1,
                                                     GridStore.IO_SEEK_CUR,
                                                     function(err, gridStore) {
+                                                      expect(err).to.not.exist;
                                                       gridStore.getc(function(err, chr) {
+                                                        expect(err).to.not.exist;
                                                         test.equal('w', chr.toString());
 
                                                         gridStore.seek(
                                                           -4,
                                                           GridStore.IO_SEEK_CUR,
                                                           function(err, gridStore) {
+                                                            expect(err).to.not.exist;
                                                             gridStore.getc(function(err, chr) {
+                                                              expect(err).to.not.exist;
                                                               test.equal('o', chr.toString());
 
                                                               gridStore.seek(
                                                                 3,
                                                                 GridStore.IO_SEEK_CUR,
                                                                 function(err, gridStore) {
+                                                                  expect(err).to.not.exist;
                                                                   gridStore.getc(function(
                                                                     err,
                                                                     chr
                                                                   ) {
+                                                                    expect(err).to.not.exist;
                                                                     test.equal('o', chr.toString());
                                                                     client.close();
                                                                     done();
@@ -2380,29 +2682,34 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         // Create a new file
         var gridStore = new GridStore(db, 'test_gs_seek_across_chunks', 'w');
         // Open the file
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           var data = new Buffer(gridStore.chunkSize * 3);
           // Write the binary file data to GridFS
           gridStore.write(data, function(err, gridStore) {
+            expect(err).to.not.exist;
             // Flush the remaining data to GridFS
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore = new GridStore(db, 'test_gs_seek_across_chunks', 'r');
               // Read in the whole file and check that it's the same content
               gridStore.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 var timeout = setTimeout(function() {
                   test.ok(false, "Didn't complete in expected timeframe");
                   done();
                 }, 2000);
 
                 gridStore.seek(gridStore.chunkSize + 1, function(err, gridStore) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
                   gridStore.tell(function(err, position) {
+                    expect(err).to.not.exist;
                     test.equal(gridStore.chunkSize + 1, position);
                     clearTimeout(timeout);
 
@@ -2433,23 +2740,30 @@ describe('GridFS', function() {
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_save_empty_file', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           db.collection('fs.files').deleteMany({}, function() {
             db.collection('fs.chunks').deleteMany({}, function() {
               gridStore.write('', function(err, gridStore) {
+                expect(err).to.not.exist;
                 gridStore.close(function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   db.collection('fs.files', function(err, collection) {
+                    expect(err).to.not.exist;
                     collection.count(function(err, count) {
+                      expect(err).to.not.exist;
                       test.equal(1, count);
                     });
                   });
 
                   db.collection('fs.chunks', function(err, collection) {
+                    expect(err).to.not.exist;
                     collection.count(function(err, count) {
+                      expect(err).to.not.exist;
                       test.equal(0, count);
 
                       client.close();
@@ -2481,15 +2795,19 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_cannot_change_chunk_size_on_read', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello, world!', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore2 = new GridStore(db, 'test_gs_cannot_change_chunk_size_on_read', 'r');
               gridStore2.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 gridStore.chunkSize = 42;
                 test.equal(Chunk.DEFAULT_CHUNK_SIZE, gridStore.chunkSize);
                 client.close();
@@ -2518,6 +2836,7 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(
           db,
@@ -2526,7 +2845,9 @@ describe('GridFS', function() {
         );
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello, world!', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.chunkSize = 42;
             test.equal(Chunk.DEFAULT_CHUNK_SIZE, gridStore.chunkSize);
             client.close();
@@ -2554,6 +2875,7 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_check_high_bits', 'w');
         var data = new Buffer(255);
@@ -2562,12 +2884,15 @@ describe('GridFS', function() {
         }
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write(data, function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Assert that we have overwriten the data
               GridStore.read(db, 'test_gs_check_high_bits', function(err, fileData) {
+                expect(err).to.not.exist;
                 // change testvalue into a string like "0,1,2,...,255"
                 test.equal(data.toString('hex'), fileData.toString('hex'));
                 // test.equal(Array.prototype.join.call(data),
@@ -2597,17 +2922,21 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_change_chunk_size', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.chunkSize = 42;
 
           gridStore.write('foo', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore2 = new GridStore(db, 'test_change_chunk_size', 'r');
               gridStore2.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 test.equal(42, gridStore.chunkSize);
                 client.close();
                 done();
@@ -2634,15 +2963,19 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_change_chunk_size', 'w', { chunk_size: 42 });
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('foo', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore2 = new GridStore(db, 'test_change_chunk_size', 'r');
               gridStore2.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 test.equal(42, gridStore.chunkSize);
                 client.close();
                 done();
@@ -2669,15 +3002,19 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'new-file', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world\n', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore2 = new GridStore(db, 'new-file', 'r');
               gridStore2.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 test.equal('6f5902ac237024bdd0c176cb93063dc4', gridStore.md5);
                 try {
                   gridStore.md5 = "can't do this";
@@ -2688,11 +3025,13 @@ describe('GridFS', function() {
 
                 var gridStore2 = new GridStore(db, 'new-file', 'w');
                 gridStore2.open(function(err, gridStore) {
+                  expect(err).to.not.exist;
                   gridStore.close(function(err) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     var gridStore3 = new GridStore(db, 'new-file', 'r');
                     gridStore3.open(function(err, gridStore) {
+                      expect(err).to.not.exist;
                       test.equal('d41d8cd98f00b204e9800998ecf8427e', gridStore.md5);
                       client.close();
                       done();
@@ -2722,35 +3061,40 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var originalFileUploadDate = null;
 
         var gridStore = new GridStore(db, 'test_gs_upload_date', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world\n', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore2 = new GridStore(db, 'test_gs_upload_date', 'r');
               gridStore2.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 test.ok(gridStore.uploadDate != null);
                 originalFileUploadDate = gridStore.uploadDate;
 
                 gridStore2.close(function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   var gridStore3 = new GridStore(db, 'test_gs_upload_date', 'w');
                   gridStore3.open(function(err) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     gridStore3.write('new data', function(err) {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
 
                       gridStore3.close(function(err) {
-                        test.equal(null, err);
+                        expect(err).to.not.exist;
 
                         var gridStore4 = new GridStore(db, 'test_gs_upload_date', 'r');
                         gridStore4.open(function(err, gridStore) {
+                          expect(err).to.not.exist;
                           test.equal(
                             originalFileUploadDate.getTime(),
                             gridStore.uploadDate.getTime()
@@ -2785,28 +3129,34 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var ct = null;
 
         var gridStore = new GridStore(db, 'test_gs_content_type', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world\n', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore2 = new GridStore(db, 'test_gs_content_type', 'r');
               gridStore2.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 ct = gridStore.contentType;
                 test.equal(GridStore.DEFAULT_CONTENT_TYPE, ct);
 
                 var gridStore3 = new GridStore(db, 'test_gs_content_type', 'w+');
                 gridStore3.open(function(err, gridStore) {
+                  expect(err).to.not.exist;
                   gridStore.contentType = 'text/html';
                   gridStore.close(function(err) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     var gridStore4 = new GridStore(db, 'test_gs_content_type', 'r');
                     gridStore4.open(function(err, gridStore) {
+                      expect(err).to.not.exist;
                       test.equal('text/html', gridStore.contentType);
                       client.close();
                       done();
@@ -2836,16 +3186,20 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_content_type_option', 'w', {
           content_type: 'image/jpg'
         });
 
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world\n', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function() {
               var gridStore2 = new GridStore(db, 'test_gs_content_type_option', 'r');
               gridStore2.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 test.equal('image/jpg', gridStore.contentType);
                 client.close();
                 done();
@@ -2872,6 +3226,7 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_unknown_mode', 'x');
         try {
@@ -2901,25 +3256,31 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_metadata', 'w', { content_type: 'image/jpg' });
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world\n', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore2 = new GridStore(db, 'test_gs_metadata', 'r');
               gridStore2.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 test.equal(null, gridStore.metadata);
 
                 var gridStore3 = new GridStore(db, 'test_gs_metadata', 'w+');
                 gridStore3.open(function(err, gridStore) {
+                  expect(err).to.not.exist;
                   gridStore.metadata = { a: 1 };
                   gridStore.close(function(err) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     var gridStore4 = new GridStore(db, 'test_gs_metadata', 'r');
                     gridStore4.open(function(err, gridStore) {
+                      expect(err).to.not.exist;
                       test.equal(1, gridStore.metadata.a);
                       client.close();
                       done();
@@ -2949,17 +3310,21 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_metadata', 'w', { content_type: 'image/jpg' });
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world\n', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore2 = new GridStore(db, 'test_gs_metadata', 'r');
               gridStore2.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 gridStore.close(function(err, fo) {
-                  test.ok(err == null);
+                  expect(err).to.not.exist;
                   test.ok(fo == null);
                   client.close();
                   done();
@@ -2988,11 +3353,13 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var fieldId = new ObjectID();
         var gridStore = new GridStore(db, fieldId, 'w', { root: 'fs' });
         gridStore.chunkSize = 1024 * 256;
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           var numberOfWrites = 1000000 / 5000;
 
           var write = function(left, callback) {
@@ -3005,7 +3372,7 @@ describe('GridFS', function() {
 
           write(numberOfWrites, function() {
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
               client.close();
               done();
             });
@@ -3030,33 +3397,40 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 500, 'test_gs_small_write2', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               db.collection('fs.files', function(err, collection) {
+                expect(err).to.not.exist;
                 collection.find({ filename: 'test_gs_small_write2' }).toArray(function(err, items) {
+                  expect(err).to.not.exist;
                   test.equal(1, items.length);
                   var item = items[0];
                   test.ok(typeof item._id === 'number');
 
                   db.collection('fs.chunks', function(err, collection) {
+                    expect(err).to.not.exist;
                     collection.find({ files_id: item._id }).toArray(function(err, items) {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
                       test.equal(1, items.length);
 
                       // Read the file
                       var gridStore = new GridStore(db, 500, 'test_gs_small_write2', 'r');
                       gridStore.open(function(err, gridStore) {
+                        expect(err).to.not.exist;
                         gridStore.read(function(err, data) {
-                          test.equal(null, err);
+                          expect(err).to.not.exist;
                           test.equal('hello world!', data.toString('ascii'));
 
                           GridStore.read(db, 'test_gs_small_write2', function(err, data) {
-                            test.equal(null, err);
+                            expect(err).to.not.exist;
                             test.equal('hello world!', data.toString('ascii'));
                             client.close();
                             done();
@@ -3090,6 +3464,7 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         // Massive data Buffer
         var data = new Buffer(1024 * 512);
@@ -3098,17 +3473,22 @@ describe('GridFS', function() {
 
         var gridStore = new GridStore(db, Long.fromNumber(100), 'test_gs_small_write3', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write(data, function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Reopen the gridstore in read only mode, seek and then attempt read
               gridStore = new GridStore(db, Long.fromNumber(100), 'test_gs_small_write3', 'r');
               gridStore.open(function(err, gridStore) {
+                expect(err).to.not.exist;
                 // Seek to middle
                 gridStore.seek(1024 * 256 + 6, function(err, gridStore) {
+                  expect(err).to.not.exist;
                   // Read
                   gridStore.read(5, function(err, data) {
+                    expect(err).to.not.exist;
                     test.equal('world', data.toString('ascii'));
                     client.close();
                     done();
@@ -3137,6 +3517,7 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var mystr = '';
         var sizestr = 1024 * 25;
@@ -3147,21 +3528,24 @@ describe('GridFS', function() {
         var fname = 'test_large_str';
         var my_chunkSize = 1024 * 10;
         GridStore.unlink(db, fname, function(err) {
-          test.equal(null, err);
+          expect(err).to.not.exist;
 
           var gs = new GridStore(db, fname, 'w');
           gs.chunkSize = my_chunkSize;
           gs.open(function(err, gs) {
+            expect(err).to.not.exist;
             gs.write(mystr, function(err, gs) {
+              expect(err).to.not.exist;
               gs.close(function(err) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 var gs2 = new GridStore(db, fname, 'r');
                 gs2.open(function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   gs2.seek(0, function() {
                     gs2.read(function(err, datar) {
+                      expect(err).to.not.exist;
                       test.equal(mystr.length, datar.length);
                       test.equal(mystr, datar.toString('ascii'));
                       client.close();
@@ -3192,10 +3576,11 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, '_i_shouldCorrectlyWriteASmallPayload', 'r');
         gridStore.open(function(err) {
-          test.ok(err != null);
+          expect(err).to.exist;
           client.close();
           done();
         });
@@ -3218,11 +3603,12 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var gridStore = new GridStore(db, 'test_gs_metadata', 'w', { content_type: 'image/jpg' });
         gridStore.open(function(err, gridStore) {
           gridStore.seek(0, function(err) {
-            test.ok(err != null);
+            expect(err).to.exist;
             client.close();
             done();
           });
@@ -3247,16 +3633,20 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var id = new ObjectID();
         var gridStore = new GridStore(db, id, id, 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.write('hello world!', function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               // Check if file exists
               GridStore.exist(db, { filename: id }, function(err, r) {
+                expect(err).to.not.exist;
                 test.equal(true, r);
 
                 client.close();
@@ -3282,12 +3672,11 @@ describe('GridFS', function() {
       var configuration = this.configuration;
       var MongoClient = configuration.require.MongoClient,
         GridStore = configuration.require.GridStore,
-        fs = require('fs'),
-        assert = require('assert');
+        fs = require('fs');
 
       // Use connect method to connect to the Server
       MongoClient.connect(configuration.url(), { sslValidate: false }, function(err, client) {
-        assert.equal(null, err);
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
 
         // Set up gridStore
@@ -3301,7 +3690,7 @@ describe('GridFS', function() {
         stream.on('end', function() {
           // Just read the content and compare to the raw binary
           GridStore.read(db, 'simple_100_document_toArray.png', function(err, gridData) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
             var fileData = fs.readFileSync(filename);
             test.equal(fileData.toString('hex'), gridData.toString('hex'));
             client.close();
@@ -3327,45 +3716,45 @@ describe('GridFS', function() {
     test: function(done) {
       var configuration = this.configuration;
       var MongoClient = configuration.require.MongoClient,
-        GridStore = configuration.require.GridStore,
-        assert = require('assert');
+        GridStore = configuration.require.GridStore;
 
       // Use connect method to connect to the Server
       MongoClient.connect(configuration.url(), { sslValidate: false }, function(err, client) {
-        assert.equal(null, err);
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
 
         var gridStore = new GridStore(db, 'test_gs_multi_chunk_exact_size', 'w');
         gridStore.open(function(err, gridStore) {
+          expect(err).to.not.exist;
           gridStore.chunkSize = 512;
 
           // Write multiple of chunk size
           gridStore.write(new Buffer(gridStore.chunkSize * 4), function(err) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               var gridStore = new GridStore(db, 'test_gs_multi_chunk_exact_size', 'r');
               gridStore.open(function(err, store) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 store.seek(0, GridStore.IO_SEEK_END, function(err) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   store.tell(function(err, pos) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
                     test.equal(512 * 4, pos);
 
                     store.seek(0, GridStore.IO_SEEK_SET, function(err) {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
 
                       store.tell(function(err, pos) {
-                        test.equal(null, err);
+                        expect(err).to.not.exist;
                         test.equal(0, pos);
 
                         store.read(function(err, data) {
-                          test.equal(null, err);
+                          expect(err).to.not.exist;
                           test.equal(512 * 4, data.length);
 
                           client.close();
@@ -3398,16 +3787,16 @@ describe('GridFS', function() {
         var configuration = this.configuration;
         var MongoClient = configuration.require.MongoClient,
           GridStore = configuration.require.GridStore,
-          ObjectID = configuration.require.ObjectID,
-          assert = require('assert');
+          ObjectID = configuration.require.ObjectID;
 
         var id = new ObjectID();
         MongoClient.connect(configuration.url(), { sslValidate: false }, function(err, client) {
-          assert.equal(null, err);
+          expect(err).to.not.exist;
           var db = client.db(configuration.db);
 
           var gridStore = new GridStore(db, id, 'w');
           gridStore.open(function(err, gridStore) {
+            expect(err).to.not.exist;
             gridStore.chunkSize = 512;
 
             // Get the data
@@ -3418,27 +3807,27 @@ describe('GridFS', function() {
 
             // Write multiple of chunk size
             gridStore.write(data, function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               gridStore.close(function(err) {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 var gridStore = new GridStore(db, id, 'r');
                 gridStore.open(function(err, store) {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
 
                   store.seek(0, GridStore.IO_SEEK_END, function(err) {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     store.tell(function(err, pos) {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
                       test.equal(512 * 2, pos);
 
                       store.seek(0, GridStore.IO_SEEK_SET, function(err) {
-                        test.equal(null, err);
+                        expect(err).to.not.exist;
 
                         store.tell(function(err, pos) {
-                          test.equal(null, err);
+                          expect(err).to.not.exist;
                           test.equal(0, pos);
 
                           // Get the stream
@@ -3481,15 +3870,14 @@ describe('GridFS', function() {
       var configuration = this.configuration;
       var MongoClient = configuration.require.MongoClient,
         GridStore = configuration.require.GridStore,
-        ObjectID = configuration.require.ObjectID,
-        assert = require('assert');
+        ObjectID = configuration.require.ObjectID;
 
       // Create a test buffer
       var buffer = new Buffer(200033);
 
       // Use connect method to connect to the Server
       MongoClient.connect(configuration.url(), { sslValidate: false }, function(err, client) {
-        assert.equal(null, err);
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
 
         var gridStore = new GridStore(db, new ObjectID(), 'w', {
@@ -3497,13 +3885,13 @@ describe('GridFS', function() {
           chunk_size: 1024 * 4
         });
         gridStore.open(function(err, gridStore) {
-          test.equal(null, err);
+          expect(err).to.not.exist;
 
           gridStore.write(buffer, function(err) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               client.close();
               done();
@@ -3533,11 +3921,12 @@ describe('GridFS', function() {
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var listener = require('../..').instrument(function(err) {
-          test.equal(null, err);
+          expect(err).to.not.exist;
         });
 
         listener.on('started', function(event) {
@@ -3553,13 +3942,13 @@ describe('GridFS', function() {
           chunk_size: 1024 * 4
         });
         gridStore.open(function(err, gridStore) {
-          test.equal(null, err);
+          expect(err).to.not.exist;
 
           gridStore.write(buffer, function(err) {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             gridStore.close(function(err) {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               listener.uninstrument();
               client.close();

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,17 +27,17 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
+acorn@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
 ajv-keywords@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.0.tgz#a296e17f7bfae7c1ce4f7e0de53d29cb32162df0"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
 ajv@^4.7.0:
   version "4.11.8"
@@ -46,7 +46,7 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0, ajv@^5.2.0, ajv@^5.2.3:
+ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
   dependencies:
@@ -169,8 +169,8 @@ async@1.x, async@^1.4.0:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 async@^2.0.1, async@^2.1.2:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
     lodash "^4.14.0"
 
@@ -313,8 +313,8 @@ babylon@^6.18.0:
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 babylon@~7.0.0-beta.19:
-  version "7.0.0-beta.29"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.29.tgz#6a3e0e6287390385a36f5511e7f94db8618574ae"
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.32.tgz#e9033cb077f64d6895f4125968b37dc0a8c3bc6e"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -560,8 +560,8 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 color-convert@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
 
@@ -943,10 +943,10 @@ eslint-scope@^3.7.1:
     estraverse "^4.1.1"
 
 eslint@^4.5.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.9.0.tgz#76879d274068261b191fe0f2f56c74c2f4208e8b"
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.11.0.tgz#39a8c82bc0a3783adf5a39fa27fdd9d36fac9a34"
   dependencies:
-    ajv "^5.2.0"
+    ajv "^5.3.0"
     babel-code-frame "^6.22.0"
     chalk "^2.1.0"
     concat-stream "^1.6.0"
@@ -954,7 +954,7 @@ eslint@^4.5.0:
     debug "^3.0.1"
     doctrine "^2.0.0"
     eslint-scope "^3.7.1"
-    espree "^3.5.1"
+    espree "^3.5.2"
     esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
@@ -967,7 +967,7 @@ eslint@^4.5.0:
     inquirer "^3.0.6"
     is-resolvable "^1.0.0"
     js-yaml "^3.9.1"
-    json-stable-stringify "^1.0.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.4"
     minimatch "^3.0.2"
@@ -984,11 +984,11 @@ eslint@^4.5.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
-espree@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
+espree@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
   dependencies:
-    acorn "^5.1.1"
+    acorn "^5.2.1"
     acorn-jsx "^3.0.0"
 
 esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
@@ -1700,8 +1700,8 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
 jschardet@^1.4.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.1.tgz#c519f629f86b3a5bedba58a88d311309eec097f9"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.6.0.tgz#c7d1a71edcff2839db2f9ec30fc5d5ebd3c1a678"
 
 jsdoc@3.5.4:
   version "3.5.4"
@@ -1731,6 +1731,10 @@ json-schema-traverse@^0.3.0:
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -2094,8 +2098,8 @@ mocha@^3.5.3:
     supports-color "3.1.2"
 
 moment@^2.10.6:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
+  version "2.19.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.2.tgz#8a7f774c95a64550b4c7ebd496683908f9419dbe"
 
 mongodb-core@2.1.17:
   version "2.1.17"
@@ -2105,15 +2109,15 @@ mongodb-core@2.1.17:
     require_optional "~1.0.0"
 
 mongodb-core@mongodb-js/mongodb-core#3.0.0:
-  version "2.1.90"
-  resolved "https://codeload.github.com/mongodb-js/mongodb-core/tar.gz/1bf9864cc427e95eccb4fcebb7334b684df61956"
+  version "3.0.0-beta1"
+  resolved "https://codeload.github.com/mongodb-js/mongodb-core/tar.gz/d7cd5cdda5fddc8635353063d245fb083ef1d545"
   dependencies:
     bson "~1.0.4"
     require_optional "^1.0.1"
 
 mongodb-download-url@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/mongodb-download-url/-/mongodb-download-url-0.3.0.tgz#de5a463b4489dd9ab043cca1672d4b8aaaf5b5d9"
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/mongodb-download-url/-/mongodb-download-url-0.3.3.tgz#e3a8a548f13eb20f5a0cdf863cbc063421a3934c"
   dependencies:
     async "^2.1.2"
     debug "^2.2.0"
@@ -2229,8 +2233,8 @@ normalize-package-data@^2.3.2:
     validate-npm-package-license "^3.0.1"
 
 npm-conf@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.2.tgz#170a2c48a0c6ad0495f03f87aec2da11ef47a525"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
   dependencies:
     config-chain "^1.1.11"
     pify "^3.0.0"
@@ -2420,8 +2424,8 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
 prettier@^1.5.3:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
 
 private@^0.1.7:
   version "0.1.8"
@@ -2908,8 +2912,8 @@ taffydb@2.6.2:
   resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
 
 tar-stream@^1.5.2:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.4.tgz#36549cf04ed1aee9b2a30c0143252238daf94016"
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.5.tgz#5cad84779f45c83b1f2508d96b09d88c7218af55"
   dependencies:
     bl "^1.0.0"
     end-of-stream "^1.0.0"
@@ -2992,8 +2996,8 @@ type-check@~0.3.2:
     prelude-ls "~1.1.2"
 
 type-detect@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.5.tgz#d70e5bc81db6de2a381bcaca0c6e0cbdc7635de2"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -3101,8 +3105,8 @@ wordwrap@~0.0.2:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 worker-farm@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.5.0.tgz#adfdf0cd40581465ed0a1f648f9735722afd5c8d"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.5.1.tgz#8e9f4a7da4f3c595aa600903051b969390423fa1"
   dependencies:
     errno "^0.1.4"
     xtend "^4.0.1"
@@ -3174,8 +3178,8 @@ yargs@~3.10.0:
     window-size "0.1.0"
 
 yauzl@^2.4.2:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.8.0.tgz#79450aff22b2a9c5a41ef54e02db907ccfbf9ee2"
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.9.1.tgz#a81981ea70a57946133883f029c5821a89359a7f"
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"


### PR DESCRIPTION
Running the test suite against 3.6.0-rc2 resulted in a slew of new and interesting errors, mostly around cursors but also related to the need to "unset" sessions when they are implicitly created.  I apologize for the large size of this PR, but you should be able to review the piecewise commits (they are generally small except for the first one where I added error checks to all the gridfs tests). 