### PR TITLE
feat(collection): updating find API

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -192,57 +192,48 @@ Object.defineProperty(Collection.prototype, 'hint', {
 /**
  * Creates a cursor for a query that can be used to iterate over results from MongoDB
  * @method
- * @param {object} query The cursor query object.
- * @param {Object} [options] Optional settings
+ * @param {object} [query={}] The cursor query object.
+ * @param {object} [options=null] Optional settings.
+ * @param {number} [options.limit=0] Sets the limit of documents returned in the query.
+ * @param {(array|object)} [options.sort=null] Set to sort the documents coming back from the query. Array of indexes, [['a', 1]] etc.
+ * @param {object} [options.projection=null] The fields to return in the query. Object of fields to include or exclude (not both), {'a':1}
+ * @param {object} [options.fields=null] **Deprecated** Use `options.projection` instead
+ * @param {number} [options.skip=0] Set to skip N documents ahead in your query (useful for pagination).
+ * @param {Object} [options.hint=null] Tell the query to use specific indexes in the query. Object of indexes to use, {'_id':1}
+ * @param {boolean} [options.explain=false] Explain the query instead of returning the data.
+ * @param {boolean} [options.snapshot=false] Snapshot query.
+ * @param {boolean} [options.timeout=false] Specify if the cursor can timeout.
+ * @param {boolean} [options.tailable=false] Specify if the cursor is tailable.
+ * @param {number} [options.batchSize=0] Set the batchSize for the getMoreCommand when iterating over the query results.
+ * @param {boolean} [options.returnKey=false] Only return the index key.
+ * @param {number} [options.maxScan=null] Limit the number of items to scan.
+ * @param {number} [options.min=null] Set index bounds.
+ * @param {number} [options.max=null] Set index bounds.
+ * @param {boolean} [options.showDiskLoc=false] Show disk location of results.
+ * @param {string} [options.comment=null] You can put a $comment field on a query to make looking in the profiler logs simpler.
+ * @param {boolean} [options.raw=false] Return document results as raw BSON buffers.
+ * @param {boolean} [options.promoteLongs=true] Promotes Long values to number if they fit inside the 53 bits resolution.
+ * @param {boolean} [options.promoteValues=true] Promotes BSON values to native types where possible, set to false to only receive wrapper types.
+ * @param {boolean} [options.promoteBuffers=false] Promotes Binary BSON values to native Node Buffers.
+ * @param {(ReadPreference|string)} [options.readPreference=null] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
+ * @param {boolean} [options.partial=false] Specify if the cursor should return partial results when querying against a sharded system
+ * @param {number} [options.maxTimeMS=null] Number of miliseconds to wait before aborting the query.
+ * @param {object} [options.collation=null] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @throws {MongoError}
  * @return {Cursor}
  */
-Collection.prototype.find = function() {
-  var options,
-    args = Array.prototype.slice.call(arguments, 0),
-    has_callback = typeof args[args.length - 1] === 'function',
-    has_weird_callback = typeof args[0] === 'function',
-    callback = has_callback ? args.pop() : has_weird_callback ? args.shift() : null,
-    len = args.length,
-    selector = len >= 1 ? args[0] : {},
-    fields = len >= 2 ? args[1] : undefined;
-
-  if (len === 1 && has_weird_callback) {
-    // backwards compat for callback?, options case
-    selector = {};
-    options = args[0];
-  }
-
-  if (len === 2 && fields !== undefined && !Array.isArray(fields)) {
-    var fieldKeys = Object.keys(fields);
-    var is_option = false;
-
-    for (var i = 0; i < fieldKeys.length; i++) {
-      if (testForFields[fieldKeys[i]] != null) {
-        is_option = true;
-        break;
-      }
+Collection.prototype.find = function(query, options, callback) {
+  let selector = query;
+  // figuring out arguments
+  if (typeof callback !== 'function') {
+    if (typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    } else if (options == null) {
+      callback = typeof selector === 'function' ? selector : undefined;
+      selector = typeof selector === 'object' ? selector : undefined;
     }
-
-    if (is_option) {
-      options = fields;
-      fields = undefined;
-    } else {
-      options = {};
-    }
-  } else if (len === 2 && Array.isArray(fields) && !Array.isArray(fields[0])) {
-    var newFields = {};
-    // Rewrite the array
-    for (i = 0; i < fields.length; i++) {
-      newFields[fields[i]] = 1;
-    }
-    // Set the fields
-    fields = newFields;
-  }
-
-  if (3 === len) {
-    options = args[2];
   }
 
   // Ensure selector is not null
@@ -264,49 +255,23 @@ Collection.prototype.find = function() {
     }
   }
 
-  // Validate correctness of the field selector
-  object = fields;
-  if (Buffer.isBuffer(object)) {
-    object_size = object[0] | (object[1] << 8) | (object[2] << 16) | (object[3] << 24);
-    if (object_size !== object.length) {
-      error = new Error(
-        'query fields raw message size does not match message header size [' +
-          object.length +
-          '] != [' +
-          object_size +
-          ']'
-      );
-      error.name = 'MongoError';
-      throw error;
-    }
-  }
-
   // Check special case where we are using an objectId
   if (selector != null && selector._bsontype === 'ObjectID') {
     selector = { _id: selector };
   }
 
-  // If it's a serialized fields field we need to just let it through
-  // user be warned it better be good
-  if (options && options.fields && !Buffer.isBuffer(options.fields)) {
-    fields = {};
-
-    if (Array.isArray(options.fields)) {
-      if (!options.fields.length) {
-        fields['_id'] = 1;
-      } else {
-        var l = options.fields.length;
-
-        for (i = 0; i < l; i++) {
-          fields[options.fields[i]] = 1;
-        }
-      }
-    } else {
-      fields = options.fields;
-    }
-  }
-
   if (!options) options = {};
+
+  let projection = options.projection || options.fields;
+
+  if (projection && !Buffer.isBuffer(projection) && Array.isArray(projection)) {
+    projection = projection.length
+      ? projection.reduce((result, field) => {
+          result[field] = 1;
+          return result;
+        }, {})
+      : { _id: 1 };
+  }
 
   var newOptions = {};
 
@@ -323,13 +288,11 @@ Collection.prototype.find = function() {
   }
 
   // Unpack options
-  newOptions.skip = len > 3 ? args[2] : options.skip ? options.skip : 0;
-  newOptions.limit = len > 3 ? args[3] : options.limit ? options.limit : 0;
-  newOptions.raw =
-    options.raw != null && typeof options.raw === 'boolean' ? options.raw : this.s.raw;
+  newOptions.skip = options.skip ? options.skip : 0;
+  newOptions.limit = options.limit ? options.limit : 0;
+  newOptions.raw = typeof options.raw === 'boolean' ? options.raw : this.s.raw;
   newOptions.hint = options.hint != null ? normalizeHintField(options.hint) : this.s.collectionHint;
-  newOptions.timeout =
-    len === 5 ? args[4] : typeof options.timeout === 'undefined' ? undefined : options.timeout;
+  newOptions.timeout = typeof options.timeout === 'undefined' ? undefined : options.timeout;
   // // If we have overridden slaveOk otherwise use the default db setting
   newOptions.slaveOk = options.slaveOk != null ? options.slaveOk : this.s.db.slaveOk;
 
@@ -372,26 +335,7 @@ Collection.prototype.find = function() {
     }
   }
 
-  // Format the fields
-  var formatFields = function(fields) {
-    var object = {};
-    if (Array.isArray(fields)) {
-      for (var i = 0; i < fields.length; i++) {
-        if (Array.isArray(fields[i])) {
-          object[fields[i][0]] = fields[i][1];
-        } else {
-          object[fields[i][0]] = 1;
-        }
-      }
-    } else {
-      object = fields;
-    }
-
-    return object;
-  };
-
-  // Special treatment for the fields selector
-  if (fields) findCommand.fields = formatFields(fields);
+  if (projection) findCommand.fields = projection;
 
   // Add db object to the new options
   newOptions.db = this.s.db;
@@ -1361,7 +1305,8 @@ define.classMethod('save', { callback: true, promise: true });
  * @param {object} [options=null] Optional settings.
  * @param {number} [options.limit=0] Sets the limit of documents returned in the query.
  * @param {(array|object)} [options.sort=null] Set to sort the documents coming back from the query. Array of indexes, [['a', 1]] etc.
- * @param {object} [options.fields=null] The fields to return in the query. Object of fields to include or exclude (not both), {'a':1}
+ * @param {object} [options.projection=null] The fields to return in the query. Object of fields to include or exclude (not both), {'a':1}
+ * @param {object} [options.fields=null] **Deprecated** Use `options.projection` instead
  * @param {number} [options.skip=0] Set to skip N documents ahead in your query (useful for pagination).
  * @param {Object} [options.hint=null] Tell the query to use specific indexes in the query. Object of indexes to use, {'_id':1}
  * @param {boolean} [options.explain=false] Explain the query instead of returning the data.
@@ -2253,7 +2198,8 @@ define.classMethod('findOneAndUpdate', { callback: true, promise: true });
  * @param {boolean} [options.remove=false] Set to true to remove the object before returning.
  * @param {boolean} [options.upsert=false] Perform an upsert operation.
  * @param {boolean} [options.new=false] Set to true if you want to return the modified object rather than the original. Ignored for remove.
- * @param {object} [options.fields=null] Object containing the field projection for the result returned from the operation.
+ * @param {object} [options.projection=null] Object containing the field projection for the result returned from the operation.
+ * @param {object} [options.fields=null] **Deprecated** Use `options.projection` instead
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~findAndModifyCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -2297,8 +2243,10 @@ var findAndModify = function(self, query, sort, doc, options, callback) {
   queryObject.remove = options.remove ? true : false;
   queryObject.upsert = options.upsert ? true : false;
 
-  if (options.fields) {
-    queryObject.fields = options.fields;
+  const projection = options.projection || options.fields;
+
+  if (projection) {
+    queryObject.fields = projection;
   }
 
   if (options.arrayFilters) {
@@ -3267,41 +3215,6 @@ var getReadPreference = function(self, options, db) {
   }
 
   return options;
-};
-
-var testForFields = {
-  limit: 1,
-  sort: 1,
-  fields: 1,
-  skip: 1,
-  hint: 1,
-  explain: 1,
-  snapshot: 1,
-  timeout: 1,
-  tailable: 1,
-  tailableRetryInterval: 1,
-  numberOfRetries: 1,
-  awaitdata: 1,
-  awaitData: 1,
-  exhaust: 1,
-  batchSize: 1,
-  returnKey: 1,
-  maxScan: 1,
-  min: 1,
-  max: 1,
-  showDiskLoc: 1,
-  comment: 1,
-  raw: 1,
-  readPreference: 1,
-  partial: 1,
-  read: 1,
-  dbName: 1,
-  oplogReplay: 1,
-  connection: 1,
-  maxTimeMS: 1,
-  transforms: 1,
-  collation: 1,
-  noCursorTimeout: 1
 };
 
 module.exports = Collection;

--- a/test/functional/collations_tests.js
+++ b/test/functional/collations_tests.js
@@ -364,19 +364,21 @@ describe('Collation', function() {
           var reduce = new Code('function(k,vals) { return 1; }');
 
           // db.collection('test').mapReduce({
-          db.collection('test').mapReduce(map,
-          reduce,
-          {
-            out: { replace: 'tempCollection' },
-            collation: { caseLevel: true }
-          },
-          function(err) {
-            test.equal(null, err);
-            test.deepEqual({ caseLevel: true }, commandResult.collation);
+          db.collection('test').mapReduce(
+            map,
+            reduce,
+            {
+              out: { replace: 'tempCollection' },
+              collation: { caseLevel: true }
+            },
+            function(err) {
+              test.equal(null, err);
+              test.deepEqual({ caseLevel: true }, commandResult.collation);
 
-            client.close();
-            done();
-          });
+              client.close();
+              done();
+            }
+          );
         });
       });
     }
@@ -802,26 +804,28 @@ describe('Collation', function() {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
-          db.collection('test').bulkWrite([
-            {
-              updateOne: {
-                q: { a: 2 },
-                u: { $set: { a: 2 } },
-                upsert: true,
-                collation: { caseLevel: true }
-              }
-            },
-            { deleteOne: { q: { c: 1 } } }
-          ],
-          { ordered: true },
-          function(err) {
-            test.equal(null, err);
-            test.ok(commandResult);
-            test.deepEqual({ caseLevel: true }, commandResult.updates[0].collation);
+          db.collection('test').bulkWrite(
+            [
+              {
+                updateOne: {
+                  q: { a: 2 },
+                  u: { $set: { a: 2 } },
+                  upsert: true,
+                  collation: { caseLevel: true }
+                }
+              },
+              { deleteOne: { q: { c: 1 } } }
+            ],
+            { ordered: true },
+            function(err) {
+              test.equal(null, err);
+              test.ok(commandResult);
+              test.deepEqual({ caseLevel: true }, commandResult.updates[0].collation);
 
-            client.close();
-            done();
-          });
+              client.close();
+              done();
+            }
+          );
         });
       });
     }
