### PR TITLE
Fix error handler in topology.connect

### DIFF
--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -407,14 +407,14 @@ function createTopology(mongoClient, topologyType, options, callback) {
   relayEvents(mongoClient, topology);
 
   // Open the connection
-  topology.connect(options, (err, topology) => {
+  topology.connect(options, (err, newTopology) => {
     if (err) {
       topology.close(true);
       return callback(err);
     }
 
-    assignTopology(mongoClient, topology);
-    callback(null, topology);
+    assignTopology(mongoClient, newTopology);
+    callback(null, newTopology);
   });
 }
 


### PR DESCRIPTION
if topology.connect has an error, topology is "overwritten" which leads to an error like:
```
     Uncaught TypeError: Cannot read property 'close' of undefined
      at topology.connect (node_modules/mongodb/lib/operations/mongo_client_ops.js:412:16)
      at ReplSet.<anonymous> (node_modules/mongodb/lib/topologies/replset.js:364:11)
      at node_modules/mongodb-core/lib/topologies/replset.js:634:14
      at Server.<anonymous> (node_modules/mongodb-core/lib/topologies/replset.js:357:9)
      at node_modules/mongodb-core/lib/topologies/server.js:508:16
      at node_modules/mongodb-core/lib/connection/pool.js:531:18
      at process._tickCallback (internal/process/next_tick.js:61:11)
```
changing the function parameter to a new name, let's "force close" the old instance.