### PR TITLE
Change db instantiation in Collection#mapReduce:

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -3008,11 +3008,10 @@ var mapReduce = function(self, map, reduce, options, callback) {
     if (result.result != null && typeof result.result === 'object') {
       var doc = result.result;
       // Return a collection from another db
-      collection = new (require('./db'))(
-        doc.db,
-        self.s.db.s.topology,
-        self.s.db.s.options
-      ).collection(doc.collection);
+      var Db = require('./db');
+      collection = new Db(doc.db, self.s.db.s.topology, self.s.db.s.options).collection(
+        doc.collection
+      );
     } else {
       // Create a collection object that wraps the result collection
       collection = self.s.db.collection(result.result);


### PR DESCRIPTION
The current syntax does not play well with Webpack in Electron 1.7.11, basically breaking all our plugins in standalone modes on the latest driver. The combination of `new` + `require` seems to be throwing it for a loop.

Example plugin before this change:
<img width="1680" alt="screen shot 2018-01-28 at 1 07 01 pm" src="https://user-images.githubusercontent.com/9030/35481905-324c7d48-042d-11e8-8f8d-ac787666a39c.png">

Example plugin after this change:
<img width="1680" alt="screen shot 2018-01-28 at 1 06 26 pm" src="https://user-images.githubusercontent.com/9030/35481906-3c9fd3c6-042d-11e8-8f72-614ffe260ee3.png">

The syntax recently got updated in this commit: https://github.com/mongodb/node-mongodb-native/commit/efa78f0f72388e567a96c6427527dacfae3fa9c1 but that actually does not resolve the issue in this specific case. Here's a SS with that fix in, still the same error:
<img width="1680" alt="screen shot 2018-01-28 at 1 18 10 pm" src="https://user-images.githubusercontent.com/9030/35481944-d31de3f6-042d-11e8-9681-72b82ce89c1a.png">

This is because the generated code, *even with the parens* is this:

```
collection = new !(function webpackMissingModule() { var e = new Error(\"Cannot find module \\\".\\\"\"); e.code = 'MODULE_NOT_FOUND'; throw e; }())('./db')(\n        doc.db,\n        self.s.db.s.topology,\n        self.s.db.s.options\n      ).collection(doc.collection);
```

