### PR TITLE
WIP: feat(cursor): new cursor.transformStream method

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Transform = require('stream').Transform;
+const PassThrough = require('stream').PassThrough;
 const inherits = require('util').inherits;
 const f = require('util').format;
 const deprecate = require('util').deprecate;
@@ -1117,6 +1119,30 @@ Cursor.prototype.destroy = function(err) {
 Cursor.prototype.stream = function(options) {
   this.s.streamOptions = options || {};
   return this;
+};
+
+/**
+ * Return a modified Readable stream that applies a given transform function, if supplied. If none supplied,
+ * returns a stream of unmodified docs.
+ * @method
+ * @param {object} [options=null] Optional settings.
+ * @param {function} [options.transform=null] A transformation method applied to each document emitted by the stream.
+ * @return {stream}
+ */
+Cursor.prototype.transformStream = function(options) {
+  let streamOptions = options || {};
+  if (streamOptions.transform != null && typeof streamOptions.transform === 'function') {
+    const stream = new Transform({
+      objectMode: true,
+      transform: function(chunk, encoding, callback) {
+        this.push(options.transform(chunk));
+        callback();
+      }
+    });
+
+    return this.pipe(stream);
+  }
+  return this.pipe(new PassThrough({ objectMode: true }));
 };
 
 /**

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -1116,9 +1116,10 @@ Cursor.prototype.destroy = function(err) {
 /**
  * Return a modified Readable stream including a possible transform method.
  * @method
- * @param {object} [options=null] Optional settings.
- * @param {function} [options.transform=null] A transformation method applied to each document emitted by the stream.
+ * @param {object} [options] Optional settings.
+ * @param {function} [options.transform] A transformation method applied to each document emitted by the stream.
  * @return {Cursor}
+ * TODO: replace this method with transformStream in next major release
  */
 Cursor.prototype.stream = function(options) {
   this.s.streamOptions = options || {};
@@ -1129,17 +1130,17 @@ Cursor.prototype.stream = function(options) {
  * Return a modified Readable stream that applies a given transform function, if supplied. If none supplied,
  * returns a stream of unmodified docs.
  * @method
- * @param {object} [options=null] Optional settings.
- * @param {function} [options.transform=null] A transformation method applied to each document emitted by the stream.
+ * @param {object} [options] Optional settings.
+ * @param {function} [options.transform] A transformation method applied to each document emitted by the stream.
  * @return {stream}
  */
 Cursor.prototype.transformStream = function(options) {
-  let streamOptions = options || {};
-  if (streamOptions.transform != null && typeof streamOptions.transform === 'function') {
+  const streamOptions = options || {};
+  if (typeof streamOptions.transform === 'function') {
     const stream = new Transform({
       objectMode: true,
       transform: function(chunk, encoding, callback) {
-        this.push(options.transform(chunk));
+        this.push(streamOptions.transform(chunk));
         callback();
       }
     });


### PR DESCRIPTION
Created a new method, cursor.transformStream, which
returns a readable stream with the transformation
applied. Does not mutate the cursor.

Fixes NODE-1208