### PR TITLE
fix(mongos): bubble up error events after the first one

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -268,9 +268,9 @@ class Mongos extends TopologyBase {
       });
 
       // Set up listeners
-      self.s.coreTopology.once('timeout', errorHandler('timeout'));
-      self.s.coreTopology.once('error', errorHandler('error'));
-      self.s.coreTopology.once('close', errorHandler('close'));
+      self.s.coreTopology.on('timeout', errorHandler('timeout'));
+      self.s.coreTopology.on('error', errorHandler('error'));
+      self.s.coreTopology.on('close', errorHandler('close'));
 
       // Set up serverConfig listeners
       self.s.coreTopology.on('fullsetup', function() {


### PR DESCRIPTION
Re: Automattic/mongoose#6249. Not really sure why this is a `once()` instead of an `on()`, but the current behavior makes it so that subsequent `close` events never make it up to the client, so `db.on('close')` will never get fired if a mongos dies for the 2nd time. I wanted to double check that this wasn't completely off base before I put in the effort to write a test.