### PR TITLE
docs(ensureIndex): undeprecate ensureIndex

### DIFF
--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -420,7 +420,6 @@ function dropIndexes(coll, options, callback) {
  * Ensure that an index exists. If the index does not exist, this function creates it.
  *
  * @method
- * @deprecated use createIndexes instead
  * @param {Collection} a Collection instance.
  * @param {(string|object)} fieldOrSpec Defines the index.
  * @param {object} [options=null] Optional settings. See Collection.prototype.ensureIndex for a list of options.

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -375,7 +375,6 @@ function dropDatabase(db, cmd, options, callback) {
  * Ensures that an index exists. If it does not, creates it.
  *
  * @method
- * @deprecated since version 2.0
  * @param {Db} db The Db instance on which to ensure the index.
  * @param {string} name The index name
  * @param {(string|object)} fieldOrSpec Defines the index.


### PR DESCRIPTION
Undeprecates ensureIndex for collection and db.

Fixes NODE-1354