### PR TITLE
refactor(export): expose AggregationCursor

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ connect.MongoNetworkError = core.MongoNetworkError;
 
 // Actual driver classes exported
 connect.Admin = require('./lib/admin');
+connect.AggregationCursor = require('./lib/aggregation_cursor');
 connect.MongoClient = require('./lib/mongo_client');
 connect.Db = require('./lib/db');
 connect.Collection = require('./lib/collection');

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ connect.MongoNetworkError = core.MongoNetworkError;
 
 // Actual driver classes exported
 connect.Admin = require('./lib/admin');
-connect.AggregationCursor = require('./lib/aggregation_cursor');
 connect.MongoClient = require('./lib/mongo_client');
 connect.Db = require('./lib/db');
 connect.Collection = require('./lib/collection');
@@ -24,6 +23,8 @@ connect.ReadPreference = require('mongodb-core').ReadPreference;
 connect.GridStore = require('./lib/gridfs/grid_store');
 connect.Chunk = require('./lib/gridfs/chunk');
 connect.Logger = core.Logger;
+connect.AggregationCursor = require('./lib/aggregation_cursor');
+connect.CommandCursor = require('./lib/command_cursor');
 connect.Cursor = require('./lib/cursor');
 connect.GridFSBucket = require('./lib/gridfs-stream');
 // Exported to be used in tests not to be used anywhere else


### PR DESCRIPTION
My use case is to be able to do `foo instanceof AggregationCursor` just as one could do with `Cursor` and I don't see any reason why `AggregationCursor` should not be exposed.