### PR TITLE
docs(GridFS): incorrect end event in GridFS docs

### DIFF
--- a/docs/reference/content/tutorials/gridfs/streaming.md
+++ b/docs/reference/content/tutorials/gridfs/streaming.md
@@ -163,7 +163,7 @@ bucket.openDownloadStreamByName('meistersinger.mp3').
   on('error', function(error) {
     assert.ifError(error);
   }).
-  on('finish', function() {
+  on('end', function() {
     console.log('done!');
     process.exit(0);
   });
@@ -182,7 +182,7 @@ bucket.openDownloadStreamByName('meistersinger.mp3').
   on('error', function(error) {
     assert.ifError(error);
   }).
-  on('finish', function() {
+  on('end', function() {
     console.log('done!');
     process.exit(0);
   });


### PR DESCRIPTION
Corrected the documentation to have users listen for
'end' events (for readable streams) rather than 'finish'
(for writable streams) when using openDownloadStreamByName.

Fixes NODE-1376