### PR TITLE
Add database to connection string for mongodb+srv

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -62,6 +62,18 @@ module.exports = function(url, options, callback) {
 
     let connectionString = connectionStrings.join(',') + '/';
     let connectionStringOptions = [];
+    
+    // Find the database name if there is one in the original url, and append it to connection string
+    if (result.pathname.indexOf('/') !== -1) {
+      // Check if multiple database names provided, or just an illegal trailing backslash
+      if (result.pathname.split('/').length > 2) {
+        if (result.pathname.split('/')[2].length === 0) {
+          return callback(new Error('Illegal trailing backslash after database name'));
+        }
+        return callback(new Error('More than 1 database name in URL'));
+      }
+      connectionString += result.pathname.split('/')[1];
+    }
 
     // Default to SSL true
     if (!options.ssl && !result.search) {

--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -62,7 +62,7 @@ module.exports = function(url, options, callback) {
 
     let connectionString = connectionStrings.join(',') + '/';
     let connectionStringOptions = [];
-    
+
     // Find the database name if there is one in the original url, and append it to connection string
     if (result.pathname.indexOf('/') !== -1) {
       // Check if multiple database names provided, or just an illegal trailing backslash


### PR DESCRIPTION
The name of the database did not get added to the final connection string after resolving the SRV record. Because of this, mongoose users could not connect to the database they required, because mongoose does not allow changing of databases after a connect has occurred.