### PR TITLE
return `group` result as bson if options.raw

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -3239,8 +3239,10 @@ var mapReduce = function(self, map, reduce, options, callback) {
   decorateWithCollation(mapCommandHash, self, options);
 
   // Execute command
-  self.s.db.command(mapCommandHash, {readPreference:options.readPreference}, function (err, result) {
+  self.s.db.command(mapCommandHash, {readPreference:options.readPreference, raw: options.raw}, function (err, result) {
     if(err) return handleCallback(callback, err);
+    // AR: in raw mode let the caller decode the raw mongo result, to support inline bson
+    if (options.raw && callback) return handleCallback(callback, err, result);
     // Check if we have an error
     if(1 != result.ok || result.err || result.errmsg) {
       return handleCallback(callback, toError(result));

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -3085,7 +3085,7 @@ var group = function(self, keys, condition, initial, reduce, finalize, command, 
     // Execute command
     self.s.db.command(selector, options, function(err, result) {
       if(err) return handleCallback(callback, err, null);
-      handleCallback(callback, null, result.retval);
+      handleCallback(callback, null, result.retval || result);
     });
   } else {
     // Create execution scope


### PR DESCRIPTION
back-ports options.raw support for the `group()` function