### PR TITLE
chore(collection): lint errors

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1295,12 +1295,12 @@ define.classMethod('save', { callback: true, promise: true });
  * @param {object} result The result object if the command was executed successfully.
  */
 
- /**
-  * The callback format for an aggregation call
+/**
+ * The callback format for an aggregation call
  * @callback Collection~aggregationCallback
  * @param {MongoError} error An error instance representing the error during the execution.
  * @param {AggregationCursor} cursor The cursor if the aggregation command was executed successfully.
-  */
+ */
 
 /**
  * Fetches the first document that matches the query


### PR DESCRIPTION
This fixes linting errors from https://github.com/mongodb/node-mongodb-native/pull/1637 that are breaking the tests.

I'll rebase https://github.com/mongodb/node-mongodb-native/pull/1640 and https://github.com/mongodb/node-mongodb-native/pull/1641 after this goes in 👍 