### PR TITLE
return on handleCallback

### DIFF
--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -233,7 +233,7 @@ function countDocuments(coll, query, options, callback) {
   coll.aggregate(pipeline, options, (err, result) => {
     if (err) return handleCallback(callback, err);
     result.toArray((err, docs) => {
-      if (err) handleCallback(err);
+      if (err) return handleCallback(err);
       handleCallback(callback, null, docs.length ? docs[0].n : 0);
     });
   });


### PR DESCRIPTION
otherwise the scucess handler is called, which results into further missleading errors (e.g. length is not defined)