### PR TITLE
docs(MongoClient): keepAliveInitialDelay should be a number

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -136,7 +136,7 @@ function validOptions(options) {
  * @param {boolean} [options.autoReconnect=true] Enable autoReconnect for single server instances
  * @param {boolean} [options.noDelay=true] TCP Connection no delay
  * @param {boolean} [options.keepAlive=true] TCP Connection keep alive enabled
- * @param {boolean} [options.keepAliveInitialDelay=30000] The number of milliseconds to wait before initiating keepAlive on the TCP socket
+ * @param {number} [options.keepAliveInitialDelay=30000] The number of milliseconds to wait before initiating keepAlive on the TCP socket
  * @param {number} [options.connectTimeoutMS=30000] TCP Connection timeout setting
  * @param {number} [options.family=4] Version of IP stack. Defaults to 4
  * @param {number} [options.socketTimeoutMS=360000] TCP Socket timeout setting


### PR DESCRIPTION
Fixing jsdoc to have proper type for `keepAliveInitialDelay`