### PR TITLE
Fix APM tests

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -156,7 +156,9 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
   var batchSize =
     cmd.cursor && cmd.cursor.batchSize
       ? cmd.cursor && cmd.cursor.batchSize
-      : options.cursor && options.cursor.batchSize ? options.cursor.batchSize : 1000;
+      : options.cursor && options.cursor.batchSize
+        ? options.cursor.batchSize
+        : 1000;
 
   // Set the batchSize
   this.setCursorBatchSize(batchSize);

--- a/test/functional/apm_tests.js
+++ b/test/functional/apm_tests.js
@@ -29,7 +29,7 @@ function ignoreNsNotFound(err) {
 
 describe('APM', function() {
   before(function() {
-    setupDatabase(this.configuration);
+    return setupDatabase(this.configuration);
   });
 
   it(


### PR DESCRIPTION
The APM tests were failing on replicaset and sharded environments, however it was because we weren't properly waiting for the `setupDatabase` method to complete. 