### PR TITLE
docs(tutorials-createIndex): Incorrect description for Create Text In…

### DIFF
--- a/docs/reference/content/tutorials/create-indexes.md
+++ b/docs/reference/content/tutorials/create-indexes.md
@@ -92,7 +92,7 @@ MongoDB also provides
 support text search of string content. Text indexes can include any
 field whose value is a string or an array of string elements.
 
-This example specifies a text index key for the ``content`` field:
+This example specifies a text index key for the ``comments`` field:
 
 ```js
 {{% create-text-index %}}


### PR DESCRIPTION
…dex example

Mismatch in field name between the code example and its description.

Fixes NODE-1319