### PR TITLE
test(url-parser): lexically scope all the things

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var ReadPreference = require('mongodb-core').ReadPreference,
+const ReadPreference = require('mongodb-core').ReadPreference,
   parser = require('url'),
   f = require('util').format,
   Logger = require('mongodb-core').Logger,
@@ -10,91 +10,92 @@ module.exports = function(url, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  var result = parser.parse(url, true);
+  let result = parser.parse(url, true);
   if (result.protocol !== 'mongodb:' && result.protocol !== 'mongodb+srv:') {
     return callback(new Error('Invalid schema, expected `mongodb` or `mongodb+srv`'));
   }
 
-  if (result.protocol === 'mongodb+srv:') {
-    if (result.hostname.split('.').length < 3) {
-      return callback(new Error('URI does not have hostname, domain name and tld'));
-    }
-
-    result.domainLength = result.hostname.split('.').length;
-
-    if (result.pathname && result.pathname.match(',')) {
-      return callback(new Error('Invalid URI, cannot contain multiple hostnames'));
-    }
-
-    if (result.port) {
-      return callback(new Error('Ports not accepted with `mongodb+srv` URIs'));
-    }
-
-    const srvAddress = `_mongodb._tcp.${result.host}`;
-    dns.resolveSrv(srvAddress, function(err, addresses) {
-      if (err) return callback(err);
-
-      if (addresses.length === 0) {
-        return callback(new Error('No addresses found at host'));
-      }
-
-      for (var i = 0; i < addresses.length; i++) {
-        if (!matchesParentDomain(addresses[i].name, result.hostname, result.domainLength)) {
-          return callback(new Error('Server record does not share hostname with parent URI'));
-        }
-      }
-
-      let connectionStrings = addresses.map(function(address, i) {
-        if (i === 0) return `mongodb://${address.name}:${address.port}`;
-        else return `${address.name}:${address.port}`;
-      });
-
-      let connectionString = connectionStrings.join(',') + '/';
-      let connectionStringOptions = [];
-
-      // Default to SSL true
-      if (!options.ssl && !result.search) {
-        connectionStringOptions.push('ssl=true');
-      } else if (!options.ssl && result.search && !result.search.match('ssl')) {
-        connectionStringOptions.push('ssl=true');
-      }
-
-      // Keep original uri options
-      if (result.search) {
-        connectionStringOptions.push(result.search.replace('?', ''));
-      }
-
-      dns.resolveTxt(result.host, function(err, record) {
-        if (err && err.code !== 'ENODATA') return callback(err);
-        if (err && err.code === 'ENODATA') record = null;
-
-        if (record) {
-          if (record.length > 1) {
-            return callback(new Error('Multiple text records not allowed'));
-          }
-
-          record = record[0];
-          if (record.length > 1) record = record.join('');
-          else record = record[0];
-
-          if (!record.includes('authSource') && !record.includes('replicaSet')) {
-            return callback(new Error('Text record must only set `authSource` or `replicaSet`'));
-          }
-
-          connectionStringOptions.push(record);
-        }
-
-        // Add any options to the connection string
-        if (connectionStringOptions.length) {
-          connectionString += `?${connectionStringOptions.join('&')}`;
-        }
-
-        parseHandler(connectionString, options, callback);
-      });
-    });
-  } else {
-    parseHandler(url, options, callback);
+  if (result.protocol === 'mongodb:') {
+    return parseHandler(url, options, callback);
   }
+
+  // Otherwise parse this as an SRV record
+  if (result.hostname.split('.').length < 3) {
+    return callback(new Error('URI does not have hostname, domain name and tld'));
+  }
+
+  result.domainLength = result.hostname.split('.').length;
+
+  if (result.pathname && result.pathname.match(',')) {
+    return callback(new Error('Invalid URI, cannot contain multiple hostnames'));
+  }
+
+  if (result.port) {
+    return callback(new Error('Ports not accepted with `mongodb+srv` URIs'));
+  }
+
+  let srvAddress = `_mongodb._tcp.${result.host}`;
+  dns.resolveSrv(srvAddress, function(err, addresses) {
+    if (err) return callback(err);
+
+    if (addresses.length === 0) {
+      return callback(new Error('No addresses found at host'));
+    }
+
+    for (let i = 0; i < addresses.length; i++) {
+      if (!matchesParentDomain(addresses[i].name, result.hostname, result.domainLength)) {
+        return callback(new Error('Server record does not share hostname with parent URI'));
+      }
+    }
+
+    let connectionStrings = addresses.map(function(address, i) {
+      if (i === 0) return `mongodb://${address.name}:${address.port}`;
+      else return `${address.name}:${address.port}`;
+    });
+
+    let connectionString = connectionStrings.join(',') + '/';
+    let connectionStringOptions = [];
+
+    // Default to SSL true
+    if (!options.ssl && !result.search) {
+      connectionStringOptions.push('ssl=true');
+    } else if (!options.ssl && result.search && !result.search.match('ssl')) {
+      connectionStringOptions.push('ssl=true');
+    }
+
+    // Keep original uri options
+    if (result.search) {
+      connectionStringOptions.push(result.search.replace('?', ''));
+    }
+
+    dns.resolveTxt(result.host, function(err, record) {
+      if (err && err.code !== 'ENODATA') return callback(err);
+      if (err && err.code === 'ENODATA') record = null;
+
+      if (record) {
+        if (record.length > 1) {
+          return callback(new Error('Multiple text records not allowed'));
+        }
+
+        record = record[0];
+        if (record.length > 1) record = record.join('');
+        else record = record[0];
+
+        if (!record.includes('authSource') && !record.includes('replicaSet')) {
+          return callback(new Error('Text record must only set `authSource` or `replicaSet`'));
+        }
+
+        connectionStringOptions.push(record);
+      }
+
+      // Add any options to the connection string
+      if (connectionStringOptions.length) {
+        connectionString += `?${connectionStringOptions.join('&')}`;
+      }
+
+      parseHandler(connectionString, options, callback);
+    });
+  });
 };
 
 function matchesParentDomain(srvAddress, parentDomain) {
@@ -118,14 +119,13 @@ function parseHandler(address, options, callback) {
 
 function parseConnectionString(url, options) {
   // Variables
-  var connection_part = '';
-  var auth_part = '';
-  var query_string_part = '';
-  var dbName = 'admin';
+  let connection_part = '';
+  let auth_part = '';
+  let query_string_part = '';
+  let dbName = 'admin';
 
   // Url parser result
-  var result = parser.parse(url, true);
-
+  let result = parser.parse(url, true);
   if ((result.hostname == null || result.hostname === '') && url.indexOf('.sock') === -1) {
     throw new Error('No hostname or hostnames provided in connection string');
   }
@@ -148,7 +148,7 @@ function parseConnectionString(url, options) {
   }
 
   if (result.query) {
-    for (var name in result.query) {
+    for (let name in result.query) {
       if (name.indexOf('::') !== -1) {
         throw new Error('Double colon in host identifier');
       }
@@ -160,7 +160,7 @@ function parseConnectionString(url, options) {
   }
 
   if (result.auth) {
-    var parts = result.auth.split(':');
+    let parts = result.auth.split(':');
     if (url.indexOf(result.auth) !== -1 && parts.length > 2) {
       throw new Error('Username with password containing an unescaped colon');
     }
@@ -171,14 +171,14 @@ function parseConnectionString(url, options) {
   }
 
   // Remove query
-  var clean = url.split('?').shift();
+  let clean = url.split('?').shift();
 
   // Extract the list of hosts
-  var strings = clean.split(',');
-  var hosts = [];
+  let strings = clean.split(',');
+  let hosts = [];
 
-  for (var i = 0; i < strings.length; i++) {
-    var hostString = strings[i];
+  for (let i = 0; i < strings.length; i++) {
+    let hostString = strings[i];
 
     if (hostString.indexOf('mongodb') !== -1) {
       if (hostString.indexOf('@') !== -1) {
@@ -193,8 +193,8 @@ function parseConnectionString(url, options) {
     }
   }
 
-  for (i = 0; i < hosts.length; i++) {
-    var r = parser.parse(f('mongodb://%s', hosts[i].trim()));
+  for (let i = 0; i < hosts.length; i++) {
+    let r = parser.parse(f('mongodb://%s', hosts[i].trim()));
     if (r.path && r.path.indexOf(':') !== -1) {
       // Not connecting to a socket so check for an extra slash in the hostname.
       // Using String#split as perf is better than match.
@@ -261,21 +261,21 @@ function parseConnectionString(url, options) {
   connection_part = decodeURIComponent(connection_part);
 
   // Result object
-  var object = {};
+  let object = {};
 
   // Pick apart the authentication part of the string
-  var authPart = auth_part || '';
-  var auth = authPart.split(':', 2);
+  let authPart = auth_part || '';
+  let auth = authPart.split(':', 2);
 
   // Decode the authentication URI components and verify integrity
-  var user = decodeURIComponent(auth[0]);
+  let user = decodeURIComponent(auth[0]);
   if (auth[0] !== encodeURIComponent(user)) {
     throw new Error('Username contains an illegal unescaped character');
   }
   auth[0] = user;
 
   if (auth[1]) {
-    var pass = decodeURIComponent(auth[1]);
+    let pass = decodeURIComponent(auth[1]);
     if (auth[1] !== encodeURIComponent(pass)) {
       throw new Error('Password contains an illegal unescaped character');
     }
@@ -288,14 +288,14 @@ function parseConnectionString(url, options) {
   if (options && options.auth != null) object.auth = options.auth;
 
   // Variables used for temporary storage
-  var hostPart;
-  var urlOptions;
-  var servers;
-  var compression;
-  var serverOptions = { socketOptions: {} };
-  var dbOptions = { read_preference_tags: [] };
-  var replSetServersOptions = { socketOptions: {} };
-  var mongosOptions = { socketOptions: {} };
+  let hostPart;
+  let urlOptions;
+  let servers;
+  let compression;
+  let serverOptions = { socketOptions: {} };
+  let dbOptions = { read_preference_tags: [] };
+  let replSetServersOptions = { socketOptions: {} };
+  let mongosOptions = { socketOptions: {} };
   // Add server options to final object
   object.server_options = serverOptions;
   object.db_options = dbOptions;
@@ -305,7 +305,7 @@ function parseConnectionString(url, options) {
   // Let's check if we are using a domain socket
   if (url.match(/\.sock/)) {
     // Split out the socket part
-    var domainSocket = url.substring(
+    let domainSocket = url.substring(
       url.indexOf('mongodb://') + 'mongodb://'.length,
       url.lastIndexOf('.sock') + '.sock'.length
     );
@@ -317,20 +317,20 @@ function parseConnectionString(url, options) {
     // Split up the db
     hostPart = connection_part;
     // Deduplicate servers
-    var deduplicatedServers = {};
+    let deduplicatedServers = {};
 
     // Parse all server results
     servers = hostPart
       .split(',')
       .map(function(h) {
-        var _host, _port, ipv6match;
+        let _host, _port, ipv6match;
         //check if it matches [IPv6]:port, where the port number is optional
         if ((ipv6match = /\[([^\]]+)\](?::(.+))?/.exec(h))) {
           _host = ipv6match[1];
           _port = parseInt(ipv6match[2], 10) || 27017;
         } else {
           //otherwise assume it's IPv4, or plain hostname
-          var hostPort = h.split(':', 2);
+          let hostPort = h.split(':', 2);
           _host = hostPort[0] || 'localhost';
           _port = hostPort[1] != null ? parseInt(hostPort[1], 10) : 27017;
           // Check for localhost?safe=true style case
@@ -359,6 +359,7 @@ function parseConnectionString(url, options) {
     var splitOpt = opt.split('='),
       name = splitOpt[0],
       value = splitOpt[1];
+
     // Options implementations
     switch (name) {
       case 'slaveOk':
@@ -448,7 +449,7 @@ function parseConnectionString(url, options) {
         if (value === 'GSSAPI') {
           // If no password provided decode only the principal
           if (object.auth == null) {
-            var urlDecodeAuthPart = decodeURIComponent(authPart);
+            let urlDecodeAuthPart = decodeURIComponent(authPart);
             if (urlDecodeAuthPart.indexOf('@') === -1)
               throw new Error('GSSAPI requires a provided principal');
             object.auth = { user: urlDecodeAuthPart, password: null };
@@ -477,11 +478,11 @@ function parseConnectionString(url, options) {
         break;
       case 'authMechanismProperties':
         // Split up into key, value pairs
-        var values = value.split(',');
-        var o = {};
+        let values = value.split(',');
+        let o = {};
         // For each value split into key, value
         values.forEach(function(x) {
-          var v = x.split(':');
+          let v = x.split(':');
           o[v[0]] = v[1];
         });
 
@@ -510,16 +511,16 @@ function parseConnectionString(url, options) {
         // Decode the value
         value = decodeURIComponent(value);
         // Contains the tag object
-        var tagObject = {};
+        let tagObject = {};
         if (value == null || value === '') {
           dbOptions.read_preference_tags.push(tagObject);
           break;
         }
 
         // Split up the tags
-        var tags = value.split(/,/);
-        for (var i = 0; i < tags.length; i++) {
-          var parts = tags[i].trim().split(/:/);
+        let tags = value.split(/,/);
+        for (let i = 0; i < tags.length; i++) {
+          let parts = tags[i].trim().split(/:/);
           tagObject[parts[0]] = parts[1];
         }
 
@@ -528,7 +529,7 @@ function parseConnectionString(url, options) {
         break;
       case 'compressors':
         compression = serverOptions.compression || {};
-        var compressors = value.split(',');
+        let compressors = value.split(',');
         if (
           !compressors.every(function(compressor) {
             return compressor === 'snappy' || compressor === 'zlib';
@@ -542,7 +543,7 @@ function parseConnectionString(url, options) {
         break;
       case 'zlibCompressionLevel':
         compression = serverOptions.compression || {};
-        var zlibCompressionLevel = parseInt(value, 10);
+        let zlibCompressionLevel = parseInt(value, 10);
         if (zlibCompressionLevel < -1 || zlibCompressionLevel > 9) {
           throw new Error('zlibCompressionLevel must be an integer between -1 and 9');
         }
@@ -557,7 +558,7 @@ function parseConnectionString(url, options) {
         dbOptions.minSize = parseInt(value, 10);
         break;
       default:
-        var logger = Logger('URL Parser');
+        let logger = Logger('URL Parser');
         logger.warn(`${name} is not supported as a connection string option`);
         break;
     }

--- a/test/functional/connection_string_spec_tests.js
+++ b/test/functional/connection_string_spec_tests.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var parse = require('../../lib/url_parser');
-var fs = require('fs'),
-  f = require('util').format;
+const parse = require('../../lib/url_parser'),
+  fs = require('fs'),
+  f = require('util').format,
+  expect = require('chai').expect;
 
-describe('Connection String', function() {
-  var testFiles = fs
+describe('Connection String (spec)', function() {
+  const testFiles = fs
     .readdirSync(f('%s/spec/connection-string', __dirname))
     .filter(function(x) {
       return x.indexOf('.json') !== -1;
@@ -15,26 +16,29 @@ describe('Connection String', function() {
     });
 
   // Execute the tests
-  for (var i = 0; i < testFiles.length; i++) {
-    var testFile = testFiles[i];
+  for (let i = 0; i < testFiles.length; i++) {
+    const testFile = testFiles[i];
 
     // Get each test
-    for (var j = 0; j < testFile.tests.length; j++) {
-      var test = testFile.tests[j];
+    for (let j = 0; j < testFile.tests.length; j++) {
+      const test = testFile.tests[j];
 
       it(test.description, {
         metadata: { requires: { topology: 'single' } },
         test: function(done) {
-          var valid = test.valid;
+          const valid = test.valid;
 
-          try {
-            parse(test.uri, {}, function() {});
-            if (valid === false) done('should not have been able to parse');
-          } catch (err) {
-            if (valid === true) done(err);
-          }
+          parse(test.uri, {}, function(err, result) {
+            if (valid === false) {
+              expect(err).to.exist;
+              expect(result).to.not.exist;
+            } else {
+              expect(err).to.not.exist;
+              expect(result).to.exist;
+            }
 
-          done();
+            done();
+          });
         }
       });
     }

--- a/test/functional/url_parser_tests.js
+++ b/test/functional/url_parser_tests.js
@@ -811,16 +811,19 @@ describe('Url Parser', function() {
       parse('mongodb://localhost/db', {}, function(err, object) {
         expect(object.db_options.read_preference_tags).to.be.null;
         parse('mongodb://localhost/db?readPreferenceTags=dc:ny', {}, function(err, object) {
+          expect(err).to.not.exist;
           expect(object.db_options.read_preference_tags).to.eql([{ dc: 'ny' }]);
           parse('mongodb://localhost/db?readPreferenceTags=dc:ny,rack:1', {}, function(
             err,
             object
           ) {
+            expect(err).to.not.exist;
             expect(object.db_options.read_preference_tags).to.eql([{ dc: 'ny', rack: '1' }]);
             parse(
               'mongodb://localhost/db?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:sf,rack:2',
               {},
               function(err, object) {
+                expect(err).to.not.exist;
                 expect(object.db_options.read_preference_tags).to.eql([
                   { dc: 'ny', rack: '1' },
                   { dc: 'sf', rack: '2' }
@@ -829,6 +832,7 @@ describe('Url Parser', function() {
                   'mongodb://localhost/db?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:sf,rack:2&readPreferenceTags=',
                   {},
                   function(err, object) {
+                    expect(err).to.not.exist;
                     expect(object.db_options.read_preference_tags).to.eql([
                       { dc: 'ny', rack: '1' },
                       { dc: 'sf', rack: '2' },


### PR DESCRIPTION
The existing url parser spec tests were using `var` judiciously
and because of hoisting were never actually testing anything but
a single uri. This change switches to let/const where appropriate
and ensures we're running the tests we intend to be running.