### PR TITLE
Updated npm install to install specifically v2.2 of the mongodb module.

### DIFF
--- a/docs/reference/content/quick-start/quick-start.md
+++ b/docs/reference/content/quick-start/quick-start.md
@@ -29,7 +29,7 @@ npm init
 Next, install the driver dependency.
 
 ```
-npm install mongodb --save
+npm install mongodb@2.2 --save
 ```
 
 You should see **NPM** download a lot of files. Once it's done you'll find all the downloaded packages under the **node_modules** directory.


### PR DESCRIPTION
Updated the installation instruction in the Quick Start guide to refer specifically to version 2.2. 

Otherwise it will install the recently released `mongodb` npm module version 3.0.0 which is not compatible with rest of the Quick Start tutorial. 

