### PR TITLE
fix(collection): fix error when calling remove with no args

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1230,6 +1230,9 @@ define.classMethod('removeMany', { callback: true, promise: true });
  * @deprecated use deleteOne, deleteMany or bulkWrite
  */
 Collection.prototype.remove = function(selector, options, callback) {
+  if (typeof options === 'function') (callback = options), (options = {});
+  options = options || {};
+
   // Add ignoreUndfined
   if (this.s.options.ignoreUndefined) {
     options = shallowClone(options);

--- a/test/functional/remove_tests.js
+++ b/test/functional/remove_tests.js
@@ -153,4 +153,38 @@ describe('Remove', function() {
       });
     }
   });
+
+  /**
+   * @ignore
+   */
+  it('should not error on empty remove', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    // The actual test we wish to run
+    test: function(done) {
+      var self = this;
+      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
+        poolSize: 1
+      });
+
+      client.connect(function(err, client) {
+        var db = client.db(self.configuration.db);
+        test.equal(null, err);
+        const collection = db.collection('remove_test');
+
+        collection.remove().then(
+          () => {
+            client.close();
+            done();
+          },
+          err => {
+            client.close();
+            done(err);
+          }
+        );
+      });
+    }
+  });
 });


### PR DESCRIPTION
Calling remove with no arguments resulted in an error b/c
of the lack of options.

Fixes NODE-1287

@mbroadst @jlord I'm wondering if we should instead fix this in `executeOperation`?