### PR TITLE
fix(server): remove unnecessary print statement

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -297,7 +297,6 @@ class Server extends TopologyBase {
       try {
         callback(null, self);
       } catch (err) {
-        console.log(err.stack);
         process.nextTick(function() {
           throw err;
         });


### PR DESCRIPTION
This `console.log()` has been causing me some grief and I think it's just something that was added for debugging and then left there.