### PR TITLE
fix(jsdoc): mark db.collection callback as optional + typo fix

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -409,7 +409,7 @@ var collectionKeys = [
  * @param {boolean} [options.strict=false] Returns an error if the collection does not exist
  * @param {object} [options.readConcern=null] Specify a read concern for the collection. (only MongoDB 3.2 or higher supported)
  * @param {object} [options.readConcern.level='local'] Specify a read concern level for the collection operations, one of [local|majority]. (only MongoDB 3.2 or higher supported)
- * @param {Db~collectionResultCallback} callback The collection result callback
+ * @param {Db~collectionResultCallback} [callback] The collection result callback
  * @return {Collection} return the new Collection instance if not in strict mode
  */
 Db.prototype.collection = function(name, options, callback) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -393,7 +393,7 @@ var collectionKeys = [
 ];
 
 /**
- * Fetch a specific collection (containing the actual collection information). If the application does not use strict mode you can
+ * Fetch a specific collection (containing the actual collection information). If the application does not use strict mode you
  * can use it without a callback in the following way: `var collection = db.collection('mycollection');`
  *
  * @method


### PR DESCRIPTION
Hello!

As stated in [JSDoc](https://github.com/mongodb/node-mongodb-native/blob/077b876ab8d90ea4938926b33c6ebdff3ae7d5eb/lib/db.js#L397) to [Db.prototype.collection](https://github.com/mongodb/node-mongodb-native/blob/077b876ab8d90ea4938926b33c6ebdff3ae7d5eb/lib/db.js#L415) function, 

```text
If the application does not use strict mode you can use it without a
callback in the following way: `var collection = db.collection('mycollection');`
```

This pull request fixes JSDoc, which removes this IDE warning:

![2018-01-31_124438](https://user-images.githubusercontent.com/4989256/35619245-09bb3148-0686-11e8-991c-7c7d99101ed5.png)

Additionally, it fixes a typo in the function description (duplicated word `can`).

Thank you for a great project and keep up the good work! 😃