### PR TITLE
feat(cursor-forEach): cursor forEach return Promise

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -808,7 +808,7 @@ var _each = function(self, callback) {
  * @param {Cursor~iteratorCallback} iterator The iteration callback.
  * @param {Cursor~endCallback} callback The end callback.
  * @throws {MongoError}
- * @return {null}
+ * @return {Promise} if no callback supplied
  */
 Cursor.prototype.forEach = function(iterator, callback) {
   if (typeof callback === 'function') {
@@ -822,7 +822,7 @@ Cursor.prototype.forEach = function(iterator, callback) {
         return true;
       }
       if (doc == null && callback) {
-        var internalCallback = callback;
+        const internalCallback = callback;
         callback = null;
         internalCallback(null);
         return false;

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -811,22 +811,39 @@ var _each = function(self, callback) {
  * @return {null}
  */
 Cursor.prototype.forEach = function(iterator, callback) {
-  this.each(function(err, doc) {
-    if (err) {
-      callback(err);
-      return false;
-    }
-    if (doc != null) {
-      iterator(doc);
-      return true;
-    }
-    if (doc == null && callback) {
-      var internalCallback = callback;
-      callback = null;
-      internalCallback(null);
-      return false;
-    }
-  });
+  if (typeof callback === 'function') {
+    this.each(function(err, doc) {
+      if (err) {
+        callback(err);
+        return false;
+      }
+      if (doc != null) {
+        iterator(doc);
+        return true;
+      }
+      if (doc == null && callback) {
+        var internalCallback = callback;
+        callback = null;
+        internalCallback(null);
+        return false;
+      }
+    });
+  } else {
+    return new this.s.promiseLibrary((fulfill, reject) => {
+      this.each(function(err, doc) {
+        if (err) {
+          reject(err);
+          return false;
+        } else if (doc == null) {
+          fulfill(null);
+          return false;
+        } else {
+          iterator(doc);
+          return true;
+        }
+      });
+    });
+  }
 };
 
 /**

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4382,4 +4382,18 @@ describe('Cursor', function() {
       }
     }
   );
+
+  it('should return a promise when no callback supplied to forEach method', function(done) {
+    const configuration = this.configuration;
+    const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
+
+    client.connect(function(err, client) {
+      const db = client.db(configuration.db);
+      const collection = db.collection('cursor_session_tests2');
+
+      const cursor = collection.find();
+      expect(cursor.forEach()).to.exist.and.to.be.an.instanceof(cursor.s.promiseLibrary);
+      cursor.close(() => client.close(() => done()));
+    });
+  });
 });


### PR DESCRIPTION
When a callback function is not specified by the user,
the forEach method returns a Promise.

Fixes NODE-1231