### PR TITLE
docs(parallelCollectionScan): remove session option

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2501,7 +2501,6 @@ Collection.prototype.watch = function(pipeline, options) {
  * @param {number} [options.batchSize=null] Set the batchSize for the getMoreCommand when iterating over the query results.
  * @param {number} [options.numCursors=1] The maximum number of parallel command cursors to return (the number of returned cursors will be in the range 1:numCursors)
  * @param {boolean} [options.raw=false] Return all BSON documents as Raw Buffer documents.
- * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~parallelCollectionScanCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2517,6 +2517,10 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
   // Add a promiseLibrary
   options.promiseLibrary = this.s.promiseLibrary;
 
+  if (options.session) {
+    options.session = undefined;
+  }
+
   return executeOperation(this.s.topology, parallelCollectionScan, [this, options, callback], {
     skipSessions: true
   });


### PR DESCRIPTION
We documented session as being a valid option for
parallelCollectionScan, but it is not a valid option,
and we do not support it.

Fixes NODE-1490