### PR TITLE
docs(aggregate): updating docs to indicate callback returns cursor

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1295,6 +1295,13 @@ define.classMethod('save', { callback: true, promise: true });
  * @param {object} result The result object if the command was executed successfully.
  */
 
+ /**
+  * The callback format for an aggregation call
+ * @callback Collection~aggregationCallback
+ * @param {MongoError} error An error instance representing the error during the execution.
+ * @param {AggregationCursor} cursor The cursor if the aggregation command was executed successfully.
+  */
+
 /**
  * Fetches the first document that matches the query
  * @method
@@ -2387,7 +2394,7 @@ function decorateWithReadConcern(command, self, options) {
  * @param {object} [options.collation=null] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {string} [options.comment] Add a comment to an aggregation command
  * @param {ClientSession} [options.session] optional session to use for this operation
- * @param {Collection~resultCallback} callback The command result callback
+ * @param {Collection~aggregationCallback} callback The command result callback
  * @return {(null|AggregationCursor)}
  */
 Collection.prototype.aggregate = function(pipeline, options, callback) {


### PR DESCRIPTION
Updates the aggregation documentation to show that the callback
should receive a cursor, not an object.

Fixes NODE-1283