### PR TITLE
refactor(sessions): modify how we check for sessions support

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -486,8 +486,7 @@ MongoClient.prototype.startSession = function(options) {
     throw new MongoError('Must connect to a server before calling this method');
   }
 
-  const capabilities = this.topology.capabilities();
-  if (capabilities && !capabilities.hasSessionSupport) {
+  if (!this.topology.hasSessionSupport()) {
     throw new MongoError('Current topology does not support sessions');
   }
 

--- a/lib/topologies/topology_base.js
+++ b/lib/topologies/topology_base.js
@@ -207,7 +207,6 @@ var ServerCapabilities = function(ismaster) {
   var maxNumberOfDocsInBatch = ismaster.maxWriteBatchSize || 1000;
   var commandsTakeWriteConcern = false;
   var commandsTakeCollation = false;
-  var sessionSupport = false;
 
   if (ismaster.minWireVersion >= 0) {
     textSearch = true;
@@ -241,10 +240,6 @@ var ServerCapabilities = function(ismaster) {
     ismaster.maxWireVersion = 0;
   }
 
-  if (typeof ismaster.logicalSessionTimeoutMinutes !== 'undefined') {
-    sessionSupport = true;
-  }
-
   // Map up read only parameters
   setup_get_property(this, 'hasAggregationCursor', aggregationCursor);
   setup_get_property(this, 'hasWriteCommands', writeCommands);
@@ -257,7 +252,6 @@ var ServerCapabilities = function(ismaster) {
   setup_get_property(this, 'maxNumberOfDocsInBatch', maxNumberOfDocsInBatch);
   setup_get_property(this, 'commandsTakeWriteConcern', commandsTakeWriteConcern);
   setup_get_property(this, 'commandsTakeCollation', commandsTakeCollation);
-  setup_get_property(this, 'hasSessionSupport', sessionSupport);
 };
 
 // Get package.json variable
@@ -288,8 +282,17 @@ class TopologyBase extends EventEmitter {
     };
   }
 
+  // Sessions related methods
+  hasSessionSupport() {
+    return this.logicalSessionTimeoutMinutes != null;
+  }
+
   startSession(options) {
     return new ClientSession(this, this.s.sessionPool, options);
+  }
+
+  endSessions(sessions, callback) {
+    return this.s.coreTopology.endSessions(sessions, callback);
   }
 
   // Server capabilities
@@ -349,10 +352,6 @@ class TopologyBase extends EventEmitter {
 
   getServer(options) {
     return this.s.coreTopology.getServer(options);
-  }
-
-  endSessions(sessions, callback) {
-    return this.s.coreTopology.endSessions(sessions, callback);
   }
 
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -406,7 +406,7 @@ const executeOperation = (topology, operation, args, options) => {
   // The driver sessions spec mandates that we implicitly create sessions for operations
   // that are not explicitly provided with a session.
   let session, opOptions;
-  if (!options.skipSessions && topology.capabilities().hasSessionSupport) {
+  if (!options.skipSessions && topology.hasSessionSupport()) {
     opOptions = args[args.length - 2];
     if (opOptions == null || opOptions.session == null) {
       session = topology.startSession();


### PR DESCRIPTION
The test for whether a deployment supports sessions is to check if
`logicalSessionTimeoutMinutes` is set. For more complicated
deployments (e.g. not single) this value is not determined by a
single ismaster. As a result I've changed this to no longer be a
part of our `ServerCapabilities` detection, but read right off
the topology.

NODE-1188