@@ -858,25 +862,27 @@ describe('Collation', function() {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
-          db.collection('test').bulkWrite([
-            {
-              updateOne: {
-                q: { a: 2 },
-                u: { $set: { a: 2 } },
-                upsert: true,
-                collation: { caseLevel: true }
-              }
-            },
-            { deleteOne: { q: { c: 1 } } }
-          ],
-          { ordered: true },
-          function(err) {
-            test.ok(err);
-            test.equal('server/primary/mongos does not support collation', err.message);
+          db.collection('test').bulkWrite(
+            [
+              {
+                updateOne: {
+                  q: { a: 2 },
+                  u: { $set: { a: 2 } },
+                  upsert: true,
+                  collation: { caseLevel: true }
+                }
+              },
+              { deleteOne: { q: { c: 1 } } }
+            ],
+            { ordered: true },
+            function(err) {
+              test.ok(err);
+              test.equal('server/primary/mongos does not support collation', err.message);
 
-            client.close();
-            done();
-          });
+              client.close();
+              done();
+            }
+          );
         });
       });
     }
@@ -980,25 +986,27 @@ describe('Collation', function() {
               test.equal(null, err);
               var db = client.db(configuration.db);
 
-              db.collection('test').bulkWrite([
-                {
-                  updateOne: {
-                    q: { a: 2 },
-                    u: { $set: { a: 2 } },
-                    upsert: true,
-                    collation: { caseLevel: true }
-                  }
-                },
-                { deleteOne: { q: { c: 1 } } }
-              ],
-              { ordered: true },
-              function(err) {
-                test.ok(err);
-                test.equal('server/primary/mongos does not support collation', err.message);
+              db.collection('test').bulkWrite(
+                [
+                  {
+                    updateOne: {
+                      q: { a: 2 },
+                      u: { $set: { a: 2 } },
+                      upsert: true,
+                      collation: { caseLevel: true }
+                    }
+                  },
+                  { deleteOne: { q: { c: 1 } } }
+                ],
+                { ordered: true },
+                function(err) {
+                  test.ok(err);
+                  test.equal('server/primary/mongos does not support collation', err.message);
 
-                client.close();
-                done();
-              });
+                  client.close();
+                  done();
+                }
+              );
             }
           );
         }, 500);

