### PR TITLE
feat(causal-consistency): add support for causally consistent reads

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -367,7 +367,9 @@ Collection.prototype.find = function() {
 
   // Merge in options to command
   for (var name in newOptions) {
-    if (newOptions[name] != null) findCommand[name] = newOptions[name];
+    if (newOptions[name] != null && name !== 'session') {
+      findCommand[name] = newOptions[name];
+    }
   }
 
   // Format the fields
@@ -2403,13 +2405,23 @@ function decorateWithCollation(command, self, options) {
   }
 }
 
-function decorateWithReadConcern(command, self, options) {  // eslint-disable-line
-  let readConcern = {};
+function decorateWithReadConcern(command, self, options) {
+  let readConcern = Object.assign({}, command.readConcern || {});
   if (self.s.readConcern) {
     Object.assign(readConcern, self.s.readConcern);
   }
 
-  Object.assign(command, readConcern);
+  if (
+    options.session &&
+    options.session.supports.causalConsistency &&
+    options.session.operationTime
+  ) {
+    Object.assign(readConcern, { afterClusterTime: options.session.operationTime });
+  }
+
+  if (Object.keys(readConcern).length > 0) {
+    Object.assign(command, { readConcern: readConcern });
+  }
 }
 
 /**

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -413,9 +413,7 @@ Collection.prototype.find = function() {
   }
 
   // Set the readConcern
-  if (this.s.readConcern) {
-    findCommand.readConcern = this.s.readConcern;
-  }
+  decorateWithReadConcern(findCommand, this, options);
 
   // Decorate find command with collation options
   decorateWithCollation(findCommand, this, options);
@@ -1958,9 +1956,7 @@ var count = function(self, query, options, callback) {
   options = getReadPreference(self, options, self.s.db);
 
   // Do we have a readConcern specified
-  if (self.s.readConcern) {
-    cmd.readConcern = self.s.readConcern;
-  }
+  decorateWithReadConcern(cmd, self, options);
 
   // Have we specified collation
   decorateWithCollation(cmd, self, options);
@@ -2020,9 +2016,7 @@ var distinct = function(self, key, query, options, callback) {
   if (typeof maxTimeMS === 'number') cmd.maxTimeMS = maxTimeMS;
 
   // Do we have a readConcern specified
-  if (self.s.readConcern) {
-    cmd.readConcern = self.s.readConcern;
-  }
+  decorateWithReadConcern(cmd, self, options);
 
   // Have we specified collation
   decorateWithCollation(cmd, self, options);
@@ -2409,6 +2403,15 @@ function decorateWithCollation(command, self, options) {
   }
 }
 
+function decorateWithReadConcern(command, self, options) {  // eslint-disable-line
+  let readConcern = {};
+  if (self.s.readConcern) {
+    Object.assign(readConcern, self.s.readConcern);
+  }
+
+  Object.assign(command, readConcern);
+}
+
 /**
  * Execute an aggregation framework pipeline against the collection, needs MongoDB >= 2.2
  * @method
@@ -2498,8 +2501,8 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
   }
 
   // Do we have a readConcern specified
-  if (!ignoreReadConcern && this.s.readConcern) {
-    command.readConcern = this.s.readConcern;
+  if (!ignoreReadConcern) {
+    decorateWithReadConcern(command, self, options);
   }
 
   // If we have allowDiskUse defined
@@ -2648,9 +2651,7 @@ var parallelCollectionScan = function(self, options, callback) {
   };
 
   // Do we have a readConcern specified
-  if (self.s.readConcern) {
-    commandObject.readConcern = self.s.readConcern;
-  }
+  decorateWithReadConcern(commandObject, self, options);
 
   // Store the raw value
   var raw = options.raw;
@@ -2737,9 +2738,7 @@ var geoNear = function(self, x, y, point, options, callback) {
   commandObject = decorateCommand(commandObject, options, exclude);
 
   // Do we have a readConcern specified
-  if (self.s.readConcern) {
-    commandObject.readConcern = self.s.readConcern;
-  }
+  decorateWithReadConcern(commandObject, self, options);
 
   // Have we specified collation
   decorateWithCollation(commandObject, self, options);
@@ -2794,9 +2793,7 @@ var geoHaystackSearch = function(self, x, y, options, callback) {
   options = getReadPreference(self, options, self.s.db, self);
 
   // Do we have a readConcern specified
-  if (self.s.readConcern) {
-    commandObject.readConcern = self.s.readConcern;
-  }
+  decorateWithReadConcern(commandObject, self, options);
 
   // Execute the command
   self.s.db.command(commandObject, options, function(err, res) {
@@ -2950,9 +2947,7 @@ var group = function(self, keys, condition, initial, reduce, finalize, command, 
     options = getReadPreference(self, options, self.s.db, self);
 
     // Do we have a readConcern specified
-    if (self.s.readConcern) {
-      selector.readConcern = self.s.readConcern;
-    }
+    decorateWithReadConcern(selector, self, options);
 
     // Have we specified collation
     decorateWithCollation(selector, self, options);
@@ -3095,8 +3090,8 @@ var mapReduce = function(self, map, reduce, options, callback) {
     options.readPreference = 'primary';
     // Decorate command with writeConcern if supported
     decorateWithWriteConcern(mapCommandHash, self, options);
-  } else if (self.s.readConcern) {
-    mapCommandHash.readConcern = self.s.readConcern;
+  } else {
+    decorateWithReadConcern(mapCommandHash, self, options);
   }
 
   // Is bypassDocumentValidation specified

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "official"
   ],
   "dependencies": {
-    "mongodb-core": "mongodb-js/mongodb-core#causally-consistent-reads"
+    "mongodb-core": "mongodb-js/mongodb-core#3.0.0"
   },
   "devDependencies": {
     "betterbenchmarks": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "official"
   ],
   "dependencies": {
-    "mongodb-core": "mongodb-js/mongodb-core#3.0.0"
+    "mongodb-core": "mongodb-js/mongodb-core#causally-consistent-reads"
   },
   "devDependencies": {
     "betterbenchmarks": "^0.1.0",

--- a/test/functional/causal_consistency_tests.js
+++ b/test/functional/causal_consistency_tests.js
@@ -1,0 +1,189 @@
+'use strict';
+const mongo = require('../..'),
+  setupDatabase = require('./shared').setupDatabase,
+  expect = require('chai').expect;
+
+const ignoredCommands = ['ismaster', 'endSessions'];
+const test = { commands: { started: [], succeeded: [] } };
+describe('Causal Consistency', function() {
+  before(function() {
+    return setupDatabase(this.configuration);
+  });
+
+  afterEach(() => test.listener.uninstrument());
+  beforeEach(function() {
+    test.commands = { started: [], succeeded: [] };
+    test.listener = mongo.instrument(err => expect(err).to.be.null);
+    test.listener.on('started', event => {
+      if (ignoredCommands.indexOf(event.commandName) === -1) test.commands.started.push(event);
+    });
+
+    test.listener.on('succeeded', event => {
+      if (ignoredCommands.indexOf(event.commandName) === -1) test.commands.succeeded.push(event);
+    });
+
+    test.client = this.configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
+    return test.client.connect();
+  });
+
+  it('should not send `afterClusterTime` on first read operation in a causal session', {
+    metadata: { requires: { topology: ['replicaset'] } },
+
+    test: function() {
+      const session = test.client.startSession({ causalConsistency: true });
+      const db = test.client.db(this.configuration.db);
+
+      return db
+        .collection('causal_test')
+        .findOne({}, null, { session: session })
+        .then(() => {
+          expect(test.commands.started).to.have.length(1);
+          expect(test.commands.succeeded).to.have.length(1);
+
+          const findCommand = test.commands.started[0];
+          expect(findCommand).to.not.have.key('readConcern');
+        });
+    }
+  });
+
+  it('should update `operationTime` on session on first read', {
+    metadata: { requires: { topology: ['replicaset'] } },
+
+    test: function() {
+      const session = test.client.startSession({ causalConsistency: true });
+      const db = test.client.db(this.configuration.db);
+      expect(session.operationTime).to.be.null;
+
+      return db
+        .collection('causal_test')
+        .findOne({}, null, { session: session })
+        .then(() => {
+          expect(test.commands.started).to.have.length(1);
+          expect(test.commands.succeeded).to.have.length(1);
+
+          const lastReply = test.commands.succeeded[0].reply;
+          expect(session.operationTime).to.equal(lastReply.operationTime);
+        });
+    }
+  });
+
+  // TODO: this should be repeated for all potential read operations
+  it('should include `afterClusterTime` on more than one read operation', {
+    metadata: { requires: { topology: ['replicaset'] } },
+
+    test: function() {
+      const session = test.client.startSession({ causalConsistency: true });
+      const db = test.client.db(this.configuration.db);
+      expect(session.operationTime).to.be.null;
+
+      let firstOperationTime;
+      return db
+        .collection('causal_test')
+        .findOne({}, null, { session: session })
+        .then(() => {
+          const firstFindCommand = test.commands.started[0].command;
+          expect(firstFindCommand).to.not.have.key('readConcern');
+          firstOperationTime = test.commands.succeeded[0].reply.operationTime;
+
+          return db.collection('causal_test').findOne({}, null, { session: session });
+        })
+        .then(() => {
+          const secondFindCommand = test.commands.started[1].command;
+          expect(secondFindCommand).to.have.any.key('readConcern');
+          expect(secondFindCommand.readConcern).to.have.any.key('afterClusterTime');
+          expect(secondFindCommand.readConcern.afterClusterTime).to.eql(firstOperationTime);
+        });
+    }
+  });
+
+  it(
+    'should not include `afterClusterTime` on read operations in a session without causal consistency',
+    {
+      metadata: { requires: { topology: ['replicaset'] } },
+
+      test: function() {
+        const session = test.client.startSession({ causalConsistency: false });
+        const db = test.client.db(this.configuration.db);
+        const coll = db.collection('causal_test', { readConcern: { level: 'majority' } });
+
+        return coll
+          .findOne({}, null, { session: session })
+          .then(() => coll.findOne({}, null, { session: session }))
+          .then(() => {
+            const command = test.commands.started[1].command;
+            expect(command).to.have.any.key('readConcern');
+            expect(command.readConcern).to.not.have.any.key('afterClusterTime');
+          });
+      }
+    }
+  );
+
+  // TODO: this should be repeated for all potential read/write operations
+  it('should include `afterClusterTime` on read operation after write operation', {
+    metadata: { requires: { topology: ['replicaset'] } },
+
+    test: function() {
+      const session = test.client.startSession({ causalConsistency: true });
+      const db = test.client.db(this.configuration.db);
+      expect(session.operationTime).to.be.null;
+
+      let firstOperationTime;
+      return db
+        .collection('causal_test')
+        .insert({}, { session: session })
+        .then(() => {
+          firstOperationTime = test.commands.succeeded[0].reply.operationTime;
+          return db.collection('causal_test').findOne({}, null, { session: session });
+        })
+        .then(() => {
+          const secondFindCommand = test.commands.started[1].command;
+          expect(secondFindCommand).to.have.any.key('readConcern');
+          expect(secondFindCommand.readConcern).to.have.any.key('afterClusterTime');
+          expect(secondFindCommand.readConcern.afterClusterTime).to.eql(firstOperationTime);
+        });
+    }
+  });
+
+  it(
+    'should not include `afterClusterTime` on read operations on a deployment which does not support clusterTime',
+    {
+      metadata: { requires: { topology: ['single'] } },
+
+      test: function() {
+        const session = test.client.startSession({ causalConsistency: true });
+        const db = test.client.db(this.configuration.db);
+        const coll = db.collection('causal_test', { readConcern: { level: 'majority' } });
+
+        return coll
+          .findOne({}, null, { session: session })
+          .then(() => coll.findOne({}, null, { session: session }))
+          .then(() => {
+            const command = test.commands.started[1].command;
+            expect(command).to.have.any.key('readConcern');
+            expect(command.readConcern).to.not.have.any.key('afterClusterTime');
+          });
+      }
+    }
+  );
+
+  // NOTE: this is likely to change such that unacknowledged writes are required to use an
+  //       implicit session.
+  it.skip(
+    'should not record `operationTime` for unacknowledged writes in a causally consistent session',
+    {
+      metadata: { requires: { topology: ['replicaset'] } },
+      test: function() {
+        const session = test.client.startSession({ causalConsistency: true });
+        const db = test.client.db(this.configuration.db);
+        expect(session.operationTime).to.be.null;
+
+        return db
+          .collection('causal_test')
+          .insert({}, { session: session, w: 0 })
+          .then(() => {
+            expect(session.operationTime).to.be.null;
+          });
+      }
+    }
+  );
+});

--- a/test/functional/causal_consistency_tests.js
+++ b/test/functional/causal_consistency_tests.js
@@ -150,13 +150,12 @@ describe('Causal Consistency', function() {
       metadata: { requires: { topology: ['single'] } },
 
       test: function() {
-        const session = test.client.startSession({ causalConsistency: true });
         const db = test.client.db(this.configuration.db);
-        const coll = db.collection('causal_test', { readConcern: { level: 'majority' } });
+        const coll = db.collection('causal_test', { readConcern: { level: 'local' } });
 
         return coll
-          .findOne({}, null, { session: session })
-          .then(() => coll.findOne({}, null, { session: session }))
+          .findOne({})
+          .then(() => coll.findOne({}))
           .then(() => {
             const command = test.commands.started[1].command;
             expect(command).to.have.any.key('readConcern');

--- a/test/mock/index.js
+++ b/test/mock/index.js
@@ -52,6 +52,15 @@ const DEFAULT_ISMASTER = {
   ok: 1
 };
 
+const DEFAULT_ISMASTER_36 = Object.assign(
+  {},
+  {
+    maxWireVersion: 5,
+    logicalSessionTimeoutMinutes: 10
+  },
+  DEFAULT_ISMASTER
+);
+
 /*
  * Main module
  */
@@ -67,5 +76,6 @@ module.exports = {
   },
 
   cleanup: cleanup,
-  DEFAULT_ISMASTER: DEFAULT_ISMASTER
+  DEFAULT_ISMASTER: DEFAULT_ISMASTER,
+  DEFAULT_ISMASTER_36: DEFAULT_ISMASTER_36
 };

