### PR TITLE
[HOLD] feat(change stream): exectue change stream cursor immediately

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -87,6 +87,10 @@ var createChangeStreamCursor = function(self) {
     self.options
   );
 
+  // In order to make events available as soon as the stream is created we need to initialize by
+  // calling hasNext()
+  changeStreamCursor.hasNext();
+
   /**
    * Fired for each new matching change in the specified namespace. Attaching a `change` event listener to a Change Stream will switch the stream into flowing mode. Data will then be passed as soon as it is available.
    *


### PR DESCRIPTION
Currently change stream cursors are created once an event happens which makes them not _immediately_ available. Users will expect a stream to be ready as soon as `.watch()` is called, this change does that by calling `.hasNext()` after the cursor is created.

cc @daprahamian for your tests 📈 
