### PR TITLE
fix(cursor-hasNext): cursor hasNext returns false when exhausted

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -236,9 +236,11 @@ const hasNext = (self, callback) => {
   if (self.s.currentDoc) {
     return callback(null, true);
   }
+
   if (self.isNotified()) {
     return callback(null, false);
   }
+
   nextObject(self, function(err, doc) {
     if (err) return callback(err, null);
     if (self.s.state === Cursor.CLOSED || self.isDead()) return callback(null, false);

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -236,7 +236,9 @@ const hasNext = (self, callback) => {
   if (self.s.currentDoc) {
     return callback(null, true);
   }
-
+  if (self.isNotified()) {
+    return callback(null, false);
+  }
   nextObject(self, function(err, doc) {
     if (err) return callback(err, null);
     if (self.s.state === Cursor.CLOSED || self.isDead()) return callback(null, false);

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4396,4 +4396,31 @@ describe('Cursor', function() {
       cursor.close(() => client.close(() => done()));
     });
   });
+
+  it('should return false when exhausted and hasNext called more than once', function(done) {
+    const configuration = this.configuration;
+    const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
+
+    client.connect(function(err, client) {
+      const db = client.db(configuration.db);
+
+      db.createCollection('cursor_hasNext_test').then(function() {
+        const cursor = db.collection('cursor_hasNext_test').find();
+
+        cursor
+          .hasNext()
+          .then(function(val1) {
+            expect(val1).to.equal(false);
+            return cursor.hasNext();
+          })
+          .then(function(val2) {
+            expect(val2).to.equal(false);
+            cursor.close(() => client.close(() => done()));
+          })
+          .catch(err => {
+            cursor.close(() => client.close(() => done(err)));
+          });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Instead of throwing an error when the cursor is exhausted, the
hasNext method returns false.

Fixes NODE-1197