### PR TITLE
Collection.prototype.remove throws an error when trying to remove all records

### DIFF
--- a/test/functional/promises_collection_tests.js
+++ b/test/functional/promises_collection_tests.js
@@ -8,6 +8,40 @@ describe('Promises (Collection)', function() {
     return setupDatabase(this.configuration);
   });
 
+  it('Should not throw an error when executing Collection.prototype.remove', {
+    metadata: {
+      requires: {
+        promises: true,
+        node: '>0.8.0',
+        topology: ['single']
+      }
+    },
+
+    // The actual test we wish to run
+    test: function(done) {
+      var configuration = this.configuration;
+      var MongoClient = configuration.require.MongoClient;
+      var url = configuration.url();
+      url =
+        url.indexOf('?') !== -1
+          ? f('%s&%s', url, 'maxPoolSize=100')
+          : f('%s?%s', url, 'maxPoolSize=100');
+
+      MongoClient.connect(url).then(function(client) {
+        test.equal(1, client.topology.connections().length);
+        var db = client.db(configuration.db);
+
+        db
+          .collection('remove')
+          .remove({})
+          .then(function() {
+            client.close();
+            done();
+          });
+      });
+    }
+  });
+
   it('Should correctly execute Collection.prototype.insertOne', {
     metadata: {
       requires: {


### PR DESCRIPTION
When trying to remove all the records from the database:

```javascript
MongoClient.connect('mongodb://localhost:27017/').then((client) => {
    client
      .db('db-name')
      .collection('collection-name')
      .remove({}).then(() => {
        done();
      });
    });
```

the lib throws an error:

```
TypeError: Cannot convert undefined or null to object
        at Function.assign (<anonymous>)
```

This looks to be the offending code in `utils.js`:

```javascript
  // The driver sessions spec mandates that we implicitly create sessions for operations
  // that are not explicitly provided with a session.
  let session, opOptions;
  if (!options.skipSessions && topology.hasSessionSupport()) {
    opOptions = args[args.length - 2];
    if (opOptions == null || opOptions.session == null) {
      session = topology.startSession();
      Object.assign(args[args.length - 2], { session: session });
    } else if (opOptions.session && opOptions.session.hasEnded) {
      throw new MongoError('Use of expired sessions is not permitted');
    }
  }
```

[Source 1](https://github.com/mongodb/node-mongodb-native/blob/3.0.0/lib/utils.js#L386), [Source 2](https://github.com/mongodb/node-mongodb-native/blob/3.0.0/lib/collection.js#L1245)

**As a sidenote:** I couldn't run the tests locally, sorry if the test of this PR is not working (mostly copy/paste from the previous one). I tried to clone and run `npm test` (as read from `package.json` test script) on my machine using node `v4.8.7` (as read from `package.json` `engines` property). However, the console got stuck on this:

```
➜  node-mongodb-native git:(3.0.0) ✗ npm test
> mongodb@3.0.2 test /Users/fagnerbrack/Git/node-mongodb-native
> npm run lint && mongodb-test-runner -t 60000 test/unit test/functional
> mongodb@3.0.2 lint /Users/fagnerbrack/Git/node-mongodb-native
> eslint lib test
[environment: single]
^C
```

I don't know what "[environment: single]" output means and why it's getting stuck there...