### PR TITLE
fix(countDocuments): don't throw error if no docs found

### DIFF
--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -233,7 +233,8 @@ function countDocuments(coll, query, options, callback) {
   coll.aggregate(pipeline, options, (err, result) => {
     if (err) return handleCallback(callback, err);
     result.toArray((err, docs) => {
-      if (err) handleCallback(err);
+      if (err) return handleCallback(err);
+      if (docs.length === 0) return handleCallback(callback, null, 0);
       handleCallback(callback, null, docs[0].n);
     });
   });


### PR DESCRIPTION
If no documents are found, `countDocuments()` throws an unhelpful "TypeError: Cannot read property 'n' of undefined"