### PR TITLE
feat(index): export entire mongodb-core

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ connect.Decimal128 = core.BSON.Decimal128;
 // Add connect method
 connect.connect = connect;
 
+// Export entire core
+connect.core = core;
+
 // Set up the instrumentation method
 connect.instrument = function(options, callback) {
   if (typeof options === 'function') {


### PR DESCRIPTION
Would be handy to have this for https://github.com/Automattic/mongoose/pull/6600 . I'm just trying to get `parseConnectionString()`, but I think it might be handy to export all of mongodb-core just in case we miss a spot