--- a/test/unit/sessions/collection_tests.js
+++ b/test/unit/sessions/collection_tests.js
@@ -1,0 +1,55 @@
+'use strict';
+const MongoClient = require('../../..').MongoClient,
+  Timestamp = require('bson').Timestamp,
+  expect = require('chai').expect,
+  mock = require('../../mock');
+
+const test = {};
+describe('Sessions', function() {
+  describe('Collection', function() {
+    afterEach(() => mock.cleanup());
+    beforeEach(() => {
+      return mock.createServer().then(server => {
+        test.server = server;
+      });
+    });
+
+    it('should include `afterClusterTime` in read command with causal consistency', {
+      metadata: { requires: { topology: 'single' } },
+
+      test: function() {
+        let findCommand;
+        let insertOperationTime = Timestamp.fromNumber(Date.now());
+        test.server.setMessageHandler(request => {
+          const doc = request.document;
+          if (doc.ismaster) {
+            request.reply(mock.DEFAULT_ISMASTER_36);
+          } else if (doc.insert) {
+            request.reply({ ok: 1, operationTime: insertOperationTime });
+          } else if (doc.find) {
+            findCommand = doc;
+            request.reply({ ok: 1 });
+          } else if (doc.endSessions) {
+            request.reply({ ok: 1 });
+          }
+        });
+
+        return MongoClient.connect(`mongodb://${test.server.uri()}/test`).then(client => {
+          const session = client.startSession({ causalConsistency: true });
+          const coll = client.db('foo').collection('bar');
+
+          return coll
+            .insert({ a: 42 }, { session: session })
+            .then(() =>
+              coll.findOne({}, null, { session: session, readConcern: { level: 'majoroy' } })
+            )
+            .then(() => {
+              expect(findCommand.readConcern).to.have.keys(['level', 'afterClusterTime']);
+              expect(findCommand.readConcern.afterClusterTime).to.eql(insertOperationTime);
+              return client.close();
+            });
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
Version 3.6 of the server introduces support for [causal consistency of reads](https://github.com/mongodb/specifications/blob/master/source/causal-consistency/causal-consistency.rst), this pull request adds support for this feature to the porcelain layer of the driver.

