### PR TITLE
docs(db): filter param is optional in Db.listCollections

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -668,7 +668,7 @@ var listCollectionsTranforms = function(databaseName) {
  * Get the list of all collection information for the specified db.
  *
  * @method
- * @param {object} filter Query to filter collections by
+ * @param {object} [filter={}] Query to filter collections by
  * @param {object} [options=null] Optional settings.
  * @param {number} [options.batchSize=null] The batchSize for the returned command cursor or if pre 2.8 the systems batch collection
  * @param {(ReadPreference|string)} [options.readPreference=null] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).


### PR DESCRIPTION
This ports a documentation fix from #1549 to `3.0.0`.

The `filter` parameter in `Db.listCollections` should me shown as optional 📖 

