### PR TITLE
[WIP] DNS/TXT Records test runner

### DIFF
--- a/test/functional/dns_txt_records_tests.js
+++ b/test/functional/dns_txt_records_tests.js
@@ -1,0 +1,39 @@
+var fs = require('fs');
+var path = require('path');
+
+var parse = require('../../lib/url_parser');
+var expect = require('chai').expect;
+
+// ./node_modules/.bin/mongodb-test-runner -l test/functional/dns_txt_records_tests.js
+
+function getTests() {
+  return fs
+    .readdirSync(path.join(__dirname, 'specs/dns-txt-records'))
+    .filter(x => x.indexOf('json') !== -1)
+    .map(x => [x, fs.readFileSync(path.join(__dirname, 'specs/dns-txt-records', x), 'utf8')])
+    .map(x => [path.basename(x[0], '.json'), JSON.parse(x[1])]);
+}
+
+describe('DNS and TXT record tests', function() {
+    getTests().forEach(function (test) {
+      if (!test[1].comment) test[1].comment = test[0];
+
+      it(test[1].comment, {
+        metadata: {
+          requires: { topology: ['single'] }
+        },
+        test: function(done) {
+          parse(test[1].uri, function(err, object) {
+            if (test[1].error) {
+              expect(err).to.exist;
+              expect(object).to.not.exist;
+            } else {
+              expect(err).to.be.null;
+              expect(object).to.exist;
+            }
+            done();
+          });
+        }
+      });
+  });
+});

--- a/test/functional/specs/dns-txt-records/README.rst
+++ b/test/functional/specs/dns-txt-records/README.rst
@@ -1,0 +1,87 @@
+====================================
+Initial DNS Seedlist Discovery tests
+====================================
+
+This directory contains platform-independent tests that drivers can use
+to prove their conformance to the Initial DNS Seedlist Discovery spec.
+
+Test Setup
+----------
+
+Start a three-node replica set on localhost, on ports 27017, 27018, and 27019,
+with replica set name "repl0". The replica set MUST be started with SSL
+enabled.
+
+To run the tests that accompany this spec, you need to configure the SRV and
+TXT records with a real name server. The following records are required for
+these tests::
+
+  Record                                    TTL    Class   Address
+  localhost.test.build.10gen.cc.            86400  IN A    127.0.0.1
+  localhost.sub.test.build.10gen.cc.        86400  IN A    127.0.0.1
+
+  Record                                    TTL    Class   Port   Target
+  _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27018  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test2.test.build.10gen.cc.  86400  IN SRV  27018  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test2.test.build.10gen.cc.  86400  IN SRV  27019  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test3.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test5.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test6.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test7.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test8.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test10.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test11.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test12.test.build.10gen.cc. 86400  IN SRV  27017  localhost.build.10gen.cc.
+  _mongodb._tcp.test13.test.build.10gen.cc. 86400  IN SRV  27017  test.build.10gen.cc.
+  _mongodb._tcp.test14.test.build.10gen.cc. 86400  IN SRV  27017  localhost.not-test.build.10gen.cc.
+  _mongodb._tcp.test15.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.not-build.10gen.cc.
+  _mongodb._tcp.test16.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.not-10gen.cc.
+  _mongodb._tcp.test17.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.not-cc.
+  _mongodb._tcp.test18.test.build.10gen.cc. 86400  IN SRV  27017  localhost.sub.test.build.10gen.cc.
+  _mongodb._tcp.test19.test.build.10gen.cc. 86400  IN SRV  27017  localhost.evil.build.10gen.cc.
+  _mongodb._tcp.test19.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
+
+  Record                                    TTL    Class   Text
+  test5.test.build.10gen.cc.                86400  IN TXT  "replicaSet=repl0&authSource=thisDB"
+  test6.test.build.10gen.cc.                86400  IN TXT  "replicaSet=repl0"
+  test6.test.build.10gen.cc.                86400  IN TXT  "authSource=otherDB"
+  test7.test.build.10gen.cc.                86400  IN TXT  "ssl=false"
+  test8.test.build.10gen.cc.                86400  IN TXT  "authSource"
+  test10.test.build.10gen.cc.               86400  IN TXT  "socketTimeoutMS=500"
+  test11.test.build.10gen.cc.               86400  IN TXT  "replicaS" "et=rep" "l0"
+
+Note that ``test4`` is omitted deliberately to test what happens with no SRV
+record. ``test9`` is missing because it was deleted during the development of
+the tests. The missing ``test.`` sub-domain in the SRV record target for
+``test12`` is deliberate.
+
+In our tests we have used ``localhost.test.build.10gen.cc`` as the domain, and
+then configured ``localhost.test.build.10gen.cc`` to resolve to 127.0.0.1.
+
+You need to adapt the records shown above to replace ``test.build.10gen.cc``
+with your own domain name, and update the "uri" field in the YAML or JSON files
+in this directory with the actual domain.
+
+Test Format and Use
+-------------------
+
+These YAML and JSON files contain the following fields:
+
+- ``uri``: a mongodb+srv connection string
+- ``seeds``: the expected set of initial seeds discovered from the SRV record
+- ``hosts``: the discovered topology's list of hosts once SDAM completes a scan
+- ``options``: the parsed connection string options as discovered from URI and
+  TXT records
+- ``error``: indicates that the parsing of the URI, or the resolving or
+  contents of the SRV or TXT records included errors.
+- ``comment``: a comment to indicate why a test would fail.
+
+For each file, create MongoClient initialized with the mongodb+srv connection
+string. You SHOULD verify that the client's initial seed list matches the list of
+seeds. You MUST verify that the set of ServerDescriptions in the client's
+TopologyDescription eventually matches the list of hosts. You MUST verify that
+each of the values of the Connection String Options under ``options`` match the
+Client's parsed value for that option. There may be other options parsed by
+the Client as well, which a test does not verify. You MUST verify that an
+error has been thrown if ``error`` is present.

