### PR TITLE
useNewUrlParser add replicaset instead replicaSet 

### DIFF
--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -203,7 +203,10 @@ function connect(mongoClient, url, options, callback) {
     }
 
     // Do we have a replicaset then skip discovery and go straight to connectivity
-    if (_finalOptions.replicaSet || _finalOptions.rs_name) {
+    if (_finalOptions.replicaSet || _finalOptions.rs_name || _finalOptions.replicaset) {
+      if(_finalOptions.replicaset && !_finalOptions.replicaSet) {
+        _finalOptions.replicaSet = _finalOptions.replicaset;
+      }
       return createTopology(
         mongoClient,
         'replicaset',


### PR DESCRIPTION
when the option useNewUrlParser is true, the function parseConnectionString in mongodb-core parses the option replicaSet of queryString uri to lowercase, "replicaset", then a wrong topology for connection is created.

[uri_parser.js:176](https://github.com/mongodb-js/mongodb-core/blob/master/lib/uri_parser.js#L176)