### PR TITLE
docs(FindOperatorsUnordered): updating return types to self

### DIFF
--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -45,9 +45,9 @@ var FindOperatorsUnordered = function(self) {
  * Add a single update document to the bulk operation
  *
  * @method
- * @param {object} doc update operations
+ * @param {object} updateDocument update operations
  * @throws {MongoError}
- * @return {UnorderedBulkOperation}
+ * @return {FindOperatorsUnordered}
  */
 FindOperatorsUnordered.prototype.update = function(updateDocument) {
   // Perform upsert
@@ -71,9 +71,9 @@ FindOperatorsUnordered.prototype.update = function(updateDocument) {
  * Add a single update one document to the bulk operation
  *
  * @method
- * @param {object} doc update operations
+ * @param {object} updateDocument update operations
  * @throws {MongoError}
- * @return {UnorderedBulkOperation}
+ * @return {FindOperatorsUnordered}
  */
 FindOperatorsUnordered.prototype.updateOne = function(updateDocument) {
   // Perform upsert
@@ -97,9 +97,9 @@ FindOperatorsUnordered.prototype.updateOne = function(updateDocument) {
  * Add a replace one operation to the bulk operation
  *
  * @method
- * @param {object} doc the new document to replace the existing one with
+ * @param {object} updateDocument the new document to replace the existing one with
  * @throws {MongoError}
- * @return {UnorderedBulkOperation}
+ * @return {FindOperatorsUnordered}
  */
 FindOperatorsUnordered.prototype.replaceOne = function(updateDocument) {
   this.updateOne(updateDocument);
@@ -122,7 +122,7 @@ FindOperatorsUnordered.prototype.upsert = function() {
  *
  * @method
  * @throws {MongoError}
- * @return {UnorderedBulkOperation}
+ * @return {FindOperatorsUnordered}
  */
 FindOperatorsUnordered.prototype.removeOne = function() {
   // Establish the update command
@@ -142,7 +142,7 @@ FindOperatorsUnordered.prototype.removeOne = function() {
  *
  * @method
  * @throws {MongoError}
- * @return {UnorderedBulkOperation}
+ * @return {FindOperatorsUnordered}
  */
 FindOperatorsUnordered.prototype.remove = function() {
   // Establish the update command
@@ -325,7 +325,7 @@ var define = (UnorderedBulkOperation.define = new Define(
 /**
  * Add a single insert document to the bulk operation
  *
- * @param {object} doc the document to insert
+ * @param {object} document the document to insert
  * @throws {MongoError}
  * @return {UnorderedBulkOperation}
  */


### PR DESCRIPTION
Updating the return types of some functions to be
FindOperatorsUnordered instead of UnorderedBulkOperation

Fixes NODE-1225