### PR TITLE
fix(db): throw readable error when creating `_id` with background: true

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1042,6 +1042,7 @@ var createIndex = function(self, name, fieldOrSpec, options, callback) {
     // 86 = 'IndexKeySpecsConflict' (index already exists with the same name)
     // 11000 = 'DuplicateKey' (couldn't build unique index because of dupes)
     // 11600 = 'InterruptedAtShutdown' (interrupted at shutdown)
+    // 197 = 'InvalidIndexSpecificationOption' (`_id` with `background: true`)
     // These errors mean that the server recognized `createIndex` as a command
     // and so we don't need to fallback to an insert.
     if (
@@ -1049,7 +1050,8 @@ var createIndex = function(self, name, fieldOrSpec, options, callback) {
       err.code === 11000 ||
       err.code === 85 ||
       err.code === 86 ||
-      err.code === 11600
+      err.code === 11600 ||
+      err.code === 197
     ) {
       return handleCallback(callback, err, result);
     }


### PR DESCRIPTION
My least favorite bug strikes again: `createIndex()` falls back to inserting an index doc and swallows the original error. Below is a minimal repro script with `mongodb@3.0.9`:

```javascript
const { MongoClient } = require('mongodb');

run().catch(error => console.error(error.stack));

async function run() {
  const client = await MongoClient.connect('mongodb://localhost:27017/test');

  const db = client.db();

  await db.collection('Test2').ensureIndex({ _id: 1 }, { background: true });

  console.log('Done');
}
```

This throws a very unhelpful error:

```
$ node gh-6109.js 
Error: cyclic dependency detected
    at serializeObject (/home/val/Workspace/MongoDB/troubleshoot-mongoose/node_modules/bson/lib/bson/parser/serializer.js:333:34)
    at serializeInto (/home/val/Workspace/MongoDB/troubleshoot-mongoose/node_modules/bson/lib/bson/parser/serializer.js:937:17)
    at serializeObject (/home/val/Workspace/MongoDB/troubleshoot-mongoose/node_modules/bson/lib/bson/parser/serializer.js:347:18)
    at serializeInto (/home/val/Workspace/MongoDB/troubleshoot-mongoose/node_modules/bson/lib/bson/parser/serializer.js:937:17)
    at serializeObject (/home/val/Workspace/MongoDB/troubleshoot-mongoose/node_modules/bson/lib/bson/parser/serializer.js:347:18)
    at serializeInto (/home/val/Workspace/MongoDB/troubleshoot-mongoose/node_modules/bson/lib/bson/parser/serializer.js:937:17)
    at serializeObject (/home/val/Workspace/MongoDB/troubleshoot-mongoose/node_modules/bson/lib/bson/parser/serializer.js:347:18)
    at serializeInto (/home/val/Workspace/MongoDB/troubleshoot-mongoose/node_modules/bson/lib/bson/parser/serializer.js:937:17)
    at serializeObject (/home/val/Workspace/MongoDB/troubleshoot-mongoose/node_modules/bson/lib/bson/parser/serializer.js:347:18)
    at serializeInto (/home/val/Workspace/MongoDB/troubleshoot-mongoose/node_modules/bson/lib/bson/parser/serializer.js:937:17)
```

Admittedly, trying to create an index on `_id` is impossible because MongoDB creates one by default, but plenty of people do this in mongoose, so a lot of people are getting this baffling "cyclic dependency detected" error (see https://github.com/Automattic/mongoose/issues/6109). Unfortunately I can't fix this issue from mongoose, so can this get into 3.0.x so I can close out Automattic/mongoose#6109? 