### PR TITLE
fix(collection): allow { upsert: 1 } for findOneAndUpdate() and update()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1044,8 +1044,8 @@ var updateDocuments = function(self, selector, document, options, callback) {
 
   // Execute the operation
   var op = {q: selector, u: document};
-  op.upsert = typeof options.upsert == 'boolean' ? options.upsert : false;
-  op.multi = typeof options.multi == 'boolean' ? options.multi : false;
+  op.upsert = options.upsert !== void 0 ? !!options.upsert : false;
+  op.multi = options.multi !== void 0 ? !!options.multi : false;
 
   // Have we specified collation
   decorateWithCollation(finalOptions, self, options);
@@ -2371,8 +2371,8 @@ var findOneAndUpdate = function(self, filter, update, options, callback) {
   var finalOptions = shallowClone(options);
   finalOptions['fields'] = options.projection;
   finalOptions['update'] = true;
-  finalOptions['new'] = typeof options.returnOriginal == 'boolean' ? !options.returnOriginal : false;
-  finalOptions['upsert'] = typeof options.upsert == 'boolean' ? options.upsert : false;
+  finalOptions['new'] = options.returnOriginal !== void 0 ? !options.returnOriginal : false;
+  finalOptions['upsert'] = options.upsert !== void 0 ? !!options.upsert : false;
 
   // Execute findAndModify
   self.findAndModify(


### PR DESCRIPTION
Re: Automattic/mongoose#5839

This is a very rough edge in the API where `findAndModify()` treats `upsert: 1` as `upsert: true`, but `findOneAndUpdate()` and `updateX()` treat `upsert: 1` as `upsert: false`. [CRUD spec does say `upsert` is a boolean](https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst) but we've had `upsert: 1` in shell examples for a while so it may be worthwhile to support both, especially since truthiness is so common in JS.