### PR TITLE
Resync Connection String Spec Tests

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -10,7 +10,13 @@ module.exports = function(url, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  let result = parser.parse(url, true);
+  let result;
+  try {
+    result = parser.parse(url, true);
+  } catch (e) {
+    return callback(new Error('URL malformed, cannot be parsed'));
+  }
+
   if (result.protocol !== 'mongodb:' && result.protocol !== 'mongodb+srv:') {
     return callback(new Error('Invalid schema, expected `mongodb` or `mongodb+srv`'));
   }

--- a/test/functional/spec/connection-string/invalid-uris.json
+++ b/test/functional/spec/connection-string/invalid-uris.json
@@ -1,256 +1,274 @@
 {
-    "tests": [
-        {
-            "auth": null,
-            "description": "Empty string",
-            "hosts": null,
-            "options": null,
-            "uri": "",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid scheme",
-            "hosts": null,
-            "options": null,
-            "uri": "mongo://localhost:27017",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Missing host",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Double colon in host identifier",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://localhost::27017",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Double colon in host identifier and trailing slash",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://localhost::27017/",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Double colon in host identifier with missing host and port",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://::",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Double colon in host identifier with missing port",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://localhost,localhost::",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Double colon in host identifier and second host",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://localhost::27017,abc",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid port (negative number) with hostname",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://localhost:-1",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid port (zero) with hostname",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://localhost:0/",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid port (positive number) with hostname",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://localhost:65536",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid port (positive number) with hostname and trailing slash",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://localhost:65536/",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid port (non-numeric string) with hostname",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://localhost:foo",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid port (negative number) with IP literal",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://[::1]:-1",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid port (zero) with IP literal",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://[::1]:0/",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid port (positive number) with IP literal",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://[::1]:65536",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid port (positive number) with IP literal and trailing slash",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://[::1]:65536/",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Invalid port (non-numeric string) with IP literal",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://[::1]:foo",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Missing delimiting slash between hosts and options",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://example.com?w=1",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Incomplete key value pair for option",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://example.com/?w",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Username with password containing an unescaped colon",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice:foo:bar@127.0.0.1",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Username with password containing an unescaped colon",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice:foo:bar@127.0.0.1",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Username containing an unescaped at-sign",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice@@127.0.0.1",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Username with password containing an unescaped at-sign",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice@foo:bar@127.0.0.1",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Username containing an unescaped slash",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice/@127.0.0.1/db",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Username containing unescaped slash with password",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice/bob:foo@127.0.0.1/db",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Username with password containing an unescaped slash",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb://alice:foo/bar@127.0.0.1/db",
-            "valid": false,
-            "warning": null
-        },
-        {
-            "auth": null,
-            "description": "Host with unescaped slash",
-            "hosts": null,
-            "options": null,
-            "uri": "mongodb:///tmp/mongodb-27017.sock/",
-            "valid": false,
-            "warning": null
-        }
-    ]
+  "tests": [
+    {
+      "description": "Empty string",
+      "uri": "",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid scheme",
+      "uri": "mongo://localhost:27017",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Missing host",
+      "uri": "mongodb://",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier",
+      "uri": "mongodb://localhost::27017",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier and trailing slash",
+      "uri": "mongodb://localhost::27017/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier with missing host and port",
+      "uri": "mongodb://::",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier with missing port",
+      "uri": "mongodb://localhost,localhost::",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier and second host",
+      "uri": "mongodb://localhost::27017,abc",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (negative number) with hostname",
+      "uri": "mongodb://localhost:-1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (zero) with hostname",
+      "uri": "mongodb://localhost:0/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with hostname",
+      "uri": "mongodb://localhost:65536",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with hostname and trailing slash",
+      "uri": "mongodb://localhost:65536/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (non-numeric string) with hostname",
+      "uri": "mongodb://localhost:foo",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (negative number) with IP literal",
+      "uri": "mongodb://[::1]:-1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (zero) with IP literal",
+      "uri": "mongodb://[::1]:0/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with IP literal",
+      "uri": "mongodb://[::1]:65536",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with IP literal and trailing slash",
+      "uri": "mongodb://[::1]:65536/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (non-numeric string) with IP literal",
+      "uri": "mongodb://[::1]:foo",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Missing delimiting slash between hosts and options",
+      "uri": "mongodb://example.com?w=1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Incomplete key value pair for option",
+      "uri": "mongodb://example.com/?w",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped colon",
+      "uri": "mongodb://alice:foo:bar@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username containing an unescaped at-sign",
+      "uri": "mongodb://alice@@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped at-sign",
+      "uri": "mongodb://alice@foo:bar@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username containing an unescaped slash",
+      "uri": "mongodb://alice/@localhost/db",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username containing unescaped slash with password",
+      "uri": "mongodb://alice/bob:foo@localhost/db",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped slash",
+      "uri": "mongodb://alice:foo/bar@localhost/db",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Host with unescaped slash",
+      "uri": "mongodb:///tmp/mongodb-27017.sock/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "mongodb+srv with multiple service names",
+      "uri": "mongodb+srv://test5.test.mongodb.com,test6.test.mongodb.com",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "mongodb+srv with port number",
+      "uri": "mongodb+srv://test7.test.mongodb.com:27018",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped percent sign",
+      "uri": "mongodb://alice%foo:bar@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    }
+  ]
 }

--- a/test/functional/spec/connection-string/invalid-uris.yml
+++ b/test/functional/spec/connection-string/invalid-uris.yml
@@ -168,14 +168,6 @@ tests:
         auth: ~
         options: ~
     -
-        description: "Username with password containing an unescaped colon"
-        uri: "mongodb://alice:foo:bar@127.0.0.1"
-        valid: false
-        warning: ~
-        hosts: ~
-        auth: ~
-        options: ~
-    -
         description: "Username containing an unescaped at-sign"
         uri: "mongodb://alice@@127.0.0.1"
         valid: false
@@ -193,7 +185,7 @@ tests:
         options: ~
     -
         description: "Username containing an unescaped slash"
-        uri: "mongodb://alice/@127.0.0.1/db"
+        uri: "mongodb://alice/@localhost/db"
         valid: false
         warning: ~
         hosts: ~
@@ -201,7 +193,7 @@ tests:
         options: ~
     -
         description: "Username containing unescaped slash with password"
-        uri: "mongodb://alice/bob:foo@127.0.0.1/db"
+        uri: "mongodb://alice/bob:foo@localhost/db"
         valid: false
         warning: ~
         hosts: ~
@@ -209,7 +201,7 @@ tests:
         options: ~
     -
         description: "Username with password containing an unescaped slash"
-        uri: "mongodb://alice:foo/bar@127.0.0.1/db"
+        uri: "mongodb://alice:foo/bar@localhost/db"
         valid: false
         warning: ~
         hosts: ~
@@ -218,6 +210,30 @@ tests:
     -
         description: "Host with unescaped slash"
         uri: "mongodb:///tmp/mongodb-27017.sock/"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+    -
+        description: "mongodb+srv with multiple service names"
+        uri: "mongodb+srv://test5.test.mongodb.com,test6.test.mongodb.com"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+    -
+        description: "mongodb+srv with port number"
+        uri: "mongodb+srv://test7.test.mongodb.com:27018"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+ -
+        description: "Username with password containing an unescaped percent sign"
+        uri: "mongodb://alice%foo:bar@127.0.0.1"
         valid: false
         warning: ~
         hosts: ~


### PR DESCRIPTION
Update to the latest tests from the connection string spec and fix our url parser so that it handles errors that come from Node's `url.parse` when given a bad uri.

The error message uses 'malformed' because this is how the original Node error describes it.

Fixes [NODE-1292](https://jira.mongodb.org/browse/NODE-1292)