--- a/test/functional/command_write_concern_tests.js
+++ b/test/functional/command_write_concern_tests.js
@@ -363,19 +363,21 @@ describe('Command Write Concern', function() {
             test.equal(null, err);
             var db = client.db(configuration.db);
 
-            db.collection('indexOptionDefault').createIndex({ a: 1 },
-            {
-              indexOptionDefaults: true,
-              w: 2,
-              wtimeout: 1000
-            },
-            function(err) {
-              test.equal(null, err);
-              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+            db.collection('indexOptionDefault').createIndex(
+              { a: 1 },
+              {
+                indexOptionDefaults: true,
+                w: 2,
+                wtimeout: 1000
+              },
+              function(err) {
+                test.equal(null, err);
+                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
-              client.close();
-              done();
-            });
+                client.close();
+                done();
+              }
+            );
           }
         );
       });
@@ -482,17 +484,19 @@ describe('Command Write Concern', function() {
             test.equal(null, err);
             var db = client.db(configuration.db);
 
-            db.collection('indexOptionDefault').drop({
-              w: 2,
-              wtimeout: 1000
-            },
-            function(err) {
-              test.equal(null, err);
-              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+            db.collection('indexOptionDefault').drop(
+              {
+                w: 2,
+                wtimeout: 1000
+              },
+              function(err) {
+                test.equal(null, err);
+                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
-              client.close();
-              done();
-            });
+                client.close();
+                done();
+              }
+            );
           }
         );
       });
@@ -718,17 +722,19 @@ describe('Command Write Concern', function() {
             test.equal(null, err);
             var db = client.db(configuration.db);
 
-            db.collection('test').dropIndexes({
-              w: 2,
-              wtimeout: 1000
-            },
-            function(err) {
-              test.equal(null, err);
-              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+            db.collection('test').dropIndexes(
+              {
+                w: 2,
+                wtimeout: 1000
+              },
+              function(err) {
+                test.equal(null, err);
+                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
-              client.close();
-              done();
-            });
+                client.close();
+                done();
+              }
+            );
           }
         );
       });
@@ -841,20 +847,22 @@ describe('Command Write Concern', function() {
             var reduce = new Code('function(k,vals) { return 1; }');
 
             // db.collection('test').mapReduce({
-            db.collection('test').mapReduce(map,
-            reduce,
-            {
-              out: { replace: 'tempCollection' },
-              w: 2,
-              wtimeout: 1000
-            },
-            function(err) {
-              test.equal(null, err);
-              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+            db.collection('test').mapReduce(
+              map,
+              reduce,
+              {
+                out: { replace: 'tempCollection' },
+                w: 2,
+                wtimeout: 1000
+              },
+              function(err) {
+                test.equal(null, err);
+                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
-              client.close();
-              done();
-            });
+                client.close();
+                done();
+              }
+            );
           }
         );
       });

--- a/test/functional/crud_api_tests.js
+++ b/test/functional/crud_api_tests.js
@@ -758,22 +758,24 @@ describe('CRUD API', function() {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
-            db.collection('t5_2').findOneAndReplace({ a: 1 },
-            { c: 1, b: 1 },
-            {
-              projection: { b: 1, c: 1 },
-              sort: { a: 1 },
-              returnOriginal: false,
-              upsert: true
-            },
-            function(err, r) {
-              test.equal(null, err);
-              test.equal(1, r.lastErrorObject.n);
-              test.equal(1, r.value.b);
-              test.equal(1, r.value.c);
+            db.collection('t5_2').findOneAndReplace(
+              { a: 1 },
+              { c: 1, b: 1 },
+              {
+                projection: { b: 1, c: 1 },
+                sort: { a: 1 },
+                returnOriginal: false,
+                upsert: true
+              },
+              function(err, r) {
+                test.equal(null, err);
+                test.equal(1, r.lastErrorObject.n);
+                test.equal(1, r.value.b);
+                test.equal(1, r.value.c);
 
-              findOneAndUpdate();
-            });
+                findOneAndUpdate();
+              }
+            );
           });
         };
 
@@ -785,23 +787,25 @@ describe('CRUD API', function() {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
-            db.collection('t5_3').findOneAndUpdate({ a: 1 },
-            { $set: { d: 1 } },
-            {
-              projection: { b: 1, d: 1 },
-              sort: { a: 1 },
-              returnOriginal: false,
-              upsert: true
-            },
-            function(err, r) {
-              test.equal(null, err);
-              test.equal(1, r.lastErrorObject.n);
-              test.equal(1, r.value.b);
-              test.equal(1, r.value.d);
+            db.collection('t5_3').findOneAndUpdate(
+              { a: 1 },
+              { $set: { d: 1 } },
+              {
+                projection: { b: 1, d: 1 },
+                sort: { a: 1 },
+                returnOriginal: false,
+                upsert: true
+              },
+              function(err, r) {
+                test.equal(null, err);
+                test.equal(1, r.lastErrorObject.n);
+                test.equal(1, r.value.b);
+                test.equal(1, r.value.d);
 
-              client.close();
-              done();
-            });
+                client.close();
+                done();
+              }
+            );
           });
         };
 

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -1719,20 +1719,16 @@ describe('Cursor', function() {
           collection.save({ x: 1, a: 2 }, configuration.writeConcernMax(), function(err) {
             test.equal(null, err);
 
-            collection.find({}, { fields: ['a'] }).toArray(function(err, items) {
-              test.equal(null, err);
-              test.equal(1, items.length);
-              test.equal(2, items[0].a);
-              test.equal(undefined, items[0].x);
-            });
-
-            collection.findOne({}, { fields: ['a'] }, function(err, item) {
-              test.equal(null, err);
-              test.equal(2, item.a);
-              test.equal(undefined, item.x);
-              client.close();
-              done();
-            });
+            collection
+              .find({})
+              .project({ a: 1 })
+              .toArray(function(err, items) {
+                test.equal(null, err);
+                test.equal(1, items.length);
+                test.equal(2, items[0].a);
+                test.equal(undefined, items[0].x);
+                done();
+              });
           });
         });
       });
