### PR TITLE
Refactor multiple `writeConcern` helpers into a single `applyWriteConcern' method

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -3,6 +3,7 @@
 const toError = require('./utils').toError;
 const shallowClone = require('./utils').shallowClone;
 const executeOperation = require('./utils').executeOperation;
+const applyWriteConcern = require('./utils').applyWriteConcern;
 
 /**
  * @fileOverview The **Admin** class is an internal class that allows convenient access to
@@ -164,27 +165,6 @@ Admin.prototype.ping = function(options, callback) {
   ]);
 };
 
-// Get write concern
-var writeConcern = function(options, db) {
-  options = shallowClone(options);
-
-  // If options already contain write concerns return it
-  if (options.w || options.wtimeout || options.j || options.fsync) {
-    return options;
-  }
-
-  // Set db write concern if available
-  if (db.writeConcern) {
-    if (options.w) options.w = db.writeConcern.w;
-    if (options.wtimeout) options.wtimeout = db.writeConcern.wtimeout;
-    if (options.j) options.j = db.writeConcern.j;
-    if (options.fsync) options.fsync = db.writeConcern.fsync;
-  }
-
-  // Return modified options
-  return options;
-};
-
 /**
  * Add a user to the database.
  * @method
@@ -209,7 +189,7 @@ Admin.prototype.addUser = function(username, password, options, callback) {
   options = args.length ? args.shift() : {};
   options = options || {};
   // Get the options
-  options = writeConcern(options, self.s.db);
+  options = applyWriteConcern(shallowClone(options), { db: self.s.db });
   // Set the db name to admin
   options.dbName = 'admin';
 
@@ -242,7 +222,7 @@ Admin.prototype.removeUser = function(username, options, callback) {
   options = args.length ? args.shift() : {};
   options = options || {};
   // Get the options
-  options = writeConcern(options, self.s.db);
+  options = applyWriteConcern(shallowClone(options), { db: self.s.db });
   // Set the db name
   options.dbName = 'admin';
 

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -15,28 +15,6 @@ var INSERT = 1;
 var UPDATE = 2;
 var REMOVE = 3;
 
-// Get write concern
-var writeConcern = function(target, col, options) {
-  var writeConcern = {};
-
-  // Collection level write concern
-  if (col.writeConcern && col.writeConcern.w != null) writeConcern.w = col.writeConcern.w;
-  if (col.writeConcern && col.writeConcern.j != null) writeConcern.j = col.writeConcern.j;
-  if (col.writeConcern && col.writeConcern.fsync != null)
-    writeConcern.fsync = col.writeConcern.fsync;
-  if (col.writeConcern && col.writeConcern.wtimeout != null)
-    writeConcern.wtimeout = col.writeConcern.wtimeout;
-
-  // Options level write concern
-  if (options && options.w != null) writeConcern.w = options.w;
-  if (options && options.wtimeout != null) writeConcern.wtimeout = options.wtimeout;
-  if (options && options.j != null) writeConcern.j = options.j;
-  if (options && options.fsync != null) writeConcern.fsync = options.fsync;
-
-  // Return write concern
-  return writeConcern;
-};
-
 /**
  * Helper function to define properties
  * @ignore
@@ -455,7 +433,6 @@ exports.Batch = Batch;
 exports.LegacyOp = LegacyOp;
 exports.mergeBatchResults = mergeBatchResults;
 exports.cloneOptions = cloneOptions;
-exports.writeConcern = writeConcern;
 exports.INVALID_BSON_ERROR = INVALID_BSON_ERROR;
 exports.WRITE_CONCERN_ERROR = WRITE_CONCERN_ERROR;
 exports.MULTIPLE_ERROR = MULTIPLE_ERROR;

--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -1,17 +1,18 @@
 'use strict';
 
-var common = require('./common'),
-  utils = require('../utils'),
-  toError = require('../utils').toError,
-  handleCallback = require('../utils').handleCallback,
-  shallowClone = utils.shallowClone,
-  BulkWriteResult = common.BulkWriteResult,
-  ObjectID = require('mongodb-core').BSON.ObjectID,
-  BSON = require('mongodb-core').BSON,
-  Batch = common.Batch,
-  mergeBatchResults = common.mergeBatchResults,
-  executeOperation = require('../utils').executeOperation,
-  BulkWriteError = require('./common').BulkWriteError;
+const common = require('./common');
+const utils = require('../utils');
+const toError = require('../utils').toError;
+const handleCallback = require('../utils').handleCallback;
+const shallowClone = utils.shallowClone;
+const BulkWriteResult = common.BulkWriteResult;
+const ObjectID = require('mongodb-core').BSON.ObjectID;
+const BSON = require('mongodb-core').BSON;
+const Batch = common.Batch;
+const mergeBatchResults = common.mergeBatchResults;
+const executeOperation = utils.executeOperation;
+const BulkWriteError = require('./common').BulkWriteError;
+const applyWriteConcern = utils.applyWriteConcern;
 
 var bson = new BSON([
   BSON.Binary,
@@ -246,7 +247,8 @@ function OrderedBulkOperation(topology, collection, options) {
       : 1000;
 
   // Get the write concern
-  var writeConcern = common.writeConcern(shallowClone(options), collection, options);
+  var writeConcern = applyWriteConcern(shallowClone(options), { collection: collection }, options);
+  writeConcern = writeConcern.writeConcern;
 
   // Get the promiseLibrary
   var promiseLibrary = options.promiseLibrary || Promise;

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -1,17 +1,18 @@
 'use strict';
 
-var common = require('./common'),
-  utils = require('../utils'),
-  toError = require('../utils').toError,
-  handleCallback = require('../utils').handleCallback,
-  shallowClone = utils.shallowClone,
-  BulkWriteResult = common.BulkWriteResult,
-  ObjectID = require('mongodb-core').BSON.ObjectID,
-  BSON = require('mongodb-core').BSON,
-  Batch = common.Batch,
-  mergeBatchResults = common.mergeBatchResults,
-  executeOperation = require('../utils').executeOperation,
-  BulkWriteError = require('./common').BulkWriteError;
+const common = require('./common');
+const utils = require('../utils');
+const toError = require('../utils').toError;
+const handleCallback = require('../utils').handleCallback;
+const shallowClone = utils.shallowClone;
+const BulkWriteResult = common.BulkWriteResult;
+const ObjectID = require('mongodb-core').BSON.ObjectID;
+const BSON = require('mongodb-core').BSON;
+const Batch = common.Batch;
+const mergeBatchResults = common.mergeBatchResults;
+const executeOperation = utils.executeOperation;
+const BulkWriteError = require('./common').BulkWriteError;
+const applyWriteConcern = utils.applyWriteConcern;
 
 var bson = new BSON([
   BSON.Binary,
@@ -256,7 +257,8 @@ var UnorderedBulkOperation = function(topology, collection, options) {
       : 1000;
 
   // Get the write concern
-  var writeConcern = common.writeConcern(shallowClone(options), collection, options);
+  var writeConcern = applyWriteConcern(shallowClone(options), { collection: collection }, options);
+  writeConcern = writeConcern.writeConcern;
 
   // Get the promiseLibrary
   var promiseLibrary = options.promiseLibrary || Promise;

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2383,7 +2383,11 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
   }
 
   // Decorate command with writeConcern if out has been specified
-  if (pipeline.length > 0 && pipeline[pipeline.length - 1]['$out']) {
+  if (
+    pipeline.length > 0 &&
+    pipeline[pipeline.length - 1]['$out'] &&
+    self.s.topology.capabilities().commandsTakeWriteConcern
+  ) {
     applyWriteConcern(command, { db: self.s.db, collection: self }, options);
   }
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -20,6 +20,7 @@ const unordered = require('./bulk/unordered');
 const ordered = require('./bulk/ordered');
 const ChangeStream = require('./change_stream');
 const executeOperation = require('./utils').executeOperation;
+const applyWriteConcern = require('./utils').applyWriteConcern;
 
 /**
  * @fileOverview The **Collection** class is an internal class that embodies a MongoDB collection
@@ -604,7 +605,12 @@ var bulkWrite = function(self, operations, options, callback) {
   }
 
   // Final options for write concern
-  var finalOptions = writeConcern(shallowClone(options), self.s.db, self, options);
+  var finalOptions = applyWriteConcern(
+    shallowClone(options),
+    { db: self.s.db, collection: self },
+    options
+  );
+
   var writeCon = finalOptions.writeConcern ? finalOptions.writeConcern : {};
   var capabilities = self.s.topology.capabilities();
 
@@ -657,7 +663,11 @@ var insertDocuments = function(self, docs, options, callback) {
   docs = Array.isArray(docs) ? docs : [docs];
 
   // Get the write concern options
-  var finalOptions = writeConcern(shallowClone(options), self.s.db, self, options);
+  var finalOptions = applyWriteConcern(
+    shallowClone(options),
+    { db: self.s.db, collection: self },
+    options
+  );
 
   // If keep going set unordered
   if (finalOptions.keepGoing === true) finalOptions.ordered = false;
@@ -985,7 +995,11 @@ var updateDocuments = function(self, selector, document, options, callback) {
     return callback(toError('document must be a valid JavaScript object'));
 
   // Get the write concern options
-  var finalOptions = writeConcern(shallowClone(options), self.s.db, self, options);
+  var finalOptions = applyWriteConcern(
+    shallowClone(options),
+    { db: self.s.db, collection: self },
+    options
+  );
 
   // Do we return the actual result document
   // Either use override on the function, or go back to default on either the collection
@@ -1161,7 +1175,11 @@ var removeDocuments = function(self, selector, options, callback) {
   options = options || {};
 
   // Get the write concern options
-  var finalOptions = writeConcern(shallowClone(options), self.s.db, self, options);
+  var finalOptions = applyWriteConcern(
+    shallowClone(options),
+    { db: self.s.db, collection: self },
+    options
+  );
 
   // If selector is null set empty
   if (selector == null) selector = {};
@@ -1244,7 +1262,11 @@ Collection.prototype.save = function(doc, options, callback) {
 
 var save = function(self, doc, options, callback) {
   // Get the write concern options
-  var finalOptions = writeConcern(shallowClone(options), self.s.db, self, options);
+  var finalOptions = applyWriteConcern(
+    shallowClone(options),
+    { db: self.s.db, collection: self },
+    options
+  );
   // Establish if we need to perform an insert or update
   if (doc._id != null) {
     finalOptions.upsert = true;
@@ -1365,7 +1387,7 @@ var rename = function(self, newName, options, callback) {
   var cmd = { renameCollection: renameCollection, to: toCollection, dropTarget: dropTarget };
 
   // Decorate command with writeConcern if supported
-  decorateWithWriteConcern(cmd, self, options);
+  applyWriteConcern(cmd, { db: self.s.db, collection: self }, options);
 
   // Execute against admin
   self.s.db.admin().command(cmd, options, function(err, doc) {
@@ -1582,7 +1604,7 @@ var dropIndex = function(self, indexName, options, callback) {
   var cmd = { dropIndexes: self.s.name, index: indexName };
 
   // Decorate command with writeConcern if supported
-  decorateWithWriteConcern(cmd, self, options);
+  applyWriteConcern(cmd, { db: self.s.db, collection: self }, options);
 
   // Execute command
   self.s.db.command(cmd, options, function(err, result) {
@@ -2203,7 +2225,7 @@ var findAndModify = function(self, query, sort, doc, options, callback) {
   options.checkKeys = false;
 
   // Get the write concern settings
-  var finalOptions = writeConcern(options, self.s.db, self, options);
+  var finalOptions = applyWriteConcern(options, { db: self.s.db, collection: self }, options);
 
   // Decorate the findAndModify command with the write Concern
   if (finalOptions.writeConcern) {
@@ -2254,20 +2276,6 @@ var findAndRemove = function(self, query, sort, options, callback) {
   // Execute the callback
   self.findAndModify(query, sort, null, options, callback);
 };
-
-function decorateWithWriteConcern(command, self, options) {
-  // Do we support collation 3.4 and higher
-  var capabilities = self.s.topology.capabilities();
-  // Do we support write concerns 3.4 and higher
-  if (capabilities && capabilities.commandsTakeWriteConcern) {
-    // Get the write concern settings
-    var finalOptions = writeConcern(shallowClone(options), self.s.db, self, options);
-    // Add the write concern to the command
-    if (finalOptions.writeConcern) {
-      command.writeConcern = finalOptions.writeConcern;
-    }
-  }
-}
 
 function decorateWithCollation(command, self, options) {
   // Do we support collation 3.4 and higher
@@ -2376,7 +2384,7 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
 
   // Decorate command with writeConcern if out has been specified
   if (pipeline.length > 0 && pipeline[pipeline.length - 1]['$out']) {
-    decorateWithWriteConcern(command, self, options);
+    applyWriteConcern(command, { db: self.s.db, collection: self }, options);
   }
 
   // Have we specified collation
@@ -2878,7 +2886,7 @@ var mapReduce = function(self, map, reduce, options, callback) {
     // Force readPreference to primary
     options.readPreference = 'primary';
     // Decorate command with writeConcern if supported
-    decorateWithWriteConcern(mapCommandHash, self, options);
+    applyWriteConcern(mapCommandHash, { db: self.s.db, collection: self }, options);
   } else {
     decorateWithReadConcern(mapCommandHash, self, options);
   }
@@ -2974,35 +2982,6 @@ Collection.prototype.initializeOrderedBulkOp = function(options) {
   options = options || {};
   options.promiseLibrary = this.s.promiseLibrary;
   return ordered(this.s.topology, this, options);
-};
-
-// Get write concern
-var writeConcern = function(target, db, col, options) {
-  if (options.w != null || options.j != null || options.fsync != null) {
-    var opts = {};
-    if (options.w != null) opts.w = options.w;
-    if (options.wtimeout != null) opts.wtimeout = options.wtimeout;
-    if (options.j != null) opts.j = options.j;
-    if (options.fsync != null) opts.fsync = options.fsync;
-    target.writeConcern = opts;
-  } else if (
-    col.writeConcern.w != null ||
-    col.writeConcern.j != null ||
-    col.writeConcern.fsync != null
-  ) {
-    target.writeConcern = col.writeConcern;
-  } else if (
-    db.writeConcern.w != null ||
-    db.writeConcern.j != null ||
-    db.writeConcern.fsync != null
-  ) {
-    target.writeConcern = db.writeConcern;
-  }
-
-  // NOTE: there is probably a much better place for this
-  if (db.s.options.retryWrites) target.retryWrites = true;
-
-  return target;
 };
 
 // Figure out the read preference

--- a/lib/db.js
+++ b/lib/db.js
@@ -21,6 +21,7 @@ const Collection = require('./collection');
 const crypto = require('crypto');
 const mergeOptionsAndWriteConcern = require('./utils').mergeOptionsAndWriteConcern;
 const executeOperation = require('./utils').executeOperation;
+const applyWriteConcern = require('./utils').applyWriteConcern;
 
 var debugFields = [
   'authSource',
@@ -474,21 +475,10 @@ Db.prototype.collection = function(name, options, callback) {
   });
 };
 
-function decorateWithWriteConcern(command, self, options) {
-  // Do we support write concerns 3.4 and higher
-  if (self.s.topology.capabilities().commandsTakeWriteConcern) {
-    // Get the write concern settings
-    var finalOptions = writeConcern(shallowClone(options), self, options);
-    // Add the write concern to the command
-    if (finalOptions.writeConcern) {
-      command.writeConcern = finalOptions.writeConcern;
-    }
-  }
-}
-
 var createCollection = function(self, name, options, callback) {
   // Get the write concern options
-  var finalOptions = writeConcern(shallowClone(options), self, options);
+  const finalOptions = applyWriteConcern(shallowClone(options), { db: self }, options);
+
   // Did the user destroy the topology
   if (self.serverConfig && self.serverConfig.isDestroyed()) {
     return callback(new MongoError('topology was destroyed'));
@@ -532,7 +522,8 @@ var createCollection = function(self, name, options, callback) {
       var cmd = { create: name };
 
       // Decorate command with writeConcern if supported
-      decorateWithWriteConcern(cmd, self, options);
+      applyWriteConcern(cmd, { db: self }, options);
+
       // Add all optional parameters
       for (var n in options) {
         if (
@@ -838,7 +829,7 @@ Db.prototype.dropCollection = function(name, options, callback) {
   var cmd = { drop: name };
 
   // Decorate with write concern
-  decorateWithWriteConcern(cmd, this, options);
+  applyWriteConcern(cmd, { db: this }, options);
 
   // options
   const opts = Object.assign({}, this.s.options, { readPreference: ReadPreference.PRIMARY });
@@ -876,7 +867,7 @@ Db.prototype.dropDatabase = function(options, callback) {
   var cmd = { dropDatabase: 1 };
 
   // Decorate with write concern
-  decorateWithWriteConcern(cmd, this, options);
+  applyWriteConcern(cmd, { db: this }, options);
 
   // Ensure primary only
   const finalOptions = Object.assign({}, this.s.options, {
@@ -1024,7 +1015,7 @@ Db.prototype.createIndex = function(name, fieldOrSpec, options, callback) {
 var createIndex = function(self, name, fieldOrSpec, options, callback) {
   // Get the write concern options
   var finalOptions = Object.assign({}, { readPreference: ReadPreference.PRIMARY }, options);
-  finalOptions = writeConcern(finalOptions, self, options);
+  finalOptions = applyWriteConcern(finalOptions, { db: self }, options);
 
   // Ensure we have a callback
   if (finalOptions.writeConcern && typeof callback !== 'function') {
@@ -1111,7 +1102,7 @@ Db.prototype.ensureIndex = function(name, fieldOrSpec, options, callback) {
 
 var ensureIndex = function(self, name, fieldOrSpec, options, callback) {
   // Get the write concern options
-  var finalOptions = writeConcern({}, self, options);
+  var finalOptions = applyWriteConcern({}, { db: self }, options);
   // Create command
   var selector = createCreateIndexCommand(self, name, fieldOrSpec, options);
   var index_name = selector.name;
@@ -1196,7 +1187,7 @@ var _executeAuthCreateUserCommand = function(self, username, password, options, 
   };
 
   // Apply write concern to command
-  command = writeConcern(command, self, options);
+  command = applyWriteConcern(command, { db: self }, options);
 
   // Use node md5 generator
   var md5 = crypto.createHash('md5');
@@ -1233,7 +1224,8 @@ var addUser = function(self, username, password, options, callback) {
   _executeAuthCreateUserCommand(self, username, password, options, function(err, r) {
     // We need to perform the backward compatible insert operation
     if (err && err.code === -5000) {
-      var finalOptions = writeConcern(shallowClone(options), self, options);
+      var finalOptions = applyWriteConcern(shallowClone(options), { db: self }, options);
+
       // Use node md5 generator
       var md5 = crypto.createHash('md5');
       // Generate keys used for authentication
@@ -1329,7 +1321,7 @@ var _executeAuthRemoveUserCommand = function(self, username, options, callback) 
   };
 
   // Apply write concern to command
-  command = writeConcern(command, self, options);
+  command = applyWriteConcern(command, { db: self }, options);
 
   // Force write using primary
   commandOptions.readPreference = ReadPreference.primary;
@@ -1346,7 +1338,7 @@ var removeUser = function(self, username, options, callback) {
   // Attempt to execute command
   _executeAuthRemoveUserCommand(self, username, options, function(err, result) {
     if (err && err.code === -5000) {
-      var finalOptions = writeConcern(shallowClone(options), self, options);
+      var finalOptions = applyWriteConcern(shallowClone(options), { db: self }, options);
       // If we have another db set
       var db = options.dbName ? new Db(options.dbName, self.s.topology, self.s.options) : self;
 
@@ -1613,10 +1605,7 @@ var createIndexUsingCreateIndexes = function(self, name, fieldOrSpec, options, c
   }
 
   // Create command, apply write concern to command
-  var cmd = writeConcern({ createIndexes: name, indexes: indexes }, self, options);
-
-  // Decorate command with writeConcern if supported
-  decorateWithWriteConcern(cmd, self, options);
+  var cmd = applyWriteConcern({ createIndexes: name, indexes: indexes }, { db: self }, options);
 
   // ReadPreference primary
   options.readPreference = ReadPreference.PRIMARY;
@@ -1646,26 +1635,6 @@ var validateDatabaseName = function(databaseName) {
         driver: true
       });
   }
-};
-
-// Get write concern
-var writeConcern = function(target, db, options) {
-  if (options.w != null || options.j != null || options.fsync != null) {
-    var opts = {};
-    if (options.w) opts.w = options.w;
-    if (options.wtimeout) opts.wtimeout = options.wtimeout;
-    if (options.j) opts.j = options.j;
-    if (options.fsync) opts.fsync = options.fsync;
-    target.writeConcern = opts;
-  } else if (
-    db.writeConcern.w != null ||
-    db.writeConcern.j != null ||
-    db.writeConcern.fsync != null
-  ) {
-    target.writeConcern = db.writeConcern;
-  }
-
-  return target;
 };
 
 // Add listeners to topology

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -454,11 +454,6 @@ function applyWriteConcern(target, sources, options) {
   options = options || {};
   const db = sources.db;
   const coll = sources.collection;
-  const topology = db ? db.s.topology : coll.s.topology;
-
-  if (!topology.capabilities().commandsTakeWriteConcern) {
-    return target;
-  }
 
   // NOTE: there is probably a much better place for this
   if (db && db.s.options.retryWrites) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var MongoError = require('mongodb-core').MongoError,
-  ReadPreference = require('mongodb-core').ReadPreference;
+const MongoError = require('mongodb-core').MongoError;
+const ReadPreference = require('mongodb-core').ReadPreference;
 
 var shallowClone = function(obj) {
   var copy = {};
@@ -441,6 +441,54 @@ const executeOperation = (topology, operation, args, options) => {
   });
 };
 
+/**
+ * Applies a write concern to a command based on well defined inheritance rules, optionally
+ * detecting support for the write concern in the first place.
+ *
+ * @param {Object} target the target command we will be applying the write concern to
+ * @param {Object} sources sources where we can inherit default write concerns from
+ * @param {Object} [options] optional settings passed into a command for write concern overrides
+ * @returns {Object} the (now) decorated target
+ */
+function applyWriteConcern(target, sources, options) {
+  options = options || {};
+  const db = sources.db;
+  const coll = sources.collection;
+  const topology = db ? db.s.topology : coll.s.topology;
+
+  if (!topology.capabilities().commandsTakeWriteConcern) {
+    return target;
+  }
+
+  if (options.w != null || options.j != null || options.fsync != null) {
+    const writeConcern = {};
+    if (options.w != null) writeConcern.w = options.w;
+    if (options.wtimeout != null) writeConcern.wtimeout = options.wtimeout;
+    if (options.j != null) writeConcern.j = options.j;
+    if (options.fsync != null) writeConcern.fsync = options.fsync;
+    return Object.assign(target, { writeConcern });
+  }
+
+  if (
+    coll &&
+    (coll.writeConcern.w != null || coll.writeConcern.j != null || coll.writeConcern.fsync != null)
+  ) {
+    return Object.assign(target, { writeConcern: Object.assign({}, coll.writeConcern) });
+  }
+
+  if (
+    db &&
+    (db.writeConcern.w != null || db.writeConcern.j != null || db.writeConcern.fsync != null)
+  ) {
+    return Object.assign(target, { writeConcern: Object.assign({}, db.writeConcern) });
+  }
+
+  // // NOTE: there is probably a much better place for this
+  // if (db.s.options.retryWrites) target.retryWrites = true;
+
+  return target;
+}
+
 exports.filterOptions = filterOptions;
 exports.mergeOptions = mergeOptions;
 exports.translateOptions = translateOptions;
@@ -459,3 +507,4 @@ exports.MAX_JS_INT = 0x20000000000000;
 exports.mergeOptionsAndWriteConcern = mergeOptionsAndWriteConcern;
 exports.translateReadPreference = translateReadPreference;
 exports.executeOperation = executeOperation;
+exports.applyWriteConcern = applyWriteConcern;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -460,6 +460,11 @@ function applyWriteConcern(target, sources, options) {
     return target;
   }
 
+  // NOTE: there is probably a much better place for this
+  if (db && db.s.options.retryWrites) {
+    target.retryWrites = true;
+  }
+
   if (options.w != null || options.j != null || options.fsync != null) {
     const writeConcern = {};
     if (options.w != null) writeConcern.w = options.w;
@@ -482,9 +487,6 @@ function applyWriteConcern(target, sources, options) {
   ) {
     return Object.assign(target, { writeConcern: Object.assign({}, db.writeConcern) });
   }
-
-  // // NOTE: there is probably a much better place for this
-  // if (db.s.options.retryWrites) target.retryWrites = true;
 
   return target;
 }


### PR DESCRIPTION
We presently have many similar methods laying around the codebase to deal with applying a write concern to some command. This has become a problem during transactions development because we need to make some decisions about whether to apply based on transaction status - and requiring changing this logic in seven locations is error-prone, and outright annoying. 