### PR TITLE
fix(topologies): add default port support

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -4,7 +4,6 @@ const CServer = require('mongodb-core').Server;
 const Cursor = require('../cursor');
 const TopologyBase = require('./topology_base').TopologyBase;
 const Store = require('./topology_base').Store;
-const MongoError = require('mongodb-core').MongoError;
 const MAX_JS_INT = require('../utils').MAX_JS_INT;
 const translateOptions = require('../utils').translateOptions;
 const filterOptions = require('../utils').filterOptions;
@@ -133,7 +132,7 @@ class Server extends TopologyBase {
         port = null;
       }
     } else if (port == null) {
-      throw MongoError.create({ message: 'port must be specified', driver: true });
+      port = 27017;
     }
 
     // Get the reconnect option

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -209,17 +209,12 @@ describe('Connection', function() {
         Server = configuration.require.Server,
         MongoClient = configuration.require.MongoClient;
 
-      var error;
-      try {
-        var client = new MongoClient(new Server('localhost', undefined), { w: 0 });
-        client.connect(function() {});
-      } catch (err) {
-        error = err;
-      }
-
-      test.ok(error instanceof Error);
-      test.ok(/port must be specified/.test(error));
-      done();
+      var client = new MongoClient(new Server('localhost', undefined), { w: 0 });
+      client.connect(function() {
+        test.equal(27017, client.topology.s.port);
+        client.close();
+        done();
+      });
     }
   });
 


### PR DESCRIPTION
This fix the issue https://jira.mongodb.org/browse/NODE-1547.

We should support the default port because the connection string specification says that port is optional and its default value is 27017.
https://docs.mongodb.com/manual/reference/connection-string/

The specs don't say the port is required in a particular scenario.