### PR TITLE
docs: updated Collection.aggregate()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1682,7 +1682,7 @@ Collection.prototype.findAndRemove = function(query, sort, options, callback) {
 /**
  * Execute an aggregation framework pipeline against the collection, needs MongoDB >= 2.2
  * @method
- * @param {object} pipeline Array containing all the aggregation framework commands for the execution.
+ * @param {object} [pipeline=[]] Array containing all the aggregation framework commands for the execution.
  * @param {object} [options] Optional settings.
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  * @param {object} [options.cursor] Return the query as cursor, on 2.6 > it returns as a real cursor on pre 2.6 it returns as an emulated cursor.


### PR DESCRIPTION
There are different ways of building aggregation pipelines, you can put the whole pipeline in the first parameter:

```javascript
db.collection('Foo').aggregate([{ $match: { bar: 1 } }, { $limit: 10 }])
```

or add them via separate method calls later:

```javascript
db.collection('Foo').aggregate([]).match({ bar: 1 }).limit(10)
```

In the second case, passing the empty array to `aggregate()` seems redundant and even though the `pipelines` parameter is currently documented as required, this also works:

```javascript
db.collection('Foo').aggregate().match({ bar: 1 }).limit(10)
```

But I'm not fully sure if this is supposed to work or perhaps just an unintended side effect of a deprecated version of the function.
Either way, I find it clearer and would prefer it to be supported.