### PR TITLE
[Port] Better error message for slash in hostname

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -198,7 +198,13 @@ function parseConnectionString(url, options) {
   for (i = 0; i < hosts.length; i++) {
     var r = parser.parse(f('mongodb://%s', hosts[i].trim()));
     if (r.path && r.path.indexOf(':') !== -1) {
-      throw new Error('Double colon in host identifier');
+      // Not connecting to a socket so check for an extra slash in the hostname.
+      // Using String#split as perf is better than match.
+      if (r.path.split('/').length > 1 && r.path.indexOf('::') === -1) {
+        throw new Error('Slash in host identifier');
+      } else {
+        throw new Error('Double colon in host identifier');
+      }
     }
   }
 

--- a/test/functional/url_parser_tests.js
+++ b/test/functional/url_parser_tests.js
@@ -990,4 +990,36 @@ describe('Url Parser', function() {
       });
     }
   });
+
+  /**
+   * @ignore
+   */
+  it('should raise exceptions on invalid hostnames with double colon in host identifier', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+    test: function(done) {
+      parse('mongodb://invalid::host:27017/db', {}, function(err) {
+        expect(err).to.exist;
+        expect(err.message).to.equal('Double colon in host identifier');
+        done();
+      });
+    }
+  });
+
+  /**
+   * @ignore
+   */
+  it('should raise exceptions on invalid hostnames with slash in host identifier', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+    test: function(done) {
+      parse('mongodb://invalid/host:27017/db', {}, function(err) {
+        expect(err).to.exist;
+        expect(err.message).to.equal('Slash in host identifier');
+        done();
+      });
+    }
+  });
 });


### PR DESCRIPTION
This ports #1559 from the `2.2` branch to `3.0`.

Notes:

- There were changes between `2.2` and `3.0` in the test set up so it's not a direct transfer there.
- I had to add the check `&& r.path.indexOf('::') === -1` to line `203` because without it both test URIs end up with the slash error because they each contain 3 items in their array after the split:
```bash
# mongodb://invalid::host:27017/db
path split [ '', '::host', 'db' ]
# mongodb://invalid/host:27017/db
path split [ '', 'host:27017', 'db' ]
```
I'm not quite sure why the tests passed without this in `2.2` cc @mbroadst for thoughts 💭 

