### PR TITLE
feat(aggregation): fail aggregation on explain + readConcern/writeCon…

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2476,7 +2476,12 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
   options = getReadPreference(this, options, this.s.db, this);
 
   // If explain has been specified add it
-  if (options.explain) command.explain = options.explain;
+  if (options.explain) {
+    if (command.readConcern || command.writeConcern) {
+      throw toError('"explain" cannot be used on an aggregate call with readConcern/writeConcern');
+    }
+    command.explain = options.explain;
+  }
 
   if (typeof options.comment === 'string') command.comment = options.comment;
 


### PR DESCRIPTION
…cern

Aggregation should fail if you try to use the explain flag while you
have a readConcern and/or writeConcern.

BREAKING CHANGE:
If you use aggregation, and try to use the explain flag while you
have a readConcern or writeConcern, your query will fail