### PR TITLE
Don't mutate options passed to commands:

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -383,7 +383,8 @@ const executeOperation = (topology, operation, args, options) => {
     opOptions = args[args.length - 2];
     if (opOptions == null || opOptions.session == null) {
       session = topology.startSession();
-      Object.assign(args[args.length - 2], { session: session });
+      const optionsIndex = args.length - 2;
+      args[optionsIndex] = Object.assign({}, args[optionsIndex], { session: session });
     } else if (opOptions.session && opOptions.session.hasEnded) {
       throw new MongoError('Use of expired sessions is not permitted');
     }

--- a/test/unit/sessions/collection_tests.js
+++ b/test/unit/sessions/collection_tests.js
@@ -49,5 +49,30 @@ describe('Sessions', function() {
         });
       }
     });
+
+    it('does not mutate command options', {
+      metadata: { requires: { topology: 'single' } },
+
+      test: function() {
+        const options = Object.freeze({});
+        test.server.setMessageHandler(request => {
+          const doc = request.document;
+          if (doc.ismaster) {
+            request.reply(mock.DEFAULT_ISMASTER_36);
+          } else if (doc.count) {
+            request.reply({ ok: 1 });
+          }
+        });
+
+        return MongoClient.connect(`mongodb://${test.server.uri()}/test`).then(client => {
+          const coll = client.db('foo').collection('bar');
+
+          return coll.count({}, options).then(() => {
+            expect(options).to.deep.equal({});
+            return client.close();
+          });
+        });
+      }
+    });
   });
 });


### PR DESCRIPTION
When the topology believes it has session support, options passed to
commands were getting mutated with the session added to them. It is our
expectation that the driver will never be mutating arguments passed to
it via the public facing API.

This commit creates a new object and copies into it, then replaces in
the args array.