### PR TITLE
NODE-1258 - Use database from URI

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -357,6 +357,11 @@ define.classMethod('close', { callback: true, promise: true });
 MongoClient.prototype.db = function(dbName, options) {
   options = options || {};
 
+  // Default to db from connection string if not provided
+  if (!dbName) {
+    dbName = this.s.options.dbName;
+  }
+
   // Copy the options and add out internal override of the not shared flag
   var finalOptions = Object.assign({}, this.s.options, options);
 

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -348,7 +348,7 @@ define.classMethod('close', { callback: true, promise: true });
  * You can control these behaviors with the options noListener and returnNonCachedInstance.
  *
  * @method
- * @param {string} name The name of the database we want to use.
+ * @param {string} dbName The name of the database we want to use.
  * @param {object} [options=null] Optional settings.
  * @param {boolean} [options.noListener=false] Do not make the db an event listener to the original connection.
  * @param {boolean} [options.returnNonCachedInstance=false] Control if you want to return a cached instance or have a new one created


### PR DESCRIPTION
Use the authentication database form the URI if no parameter is provided to `MongoClient.db()`