### PR TITLE
fix(change-stream): fix change stream resuming with promises

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -302,8 +302,8 @@ function recreateCursor(self) {
 
   // Attempt to reconfigure piping
   if (self.pipeDestinations) {
-    var cursorStream = self.cursor.stream(self.streamOptions);
-    for (var pipeDestination in self.pipeDestinations) {
+    const cursorStream = self.cursor.stream(self.streamOptions);
+    for (let pipeDestination in self.pipeDestinations) {
       cursorStream.pipe(pipeDestination);
     }
   }

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -296,6 +296,19 @@ ChangeStream.prototype.stream = function(options) {
   return this.cursor.stream(options);
 };
 
+function recreateCursor(self) {
+  // Establish a new cursor
+  self.cursor = createChangeStreamCursor(self);
+
+  // Attempt to reconfigure piping
+  if (self.pipeDestinations) {
+    var cursorStream = self.cursor.stream(self.streamOptions);
+    for (var pipeDestination in self.pipeDestinations) {
+      cursorStream.pipe(pipeDestination);
+    }
+  }
+}
+
 // Handle new change events. This method brings together the routes from the callback, event emitter, and promise ways of using ChangeStream.
 var processNewChange = function(self, err, change, callback) {
   // Handle errors
@@ -303,27 +316,22 @@ var processNewChange = function(self, err, change, callback) {
     // Handle resumable MongoNetworkErrors
     if (isResumableError(err) && !self.attemptingResume) {
       self.attemptingResume = true;
-      return self.cursor.close(function(closeErr) {
-        if (closeErr) {
-          if (callback) return callback(err, null);
-          return self.promiseLibrary.reject(err);
-        }
-
-        // Establish a new cursor
-        self.cursor = createChangeStreamCursor(self);
-
-        // Attempt to reconfigure piping
-        if (self.pipeDestinations) {
-          var cursorStream = self.cursor.stream(self.streamOptions);
-          for (var pipeDestination in self.pipeDestinations) {
-            cursorStream.pipe(pipeDestination);
+      if (callback) {
+        return self.cursor.close(function(closeErr) {
+          if (closeErr) {
+            return callback(err, null);
           }
-        }
 
-        // Attempt the next() operation again
-        if (callback) return self.next(callback);
-        return self.next();
-      });
+          recreateCursor(self);
+
+          return self.next(callback);
+        });
+      }
+
+      return self.cursor
+        .close()
+        .then(() => recreateCursor(self), err => self.promiseLibrary.reject(err))
+        .then(() => self.next());
     }
 
     if (typeof callback === 'function') return callback(err, null);

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -129,6 +129,13 @@ var createChangeStreamCursor = function(self) {
     self.emit('error', error);
   });
 
+  if (self.pipeDestinations) {
+    const cursorStream = changeStreamCursor.stream(self.streamOptions);
+    for (let pipeDestination in self.pipeDestinations) {
+      cursorStream.pipe(pipeDestination);
+    }
+  }
+
   return changeStreamCursor;
 };
 
@@ -296,19 +303,6 @@ ChangeStream.prototype.stream = function(options) {
   return this.cursor.stream(options);
 };
 
-function recreateCursor(self) {
-  // Establish a new cursor
-  self.cursor = createChangeStreamCursor(self);
-
-  // Attempt to reconfigure piping
-  if (self.pipeDestinations) {
-    const cursorStream = self.cursor.stream(self.streamOptions);
-    for (let pipeDestination in self.pipeDestinations) {
-      cursorStream.pipe(pipeDestination);
-    }
-  }
-}
-
 // Handle new change events. This method brings together the routes from the callback, event emitter, and promise ways of using ChangeStream.
 var processNewChange = function(self, err, change, callback) {
   // Handle errors
@@ -322,7 +316,7 @@ var processNewChange = function(self, err, change, callback) {
             return callback(err, null);
           }
 
-          recreateCursor(self);
+          self.cursor = createChangeStreamCursor(self);
 
           return self.next(callback);
         });
@@ -330,7 +324,7 @@ var processNewChange = function(self, err, change, callback) {
 
       return self.cursor
         .close()
-        .then(() => recreateCursor(self), err => self.promiseLibrary.reject(err))
+        .then(() => (self.cursor = createChangeStreamCursor(self)))
         .then(() => self.next());
     }
 


### PR DESCRIPTION
If a change stream resume occurred, and the user was using the
Promise-based version of .next, the promise would resolve before
waiting for the change stream to resume, resulting in bad behavior.

Fixes NODE-1493

There is no test for this, but #1697 will incorporate tests.