### PR TITLE
fix(utils): fixes executeOperation to clean up sessions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -436,7 +436,6 @@ const executeOperation = (topology, operation, args, options) => {
       return operation.apply(null, args);
     } catch (e) {
       handler(e);
-      throw e;
     }
   });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -390,23 +390,37 @@ const executeOperation = (topology, operation, args, options) => {
     }
   }
 
-  // Execute using callback
-  if (typeof callback === 'function') {
-    callback = args.pop();
-    args.push((err, result) => {
+  const makeExecuteCallback = (resolve, reject) =>
+    function executeCallback(err, result) {
       if (session && !options.returnsCursor) {
         session.endSession(() => {
           delete opOptions.session;
-          if (err) return callback(err, null);
-          return resultMutator ? callback(null, resultMutator(result)) : callback(null, result);
+          if (err) return reject(err);
+          if (resultMutator) return resolve(resultMutator(result));
+          resolve(result);
         });
       } else {
-        if (err) return callback(err, null);
-        return resultMutator ? callback(null, resultMutator(result)) : callback(null, result);
+        if (err) return reject(err);
+        if (resultMutator) return resolve(resultMutator(result));
+        resolve(result);
       }
-    });
+    };
 
-    return operation.apply(null, args);
+  // Execute using callback
+  if (typeof callback === 'function') {
+    callback = args.pop();
+    const handler = makeExecuteCallback(
+      result => callback(null, result),
+      err => callback(err, null)
+    );
+    args.push(handler);
+
+    try {
+      return operation.apply(null, args);
+    } catch (e) {
+      handler(e);
+      throw e;
+    }
   }
 
   // Return a Promise
@@ -415,22 +429,15 @@ const executeOperation = (topology, operation, args, options) => {
   }
 
   return new Promise(function(resolve, reject) {
-    args[args.length - 1] = (err, r) => {
-      if (session && !options.returnsCursor) {
-        session.endSession(() => {
-          delete opOptions.session;
-          if (err) return reject(err);
-          if (resultMutator) return resolve(resultMutator(r));
-          resolve(r);
-        });
-      } else {
-        if (err) return reject(err);
-        if (resultMutator) return resolve(resultMutator(r));
-        resolve(r);
-      }
-    };
+    const handler = makeExecuteCallback(resolve, reject);
+    args[args.length - 1] = handler;
 
-    operation.apply(null, args);
+    try {
+      return operation.apply(null, args);
+    } catch (e) {
+      handler(e);
+      throw e;
+    }
   });
 };
 

--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -3170,8 +3170,7 @@ describe('Operation Examples', function() {
    */
   it('shouldCorrectlyRenameCollection', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] },
-      sessions: { skipLeakTests: true }
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
     // The actual test we wish to run

--- a/test/functional/operation_generators_example_tests.js
+++ b/test/functional/operation_generators_example_tests.js
@@ -2337,8 +2337,7 @@ describe('Operation (Generators)', function() {
    */
   it('shouldCorrectlyRenameCollectionWithGenerators', {
     metadata: {
-      requires: { generators: true, topology: ['single'] },
-      sessions: { skipLeakTests: true }
+      requires: { generators: true, topology: ['single'] }
     },
 
     // The actual test we wish to run

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -2432,8 +2432,7 @@ describe('Operation (Promises)', function() {
    */
   it('shouldCorrectlyRenameCollectionWithPromises', {
     metadata: {
-      requires: { promises: true, topology: ['single'] },
-      sessions: { skipLeakTests: true }
+      requires: { promises: true, topology: ['single'] }
     },
 
     // The actual test we wish to run

--- a/test/unit/execute_operation_tests.js
+++ b/test/unit/execute_operation_tests.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const expect = require('chai').expect;
+const executeOperation = require('../../lib/utils').executeOperation;
+
+describe('executeOperation', function() {
+  it('should call callback with errors on throw errors, and rethrow error', function() {
+    const expectedError = new Error('THIS IS AN ERROR');
+    let callbackError, caughtError;
+
+    const topology = {
+      logicalSessionTimeoutMinutes: null,
+      s: {
+        promiseLibrary: Promise
+      }
+    };
+    const operation = () => {
+      throw expectedError;
+    };
+
+    const callback = err => (callbackError = err);
+    const options = { skipSessions: true };
+
+    try {
+      executeOperation(topology, operation, [{}, callback], options);
+    } catch (e) {
+      caughtError = e;
+    }
+
+    expect(callbackError).to.equal(expectedError);
+    expect(caughtError).to.equal(expectedError);
+  });
+
+  it('should reject promise with errors on throw errors, and rethrow error', function(done) {
+    const expectedError = new Error('THIS IS AN ERROR');
+    let callbackError;
+
+    const topology = {
+      logicalSessionTimeoutMinutes: null,
+      s: {
+        promiseLibrary: Promise
+      }
+    };
+    const operation = () => {
+      throw expectedError;
+    };
+
+    const callback = err => (callbackError = err);
+    const options = { skipSessions: true };
+
+    executeOperation(topology, operation, [{}, null], options).then(null, callback);
+
+    setTimeout(() => {
+      try {
+        expect(callbackError).to.equal(expectedError);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Makes sure that, if an error is thrown before the async part
of executeOperation, the implicit session is cleaned up

Fixes NODE-1335

~~WIP waiting for unit tests~~ Unit tests done