### PR TITLE
Allow `$meta` based sort when passing an array to `Cursor.sort()`

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -557,7 +557,7 @@ Cursor.prototype.sort = function(keyOrList, direction) {
           value[1] = 1;
         } else if (x[1] === 'desc') {
           value[1] = -1;
-        } else if (x[1] === 1 || x[1] === -1) {
+        } else if (x[1] === 1 || x[1] === -1 || x[1].$meta) {
           value[1] = x[1];
         } else {
           throw new MongoError(


### PR DESCRIPTION
You may pass an object with a `$meta` key in place of the order parameter to `sort`.  The previous code would incorrectly reject this input as illegal.  See https://docs.mongodb.com/manual/reference/method/cursor.sort/#sort-metadata for documentation.