### PR TITLE
docs(collection): add `arrayFilters` option to docs

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -818,6 +818,7 @@ define.classMethod('insert', { callback: true, promise: true });
  * @param {number} [options.wtimeout=null] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {Array} [options.arrayFilters=null] optional list of array filters referenced in filtered positional operators
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -943,6 +944,7 @@ define.classMethod('replaceOne', { callback: true, promise: true });
  * @param {(number|string)} [options.w=null] The write concern.
  * @param {number} [options.wtimeout=null] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {Array} [options.arrayFilters=null] optional list of array filters referenced in filtered positional operators
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -1049,6 +1051,7 @@ var updateDocuments = function(self, selector, document, options, callback) {
  * @param {boolean} [options.multi=false] Update one/all documents with operation.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {object} [options.collation=null] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
+ * @param {Array} [options.arrayFilters=null] optional list of array filters referenced in filtered positional operators
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~writeOpCallback} [callback] The command result callback
  * @throws {MongoError}


### PR DESCRIPTION
[`arrayFilters` is necessary for the filtered positional operator](https://docs.mongodb.com/manual/reference/operator/update/positional-filtered/) but it looks like it isn't in the docs yet