### PR TITLE
docs(cursor): fix documentation for cursor.addQueryModifier

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -448,7 +448,7 @@ Cursor.prototype.addCursorFlag = function(flag, value) {
  * Add a query modifier to the cursor query
  * @method
  * @param {string} name The query modifier (must start with $, such as $orderby etc)
- * @param {boolean} value The flag boolean value.
+ * @param {string|boolean|number} value The modifier value.
  * @throws {MongoError}
  * @return {Cursor}
  */


### PR DESCRIPTION
Corrected the type and description for parameter 'value' in
cursor.addQueryModifier

Fixes NODE-1126