### PR TITLE
docs(aggregate): update example to use cursor

### DIFF
--- a/docs/reference/content/tutorials/aggregation.md
+++ b/docs/reference/content/tutorials/aggregation.md
@@ -48,11 +48,13 @@ function simplePipeline(db, callback) {
         { '$unwind': '$categories'},
         { '$group': { '_id': "$categories", 'Bronx restaurants': { '$sum': 1 } } }
       ],
-	  function(err, results) {
+    function(err, cursor) {
         assert.equal(err, null);
 
-        console.log(results)
-        callback(results);
+        cursor.toArray(function(err, documents) {
+          console.log(documents)
+          callback(documents);
+        });
       }
   );
 }


### PR DESCRIPTION
Updates the aggregation tutorial so that the example uses the
cursor instead of just returning it.

Fixes NODE-1236