### PR TITLE
fix(collection): countDocuments throws error when query doesn't match docs

### DIFF
--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -234,7 +234,7 @@ function countDocuments(coll, query, options, callback) {
     if (err) return handleCallback(callback, err);
     result.toArray((err, docs) => {
       if (err) handleCallback(err);
-      handleCallback(callback, null, docs[0].n);
+      handleCallback(callback, null, docs.length ? docs[0].n : 0);
     });
   });
 }

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -1581,6 +1581,44 @@ describe('Collection', function() {
     }
   });
 
+  it('should correctly perform estimatedDocumentCount on non-matching query', function(done) {
+    const configuration = this.configuration;
+    const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
+
+    client.connect(function(err, client) {
+      const db = client.db(configuration.db);
+      let collection;
+      const close = e => client.close(() => done(e));
+
+      Promise.resolve()
+        .then(() => db.collection('nonexistent_coll_1'))
+        .then(_coll => (collection = _coll))
+        .then(() => collection.estimatedDocumentCount({ a: 'b' }))
+        .then(count => expect(count).to.equal(0))
+        .then(() => close())
+        .catch(e => close(e));
+    });
+  });
+
+  it('should correctly perform countDocuments on non-matching query', function(done) {
+    const configuration = this.configuration;
+    const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
+
+    client.connect(function(err, client) {
+      const db = client.db(configuration.db);
+      let collection;
+      const close = e => client.close(() => done(e));
+
+      Promise.resolve()
+        .then(() => db.collection('nonexistent_coll_2'))
+        .then(_coll => (collection = _coll))
+        .then(() => collection.countDocuments({ a: 'b' }))
+        .then(count => expect(count).to.equal(0))
+        .then(() => close())
+        .catch(e => close(e));
+    });
+  });
+
   describe('Retryable Writes on bulk ops', function() {
     const MongoClient = require('../../lib/mongo_client');
 

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -2,6 +2,7 @@
 const test = require('./shared').assert;
 const setupDatabase = require('./shared').setupDatabase;
 const expect = require('chai').expect;
+const MongoClient = require('../..').MongoClient;
 
 describe('Collection', function() {
   before(function() {
@@ -1583,16 +1584,14 @@ describe('Collection', function() {
 
   it('should correctly perform estimatedDocumentCount on non-matching query', function(done) {
     const configuration = this.configuration;
-    const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
+    const client = new MongoClient(configuration.url(), { w: 1 });
 
     client.connect(function(err, client) {
       const db = client.db(configuration.db);
-      let collection;
+      const collection = db.collection('nonexistent_coll_1');
       const close = e => client.close(() => done(e));
 
       Promise.resolve()
-        .then(() => db.collection('nonexistent_coll_1'))
-        .then(_coll => (collection = _coll))
         .then(() => collection.estimatedDocumentCount({ a: 'b' }))
         .then(count => expect(count).to.equal(0))
         .then(() => close())
@@ -1602,16 +1601,14 @@ describe('Collection', function() {
 
   it('should correctly perform countDocuments on non-matching query', function(done) {
     const configuration = this.configuration;
-    const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
+    const client = new MongoClient(configuration.url(), { w: 1 });
 
     client.connect(function(err, client) {
       const db = client.db(configuration.db);
-      let collection;
+      const collection = db.collection('nonexistent_coll_2');
       const close = e => client.close(() => done(e));
 
       Promise.resolve()
-        .then(() => db.collection('nonexistent_coll_2'))
-        .then(_coll => (collection = _coll))
         .then(() => collection.countDocuments({ a: 'b' }))
         .then(count => expect(count).to.equal(0))
         .then(() => close())


### PR DESCRIPTION
The countDocuments method was not properly checking that documents were
returned from the query. Added tests on top of astanciu's bug fix.

Fixes NODE-1543