### PR TITLE
fix(collection): only send bypassDocumentValidation if true

### DIFF
--- a/lib/apm.js
+++ b/lib/apm.js
@@ -9,7 +9,7 @@ class Instrumentation extends EventEmitter {
   instrument(MongoClient, callback) {
     // store a reference to the original functions
     this.$MongoClient = MongoClient;
-    const $prototypeConnect = this.$prototypeConnect = MongoClient.prototype.connect; // eslint-disable-line
+    const $prototypeConnect = (this.$prototypeConnect = MongoClient.prototype.connect); // eslint-disable-line
 
     const instrumentation = this;
     MongoClient.prototype.connect = function(callback) {

--- a/lib/apm.js
+++ b/lib/apm.js
@@ -9,7 +9,7 @@ class Instrumentation extends EventEmitter {
   instrument(MongoClient, callback) {
     // store a reference to the original functions
     this.$MongoClient = MongoClient;
-    const $prototypeConnect = (this.$prototypeConnect = MongoClient.prototype.connect); // eslint-disable-line
+    const $prototypeConnect = (this.$prototypeConnect = MongoClient.prototype.connect);
 
     const instrumentation = this;
     MongoClient.prototype.connect = function(callback) {

--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -300,14 +300,13 @@ function OrderedBulkOperation(topology, collection, options) {
     promiseLibrary: promiseLibrary,
     // Fundamental error
     err: null,
-    // Bypass validation
-    bypassDocumentValidation:
-      typeof options.bypassDocumentValidation === 'boolean'
-        ? options.bypassDocumentValidation
-        : false,
     // check keys
     checkKeys: typeof options.checkKeys === 'boolean' ? options.checkKeys : true
   };
+  // bypass Validation
+  if (options.bypassDocumentValidation === true) {
+    this.s.bypassDocumentValidation = true;
+  }
 }
 
 OrderedBulkOperation.prototype.raw = function(op) {
@@ -488,6 +487,10 @@ var executeCommands = function(self, options, callback) {
   var finalOptions = Object.assign({ ordered: true }, options);
   if (self.s.writeConcern != null) {
     finalOptions.writeConcern = self.s.writeConcern;
+  }
+
+  if (finalOptions.bypassDocumentValidation !== true) {
+    delete finalOptions.bypassDocumentValidation;
   }
 
   // Set an operationIf if provided

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -161,6 +161,8 @@ FindOperatorsUnordered.prototype.remove = function() {
 // Add to the operations list
 //
 var addToOperationsList = function(_self, docType, document) {
+  console.log('here is document: ');
+  console.log(document);
   // Get the bsonSize
   var bsonSize = bson.calculateObjectSize(document, {
     checkKeys: false
@@ -309,14 +311,13 @@ var UnorderedBulkOperation = function(topology, collection, options) {
     collection: collection,
     // Promise Library
     promiseLibrary: promiseLibrary,
-    // Bypass validation
-    bypassDocumentValidation:
-      typeof options.bypassDocumentValidation === 'boolean'
-        ? options.bypassDocumentValidation
-        : false,
     // check keys
     checkKeys: typeof options.checkKeys === 'boolean' ? options.checkKeys : true
   };
+  // bypass Validation
+  if (options.bypassDocumentValidation === true) {
+    this.s.bypassDocumentValidation = true;
+  }
 };
 
 /**
@@ -438,6 +439,10 @@ var executeBatch = function(self, batch, options, callback) {
   var finalOptions = Object.assign({ ordered: false }, options);
   if (self.s.writeConcern != null) {
     finalOptions.writeConcern = self.s.writeConcern;
+  }
+
+  if (finalOptions.bypassDocumentValidation !== true) {
+    delete finalOptions.bypassDocumentValidation;
   }
 
   var resultHandler = function(err, result) {

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -161,8 +161,6 @@ FindOperatorsUnordered.prototype.remove = function() {
 // Add to the operations list
 //
 var addToOperationsList = function(_self, docType, document) {
-  console.log('here is document: ');
-  console.log(document);
   // Get the bsonSize
   var bsonSize = bson.calculateObjectSize(document, {
     checkKeys: false

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -581,7 +581,6 @@ var bulkWrite = function(self, operations, options, callback) {
     options.ordered === true || options.ordered == null
       ? self.initializeOrderedBulkOp(options)
       : self.initializeUnorderedBulkOp(options);
-
   // Do we have a collation
   var collation = false;
 
@@ -2225,12 +2224,13 @@ var findAndModify = function(self, query, sort, doc, options, callback) {
   var finalOptions = applyWriteConcern(options, { db: self.s.db, collection: self }, options);
 
   // Decorate the findAndModify command with the write Concern
+
   if (finalOptions.writeConcern) {
     queryObject.writeConcern = finalOptions.writeConcern;
   }
 
   // Have we specified bypassDocumentValidation
-  if (typeof finalOptions.bypassDocumentValidation === 'boolean') {
+  if (finalOptions.bypassDocumentValidation === true) {
     queryObject.bypassDocumentValidation = finalOptions.bypassDocumentValidation;
   }
 
@@ -2397,7 +2397,7 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
   decorateWithCollation(command, self, options);
 
   // If we have bypassDocumentValidation set
-  if (typeof options.bypassDocumentValidation === 'boolean') {
+  if (options.bypassDocumentValidation === true) {
     command.bypassDocumentValidation = options.bypassDocumentValidation;
   }
 
@@ -2867,7 +2867,7 @@ var mapReduce = function(self, map, reduce, options, callback) {
   };
 
   // Exclusion list
-  var exclusionList = ['readPreference', 'session'];
+  var exclusionList = ['readPreference', 'session', 'bypassDocumentValidation'];
 
   // Add any other options passed in
   for (var n in options) {
@@ -2902,7 +2902,7 @@ var mapReduce = function(self, map, reduce, options, callback) {
   }
 
   // Is bypassDocumentValidation specified
-  if (typeof options.bypassDocumentValidation === 'boolean') {
+  if (options.bypassDocumentValidation === true) {
     mapCommandHash.bypassDocumentValidation = options.bypassDocumentValidation;
   }
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -581,6 +581,7 @@ var bulkWrite = function(self, operations, options, callback) {
     options.ordered === true || options.ordered == null
       ? self.initializeOrderedBulkOp(options)
       : self.initializeUnorderedBulkOp(options);
+
   // Do we have a collation
   var collation = false;
 
@@ -2224,7 +2225,6 @@ var findAndModify = function(self, query, sort, doc, options, callback) {
   var finalOptions = applyWriteConcern(options, { db: self.s.db, collection: self }, options);
 
   // Decorate the findAndModify command with the write Concern
-
   if (finalOptions.writeConcern) {
     queryObject.writeConcern = finalOptions.writeConcern;
   }

--- a/test/unit/bypass_validation_tests.js
+++ b/test/unit/bypass_validation_tests.js
@@ -13,8 +13,8 @@ describe('bypass document validation', function() {
   });
   afterEach(() => mock.cleanup());
 
-  // aggregate
-  it('should only set bypass document validation if strictly true in aggregate', function(done) {
+  // general test for aggregate function
+  function testAggregate(bypassDocumentValidation, done) {
     const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
@@ -25,7 +25,7 @@ describe('bypass document validation', function() {
       var doc = request.document;
       if (doc.aggregate) {
         try {
-          expect(doc.bypassDocumentValidation).equal(true);
+          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation || undefined);
           request.reply({
             ok: 1,
             cursor: {
@@ -52,7 +52,7 @@ describe('bypass document validation', function() {
       var collection = db.collection('test_c');
 
       var options = {
-        bypassDocumentValidation: true
+        bypassDocumentValidation: bypassDocumentValidation
       };
 
       var pipeline = [
@@ -62,60 +62,18 @@ describe('bypass document validation', function() {
       ];
       collection.aggregate(pipeline, options).next(() => close());
     });
+  }
+  // aggregate
+  it('should only set bypass document validation if strictly true in aggregate', function(done) {
+    testAggregate(true, done);
   });
 
   it('should not set bypass document validation if not strictly true in aggregate', function(done) {
-    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
-    let close = e => {
-      close = () => {};
-      client.close(() => done(e));
-    };
-
-    test.server.setMessageHandler(request => {
-      var doc = request.document;
-      if (doc.aggregate) {
-        try {
-          expect(doc.bypassDocumentValidation).equal(undefined);
-          request.reply({
-            ok: 1,
-            cursor: {
-              firstBatch: [{}],
-              id: 23,
-              ns: 'test.test'
-            }
-          });
-        } catch (e) {
-          close(e);
-        }
-      }
-      if (doc.ismaster) {
-        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
-      } else if (doc.endSessions) {
-        request.reply({ ok: 1 });
-      }
-    });
-
-    client.connect(function(err, client) {
-      expect(err).to.not.exist;
-      var db = client.db('test');
-      var collection = db.collection('test_c');
-
-      var options = {
-        bypassDocumentValidation: false
-      };
-
-      var pipeline = [
-        {
-          $project: {}
-        }
-      ];
-
-      collection.aggregate(pipeline, options).next(() => close());
-    });
+    testAggregate(false, done);
   });
 
-  // map reduce
-  it('should only set bypass document validation if strictly true in mapReduce', function(done) {
+  // general test for mapReduce function
+  function testMapReduce(bypassDocumentValidation, done) {
     const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
@@ -126,7 +84,7 @@ describe('bypass document validation', function() {
       var doc = request.document;
       if (doc.mapreduce) {
         try {
-          expect(doc.bypassDocumentValidation).equal(true);
+          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation || undefined);
           request.reply({
             results: 't',
             ok: 1
@@ -150,61 +108,25 @@ describe('bypass document validation', function() {
 
       var options = {
         out: 'test_c',
-        bypassDocumentValidation: true
+        bypassDocumentValidation: bypassDocumentValidation
       };
 
       collection.mapReduce(function map() {}, function reduce() {}, options, e => {
         close(e);
       });
     });
+  }
+  // map reduce
+  it('should only set bypass document validation if strictly true in mapReduce', function(done) {
+    testMapReduce(true, done);
   });
 
   it('should not set bypass document validation if not strictly true in mapReduce', function(done) {
-    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
-    let close = e => {
-      close = () => {};
-      client.close(() => done(e));
-    };
-
-    test.server.setMessageHandler(request => {
-      var doc = request.document;
-      if (doc.mapreduce) {
-        try {
-          expect(doc.bypassDocumentValidation).equal(undefined);
-          request.reply({
-            results: 't',
-            ok: 1
-          });
-        } catch (e) {
-          close(e);
-        }
-      }
-
-      if (doc.ismaster) {
-        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
-      } else if (doc.endSessions) {
-        request.reply({ ok: 1 });
-      }
-    });
-
-    client.connect(function(err, client) {
-      expect(err).to.not.exist;
-      var db = client.db('test_2');
-      var collection = db.collection('test_c2');
-
-      var options = {
-        out: 'test_c2',
-        bypassDocumentValidation: false
-      };
-
-      collection.mapReduce(function map() {}, function reduce() {}, options, e => {
-        close(e);
-      });
-    });
+    testMapReduce(false, done);
   });
 
-  // find and modify
-  it('should only set bypass document validation if strictly true in findAndModify', function(done) {
+  // general test for findAndModify function
+  function testFindAndModify(bypassDocumentValidation, done) {
     const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
@@ -215,7 +137,7 @@ describe('bypass document validation', function() {
       var doc = request.document;
       if (doc.findAndModify) {
         try {
-          expect(doc.bypassDocumentValidation).equal(true);
+          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation || undefined);
           request.reply({
             ok: 1
           });
@@ -237,7 +159,7 @@ describe('bypass document validation', function() {
       var collection = db.collection('test_c');
 
       var options = {
-        bypassDocumentValidation: true
+        bypassDocumentValidation: bypassDocumentValidation
       };
 
       collection.findAndModify(
@@ -250,58 +172,18 @@ describe('bypass document validation', function() {
         }
       );
     });
+  }
+  // find and modify
+  it('should only set bypass document validation if strictly true in findAndModify', function(done) {
+    testFindAndModify(true, done);
   });
 
   it('should not set bypass document validation if not strictly true in findAndModify', function(done) {
-    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
-    let close = e => {
-      close = () => {};
-      client.close(() => done(e));
-    };
-
-    test.server.setMessageHandler(request => {
-      var doc = request.document;
-      if (doc.findAndModify) {
-        try {
-          expect(doc.bypassDocumentValidation).equal(undefined);
-          request.reply({
-            ok: 1
-          });
-        } catch (e) {
-          close(e);
-        }
-      }
-
-      if (doc.ismaster) {
-        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
-      } else if (doc.endSessions) {
-        request.reply({ ok: 1 });
-      }
-    });
-
-    client.connect(function(err, client) {
-      expect(err).to.not.exist;
-      var db = client.db('test');
-      var collection = db.collection('test_c');
-
-      var options = {
-        bypassDocumentValidation: false
-      };
-
-      collection.findAndModify(
-        { name: 'Andy' },
-        { rating: 1 },
-        { $inc: { score: 1 } },
-        options,
-        e => {
-          close(e);
-        }
-      );
-    });
+    testFindAndModify(false, done);
   });
 
-  // ordered bulk write, testing change in ordered.js
-  it('should only set bypass document validation if strictly true in ordered bulkWrite', function(done) {
+  // general test for BlukWrite to test changes made in ordered.js and unordered.js
+  function testBulkWrite(bypassDocumentValidation, ordered, done) {
     const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
@@ -312,7 +194,7 @@ describe('bypass document validation', function() {
       var doc = request.document;
       if (doc.insert) {
         try {
-          expect(doc.bypassDocumentValidation).equal(true);
+          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation || undefined);
           request.reply({
             ok: 1
           });
@@ -334,136 +216,28 @@ describe('bypass document validation', function() {
       var collection = db.collection('test_c');
 
       var options = {
-        bypassDocumentValidation: true,
-        ordered: true
+        bypassDocumentValidation: bypassDocumentValidation,
+        ordered: ordered
       };
 
       collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], options, () => close());
     });
+  }
+  // ordered bulk write, testing change in ordered.js
+  it('should only set bypass document validation if strictly true in ordered bulkWrite', function(done) {
+    testBulkWrite(true, true, done);
   });
 
   it('should not set bypass document validation if not strictly true in ordered bulkWrite', function(done) {
-    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
-    let close = e => {
-      close = () => {};
-      client.close(() => done(e));
-    };
-
-    test.server.setMessageHandler(request => {
-      var doc = request.document;
-
-      if (doc.insert) {
-        try {
-          expect(doc.bypassDocumentValidation).equal(undefined);
-          request.reply({
-            ok: 1
-          });
-        } catch (e) {
-          close(e);
-        }
-      }
-
-      if (doc.ismaster) {
-        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
-      } else if (doc.endSessions) {
-        request.reply({ ok: 1 });
-      }
-    });
-
-    client.connect(function(err, client) {
-      expect(err).to.not.exist;
-      var db = client.db('test');
-      var collection = db.collection('test_c');
-
-      var options = {
-        bypassDocumentValidation: false,
-        ordered: true
-      };
-
-      collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], options, () => close());
-    });
+    testBulkWrite(false, true, done);
   });
 
   // unordered bulk write, testing change in ordered.js
   it('should only set bypass document validation if strictly true in unordered bulkWrite', function(done) {
-    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
-    let close = e => {
-      close = () => {};
-      client.close(() => done(e));
-    };
-
-    test.server.setMessageHandler(request => {
-      var doc = request.document;
-      if (doc.insert) {
-        try {
-          expect(doc.bypassDocumentValidation).equal(true);
-          request.reply({
-            ok: 1
-          });
-        } catch (e) {
-          close(e);
-        }
-      }
-
-      if (doc.ismaster) {
-        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
-      } else if (doc.endSessions) {
-        request.reply({ ok: 1 });
-      }
-    });
-
-    client.connect(function(err, client) {
-      expect(err).to.not.exist;
-      var db = client.db('test');
-      var collection = db.collection('test_c');
-
-      var options = {
-        bypassDocumentValidation: true,
-        ordered: false
-      };
-
-      collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], options, () => close());
-    });
+    testBulkWrite(true, false, done);
   });
 
   it('should not set bypass document validation if not strictly true in unordered bulkWrite', function(done) {
-    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
-    let close = e => {
-      close = () => {};
-      client.close(() => done(e));
-    };
-
-    test.server.setMessageHandler(request => {
-      var doc = request.document;
-      if (doc.insert) {
-        try {
-          expect(doc.bypassDocumentValidation).equal(undefined);
-          request.reply({
-            ok: 1
-          });
-        } catch (e) {
-          close(e);
-        }
-      }
-
-      if (doc.ismaster) {
-        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
-      } else if (doc.endSessions) {
-        request.reply({ ok: 1 });
-      }
-    });
-
-    client.connect(function(err, client) {
-      expect(err).to.not.exist;
-      var db = client.db('test');
-      var collection = db.collection('test_c');
-
-      var options = {
-        bypassDocumentValidation: false,
-        ordered: false
-      };
-
-      collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], options, () => close());
-    });
+    testBulkWrite(false, false, done);
   });
 });

--- a/test/unit/bypass_validation_tests.js
+++ b/test/unit/bypass_validation_tests.js
@@ -1,0 +1,469 @@
+'use strict';
+
+const MongoClient = require('../..').MongoClient;
+const expect = require('chai').expect;
+const mock = require('mongodb-mock-server');
+
+describe('bypass document validation', function() {
+  const test = {};
+  beforeEach(() => {
+    return mock.createServer().then(server => {
+      test.server = server;
+    });
+  });
+  afterEach(() => mock.cleanup());
+
+  // aggregate
+  it('should only set bypass document validation if strictly true in aggregate', function(done) {
+    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+    let close = e => {
+      close = () => {};
+      client.close(() => done(e));
+    };
+
+    test.server.setMessageHandler(request => {
+      var doc = request.document;
+      if (doc.aggregate) {
+        try {
+          expect(doc.bypassDocumentValidation).equal(true);
+          request.reply({
+            ok: 1,
+            cursor: {
+              firstBatch: [{}],
+              id: 23,
+              ns: 'test.test'
+            }
+          });
+        } catch (e) {
+          close(e);
+        }
+      }
+
+      if (doc.ismaster) {
+        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+
+    client.connect(function(err, client) {
+      expect(err).to.not.exist;
+      var db = client.db('test');
+      var collection = db.collection('test_c');
+
+      var options = {
+        bypassDocumentValidation: true
+      };
+
+      var pipeline = [
+        {
+          $project: {}
+        }
+      ];
+      collection.aggregate(pipeline, options).next(() => close());
+    });
+  });
+
+  it('should not set bypass document validation if not strictly true in aggregate', function(done) {
+    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+    let close = e => {
+      close = () => {};
+      client.close(() => done(e));
+    };
+
+    test.server.setMessageHandler(request => {
+      var doc = request.document;
+      if (doc.aggregate) {
+        try {
+          expect(doc.bypassDocumentValidation).equal(undefined);
+          request.reply({
+            ok: 1,
+            cursor: {
+              firstBatch: [{}],
+              id: 23,
+              ns: 'test.test'
+            }
+          });
+        } catch (e) {
+          close(e);
+        }
+      }
+      if (doc.ismaster) {
+        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+
+    client.connect(function(err, client) {
+      expect(err).to.not.exist;
+      var db = client.db('test');
+      var collection = db.collection('test_c');
+
+      var options = {
+        bypassDocumentValidation: false
+      };
+
+      var pipeline = [
+        {
+          $project: {}
+        }
+      ];
+
+      collection.aggregate(pipeline, options).next(() => close());
+    });
+  });
+
+  // map reduce
+  it('should only set bypass document validation if strictly true in mapReduce', function(done) {
+    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+    let close = e => {
+      close = () => {};
+      client.close(() => done(e));
+    };
+
+    test.server.setMessageHandler(request => {
+      var doc = request.document;
+      if (doc.mapreduce) {
+        try {
+          expect(doc.bypassDocumentValidation).equal(true);
+          request.reply({
+            results: 't',
+            ok: 1
+          });
+        } catch (e) {
+          close(e);
+        }
+      }
+
+      if (doc.ismaster) {
+        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+
+    client.connect(function(err, client) {
+      expect(err).to.not.exist;
+      var db = client.db('test');
+      var collection = db.collection('test_c');
+
+      var options = {
+        out: 'test_c',
+        bypassDocumentValidation: true
+      };
+
+      collection.mapReduce(function map() {}, function reduce() {}, options, e => {
+        close(e);
+      });
+    });
+  });
+
+  it('should not set bypass document validation if not strictly true in mapReduce', function(done) {
+    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+    let close = e => {
+      close = () => {};
+      client.close(() => done(e));
+    };
+
+    test.server.setMessageHandler(request => {
+      var doc = request.document;
+      if (doc.mapreduce) {
+        try {
+          expect(doc.bypassDocumentValidation).equal(undefined);
+          request.reply({
+            results: 't',
+            ok: 1
+          });
+        } catch (e) {
+          close(e);
+        }
+      }
+
+      if (doc.ismaster) {
+        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+
+    client.connect(function(err, client) {
+      expect(err).to.not.exist;
+      var db = client.db('test_2');
+      var collection = db.collection('test_c2');
+
+      var options = {
+        out: 'test_c2',
+        bypassDocumentValidation: false
+      };
+
+      collection.mapReduce(function map() {}, function reduce() {}, options, e => {
+        close(e);
+      });
+    });
+  });
+
+  // find and modify
+  it('should only set bypass document validation if strictly true in findAndModify', function(done) {
+    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+    let close = e => {
+      close = () => {};
+      client.close(() => done(e));
+    };
+
+    test.server.setMessageHandler(request => {
+      var doc = request.document;
+      if (doc.findAndModify) {
+        try {
+          expect(doc.bypassDocumentValidation).equal(true);
+          request.reply({
+            ok: 1
+          });
+        } catch (e) {
+          close(e);
+        }
+      }
+
+      if (doc.ismaster) {
+        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+
+    client.connect(function(err, client) {
+      expect(err).to.not.exist;
+      var db = client.db('test');
+      var collection = db.collection('test_c');
+
+      var options = {
+        bypassDocumentValidation: true
+      };
+
+      collection.findAndModify(
+        { name: 'Andy' },
+        { rating: 1 },
+        { $inc: { score: 1 } },
+        options,
+        e => {
+          close(e);
+        }
+      );
+    });
+  });
+
+  it('should not set bypass document validation if not strictly true in findAndModify', function(done) {
+    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+    let close = e => {
+      close = () => {};
+      client.close(() => done(e));
+    };
+
+    test.server.setMessageHandler(request => {
+      var doc = request.document;
+      if (doc.findAndModify) {
+        try {
+          expect(doc.bypassDocumentValidation).equal(undefined);
+          request.reply({
+            ok: 1
+          });
+        } catch (e) {
+          close(e);
+        }
+      }
+
+      if (doc.ismaster) {
+        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+
+    client.connect(function(err, client) {
+      expect(err).to.not.exist;
+      var db = client.db('test');
+      var collection = db.collection('test_c');
+
+      var options = {
+        bypassDocumentValidation: false
+      };
+
+      collection.findAndModify(
+        { name: 'Andy' },
+        { rating: 1 },
+        { $inc: { score: 1 } },
+        options,
+        e => {
+          close(e);
+        }
+      );
+    });
+  });
+
+  // ordered bulk write, testing change in ordered.js
+  it('should only set bypass document validation if strictly true in ordered bulkWrite', function(done) {
+    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+    let close = e => {
+      close = () => {};
+      client.close(() => done(e));
+    };
+
+    test.server.setMessageHandler(request => {
+      var doc = request.document;
+      if (doc.insert) {
+        try {
+          expect(doc.bypassDocumentValidation).equal(true);
+          request.reply({
+            ok: 1
+          });
+        } catch (e) {
+          close(e);
+        }
+      }
+
+      if (doc.ismaster) {
+        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+
+    client.connect(function(err, client) {
+      expect(err).to.not.exist;
+      var db = client.db('test');
+      var collection = db.collection('test_c');
+
+      var options = {
+        bypassDocumentValidation: true,
+        ordered: true
+      };
+
+      collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], options, () => close());
+    });
+  });
+
+  it('should not set bypass document validation if not strictly true in ordered bulkWrite', function(done) {
+    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+    let close = e => {
+      close = () => {};
+      client.close(() => done(e));
+    };
+
+    test.server.setMessageHandler(request => {
+      var doc = request.document;
+
+      if (doc.insert) {
+        try {
+          expect(doc.bypassDocumentValidation).equal(undefined);
+          request.reply({
+            ok: 1
+          });
+        } catch (e) {
+          close(e);
+        }
+      }
+
+      if (doc.ismaster) {
+        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+
+    client.connect(function(err, client) {
+      expect(err).to.not.exist;
+      var db = client.db('test');
+      var collection = db.collection('test_c');
+
+      var options = {
+        bypassDocumentValidation: false,
+        ordered: true
+      };
+
+      collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], options, () => close());
+    });
+  });
+
+  // unordered bulk write, testing change in ordered.js
+  it('should only set bypass document validation if strictly true in unordered bulkWrite', function(done) {
+    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+    let close = e => {
+      close = () => {};
+      client.close(() => done(e));
+    };
+
+    test.server.setMessageHandler(request => {
+      var doc = request.document;
+      if (doc.insert) {
+        try {
+          expect(doc.bypassDocumentValidation).equal(true);
+          request.reply({
+            ok: 1
+          });
+        } catch (e) {
+          close(e);
+        }
+      }
+
+      if (doc.ismaster) {
+        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+
+    client.connect(function(err, client) {
+      expect(err).to.not.exist;
+      var db = client.db('test');
+      var collection = db.collection('test_c');
+
+      var options = {
+        bypassDocumentValidation: true,
+        ordered: false
+      };
+
+      collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], options, () => close());
+    });
+  });
+
+  it('should not set bypass document validation if not strictly true in unordered bulkWrite', function(done) {
+    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+    let close = e => {
+      close = () => {};
+      client.close(() => done(e));
+    };
+
+    test.server.setMessageHandler(request => {
+      var doc = request.document;
+      if (doc.insert) {
+        try {
+          expect(doc.bypassDocumentValidation).equal(undefined);
+          request.reply({
+            ok: 1
+          });
+        } catch (e) {
+          close(e);
+        }
+      }
+
+      if (doc.ismaster) {
+        request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+
+    client.connect(function(err, client) {
+      expect(err).to.not.exist;
+      var db = client.db('test');
+      var collection = db.collection('test_c');
+
+      var options = {
+        bypassDocumentValidation: false,
+        ordered: false
+      };
+
+      collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], options, () => close());
+    });
+  });
+});

--- a/test/unit/bypass_validation_tests.js
+++ b/test/unit/bypass_validation_tests.js
@@ -14,7 +14,7 @@ describe('bypass document validation', function() {
   afterEach(() => mock.cleanup());
 
   // general test for aggregate function
-  function testAggregate(bypassDocumentValidation, done) {
+  function testAggregate(config, done) {
     const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
@@ -25,7 +25,7 @@ describe('bypass document validation', function() {
       const doc = request.document;
       if (doc.aggregate) {
         try {
-          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation.expected);
+          expect(doc.bypassDocumentValidation).equal(config.expected);
           request.reply({
             ok: 1,
             cursor: {
@@ -51,7 +51,7 @@ describe('bypass document validation', function() {
       const db = client.db('test');
       const collection = db.collection('test_c');
 
-      const options = { bypassDocumentValidation: bypassDocumentValidation.actual };
+      const options = { bypassDocumentValidation: config.actual };
 
       const pipeline = [
         {
@@ -71,7 +71,7 @@ describe('bypass document validation', function() {
   });
 
   // general test for mapReduce function
-  function testMapReduce(bypassDocumentValidation, done) {
+  function testMapReduce(config, done) {
     const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
@@ -82,7 +82,7 @@ describe('bypass document validation', function() {
       const doc = request.document;
       if (doc.mapreduce) {
         try {
-          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation.expected);
+          expect(doc.bypassDocumentValidation).equal(config.expected);
           request.reply({
             results: 't',
             ok: 1
@@ -106,7 +106,7 @@ describe('bypass document validation', function() {
 
       const options = {
         out: 'test_c',
-        bypassDocumentValidation: bypassDocumentValidation.actual
+        bypassDocumentValidation: config.actual
       };
 
       collection.mapReduce(function map() {}, function reduce() {}, options, e => {
@@ -124,7 +124,7 @@ describe('bypass document validation', function() {
   });
 
   // general test for findAndModify function
-  function testFindAndModify(bypassDocumentValidation, done) {
+  function testFindAndModify(config, done) {
     const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
@@ -135,7 +135,7 @@ describe('bypass document validation', function() {
       const doc = request.document;
       if (doc.findAndModify) {
         try {
-          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation.expected);
+          expect(doc.bypassDocumentValidation).equal(config.expected);
           request.reply({
             ok: 1
           });
@@ -156,7 +156,7 @@ describe('bypass document validation', function() {
       const db = client.db('test');
       const collection = db.collection('test_c');
 
-      const options = { bypassDocumentValidation: bypassDocumentValidation.actual };
+      const options = { bypassDocumentValidation: config.actual };
 
       collection.findAndModify(
         { name: 'Andy' },
@@ -179,7 +179,7 @@ describe('bypass document validation', function() {
   });
 
   // general test for BlukWrite to test changes made in ordered.js and unordered.js
-  function testBulkWrite(bypassDocumentValidation, done) {
+  function testBulkWrite(config, done) {
     const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
@@ -190,7 +190,7 @@ describe('bypass document validation', function() {
       const doc = request.document;
       if (doc.insert) {
         try {
-          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation.expected);
+          expect(doc.bypassDocumentValidation).equal(config.expected);
           request.reply({
             ok: 1
           });
@@ -212,8 +212,8 @@ describe('bypass document validation', function() {
       const collection = db.collection('test_c');
 
       const options = {
-        bypassDocumentValidation: bypassDocumentValidation.actual,
-        ordered: bypassDocumentValidation.ordered
+        bypassDocumentValidation: config.actual,
+        ordered: config.ordered
       };
 
       collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], options, () => close());

--- a/test/unit/bypass_validation_tests.js
+++ b/test/unit/bypass_validation_tests.js
@@ -22,10 +22,10 @@ describe('bypass document validation', function() {
     };
 
     test.server.setMessageHandler(request => {
-      var doc = request.document;
+      const doc = request.document;
       if (doc.aggregate) {
         try {
-          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation || undefined);
+          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation.expected);
           request.reply({
             ok: 1,
             cursor: {
@@ -48,14 +48,12 @@ describe('bypass document validation', function() {
 
     client.connect(function(err, client) {
       expect(err).to.not.exist;
-      var db = client.db('test');
-      var collection = db.collection('test_c');
+      const db = client.db('test');
+      const collection = db.collection('test_c');
 
-      var options = {
-        bypassDocumentValidation: bypassDocumentValidation
-      };
+      const options = { bypassDocumentValidation: bypassDocumentValidation.actual };
 
-      var pipeline = [
+      const pipeline = [
         {
           $project: {}
         }
@@ -65,11 +63,11 @@ describe('bypass document validation', function() {
   }
   // aggregate
   it('should only set bypass document validation if strictly true in aggregate', function(done) {
-    testAggregate(true, done);
+    testAggregate({ expected: true, actual: true }, done);
   });
 
   it('should not set bypass document validation if not strictly true in aggregate', function(done) {
-    testAggregate(false, done);
+    testAggregate({ expected: undefined, actual: false }, done);
   });
 
   // general test for mapReduce function
@@ -81,10 +79,10 @@ describe('bypass document validation', function() {
     };
 
     test.server.setMessageHandler(request => {
-      var doc = request.document;
+      const doc = request.document;
       if (doc.mapreduce) {
         try {
-          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation || undefined);
+          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation.expected);
           request.reply({
             results: 't',
             ok: 1
@@ -103,12 +101,12 @@ describe('bypass document validation', function() {
 
     client.connect(function(err, client) {
       expect(err).to.not.exist;
-      var db = client.db('test');
-      var collection = db.collection('test_c');
+      const db = client.db('test');
+      const collection = db.collection('test_c');
 
-      var options = {
+      const options = {
         out: 'test_c',
-        bypassDocumentValidation: bypassDocumentValidation
+        bypassDocumentValidation: bypassDocumentValidation.actual
       };
 
       collection.mapReduce(function map() {}, function reduce() {}, options, e => {
@@ -118,11 +116,11 @@ describe('bypass document validation', function() {
   }
   // map reduce
   it('should only set bypass document validation if strictly true in mapReduce', function(done) {
-    testMapReduce(true, done);
+    testMapReduce({ expected: true, actual: true }, done);
   });
 
   it('should not set bypass document validation if not strictly true in mapReduce', function(done) {
-    testMapReduce(false, done);
+    testMapReduce({ expected: undefined, actual: false }, done);
   });
 
   // general test for findAndModify function
@@ -134,10 +132,10 @@ describe('bypass document validation', function() {
     };
 
     test.server.setMessageHandler(request => {
-      var doc = request.document;
+      const doc = request.document;
       if (doc.findAndModify) {
         try {
-          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation || undefined);
+          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation.expected);
           request.reply({
             ok: 1
           });
@@ -155,12 +153,10 @@ describe('bypass document validation', function() {
 
     client.connect(function(err, client) {
       expect(err).to.not.exist;
-      var db = client.db('test');
-      var collection = db.collection('test_c');
+      const db = client.db('test');
+      const collection = db.collection('test_c');
 
-      var options = {
-        bypassDocumentValidation: bypassDocumentValidation
-      };
+      const options = { bypassDocumentValidation: bypassDocumentValidation.actual };
 
       collection.findAndModify(
         { name: 'Andy' },
@@ -175,15 +171,15 @@ describe('bypass document validation', function() {
   }
   // find and modify
   it('should only set bypass document validation if strictly true in findAndModify', function(done) {
-    testFindAndModify(true, done);
+    testFindAndModify({ expected: true, actual: true }, done);
   });
 
   it('should not set bypass document validation if not strictly true in findAndModify', function(done) {
-    testFindAndModify(false, done);
+    testFindAndModify({ expected: undefined, actual: false }, done);
   });
 
   // general test for BlukWrite to test changes made in ordered.js and unordered.js
-  function testBulkWrite(bypassDocumentValidation, ordered, done) {
+  function testBulkWrite(bypassDocumentValidation, done) {
     const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
@@ -191,10 +187,10 @@ describe('bypass document validation', function() {
     };
 
     test.server.setMessageHandler(request => {
-      var doc = request.document;
+      const doc = request.document;
       if (doc.insert) {
         try {
-          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation || undefined);
+          expect(doc.bypassDocumentValidation).equal(bypassDocumentValidation.expected);
           request.reply({
             ok: 1
           });
@@ -212,12 +208,12 @@ describe('bypass document validation', function() {
 
     client.connect(function(err, client) {
       expect(err).to.not.exist;
-      var db = client.db('test');
-      var collection = db.collection('test_c');
+      const db = client.db('test');
+      const collection = db.collection('test_c');
 
-      var options = {
-        bypassDocumentValidation: bypassDocumentValidation,
-        ordered: ordered
+      const options = {
+        bypassDocumentValidation: bypassDocumentValidation.actual,
+        ordered: bypassDocumentValidation.ordered
       };
 
       collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], options, () => close());
@@ -225,19 +221,19 @@ describe('bypass document validation', function() {
   }
   // ordered bulk write, testing change in ordered.js
   it('should only set bypass document validation if strictly true in ordered bulkWrite', function(done) {
-    testBulkWrite(true, true, done);
+    testBulkWrite({ expected: true, actual: true, ordered: true }, done);
   });
 
   it('should not set bypass document validation if not strictly true in ordered bulkWrite', function(done) {
-    testBulkWrite(false, true, done);
+    testBulkWrite({ expected: undefined, actual: false, ordered: true }, done);
   });
 
   // unordered bulk write, testing change in ordered.js
   it('should only set bypass document validation if strictly true in unordered bulkWrite', function(done) {
-    testBulkWrite(true, false, done);
+    testBulkWrite({ expected: true, actual: true, ordered: false }, done);
   });
 
   it('should not set bypass document validation if not strictly true in unordered bulkWrite', function(done) {
-    testBulkWrite(false, false, done);
+    testBulkWrite({ expected: undefined, actual: false, ordered: false }, done);
   });
 });


### PR DESCRIPTION
The bypassDocumentValidation key will only be set if it explicitly
receives a true, otherwise it remains undefined.

Fixes NODE-1492