### PR TITLE
Doc what promises resolve to. Consistent params. Fix English.

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -688,7 +688,7 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @property {Object} upsertedId The upserted id.
  * @property {ObjectId} upsertedId._id The upserted _id returned from the server.
  * @property {Object} message TBD
- * @propert {Array} ops TBD
+ * @property {Array} ops TBD
  */
 
 /**
@@ -748,7 +748,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
- * @return {Promise} returns Promise resolving to {Collection~updateWriteOpResultObject} if no callback passed
+ * @return {Promise<Collection~updatewriteOpResultObject>} returns Promise if no callback passed
  */
 Collection.prototype.replaceOne = function(filter, doc, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -776,7 +776,7 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
- * @return {Promise} returns Promise resolving to {Collection~updateWriteOpResultObject} if no callback passed
+ * @return {Promise<Collection~updateWriteOpResultObject>} returns Promise if no callback passed
  */
 Collection.prototype.updateMany = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -1536,7 +1536,7 @@ Collection.prototype.stats = function(options, callback) {
  * @param {number} [options.maxTimeMS] The maximum amount of time to allow the query to run.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
- * @return {Promise} returns Promise resolving to {Collection~findAndModifyWriteOpResultObject} if no callback passed
+ * @return {Promise<Collection~findAndModifyWriteOpResultObject>} returns Promise if no callback passed
  */
 Collection.prototype.findOneAndDelete = function(filter, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -1563,7 +1563,7 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
  * @param {boolean} [options.returnOriginal=true] When false, returns the updated document rather than the original. The default is true.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
- * @return {Promise} returns Promise resolving to {Collection~findAndModifyWriteOpResultObject} if no callback passed
+ * @return {Promise<Collection~findAndModifyWriteOpResultObject>} returns Promise if no callback passed
  */
 Collection.prototype.findOneAndReplace = function(filter, replacement, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -1599,7 +1599,7 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
- * @return {Promise} returns Promise resolving to {Collection~findAndModifyWriteOpResultObject} if no callback passed
+ * @return {Promise<Collection~findAndModifyWriteOpResultObject>} returns Promise if no callback passed
  */
 Collection.prototype.findOneAndUpdate = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -677,7 +677,7 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
 
 /**
  * @typedef {Object} Collection~updateWriteOpResult
- * @property {Object} result The raw result returned from MongoDB, field will vary depending on server version.
+ * @property {Object} result The raw result returned from MongoDB. Will vary depending on server version.
  * @property {Number} result.ok Is 1 if the command executed correctly.
  * @property {Number} result.n The total count of documents scanned.
  * @property {Number} result.nModified The total count of documents modified.
@@ -687,6 +687,8 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @property {Number} upsertedCount The number of documents upserted.
  * @property {Object} upsertedId The upserted id.
  * @property {ObjectId} upsertedId._id The upserted _id returned from the server.
+ * @property {Object} message TBD
+ * @propert {Array} ops TBD
  */
 
 /**
@@ -697,7 +699,7 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  */
 
 /**
- * Update a single document on MongoDB
+ * Update a single document in a collection
  * @method
  * @param {object} filter The Filter used to select the document to update
  * @param {object} update The update operations to be applied to the document
@@ -734,9 +736,9 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
 };
 
 /**
- * Replace a document on MongoDB
+ * Replace a document in a collection with another document
  * @method
- * @param {object} filter The Filter used to select the document to update
+ * @param {object} filter The Filter used to select the document to replace
  * @param {object} doc The Document that replaces the matching document
  * @param {object} [options] Optional settings.
  * @param {boolean} [options.upsert=false] Update operation is an upsert.
@@ -746,7 +748,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
- * @return {Promise} returns Promise if no callback passed
+ * @return {Promise} returns Promise resolving to {Collection~updateWriteOpResultObject} if no callback passed
  */
 Collection.prototype.replaceOne = function(filter, doc, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -762,7 +764,7 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
 };
 
 /**
- * Update multiple documents on MongoDB
+ * Update multiple documents in a collection
  * @method
  * @param {object} filter The Filter used to select the documents to update
  * @param {object} update The update operations to be applied to the document
@@ -838,7 +840,7 @@ Collection.prototype.update = deprecate(function(selector, document, options, ca
 
 /**
  * @typedef {Object} Collection~deleteWriteOpResult
- * @property {Object} result The raw result returned from MongoDB, field will vary depending on server version.
+ * @property {Object} result The raw result returned from MongoDB. Will vary depending on server version.
  * @property {Number} result.ok Is 1 if the command executed correctly.
  * @property {Number} result.n The total count of documents deleted.
  * @property {Object} connection The connection object used for the operation.
@@ -853,7 +855,7 @@ Collection.prototype.update = deprecate(function(selector, document, options, ca
  */
 
 /**
- * Delete a document on MongoDB
+ * Delete a document from a collection
  * @method
  * @param {object} filter The Filter used to select the document to remove
  * @param {object} [options] Optional settings.
@@ -880,7 +882,7 @@ Collection.prototype.deleteOne = function(filter, options, callback) {
 Collection.prototype.removeOne = Collection.prototype.deleteOne;
 
 /**
- * Delete multiple documents on MongoDB
+ * Delete multiple documents from a collection
  * @method
  * @param {object} filter The Filter used to select the documents to remove
  * @param {object} [options] Optional settings.
@@ -1524,17 +1526,17 @@ Collection.prototype.stats = function(options, callback) {
  */
 
 /**
- * Find a document and delete it in one atomic operation, requires a write lock for the duration of the operation.
+ * Find a document and delete it in one atomic operation. Requires a write lock for the duration of the operation.
  *
  * @method
- * @param {object} filter Document selection filter.
+ * @param {object} filter The Filter used to select the document to remove
  * @param {object} [options] Optional settings.
  * @param {object} [options.projection] Limits the fields to return for all matching documents.
  * @param {object} [options.sort] Determines which document the operation modifies if the query selects multiple documents.
  * @param {number} [options.maxTimeMS] The maximum amount of time to allow the query to run.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
- * @return {Promise} returns Promise if no callback passed
+ * @return {Promise} returns Promise resolving to {Collection~findAndModifyWriteOpResultObject} if no callback passed
  */
 Collection.prototype.findOneAndDelete = function(filter, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -1548,11 +1550,11 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
 };
 
 /**
- * Find a document and replace it in one atomic operation, requires a write lock for the duration of the operation.
+ * Find a document and replace it in one atomic operation. Requires a write lock for the duration of the operation.
  *
  * @method
- * @param {object} filter Document selection filter.
- * @param {object} replacement Document replacing the matching document.
+ * @param {object} filter The Filter used to select the document to replace
+ * @param {object} replacement The Document that replaces the matching document
  * @param {object} [options] Optional settings.
  * @param {object} [options.projection] Limits the fields to return for all matching documents.
  * @param {object} [options.sort] Determines which document the operation modifies if the query selects multiple documents.
@@ -1561,7 +1563,7 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
  * @param {boolean} [options.returnOriginal=true] When false, returns the updated document rather than the original. The default is true.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
- * @return {Promise} returns Promise if no callback passed
+ * @return {Promise} returns Promise resolving to {Collection~findAndModifyWriteOpResultObject} if no callback passed
  */
 Collection.prototype.findOneAndReplace = function(filter, replacement, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -1583,10 +1585,10 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
 };
 
 /**
- * Find a document and update it in one atomic operation, requires a write lock for the duration of the operation.
+ * Find a document and update it in one atomic operation. Requires a write lock for the duration of the operation.
  *
  * @method
- * @param {object} filter Document selection filter.
+ * @param {object} filter The Filter used to select the document to update
  * @param {object} update Update operations to be performed on the document
  * @param {object} [options] Optional settings.
  * @param {object} [options.projection] Limits the fields to return for all matching documents.
@@ -1597,7 +1599,7 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
- * @return {Promise} returns Promise if no callback passed
+ * @return {Promise} returns Promise resolving to {Collection~findAndModifyWriteOpResultObject} if no callback passed
  */
 Collection.prototype.findOneAndUpdate = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -767,7 +767,7 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  * Update multiple documents in a collection
  * @method
  * @param {object} filter The Filter used to select the documents to update
- * @param {object} update The update operations to be applied to the document
+ * @param {object} update The update operations to be applied to the documents
  * @param {object} [options] Optional settings.
  * @param {boolean} [options.upsert=false] Update operation is an upsert.
  * @param {(number|string)} [options.w] The write concern.
@@ -776,7 +776,7 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
- * @return {Promise} returns Promise if no callback passed
+ * @return {Promise} returns Promise resolving to {Collection~updateWriteOpResultObject} if no callback passed
  */
 Collection.prototype.updateMany = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -687,8 +687,8 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @property {Number} upsertedCount The number of documents upserted.
  * @property {Object} upsertedId The upserted id.
  * @property {ObjectId} upsertedId._id The upserted _id returned from the server.
- * @property {Object} message TBD
- * @property {Array} ops TBD
+ * @property {Object} message
+ * @property {Array} ops
  */
 
 /**


### PR DESCRIPTION
* document what findAnd* promises resolve to
* fix run-on sentences
* replace "on MongoDB" with "in/from a collection"
* be specific re. update vs. replace
* consistent @param descriptions