### PR TITLE
fix(connect): unifying topology connect options

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -209,7 +209,7 @@ class Mongos extends TopologyBase {
   }
 
   // Connect
-  connect(db, _options, callback) {
+  connect(_options, callback) {
     var self = this;
     if ('function' === typeof _options) (callback = _options), (_options = {});
     if (_options == null) _options = {};
@@ -218,7 +218,8 @@ class Mongos extends TopologyBase {
     self.s.options = _options;
 
     // Update bufferMaxEntries
-    self.s.storeOptions.bufferMaxEntries = db.bufferMaxEntries;
+    self.s.storeOptions.bufferMaxEntries =
+      typeof _options.bufferMaxEntries === 'number' ? _options.bufferMaxEntries : -1;
 
     // Error handler
     var connectErrorHandler = function() {

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -236,7 +236,7 @@ class ReplSet extends TopologyBase {
   }
 
   // Connect method
-  connect(db, _options, callback) {
+  connect(_options, callback) {
     var self = this;
     if ('function' === typeof _options) (callback = _options), (_options = {});
     if (_options == null) _options = {};
@@ -245,7 +245,8 @@ class ReplSet extends TopologyBase {
     self.s.options = _options;
 
     // Update bufferMaxEntries
-    self.s.storeOptions.bufferMaxEntries = db.bufferMaxEntries;
+    self.s.storeOptions.bufferMaxEntries =
+      typeof _options.bufferMaxEntries === 'number' ? _options.bufferMaxEntries : -1;
 
     // Actual handler
     var errorHandler = function(event) {


### PR DESCRIPTION
UPDATE: Eliminates the DB parameter from the `connect` call in replset
and mongos to unify the api with server

Would like some discussion on this, as some fix is needed for NODE-1089