@@ -4139,28 +4135,28 @@ describe('Cursor', function() {
         test.equal(null, err);
 
         db.collection('cursor_count_test1', { readConcern: { level: 'local' } }).count({
-          project: '123'
-        },
-        {
-          readConcern: { level: 'local' },
-          limit: 5,
-          skip: 5,
-          hint: { project: 1 }
-        },
-        function(err) {
-          test.equal(null, err);
-          test.equal(1, started.length);
-          if (started[0].command.readConcern)
-            test.deepEqual({ level: 'local' }, started[0].command.readConcern);
-          test.deepEqual({ project: 1 }, started[0].command.hint);
-          test.equal(5, started[0].command.skip);
-          test.equal(5, started[0].command.limit);
+            project: '123'
+          },
+          {
+            readConcern: { level: 'local' },
+            limit: 5,
+            skip: 5,
+            hint: { project: 1 }
+          },
+          function(err) {
+            test.equal(null, err);
+            test.equal(1, started.length);
+            if (started[0].command.readConcern)
+              test.deepEqual({ level: 'local' }, started[0].command.readConcern);
+            test.deepEqual({ project: 1 }, started[0].command.hint);
+            test.equal(5, started[0].command.skip);
+            test.equal(5, started[0].command.limit);
 
-          listener.uninstrument();
+            listener.uninstrument();
 
-          client.close();
-          done();
-        });
+            client.close();
+            done();
+          });
       });
     }
   });

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4134,7 +4134,8 @@ describe('Cursor', function() {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
-        db.collection('cursor_count_test1', { readConcern: { level: 'local' } }).count({
+        db.collection('cursor_count_test1', { readConcern: { level: 'local' } }).count(
+          {
             project: '123'
           },
           {
@@ -4156,7 +4157,8 @@ describe('Cursor', function() {
 
             client.close();
             done();
-          });
+          }
+        );
       });
     }
   });

--- a/test/functional/db_tests.js
+++ b/test/functional/db_tests.js
@@ -96,7 +96,9 @@ describe('Db', function() {
 
         try {
           coll.findOne({}, null, function() {
-            //e - Cannot convert undefined or null to object
+            //e - errors b/c findOne needs a query selector
+            test.equal(1, count);
+            done();
           });
         } catch (e) {
           process.nextTick(function() {

--- a/test/functional/decimal128_tests.js
+++ b/test/functional/decimal128_tests.js
@@ -36,17 +36,19 @@ describe('Decimal128', function() {
         db.collection('decimal128').insertOne(object, function(err) {
           test.equal(null, err);
 
-          db.collection('decimal128').findOne({
-            id: 1
-          },
-          function(err, doc) {
-            test.equal(null, err);
-            test.ok(doc.value instanceof Decimal128);
-            test.equal('1', doc.value.toString());
+          db.collection('decimal128').findOne(
+            {
+              id: 1
+            },
+            function(err, doc) {
+              test.equal(null, err);
+              test.ok(doc.value instanceof Decimal128);
+              test.equal('1', doc.value.toString());
 
-            client.close();
-            done();
-          });
+              client.close();
+              done();
+            }
+          );
         });
       });
     }

--- a/test/functional/insert_tests.js
+++ b/test/functional/insert_tests.js
@@ -2023,12 +2023,15 @@ describe('Insert', function() {
             test.equal(null, err);
             test.ok(ids);
 
-            collection.find({}, { fields: ['b'] }).toArray(function(err, items) {
-              test.equal('' + regexp, '' + items[0].b);
-              // Let's close the db
-              client.close();
-              done();
-            });
+            collection
+              .find({})
+              .project({ b: 1 })
+              .toArray(function(err, items) {
+                test.equal('' + regexp, '' + items[0].b);
+                // Let's close the db
+                client.close();
+                done();
+              });
           });
         });
       });
@@ -2056,13 +2059,16 @@ describe('Insert', function() {
           test.equal(null, err);
           test.ok(ids);
 
-          collection.find({}, { fields: ['b'] }).toArray(function(err, items) {
-            test.equal(null, err);
-            test.equal('' + regexp, '' + items[0].b);
-            // Let's close the db
-            client.close();
-            done();
-          });
+          collection
+            .find({})
+            .project({ b: 1 })
+            .toArray(function(err, items) {
+              test.equal(null, err);
+              test.equal('' + regexp, '' + items[0].b);
+              // Let's close the db
+              client.close();
+              done();
+            });
         });
       });
     }
@@ -2120,21 +2126,21 @@ describe('Insert', function() {
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteLong').insert({
-          doc: Long.fromNumber(10),
-          array: [[Long.fromNumber(10)]]
-        },
-        function(err, doc) {
-          test.equal(null, err);
-          test.ok(doc);
-
-          db.collection('shouldCorrectlyHonorPromoteLong').findOne(function(err, doc) {
+            doc: Long.fromNumber(10),
+            array: [[Long.fromNumber(10)]]
+          },
+          function(err, doc) {
             test.equal(null, err);
-            test.ok(doc.doc._bsontype === 'Long');
-            test.ok(doc.array[0][0]._bsontype === 'Long');
-            client.close();
-            done();
+            test.ok(doc);
+
+            db.collection('shouldCorrectlyHonorPromoteLong').findOne(function(err, doc) {
+              test.equal(null, err);
+              test.ok(doc.doc._bsontype === 'Long');
+              test.ok(doc.array[0][0]._bsontype === 'Long');
+              client.close();
+              done();
+            });
           });
-        });
       });
     }
   });
@@ -2226,23 +2232,23 @@ describe('Insert', function() {
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteLongTrueNativeBSON').insert({
-          doc: Long.fromNumber(10),
-          array: [[Long.fromNumber(10)]]
-        },
-        function(err, doc) {
-          test.equal(null, err);
-          test.ok(doc);
+            doc: Long.fromNumber(10),
+            array: [[Long.fromNumber(10)]]
+          },
+          function(err, doc) {
+            test.equal(null, err);
+            test.ok(doc);
 
-          db
-            .collection('shouldCorrectlyHonorPromoteLongTrueNativeBSON')
-            .findOne(function(err, doc) {
-              test.equal(null, err);
-              test.equal(null, err);
-              test.ok('number', typeof doc.doc);
-              test.ok('number', typeof doc.array[0][0]);
-              client.close();
-              done();
-            });
+            db
+              .collection('shouldCorrectlyHonorPromoteLongTrueNativeBSON')
+              .findOne(function(err, doc) {
+                test.equal(null, err);
+                test.equal(null, err);
+                test.ok('number', typeof doc.doc);
+                test.ok('number', typeof doc.array[0][0]);
+                client.close();
+                done();
+              });
         });
       });
     }