--- a/test/functional/specs/dns-txt-records/longer-parent-in-return.json
+++ b/test/functional/specs/dns-txt-records/longer-parent-in-return.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test18.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.sub.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "comment": "Is correct, as returned host name shared the URI root \"test.build.10gen.cc\"."
+}

--- a/test/functional/specs/dns-txt-records/longer-parent-in-return.yml
+++ b/test/functional/specs/dns-txt-records/longer-parent-in-return.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test18.test.build.10gen.cc/?replicaSet=repl0"
+seeds:
+    - localhost.sub.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    ssl: true
+comment: Is correct, as returned host name shared the URI root "test.build.10gen.cc".

--- a/test/functional/specs/dns-txt-records/misformatted-option.json
+++ b/test/functional/specs/dns-txt-records/misformatted-option.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test8.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because the options in the TXT record are incorrectly formatted (misses value)."
+}

--- a/test/functional/specs/dns-txt-records/misformatted-option.yml
+++ b/test/functional/specs/dns-txt-records/misformatted-option.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test8.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because the options in the TXT record are incorrectly formatted (misses value).

--- a/test/functional/specs/dns-txt-records/no-results.json
+++ b/test/functional/specs/dns-txt-records/no-results.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test4.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because no SRV records are present for this URI."
+}

--- a/test/functional/specs/dns-txt-records/no-results.yml
+++ b/test/functional/specs/dns-txt-records/no-results.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test4.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because no SRV records are present for this URI.

--- a/test/functional/specs/dns-txt-records/not-enough-parts.json
+++ b/test/functional/specs/dns-txt-records/not-enough-parts.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because host in URI does not have {hostname}, {domainname} and {tld}."
+}

--- a/test/functional/specs/dns-txt-records/not-enough-parts.yml
+++ b/test/functional/specs/dns-txt-records/not-enough-parts.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because host in URI does not have {hostname}, {domainname} and {tld}.

--- a/test/functional/specs/dns-txt-records/one-result-default-port.json
+++ b/test/functional/specs/dns-txt-records/one-result-default-port.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  }
+}

--- a/test/functional/specs/dns-txt-records/one-result-default-port.yml
+++ b/test/functional/specs/dns-txt-records/one-result-default-port.yml
@@ -1,0 +1,10 @@
+uri: "mongodb+srv://test3.test.build.10gen.cc/?replicaSet=repl0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    ssl: true

--- a/test/functional/specs/dns-txt-records/one-txt-record-multiple-strings.json
+++ b/test/functional/specs/dns-txt-records/one-txt-record-multiple-strings.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test11.test.build.10gen.cc/",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  }
+}

--- a/test/functional/specs/dns-txt-records/one-txt-record-multiple-strings.yml
+++ b/test/functional/specs/dns-txt-records/one-txt-record-multiple-strings.yml
@@ -1,0 +1,10 @@
+uri: "mongodb+srv://test11.test.build.10gen.cc/"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    ssl: true

