### PR TITLE
Fixes NODE-1543

### DIFF
--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -234,7 +234,7 @@ function countDocuments(coll, query, options, callback) {
     if (err) return handleCallback(callback, err);
     result.toArray((err, docs) => {
       if (err) handleCallback(err);
-      handleCallback(callback, null, docs[0].n);
+      handleCallback(callback, null, docs.length ? docs[0].n : 0);
     });
   });
 }


### PR DESCRIPTION
if the query to countDocuments results in zero matches, the results are an empty array. This causes `docs[0].n` to throw.