### PR TITLE
docs: link to 3.0.0 API in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official [MongoDB](https://www.mongodb.com/) driver for Node.js. Provides a 
 | what          | where                                          |
 |---------------|------------------------------------------------|
 | documentation | http://mongodb.github.io/node-mongodb-native  |
-| api-doc        | http://mongodb.github.io/node-mongodb-native/2.2/api  |
+| api-doc        | http://mongodb.github.io/node-mongodb-native/3.0/api  |
 | source        | https://github.com/mongodb/node-mongodb-native |
 | mongodb       | http://www.mongodb.org                        |
 


### PR DESCRIPTION
Not sure if the 2.2 link is by design but it's caused me some confusion so I figured I'd point it out.