### PR TITLE
Added missed ssl options for `ciphers` and `ecdhCurve`

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -30,7 +30,7 @@ var parse = require('./url_parser')
  *   db.close();
  * });
  */
-var validOptionNames = ['poolSize', 'ssl', 'sslValidate', 'sslCA', 'sslCert',
+var validOptionNames = ['poolSize', 'ssl', 'sslValidate', 'sslCA', 'sslCert', 'ciphers', 'ecdhCurve',
   'sslKey', 'sslPass', 'sslCRL', 'autoReconnect', 'noDelay', 'keepAlive', 'connectTimeoutMS', 'family',
   'socketTimeoutMS', 'reconnectTries', 'reconnectInterval', 'ha', 'haInterval',
   'replicaSet', 'secondaryAcceptableLatencyMS', 'acceptableLatencyMS',

--- a/lib/mongos.js
+++ b/lib/mongos.js
@@ -48,7 +48,7 @@ var release = os.release();
 
  // Allowed parameters
  var legalOptionNames = ['ha', 'haInterval', 'acceptableLatencyMS'
-   , 'poolSize', 'ssl', 'checkServerIdentity', 'sslValidate'
+   , 'poolSize', 'ssl', 'checkServerIdentity', 'sslValidate', 'ciphers', 'ecdhCurve'
    , 'sslCA', 'sslCRL', 'sslCert', 'sslKey', 'sslPass', 'socketOptions', 'bufferMaxEntries'
    , 'store', 'auto_reconnect', 'autoReconnect', 'emitError'
    , 'keepAlive', 'noDelay', 'connectTimeoutMS', 'socketTimeoutMS'

--- a/lib/server.js
+++ b/lib/server.js
@@ -45,7 +45,7 @@ var release = os.release();
 
  // Allowed parameters
  var legalOptionNames = ['ha', 'haInterval', 'acceptableLatencyMS'
-   , 'poolSize', 'ssl', 'checkServerIdentity', 'sslValidate'
+   , 'poolSize', 'ssl', 'checkServerIdentity', 'sslValidate', 'ciphers', 'ecdhCurve'
    , 'sslCA', 'sslCRL', 'sslCert', 'sslKey', 'sslPass', 'socketOptions', 'bufferMaxEntries'
    , 'store', 'auto_reconnect', 'autoReconnect', 'emitError'
    , 'keepAlive', 'noDelay', 'connectTimeoutMS', 'socketTimeoutMS', 'family'

--- a/test/runner.js
+++ b/test/runner.js
@@ -116,7 +116,7 @@ var Configuration = function(options) {
             console.log("[purge the directories]");
 
             var Logger = require('mongodb-topology-manager').Logger;
-            manager.start().then(function() {
+            return manager.start().then(function() {
               console.log("[started the topology]");
               var Logger = require('mongodb-topology-manager').Logger;
               // Logger.setLevel('info');


### PR DESCRIPTION
Hi, this is related with [this](https://github.com/mongodb-js/mongodb-core/issues/245) and [this](https://github.com/mongodb-js/mongodb-core/issues/242).

In short, is it currently impossible to do ssl handshake with mongos/mongod if it is used certificate with ECDH curve. This is due to recently added `ecdhCurve` ssl option to nodejs. Here we are passing this option and `cipher` option to `mongodb-core`

Also, I was faced with Promise error about missed `return` statement while runned tests.