### PR TITLE
fix(cursor): cursor.count not respecting parent readPreference

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -115,7 +115,6 @@ const validOptions = require('./operations/mongo_client_ops').validOptions;
  */
 function MongoClient(url, options) {
   if (!(this instanceof MongoClient)) return new MongoClient(url, options);
-
   // Set up event emitter
   EventEmitter.call(this);
 

--- a/lib/operations/cursor_ops.js
+++ b/lib/operations/cursor_ops.js
@@ -60,10 +60,10 @@ function count(cursor, applySkipLimit, opts, callback) {
   cursor.s.topology.command(
     `${cursor.s.ns.substr(0, delimiter)}.$cmd`,
     command,
+    cursor.s.options,
     (err, result) => {
       callback(err, result ? result.result.n : null);
-    },
-    cursor.options
+    }
   );
 }
 

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4,6 +4,7 @@ const setupDatabase = require('./shared').setupDatabase;
 const fs = require('fs');
 const expect = require('chai').expect;
 const Long = require('bson').Long;
+const sinon = require('sinon');
 
 describe('Cursor', function() {
   before(function() {
@@ -4500,5 +4501,35 @@ describe('Cursor', function() {
     };
 
     testTransformStream(config, done);
+  });
+
+  it('should apply parent read preference to count command', function(done) {
+    const configuration = this.configuration;
+    const ReadPreference = this.configuration.require.ReadPreference;
+    const client = configuration.newClient(
+      { w: 1, readPreference: ReadPreference.SECONDARY },
+      { poolSize: 1, auto_reconnect: false }
+    );
+
+    client.connect(function(err, client) {
+      const db = client.db(configuration.db);
+      let collection, cursor, spy;
+      const close = e => cursor.close(() => client.close(() => done(e)));
+
+      Promise.resolve()
+        .then(() => db.createCollection('test_count_readPreference'))
+        .then(() => (collection = db.collection('test_count_readPreference')))
+        .then(() => collection.find())
+        .then(_cursor => (cursor = _cursor))
+        .then(() => (spy = sinon.spy(cursor.s.topology, 'command')))
+        .then(() => cursor.count())
+        .then(() =>
+          expect(spy.firstCall.args[2])
+            .to.have.nested.property('readPreference.mode')
+            .that.equals('secondary')
+        )
+        .then(() => close())
+        .catch(e => close(e));
+    });
   });
 });

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4507,7 +4507,7 @@ describe('Cursor', function() {
     const configuration = this.configuration;
     const ReadPreference = this.configuration.require.ReadPreference;
     const client = configuration.newClient(
-      { w: 1, readPreference: ReadPreference.SECONDARY },
+      { w: 1, readPreference: ReadPreference.secondary },
       { poolSize: 1, auto_reconnect: false }
     );
 


### PR DESCRIPTION
Fix wrong placement and typo in options argument in
cursor.s.topology.command, and test that specified readPreference
is passed in to that call.

Fixes NODE-1511