@@ -2267,21 +2273,21 @@ describe('Insert', function() {
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteLongFalseJSBSON').insert({
-          doc: Long.fromNumber(10),
-          array: [[Long.fromNumber(10)]]
-        },
-        function(err, doc) {
-          test.equal(null, err);
-          test.ok(doc);
+            doc: Long.fromNumber(10),
+            array: [[Long.fromNumber(10)]]
+          },
+          function(err, doc) {
+            test.equal(null, err);
+            test.ok(doc);
 
-          db.collection('shouldCorrectlyHonorPromoteLongFalseJSBSON').findOne(function(err, doc) {
-            test.equal(null, err);
-            test.equal(null, err);
-            test.ok(doc.doc._bsontype === 'Long');
-            test.ok(doc.array[0][0]._bsontype === 'Long');
-            client.close();
-            done();
-          });
+            db.collection('shouldCorrectlyHonorPromoteLongFalseJSBSON').findOne(function(err, doc) {
+              test.equal(null, err);
+              test.equal(null, err);
+              test.ok(doc.doc._bsontype === 'Long');
+              test.ok(doc.array[0][0]._bsontype === 'Long');
+              client.close();
+              done();
+            });
         });
       });
     }
@@ -2303,21 +2309,21 @@ describe('Insert', function() {
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteLongTrueJSBSON').insert({
-          doc: Long.fromNumber(10),
-          array: [[Long.fromNumber(10)]]
-        },
-        function(err, doc) {
-          test.equal(null, err);
-          test.ok(doc);
+            doc: Long.fromNumber(10),
+            array: [[Long.fromNumber(10)]]
+          },
+          function(err, doc) {
+            test.equal(null, err);
+            test.ok(doc);
 
-          db.collection('shouldCorrectlyHonorPromoteLongTrueJSBSON').findOne(function(err, doc) {
-            test.equal(null, err);
-            test.equal(null, err);
-            test.ok('number', typeof doc.doc);
-            test.ok('number', typeof doc.array[0][0]);
-            client.close();
-            done();
-          });
+            db.collection('shouldCorrectlyHonorPromoteLongTrueJSBSON').findOne(function(err, doc) {
+              test.equal(null, err);
+              test.equal(null, err);
+              test.ok('number', typeof doc.doc);
+              test.ok('number', typeof doc.array[0][0]);
+              client.close();
+              done();
+            });
         });
       });
     }
@@ -2338,16 +2344,16 @@ describe('Insert', function() {
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyOverrideCheckKeysJSOnUpdate').update({
-          'ps.op.t': 1
-        },
-        { $set: { b: 1 } },
-        { checkKeys: false },
-        function(err, doc) {
-          test.equal(null, err);
-          test.ok(doc);
+            'ps.op.t': 1
+          },
+          { $set: { b: 1 } },
+          { checkKeys: false },
+          function(err, doc) {
+            test.equal(null, err);
+            test.ok(doc);
 
-          client.close();
-          done();
+            client.close();
+            done();
         });
       });
     }

--- a/test/functional/insert_tests.js
+++ b/test/functional/insert_tests.js
@@ -2125,7 +2125,8 @@ describe('Insert', function() {
       });
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
-        db.collection('shouldCorrectlyHonorPromoteLong').insert({
+        db.collection('shouldCorrectlyHonorPromoteLong').insert(
+          {
             doc: Long.fromNumber(10),
             array: [[Long.fromNumber(10)]]
           },
@@ -2140,7 +2141,8 @@ describe('Insert', function() {
               client.close();
               done();
             });
-          });
+          }
+        );
       });
     }
   });
@@ -2231,7 +2233,8 @@ describe('Insert', function() {
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
-        db.collection('shouldCorrectlyHonorPromoteLongTrueNativeBSON').insert({
+        db.collection('shouldCorrectlyHonorPromoteLongTrueNativeBSON').insert(
+          {
             doc: Long.fromNumber(10),
             array: [[Long.fromNumber(10)]]
           },
@@ -2249,7 +2252,8 @@ describe('Insert', function() {
                 client.close();
                 done();
               });
-        });
+          }
+        );
       });
     }
   });
@@ -2272,7 +2276,8 @@ describe('Insert', function() {
       });
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
-        db.collection('shouldCorrectlyHonorPromoteLongFalseJSBSON').insert({
+        db.collection('shouldCorrectlyHonorPromoteLongFalseJSBSON').insert(
+          {
             doc: Long.fromNumber(10),
             array: [[Long.fromNumber(10)]]
           },
@@ -2288,7 +2293,8 @@ describe('Insert', function() {
               client.close();
               done();
             });
-        });
+          }
+        );
       });
     }
   });
@@ -2308,7 +2314,8 @@ describe('Insert', function() {
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
-        db.collection('shouldCorrectlyHonorPromoteLongTrueJSBSON').insert({
+        db.collection('shouldCorrectlyHonorPromoteLongTrueJSBSON').insert(
+          {
             doc: Long.fromNumber(10),
             array: [[Long.fromNumber(10)]]
           },
@@ -2324,7 +2331,8 @@ describe('Insert', function() {
               client.close();
               done();
             });
-        });
+          }
+        );
       });
     }
   });
@@ -2343,7 +2351,8 @@ describe('Insert', function() {
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
-        db.collection('shouldCorrectlyOverrideCheckKeysJSOnUpdate').update({
+        db.collection('shouldCorrectlyOverrideCheckKeysJSOnUpdate').update(
+          {
             'ps.op.t': 1
           },
           { $set: { b: 1 } },
@@ -2354,7 +2363,8 @@ describe('Insert', function() {
 
             client.close();
             done();
-        });
+          }
+        );
       });
     }
   });

