### PR TITLE
fix(db): only callback with MongoError NODE-1293

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -445,8 +445,7 @@ Db.prototype.collection = function(name, options, callback) {
       if (callback) callback(null, collection);
       return collection;
     } catch (err) {
-      // if(err instanceof MongoError && callback) return callback(err);
-      if (callback) return callback(err);
+      if (err instanceof MongoError && callback) return callback(err);
       throw err;
     }
   }

--- a/test/functional/index_tests.js
+++ b/test/functional/index_tests.js
@@ -1123,7 +1123,8 @@ describe('Indexes', function() {
             db.collection('nonexisting', { strict: true }, function(err) {
               test.ok(err != null);
               db.collection('nonexisting', { strict: false }, function(err) {
-                test.ok(err != null);
+                // When set to false (default) it should not create an error
+                test.ok(err === null);
                 done();
               });
             });


### PR DESCRIPTION
If an error occurs within the users callback the callback is called twice. This checks and only returns the callback with an error if it is a `MongoError` from the server.

Fixes NODE-1293