### PR TITLE
Removed extraneous parameter from JSDoc

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -440,7 +440,6 @@ MongoClient.prototype.db = function(dbName, options) {
  * Check if MongoClient is connected
  *
  * @method
- * @param {string} name The name of the database we want to use.
  * @param {object} [options=null] Optional settings.
  * @param {boolean} [options.noListener=false] Do not make the db an event listener to the original connection.
  * @param {boolean} [options.returnNonCachedInstance=false] Control if you want to return a cached instance or have a new one created


### PR DESCRIPTION
The `isConnected` method does not take a `name` parameter before `options`, its code is:

```javascript
 MongoClient.prototype.isConnected = function(options) {
   options = options || {};
 
   if (!this.topology) return false;
   return this.topology.isConnected(options);
 };
```

Perhaps this parameter existed once, but was removed at some point without updating the JSDoc.