--- a/test/functional/mapreduce_tests.js
+++ b/test/functional/mapreduce_tests.js
@@ -8,8 +8,8 @@ describe('MapReduce', function() {
   });
 
   /**
-  * @ignore
-  */
+   * @ignore
+   */
   it('shouldCorrectlyExecuteGroupFunctionWithFinalizeFunction', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
@@ -66,9 +66,9 @@ describe('MapReduce', function() {
   });
 
   /**
-  * Mapreduce tests
-  * @ignore
-  */
+   * Mapreduce tests
+   * @ignore
+   */
   it('shouldPerformMapReduceWithStringFunctions', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
@@ -113,9 +113,9 @@ describe('MapReduce', function() {
   });
 
   /**
-  * Mapreduce tests
-  * @ignore
-  */
+   * Mapreduce tests
+   * @ignore
+   */
   it('shouldForceMapReduceError', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
@@ -155,8 +155,8 @@ describe('MapReduce', function() {
   });
 
   /**
-  * @ignore
-  */
+   * @ignore
+   */
   it('shouldPerformMapReduceWithParametersBeingFunctions', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
@@ -209,8 +209,8 @@ describe('MapReduce', function() {
   });
 
   /**
-  * @ignore
-  */
+   * @ignore
+   */
   it('shouldPerformMapReduceWithCodeObjects', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
@@ -256,8 +256,8 @@ describe('MapReduce', function() {
   });
 
   /**
-  * @ignore
-  */
+   * @ignore
+   */
   it('shouldPerformMapReduceWithOptions', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
@@ -309,8 +309,8 @@ describe('MapReduce', function() {
   });
 
   /**
-  * @ignore
-  */
+   * @ignore
+   */
   it('shouldHandleMapReduceErrors', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
@@ -352,8 +352,8 @@ describe('MapReduce', function() {
   });
 
   /**
-  * @ignore
-  */
+   * @ignore
+   */
   it('shouldSaveDataToDifferentDbFromMapreduce', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
@@ -410,8 +410,8 @@ describe('MapReduce', function() {
   });
 
   /**
-  * @ignore
-  */
+   * @ignore
+   */
   it('shouldCorrectlyReturnNestedKeys', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
@@ -474,9 +474,9 @@ describe('MapReduce', function() {
   });
 
   /**
-  * Mapreduce tests
-  * @ignore
-  */
+   * Mapreduce tests
+   * @ignore
+   */
   it.skip('shouldPerformMapReduceWithScopeContainingFunction', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }

--- a/test/functional/promote_buffers_tests.js
+++ b/test/functional/promote_buffers_tests.js
@@ -25,20 +25,22 @@ describe('Promote Buffers', function() {
 
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
-        db.collection('shouldCorrectlyHonorPromoteBuffer1').insert({
-          doc: new Buffer(256)
-        },
-        function(err) {
-          test.equal(null, err);
-
-          db.collection('shouldCorrectlyHonorPromoteBuffer1').findOne(function(err, doc) {
+        db.collection('shouldCorrectlyHonorPromoteBuffer1').insert(
+          {
+            doc: new Buffer(256)
+          },
+          function(err) {
             test.equal(null, err);
-            test.ok(doc.doc instanceof Buffer);
 
-            client.close();
-            done();
-          });
-        });
+            db.collection('shouldCorrectlyHonorPromoteBuffer1').findOne(function(err, doc) {
+              test.equal(null, err);
+              test.ok(doc.doc instanceof Buffer);
+
+              client.close();
+              done();
+            });
+          }
+        );
       });
     }
   });
@@ -63,20 +65,22 @@ describe('Promote Buffers', function() {
         function(err, client) {
           var db = client.db(configuration.db);
 
-          db.collection('shouldCorrectlyHonorPromoteBuffer2').insert({
-            doc: new Buffer(256)
-          },
-          function(err) {
-            test.equal(null, err);
-
-            db.collection('shouldCorrectlyHonorPromoteBuffer2').findOne(function(err, doc) {
+          db.collection('shouldCorrectlyHonorPromoteBuffer2').insert(
+            {
+              doc: new Buffer(256)
+            },
+            function(err) {
               test.equal(null, err);
-              test.ok(doc.doc instanceof Buffer);
 
-              client.close();
-              done();
-            });
-          });
+              db.collection('shouldCorrectlyHonorPromoteBuffer2').findOne(function(err, doc) {
+                test.equal(null, err);
+                test.ok(doc.doc instanceof Buffer);
+
+                client.close();
+                done();
+              });
+            }
+          );
         }
       );
     }
@@ -102,23 +106,25 @@ describe('Promote Buffers', function() {
         function(err, client) {
           var db = client.db(configuration.db);
 
-          db.collection('shouldCorrectlyHonorPromoteBuffer3').insert({
-            doc: new Buffer(256)
-          },
-          function(err) {
-            test.equal(null, err);
+          db.collection('shouldCorrectlyHonorPromoteBuffer3').insert(
+            {
+              doc: new Buffer(256)
+            },
+            function(err) {
+              test.equal(null, err);
 
-            db
-              .collection('shouldCorrectlyHonorPromoteBuffer3')
-              .find()
-              .next(function(err, doc) {
-                test.equal(null, err);
-                test.ok(doc.doc instanceof Buffer);
+              db
+                .collection('shouldCorrectlyHonorPromoteBuffer3')
+                .find()
+                .next(function(err, doc) {
+                  test.equal(null, err);
+                  test.ok(doc.doc instanceof Buffer);
 
-                client.close();
-                done();
-              });
-          });
+                  client.close();
+                  done();
+                });
+            }
+          );
         }
       );
     }
@@ -138,23 +144,25 @@ describe('Promote Buffers', function() {
 
       MongoClient.connect(configuration.url(), {}, function(err, client) {
         var db = client.db(configuration.db);
-        db.collection('shouldCorrectlyHonorPromoteBuffer4').insert({
-          doc: new Buffer(256)
-        },
-        function(err) {
-          test.equal(null, err);
+        db.collection('shouldCorrectlyHonorPromoteBuffer4').insert(
+          {
+            doc: new Buffer(256)
+          },
+          function(err) {
+            test.equal(null, err);
 
-          db
-            .collection('shouldCorrectlyHonorPromoteBuffer4')
-            .find({}, { promoteBuffers: true })
-            .next(function(err, doc) {
-              test.equal(null, err);
-              test.ok(doc.doc instanceof Buffer);
+            db
+              .collection('shouldCorrectlyHonorPromoteBuffer4')
+              .find({}, { promoteBuffers: true })
+              .next(function(err, doc) {
+                test.equal(null, err);
+                test.ok(doc.doc instanceof Buffer);
 
-              client.close();
-              done();
-            });
-        });
+                client.close();
+                done();
+              });
+          }
+        );
       });
     }
   });
@@ -176,23 +184,25 @@ describe('Promote Buffers', function() {
 
       MongoClient.connect(configuration.url(), {}, function(err, client) {
         var db = client.db(configuration.db);
-        db.collection('shouldCorrectlyHonorPromoteBuffer5').insert({
-          doc: new Buffer(256)
-        },
-        function(err) {
-          test.equal(null, err);
+        db.collection('shouldCorrectlyHonorPromoteBuffer5').insert(
+          {
+            doc: new Buffer(256)
+          },
+          function(err) {
+            test.equal(null, err);
 
-          db
-            .collection('shouldCorrectlyHonorPromoteBuffer5')
-            .aggregate([{ $match: {} }], { promoteBuffers: true })
-            .next(function(err, doc) {
-              test.equal(null, err);
-              test.ok(doc.doc instanceof Buffer);
+            db
+              .collection('shouldCorrectlyHonorPromoteBuffer5')
+              .aggregate([{ $match: {} }], { promoteBuffers: true })
+              .next(function(err, doc) {
+                test.equal(null, err);
+                test.ok(doc.doc instanceof Buffer);
 
-              client.close();
-              done();
-            });
-        });
+                client.close();
+                done();
+              });
+          }
+        );
       });
     }
   });

--- a/test/functional/promote_buffers_tests.js
+++ b/test/functional/promote_buffers_tests.js
@@ -146,7 +146,7 @@ describe('Promote Buffers', function() {
 
           db
             .collection('shouldCorrectlyHonorPromoteBuffer4')
-            .find({}, {}, { promoteBuffers: true })
+            .find({}, { promoteBuffers: true })
             .next(function(err, doc) {
               test.equal(null, err);
               test.ok(doc.doc instanceof Buffer);

--- a/test/functional/promote_values_tests.js
+++ b/test/functional/promote_values_tests.js
@@ -29,26 +29,28 @@ describe('Promote Values', function() {
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
 
-        db.collection('shouldCorrectlyHonorPromoteValues').insert({
-          doc: Long.fromNumber(10),
-          int: 10,
-          double: 2.2222,
-          array: [[Long.fromNumber(10)]]
-        },
-        function(err) {
-          test.equal(null, err);
-
-          db.collection('shouldCorrectlyHonorPromoteValues').findOne(function(err, doc) {
+        db.collection('shouldCorrectlyHonorPromoteValues').insert(
+          {
+            doc: Long.fromNumber(10),
+            int: 10,
+            double: 2.2222,
+            array: [[Long.fromNumber(10)]]
+          },
+          function(err) {
             test.equal(null, err);
 
-            test.deepEqual(Long.fromNumber(10), doc.doc);
-            test.deepEqual(new Int32(10), doc.int);
-            test.deepEqual(new Double(2.2222), doc.double);
+            db.collection('shouldCorrectlyHonorPromoteValues').findOne(function(err, doc) {
+              test.equal(null, err);
 
-            client.close();
-            done();
-          });
-        });
+              test.deepEqual(Long.fromNumber(10), doc.doc);
+              test.deepEqual(new Int32(10), doc.int);
+              test.deepEqual(new Double(2.2222), doc.double);
+
+              client.close();
+              done();
+            });
+          }
+        );
       });
     }
   });
@@ -75,26 +77,28 @@ describe('Promote Values', function() {
         },
         function(err, client) {
           var db = client.db(configuration.db);
-          db.collection('shouldCorrectlyHonorPromoteValues').insert({
-            doc: Long.fromNumber(10),
-            int: 10,
-            double: 2.2222,
-            array: [[Long.fromNumber(10)]]
-          },
-          function(err) {
-            test.equal(null, err);
-
-            db.collection('shouldCorrectlyHonorPromoteValues').findOne(function(err, doc) {
+          db.collection('shouldCorrectlyHonorPromoteValues').insert(
+            {
+              doc: Long.fromNumber(10),
+              int: 10,
+              double: 2.2222,
+              array: [[Long.fromNumber(10)]]
+            },
+            function(err) {
               test.equal(null, err);
 
-              test.deepEqual(Long.fromNumber(10), doc.doc);
-              test.deepEqual(new Int32(10), doc.int);
-              test.deepEqual(new Double(2.2222), doc.double);
+              db.collection('shouldCorrectlyHonorPromoteValues').findOne(function(err, doc) {
+                test.equal(null, err);
 
-              client.close();
-              done();
-            });
-          });
+                test.deepEqual(Long.fromNumber(10), doc.doc);
+                test.deepEqual(new Int32(10), doc.int);
+                test.deepEqual(new Double(2.2222), doc.double);
+
+                client.close();
+                done();
+              });
+            }
+          );
         }
       );
     }
@@ -122,29 +126,31 @@ describe('Promote Values', function() {
         },
         function(err, client) {
           var db = client.db(configuration.db);
-          db.collection('shouldCorrectlyHonorPromoteValues').insert({
-            doc: Long.fromNumber(10),
-            int: 10,
-            double: 2.2222,
-            array: [[Long.fromNumber(10)]]
-          },
-          function(err) {
-            test.equal(null, err);
+          db.collection('shouldCorrectlyHonorPromoteValues').insert(
+            {
+              doc: Long.fromNumber(10),
+              int: 10,
+              double: 2.2222,
+              array: [[Long.fromNumber(10)]]
+            },
+            function(err) {
+              test.equal(null, err);
 
-            db
-              .collection('shouldCorrectlyHonorPromoteValues')
-              .find()
-              .next(function(err, doc) {
-                test.equal(null, err);
+              db
+                .collection('shouldCorrectlyHonorPromoteValues')
+                .find()
+                .next(function(err, doc) {
+                  test.equal(null, err);
 
-                test.deepEqual(Long.fromNumber(10), doc.doc);
-                test.deepEqual(new Int32(10), doc.int);
-                test.deepEqual(new Double(2.2222), doc.double);
+                  test.deepEqual(Long.fromNumber(10), doc.doc);
+                  test.deepEqual(new Int32(10), doc.int);
+                  test.deepEqual(new Double(2.2222), doc.double);
 
-                client.close();
-                done();
-              });
-          });
+                  client.close();
+                  done();
+                });
+            }
+          );
         }
       );
     }
@@ -167,29 +173,31 @@ describe('Promote Values', function() {
 
       MongoClient.connect(configuration.url(), {}, function(err, client) {
         var db = client.db(configuration.db);
-        db.collection('shouldCorrectlyHonorPromoteValues').insert({
-          doc: Long.fromNumber(10),
-          int: 10,
-          double: 2.2222,
-          array: [[Long.fromNumber(10)]]
-        },
-        function(err) {
-          test.equal(null, err);
+        db.collection('shouldCorrectlyHonorPromoteValues').insert(
+          {
+            doc: Long.fromNumber(10),
+            int: 10,
+            double: 2.2222,
+            array: [[Long.fromNumber(10)]]
+          },
+          function(err) {
+            test.equal(null, err);
 
-          db
-            .collection('shouldCorrectlyHonorPromoteValues')
-            .find({}, { promoteValues: false })
-            .next(function(err, doc) {
-              test.equal(null, err);
+            db
+              .collection('shouldCorrectlyHonorPromoteValues')
+              .find({}, { promoteValues: false })
+              .next(function(err, doc) {
+                test.equal(null, err);
 
-              test.deepEqual(Long.fromNumber(10), doc.doc);
-              test.deepEqual(new Int32(10), doc.int);
-              test.deepEqual(new Double(2.2222), doc.double);
+                test.deepEqual(Long.fromNumber(10), doc.doc);
+                test.deepEqual(new Int32(10), doc.int);
+                test.deepEqual(new Double(2.2222), doc.double);
 
-              client.close();
-              done();
-            });
-        });
+                client.close();
+                done();
+              });
+          }
+        );
       });
     }
   });
@@ -211,29 +219,31 @@ describe('Promote Values', function() {
 
       MongoClient.connect(configuration.url(), {}, function(err, client) {
         var db = client.db(configuration.db);
-        db.collection('shouldCorrectlyHonorPromoteValues2').insert({
-          doc: Long.fromNumber(10),
-          int: 10,
-          double: 2.2222,
-          array: [[Long.fromNumber(10)]]
-        },
-        function(err) {
-          test.equal(null, err);
+        db.collection('shouldCorrectlyHonorPromoteValues2').insert(
+          {
+            doc: Long.fromNumber(10),
+            int: 10,
+            double: 2.2222,
+            array: [[Long.fromNumber(10)]]
+          },
+          function(err) {
+            test.equal(null, err);
 
-          db
-            .collection('shouldCorrectlyHonorPromoteValues2')
-            .aggregate([{ $match: {} }], { promoteValues: false })
-            .next(function(err, doc) {
-              test.equal(null, err);
+            db
+              .collection('shouldCorrectlyHonorPromoteValues2')
+              .aggregate([{ $match: {} }], { promoteValues: false })
+              .next(function(err, doc) {
+                test.equal(null, err);
 
-              test.deepEqual(Long.fromNumber(10), doc.doc);
-              test.deepEqual(new Int32(10), doc.int);
-              test.deepEqual(new Double(2.2222), doc.double);
+                test.deepEqual(Long.fromNumber(10), doc.doc);
+                test.deepEqual(new Int32(10), doc.int);
+                test.deepEqual(new Double(2.2222), doc.double);
 
-              client.close();
-              done();
-            });
-        });
+                client.close();
+                done();
+              });
+          }
+        );
       });
     }
   });

--- a/test/functional/promote_values_tests.js
+++ b/test/functional/promote_values_tests.js
@@ -178,7 +178,7 @@ describe('Promote Values', function() {
 
           db
             .collection('shouldCorrectlyHonorPromoteValues')
-            .find({}, {}, { promoteValues: false })
+            .find({}, { promoteValues: false })
             .next(function(err, doc) {
               test.equal(null, err);
 

--- a/test/functional/raw_tests.js
+++ b/test/functional/raw_tests.js
@@ -49,7 +49,7 @@ describe('Raw', function() {
           collection.insert([{ a: 1 }, { b: 2000 }, { c: 2.3 }], { w: 1 }, function(err) {
             test.equal(null, err);
             // You have to pass at least query + fields before passing options
-            collection.find({}, null, { raw: true, batchSize: 2 }).toArray(function(err, items) {
+            collection.find({}, { raw: true, batchSize: 2 }).toArray(function(err, items) {
               var objects = [];
 
               for (var i = 0; i < items.length; i++) {

--- a/test/functional/sharding_read_preference_tests.js
+++ b/test/functional/sharding_read_preference_tests.js
@@ -424,39 +424,41 @@ describe('Sharding (Read Preference)', function() {
             col.createIndex({ _id: 'hashed' }, function(err) {
               test.equal(null, err);
 
-              client.db('admin').command({
-                shardCollection: 'integration_test_2.items',
-                key: { _id: 'hashed' }
-              },
-              function(err) {
-                test.equal(null, err);
+              client.db('admin').command(
+                {
+                  shardCollection: 'integration_test_2.items',
+                  key: { _id: 'hashed' }
+                },
+                function(err) {
+                  test.equal(null, err);
 
-                var map = function() {
+                  var map = function() {
                   emit(this._id, this._id); // eslint-disable-line
-                };
+                  };
 
                 var reduce = function(key, values) {  // eslint-disable-line
                   // eslint-disable-line
-                  return 123;
-                };
+                    return 123;
+                  };
 
-                col.mapReduce(
-                  map,
-                  reduce,
-                  {
-                    out: {
-                      inline: 1
+                  col.mapReduce(
+                    map,
+                    reduce,
+                    {
+                      out: {
+                        inline: 1
+                      },
+                      readPreference: ReadPreference.SECONDARY_PREFERRED
                     },
-                    readPreference: ReadPreference.SECONDARY_PREFERRED
-                  },
-                  function(err, r) {
-                    test.equal(null, err);
-                    test.equal(3, r.length);
-                    client.close();
-                    done();
-                  }
-                );
-              });
+                    function(err, r) {
+                      test.equal(null, err);
+                      test.equal(3, r.length);
+                      client.close();
+                      done();
+                    }
+                  );
+                }
+              );
             });
           });
         });

--- a/test/functional/unicode_tests.js
+++ b/test/functional/unicode_tests.js
@@ -177,12 +177,15 @@ describe('Unicode', function() {
         db.createCollection('test_utf8_key_name', function(err, collection) {
           collection.insert({ šđžčćŠĐŽČĆ: 1 }, { w: 1 }, function(err) {
             test.equal(null, err);
-            collection.find({}, { fields: ['šđžčćŠĐŽČĆ'] }).toArray(function(err, items) {
-              test.equal(1, items[0]['šđžčćŠĐŽČĆ']);
-              // Let's close the db
-              client.close();
-              done();
-            });
+            collection
+              .find({})
+              .project({ šđžčćŠĐŽČĆ: 1 })
+              .toArray(function(err, items) {
+                test.equal(1, items[0]['šđžčćŠĐŽČĆ']);
+                // Let's close the db
+                client.close();
+                done();
+              });
           });
         });
       });

--- a/test/mock/lib/request.js
+++ b/test/mock/lib/request.js
@@ -115,9 +115,9 @@ var Response = function(bson, documents, options) {
 };
 
 /**
-* @ignore
-* Preparing a compressed response of the OP_COMPRESSED type
-*/
+ * @ignore
+ * Preparing a compressed response of the OP_COMPRESSED type
+ */
 var CompressedResponse = function(bson, uncompressedResponse, options) {
   this.bson = bson;
 

--- a/test/unit/sessions/collection_tests.js
+++ b/test/unit/sessions/collection_tests.js
@@ -40,9 +40,7 @@ describe('Sessions', function() {
 
           return coll
             .insert({ a: 42 }, { session: session })
-            .then(() =>
-              coll.findOne({}, null, { session: session, readConcern: { level: 'majoroy' } })
-            )
+            .then(() => coll.findOne({}, { session: session, readConcern: { level: 'majoroy' } }))
             .then(() => {
               expect(findCommand.readConcern).to.have.keys(['level', 'afterClusterTime']);
               expect(findCommand.readConcern.afterClusterTime).to.eql(insertOperationTime);

--- a/test/unit/sessions/collection_tests.js
+++ b/test/unit/sessions/collection_tests.js
@@ -40,7 +40,7 @@ describe('Sessions', function() {
 
           return coll
             .insert({ a: 42 }, { session: session })
-            .then(() => coll.findOne({}, { session: session, readConcern: { level: 'majoroy' } }))
+            .then(() => coll.findOne({}, { session: session, readConcern: { level: 'majority' } }))
             .then(() => {
               expect(findCommand.readConcern).to.have.keys(['level', 'afterClusterTime']);
               expect(findCommand.readConcern.afterClusterTime).to.eql(insertOperationTime);


### PR DESCRIPTION
Find api is now updated and clarified. You can no longer pass in
fields, and you cannot pass in individual options as parameters.

BREAKING CHANGE:
`find` and `findOne` no longer support the `fields` parameter.
You can achieve the same results as the `fields` parameter by
using `Cursor.prototype.project` or by passing the `projection`
property in on the `options` object . Additionally, `find` does not
support individual options like `skip` and `limit` as positional
parameters. You must pass in these parameters in the `options` object