### PR TITLE
fix(cursor): cursor.count not respecting parent readPreference

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -1009,10 +1009,10 @@ var count = function(self, applySkipLimit, opts, callback) {
   self.s.topology.command(
     f('%s.$cmd', self.s.ns.substr(0, delimiter)),
     command,
+    self.s.options,
     function(err, result) {
       callback(err, result ? result.result.n : null);
-    },
-    self.options
+    }
   );
 };
 

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4,6 +4,7 @@ const setupDatabase = require('./shared').setupDatabase;
 const fs = require('fs');
 const expect = require('chai').expect;
 const Long = require('bson').Long;
+const sinon = require('sinon');
 
 describe('Cursor', function() {
   before(function() {
@@ -4389,4 +4390,34 @@ describe('Cursor', function() {
       }
     }
   );
+
+  it('should apply parent read preference to count command', function(done) {
+    const configuration = this.configuration;
+    const ReadPreference = this.configuration.require.ReadPreference;
+    const client = configuration.newClient(
+      { w: 1, readPreference: ReadPreference.secondary },
+      { poolSize: 1, auto_reconnect: false }
+    );
+
+    client.connect(function(err, client) {
+      const db = client.db(configuration.db);
+      let collection, cursor, spy;
+      const close = e => cursor.close(() => client.close(() => done(e)));
+
+      Promise.resolve()
+        .then(() => db.createCollection('test_count_readPreference'))
+        .then(() => (collection = db.collection('test_count_readPreference')))
+        .then(() => collection.find())
+        .then(_cursor => (cursor = _cursor))
+        .then(() => (spy = sinon.spy(cursor.s.topology, 'command')))
+        .then(() => cursor.count())
+        .then(() =>
+          expect(spy.firstCall.args[2])
+            .to.have.nested.property('readPreference.mode')
+            .that.equals('secondary')
+        )
+        .then(() => close())
+        .catch(e => close(e));
+    });
+  });
 });


### PR DESCRIPTION
Fix wrong placement and typo in options argument in
cursor.s.topology.command, and test that specified readPreference
is passed in to that call.

Fixes NODE-1511