### PR TITLE
docs(connect): remove references to MongoClient.connect

### DIFF
--- a/docs/reference/content/quick-start/quick-start.md
+++ b/docs/reference/content/quick-start/quick-start.md
@@ -106,9 +106,10 @@ const url = 'mongodb://localhost:27017';
 
 // Database Name
 const dbName = 'myproject';
+const client = new MongoClient(url);
 
 // Use connect method to connect to the server
-MongoClient.connect(url, function(err, client) {
+client.connect(url, function(err) {
   assert.equal(null, err);
   console.log("Connected successfully to server");
 
@@ -156,7 +157,7 @@ rather than from within a browser console, and console.log returns better format
 -->
 
 
-This query returns all the documents in the **documents** collection. Add the **findDocument** method to the **MongoClient.connect** callback:
+This query returns all the documents in the **documents** collection. Add the **findDocument** method to the **client.connect** callback:
 
 <!---
 Removed the assert line for number of documents returned on the grounds that it's too brittle.
@@ -174,8 +175,9 @@ const url = 'mongodb://localhost:27017';
 // Database Name
 const dbName = 'myproject';
 
+const client = new MongoClient(url);
 // Use connect method to connect to the server
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 
@@ -229,7 +231,7 @@ const updateDocument = function(db, callback) {
 }
 ```
 
-The method updates the first document where the field **a** is equal to **2** by adding a new field **b** to the document set to **1**. Next, update the callback function from **MongoClient.connect** to include the update method.
+The method updates the first document where the field **a** is equal to **2** by adding a new field **b** to the document set to **1**. Next, update the callback function from **client.connect** to include the update method.
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
@@ -241,8 +243,9 @@ const url = 'mongodb://localhost:27017';
 // Database Name
 const dbName = 'myproject';
 
+const client = new MongoClient(url);
 // Use connect method to connect to the server
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected successfully to server");
 
@@ -274,7 +277,7 @@ const removeDocument = function(db, callback) {
 }
 ```
 
-Add the new method to the **MongoClient.connect** callback function.
+Add the new method to the **client.connect** callback function.
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
@@ -286,8 +289,9 @@ const url = 'mongodb://localhost:27017';
 // Database Name
 const dbName = 'myproject';
 
+const client = new MongoClient(url);
 // Use connect method to connect to the server
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected successfully to server");
 
@@ -325,8 +329,9 @@ const url = 'mongodb://localhost:27017';
 
 const dbName = 'myproject';
 
+const client = new MongoClient(url);
 // Use connect method to connect to the server
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected successfully to server");
 

--- a/docs/reference/content/reference/connecting/connection-settings.md
+++ b/docs/reference/content/reference/connecting/connection-settings.md
@@ -10,7 +10,7 @@ title = "Connection Settings"
 
 # URI Connection Settings
 
-Optional connection settings are settings not covered by the [URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/). The following options are passed in the options parameter for when you create a mongo client.
+Optional connection settings are settings not covered by the [URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/). The following options are passed in the options parameter when you create a mongo client.
 
 ```js
 const MongoClient = require('mongodb').MongoClient;

--- a/docs/reference/content/reference/connecting/connection-settings.md
+++ b/docs/reference/content/reference/connecting/connection-settings.md
@@ -10,7 +10,7 @@ title = "Connection Settings"
 
 # URI Connection Settings
 
-Optional connection settings are settings not covered by the [URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/). The following options are passed in the options parameter in the MongoClient.connect function.
+Optional connection settings are settings not covered by the [URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/). The following options are passed in the options parameter for when you create a mongo client.
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
@@ -20,11 +20,14 @@ const assert = require('assert');
 const url = 'mongodb://localhost:50000,localhost:50001';
 // Database Name
 const dbName = 'myproject';
-// Use connect method to connect to the Server passing in
-// additional options
-MongoClient.connect(url, {
+
+// create a client, passing in additional options
+const client = new MongoClient(url, {
   poolSize: 10, ssl: true
-}, function(err, client) {
+});
+
+// Use connect method to connect to the server
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 

--- a/docs/reference/content/reference/ecmascriptnext/connecting.md
+++ b/docs/reference/content/reference/ecmascriptnext/connecting.md
@@ -21,21 +21,19 @@ const assert = require('assert');
   const url = 'mongodb://localhost:27017/myproject';
   // Database Name
   const dbName = 'myproject';
-  let client;
+  const client = new MongoClient(url);
 
   try {
     // Use connect method to connect to the Server
-    client = await MongoClient.connect(url);
+    await client.connect();
 
     const db = client.db(dbName);
   } catch (err) {
     console.log(err.stack);
   }
 
-  if (client) {
-    client.close();
-  }
+  client.close();
 })();
 ```
 
-The `MongoClient.connect` function returns a `Promise` that we then execute using the `await` keyword inside of an `async` function. If an error happens during the `MongoClient.connect` the error is caught by the `try`/`catch` and can be handled as if it were a normal Javascript error.
+The `client.connect` function returns a `Promise` that we then execute using the `await` keyword inside of an `async` function. If an error happens during the `client.connect` the error is caught by the `try`/`catch` and can be handled as if it were a normal Javascript error.

--- a/docs/reference/content/reference/ecmascriptnext/crud.md
+++ b/docs/reference/content/reference/ecmascriptnext/crud.md
@@ -27,10 +27,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);
@@ -61,10 +61,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);
@@ -104,10 +104,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);
@@ -152,10 +152,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);
@@ -195,10 +195,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);
@@ -238,10 +238,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);
@@ -277,10 +277,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);
@@ -327,10 +327,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);
@@ -417,10 +417,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);
@@ -454,10 +454,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);
@@ -497,10 +497,10 @@ const url = 'mongodb://localhost:27017';
 const dbName = 'myproject';
 
 (async function() {
-  let client;
+  const client = new MongoClient(url);
 
   try {
-    client = await MongoClient.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
 
     const db = client.db(dbName);

--- a/docs/reference/content/reference/faq/index.md
+++ b/docs/reference/content/reference/faq/index.md
@@ -10,7 +10,7 @@ title = "Frequently Asked Questions"
 
 # What is the difference between connectTimeoutMS, socketTimeoutMS and maxTimeMS ?
 
-| Setting | Default Value MongoClient.connect | Description |
+| Setting | Default Value client.connect | Description |
 | :----------| :------------- | :------------- |
 | connectTimeoutMS | 30000 | The connectTimeoutMS sets the number of milliseconds a socket stays inactive before closing during the connection phase of the driver. That is to say, when the application initiates a connection, when a replica set connects to new members, or when a replica set reconnects to members. A value of 10000 milliseconds would mean the driver would wait up to 10 seconds for a response from a MongoDB server.|
 | socketTimeoutMS | 360000 | The socketTimeoutMS sets the number of milliseconds a socket stays inactive after the driver has successfully connected before closing. If the value is set to 360000 milliseconds, the socket closes if there is no activity during a 6 minutes window.|
@@ -106,12 +106,13 @@ are some things to check:
 allowing the driver to detect that the socket is closed.
 2. The firewall should allow keepAlive probes.
 
-# I'm getting ECONNRESET when calling MongoClient.connect
+# I'm getting ECONNRESET when calling client.connect
 This can occur if the connection pool is too large.
 
 ```js
-MongoClient.connect('mongodb://localhost:27017/test?maxPoolSize=5000',
-  function(err, client) {
+const client = new MongoClient('mongodb://localhost:27017/test?maxPoolSize=5000');
+client.connect('mongodb://localhost:27017/test?maxPoolSize=5000',
+  function(err) {
     // connection
   });
 ```

--- a/docs/reference/content/reference/management/logging.md
+++ b/docs/reference/content/reference/management/logging.md
@@ -28,8 +28,9 @@ const url = 'mongodb://localhost:27017';
 // Database Name
 const dbName = 'myprojeect';
 
-// Use connect method to connect to the Server
-MongoClient.connect(url, function(err, client) {
+const client = new MongoClient(url);
+// Use connect method to connect to the server
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 
@@ -61,8 +62,9 @@ const url = 'mongodb://localhost:27017';
 // Database Name
 const dbName = 'myprojeect';
 
-// Use connect method to connect to the Server
-MongoClient.connect(url, function(err, client) {
+const client = new MongoClient(url);
+// Use connect method to connect to the server
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 
@@ -129,8 +131,9 @@ const url = 'mongodb://localhost:27017';
 // Database Name
 const dbName = 'myprojeect';
 
-// Use connect method to connect to the Server
-MongoClient.connect(url, function(err, client) {
+const client = new MongoClient(url);
+// Use connect method to connect to the server
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 

--- a/docs/reference/content/tutorials/connect/authenticating.md
+++ b/docs/reference/content/tutorials/connect/authenticating.md
@@ -31,7 +31,6 @@ The user and password should always be **URI** encoded using `encodeURIComponent
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const assert = require('assert');
 
 const user = encodeURIComponent('dave');
@@ -39,11 +38,13 @@ const password = encodeURIComponent('abc123');
 const authMechanism = 'DEFAULT';
 
 // Connection URL
-const url = f('mongodb://%s:%s@localhost:27017/?authMechanism=%s',
-  user, password, authMechanism);
+const url = `mongodb://${user}:${password}@localhost:27017/?authMechanism=${authMechanism}`;
+
+// Create a new MongoClient
+const client = new MongoClient(url);
 
 // Use connect method to connect to the Server
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 
@@ -61,13 +62,16 @@ In the following example, the connection string specifies the user `dave`, passw
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const assert = require('assert');
 
 // Connection URL
 const url = 'mongodb://dave:abc123@localhost:27017/?authMechanism=SCRAM-SHA-1&authSource=myprojectdb';
+
+// Create a new MongoClient
+const client = new MongoClient(url);
+
 // Use connect method to connect to the Server
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 
@@ -90,13 +94,16 @@ In the following example, the connection string specifies the user `dave`, passw
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const assert = require('assert');
 
 // Connection URL
 const url = 'mongodb://dave:abc123@localhost:27017/?authMechanism=MONGODB-CR&authSource=myprojectdb';
+
+// Create a new MongoClient
+const client = new MongoClient(url);
+
 // Use connect method to connect to the Server
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 
@@ -119,12 +126,11 @@ X.509 authentication requires the use of SSL connections with certificate valida
 
 To connect using the X.509 authentication mechanism, specify `MONGODB-X509` as the mechanism in the [URI connection string](https://docs.mongodb.org/manual/reference/connection-string/), `ssl=true`, and the username. Use `enodeURIComponent` to encode the username string.
 
-In addition to the connection string, pass to the `MongoClient.connect` method a connections options for the `server` with  the X.509 certificate and other [TLS/SSL connections]({{< relref "tutorials/connect/ssl.md" >}}) options.
+In addition to the connection string, pass to the new `MongoClient` a connections options for the `server` with  the X.509 certificate and other [TLS/SSL connections]({{< relref "tutorials/connect/ssl.md" >}}) options.
 
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const assert = require('assert');
 
 // Read the cert and key
@@ -133,15 +139,17 @@ const key = fs.readFileSync(__dirname + "/ssl/x509/client.pem");
 
 // User name
 const userName = encodeURIComponent("CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US");
+const url = `mongodb://${userName}:${password}@server:27017?authMechanism=MONGODB-X509&ssl=true`;
 
-// Connect using X509 authentication
-MongoClient.connect(f('mongodb://%s@server:27017?authMechanism=MONGODB-X509&ssl=true', userName), {
-  server: {
-      sslKey:key
-    , sslCert:cert
-    , sslValidate:false
-  }
-}, function(err, client) {
+// Create a new MongoClient
+const client = new MongoClient(url, {
+  sslKey: key,
+  sslCert: cert,
+  sslValidate: false
+});
+
+// Use connect method to connect to the Server
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 
@@ -164,7 +172,6 @@ The following example connects to MongoDB using Kerberos for UNIX.
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const assert = require('assert');
 
 // KDC Server
@@ -172,8 +179,12 @@ const server = "mongo-server.example.com";
 const principal = "drivers@KERBEROS.EXAMPLE.COM";
 const urlEncodedPrincipal = encodeURIComponent(principal);
 
+const url = `mongodb://${urlEncodedPrincipal}@${server}?authMechanism=GSSAPI&gssapiServiceName=mongodb`;
+
+const client = new MongoClient(url);
+
 // Let's write the actual connection code
-MongoClient.connect(f("mongodb://%s@%s?authMechanism=GSSAPI&gssapiServiceName=mongodb", urlEncodedPrincipal, server), function(err, client) {
+client.connect(function(err) {
   assert.equal(null, err);
 
   client.close();
@@ -193,7 +204,6 @@ To connect using the LDAP authentication mechanism, specify ``authMechanism=PLAI
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const assert = require('assert');
 
 // LDAP Server
@@ -202,10 +212,13 @@ const user = "ldap-user";
 const pass = "ldap-password";
 
 // Url
-const url = f("mongodb://%s:%s@%s?authMechanism=PLAIN&maxPoolSize=1", user, pass, server);
+const url = `mongodb://${user}:${pass}@${server}?authMechanism=PLAIN&maxPoolSize=1`;
+
+// Client
+const client = new MongoClient(url);
 
 // Let's write the actual connection code
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err) {
   assert.equal(null, err);
 
   client.close();

--- a/docs/reference/content/tutorials/connect/index.md
+++ b/docs/reference/content/tutorials/connect/index.md
@@ -10,7 +10,7 @@ title = "Connect to MongoDB"
 
 # Connect to MongoDB
 
-Use the `MongoClient.connect` method to connect to a running MongoDB deployment.
+Use the `client.connect` method to connect to a running MongoDB deployment.
 
 ## Connect to a Single MongoDB Instance
 
@@ -68,7 +68,6 @@ For example, you can specify TLS/SSL and authentication setting.
 ```js
 
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const assert = require('assert');
 const fs = require('fs');
 
@@ -79,15 +78,15 @@ const cert = fs.readFileSync(__dirname + "/ssl/client.pem");
 // Connection URL
 const url = 'mongodb://dave:password@localhost:27017?authMechanism=DEFAULT&authSource=db&ssl=true"';
 
-// Use connect method to connect to the Server passing in
-// additional options
-MongoClient.connect(url,  {
-  server: {
-      sslValidate:true
-    , sslCA:ca
-    , sslCert:cert
-  }
-}, function(err, client) {
+// Ceate a client, passing in additional options
+const client = new MongoClient(url,  {
+  sslValidate: true,
+  sslCA: ca,
+  sslCert: cert
+});
+
+// Use connect method to connect to the server
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 

--- a/docs/reference/content/tutorials/connect/index.md
+++ b/docs/reference/content/tutorials/connect/index.md
@@ -78,7 +78,7 @@ const cert = fs.readFileSync(__dirname + "/ssl/client.pem");
 // Connection URL
 const url = 'mongodb://dave:password@localhost:27017?authMechanism=DEFAULT&authSource=db&ssl=true"';
 
-// Ceate a client, passing in additional options
+// Create a client, passing in additional options
 const client = new MongoClient(url,  {
   sslValidate: true,
   sslCA: ca,

--- a/docs/reference/content/tutorials/connect/ssl.md
+++ b/docs/reference/content/tutorials/connect/ssl.md
@@ -18,13 +18,15 @@ If the MongoDB instance does not perform any validation of the certificate chain
 ```js
 const MongoClient = require('mongodb').MongoClient;
 
-MongoClient.connect("mongodb://localhost:27017?ssl=true", function(err, client) {
+const client = new MongoClient('mongodb://localhost:27017?ssl=true');
+
+client.connect(function(err) {
   client.close();
 });
 ```
 
 ## Validate Server Certificate
-If the MongoDB instance presents a certificate, to validate the server's certificate, pass to the `MongoClient.connect` method:
+If the MongoDB instance presents a certificate, to validate the server's certificate, pass the following when creating a `MongoClient`:
 
 - A [URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/) that includes `ssl=true` setting,
 
@@ -32,24 +34,25 @@ If the MongoDB instance presents a certificate, to validate the server's certifi
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const fs = require('fs');
 
 // Read the certificate authority
 const ca = [fs.readFileSync(__dirname + "/ssl/ca.pem")];
 
-// Connect validating the returned certificates from the server
-MongoClient.connect("mongodb://localhost:27017?ssl=true", {
+const client = new MongoClient('mongodb://localhost:27017?ssl=true', {
   sslValidate:true,
   sslCA:ca
-}, function(err, client) {
+});
+
+// Connect validating the returned certificates from the server
+client.connect(function(err) {
   client.close();
 });
 ```
 
 ## Disable Hostname Verification
 By default, the driver ensures that the hostname included in the
-server's SSL certificate(s) matches the hostname(s) provided in the URI connection string. If you need to disable the hostname verification, but otherwise validate the server's certificate, pass to the `MongoClient.connect` method:
+server's SSL certificate(s) matches the hostname(s) provided in the URI connection string. If you need to disable the hostname verification, but otherwise validate the server's certificate, pass to the new `MongoClient`:
 
 - A [URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/) that includes `ssl=true` setting,
 
@@ -57,25 +60,26 @@ server's SSL certificate(s) matches the hostname(s) provided in the URI connecti
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const fs = require('fs');
 
 // Read the certificate authority
 const ca = [fs.readFileSync(__dirname + "/ssl/ca.pem")];
 
-// Connect validating the returned certificates from the server
-MongoClient.connect("mongodb://localhost:27017?ssl=true", {
+const client = new MongoClient('mongodb://localhost:27017?ssl=true', {
   sslValidate:true,
   checkServerIdentity:false,
   sslCA:ca
-}, function(err, client) {
+});
+
+// Connect validating the returned certificates from the server
+client.connect(function(err) {
   client.close();
 });
 ```
 
 ## Validate Server Certificate and Present Valid Certificate
 If the MongoDB server performs certificate validation, the client must pass its
-certificate to the server. To pass the client's certificate as well as to validate the server's certificate, pass to the `MongoClient.connect` method:
+certificate to the server. To pass the client's certificate as well as to validate the server's certificate, pass to the new `MongoClient`:
 
 - A [URI Connection String ](https://docs.mongodb.org/manual/reference/connection-string/) that includes `ssl=true` setting,
 
@@ -83,7 +87,6 @@ certificate to the server. To pass the client's certificate as well as to valida
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const fs = require('fs');
 
 // Read the certificates
@@ -91,14 +94,16 @@ const ca = [fs.readFileSync(__dirname + "/ssl/ca.pem")];
 const cert = fs.readFileSync(__dirname + "/ssl/client.pem");
 const key = fs.readFileSync(__dirname + "/ssl/client.pem");
 
-// Connect validating the returned certificates from the server
-MongoClient.connect("mongodb://localhost:27017?ssl=true", {
+const client = new MongoClient('mongodb://localhost:27017?ssl=true', {
   sslValidate:true,
   sslCA:ca,
   sslKey:key,
   sslCert:cert,
   sslPass:'10gen',
-}, function(err, client) {
+});
+
+// Connect validating the returned certificates from the server
+client.connect(function(err) {
   client.close();
 });
 ```
@@ -108,12 +113,11 @@ MongoClient.connect("mongodb://localhost:27017?ssl=true", {
 
 To connect using the X.509 authentication mechanism, specify `MONGODB-X509` as the mechanism in the [URI connection string](https://docs.mongodb.org/manual/reference/connection-string/), `ssl=true`, and the username. Use `enodeURIComponent` to encode the username string.
 
-In addition to the connection string, pass to the `MongoClient.connect` method
+In addition to the connection string, pass to the new `MongoClient`
 a connections options with  the X.509 certificate and other [TLS/SSL connections]({{< relref "reference/connecting/connection-settings.md" >}}) options.
 
 ```js
 const MongoClient = require('mongodb').MongoClient;
-const f = require('util').format;
 const fs = require('fs');
 
 // Read the cert and key
@@ -123,12 +127,13 @@ const key = fs.readFileSync(__dirname + "/ssl/x509/client.pem");
 // User name
 const userName = "CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US";
 
-// Connect using the MONGODB-X509 authentication mechanism
-MongoClient.connect(f('mongodb://%s@server:27017?authMechanism=%s&ssl=true'
-    , encodeURIComponent(userName), 'MONGODB-X509'), {
+const client = new MongoClient(`mongodb://${encodeURIComponent(userName)}@server:27017?authMechanism=MONGODB-X509&ssl=true`, {
   sslKey:key,
   sslCert:cert,
-}, function(err, client) {
+});
+
+// Connect using the MONGODB-X509 authentication mechanism
+client.connect(function(err) {
   client.close();
 });
 ```
@@ -157,11 +162,13 @@ const ca = [fs.readFileSync(__dirname + "/ssl/ca.pem")];
 const cert = fs.readFileSync(__dirname + "/ssl/client.pem");
 const key = fs.readFileSync(__dirname + "/ssl/client.pem");
 
-MongoClient.connect('mongodb://server:27017?ssl=true', {
+const client = new MongoClient('mongodb://server:27017?ssl=true', {
   sslCA:ca,
   sslKey:key,
   sslCert:cert,
-}, function(err, client) {
+});
+
+client.connect(function(err) {
   client.close();
 });
 ```
@@ -177,11 +184,13 @@ const ca = [fs.readFileSync(__dirname + "/ssl/ca.pem")];
 const cert = fs.readFileSync(__dirname + "/ssl/client.pem");
 const key = fs.readFileSync(__dirname + "/ssl/client.pem");
 
-MongoClient.connect('mongodb://server:27017?replicaSet=foo&ssl=true', {
+const client = new MongoClient('mongodb://server:27017?replicaSet=foo&ssl=true', {
   sslCA:ca,
   sslKey:key,
   sslCert:cert,
-}, function(err, client) {
+});
+
+client.connect(function(err) {
   client.close();
 });
 ```
@@ -197,11 +206,13 @@ const ca = [fs.readFileSync(__dirname + "/ssl/ca.pem")];
 const cert = fs.readFileSync(__dirname + "/ssl/client.pem");
 const key = fs.readFileSync(__dirname + "/ssl/client.pem");
 
-MongoClient.connect('mongodb://server:27017?ssl=true', {
+const client = new MongoClient('mongodb://server:27017?ssl=true', {
   sslCA:ca,
   sslKey:key,
   sslCert:cert,
-}, function(err, client) {
+});
+
+client.connect(function(err) {
   client.close();
 });
 ```

--- a/docs/reference/content/tutorials/gridfs/streaming.md
+++ b/docs/reference/content/tutorials/gridfs/streaming.md
@@ -30,7 +30,8 @@ In order to use the streaming GridFS API, you first need to create
 a `GridFSBucket`.
 
 ```javascript
-mongodb.MongoClient.connect(uri, function(error, client) {
+const client = new mongodb.MongoClient(uri);
+client.connect(function(error) {
   assert.ifError(error);
 
   const db = client.db(dbName);
@@ -54,7 +55,9 @@ const mongodb = require('mongodb');
 const uri = 'mongodb://localhost:27017';
 const dbName = 'test';
 
-mongodb.MongoClient.connect(uri, function(error, client) {
+const client = new mongodb.MongoClient(uri);
+
+client.connect(unction(error) {
   assert.ifError(error);
 
   const db = client.db(dbName);

--- a/docs/reference/layouts/shortcodes/basic-connection.html
+++ b/docs/reference/layouts/shortcodes/basic-connection.html
@@ -7,7 +7,7 @@ const url = 'mongodb://localhost:27017';
 // Database Name
 const dbName = 'myproject';
 
-// Create a new MonogClient
+// Create a new MongoClient
 const client = new MongoClient(url);
 
 // Use connect method to connect to the Server

--- a/docs/reference/layouts/shortcodes/basic-connection.html
+++ b/docs/reference/layouts/shortcodes/basic-connection.html
@@ -7,8 +7,11 @@ const url = 'mongodb://localhost:27017';
 // Database Name
 const dbName = 'myproject';
 
-// Use connect method to connect to the server
-MongoClient.connect(url, function(err, client) {
+// Create a new MonogClient
+const client = new MongoClient(url);
+
+// Use connect method to connect to the Server
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected successfully to server");
 

--- a/docs/reference/layouts/shortcodes/connect-to-replicaset.html
+++ b/docs/reference/layouts/shortcodes/connect-to-replicaset.html
@@ -7,7 +7,7 @@ const url = 'mongodb://localhost:27017,localhost:27018/?replicaSet=foo';
 // Database Name
 const dbName = 'myproject';
 
-// Create a new MonogClient
+// Create a new MongoClient
 const client = new MongoClient(url);
 
 // Use connect method to connect to the Server

--- a/docs/reference/layouts/shortcodes/connect-to-replicaset.html
+++ b/docs/reference/layouts/shortcodes/connect-to-replicaset.html
@@ -7,8 +7,11 @@ const url = 'mongodb://localhost:27017,localhost:27018/?replicaSet=foo';
 // Database Name
 const dbName = 'myproject';
 
+// Create a new MonogClient
+const client = new MongoClient(url);
+
 // Use connect method to connect to the Server
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 

--- a/docs/reference/layouts/shortcodes/connect-to-sharded-cluster.html
+++ b/docs/reference/layouts/shortcodes/connect-to-sharded-cluster.html
@@ -7,7 +7,7 @@ const url = 'mongodb://localhost:50000,localhost:50001';
 // Database Name
 const dbName = 'myproject';
 
-// Create a new MonogClient
+// Create a new MongoClient
 const client = new MongoClient(url);
 
 // Use connect method to connect to the Server

--- a/docs/reference/layouts/shortcodes/connect-to-sharded-cluster.html
+++ b/docs/reference/layouts/shortcodes/connect-to-sharded-cluster.html
@@ -7,8 +7,11 @@ const url = 'mongodb://localhost:50000,localhost:50001';
 // Database Name
 const dbName = 'myproject';
 
+// Create a new MonogClient
+const client = new MongoClient(url);
+
 // Use connect method to connect to the Server
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err, client) {
   assert.equal(null, err);
   console.log("Connected successfully to server");
 

--- a/docs/reference/layouts/shortcodes/find-documents.html
+++ b/docs/reference/layouts/shortcodes/find-documents.html
@@ -7,8 +7,10 @@ const url = 'mongodb://localhost:27017';
 // Database Name
 const dbName = 'myproject';
 
+const client = new MongoClient(url);
+
 // Use connect method to connect to the Server
-MongoClient.connect(url, function(err, client) {
+client.connect(function(err, client) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 

--- a/docs/reference/layouts/shortcodes/js6-connect.html
+++ b/docs/reference/layouts/shortcodes/js6-connect.html
@@ -6,7 +6,7 @@ const url = 'mongodb://localhost:27017';
 // Database name
 const dbName = 'myproject';
 
-const client = new MonogClient(url);
+const client = new MongoClient(url);
 
 (async function() {
   try {

--- a/docs/reference/layouts/shortcodes/js6-connect.html
+++ b/docs/reference/layouts/shortcodes/js6-connect.html
@@ -6,8 +6,10 @@ const url = 'mongodb://localhost:27017';
 // Database name
 const dbName = 'myproject';
 
+const client = new MonogClient(url);
+
 (async function() {
   try {
-    const client = await MongoClient.connect(url);
+    await client.connect(url);
     console.log("Connected correctly to server");
     const db = client.db(dbName);

--- a/docs/reference/layouts/shortcodes/myproject-connect.html
+++ b/docs/reference/layouts/shortcodes/myproject-connect.html
@@ -7,8 +7,11 @@ const url = 'mongodb://localhost:27017';
 // Database Name
 const dbName = 'myproject';
 
+// Create a new MongoClient
+const client = new MongoClient(url);
+
 // Use connect method to connect to the Server
-MongoClient.connect(url, function(err, client) {
+client.connect(url, function(err, client) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 


### PR DESCRIPTION
We want to encourage people to manually create a new MongoClient,
and then call connect, instead of using the static method MongoClient.connect

Fixes NODE-1585