### PR TITLE
fix(collection): make the parameters of findOne very explicit

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1331,17 +1331,21 @@ define.classMethod('save', { callback: true, promise: true });
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-Collection.prototype.findOne = function() {
-  var args = Array.prototype.slice.call(arguments, 0);
-  var callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
-  return executeOperation(this.s.topology, findOne, [this, args, callback]);
+Collection.prototype.findOne = function(query, options, callback) {
+  if (typeof query === 'function') (callback = query), (query = {}), (options = {});
+  if (typeof options === 'function') (callback = options), (options = {});
+  query = query || {};
+  options = options || {};
+
+  return executeOperation(this.s.topology, findOne, [this, query, options, callback]);
 };
 
-var findOne = function(self, args, callback) {
-  var cursor = self.find
-    .apply(self, args)
+var findOne = function(self, query, options, callback) {
+  const cursor = self
+    .find(query, options)
     .limit(-1)
     .batchSize(1);
+
   // Return the item
   cursor.next(function(err, item) {
     if (err != null) return handleCallback(callback, toError(err), null);

--- a/test/functional/causal_consistency_tests.js
+++ b/test/functional/causal_consistency_tests.js
@@ -35,7 +35,7 @@ describe('Causal Consistency', function() {
 
       return db
         .collection('causal_test')
-        .findOne({}, null, { session: session })
+        .findOne({}, { session: session })
         .then(() => {
           expect(test.commands.started).to.have.length(1);
           expect(test.commands.succeeded).to.have.length(1);
@@ -56,7 +56,7 @@ describe('Causal Consistency', function() {
 
       return db
         .collection('causal_test')
-        .findOne({}, null, { session: session })
+        .findOne({}, { session: session })
         .then(() => {
           expect(test.commands.started).to.have.length(1);
           expect(test.commands.succeeded).to.have.length(1);
@@ -79,13 +79,13 @@ describe('Causal Consistency', function() {
       let firstOperationTime;
       return db
         .collection('causal_test')
-        .findOne({}, null, { session: session })
+        .findOne({}, { session: session })
         .then(() => {
           const firstFindCommand = test.commands.started[0].command;
           expect(firstFindCommand).to.not.have.key('readConcern');
           firstOperationTime = test.commands.succeeded[0].reply.operationTime;
 
-          return db.collection('causal_test').findOne({}, null, { session: session });
+          return db.collection('causal_test').findOne({}, { session: session });
         })
         .then(() => {
           const secondFindCommand = test.commands.started[1].command;
@@ -107,8 +107,8 @@ describe('Causal Consistency', function() {
         const coll = db.collection('causal_test', { readConcern: { level: 'majority' } });
 
         return coll
-          .findOne({}, null, { session: session })
-          .then(() => coll.findOne({}, null, { session: session }))
+          .findOne({}, { session: session })
+          .then(() => coll.findOne({}, { session: session }))
           .then(() => {
             const command = test.commands.started[1].command;
             expect(command).to.have.any.key('readConcern');
@@ -133,7 +133,7 @@ describe('Causal Consistency', function() {
         .insert({}, { session: session })
         .then(() => {
           firstOperationTime = test.commands.succeeded[0].reply.operationTime;
-          return db.collection('causal_test').findOne({}, null, { session: session });
+          return db.collection('causal_test').findOne({}, { session: session });
         })
         .then(() => {
           const secondFindCommand = test.commands.started[1].command;


### PR DESCRIPTION
`Collection.prototype.findOne` needs to use the new explicit
parameters for `find` (since it internally delegates). In the
process it made sense to clean up the methods own parameter
handling code as well