### PR TITLE
fix(db): don't send session down to createIndex command

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1573,7 +1573,7 @@ var createCreateIndexCommand = function(db, name, fieldOrSpec, options) {
   if (selector['unique'] == null) selector['unique'] = finalUnique;
 
   // Remove any write concern operations
-  var removeKeys = ['w', 'wtimeout', 'j', 'fsync', 'readPreference'];
+  var removeKeys = ['w', 'wtimeout', 'j', 'fsync', 'readPreference', 'session'];
   for (var i = 0; i < removeKeys.length; i++) {
     delete selector[removeKeys[i]];
   }


### PR DESCRIPTION
Found another issue re: https://github.com/Automattic/mongoose/issues/6109#issuecomment-398403430 . Looks like index builds always fail if `retryWrites` is turned on, for example:

```javascript
run2.catch(error => console.error(error.stack));

async function run() {
  const { MongoClient } = require('mongodb');
  const client = await MongoClient.connect('mongodb://localhost:27017/test?retryWrites=true');

  await client.db('test').collection('test').createIndex({ email: 1 }, {
    unique: true
  });

  console.log('done');
}
```

Gives you a very unhelpful "Error: cyclic dependency detected" error. This will make it so that `session` doesn't make it into the return value from `createCreateIndexesCommand()`