### PR TITLE
Fixed JSDoc for Collection.count

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1329,7 +1329,7 @@ Collection.prototype.indexInformation = function(options, callback) {
 /**
  * Count number of matching documents in the db to a query.
  * @method
- * @param {object} query The query for the count.
+ * @param {object} [query={}] The query for the count.
  * @param {object} [options=null] Optional settings.
  * @param {boolean} [options.limit=null] The limit of documents to count.
  * @param {boolean} [options.skip=null] The number of documents to skip for the count.


### PR DESCRIPTION
The `query` parameter is optional and will default to `{}` if omitted.