### PR TITLE
fix links, remove unused metadata

### DIFF
--- a/docs/reference/content/tutorials/main.md
+++ b/docs/reference/content/tutorials/main.md
@@ -1,36 +1,25 @@
-+++
-date = "2015-03-17T15:36:56Z"
-title = "Tutorials"
-[menu.main]
-  identifier = "Tutorials"
-  weight = 20
-  pre = "<i class='fa fa-thumb-tack'></i>"
-+++
-
 # Tutorials
 
 The tutorials in this section provide examples of some frequently used operations. This section is not meant to be an exhaustive list of all operations available in the Node.js driver.
 
+[Connect to MongoDB](./connect/index.md)
 
-[Connect to MongoDB]({{< relref "tutorials/connect/index.md" >}})
+[Collections](./collections.md)
 
-[Collections]({{< relref "tutorials/collections.md" >}})
+[Create Indexes](./create-indexes.md)
 
-[Create Indexes]({{< relref "tutorials/create-indexes.md" >}})
+[CRUD Operations](./crud.md)
 
-[CRUD Operations]({{< relref "tutorials/crud.md" >}})
+[Collations](./collations.md)
 
-[Collations]({{< relref "tutorials/collations.md" >}})
+[Projections](./projections.md)
 
-[Projections]({{< relref "tutorials/projections.md" >}})
+[Aggregation](./aggregation.md)
 
-[Aggregation]({{< relref "tutorials/aggregation.md" >}})
+[Text Search](./text-search.md)
 
-[Text Search]({{< relref "tutorials/text-search.md" >}})
+[Geospatial Search](./geospatial-search.md)
 
-[Geospatial Search]({{< relref "tutorials/geospatial-search.md" >}})
+[Database Commands](./commands.md)
 
-[Database Commands]({{< relref "tutorials/commands.md" >}})
-
-[GridFS]({{< relref "tutorials/gridfs/index.md" >}})
-
+[GridFS](./gridfs/index.md)


### PR DESCRIPTION
Fixed the tutorial links using relative paths. Before, these were rendered as broken plain text.

Also removed the metadata, since it was simply being rendered as plain text and therefore not being used.