--- a/test/functional/specs/dns-txt-records/one-txt-record.json
+++ b/test/functional/specs/dns-txt-records/one-txt-record.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "authSource": "thisDB",
+    "ssl": true
+  }
+}

--- a/test/functional/specs/dns-txt-records/one-txt-record.yml
+++ b/test/functional/specs/dns-txt-records/one-txt-record.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test5.test.build.10gen.cc/"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    authSource: thisDB
+    ssl: true

--- a/test/functional/specs/dns-txt-records/parent-part-mismatch1.json
+++ b/test/functional/specs/dns-txt-records/parent-part-mismatch1.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test14.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name's part \"not-test\" mismatches URI parent part \"test\"."
+}

--- a/test/functional/specs/dns-txt-records/parent-part-mismatch1.yml
+++ b/test/functional/specs/dns-txt-records/parent-part-mismatch1.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test14.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because returned host name's part "not-test" mismatches URI parent part "test".

--- a/test/functional/specs/dns-txt-records/parent-part-mismatch2.json
+++ b/test/functional/specs/dns-txt-records/parent-part-mismatch2.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test15.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name's part \"not-build\" mismatches URI parent part \"build\"."
+}

--- a/test/functional/specs/dns-txt-records/parent-part-mismatch2.yml
+++ b/test/functional/specs/dns-txt-records/parent-part-mismatch2.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test15.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because returned host name's part "not-build" mismatches URI parent part "build".

--- a/test/functional/specs/dns-txt-records/parent-part-mismatch3.json
+++ b/test/functional/specs/dns-txt-records/parent-part-mismatch3.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test16.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name's part \"not-10gen\" mismatches URI parent part \"10gen\"."
+}

--- a/test/functional/specs/dns-txt-records/parent-part-mismatch3.yml
+++ b/test/functional/specs/dns-txt-records/parent-part-mismatch3.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test16.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because returned host name's part "not-10gen" mismatches URI parent part "10gen".

--- a/test/functional/specs/dns-txt-records/parent-part-mismatch4.json
+++ b/test/functional/specs/dns-txt-records/parent-part-mismatch4.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test17.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name's TLD \"not-cc\" mismatches URI TLD \"cc\"."
+}

--- a/test/functional/specs/dns-txt-records/parent-part-mismatch4.yml
+++ b/test/functional/specs/dns-txt-records/parent-part-mismatch4.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test17.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because returned host name's TLD "not-cc" mismatches URI TLD "cc".

--- a/test/functional/specs/dns-txt-records/parent-part-mismatch5.json
+++ b/test/functional/specs/dns-txt-records/parent-part-mismatch5.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test19.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because one of the returned host names' domain name parts \"evil\" mismatches \"test\"."
+}

--- a/test/functional/specs/dns-txt-records/parent-part-mismatch5.yml
+++ b/test/functional/specs/dns-txt-records/parent-part-mismatch5.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test19.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because one of the returned host names' domain name parts "evil" mismatches "test".

--- a/test/functional/specs/dns-txt-records/returned-parent-too-short.json
+++ b/test/functional/specs/dns-txt-records/returned-parent-too-short.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test13.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name's parent (build.10gen.cc) misses \"test.\""
+}

--- a/test/functional/specs/dns-txt-records/returned-parent-too-short.yml
+++ b/test/functional/specs/dns-txt-records/returned-parent-too-short.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test13.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because returned host name's parent (build.10gen.cc) misses "test."

--- a/test/functional/specs/dns-txt-records/returned-parent-wrong.json
+++ b/test/functional/specs/dns-txt-records/returned-parent-wrong.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test12.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because returned host name is too short and mismatches a parent."
+}

--- a/test/functional/specs/dns-txt-records/returned-parent-wrong.yml
+++ b/test/functional/specs/dns-txt-records/returned-parent-wrong.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test12.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because returned host name is too short and mismatches a parent.

--- a/test/functional/specs/dns-txt-records/two-results-default-port.json
+++ b/test/functional/specs/dns-txt-records/two-results-default-port.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  }
+}

--- a/test/functional/specs/dns-txt-records/two-results-default-port.yml
+++ b/test/functional/specs/dns-txt-records/two-results-default-port.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    ssl: true

