### PR TITLE
feat(withSession): add top level helper for session lifetime

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -511,34 +511,27 @@ MongoClient.prototype.startSession = function(options) {
  *
  * NOTE: presently the operation MUST return a Promise (either explicit or implicity as an async function)
  *
- * @param {Function} operation An operation to execute with an implicitly created session. The signature of this MUST be `(session) => {}`
  * @param {Object} [options] Optional settings to be appled to implicitly created session
- * @return {Promise} returns Promise if no callback passed
+ * @param {Function} operation An operation to execute with an implicitly created session. The signature of this MUST be `(session) => {}`
+ * @return {Promise}
  */
-MongoClient.prototype.withSession = function(operation, options, callback) {
-  if (typeof options === 'function') (callback = options), (options = undefined);
+MongoClient.prototype.withSession = function(options, operation) {
+  if (typeof options === 'function') (operation = options), (options = undefined);
   const session = this.startSession(options);
 
   const cleanupHandler = (err, result, opts) => {
     opts = Object.assign({ throw: true }, opts);
     session.endSession();
 
-    if (typeof callback === 'function') {
-      return err ? callback(err, null) : callback(null, result);
-    } else {
-      if (err) {
-        if (opts.throw) throw err;
-        return Promise.reject(err);
-      }
-      return result;
+    if (err) {
+      if (opts.throw) throw err;
+      return Promise.reject(err);
     }
   };
 
   try {
     const result = operation(session);
-    const promise = isPromiseLike(result) ? result : Promise.resolve(result);
-
-    return promise
+    return Promise.resolve(result)
       .then(result => cleanupHandler(null, result))
       .catch(err => cleanupHandler(err, null, { throw: true }));
   } catch (err) {

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -16,6 +16,7 @@ const shallowClone = require('./utils').shallowClone;
 const authenticate = require('./authenticate');
 const ServerSessionPool = require('mongodb-core').Sessions.ServerSessionPool;
 const executeOperation = require('./utils').executeOperation;
+const isPromiseLike = require('./utils').isPromiseLike;
 
 /**
  * @fileOverview The **MongoClient** class is a class that allows for making Connections to MongoDB.
@@ -502,6 +503,47 @@ MongoClient.prototype.startSession = function(options) {
   }
 
   return this.topology.startSession(options, this.s.options);
+};
+
+/**
+ * Runs a given operation with an implicitly created session. The lifetime of the session
+ * will be handled without the need for user interaction.
+ *
+ * NOTE: presently the operation MUST return a Promise (either explicit or implicity as an async function)
+ *
+ * @param {Function} operation An operation to execute with an implicitly created session. The signature of this MUST be `(session) => {}`
+ * @param {Object} [options] Optional settings to be appled to implicitly created session
+ * @return {Promise} returns Promise if no callback passed
+ */
+MongoClient.prototype.withSession = function(operation, options, callback) {
+  if (typeof options === 'function') (callback = options), (options = undefined);
+  const session = this.startSession(options);
+
+  const cleanupHandler = (err, result, opts) => {
+    opts = Object.assign({ throw: true }, opts);
+    session.endSession();
+
+    if (typeof callback === 'function') {
+      return err ? callback(err, null) : callback(null, result);
+    } else {
+      if (err) {
+        if (opts.throw) throw err;
+        return Promise.reject(err);
+      }
+      return result;
+    }
+  };
+
+  try {
+    const result = operation(session);
+    const promise = isPromiseLike(result) ? result : Promise.resolve(result);
+
+    return promise
+      .then(result => cleanupHandler(null, result))
+      .catch(err => cleanupHandler(err, null, { throw: true }));
+  } catch (err) {
+    return cleanupHandler(err, null, { throw: false });
+  }
 };
 
 var mergeOptions = function(target, source, flatten) {

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -16,7 +16,6 @@ const shallowClone = require('./utils').shallowClone;
 const authenticate = require('./authenticate');
 const ServerSessionPool = require('mongodb-core').Sessions.ServerSessionPool;
 const executeOperation = require('./utils').executeOperation;
-const isPromiseLike = require('./utils').isPromiseLike;
 
 /**
  * @fileOverview The **MongoClient** class is a class that allows for making Connections to MongoDB.
@@ -519,7 +518,12 @@ MongoClient.prototype.withSession = function(options, operation) {
   if (typeof options === 'function') (operation = options), (options = undefined);
   const session = this.startSession(options);
 
-  const cleanupHandler = (err, result, opts) => {
+  let cleanupHandler = (err, result, opts) => {
+    // prevent multiple calls to cleanupHandler
+    cleanupHandler = () => {
+      throw new ReferenceError('cleanupHandler was called too many times');
+    };
+
     opts = Object.assign({ throw: true }, opts);
     session.endSession();
 

--- a/lib/topologies/topology_base.js
+++ b/lib/topologies/topology_base.js
@@ -397,7 +397,7 @@ class TopologyBase extends EventEmitter {
     // If we have sessions, we want to individually move them to the session pool,
     // and then send a single endSessions call.
     if (this.s.sessions.length) {
-      this.s.sessions.forEach(session => session.endSession({ skipCommand: true }));
+      this.s.sessions.forEach(session => session.endSession());
     }
 
     if (this.s.sessionPool) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -495,6 +495,16 @@ function applyWriteConcern(target, sources, options) {
   return target;
 }
 
+/**
+ * Checks if a given value is a Promise
+ *
+ * @param {*} maybePromise
+ * @return true if the provided value is a Promise
+ */
+function isPromiseLike(maybePromise) {
+  return maybePromise && typeof maybePromise.then === 'function';
+}
+
 exports.filterOptions = filterOptions;
 exports.mergeOptions = mergeOptions;
 exports.translateOptions = translateOptions;
@@ -514,3 +524,4 @@ exports.mergeOptionsAndWriteConcern = mergeOptionsAndWriteConcern;
 exports.translateReadPreference = translateReadPreference;
 exports.executeOperation = executeOperation;
 exports.applyWriteConcern = applyWriteConcern;
+exports.isPromiseLike = isPromiseLike;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "version": "3.1.0-beta1",
+  "version": "3.1.0-beta2",
   "description": "The official MongoDB driver for Node.js",
   "main": "index.js",
   "repository": {
@@ -13,7 +13,7 @@
     "official"
   ],
   "dependencies": {
-    "mongodb-core": "3.1.0-beta1"
+    "mongodb-core": "3.1.0-beta2"
   },
   "devDependencies": {
     "bluebird": "3.5.0",

--- a/test/functional/sessions_tests.js
+++ b/test/functional/sessions_tests.js
@@ -50,7 +50,7 @@ describe('Sessions', function() {
     }
   });
 
-  describe.only('withSession', {
+  describe('withSession', {
     metadata: { requires: { mongodb: '>3.6.0' } },
     test: function() {
       [

--- a/test/functional/sessions_tests.js
+++ b/test/functional/sessions_tests.js
@@ -93,54 +93,6 @@ describe('Sessions', function() {
           operation: (/* client */) => (/* session */) => {
             throw new Error('something went wrong!');
           }
-        },
-        {
-          description: 'should support operations that return promises with a callback',
-          operation: client => session => {
-            return client
-              .db('test')
-              .collection('foo')
-              .find({}, { session })
-              .toArray();
-          },
-          callback: resolve => (err, res) => {
-            expect(err).to.not.exist;
-            expect(res).to.exist;
-            resolve();
-          }
-        },
-        {
-          description: 'should support operations that return rejected promises and a callback',
-          operation: (/* client */) => (/* session */) => {
-            return Promise.reject(new Error('something awful'));
-          },
-          callback: resolve => (err, res) => {
-            expect(err).to.exist;
-            expect(res).to.not.exist;
-            resolve();
-          }
-        },
-        {
-          description: "should support operations that don't return promises with a callback",
-          operation: (/* client */) => (/* session */) => {
-            setTimeout(() => {});
-          },
-          callback: resolve => (err, res) => {
-            expect(err).to.exist;
-            expect(res).to.not.exist;
-            resolve();
-          }
-        },
-        {
-          description: 'should support operations that throw exceptions with a callback',
-          operation: (/* client */) => (/* session */) => {
-            throw new Error('something went wrong!');
-          },
-          callback: resolve => (err, res) => {
-            expect(err).to.exist;
-            expect(res).to.not.exist;
-            resolve();
-          }
         }
       ].forEach(testCase => {
         it(testCase.description, function() {


### PR DESCRIPTION
`withSession` allows users to ignore resource management while
using sessions. A provided method/operation will be provided with
an implicitly created session, which will be cleaned up for them
automatically once the operation is complete.

NODE-1418