### PR TITLE
fix(collection): isCapped returns undefined

### DIFF
--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -846,7 +846,7 @@ function insertOne(coll, doc, options, callback) {
 function isCapped(coll, options, callback) {
   optionsOp(coll, options, (err, document) => {
     if (err) return handleCallback(callback, err);
-    handleCallback(callback, null, document && document.capped);
+    handleCallback(callback, null, document && !!document.capped);
   });
 }
 

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -846,7 +846,7 @@ function insertOne(coll, doc, options, callback) {
 function isCapped(coll, options, callback) {
   optionsOp(coll, options, (err, document) => {
     if (err) return handleCallback(callback, err);
-    handleCallback(callback, null, document && !!document.capped);
+    handleCallback(callback, null, !!(document && document.capped));
   });
 }
 

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -1780,6 +1780,44 @@ describe('Collection', function() {
     });
   });
 
+  it('isCapped should return false for uncapped collections', function(done) {
+    const configuration = this.configuration;
+    const client = new MongoClient(configuration.url(), { w: 1, monitorCommands: true });
+
+    client.connect(function(err, client) {
+      const db = client.db(configuration.db);
+      const close = e => client.close(() => done(e));
+      let collection;
+
+      db
+        .createCollection('uncapped', { capped: false })
+        .then(_coll => (collection = _coll))
+        .then(() => collection.isCapped())
+        .then(capped => expect(capped).to.be.false)
+        .then(() => close())
+        .catch(e => close(e));
+    });
+  });
+
+  it('isCapped should return false for collections instantiated without specifying capped', function(done) {
+    const configuration = this.configuration;
+    const client = new MongoClient(configuration.url(), { w: 1, monitorCommands: true });
+
+    client.connect(function(err, client) {
+      const db = client.db(configuration.db);
+      const close = e => client.close(() => done(e));
+      let collection;
+
+      db
+        .createCollection('uncapped2')
+        .then(_coll => (collection = _coll))
+        .then(() => collection.isCapped())
+        .then(capped => expect(capped).to.be.false)
+        .then(() => close())
+        .catch(e => close(e));
+    });
+  });
+
   describe('Retryable Writes on bulk ops', function() {
     const MongoClient = require('../../lib/mongo_client');
 

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -1780,42 +1780,29 @@ describe('Collection', function() {
     });
   });
 
-  it('isCapped should return false for uncapped collections', function(done) {
-    const configuration = this.configuration;
-    const client = new MongoClient(configuration.url(), { w: 1, monitorCommands: true });
+  function testCapped(config, done) {
+    const configuration = config.config;
+    const client = new MongoClient(configuration.url(), { w: 1 });
 
     client.connect(function(err, client) {
       const db = client.db(configuration.db);
       const close = e => client.close(() => done(e));
-      let collection;
 
       db
-        .createCollection('uncapped', { capped: false })
-        .then(_coll => (collection = _coll))
-        .then(() => collection.isCapped())
+        .createCollection(config.collName, config.opts)
+        .then(collection => collection.isCapped())
         .then(capped => expect(capped).to.be.false)
         .then(() => close())
         .catch(e => close(e));
     });
+  }
+
+  it('isCapped should return false for uncapped collections', function(done) {
+    testCapped({ config: this.configuration, collName: 'uncapped', opts: { capped: false } }, done);
   });
 
   it('isCapped should return false for collections instantiated without specifying capped', function(done) {
-    const configuration = this.configuration;
-    const client = new MongoClient(configuration.url(), { w: 1, monitorCommands: true });
-
-    client.connect(function(err, client) {
-      const db = client.db(configuration.db);
-      const close = e => client.close(() => done(e));
-      let collection;
-
-      db
-        .createCollection('uncapped2')
-        .then(_coll => (collection = _coll))
-        .then(() => collection.isCapped())
-        .then(capped => expect(capped).to.be.false)
-        .then(() => close())
-        .catch(e => close(e));
-    });
+    testCapped({ config: this.configuration, collName: 'uncapped2', opts: {} }, done);
   });
 
   describe('Retryable Writes on bulk ops', function() {


### PR DESCRIPTION
The collection method isCapped was returning undefined
when the capped option was either unspecified or specified
as false.

Fixes NODE-1380