### PR TITLE
docs(collection): Add arrayFilters option for methods

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2094,6 +2094,7 @@ var findOneAndReplace = function(self, filter, replacement, options, callback) {
  * @param {boolean} [options.upsert=false] Upsert the document if it does not exist.
  * @param {boolean} [options.returnOriginal=true] When false, returns the updated document rather than the original. The default is true.
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {Array} [options.arrayFilters=null] optional list of array filters referenced in filtered positional operators
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
  * @return {Promise} returns Promise if no callback passed
  */
@@ -2151,6 +2152,7 @@ var findOneAndUpdate = function(self, filter, update, options, callback) {
  * @param {object} [options.projection=null] Object containing the field projection for the result returned from the operation.
  * @param {object} [options.fields=null] **Deprecated** Use `options.projection` instead
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {Array} [options.arrayFilters=null] optional list of array filters referenced in filtered positional operators
  * @param {Collection~findAndModifyCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  * @deprecated use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2087,14 +2087,14 @@ var findOneAndReplace = function(self, filter, replacement, options, callback) {
  * @method
  * @param {object} filter Document selection filter.
  * @param {object} update Update operations to be performed on the document
- * @param {object} [options=null] Optional settings.
- * @param {object} [options.projection=null] Limits the fields to return for all matching documents.
- * @param {object} [options.sort=null] Determines which document the operation modifies if the query selects multiple documents.
- * @param {number} [options.maxTimeMS=null] The maximum amount of time to allow the query to run.
+ * @param {object} [options] Optional settings.
+ * @param {object} [options.projection] Limits the fields to return for all matching documents.
+ * @param {object} [options.sort] Determines which document the operation modifies if the query selects multiple documents.
+ * @param {number} [options.maxTimeMS] The maximum amount of time to allow the query to run.
  * @param {boolean} [options.upsert=false] Upsert the document if it does not exist.
  * @param {boolean} [options.returnOriginal=true] When false, returns the updated document rather than the original. The default is true.
  * @param {ClientSession} [options.session] optional session to use for this operation
- * @param {Array} [options.arrayFilters=null] optional list of array filters referenced in filtered positional operators
+ * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
  * @return {Promise} returns Promise if no callback passed
  */
@@ -2142,17 +2142,17 @@ var findOneAndUpdate = function(self, filter, update, options, callback) {
  * @param {object} query Query object to locate the object to modify.
  * @param {array} sort If multiple docs match, choose the first one in the specified sort order as the object to manipulate.
  * @param {object} doc The fields/vals to be updated.
- * @param {object} [options=null] Optional settings.
- * @param {(number|string)} [options.w=null] The write concern.
- * @param {number} [options.wtimeout=null] The write concern timeout.
+ * @param {object} [options] Optional settings.
+ * @param {(number|string)} [options.w] The write concern.
+ * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
  * @param {boolean} [options.remove=false] Set to true to remove the object before returning.
  * @param {boolean} [options.upsert=false] Perform an upsert operation.
  * @param {boolean} [options.new=false] Set to true if you want to return the modified object rather than the original. Ignored for remove.
- * @param {object} [options.projection=null] Object containing the field projection for the result returned from the operation.
- * @param {object} [options.fields=null] **Deprecated** Use `options.projection` instead
+ * @param {object} [options.projection] Object containing the field projection for the result returned from the operation.
+ * @param {object} [options.fields] **Deprecated** Use `options.projection` instead
  * @param {ClientSession} [options.session] optional session to use for this operation
- * @param {Array} [options.arrayFilters=null] optional list of array filters referenced in filtered positional operators
+ * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {Collection~findAndModifyCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  * @deprecated use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead


### PR DESCRIPTION
findAndModify and findOneAndUpdate were missing
documentation for the optional options.arrayFilters
parameter.

Fixes NODE-1422