### PR TITLE
fix(aggregate): remove support for inline results for aggregate

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2493,10 +2493,8 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
     throw toError('cursor options must be an object');
   }
 
-  if (this.s.topology.capabilities().hasAggregationCursor) {
-    options.cursor = options.cursor || { batchSize: 1000 };
-    command.cursor = options.cursor;
-  }
+  options.cursor = options.cursor || { batchSize: 1000 };
+  command.cursor = options.cursor;
 
   // promiseLibrary
   options.promiseLibrary = this.s.promiseLibrary;
@@ -2516,28 +2514,7 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
     return this.s.topology.cursor(this.s.namespace, command, options);
   }
 
-  if (options.cursor) {
-    return handleCallback(
-      callback,
-      null,
-      this.s.topology.cursor(this.s.namespace, command, options)
-    );
-  }
-
-  // For legacy server versions, we execute the command and format the result
-  this.s.db.command(command, options, function(err, result) {
-    if (err) {
-      handleCallback(callback, err);
-    } else if (result['err'] || result['errmsg']) {
-      handleCallback(callback, toError(result));
-    } else if (typeof result === 'object' && result['serverPipeline']) {
-      handleCallback(callback, null, result['serverPipeline']);
-    } else if (typeof result === 'object' && result['stages']) {
-      handleCallback(callback, null, result['stages']);
-    } else {
-      handleCallback(callback, null, result.result);
-    }
-  });
+  return handleCallback(callback, null, this.s.topology.cursor(this.s.namespace, command, options));
 };
 
 define.classMethod('aggregate', { callback: true, promise: false });


### PR DESCRIPTION
Per DRIVERS-350, All aggregation commands must either include
the 'cursor' option or 'explain':true.

Note that this is the simplest fix for this issue. Depending on what gets removed for NODE-1122, there are more items that might get cleaned up.