### PR TITLE
docs(mongo_client): add options for `startSession()`

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -484,6 +484,9 @@ MongoClient.connect = function(url, options, callback) {
  * Starts a new session on the server
  *
  * @param {object} [options] optional settings for a driver session
+ * @param {Boolean} [options.causalConsistency=false] Whether causal consistency should be enabled on this session
+ * @param {Boolean} [options.autoStartTransaction=false] When enabled this session automatically starts a transaction with the provided defaultTransactionOptions.
+ * @param {Object} [options.defaultTransactionOptions] The default TransactionOptions to use for transactions started on this session.
  * @return {ClientSession} the newly established session
  */
 MongoClient.prototype.startSession = function(options) {


### PR DESCRIPTION
Right now the only way to find what options `startSession()` accepts is to dig into mongodb-core: https://github.com/mongodb-js/mongodb-core/blob/master/lib/sessions.js