### PR TITLE
fix(collection): support skipSessions in `findOne()`

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1327,7 +1327,7 @@ Collection.prototype.findOne = function(query, options, callback) {
   query = query || {};
   options = options || {};
 
-  return executeOperation(this.s.topology, findOne, [this, query, options, callback]);
+  return executeOperation(this.s.topology, findOne, [this, query, options, callback], options);
 };
 
 var findOne = function(self, query, options, callback) {


### PR DESCRIPTION
I've been tinkering with transactions in 4.0.0-rc2, came up with the below script:

```javascript
const assert = require('assert');
const { MongoClient } = require('mongodb');

run().catch(error => console.error(error.stack));

async function run() {
  const client = await MongoClient.connect('mongodb://localhost:31000,localhost:31001,localhost:31002/test?replicaSet=rs');

  const coll = client.db('test').collection('test');
  await client.db('test').dropDatabase();
  await client.db('test').createCollection('test', {});

  const session = client.startSession();
  session.startTransaction();

  let doc = await coll.findOne({}, { session });
  assert.ok(!doc);

  doc = { hello: 'world' };
  await coll.insertOne(doc, { session });

  doc = await coll.findOne({}, { session });
  assert.ok(doc);

  await session.abortTransaction();
  session.endSession();

  console.log('Transaction Done');
  doc = await coll.findOne({}, { skipSessions: true });
  assert.ok(!doc);

  console.log('Done');
}
```

Without this PR, I get this strange error in that last `findOne()` because `skipSessions` isn't actually getting to `executeOperation()`:

```
$ node .
Transaction Done
MongoError: Must specify autocommit=false on all operations of a multi-statement transaction.
    at queryCallback (/home/val/Workspace/txn/node_modules/mongodb-core/lib/cursor.js:244:25)
    at /home/val/Workspace/txn/node_modules/mongodb-core/lib/connection/pool.js:544:18
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
^C
$ 
```

With this PR, everything goes through nicely:

```
$ node .
Transaction Done
Done
^C
$ 
```