### PR TITLE
docs(reference): update version dropdown root path

### DIFF
--- a/docs/reference/themes/mongodb/theme.toml
+++ b/docs/reference/themes/mongodb/theme.toml
@@ -2,7 +2,7 @@ name = "MongoDB"
 license = "Creative Commons Attribution NonCommercial ShareAlike 3.0 Unported"
 licenselink = "http://creativecommons.org/licenses/by-nc-sa/3.0/"
 description = "A standalone mongodb docs theme, for individual driver homepages"
-homepage = "http://mongodb.github.io/mongo-java-driver"
+homepage = "http://mongodb.github.io/node-mongodb-native"
 
 [author]
   name = "MongoDB Node.js driver authors"


### PR DESCRIPTION
Update the root path for the versions dropdown to point to
node-mongodb-native

Deals with NODE-1235, but also requires a change to
learn-mongodb-docs