### PR TITLE
fix(import): adds missing import to lib/authenticate.js

### DIFF
--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -1,6 +1,7 @@
 var shallowClone = require('./utils').shallowClone
   , handleCallback = require('./utils').handleCallback
-  , MongoError = require('mongodb-core').MongoError;
+  , MongoError = require('mongodb-core').MongoError
+  , f = require('util').format;
 
 var authenticate = function(self, username, password, options, callback) {
   // Did the user destroy the topology


### PR DESCRIPTION
Backpatching this to 2.2, to fix NODE-1173