--- a/test/functional/specs/dns-txt-records/two-results-nonstandard-port.json
+++ b/test/functional/specs/dns-txt-records/two-results-nonstandard-port.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test2.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27018",
+    "localhost.test.build.10gen.cc:27019"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  }
+}

--- a/test/functional/specs/dns-txt-records/two-results-nonstandard-port.yml
+++ b/test/functional/specs/dns-txt-records/two-results-nonstandard-port.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test2.test.build.10gen.cc/?replicaSet=repl0"
+seeds:
+    - localhost.test.build.10gen.cc:27018
+    - localhost.test.build.10gen.cc:27019
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    ssl: true

--- a/test/functional/specs/dns-txt-records/two-txt-records.json
+++ b/test/functional/specs/dns-txt-records/two-txt-records.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test6.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because there are two TXT records."
+}

--- a/test/functional/specs/dns-txt-records/two-txt-records.yml
+++ b/test/functional/specs/dns-txt-records/two-txt-records.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test6.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because there are two TXT records.

--- a/test/functional/specs/dns-txt-records/txt-record-not-allowed-option.json
+++ b/test/functional/specs/dns-txt-records/txt-record-not-allowed-option.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test10.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because socketTimeoutMS is not an allowed option."
+}

--- a/test/functional/specs/dns-txt-records/txt-record-not-allowed-option.yml
+++ b/test/functional/specs/dns-txt-records/txt-record-not-allowed-option.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test10.test.build.10gen.cc/?replicaSet=repl0"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because socketTimeoutMS is not an allowed option.

--- a/test/functional/specs/dns-txt-records/txt-record-with-overridden-ssl-option.json
+++ b/test/functional/specs/dns-txt-records/txt-record-with-overridden-ssl-option.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?ssl=false",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "authSource": "thisDB",
+    "ssl": false
+  }
+}

--- a/test/functional/specs/dns-txt-records/txt-record-with-overridden-ssl-option.yml
+++ b/test/functional/specs/dns-txt-records/txt-record-with-overridden-ssl-option.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test5.test.build.10gen.cc/?ssl=false"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    authSource: thisDB
+    ssl: false

--- a/test/functional/specs/dns-txt-records/txt-record-with-overridden-uri-option.json
+++ b/test/functional/specs/dns-txt-records/txt-record-with-overridden-uri-option.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?authSource=otherDB",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "authSource": "otherDB",
+    "ssl": true
+  }
+}

--- a/test/functional/specs/dns-txt-records/txt-record-with-overridden-uri-option.yml
+++ b/test/functional/specs/dns-txt-records/txt-record-with-overridden-uri-option.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test5.test.build.10gen.cc/?authSource=otherDB"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    authSource: otherDB
+    ssl: true

--- a/test/functional/specs/dns-txt-records/txt-record-with-unallowed-option.json
+++ b/test/functional/specs/dns-txt-records/txt-record-with-unallowed-option.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test7.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because \"ssl\" is not an allowed option."
+}

--- a/test/functional/specs/dns-txt-records/txt-record-with-unallowed-option.yml
+++ b/test/functional/specs/dns-txt-records/txt-record-with-unallowed-option.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test7.test.build.10gen.cc/"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because "ssl" is not an allowed option.

--- a/test/functional/specs/dns-txt-records/uri-with-port.json
+++ b/test/functional/specs/dns-txt-records/uri-with-port.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc:8123/?replicaSet=repl0",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because the mongodb+srv URI includes a port."
+}

--- a/test/functional/specs/dns-txt-records/uri-with-port.yml
+++ b/test/functional/specs/dns-txt-records/uri-with-port.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test5.test.build.10gen.cc:8123/?replicaSet=repl0"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because the mongodb+srv URI includes a port.

--- a/test/functional/specs/dns-txt-records/uri-with-two-hosts.json
+++ b/test/functional/specs/dns-txt-records/uri-with-two-hosts.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc,test6.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because the mongodb+srv URI includes two host names."
+}

--- a/test/functional/specs/dns-txt-records/uri-with-two-hosts.yml
+++ b/test/functional/specs/dns-txt-records/uri-with-two-hosts.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test5.test.build.10gen.cc,test6.test.build.10gen.cc/?replicaSet=repl0"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because the mongodb+srv URI includes two host names.


### PR DESCRIPTION
This gets started a test runner for DNS and TXT records started. The tests are still in flux and can be found: https://github.com/mongodb/specifications.

🔗 #1561 