### PR TITLE
docs(mongo-client): the new method MongoClient().connect() was wrongly…

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -22,6 +22,7 @@ var parse = require('./url_parser'),
  * @fileOverview The **MongoClient** class is a class that allows for making Connections to MongoDB.
  *
  * @example
+ * // Connect using a MongoClient instance
  * const MongoClient = require('mongodb').MongoClient;
  * const test = require('assert');
  * // Connection url
@@ -31,6 +32,20 @@ var parse = require('./url_parser'),
  * // Connect using MongoClient
  * const mongoClient = new MongoClient(url);
  * mongoClient.connect(function(err, client) {
+ *   const db = client.db(dbName);
+ *   client.close();
+ * });
+ *
+ * @example
+ * // Connect using the MongoClient.connect static method
+ * const MongoClient = require('mongodb').MongoClient;
+ * const test = require('assert');
+ * // Connection url
+ * const url = 'mongodb://localhost:27017';
+ * // Database Name
+ * const dbName = 'test';
+ * // Connect using MongoClient
+ * MongoClient.connect(url, function(err, client) {
  *   const db = client.db(dbName);
  *   client.close();
  * });
@@ -459,7 +474,6 @@ MongoClient.prototype.isConnected = function(options) {
  * @param {boolean} [options.auto_reconnect=true] Enable auto reconnecting for single server instances
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {Promise<MongoClient>} returns Promise if no callback passed
- * @deprecated MongoClient.connect is deprecated, please use new MongoClient().connect() to connect.
  */
 MongoClient.connect = function(url, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -29,7 +29,8 @@ var parse = require('./url_parser'),
  * // Database Name
  * const dbName = 'test';
  * // Connect using MongoClient
- * MongoClient.connect(url, function(err, client) {
+ * const mongoClient = new MongoClient(url);
+ * mongoClient.connect(function(err, client) {
  *   const db = client.db(dbName);
  *   client.close();
  * });
@@ -231,7 +232,6 @@ var define = (MongoClient.define = new Define('MongoClient', MongoClient, false)
  * @method
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {Promise<MongoClient>} returns Promise if no callback passed
- * @deprecated MongoClient.connect is deprecated, please use new MongoClient().connect() to connect.
  */
 MongoClient.prototype.connect = function(callback) {
   // Validate options object
@@ -459,6 +459,7 @@ MongoClient.prototype.isConnected = function(options) {
  * @param {boolean} [options.auto_reconnect=true] Enable auto reconnecting for single server instances
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {Promise<MongoClient>} returns Promise if no callback passed
+ * @deprecated MongoClient.connect is deprecated, please use new MongoClient().connect() to connect.
  */
 MongoClient.connect = function(url, options, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
@@ -467,9 +468,9 @@ MongoClient.connect = function(url, options, callback) {
   options = options || {};
 
   // Create client
-  var mongoclient = new MongoClient(url, options);
+  var mongoClient = new MongoClient(url, options);
   // Execute the connect method
-  return mongoclient.connect(callback);
+  return mongoClient.connect(callback);
 };
 
 define.staticMethod('connect', { callback: true, promise: true });


### PR DESCRIPTION
… marked as deprecated instead of the old static MongoClient.connect()