### PR TITLE
fix(collection): make `findOne()` report a more readable error if passing options as 3rd param

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1324,6 +1324,9 @@ var save = function(self, doc, options, callback) {
 Collection.prototype.findOne = function(query, options, callback) {
   if (typeof query === 'function') (callback = query), (query = {}), (options = {});
   if (typeof options === 'function') (callback = options), (options = {});
+  if (typeof callback === 'object') {
+    throw new Error('Third parameter to `findOne()` must be a callback or undefined'); 
+  }
   query = query || {};
   options = options || {};
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1325,7 +1325,7 @@ Collection.prototype.findOne = function(query, options, callback) {
   if (typeof query === 'function') (callback = query), (query = {}), (options = {});
   if (typeof options === 'function') (callback = options), (options = {});
   if (typeof callback === 'object') {
-    throw new Error('Third parameter to `findOne()` must be a callback or undefined'); 
+    throw new Error('Third parameter to `findOne()` must be a callback or undefined');
   }
   query = query || {};
   options = options || {};


### PR DESCRIPTION
Small detail that's bitten me a couple times, so I figured I'd bring it up. When passing options to `find()` you need to pass options as the 3rd parameter

```javascript
coll.find({}, null, { session });
```

But with `findOne()`, the 3rd parameter is a callback, not an options object.

```javascript
// Wrong, throws "final argument to `executeOperation` must be a callback"
coll.findOne({}, null, { session });
// Right
coll.findOne({}, { session });
```

As sessions become more important I suspect more people will run into this error.