### PR TITLE
chore(jsdoc): updating version of jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^4.5.0",
     "eslint-plugin-prettier": "^2.2.0",
     "istanbul": "^0.4.5",
-    "jsdoc": "3.5.4",
+    "jsdoc": "3.5.5",
     "mongodb-extjson": "^2.1.1",
     "mongodb-mock-server": "^1.0.0",
     "mongodb-test-runner": "^1.1.18",


### PR DESCRIPTION
Normally would not do this, but 3.5.4 does not lock version of
babylon, leading to the install not having compatible engines