### PR TITLE
Fix an issue where handleCallback was not returning the callback.

### DIFF
--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -233,7 +233,7 @@ function countDocuments(coll, query, options, callback) {
   coll.aggregate(pipeline, options, (err, result) => {
     if (err) return handleCallback(callback, err);
     result.toArray((err, docs) => {
-      if (err) return handleCallback(err);
+      if (err) return handleCallback(callback, err);
       handleCallback(callback, null, docs.length ? docs[0].n : 0);
     });
   });


### PR DESCRIPTION
We are having customer complaints that they are getting server failures due to an issue with the MongoDB driver for the 3.1 branch where it is passing an Error object as the callback function within an error handler. I noticed that this is not the case within your ```master``` branch, but for some reason your most recent release 3.1.x has this problem. It is a pretty simple fix.