### PR TITLE
fix(parallelCollectionScan): do not use implicit sessions on cursors

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -144,10 +144,13 @@ function Cursor(bson, ns, cmd, options, topology, topologyOptions) {
     // Current doc
     currentDoc: null,
     // explicitlyIgnoreSession
-    explicitlyIgnoreSession: options.explicitlyIgnoreSession,
-    // Optional ClientSession
-    session: options.explicitlyIgnoreSession ? undefined : options.session
+    explicitlyIgnoreSession: options.explicitlyIgnoreSession
   };
+
+  // Optional ClientSession
+  if (!options.explicitlyIgnoreSession && options.session) {
+    this.s.session = options.session;
+  }
 
   // Translate correctly
   if (this.s.options.noCursorTimeout === true) {

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -143,8 +143,10 @@ function Cursor(bson, ns, cmd, options, topology, topologyOptions) {
     promiseLibrary: promiseLibrary,
     // Current doc
     currentDoc: null,
+    // expicitlyDoNotUseSession
+    expicitlyDoNotUseSession: options.expicitlyDoNotUseSession,
     // Optional ClientSession
-    session: options.session
+    session: options.explicitlyDoNotUseSession ? undefined : options.session
   };
 
   // Translate correctly
@@ -211,7 +213,7 @@ for (let name in CoreCursor.prototype) {
 }
 
 Cursor.prototype._initImplicitSession = function() {
-  if (!this.s.session && this.s.topology.hasSessionSupport()) {
+  if (!this.s.expicitlyDoNotUseSession && !this.s.session && this.s.topology.hasSessionSupport()) {
     this.s.session = this.s.topology.startSession({ owner: this });
     this.cursorState.session = this.s.session;
   }

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -143,10 +143,10 @@ function Cursor(bson, ns, cmd, options, topology, topologyOptions) {
     promiseLibrary: promiseLibrary,
     // Current doc
     currentDoc: null,
-    // expicitlyDoNotUseSession
-    expicitlyDoNotUseSession: options.expicitlyDoNotUseSession,
+    // explicitlyIgnoreSession
+    explicitlyIgnoreSession: options.explicitlyIgnoreSession,
     // Optional ClientSession
-    session: options.explicitlyDoNotUseSession ? undefined : options.session
+    session: options.explicitlyIgnoreSession ? undefined : options.session
   };
 
   // Translate correctly
@@ -213,7 +213,7 @@ for (let name in CoreCursor.prototype) {
 }
 
 Cursor.prototype._initImplicitSession = function() {
-  if (!this.s.expicitlyDoNotUseSession && !this.s.session && this.s.topology.hasSessionSupport()) {
+  if (!this.s.explicitlyIgnoreSession && !this.s.session && this.s.topology.hasSessionSupport()) {
     this.s.session = this.s.topology.startSession({ owner: this });
     this.cursorState.session = this.s.session;
   }

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -1021,7 +1021,7 @@ function parallelCollectionScan(coll, options, callback) {
         null
       );
 
-    options = Object.assign({ expicitlyDoNotUseSession: true }, options);
+    options = Object.assign({ explicitlyIgnoreSession: true }, options);
 
     const cursors = [];
     // Add the raw back to the option

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -1021,6 +1021,8 @@ function parallelCollectionScan(coll, options, callback) {
         null
       );
 
+    options = Object.assign({ expicitlyDoNotUseSession: true }, options);
+
     const cursors = [];
     // Add the raw back to the option
     if (raw) options.raw = raw;


### PR DESCRIPTION
When we removed the session use from parallelCollectionScan,
we introduced an error where parallelCollectionScan cursors would
attempt to use implicit sessions on their cursors.

Looking for feedback on the name of the field :)