### PR TITLE
fix(topology base): allow more than 10 event listeners

### DIFF
--- a/lib/topologies/topology_base.js
+++ b/lib/topologies/topology_base.js
@@ -280,6 +280,8 @@ class TopologyBase extends EventEmitter {
       },
       platform: nodejsversion
     };
+
+    this.setMaxListeners(Infinity);
   }
 
   // Sessions related methods


### PR DESCRIPTION
Fixes [NODE-1270](https://jira.mongodb.org/browse/NODE-1270)