### PR TITLE
Update documentation for startSession

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -495,8 +495,7 @@ define.staticMethod('connect', { callback: true, promise: true });
  * Starts a new session on the server
  *
  * @param {object} [options] optional settings for a driver session
- * @param {MongoClient~sessionCallback} [callback] The callback called with a newly establish session, or an error if one occurred
- * @return {Promise} if no callback is specified, a promise will be returned for the newly established session
+ * @return {ClientSession} the newly established session
  */
 MongoClient.prototype.startSession = function(options) {
   options = options || {};


### PR DESCRIPTION
`MongoClient.prototype.startSession` doesn't take a second argument, or return a Promise. It returns the ClientSession from the mongodb-core:
https://github.com/mongodb-js/mongodb-core/blob/2d3fa98db1d1430558979af092fd033315551406/lib/sessions.js#L12