### PR TITLE
fix(createUser): allow creating a user against 4.0 server

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1191,6 +1191,8 @@ var _executeAuthCreateUserCommand = function(self, username, password, options, 
     roles = ['dbOwner'];
   }
 
+  const lastIsMaster = self.serverConfig.lastIsMaster();
+
   // Build the command to execute
   var command = {
     createUser: username,
@@ -1198,6 +1200,14 @@ var _executeAuthCreateUserCommand = function(self, username, password, options, 
     roles: roles,
     digestPassword: false
   };
+
+  if (lastIsMaster && lastIsMaster.maxWireVersion >= 7) {
+    console.warn(
+      'Warning: creating a user against Server version >= 4.0 will enforce SCRAM-SHA-1 auth method'
+    );
+
+    command.mechanisms = ['SCRAM-SHA-1'];
+  }
 
   // Apply write concern to command
   command = applyWriteConcern(command, { db: self }, options);

--- a/lib/db.js
+++ b/lib/db.js
@@ -1191,32 +1191,30 @@ var _executeAuthCreateUserCommand = function(self, username, password, options, 
     roles = ['dbOwner'];
   }
 
-  const lastIsMaster = self.serverConfig.lastIsMaster();
+  const lastIsMaster = self.serverConfig.lastIsMaster() || {};
+
+  const digestPassword = lastIsMaster.maxWireVersion >= 7;
 
   // Build the command to execute
-  var command = {
+  let command = {
     createUser: username,
     customData: customData,
     roles: roles,
-    digestPassword: false
+    digestPassword
   };
-
-  if (lastIsMaster && lastIsMaster.maxWireVersion >= 7) {
-    console.warn(
-      'Warning: creating a user against Server version >= 4.0 will enforce SCRAM-SHA-1 auth method'
-    );
-
-    command.mechanisms = ['SCRAM-SHA-1'];
-  }
 
   // Apply write concern to command
   command = applyWriteConcern(command, { db: self }, options);
 
-  // Use node md5 generator
-  var md5 = crypto.createHash('md5');
-  // Generate keys used for authentication
-  md5.update(username + ':mongo:' + password);
-  var userPassword = md5.digest('hex');
+  let userPassword = password;
+
+  if (!digestPassword) {
+    // Use node md5 generator
+    const md5 = crypto.createHash('md5');
+    // Generate keys used for authentication
+    md5.update(username + ':mongo:' + password);
+    userPassword = md5.digest('hex');
+  }
 
   // No password
   if (typeof password === 'string') {
@@ -1299,6 +1297,9 @@ var addUser = function(self, username, password, options, callback) {
 
 /**
  * Add a user to the database.
+ *
+ * NOTE: if you are connecting to MongoDB >= 4.0, the password will not be digested.
+ * We STRONGLY recommend that adding users be done exclusively over a TLS connection.
  * @method
  * @param {string} username The username.
  * @param {string} password The password.


### PR DESCRIPTION
Creating a user normally does not specify an auth mechanism, leaving
it to the server to select a default mechanism. 4.0 server introduced
default of SCRAM-SHA-256, which is not supported by the driver.
For server versions >= 4.0, we will enforce SCRAM-SHA-1.