### PR TITLE
docs(MongoClient): updating documentation of IP family field

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -140,7 +140,8 @@ function validOptions(options) {
  * @param {boolean} [options.keepAlive=true] TCP Connection keep alive enabled
  * @param {number} [options.keepAliveInitialDelay=30000] The number of milliseconds to wait before initiating keepAlive on the TCP socket
  * @param {number} [options.connectTimeoutMS=30000] TCP Connection timeout setting
- * @param {number} [options.family=4] Version of IP stack. Defaults to 4
+ * @param {number} [options.family=null] Version of IP stack. Can be 4, 6 or null (default).
+ * If null, will attempt to connect with IPv6, and will fall back to IPv4 on failure
  * @param {number} [options.socketTimeoutMS=360000] TCP Socket timeout setting
  * @param {number} [options.reconnectTries=30] Server attempt to reconnect #times
  * @param {number} [options.reconnectInterval=1000] Server will wait # milliseconds between retries
@@ -415,7 +416,8 @@ MongoClient.prototype.isConnected = function(options) {
  * @param {boolean} [options.keepAlive=true] TCP Connection keep alive enabled
  * @param {boolean} [options.keepAliveInitialDelay=30000] The number of milliseconds to wait before initiating keepAlive on the TCP socket
  * @param {number} [options.connectTimeoutMS=30000] TCP Connection timeout setting
- * @param {number} [options.family=4] Version of IP stack. Defaults to 4
+ * @param {number} [options.family=null] Version of IP stack. Can be 4, 6 or null (default).
+ * If null, will attempt to connect with IPv6, and will fall back to IPv4 on failure
  * @param {number} [options.socketTimeoutMS=360000] TCP Socket timeout setting
  * @param {number} [options.reconnectTries=30] Server attempt to reconnect #times
  * @param {number} [options.reconnectInterval=1000] Server will wait # milliseconds between retries


### PR DESCRIPTION
Updating documentation of IP family field to indicate new default
behavior of attempting IPv6, followed by IPv4.

Fixes NODE-1260