### PR TITLE
fix(mongos): bubble up close events after the first one

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -268,9 +268,9 @@ class Mongos extends TopologyBase {
       });
 
       // Set up listeners
-      self.s.coreTopology.once('timeout', errorHandler('timeout'));
-      self.s.coreTopology.once('error', errorHandler('error'));
-      self.s.coreTopology.once('close', errorHandler('close'));
+      self.s.coreTopology.on('timeout', errorHandler('timeout'));
+      self.s.coreTopology.on('error', errorHandler('error'));
+      self.s.coreTopology.on('close', errorHandler('close'));
 
       // Set up serverConfig listeners
       self.s.coreTopology.on('fullsetup', function() {


### PR DESCRIPTION
Fix Automattic/mongoose#6249

In addition to the changes in #1685, I put together a test that fails when `mongos.js` is unchanged. Should make it clear why this change is necessary.

As far as mongoose is concerned, the 'close' event is what matters, so I'd be open to leaving the 'timeout' and 'error' events as `once()` if that helps address any concerns.