### PR TITLE
Update SRV tests with latest from specifications

### DIFF
--- a/test/functional/mongodb_srv_tests.js
+++ b/test/functional/mongodb_srv_tests.js
@@ -36,29 +36,18 @@ describe('DNS and TXT record tests', function() {
             if (test[1].options && test[1].options.ssl) {
               expect(object.server_options.ssl).to.equal(test[1].options.ssl);
             }
+            if (
+              test[1].parsed_options &&
+              test[1].parsed_options.user &&
+              test[1].parsed_options.password
+            ) {
+              expect(object.auth.user).to.equal(test[1].parsed_options.user);
+              expect(object.auth.password).to.equal(test[1].parsed_options.password);
+            }
           }
           done();
         });
       }
     });
-  });
-
-  it('preserves auth credentials in the connection string', {
-    metadata: {
-      requires: { topology: ['single'] }
-    },
-    test: function(done) {
-      let user = 'auser';
-      let password = 'apass';
-      let uri = `mongodb+srv://${user}:${password}@test18.test.build.10gen.cc/?replicaSet=repl0`;
-      parse(uri, function(err, object) {
-        expect(err).to.not.exist;
-        expect(object.auth.user).to.not.be.undefined;
-        expect(object.auth.user).to.equal(user);
-        expect(object.auth.password).to.not.be.undefined;
-        expect(object.auth.password).to.equal(password);
-        done();
-      });
-    }
   });
 });

--- a/test/functional/spec/dns-txt-records/README.rst
+++ b/test/functional/spec/dns-txt-records/README.rst
@@ -73,6 +73,8 @@ These YAML and JSON files contain the following fields:
 - ``hosts``: the discovered topology's list of hosts once SDAM completes a scan
 - ``options``: the parsed connection string options as discovered from URI and
   TXT records
+- ``parsed_options``: additional options present in the URI such as user/password
+credentials
 - ``error``: indicates that the parsing of the URI, or the resolving or
   contents of the SRV or TXT records included errors.
 - ``comment``: a comment to indicate why a test would fail.
@@ -83,5 +85,8 @@ seeds. You MUST verify that the set of ServerDescriptions in the client's
 TopologyDescription eventually matches the list of hosts. You MUST verify that
 each of the values of the Connection String Options under ``options`` match the
 Client's parsed value for that option. There may be other options parsed by
-the Client as well, which a test does not verify. You MUST verify that an
-error has been thrown if ``error`` is present.
+the Client as well, which a test does not verify. In ``uri-with-auth`` the URI
+contains a user/password set and additional options are provided in
+``parsed_options`` so that tests can verify authentication is maintained when
+evaluating URIs. You MUST verify that an error has been thrown if ``error`` is
+present.

--- a/test/functional/spec/dns-txt-records/uri-with-auth.json
+++ b/test/functional/spec/dns-txt-records/uri-with-auth.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://auser:apass@test1.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "parsed_options": {
+    "user": "auser",
+    "password": "apass"
+  },
+  "comment": "Should preserve auth credentials"
+}

--- a/test/functional/spec/dns-txt-records/uri-with-auth.yml
+++ b/test/functional/spec/dns-txt-records/uri-with-auth.yml
@@ -1,0 +1,12 @@
+uri: "mongodb+srv://auser:apass@test1.test.build.10gen.cc/?replicaSet=repl0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+parsed_options:
+    user: auser
+    password: apass
+comment: Should preserve auth credentials


### PR DESCRIPTION
Two new test files went into the specifications for DNS Seedlist discovery in: https://github.com/mongodb/specifications/pull/262. This PR updates our specs to match these new files (which check that auth is preserved).

Related to https://github.com/mongodb/node-mongodb-native/pull/1640.
