### PR TITLE
Update SRV tests with latest from specifications (backport)

### DIFF
--- a/test/functional/mongodb_srv_tests.js
+++ b/test/functional/mongodb_srv_tests.js
@@ -41,6 +41,11 @@ exports['mongodb+srv tests'] = {
           if (options.ssl) {
             test.equal(object.server_options.ssl, options.ssl);
           }
+
+          if (options.parsed_options) {
+            test.equal(object.auth.user, options.parsed_options.user);
+            test.equal(object.auth.password, options.parsed_options.password);
+          }
         }
       });
     });

--- a/test/functional/specs/dns-txt-records/README.rst
+++ b/test/functional/specs/dns-txt-records/README.rst
@@ -73,6 +73,8 @@ These YAML and JSON files contain the following fields:
 - ``hosts``: the discovered topology's list of hosts once SDAM completes a scan
 - ``options``: the parsed connection string options as discovered from URI and
   TXT records
+- ``parsed_options``: additional options present in the URI such as user/password
+credentials
 - ``error``: indicates that the parsing of the URI, or the resolving or
   contents of the SRV or TXT records included errors.
 - ``comment``: a comment to indicate why a test would fail.
@@ -83,5 +85,8 @@ seeds. You MUST verify that the set of ServerDescriptions in the client's
 TopologyDescription eventually matches the list of hosts. You MUST verify that
 each of the values of the Connection String Options under ``options`` match the
 Client's parsed value for that option. There may be other options parsed by
-the Client as well, which a test does not verify. You MUST verify that an
-error has been thrown if ``error`` is present.
+the Client as well, which a test does not verify. In ``uri-with-auth`` the URI
+contains a user/password set and additional options are provided in
+``parsed_options`` so that tests can verify authentication is maintained when
+evaluating URIs. You MUST verify that an error has been thrown if ``error`` is
+present.

--- a/test/functional/specs/dns-txt-records/uri-with-auth.json
+++ b/test/functional/specs/dns-txt-records/uri-with-auth.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://auser:apass@test1.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "parsed_options": {
+    "user": "auser",
+    "password": "apass"
+  },
+  "comment": "Should preserve auth credentials"
+}

--- a/test/functional/specs/dns-txt-records/uri-with-auth.yml
+++ b/test/functional/specs/dns-txt-records/uri-with-auth.yml
@@ -1,0 +1,12 @@
+uri: "mongodb+srv://auser:apass@test1.test.build.10gen.cc/?replicaSet=repl0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+parsed_options:
+    user: auser
+    password: apass
+comment: Should preserve auth credentials


### PR DESCRIPTION
_This backports the update of srv files to `2.2`. The sibling PR is #1649._

Two new test files went into the specifications for DNS Seedlist discovery in: https://github.com/mongodb/specifications/pull/262. This PR updates our specs to match these new files (which check that auth is preserved).

Related to https://github.com/mongodb/node-mongodb-native/pull/1641.
