### PR TITLE
fix(changeStreams): fixing node4 issue with util.inherits

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -71,6 +71,8 @@ var ChangeStream = function(collection, pipeline, options) {
   });
 };
 
+inherits(ChangeStream, EventEmitter);
+
 // Create a new change stream cursor based on self's configuration
 var createChangeStreamCursor = function(self) {
   if (self.resumeToken) {
@@ -353,7 +355,5 @@ var processNewChange = function(self, err, change, callback) {
  * @param {MongoError} error An error instance representing the error during the execution.
  * @param {(object|null)} result The result object if the command was executed successfully.
  */
-
-inherits(ChangeStream, EventEmitter);
 
 module.exports = ChangeStream;


### PR DESCRIPTION
`require('util').inherits(ctor, super)` blows away the original prototype
of ctor. If we wish to use it, we need to move the inherits call to
directly after the constructor creation. In the future, we should
switch to using classes.