### PR TITLE
docs(cursor): incorrect returnKey documentation

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -86,7 +86,7 @@ var push = Array.prototype.push;
  * collection.find({}).max(10)                                    // Set the cursor max
  * collection.find({}).maxTimeMS(1000)                            // Set the cursor maxTimeMS
  * collection.find({}).min(100)                                   // Set the cursor min
- * collection.find({}).returnKey(10)                              // Set the cursor returnKey
+ * collection.find({}).returnKey(true)                            // Set the cursor returnKey
  * collection.find({}).setReadPreference(ReadPreference.PRIMARY)  // Set the cursor readPreference
  * collection.find({}).showRecordId(true)                         // Set the cursor showRecordId
  * collection.find({}).sort([['a', 1]])                           // Sets the sort order of the cursor query
@@ -350,9 +350,9 @@ Cursor.prototype.max = function(max) {
 };
 
 /**
- * Set the cursor returnKey
+ * Set the cursor returnKey. If set to true, modifies the cursor to only return the index field or fields for the results of the query, rather than documents. If set to true and the query does not use an index to perform the read operation, the returned documents will not contain any fields.
  * @method
- * @param {object} returnKey Only return the index field or fields for the results of the query. If $returnKey is set to true and the query does not use an index to perform the read operation, the returned documents will not contain any fields. Use one of the following forms:
+ * @param {bool} returnKey the returnKey value.
  * @return {Cursor}
  */
 Cursor.prototype.returnKey = function(value) {


### PR DESCRIPTION
It was unclear what type the 'returnKey' parameter
for cursor.returnKey should be and what it meant.

Fixes NODE-1182