### PR TITLE
NODE-1640: normalize use of connection strings in all tests

### DIFF
--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -31,7 +31,8 @@ const monitoringEvents = [
   'ping',
   'ha',
   'all',
-  'fullsetup'
+  'fullsetup',
+  'open'
 ];
 const ignoreOptionNames = ['native_parser'];
 const legacyOptionNames = ['server', 'replset', 'replSet', 'mongos', 'db'];
@@ -132,11 +133,11 @@ function collectEvents(mongoClient, topology) {
   if (mongoClient instanceof MongoClient) {
     monitoringEvents.forEach(event => {
       topology.on(event, (object1, object2) => {
-        collectedEvents.push({
-          event: event,
-          object1: object1,
-          object2: object2
-        });
+        if (event === 'open') {
+          collectedEvents.push({ event: event, object1: mongoClient });
+        } else {
+          collectedEvents.push({ event: event, object1: object1, object2: object2 });
+        }
       });
     });
   }
@@ -346,10 +347,10 @@ function createServer(mongoClient, options, callback) {
   // Set default options
   const servers = translateOptions(options);
 
-  // Propagate the events to the client
-  const collectedEvents = collectEvents(mongoClient, servers[0]);
-
   const server = servers[0];
+
+  // Propagate the events to the client
+  const collectedEvents = collectEvents(mongoClient, server);
 
   // Connect to topology
   server.connect(options, (err, topology) => {
@@ -389,8 +390,11 @@ function createTopology(mongoClient, topologyType, options, callback) {
   // Pass in the promise library
   options.promiseLibrary = mongoClient.s.promiseLibrary;
 
+  const translationOptions = {};
+  if (topologyType === 'unified') translationOptions.createServers = false;
+
   // Set default options
-  const servers = translateOptions(options);
+  const servers = translateOptions(options, translationOptions);
 
   // Create the topology
   let topology;
@@ -571,7 +575,9 @@ function transformUrlOptions(_object) {
   return object;
 }
 
-function translateOptions(options) {
+function translateOptions(options, translationOptions) {
+  translationOptions = Object.assign({}, { createServers: true }, translationOptions);
+
   // If we have a readPreference passed in by the db options
   if (typeof options.readPreference === 'string' || typeof options.read_preference === 'string') {
     options.readPreference = new ReadPreference(options.readPreference || options.read_preference);
@@ -590,6 +596,10 @@ function translateOptions(options) {
   // Set the socket and connection timeouts
   if (options.socketTimeoutMS == null) options.socketTimeoutMS = 360000;
   if (options.connectTimeoutMS == null) options.connectTimeoutMS = 30000;
+
+  if (!translationOptions.createServers) {
+    return;
+  }
 
   // Create server instances
   return options.servers.map(serverObj => {

--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -212,6 +212,7 @@ function parseConnectionString(url, options) {
 
   for (let i = 0; i < hosts.length; i++) {
     let r = parser.parse(f('mongodb://%s', hosts[i].trim()));
+    if (r.path && r.path.indexOf('.sock') !== -1) continue;
     if (r.path && r.path.indexOf(':') !== -1) {
       // Not connecting to a socket so check for an extra slash in the hostname.
       // Using String#split as perf is better than match.

--- a/test/config.js
+++ b/test/config.js
@@ -48,6 +48,11 @@ class NativeConfiguration extends ConfigurationBase {
   }
 
   newClient(dbOptions, serverOptions) {
+    // support MongoClient contructor form (url, options) for `newClient`
+    if (typeof dbOptions === 'string') {
+      return new this.mongo.MongoClient(dbOptions, serverOptions);
+    }
+
     serverOptions = Object.assign({}, { haInterval: 100 }, serverOptions);
 
     // Override implementation

--- a/test/config.js
+++ b/test/config.js
@@ -67,6 +67,10 @@ class NativeConfiguration extends ConfigurationBase {
       dbHost = qs.escape(dbHost);
     }
 
+    if (this.options.setName) {
+      Object.assign(dbOptions, { replicaSet: this.options.setName, auto_reconnect: false });
+    }
+
     const connectionString = url.format({
       protocol: 'mongodb',
       slashes: true,

--- a/test/config.js
+++ b/test/config.js
@@ -1,7 +1,8 @@
 'use strict';
 const ConfigurationBase = require('mongodb-test-runner').ConfigurationBase;
 const f = require('util').format;
-
+const url = require('url');
+const qs = require('querystring');
 class NativeConfiguration extends ConfigurationBase {
   constructor(options) {
     super(options);
@@ -59,17 +60,23 @@ class NativeConfiguration extends ConfigurationBase {
     if (keys.indexOf('sslOnNormalPorts') !== -1) serverOptions.ssl = true;
 
     // Fall back
-    const dbHost = (serverOptions && serverOptions.host) || 'localhost';
+    let dbHost = (serverOptions && serverOptions.host) || 'localhost';
     const dbPort = (serverOptions && serverOptions.port) || this.options.port || 27017;
 
-    // Default topology
-    const DbTopology = this.options.topology ? this.options.topology : this.mongo.Server;
+    if (dbHost.indexOf('.sock') !== -1) {
+      dbHost = qs.escape(dbHost);
+    }
 
-    // Return a new MongoClient instance
-    return new this.mongo.MongoClient(
-      new DbTopology(dbHost, dbPort, serverOptions, this.mongo),
-      dbOptions
-    );
+    const connectionString = url.format({
+      protocol: 'mongodb',
+      slashes: true,
+      hostname: dbHost,
+      port: dbPort,
+      query: dbOptions,
+      pathname: '/'
+    });
+
+    return new this.mongo.MongoClient(connectionString, serverOptions);
   }
 
   url(username, password) {

--- a/test/config.js
+++ b/test/config.js
@@ -53,6 +53,7 @@ class NativeConfiguration extends ConfigurationBase {
       return new this.mongo.MongoClient(dbOptions, serverOptions);
     }
 
+    dbOptions = dbOptions || {};
     serverOptions = Object.assign({}, { haInterval: 100 }, serverOptions);
 
     // Override implementation

--- a/test/examples/change_streams.js
+++ b/test/examples/change_streams.js
@@ -28,9 +28,10 @@ describe('examples(change-stream):', function() {
   it('Open A Change Stream', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.6.0' } },
     test: async function() {
+      await db.collection('inventory').insertOne({ a: 1 });
       setTimeout(async function() {
         await db.collection('inventory').insertOne({ a: 1 });
-      });
+      }, 250);
 
       // Start Changestream Example 1
       const collection = db.collection('inventory');
@@ -52,7 +53,7 @@ describe('examples(change-stream):', function() {
       await db.collection('inventory').insertOne({ a: 1, b: 2 });
       setTimeout(async function() {
         await db.collection('inventory').updateOne({ a: 1 }, { $set: { a: 2 } });
-      });
+      }, 250);
 
       // Start Changestream Example 2
       const collection = db.collection('inventory');
@@ -77,7 +78,7 @@ describe('examples(change-stream):', function() {
       setTimeout(async function() {
         await db.collection('inventory').insertOne({ a: 1 });
         await db.collection('inventory').insertOne({ b: 2 });
-      });
+      }, 250);
 
       // Start Changestream Example 3
       const collection = db.collection('inventory');
@@ -103,7 +104,7 @@ describe('examples(change-stream):', function() {
     test: async function() {
       setTimeout(async function() {
         await db.collection('inventory').insertOne({ username: 'alice' });
-      });
+      }, 250);
 
       // Start Changestream Example 4
       const pipeline = [

--- a/test/functional/aggregation_tests.js
+++ b/test/functional/aggregation_tests.js
@@ -25,7 +25,7 @@ describe('Aggregation', function() {
         databaseName = this.configuration.db;
 
       // LINE var MongoClient = require('mongodb').MongoClient;
-      // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
@@ -117,7 +117,7 @@ describe('Aggregation', function() {
         databaseName = this.configuration.db;
 
       // LINE var MongoClient = require('mongodb').MongoClient;
-      // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
@@ -210,7 +210,7 @@ describe('Aggregation', function() {
         databaseName = this.configuration.db;
 
       // LINE var MongoClient = require('mongodb').MongoClient;
-      // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
@@ -303,7 +303,7 @@ describe('Aggregation', function() {
         databaseName = this.configuration.db;
 
       // LINE var MongoClient = require('mongodb').MongoClient;
-      // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
@@ -388,7 +388,7 @@ describe('Aggregation', function() {
         databaseName = this.configuration.db;
 
       // LINE var MongoClient = require('mongodb').MongoClient;
-      // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
@@ -478,7 +478,7 @@ describe('Aggregation', function() {
         databaseName = this.configuration.db;
 
       // LINE var MongoClient = require('mongodb').MongoClient;
-      // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
@@ -572,7 +572,7 @@ describe('Aggregation', function() {
         databaseName = this.configuration.db;
 
       // LINE var MongoClient = require('mongodb').MongoClient;
-      // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
@@ -664,7 +664,7 @@ describe('Aggregation', function() {
         databaseName = this.configuration.db;
 
       // LINE var MongoClient = require('mongodb').MongoClient;
-      // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN

--- a/test/functional/apm_tests.js
+++ b/test/functional/apm_tests.js
@@ -266,7 +266,7 @@ describe('APM', function() {
       client.on('commandStarted', filterForCommands(desiredEvents, started));
       client.on('commandSucceeded', filterForCommands(desiredEvents, succeeded));
 
-      client.on('fullsetup', client => {
+      client.connect().then(() => {
         const db = client.db(self.configuration.db);
 
         db
@@ -295,8 +295,6 @@ describe('APM', function() {
             done();
           });
       });
-
-      client.connect();
     }
   });
 

--- a/test/functional/apm_tests.js
+++ b/test/functional/apm_tests.js
@@ -414,7 +414,6 @@ describe('APM', function() {
               .limit(100)
               .batchSize(2)
               .comment('some comment')
-              .maxScan(1000)
               .maxTimeMS(5000)
               .setReadPreference(ReadPreference.PRIMARY)
               .addCursorFlag('noCursorTimeout', true)
@@ -489,7 +488,6 @@ describe('APM', function() {
               .limit(100)
               .batchSize(2)
               .comment('some comment')
-              .maxScan(1000)
               .maxTimeMS(5000)
               .setReadPreference(ReadPreference.PRIMARY)
               .addCursorFlag('noCursorTimeout', true)
@@ -1001,11 +999,17 @@ describe('APM', function() {
           expect(data).to.have.length(r.insertedCount);
 
           // Set up the listeners
-          client.on('commandStarted', filterOutCommands('endSessions', monitoringResults.starts));
-          client.on('commandFailed', filterOutCommands('endSessions', monitoringResults.failures));
+          client.on(
+            'commandStarted',
+            filterOutCommands(['ismaster', 'endSessions'], monitoringResults.starts)
+          );
+          client.on(
+            'commandFailed',
+            filterOutCommands(['ismaster', 'endSessions'], monitoringResults.failures)
+          );
           client.on(
             'commandSucceeded',
-            filterOutCommands('endSessions', monitoringResults.successes)
+            filterOutCommands(['ismaster', 'endSessions'], monitoringResults.successes)
           );
 
           // Unpack the operation

--- a/test/functional/apm_tests.js
+++ b/test/functional/apm_tests.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const MongoClient = require('../..').MongoClient;
 const instrument = require('../..').instrument;
 const path = require('path');
 const fs = require('fs');
@@ -94,7 +93,7 @@ describe('APM', function() {
     }
   );
 
-  it('should support legacy `instrument`/`uninstrument` methods with MongoClient.connect', {
+  it('should support legacy `instrument`/`uninstrument` methods with MongoClient `connect`', {
     metadata: { requires: { topology: ['single', 'replicaset', 'sharded'] } },
 
     // The actual test we wish to run
@@ -106,8 +105,9 @@ describe('APM', function() {
       instrumentation.on('started', filterForCommands('insert', started));
       instrumentation.on('succeeded', filterForCommands('insert', succeeded));
 
-      const uri = this.configuration.url();
-      return MongoClient.connect(uri, { monitorCommands: true }).then(client => {
+      const firstClient = this.configuration.newClient({}, { monitorCommands: true });
+      const secondClient = this.configuration.newClient({}, { monitorCommands: true });
+      return firstClient.connect().then(client => {
         return client
           .db(this.configuration.db)
           .collection('apm_test')
@@ -124,7 +124,7 @@ describe('APM', function() {
           .then(() => {
             started = [];
             succeeded = [];
-            return MongoClient.connect(uri, { monitorCommands: true });
+            return secondClient.connect();
           })
           .then(newClient => {
             return newClient
@@ -1108,9 +1108,8 @@ describe('APM', function() {
             it(test.description, {
               metadata: { requires: requirements },
               test: function() {
-                return MongoClient.connect(this.configuration.url(), {
-                  monitorCommands: true
-                }).then(client => {
+                const client = this.configuration.newClient({}, { monitorCommands: true });
+                return client.connect().then(client => {
                   expect(client).to.exist;
                   return executeOperation(client, scenario, test).then(() => client.close());
                 });

--- a/test/functional/buffering_proxy_tests.js
+++ b/test/functional/buffering_proxy_tests.js
@@ -29,7 +29,6 @@ describe.skip('Buffering Proxy', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId,
         ReadPreference = configuration.require.ReadPreference;
 
@@ -179,68 +178,69 @@ describe.skip('Buffering Proxy', function() {
           }
         });
 
-        MongoClient.connect(
+        const client = configuration.newClient(
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
           {
             socketTimeoutMS: 2000,
             haInterval: 1000
-          },
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-            var results = [];
-
-            setTimeout(function() {
-              die = true;
-              dieSecondary = true;
-
-              setTimeout(function() {
-                db.collection('test').insertOne({ a: 1 }, function(err) {
-                  test.equal(null, err);
-                  results.push('insertOne');
-                });
-
-                db.command(
-                  { count: 'test', query: {} },
-                  { readPreference: new ReadPreference(ReadPreference.SECONDARY) },
-                  function(err) {
-                    test.equal(null, err);
-                    results.push('count');
-                  }
-                );
-
-                db
-                  .collection('test')
-                  .aggregate([{ $match: {} }])
-                  .toArray(function(err) {
-                    test.equal(null, err);
-                    results.push('aggregate');
-                  });
-
-                db
-                  .collection('test')
-                  .find({})
-                  .setReadPreference(new ReadPreference(ReadPreference.SECONDARY))
-                  .toArray(function(err) {
-                    test.equal(null, err);
-                    results.push('find');
-                  });
-
-                setTimeout(function() {
-                  die = false;
-
-                  setTimeout(function() {
-                    test.deepEqual(['insertOne', 'aggregate'].sort(), results.sort());
-
-                    client.close();
-                    // test.deepEqual(['insertOne', 'aggregate', 'count', 'find'], results);
-                    done();
-                  }, 1000);
-                }, 1000);
-              }, 3000);
-            }, 1000);
           }
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+          var results = [];
+
+          setTimeout(function() {
+            die = true;
+            dieSecondary = true;
+
+            setTimeout(function() {
+              db.collection('test').insertOne({ a: 1 }, function(err) {
+                test.equal(null, err);
+                results.push('insertOne');
+              });
+
+              db.command(
+                { count: 'test', query: {} },
+                { readPreference: new ReadPreference(ReadPreference.SECONDARY) },
+                function(err) {
+                  test.equal(null, err);
+                  results.push('count');
+                }
+              );
+
+              db
+                .collection('test')
+                .aggregate([{ $match: {} }])
+                .toArray(function(err) {
+                  test.equal(null, err);
+                  results.push('aggregate');
+                });
+
+              db
+                .collection('test')
+                .find({})
+                .setReadPreference(new ReadPreference(ReadPreference.SECONDARY))
+                .toArray(function(err) {
+                  test.equal(null, err);
+                  results.push('find');
+                });
+
+              setTimeout(function() {
+                die = false;
+
+                setTimeout(function() {
+                  test.deepEqual(['insertOne', 'aggregate'].sort(), results.sort());
+
+                  client.close();
+                  // test.deepEqual(['insertOne', 'aggregate', 'count', 'find'], results);
+                  done();
+                }, 1000);
+              }, 1000);
+            }, 3000);
+          }, 1000);
+        });
       });
     }
   });
@@ -255,7 +255,6 @@ describe.skip('Buffering Proxy', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId,
         ReadPreference = configuration.require.ReadPreference;
 
@@ -409,70 +408,71 @@ describe.skip('Buffering Proxy', function() {
           }
         });
 
-        MongoClient.connect(
+        const client = configuration.newClient(
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
           {
             socketTimeoutMS: 2000,
             haInterval: 1000
-          },
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            setTimeout(function() {
-              die = true;
-              diePrimary = true;
-
-              setTimeout(function() {
-                var results = [];
-
-                db.collection('test').insertOne({ a: 1 }, function(err) {
-                  test.equal(null, err);
-                  results.push('insertOne');
-                });
-
-                db.command(
-                  { count: 'test', query: {} },
-                  { readPreference: new ReadPreference(ReadPreference.SECONDARY) },
-                  function(err) {
-                    test.equal(null, err);
-                    results.push('count');
-                  }
-                );
-
-                db
-                  .collection('test')
-                  .aggregate([{ $match: {} }])
-                  .toArray(function(err) {
-                    test.equal(null, err);
-                    results.push('aggregate');
-                  });
-
-                db
-                  .collection('test')
-                  .find({})
-                  .setReadPreference(new ReadPreference(ReadPreference.SECONDARY))
-                  .toArray(function(err) {
-                    test.equal(null, err);
-                    results.push('find');
-                  });
-
-                setTimeout(function() {
-                  die = false;
-
-                  setTimeout(function() {
-                    test.deepEqual(['count', 'find'].sort(), results.sort());
-
-                    client.close();
-
-                    // test.deepEqual(['count', 'find', 'insertOne', 'aggregate'], results);
-                    done();
-                  }, 1500);
-                }, 1000);
-              }, 3000);
-            }, 1000);
           }
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          setTimeout(function() {
+            die = true;
+            diePrimary = true;
+
+            setTimeout(function() {
+              var results = [];
+
+              db.collection('test').insertOne({ a: 1 }, function(err) {
+                test.equal(null, err);
+                results.push('insertOne');
+              });
+
+              db.command(
+                { count: 'test', query: {} },
+                { readPreference: new ReadPreference(ReadPreference.SECONDARY) },
+                function(err) {
+                  test.equal(null, err);
+                  results.push('count');
+                }
+              );
+
+              db
+                .collection('test')
+                .aggregate([{ $match: {} }])
+                .toArray(function(err) {
+                  test.equal(null, err);
+                  results.push('aggregate');
+                });
+
+              db
+                .collection('test')
+                .find({})
+                .setReadPreference(new ReadPreference(ReadPreference.SECONDARY))
+                .toArray(function(err) {
+                  test.equal(null, err);
+                  results.push('find');
+                });
+
+              setTimeout(function() {
+                die = false;
+
+                setTimeout(function() {
+                  test.deepEqual(['count', 'find'].sort(), results.sort());
+
+                  client.close();
+
+                  // test.deepEqual(['count', 'find', 'insertOne', 'aggregate'], results);
+                  done();
+                }, 1500);
+              }, 1000);
+            }, 3000);
+          }, 1000);
+        });
       });
     }
   });

--- a/test/functional/byo_promises_tests.js
+++ b/test/functional/byo_promises_tests.js
@@ -12,13 +12,18 @@ describe('BYO Promises', function() {
     // The actual test we wish to run
     test: function(done) {
       var self = this;
-      var MongoClient = self.configuration.require.MongoClient;
+      const configuration = this.configuration;
       var Promise = require('bluebird');
 
-      MongoClient.connect(self.configuration.url(), {
-        promiseLibrary: Promise,
-        sslValidate: false
-      }).then(function(client) {
+      const client = configuration.newClient(
+        {},
+        {
+          promiseLibrary: Promise,
+          sslValidate: false
+        }
+      );
+
+      client.connect().then(function(client) {
         var db = client.db(self.configuration.db);
         var promise = db.collection('test').insert({ a: 1 });
         expect(promise).to.be.an.instanceOf(Promise);

--- a/test/functional/change_stream_spec_tests.js
+++ b/test/functional/change_stream_spec_tests.js
@@ -4,7 +4,6 @@ const EJSON = require('mongodb-extjson');
 const chai = require('chai');
 const fs = require('fs');
 const camelCase = require('lodash.camelcase');
-const MongoClient = require('../../lib/mongo_client');
 const setupDatabase = require('./shared').setupDatabase;
 const delay = require('./shared').delay;
 const expect = chai.expect;
@@ -17,8 +16,9 @@ describe('Change Stream Spec', function() {
   let events;
 
   before(function() {
-    return setupDatabase(this.configuration).then(() => {
-      globalClient = new MongoClient(this.configuration.url());
+    const configuration = this.configuration;
+    return setupDatabase(configuration).then(() => {
+      globalClient = configuration.newClient();
       return globalClient.connect();
     });
   });
@@ -43,11 +43,10 @@ describe('Change Stream Spec', function() {
           const gc = globalClient;
           const sDB = specData.database_name;
           const sColl = specData.collection_name;
+          const configuration = this.configuration;
           return Promise.all(ALL_DBS.map(db => gc.db(db).dropDatabase()))
             .then(() => gc.db(sDB).createCollection(sColl))
-            .then(() =>
-              new MongoClient(this.configuration.url(), { monitorCommands: true }).connect()
-            )
+            .then(() => configuration.newClient({}, { monitorCommands: true }).connect())
             .then(client => {
               ctx = { gc, client };
               events = [];

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -39,7 +39,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var client = configuration.newClient();
+      const client = configuration.newClient();
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -712,7 +712,7 @@ describe('Change Streams', function() {
       });
 
       const mockServerURL = 'mongodb://localhost:32000/';
-      var client = configuration.newClient(mockServerURL);
+      const client = configuration.newClient(mockServerURL);
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -1441,7 +1441,7 @@ describe('Change Streams', function() {
     test: function(done) {
       var configuration = this.configuration;
       var crypto = require('crypto');
-      var client = configuration.newClient(configuration.url(), {
+      const client = configuration.newClient(configuration.url(), {
         poolSize: 1,
         autoReconnect: false
       });

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -25,8 +25,7 @@ describe('Change Streams', function() {
 
   beforeEach(function() {
     const configuration = this.configuration;
-    const MongoClient = configuration.require.MongoClient;
-    const client = new MongoClient(configuration.url());
+    const client = configuration.newClient();
 
     return client.connect().then(() => {
       const db = client.db('integration_tests');
@@ -40,8 +39,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      var client = configuration.newClient();
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -95,8 +93,7 @@ describe('Change Streams', function() {
       // The actual test we wish to run
       test: function(done) {
         var configuration = this.configuration;
-        var MongoClient = configuration.require.MongoClient;
-        var client = new MongoClient(configuration.url());
+        const client = configuration.newClient();
 
         client.connect(function(err, client) {
           assert.ifError(err);
@@ -155,8 +152,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -242,8 +238,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -274,8 +269,7 @@ describe('Change Streams', function() {
       // The actual test we wish to run
       test: function(done) {
         var configuration = this.configuration;
-        var MongoClient = configuration.require.MongoClient;
-        var client = new MongoClient(configuration.url());
+        const client = configuration.newClient();
 
         client.connect(function(err, client) {
           assert.ifError(err);
@@ -302,8 +296,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -342,8 +335,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function() {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       return client.connect().then(function() {
         var theDatabase = client.db('integration_tests');
@@ -380,8 +372,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -417,8 +408,7 @@ describe('Change Streams', function() {
       // The actual test we wish to run
       test: function(done) {
         var configuration = this.configuration;
-        var MongoClient = configuration.require.MongoClient;
-        var client = new MongoClient(configuration.url());
+        const client = configuration.newClient();
 
         client.connect(function(err, client) {
           assert.ifError(err);
@@ -465,8 +455,8 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
+
       client.connect(function(err, client) {
         assert.ifError(err);
 
@@ -508,8 +498,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -564,8 +553,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -610,8 +598,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -664,8 +651,7 @@ describe('Change Streams', function() {
 
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        ObjectId = configuration.require.ObjectId;
+      const ObjectId = configuration.require.ObjectId;
 
       // Contain mock server
       var primaryServer = null;
@@ -712,8 +698,7 @@ describe('Change Streams', function() {
       });
 
       const mockServerURL = 'mongodb://localhost:32000/';
-
-      var client = new MongoClient(mockServerURL);
+      var client = configuration.newClient(mockServerURL);
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -763,8 +748,7 @@ describe('Change Streams', function() {
     },
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        ObjectId = configuration.require.ObjectId;
+      const ObjectId = configuration.require.ObjectId;
 
       // Contain mock server
       var primaryServer = null;
@@ -815,39 +799,37 @@ describe('Change Streams', function() {
         });
       });
 
-      MongoClient.connect(
-        'mongodb://localhost:32000/',
-        {
-          socketTimeoutMS: 500,
-          validateOptions: true
-        },
-        function(err, client) {
-          assert.ifError(err);
+      const client = configuration.newClient('mongodb://localhost:32000/', {
+        socketTimeoutMS: 500,
+        validateOptions: true
+      });
 
-          var theDatabase = client.db('integration_tests');
-          var theCollection = theDatabase.collection('MongoNetworkErrorTestPromises');
-          var thisChangeStream = theCollection.watch(pipeline);
+      client.connect(function(err, client) {
+        assert.ifError(err);
 
-          thisChangeStream.next(function(err, change) {
-            assert.ok(err instanceof MongoNetworkError);
-            assert.ok(err.message);
-            assert.ok(err.message.indexOf('timed out') > -1);
+        var theDatabase = client.db('integration_tests');
+        var theCollection = theDatabase.collection('MongoNetworkErrorTestPromises');
+        var thisChangeStream = theCollection.watch(pipeline);
 
-            assert.equal(
-              change,
-              null,
-              'ChangeStream.next() returned a change document but it should have returned a MongoNetworkError'
-            );
+        thisChangeStream.next(function(err, change) {
+          assert.ok(err instanceof MongoNetworkError);
+          assert.ok(err.message);
+          assert.ok(err.message.indexOf('timed out') > -1);
 
-            thisChangeStream.close(function(err) {
-              assert.ifError(err);
-              thisChangeStream.close();
+          assert.equal(
+            change,
+            null,
+            'ChangeStream.next() returned a change document but it should have returned a MongoNetworkError'
+          );
 
-              client.close(() => mock.cleanup(() => done()));
-            });
+          thisChangeStream.close(function(err) {
+            assert.ifError(err);
+            thisChangeStream.close();
+
+            client.close(() => mock.cleanup(() => done()));
           });
-        }
-      );
+        });
+      });
     }
   });
 
@@ -861,10 +843,9 @@ describe('Change Streams', function() {
     },
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        ObjectId = configuration.require.ObjectId,
-        Timestamp = configuration.require.Timestamp,
-        Long = configuration.require.Long;
+      const ObjectId = configuration.require.ObjectId;
+      const Timestamp = configuration.require.Timestamp;
+      const Long = configuration.require.Long;
 
       // Contain mock server
       var primaryServer = null;
@@ -939,11 +920,13 @@ describe('Change Streams', function() {
       });
 
       let finalError = undefined;
-
-      MongoClient.connect('mongodb://localhost:32000/', {
+      const client = configuration.newClient('mongodb://localhost:32000/', {
         socketTimeoutMS: 500,
         validateOptions: true
-      })
+      });
+
+      client
+        .connect()
         .then(client => {
           var database = client.db('integration_tests');
           var collection = database.collection('MongoNetworkErrorTestPromises');
@@ -990,8 +973,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function() {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       return client.connect().then(client => {
         var database = client.db('integration_tests');
@@ -1081,8 +1063,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function() {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       return client.connect().then(client => {
         var database = client.db('integration_tests');
@@ -1137,8 +1118,7 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function() {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       return client.connect().then(client => {
         var database = client.db('integration_tests');
@@ -1206,9 +1186,8 @@ describe('Change Streams', function() {
     // The actual test we wish to run
     test: function() {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var ReadPreference = configuration.require.ReadPreference;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       return client.connect().then(client => {
         // Should get preference from database
@@ -1256,8 +1235,7 @@ describe('Change Streams', function() {
     test: function(done) {
       var configuration = this.configuration;
       var fs = require('fs');
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       client.connect(function(err, client) {
         assert.ifError(err);
@@ -1304,10 +1282,9 @@ describe('Change Streams', function() {
     },
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        ObjectId = configuration.require.ObjectId,
-        Timestamp = configuration.require.Timestamp,
-        Long = configuration.require.Long;
+      const ObjectId = configuration.require.ObjectId;
+      const Timestamp = configuration.require.Timestamp;
+      const Long = configuration.require.Long;
 
       // Contain mock server
       var primaryServer = null;
@@ -1403,44 +1380,42 @@ describe('Change Streams', function() {
           }
         });
 
-        MongoClient.connect(
-          `mongodb://${primaryServer.uri()}/`,
-          {
-            socketTimeoutMS: 500,
-            validateOptions: true
-          },
-          function(err, client) {
-            assert.ifError(err);
+        const client = configuration.newClient(`mongodb://${primaryServer.uri()}/`, {
+          socketTimeoutMS: 500,
+          validateOptions: true
+        });
 
-            var fs = require('fs');
-            var theDatabase = client.db('integration_tests5');
-            var theCollection = theDatabase.collection('MongoNetworkErrorTestPromises');
-            var thisChangeStream = theCollection.watch(pipeline);
+        client.connect(function(err, client) {
+          assert.ifError(err);
 
-            var filename = '/tmp/_nodemongodbnative_resumepipe.txt';
-            var outStream = fs.createWriteStream(filename);
+          var fs = require('fs');
+          var theDatabase = client.db('integration_tests5');
+          var theCollection = theDatabase.collection('MongoNetworkErrorTestPromises');
+          var thisChangeStream = theCollection.watch(pipeline);
 
-            thisChangeStream.stream({ transform: JSON.stringify }).pipe(outStream);
+          var filename = '/tmp/_nodemongodbnative_resumepipe.txt';
+          var outStream = fs.createWriteStream(filename);
 
-            // Listen for changes to the file
-            var watcher = fs.watch(filename, function(eventType) {
-              assert.equal(eventType, 'change');
+          thisChangeStream.stream({ transform: JSON.stringify }).pipe(outStream);
 
-              var fileContents = fs.readFileSync(filename, 'utf8');
+          // Listen for changes to the file
+          var watcher = fs.watch(filename, function(eventType) {
+            assert.equal(eventType, 'change');
 
-              var parsedFileContents = JSON.parse(fileContents);
-              assert.equal(parsedFileContents.fullDocument.a, 1);
+            var fileContents = fs.readFileSync(filename, 'utf8');
 
-              watcher.close();
+            var parsedFileContents = JSON.parse(fileContents);
+            assert.equal(parsedFileContents.fullDocument.a, 1);
 
-              thisChangeStream.close(function(err) {
-                assert.ifError(err);
+            watcher.close();
 
-                mock.cleanup(() => done());
-              });
+            thisChangeStream.close(function(err) {
+              assert.ifError(err);
+
+              mock.cleanup(() => done());
             });
-          }
-        );
+          });
+        });
       });
     }
   });
@@ -1452,8 +1427,7 @@ describe('Change Streams', function() {
     test: function(done) {
       var configuration = this.configuration;
       var crypto = require('crypto');
-      var MongoClient = configuration.require.MongoClient;
-      var client = new MongoClient(configuration.url(), {
+      var client = configuration.newClient(configuration.url(), {
         poolSize: 1,
         autoReconnect: false
       });
@@ -1512,8 +1486,7 @@ describe('Change Streams', function() {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.5.10' } },
     test: function(done) {
       const configuration = this.configuration;
-      const MongoClient = configuration.require.MongoClient;
-      const client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       const collectionName = 'resumeAfterKillCursor';
 
@@ -1552,7 +1525,6 @@ describe('Change Streams', function() {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.7.3' } },
     test: function(done) {
       const configuration = this.configuration;
-      const MongoClient = configuration.require.MongoClient;
       const ObjectId = configuration.require.ObjectId;
       const Timestamp = configuration.require.Timestamp;
       const Long = configuration.require.Long;
@@ -1630,9 +1602,9 @@ describe('Change Streams', function() {
         validateOptions: true
       };
 
+      const client = configuration.newClient(`mongodb://${server.uri()}`, connectOptions);
       let getMoreCounter = 0;
       let aggregateCounter = 0;
-      let client;
       let changeStream;
       let server;
 
@@ -1681,8 +1653,7 @@ describe('Change Streams', function() {
         .createServer()
         .then(_server => (server = _server))
         .then(() => server.setMessageHandler(primaryServerHandler))
-        .then(() => MongoClient.connect(`mongodb://${server.uri()}`, connectOptions))
-        .then(_client => (client = _client))
+        .then(() => client.connect())
         .then(() => client.db(dbName))
         .then(db => db.collection(collectionName))
         .then(col => col.watch(pipeline))

--- a/test/functional/collations_tests.js
+++ b/test/functional/collations_tests.js
@@ -27,8 +27,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -50,7 +49,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -79,8 +79,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -102,7 +101,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -123,8 +123,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -148,7 +147,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -174,8 +174,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -199,7 +198,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -222,8 +222,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -247,7 +246,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -280,7 +280,6 @@ describe('Collation', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         Code = configuration.require.Code;
 
       // Primary server states
@@ -305,7 +304,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -338,8 +338,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -363,7 +362,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -384,8 +384,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -409,7 +408,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -434,8 +434,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -459,7 +458,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -483,8 +483,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -508,7 +507,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -533,8 +533,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -558,7 +557,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -582,7 +582,6 @@ describe('Collation', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         Long = configuration.require.Long;
 
       // Primary server states
@@ -616,7 +615,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -637,8 +637,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields, { maxWireVersion: 4 })];
@@ -659,7 +658,8 @@ describe('Collation', function() {
         });
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -681,8 +681,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields, { maxWireVersion: 4 })];
@@ -703,7 +702,8 @@ describe('Collation', function() {
         });
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -723,8 +723,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -750,7 +749,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -785,8 +785,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields, { maxWireVersion: 4 })];
@@ -808,7 +807,8 @@ describe('Collation', function() {
         });
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -843,7 +843,6 @@ describe('Collation', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId;
 
       var electionIds = [new ObjectId(), new ObjectId()];
@@ -930,35 +929,36 @@ describe('Collation', function() {
 
         setTimeout(() => {
           // Connect to the mocks
-          MongoClient.connect(
-            'mongodb://localhost:32000,localhost:32001/test?replicaSet=rs',
-            function(err, client) {
-              test.equal(null, err);
-              var db = client.db(configuration.db);
-
-              db.collection('test').bulkWrite(
-                [
-                  {
-                    updateOne: {
-                      q: { a: 2 },
-                      u: { $set: { a: 2 } },
-                      upsert: true,
-                      collation: { caseLevel: true }
-                    }
-                  },
-                  { deleteOne: { q: { c: 1 } } }
-                ],
-                { ordered: true },
-                function(err) {
-                  test.ok(err);
-                  test.equal('server/primary/mongos does not support collation', err.message);
-
-                  client.close();
-                  done();
-                }
-              );
-            }
+          const client = configuration.newClient(
+            'mongodb://localhost:32000,localhost:32001/test?replicaSet=rs'
           );
+
+          client.connect(function(err, client) {
+            test.equal(null, err);
+            var db = client.db(configuration.db);
+
+            db.collection('test').bulkWrite(
+              [
+                {
+                  updateOne: {
+                    q: { a: 2 },
+                    u: { $set: { a: 2 } },
+                    upsert: true,
+                    collation: { caseLevel: true }
+                  }
+                },
+                { deleteOne: { q: { c: 1 } } }
+              ],
+              { ordered: true },
+              function(err) {
+                test.ok(err);
+                test.equal('server/primary/mongos does not support collation', err.message);
+
+                client.close();
+                done();
+              }
+            );
+          });
         }, 500);
       });
     }
@@ -968,8 +968,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields)];
@@ -991,7 +990,8 @@ describe('Collation', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -1017,8 +1017,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields, { maxWireVersion: 4 })];
@@ -1039,7 +1038,8 @@ describe('Collation', function() {
         });
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -1062,8 +1062,7 @@ describe('Collation', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Primary server states
       var primary = [Object.assign({}, defaultFields, { maxWireVersion: 4 })];
@@ -1084,7 +1083,8 @@ describe('Collation', function() {
         });
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -1142,11 +1142,11 @@ describe('Collation', function() {
     metadata: { requires: { topology: 'single', mongodb: '>=3.3.12' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Connect to the mocks
-      MongoClient.connect(configuration.url(), function(err, client) {
+      const client = configuration.newClient();
+      client.connect(function(err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
@@ -1184,11 +1184,11 @@ describe('Collation', function() {
     metadata: { requires: { topology: 'single', mongodb: '>=3.3.12' } },
 
     test: function(done) {
-      var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient;
+      var configuration = this.configuration;
 
       // Connect to the mocks
-      MongoClient.connect(configuration.url(), function(err, client) {
+      const client = configuration.newClient();
+      client.connect(function(err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 

--- a/test/functional/command_write_concern_tests.js
+++ b/test/functional/command_write_concern_tests.js
@@ -30,7 +30,6 @@ describe('Command Write Concern', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId;
 
       var electionIds = [new ObjectId(), new ObjectId()];
@@ -112,27 +111,28 @@ describe('Command Write Concern', function() {
         });
 
         var commandResult = null;
-        MongoClient.connect(
-          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            db
-              .collection('test')
-              .aggregate([{ $match: {} }, { $out: 'readConcernCollectionAggregate1Output' }], {
-                w: 2,
-                wtimeout: 1000
-              })
-              .toArray(function(err) {
-                test.equal(null, err);
-                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
-
-                client.close();
-                done();
-              });
-          }
+        const client = configuration.newClient(
+          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          db
+            .collection('test')
+            .aggregate([{ $match: {} }, { $out: 'readConcernCollectionAggregate1Output' }], {
+              w: 2,
+              wtimeout: 1000
+            })
+            .toArray(function(err) {
+              test.equal(null, err);
+              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+
+              client.close();
+              done();
+            });
+        });
       });
     }
   });
@@ -147,7 +147,6 @@ describe('Command Write Concern', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId,
         Long = configuration.require.Long;
 
@@ -242,21 +241,22 @@ describe('Command Write Concern', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(
-          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            db.createCollection('test_collection_methods', { w: 2, wtimeout: 1000 }, function(err) {
-              test.equal(null, err);
-              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
-
-              client.close();
-              done();
-            });
-          }
+        const client = configuration.newClient(
+          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          db.createCollection('test_collection_methods', { w: 2, wtimeout: 1000 }, function(err) {
+            test.equal(null, err);
+            test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+
+            client.close();
+            done();
+          });
+        });
       });
     }
   });
@@ -271,7 +271,6 @@ describe('Command Write Concern', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId;
 
       var electionIds = [new ObjectId(), new ObjectId()];
@@ -356,29 +355,30 @@ describe('Command Write Concern', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(
-          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            db.collection('indexOptionDefault').createIndex(
-              { a: 1 },
-              {
-                indexOptionDefaults: true,
-                w: 2,
-                wtimeout: 1000
-              },
-              function(err) {
-                test.equal(null, err);
-                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
-
-                client.close();
-                done();
-              }
-            );
-          }
+        const client = configuration.newClient(
+          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          db.collection('indexOptionDefault').createIndex(
+            { a: 1 },
+            {
+              indexOptionDefaults: true,
+              w: 2,
+              wtimeout: 1000
+            },
+            function(err) {
+              test.equal(null, err);
+              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+
+              client.close();
+              done();
+            }
+          );
+        });
       });
     }
   });
@@ -393,7 +393,6 @@ describe('Command Write Concern', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId;
 
       var electionIds = [new ObjectId(), new ObjectId()];
@@ -477,27 +476,28 @@ describe('Command Write Concern', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(
-          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            db.collection('indexOptionDefault').drop(
-              {
-                w: 2,
-                wtimeout: 1000
-              },
-              function(err) {
-                test.equal(null, err);
-                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
-
-                client.close();
-                done();
-              }
-            );
-          }
+        const client = configuration.newClient(
+          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          db.collection('indexOptionDefault').drop(
+            {
+              w: 2,
+              wtimeout: 1000
+            },
+            function(err) {
+              test.equal(null, err);
+              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+
+              client.close();
+              done();
+            }
+          );
+        });
       });
     }
   });
@@ -512,7 +512,6 @@ describe('Command Write Concern', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId;
 
       var electionIds = [new ObjectId(), new ObjectId()];
@@ -596,27 +595,28 @@ describe('Command Write Concern', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(
-          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            db.dropDatabase(
-              {
-                w: 2,
-                wtimeout: 1000
-              },
-              function(err) {
-                test.equal(null, err);
-                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
-
-                client.close();
-                done();
-              }
-            );
-          }
+        const client = configuration.newClient(
+          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          db.dropDatabase(
+            {
+              w: 2,
+              wtimeout: 1000
+            },
+            function(err) {
+              test.equal(null, err);
+              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+
+              client.close();
+              done();
+            }
+          );
+        });
       });
     }
   });
@@ -631,7 +631,6 @@ describe('Command Write Concern', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId;
 
       var electionIds = [new ObjectId(), new ObjectId()];
@@ -715,27 +714,28 @@ describe('Command Write Concern', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(
-          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            db.collection('test').dropIndexes(
-              {
-                w: 2,
-                wtimeout: 1000
-              },
-              function(err) {
-                test.equal(null, err);
-                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
-
-                client.close();
-                done();
-              }
-            );
-          }
+        const client = configuration.newClient(
+          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          db.collection('test').dropIndexes(
+            {
+              w: 2,
+              wtimeout: 1000
+            },
+            function(err) {
+              test.equal(null, err);
+              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+
+              client.close();
+              done();
+            }
+          );
+        });
       });
     }
   });
@@ -750,7 +750,6 @@ describe('Command Write Concern', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId,
         Code = configuration.require.Code;
 
@@ -835,35 +834,36 @@ describe('Command Write Concern', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(
-          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            // String functions
-            var map = new Code('function() { emit(this.user_id, 1); }');
-            var reduce = new Code('function(k,vals) { return 1; }');
-
-            // db.collection('test').mapReduce({
-            db.collection('test').mapReduce(
-              map,
-              reduce,
-              {
-                out: { replace: 'tempCollection' },
-                w: 2,
-                wtimeout: 1000
-              },
-              function(err) {
-                test.equal(null, err);
-                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
-
-                client.close();
-                done();
-              }
-            );
-          }
+        const client = configuration.newClient(
+          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          // String functions
+          var map = new Code('function() { emit(this.user_id, 1); }');
+          var reduce = new Code('function(k,vals) { return 1; }');
+
+          // db.collection('test').mapReduce({
+          db.collection('test').mapReduce(
+            map,
+            reduce,
+            {
+              out: { replace: 'tempCollection' },
+              w: 2,
+              wtimeout: 1000
+            },
+            function(err) {
+              test.equal(null, err);
+              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+
+              client.close();
+              done();
+            }
+          );
+        });
       });
     }
   });
@@ -878,7 +878,6 @@ describe('Command Write Concern', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId;
 
       var electionIds = [new ObjectId(), new ObjectId()];
@@ -962,21 +961,22 @@ describe('Command Write Concern', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(
-          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            db.admin().addUser('kay:kay', 'abc123', { w: 2, wtimeout: 1000 }, function(err) {
-              test.equal(null, err);
-              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
-
-              client.close();
-              done();
-            });
-          }
+        const client = configuration.newClient(
+          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          db.admin().addUser('kay:kay', 'abc123', { w: 2, wtimeout: 1000 }, function(err) {
+            test.equal(null, err);
+            test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+
+            client.close();
+            done();
+          });
+        });
       });
     }
   });
@@ -991,7 +991,6 @@ describe('Command Write Concern', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId;
 
       var electionIds = [new ObjectId(), new ObjectId()];
@@ -1075,21 +1074,22 @@ describe('Command Write Concern', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(
-          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            db.admin().removeUser('kay:kay', { w: 2, wtimeout: 1000 }, function(err) {
-              test.equal(null, err);
-              test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
-
-              client.close();
-              done();
-            });
-          }
+        const client = configuration.newClient(
+          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          db.admin().removeUser('kay:kay', { w: 2, wtimeout: 1000 }, function(err) {
+            test.equal(null, err);
+            test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+
+            client.close();
+            done();
+          });
+        });
       });
     }
   });
@@ -1104,7 +1104,6 @@ describe('Command Write Concern', function() {
 
     test: function(done) {
       var configuration = this.configuration,
-        MongoClient = configuration.require.MongoClient,
         ObjectId = configuration.require.ObjectId;
 
       var electionIds = [new ObjectId(), new ObjectId()];
@@ -1188,30 +1187,31 @@ describe('Command Write Concern', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(
-          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs',
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db(configuration.db);
-
-            // Simple findAndModify command returning the new document
-            db
-              .collection('test')
-              .findAndModify(
-                { a: 1 },
-                [['a', 1]],
-                { $set: { b1: 1 } },
-                { new: true, w: 2, wtimeout: 1000 },
-                function(err) {
-                  test.equal(null, err);
-                  test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
-
-                  client.close();
-                  done();
-                }
-              );
-          }
+        const client = configuration.newClient(
+          'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
+
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db(configuration.db);
+
+          // Simple findAndModify command returning the new document
+          db
+            .collection('test')
+            .findAndModify(
+              { a: 1 },
+              [['a', 1]],
+              { $set: { b1: 1 } },
+              { new: true, w: 2, wtimeout: 1000 },
+              function(err) {
+                test.equal(null, err);
+                test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+
+                client.close();
+                done();
+              }
+            );
+        });
       });
     }
   });

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -128,14 +128,12 @@ describe('Connection', function() {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: true });
 
-      client.on('open', function(client) {
+      client.connect().then(() => {
         test.equal('js', client.topology.parserType);
 
         client.close();
         done();
       });
-
-      client.connect();
     }
   });
 

--- a/test/functional/crud_spec_tests.js
+++ b/test/functional/crud_spec_tests.js
@@ -19,8 +19,8 @@ const testContext = {};
 describe('CRUD spec', function() {
   beforeEach(function() {
     const configuration = this.configuration;
-    const MongoClient = configuration.require.MongoClient;
-    return MongoClient.connect(configuration.url()).then(client => {
+    const client = configuration.newClient();
+    return client.connect().then(client => {
       testContext.client = client;
       testContext.db = client.db(configuration.db);
     });

--- a/test/functional/crud_spec_tests.js
+++ b/test/functional/crud_spec_tests.js
@@ -227,17 +227,14 @@ describe('CRUD spec', function() {
     });
     const options = Object.assign({}, args.options);
 
-    collection
+    return collection
       .bulkWrite(operations, options)
       .then(result =>
         Object.keys(scenarioTest.outcome.result).forEach(resultName =>
           test.deepEqual(result[resultName], scenarioTest.outcome.result[resultName])
         )
-      );
-
-    return collection
-      .find({})
-      .toArray()
+      )
+      .then(() => collection.find({}).toArray())
       .then(results => test.deepEqual(results, scenarioTest.outcome.collection.data));
   }
 

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4541,7 +4541,7 @@ describe('Cursor', function() {
     const configuration = this.configuration;
     const ReadPreference = this.configuration.require.ReadPreference;
     const client = configuration.newClient(
-      { w: 1, readPreference: ReadPreference.secondary },
+      { w: 1, readPreference: ReadPreference.SECONDARY },
       { poolSize: 1, auto_reconnect: false }
     );
 

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4542,15 +4542,18 @@ describe('Cursor', function() {
     const ReadPreference = this.configuration.require.ReadPreference;
     const client = configuration.newClient(
       { w: 1, readPreference: ReadPreference.SECONDARY },
-      { poolSize: 1, auto_reconnect: false }
+      { poolSize: 1, auto_reconnect: false, connectWithNoPrimary: true }
     );
 
     client.connect(function(err, client) {
+      expect(err).to.not.exist;
+
       const db = client.db(configuration.db);
       let collection, cursor, spy;
       const close = e => cursor.close(() => client.close(() => done(e)));
 
       Promise.resolve()
+        .then(() => new Promise(resolve => setTimeout(() => resolve(), 500)))
         .then(() => db.createCollection('test_count_readPreference'))
         .then(() => (collection = db.collection('test_count_readPreference')))
         .then(() => collection.find())

--- a/test/functional/custom_pk_tests.js
+++ b/test/functional/custom_pk_tests.js
@@ -27,11 +27,15 @@ describe('Custom PK', function() {
         return new ObjectID('aaaaaaaaaaaa');
       };
 
-      var client = configuration.newClient({
-        w: 1,
-        poolSize: 1,
-        pkFactory: CustomPKFactory
-      });
+      var client = configuration.newClient(
+        {
+          w: 1,
+          poolSize: 1
+        },
+        {
+          pkFactory: CustomPKFactory
+        }
+      );
 
       client.connect(function(err, client) {
         var db = client.db(configuration.db);

--- a/test/functional/db_tests.js
+++ b/test/functional/db_tests.js
@@ -232,13 +232,10 @@ describe('Db', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        Server = configuration.require.Server;
+      var fs_client = configuration.newClient('mongodb://127.0.0.1:25117/test', {
+        auto_reconnect: false
+      });
 
-      var fs_client = new MongoClient(
-        new Server('127.0.0.1', 25117, { auto_reconnect: false }),
-        configuration.writeConcernMax()
-      );
       fs_client.connect(function(err) {
         test.ok(err != null);
         done();
@@ -426,13 +423,11 @@ describe('Db', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        Server = configuration.require.Server;
+      var client = configuration.newClient(`mongodb://127.0.0.1:27088/test`, {
+        auto_reconnect: false,
+        poolSize: 4
+      });
 
-      var client = new MongoClient(
-        new Server('127.0.0.1', 27088, { auto_reconnect: false, poolSize: 4 }),
-        configuration.writeConcernMax()
-      );
       // Establish connection to db
       client.connect(function(err) {
         test.ok(err != null);

--- a/test/functional/db_tests.js
+++ b/test/functional/db_tests.js
@@ -196,8 +196,8 @@ describe('Db', function() {
     test: function(done) {
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, bufferMaxEntries: 0 },
-        { poolSize: 1, auto_reconnect: true }
+        { w: 1 },
+        { poolSize: 1, auto_reconnect: true, bufferMaxEntries: 0 }
       );
 
       client.connect(function(err, client) {

--- a/test/functional/disconnect_handler_tests.js
+++ b/test/functional/disconnect_handler_tests.js
@@ -11,9 +11,9 @@ describe('Disconnect Handler', function() {
 
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
-      MongoClient.connect(configuration.url(), {}, function(err, client) {
+      const client = configuration.newCLient();
+      client.connect(function(err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 

--- a/test/functional/domain_tests.js
+++ b/test/functional/domain_tests.js
@@ -53,30 +53,24 @@ describe('Decimal128', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var Domain = require('domain');
       var domainInstance = Domain.create();
 
-      MongoClient.connect(
-        configuration.url(),
-        {
-          domainsEnabled: true
-        },
-        function(err, client) {
-          test.ok(!err);
-          var db = client.db(configuration.db);
-          var collection = db.collection('test');
-          domainInstance.run(function() {
-            collection.count({}, function(err) {
-              test.ok(!err);
-              test.ok(domainInstance === process.domain);
-              domainInstance.exit();
-              client.close();
-              done();
-            });
+      const client = configuration.newClient({}, { domainsEnabled: true });
+      client.connect(function(err, client) {
+        test.ok(!err);
+        var db = client.db(configuration.db);
+        var collection = db.collection('test');
+        domainInstance.run(function() {
+          collection.count({}, function(err) {
+            test.ok(!err);
+            test.ok(domainInstance === process.domain);
+            domainInstance.exit();
+            client.close();
+            done();
           });
-        }
-      );
+        });
+      });
     }
   });
 

--- a/test/functional/domain_tests.js
+++ b/test/functional/domain_tests.js
@@ -129,8 +129,8 @@ describe('Decimal128', function() {
       var domainInstance = Domain.create();
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 0, bufferMaxEntries: 0 },
-        { poolSize: 1, auto_reconnect: true, domainsEnabled: true }
+        { w: 0 },
+        { poolSize: 1, auto_reconnect: true, domainsEnabled: true, bufferMaxEntries: 0 }
       );
 
       client.connect(function(err, client) {
@@ -168,8 +168,8 @@ describe('Decimal128', function() {
       var domainInstance = Domain.create();
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, bufferMaxEntries: 0 },
-        { poolSize: 1, auto_reconnect: true, domainsEnabled: true }
+        { w: 1 },
+        { poolSize: 1, auto_reconnect: true, domainsEnabled: true, bufferMaxEntries: 0 }
       );
 
       client.connect(function(err, client) {

--- a/test/functional/find_and_modify_tests.js
+++ b/test/functional/find_and_modify_tests.js
@@ -166,7 +166,7 @@ describe('Find and Modify', function() {
       url = url.indexOf('?') !== -1 ? f('%s&%s', url, 'fsync=true') : f('%s?%s', url, 'fsync=true');
 
       // Establish connection to db
-      const client = configuration.newClient(url);
+      const client = configuration.newClient(url, { sslValidate: false });
       client.connect(function(err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);

--- a/test/functional/find_and_modify_tests.js
+++ b/test/functional/find_and_modify_tests.js
@@ -147,7 +147,6 @@ describe('Find and Modify', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var started = [];
       var succeeded = [];
 
@@ -167,7 +166,8 @@ describe('Find and Modify', function() {
       url = url.indexOf('?') !== -1 ? f('%s&%s', url, 'fsync=true') : f('%s?%s', url, 'fsync=true');
 
       // Establish connection to db
-      MongoClient.connect(url, { sslValidate: false }, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
         var collection = db.collection('findAndModifyTEST');

--- a/test/functional/find_tests.js
+++ b/test/functional/find_tests.js
@@ -2,7 +2,6 @@
 const test = require('./shared').assert;
 const setupDatabase = require('./shared').setupDatabase;
 const expect = require('chai').expect;
-const MongoClient = require('../../lib/mongo_client');
 const Buffer = require('safe-buffer').Buffer;
 
 describe('Find', function() {
@@ -2635,7 +2634,7 @@ describe('Find', function() {
     },
     test: function(done) {
       const configuration = this.configuration;
-      const client = new MongoClient(configuration.url());
+      const client = configuration.newClient();
 
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
@@ -3096,35 +3095,29 @@ describe('Find', function() {
       });
 
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect(
-        configuration.url(),
-        {
-          ignoreUndefined: true
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
-          var collection = db.collection('test_find_simple_cursor_inheritance');
+      const client = configuration.newClient({}, { ignoreUndefined: true });
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+        var collection = db.collection('test_find_simple_cursor_inheritance');
 
-          // Insert some test documents
-          collection.insert([{ a: 2 }, { b: 3, c: undefined }], function(err) {
-            test.equal(null, err);
-            // Ensure correct insertion testing via the cursor and the count function
-            var cursor = collection.find({ c: undefined });
-            test.equal(true, cursor.s.options.ignoreUndefined);
+        // Insert some test documents
+        collection.insert([{ a: 2 }, { b: 3, c: undefined }], function(err) {
+          test.equal(null, err);
+          // Ensure correct insertion testing via the cursor and the count function
+          var cursor = collection.find({ c: undefined });
+          test.equal(true, cursor.s.options.ignoreUndefined);
 
-            cursor.toArray(function(err, documents) {
-              test.equal(2, documents.length);
-              // process.exit(0)
-              listener.uninstrument();
+          cursor.toArray(function(err, documents) {
+            test.equal(2, documents.length);
+            // process.exit(0)
+            listener.uninstrument();
 
-              // Let's close the db
-              client.close();
-              done();
-            });
+            // Let's close the db
+            client.close();
+            done();
           });
-        }
-      );
+        });
+      });
     }
   });
 });

--- a/test/functional/find_tests.js
+++ b/test/functional/find_tests.js
@@ -2628,7 +2628,7 @@ describe('Find', function() {
   it('Should not use a session when using parallelCollectionScan', {
     metadata: {
       requires: {
-        mongodb: '>=3.6.0',
+        mongodb: '>=3.6.0 <= 4.1.0',
         topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
       }
     },

--- a/test/functional/find_tests.js
+++ b/test/functional/find_tests.js
@@ -2413,7 +2413,7 @@ describe('Find', function() {
   it('Should correctly execute parallelCollectionScan with multiple cursors using each', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
-    metadata: { requires: { mongodb: '>2.5.5', topology: ['single', 'replicaset'] } },
+    metadata: { requires: { mongodb: '>2.5.5 <=4.1.0', topology: ['single', 'replicaset'] } },
 
     // The actual test we wish to run
     test: function(done) {
@@ -2478,7 +2478,7 @@ describe('Find', function() {
   it('Should correctly execute parallelCollectionScan with multiple cursors using next', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
-    metadata: { requires: { mongodb: '>2.5.5', topology: ['single', 'replicaset'] } },
+    metadata: { requires: { mongodb: '>2.5.5 <=4.1.0', topology: ['single', 'replicaset'] } },
 
     // The actual test we wish to run
     test: function(done) {
@@ -2536,7 +2536,7 @@ describe('Find', function() {
   it('Should correctly execute parallelCollectionScan with single cursor and close', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
-    metadata: { requires: { mongodb: '>2.5.5', topology: ['single', 'replicaset'] } },
+    metadata: { requires: { mongodb: '>2.5.5 <=4.1.0', topology: ['single', 'replicaset'] } },
 
     // The actual test we wish to run
     test: function(done) {
@@ -2580,7 +2580,7 @@ describe('Find', function() {
   it('Should correctly execute parallelCollectionScan with single cursor streaming', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
-    metadata: { requires: { mongodb: '>2.5.5', topology: ['single', 'replicaset'] } },
+    metadata: { requires: { mongodb: '>2.5.5 <=4.1.0', topology: ['single', 'replicaset'] } },
 
     // The actual test we wish to run
     test: function(done) {
@@ -2754,7 +2754,7 @@ describe('Find', function() {
     {
       // Add a tag that our runner can trigger on
       // in this case we are setting that node needs to be higher than 0.10.X to run
-      metadata: { requires: { mongodb: '>2.5.5', topology: ['single', 'replicaset'] } },
+      metadata: { requires: { mongodb: '>2.5.5 <=4.1.0', topology: ['single', 'replicaset'] } },
 
       // The actual test we wish to run
       test: function(done) {

--- a/test/functional/gridfs_stream_tests.js
+++ b/test/functional/gridfs_stream_tests.js
@@ -29,16 +29,17 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         db.dropDatabase(function(error) {
           test.equal(error, null);
@@ -113,16 +114,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         db.dropDatabase(function(error) {
           test.equal(error, null);
@@ -199,16 +200,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var CHUNKS_COLL = 'gridfsdownload.chunks';
@@ -267,16 +268,16 @@ describe('GridFS Stream', function() {
         ObjectId = configuration.require.ObjectID;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
 
@@ -311,16 +312,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var readStream = fs.createReadStream('./LICENSE');
@@ -365,16 +366,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, {
           bucketName: 'gridfsdownload',
@@ -434,16 +435,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var CHUNKS_COLL = 'gridfsdownload.chunks';
@@ -495,16 +496,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
         var CHUNKS_COLL = 'gridfsabort.chunks';
@@ -557,16 +558,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
         var CHUNKS_COLL = 'gridfsabort.chunks';
@@ -621,16 +622,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdestroy', chunkSizeBytes: 10 });
         var readStream = fs.createReadStream('./LICENSE');
@@ -693,16 +694,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var CHUNKS_COLL = 'gridfsdownload.chunks';
@@ -746,16 +747,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'fs' });
 
@@ -792,16 +793,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var CHUNKS_COLL = 'gridfsdownload.chunks';
@@ -854,16 +855,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var CHUNKS_COLL = 'gridfsdownload.chunks';
@@ -914,16 +915,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload_2' });
         var readStream = fs.createReadStream('./LICENSE');
@@ -961,16 +962,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload_3' });
         var readStream = fs.createReadStream('./LICENSE');
@@ -1287,16 +1288,16 @@ describe('GridFS Stream', function() {
       var configuration = this.configuration;
       var GridFSBucket = configuration.require.GridFSBucket;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
         var CHUNKS_COLL = 'gridfsabort.chunks';
@@ -1356,16 +1357,16 @@ describe('GridFS Stream', function() {
       var GridFSBucket = configuration.require.GridFSBucket;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      // LINE var MongoClient = require('mongodb').MongoClient,
+      // LINE   test = require('assert');
+      // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+      // LINE const db = client.db('test);
+      // REPLACE configuration.writeConcernMax() WITH {w:1}
+      // REMOVE-LINE restartAndDone
+      // REMOVE-LINE done();
+      // REMOVE-LINE var db = client.db(configuration.db);
+      // BEGIN
       client.connect(function(err, client) {
-        // LINE var MongoClient = require('mongodb').MongoClient,
-        // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-        // LINE   var db = client.db('test);
-        // REPLACE configuration.writeConcernMax() WITH {w:1}
-        // REMOVE-LINE restartAndDone
-        // REMOVE-LINE done();
-        // REMOVE-LINE var db = client.db(configuration.db);
-        // BEGIN
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, {
           bucketName: 'gridfsdownload',

--- a/test/functional/gridfs_tests.js
+++ b/test/functional/gridfs_tests.js
@@ -3671,12 +3671,12 @@ describe('GridFS', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        GridStore = configuration.require.GridStore,
+      var GridStore = configuration.require.GridStore,
         fs = require('fs');
 
       // Use connect method to connect to the Server
-      MongoClient.connect(configuration.url(), { sslValidate: false }, function(err, client) {
+      const client = configuration.newClient({}, { sslValidate: false });
+      client.connect(function(err, client) {
         expect(err).to.not.exist;
         var db = client.db(configuration.db);
 
@@ -3716,11 +3716,11 @@ describe('GridFS', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        GridStore = configuration.require.GridStore;
+      var GridStore = configuration.require.GridStore;
 
       // Use connect method to connect to the Server
-      MongoClient.connect(configuration.url(), { sslValidate: false }, function(err, client) {
+      const client = configuration.newClient({}, { sslValidate: false });
+      client.connect(function(err, client) {
         expect(err).to.not.exist;
         var db = client.db(configuration.db);
 
@@ -3786,12 +3786,12 @@ describe('GridFS', function() {
       // The actual test we wish to run
       test: function(done) {
         var configuration = this.configuration;
-        var MongoClient = configuration.require.MongoClient,
-          GridStore = configuration.require.GridStore,
+        var GridStore = configuration.require.GridStore,
           ObjectID = configuration.require.ObjectID;
 
         var id = new ObjectID();
-        MongoClient.connect(configuration.url(), { sslValidate: false }, function(err, client) {
+        const client = configuration.newClient({}, { sslValidate: false });
+        client.connect(function(err, client) {
           expect(err).to.not.exist;
           var db = client.db(configuration.db);
 
@@ -3869,15 +3869,15 @@ describe('GridFS', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        GridStore = configuration.require.GridStore,
+      var GridStore = configuration.require.GridStore,
         ObjectID = configuration.require.ObjectID;
 
       // Create a test buffer
       var buffer = Buffer.alloc(200033);
 
       // Use connect method to connect to the Server
-      MongoClient.connect(configuration.url(), { sslValidate: false }, function(err, client) {
+      const client = configuration.newClient({}, { sslValidate: false });
+      client.connect(function(err, client) {
         expect(err).to.not.exist;
         var db = client.db(configuration.db);
 

--- a/test/functional/ignore_undefined_tests.js
+++ b/test/functional/ignore_undefined_tests.js
@@ -15,12 +15,10 @@ describe('Ignore Undefined', function() {
 
     test: function(done) {
       var configuration = this.configuration;
-      var client = configuration.newClient(
-        Object.assign({}, configuration.writeConcernMax(), {
-          poolSize: 1,
-          ignoreUndefined: true
-        })
-      );
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1,
+        ignoreUndefined: true
+      });
 
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
@@ -108,12 +106,10 @@ describe('Ignore Undefined', function() {
       var configuration = this.configuration;
       var ObjectId = configuration.require.ObjectID;
 
-      var client = configuration.newClient(
-        Object.assign({}, configuration.writeConcernMax(), {
-          poolSize: 1,
-          ignoreUndefined: true
-        })
-      );
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1,
+        ignoreUndefined: true
+      });
 
       client.connect(function(err, client) {
         var db = client.db(configuration.db);

--- a/test/functional/ignore_undefined_tests.js
+++ b/test/functional/ignore_undefined_tests.js
@@ -50,48 +50,47 @@ describe('Ignore Undefined', function() {
 
       test: function(done) {
         var configuration = this.configuration;
-        var MongoClient = configuration.require.MongoClient;
-
-        MongoClient.connect(
-          configuration.url(),
+        const client = configuration.newClient(
+          {},
           {
             bufferMaxEntries: 0,
             ignoreUndefined: true,
             sslValidate: false
-          },
-          function(err, client) {
-            var db = client.db(configuration.db);
-            var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue1');
-            collection.insert({ a: 1, b: undefined }, function(err) {
-              test.equal(null, err);
+          }
+        );
 
-              collection.findOne(function(err, item) {
-                test.equal(1, item.a);
-                test.ok(item.b === undefined);
+        client.connect(function(err, client) {
+          var db = client.db(configuration.db);
+          var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue1');
+          collection.insert({ a: 1, b: undefined }, function(err) {
+            test.equal(null, err);
 
-                collection.insertOne({ a: 2, b: undefined }, function(err) {
-                  test.equal(null, err);
+            collection.findOne(function(err, item) {
+              test.equal(1, item.a);
+              test.ok(item.b === undefined);
 
-                  collection.findOne({ a: 2 }, function(err, item) {
-                    test.equal(2, item.a);
-                    test.ok(item.b === undefined);
+              collection.insertOne({ a: 2, b: undefined }, function(err) {
+                test.equal(null, err);
 
-                    collection.insertMany([{ a: 3, b: undefined }], function(err) {
-                      test.equal(null, err);
+                collection.findOne({ a: 2 }, function(err, item) {
+                  test.equal(2, item.a);
+                  test.ok(item.b === undefined);
 
-                      collection.findOne({ a: 3 }, function(err, item) {
-                        test.equal(3, item.a);
-                        test.ok(item.b === undefined);
-                        client.close();
-                        done();
-                      });
+                  collection.insertMany([{ a: 3, b: undefined }], function(err) {
+                    test.equal(null, err);
+
+                    collection.findOne({ a: 3 }, function(err, item) {
+                      test.equal(3, item.a);
+                      test.ok(item.b === undefined);
+                      client.close();
+                      done();
                     });
                   });
                 });
               });
             });
-          }
-        );
+          });
+        });
       }
     }
   );

--- a/test/functional/kerberos_tests.js
+++ b/test/functional/kerberos_tests.js
@@ -23,36 +23,33 @@ describe('Kerberos', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
       // KDC Server
       var server = 'ldaptest.10gen.cc';
       var principal = 'drivers@LDAPTEST.10GEN.CC';
       var urlEncodedPrincipal = encodeURIComponent(principal);
-
-      // Let's write the actual connection code
-      MongoClient.connect(
-        format(
-          'mongodb://%s@%s/kerberos?authMechanism=GSSAPI&gssapiServiceName=mongodb&maxPoolSize=1',
-          urlEncodedPrincipal,
-          server
-        ),
-        function(err, client) {
-          test.equal(null, err);
-          var db = client.db('kerberos');
-
-          db
-            .collection('test')
-            .find()
-            .toArray(function(err, docs) {
-              test.equal(null, err);
-              test.ok(true, docs[0].kerberos);
-
-              client.close();
-              done();
-            });
-        }
+      const url = format(
+        'mongodb://%s@%s/kerberos?authMechanism=GSSAPI&gssapiServiceName=mongodb&maxPoolSize=1',
+        urlEncodedPrincipal,
+        server
       );
+
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
+        test.equal(null, err);
+        var db = client.db('kerberos');
+
+        db
+          .collection('test')
+          .find()
+          .toArray(function(err, docs) {
+            test.equal(null, err);
+            test.ok(true, docs[0].kerberos);
+
+            client.close();
+            done();
+          });
+      });
     }
   });
 
@@ -65,36 +62,33 @@ describe('Kerberos', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
       // KDC Server
       var server = 'ldaptest.10gen.cc';
       var principal = 'drivers@LDAPTEST.10GEN.CC';
       var urlEncodedPrincipal = encodeURIComponent(principal);
-
-      // Let's write the actual connection code
-      MongoClient.connect(
-        format(
-          'mongodb://%s@%s/kerberos?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false,SERVICE_REALM:windows&maxPoolSize=1',
-          urlEncodedPrincipal,
-          server
-        ),
-        function(err, client) {
-          test.equal(null, err);
-          var db = client.db('kerberos');
-
-          db
-            .collection('test')
-            .find()
-            .toArray(function(err, docs) {
-              test.equal(null, err);
-              test.ok(true, docs[0].kerberos);
-
-              client.close();
-              done();
-            });
-        }
+      const url = format(
+        'mongodb://%s@%s/kerberos?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false,SERVICE_REALM:windows&maxPoolSize=1',
+        urlEncodedPrincipal,
+        server
       );
+
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
+        test.equal(null, err);
+        var db = client.db('kerberos');
+
+        db
+          .collection('test')
+          .find()
+          .toArray(function(err, docs) {
+            test.equal(null, err);
+            test.ok(true, docs[0].kerberos);
+
+            client.close();
+            done();
+          });
+      });
     }
   });
 
@@ -109,36 +103,33 @@ describe('Kerberos', function() {
       // The actual test we wish to run
       test: function(done) {
         var configuration = this.configuration;
-        var MongoClient = configuration.require.MongoClient;
 
         // KDC Server
         var server = 'ldaptest.10gen.cc';
         var principal = 'drivers@LDAPTEST.10GEN.CC';
         var urlEncodedPrincipal = encodeURIComponent(principal);
-
-        // Let's write the actual connection code
-        MongoClient.connect(
-          format(
-            'mongodb://%s@%s/kerberos?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false&maxPoolSize=1',
-            urlEncodedPrincipal,
-            server
-          ),
-          function(err, client) {
-            test.equal(null, err);
-            var db = client.db('kerberos');
-
-            db
-              .collection('test')
-              .find()
-              .toArray(function(err, docs) {
-                test.equal(null, err);
-                test.ok(true, docs[0].kerberos);
-
-                client.close();
-                done();
-              });
-          }
+        const url = format(
+          'mongodb://%s@%s/kerberos?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false&maxPoolSize=1',
+          urlEncodedPrincipal,
+          server
         );
+
+        const client = configuration.newClient(url);
+        client.connect(function(err, client) {
+          test.equal(null, err);
+          var db = client.db('kerberos');
+
+          db
+            .collection('test')
+            .find()
+            .toArray(function(err, docs) {
+              test.equal(null, err);
+              test.ok(true, docs[0].kerberos);
+
+              client.close();
+              done();
+            });
+        });
       }
     }
   );
@@ -152,61 +143,58 @@ describe('Kerberos', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
       // KDC Server
       var server = 'ldaptest.10gen.cc';
       var principal = 'drivers@LDAPTEST.10GEN.CC';
       var urlEncodedPrincipal = encodeURIComponent(principal);
-
-      // Let's write the actual connection code
-      MongoClient.connect(
-        format(
-          'mongodb://%s@%s/kerberos?authMechanism=GSSAPI&gssapiServiceName=mongodb&maxPoolSize=5',
-          urlEncodedPrincipal,
-          server
-        ),
-        function(err, client) {
-          test.equal(null, err);
-
-          client
-            .db('kerberos')
-            .collection('test')
-            .findOne(function(err, doc) {
-              test.equal(null, err);
-              test.equal(true, doc.kerberos);
-
-              client.topology.once('reconnect', function() {
-                // Await reconnect and re-authentication
-                client
-                  .db('kerberos')
-                  .collection('test')
-                  .findOne(function(err, doc) {
-                    test.equal(null, err);
-                    test.equal(true, doc.kerberos);
-
-                    // Attempt disconnect again
-                    client.topology.connections()[0].destroy();
-
-                    // Await reconnect and re-authentication
-                    client
-                      .db('kerberos')
-                      .collection('test')
-                      .findOne(function(err, doc) {
-                        test.equal(null, err);
-                        test.equal(true, doc.kerberos);
-
-                        client.close();
-                        done();
-                      });
-                  });
-              });
-
-              // Force close
-              client.topology.connections()[0].destroy();
-            });
-        }
+      const url = format(
+        'mongodb://%s@%s/kerberos?authMechanism=GSSAPI&gssapiServiceName=mongodb&maxPoolSize=5',
+        urlEncodedPrincipal,
+        server
       );
+
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
+        test.equal(null, err);
+
+        client
+          .db('kerberos')
+          .collection('test')
+          .findOne(function(err, doc) {
+            test.equal(null, err);
+            test.equal(true, doc.kerberos);
+
+            client.topology.once('reconnect', function() {
+              // Await reconnect and re-authentication
+              client
+                .db('kerberos')
+                .collection('test')
+                .findOne(function(err, doc) {
+                  test.equal(null, err);
+                  test.equal(true, doc.kerberos);
+
+                  // Attempt disconnect again
+                  client.topology.connections()[0].destroy();
+
+                  // Await reconnect and re-authentication
+                  client
+                    .db('kerberos')
+                    .collection('test')
+                    .findOne(function(err, doc) {
+                      test.equal(null, err);
+                      test.equal(true, doc.kerberos);
+
+                      client.close();
+                      done();
+                    });
+                });
+            });
+
+            // Force close
+            client.topology.connections()[0].destroy();
+          });
+      });
     }
   });
 
@@ -258,25 +246,22 @@ describe('Kerberos', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
       // KDC Server
       var server = 'ldaptest.10gen.cc';
       var principal = 'drivers@LDAPTEST.10GEN.CC';
       var urlEncodedPrincipal = encodeURIComponent(principal);
-
-      // Let's write the actual connection code
-      MongoClient.connect(
-        format(
-          'mongodb://%s@%s/test?authMechanism=GSSAPI&gssapiServiceName=mongodb2&maxPoolSize=1',
-          urlEncodedPrincipal,
-          server
-        ),
-        function(err) {
-          test.ok(err != null);
-          done();
-        }
+      const url = format(
+        'mongodb://%s@%s/test?authMechanism=GSSAPI&gssapiServiceName=mongodb2&maxPoolSize=1',
+        urlEncodedPrincipal,
+        server
       );
+
+      const client = configuration.newClient(url);
+      client.connect(function(err) {
+        test.ok(err != null);
+        done();
+      });
     }
   });
 
@@ -289,7 +274,6 @@ describe('Kerberos', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
       // KDC Server
       var server = 'ldaptest.10gen.cc';
@@ -298,31 +282,29 @@ describe('Kerberos', function() {
 
       if (pass == null) throw new Error('The env parameter LDAPTEST_PASSWORD must be set');
       var urlEncodedPrincipal = encodeURIComponent(principal);
-
-      // Let's write the actual connection code
-      MongoClient.connect(
-        format(
-          'mongodb://%s:%s@%s/kerberos?authMechanism=GSSAPI&maxPoolSize=1',
-          urlEncodedPrincipal,
-          pass,
-          server
-        ),
-        function(err, client) {
-          test.equal(null, err);
-          var db = client.db('kerberos');
-
-          db
-            .collection('test')
-            .find()
-            .toArray(function(err, docs) {
-              test.equal(null, err);
-              test.ok(true, docs[0].kerberos);
-
-              client.close();
-              done();
-            });
-        }
+      const url = format(
+        'mongodb://%s:%s@%s/kerberos?authMechanism=GSSAPI&maxPoolSize=1',
+        urlEncodedPrincipal,
+        pass,
+        server
       );
+
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
+        test.equal(null, err);
+        var db = client.db('kerberos');
+
+        db
+          .collection('test')
+          .find()
+          .toArray(function(err, docs) {
+            test.equal(null, err);
+            test.ok(true, docs[0].kerberos);
+
+            client.close();
+            done();
+          });
+      });
     }
   });
 
@@ -335,7 +317,6 @@ describe('Kerberos', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
       // KDC Server
       var server = 'ldaptest.10gen.cc';
@@ -343,56 +324,54 @@ describe('Kerberos', function() {
       var pass = process.env['LDAPTEST_PASSWORD'];
       if (pass == null) throw new Error('The env parameter LDAPTEST_PASSWORD must be set');
       var urlEncodedPrincipal = encodeURIComponent(principal);
-
-      // Let's write the actual connection code
-      MongoClient.connect(
-        format(
-          'mongodb://%s:%s@%s/kerberos?authMechanism=GSSAPI&maxPoolSize=5',
-          urlEncodedPrincipal,
-          pass,
-          server
-        ),
-        function(err, client) {
-          test.equal(null, err);
-
-          client
-            .db('kerberos')
-            .collection('test')
-            .findOne(function(err, doc) {
-              test.equal(null, err);
-              test.equal(true, doc.kerberos);
-
-              client.topology.once('reconnect', function() {
-                // Await reconnect and re-authentication
-                client
-                  .db('kerberos')
-                  .collection('test')
-                  .findOne(function(err, doc) {
-                    test.equal(null, err);
-                    test.equal(true, doc.kerberos);
-
-                    // Attempt disconnect again
-                    client.topology.connections()[0].destroy();
-
-                    // Await reconnect and re-authentication
-                    client
-                      .db('kerberos')
-                      .collection('test')
-                      .findOne(function(err, doc) {
-                        test.equal(null, err);
-                        test.equal(true, doc.kerberos);
-
-                        client.close();
-                        done();
-                      });
-                  });
-              });
-
-              // Force close
-              client.topology.connections()[0].destroy();
-            });
-        }
+      const url = format(
+        'mongodb://%s:%s@%s/kerberos?authMechanism=GSSAPI&maxPoolSize=5',
+        urlEncodedPrincipal,
+        pass,
+        server
       );
+
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
+        test.equal(null, err);
+
+        client
+          .db('kerberos')
+          .collection('test')
+          .findOne(function(err, doc) {
+            test.equal(null, err);
+            test.equal(true, doc.kerberos);
+
+            client.topology.once('reconnect', function() {
+              // Await reconnect and re-authentication
+              client
+                .db('kerberos')
+                .collection('test')
+                .findOne(function(err, doc) {
+                  test.equal(null, err);
+                  test.equal(true, doc.kerberos);
+
+                  // Attempt disconnect again
+                  client.topology.connections()[0].destroy();
+
+                  // Await reconnect and re-authentication
+                  client
+                    .db('kerberos')
+                    .collection('test')
+                    .findOne(function(err, doc) {
+                      test.equal(null, err);
+                      test.equal(true, doc.kerberos);
+
+                      client.close();
+                      done();
+                    });
+                });
+            });
+
+            // Force close
+            client.topology.connections()[0].destroy();
+          });
+      });
     }
   });
 
@@ -413,13 +392,13 @@ describe('Kerberos', function() {
       var principal = 'drivers@LDAPTEST.10GEN.CC';
       var pass = process.env['LDAPTEST_PASSWORD'];
       if (pass == null) throw new Error('The env parameter LDAPTEST_PASSWORD must be set');
-
       var client = new MongoClient(new Server(server, 27017), {
         w: 1,
         user: principal,
         password: pass,
         authMechanism: 'GSSAPI'
       });
+
       client.connect(function(err, client) {
         test.equal(null, err);
         var db = client.db('kerberos');
@@ -447,7 +426,6 @@ describe('Kerberos', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
       // KDC Server
       var server = 'ldaptest.10gen.cc';
@@ -456,20 +434,18 @@ describe('Kerberos', function() {
 
       if (pass == null) throw new Error('The env parameter LDAPTEST_PASSWORD must be set');
       var urlEncodedPrincipal = encodeURIComponent(principal);
-
-      // Let's write the actual connection code
-      MongoClient.connect(
-        format(
-          'mongodb://%s:%s@%s/kerberos?authMechanism=GSSAPI&gssapiServiceName=mongodb2&maxPoolSize=1',
-          urlEncodedPrincipal,
-          pass,
-          server
-        ),
-        function(err) {
-          test.ok(err != null);
-          done();
-        }
+      const url = format(
+        'mongodb://%s:%s@%s/kerberos?authMechanism=GSSAPI&gssapiServiceName=mongodb2&maxPoolSize=1',
+        urlEncodedPrincipal,
+        pass,
+        server
       );
+
+      const client = configuration.newClient(url);
+      client.connect(function(err) {
+        test.ok(err != null);
+        done();
+      });
     }
   });
 });

--- a/test/functional/ldap_tests.js
+++ b/test/functional/ldap_tests.js
@@ -18,7 +18,6 @@ describe('LDAP', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
       // KDC Server
       var server = 'ldaptest.10gen.cc';
@@ -33,8 +32,8 @@ describe('LDAP', function() {
         server
       );
 
-      // Let's write the actual connection code
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
 
         client
@@ -60,7 +59,6 @@ describe('LDAP', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
       // KDC Server
       var server = 'ldaptest.10gen.cc';
@@ -75,8 +73,8 @@ describe('LDAP', function() {
         server
       );
 
-      // Let's write the actual connection code
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
 
         client

--- a/test/functional/mapreduce_tests.js
+++ b/test/functional/mapreduce_tests.js
@@ -12,7 +12,10 @@ describe('MapReduce', function() {
    */
   it('shouldCorrectlyExecuteGroupFunctionWithFinalizeFunction', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      requires: {
+        mongodb: '<=4.1.0',
+        topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
+      }
     },
 
     // The actual test we wish to run
@@ -414,7 +417,10 @@ describe('MapReduce', function() {
    */
   it('shouldCorrectlyReturnNestedKeys', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      requires: {
+        mongodb: '<=4.1.0', // Because of use of `group` command
+        topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
+      }
     },
 
     // The actual test we wish to run

--- a/test/functional/max_staleness_tests.js
+++ b/test/functional/max_staleness_tests.js
@@ -41,7 +41,7 @@ describe('Max Staleness', function() {
     });
   });
 
-  it('should correctly set maxStalenessSeconds on Mongos query using MongoClient.connect', {
+  it('should correctly set maxStalenessSeconds on Mongos query on connect', {
     metadata: {
       requires: {
         generators: true,
@@ -50,30 +50,30 @@ describe('Max Staleness', function() {
     },
 
     test: function(done) {
-      var self = this,
-        MongoClient = self.configuration.require.MongoClient;
-
-      MongoClient.connect(
-        `mongodb://${test.server.uri()}/test?readPreference=secondary&maxStalenessSeconds=250`,
-        function(err, client) {
-          expect(err).to.not.exist;
-          var db = client.db(self.configuration.db);
-
-          db
-            .collection('test')
-            .find({})
-            .toArray(function(err) {
-              expect(err).to.not.exist;
-              expect(test.checkCommand).to.eql({
-                $query: { find: 'test', filter: {}, returnKey: false, showRecordId: false },
-                $readPreference: { mode: 'secondary', maxStalenessSeconds: 250 }
-              });
-
-              client.close();
-              done();
-            });
-        }
+      var self = this;
+      const configuration = this.configuration;
+      const client = configuration.newClient(
+        `mongodb://${test.server.uri()}/test?readPreference=secondary&maxStalenessSeconds=250`
       );
+
+      client.connect(function(err, client) {
+        expect(err).to.not.exist;
+        var db = client.db(self.configuration.db);
+
+        db
+          .collection('test')
+          .find({})
+          .toArray(function(err) {
+            expect(err).to.not.exist;
+            expect(test.checkCommand).to.eql({
+              $query: { find: 'test', filter: {}, returnKey: false, showRecordId: false },
+              $readPreference: { mode: 'secondary', maxStalenessSeconds: 250 }
+            });
+
+            client.close();
+            done();
+          });
+      });
     }
   });
 
@@ -86,11 +86,12 @@ describe('Max Staleness', function() {
     },
 
     test: function(done) {
-      var self = this,
-        MongoClient = self.configuration.require.MongoClient,
-        ReadPreference = self.configuration.require.ReadPreference;
+      var self = this;
+      const configuration = this.configuration;
+      const ReadPreference = self.configuration.require.ReadPreference;
 
-      MongoClient.connect(`mongodb://${test.server.uri()}/test`, function(err, client) {
+      const client = configuration.newClient(`mongodb://${test.server.uri()}/test`);
+      client.connect(function(err, client) {
         expect(err).to.not.exist;
 
         // Get a db with a new readPreference
@@ -126,11 +127,12 @@ describe('Max Staleness', function() {
       },
 
       test: function(done) {
-        var self = this,
-          MongoClient = self.configuration.require.MongoClient,
-          ReadPreference = self.configuration.require.ReadPreference;
+        var self = this;
+        const configuration = this.configuration;
+        const ReadPreference = self.configuration.require.ReadPreference;
 
-        MongoClient.connect(`mongodb://${test.server.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${test.server.uri()}/test`);
+        client.connect(function(err, client) {
           expect(err).to.not.exist;
           var db = client.db(self.configuration.db);
 
@@ -164,11 +166,12 @@ describe('Max Staleness', function() {
     },
 
     test: function(done) {
-      var self = this,
-        MongoClient = self.configuration.require.MongoClient,
-        ReadPreference = self.configuration.require.ReadPreference;
+      var self = this;
+      const configuration = this.configuration;
+      const ReadPreference = self.configuration.require.ReadPreference;
 
-      MongoClient.connect(`mongodb://${test.server.uri()}/test`, function(err, client) {
+      const client = configuration.newClient(`mongodb://${test.server.uri()}/test`);
+      client.connect(function(err, client) {
         expect(err).to.not.exist;
         var db = client.db(self.configuration.db);
         var readPreference = new ReadPreference('secondary', null, { maxStalenessSeconds: 250 });

--- a/test/functional/mongo_client_tests.js
+++ b/test/functional/mongo_client_tests.js
@@ -345,7 +345,7 @@ describe('MongoClient', function() {
 
         secondClient.connect(function(err) {
           test.equal(null, err);
-          test.ok(client.topology.connections().length >= 1);
+          test.ok(secondClient.topology.connections().length >= 1);
 
           var connections = secondClient.topology.connections();
 

--- a/test/functional/mongo_client_tests.js
+++ b/test/functional/mongo_client_tests.js
@@ -19,39 +19,33 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect(
-        configuration.url(),
-        {
-          bufferMaxEntries: 0,
-          sslValidate: false
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
-          // Listener for closing event
-          var closeListener = function() {
-            // Let's insert a document
-            var collection = db.collection('test_object_id_generation.data2');
-            // Insert another test document and collect using ObjectId
-            var docs = [];
-            for (var i = 0; i < 1500; i++) docs.push({ a: i });
+      const client = configuration.newClient({}, { bufferMaxEntries: 0, sslValidate: false });
 
-            collection.insert(docs, configuration.writeConcern(), function(err) {
-              test.ok(err != null);
-              test.ok(err.message.indexOf('0') !== -1);
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+        // Listener for closing event
+        var closeListener = function() {
+          // Let's insert a document
+          var collection = db.collection('test_object_id_generation.data2');
+          // Insert another test document and collect using ObjectId
+          var docs = [];
+          for (var i = 0; i < 1500; i++) docs.push({ a: i });
 
-              // Let's close the db
-              client.close();
-              done();
-            });
-          };
+          collection.insert(docs, configuration.writeConcern(), function(err) {
+            test.ok(err != null);
+            test.ok(err.message.indexOf('0') !== -1);
 
-          // Add listener to close event
-          db.once('close', closeListener);
-          // Ensure death of server instance
-          client.topology.connections()[0].destroy();
-        }
-      );
+            // Let's close the db
+            client.close();
+            done();
+          });
+        };
+
+        // Add listener to close event
+        db.once('close', closeListener);
+        // Ensure death of server instance
+        client.topology.connections()[0].destroy();
+      });
     }
   });
 
@@ -65,42 +59,36 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect(
-        configuration.url(),
-        {
-          bufferMaxEntries: 0,
-          sslValidate: false
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
-          // Listener for closing event
-          var closeListener = function() {
-            // Let's insert a document
-            var collection = db.collection('test_object_id_generation.data_3');
-            // Insert another test document and collect using ObjectId
-            var docs = [];
-            for (var i = 0; i < 1500; i++) docs.push({ a: i });
+      const client = configuration.newClient({}, { bufferMaxEntries: 0, sslValidate: false });
 
-            var opts = configuration.writeConcern();
-            opts.keepGoing = true;
-            // Execute insert
-            collection.insert(docs, opts, function(err) {
-              test.ok(err != null);
-              test.ok(err.message.indexOf('0') !== -1);
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+        // Listener for closing event
+        var closeListener = function() {
+          // Let's insert a document
+          var collection = db.collection('test_object_id_generation.data_3');
+          // Insert another test document and collect using ObjectId
+          var docs = [];
+          for (var i = 0; i < 1500; i++) docs.push({ a: i });
 
-              // Let's close the db
-              client.close();
-              done();
-            });
-          };
+          var opts = configuration.writeConcern();
+          opts.keepGoing = true;
+          // Execute insert
+          collection.insert(docs, opts, function(err) {
+            test.ok(err != null);
+            test.ok(err.message.indexOf('0') !== -1);
 
-          // Add listener to close event
-          db.once('close', closeListener);
-          // Ensure death of server instance
-          client.topology.connections()[0].destroy();
-        }
-      );
+            // Let's close the db
+            client.close();
+            done();
+          });
+        };
+
+        // Add listener to close event
+        db.once('close', closeListener);
+        // Ensure death of server instance
+        client.topology.connections()[0].destroy();
+      });
     }
   });
 
@@ -114,9 +102,8 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect(
-        configuration.url(),
+      const client = configuration.newClient(
+        {},
         {
           w: 1,
           wtimeout: 1000,
@@ -133,30 +120,31 @@ describe('MongoClient', function() {
           raw: true,
           numberOfRetries: 10,
           bufferMaxEntries: 0
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
-
-          test.equal(1, db.writeConcern.w);
-          test.equal(1000, db.writeConcern.wtimeout);
-          test.equal(true, db.writeConcern.fsync);
-          test.equal(true, db.writeConcern.j);
-
-          test.equal('nearest', db.s.readPreference.mode);
-          test.deepEqual({ loc: 'ny' }, db.s.readPreference.tags);
-
-          test.equal(false, db.s.nativeParser);
-          test.equal(true, db.s.options.forceServerObjectId);
-          test.equal(1, db.s.pkFactory());
-          test.equal(true, db.s.options.serializeFunctions);
-          test.equal(true, db.s.options.raw);
-          test.equal(10, db.s.options.numberOfRetries);
-          test.equal(0, db.s.options.bufferMaxEntries);
-
-          client.close();
-          done();
         }
       );
+
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+
+        test.equal(1, db.writeConcern.w);
+        test.equal(1000, db.writeConcern.wtimeout);
+        test.equal(true, db.writeConcern.fsync);
+        test.equal(true, db.writeConcern.j);
+
+        test.equal('nearest', db.s.readPreference.mode);
+        test.deepEqual({ loc: 'ny' }, db.s.readPreference.tags);
+
+        test.equal(false, db.s.nativeParser);
+        test.equal(true, db.s.options.forceServerObjectId);
+        test.equal(1, db.s.pkFactory());
+        test.equal(true, db.s.options.serializeFunctions);
+        test.equal(true, db.s.options.raw);
+        test.equal(10, db.s.options.numberOfRetries);
+        test.equal(0, db.s.options.bufferMaxEntries);
+
+        client.close();
+        done();
+      });
     }
   });
 
@@ -170,9 +158,8 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect(
-        configuration.url(),
+      const client = configuration.newClient(
+        {},
         {
           poolSize: 10,
           autoReconnect: false,
@@ -181,20 +168,21 @@ describe('MongoClient', function() {
           keepAliveInitialDelay: 100,
           connectTimeoutMS: 444444,
           socketTimeoutMS: 555555
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
-          test.equal(10, db.s.topology.s.poolSize);
-          test.equal(false, db.s.topology.autoReconnect);
-          test.equal(444444, db.s.topology.s.clonedOptions.connectionTimeout);
-          test.equal(555555, db.s.topology.s.clonedOptions.socketTimeout);
-          test.equal(true, db.s.topology.s.clonedOptions.keepAlive);
-          test.equal(100, db.s.topology.s.clonedOptions.keepAliveInitialDelay);
-
-          client.close();
-          done();
         }
       );
+
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+        test.equal(10, db.s.topology.s.poolSize);
+        test.equal(false, db.s.topology.autoReconnect);
+        test.equal(444444, db.s.topology.s.clonedOptions.connectionTimeout);
+        test.equal(555555, db.s.topology.s.clonedOptions.socketTimeout);
+        test.equal(true, db.s.topology.s.clonedOptions.keepAlive);
+        test.equal(100, db.s.topology.s.clonedOptions.keepAliveInitialDelay);
+
+        client.close();
+        done();
+      });
     }
   });
 
@@ -208,46 +196,43 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url().replace('rs_name=rs', 'rs_name=rs1');
-      MongoClient.connect(
-        url,
-        {
-          replSet: {
-            ha: false,
-            haInterval: 10000,
-            replicaSet: 'rs',
-            secondaryAcceptableLatencyMS: 100,
-            connectWithNoPrimary: true,
-            poolSize: 1,
-            socketOptions: {
-              noDelay: false,
-              keepAlive: true,
-              keepAliveInitialDelay: 100,
-              connectTimeoutMS: 444444,
-              socketTimeoutMS: 555555
-            }
+      const client = configuration.newClient(url, {
+        replSet: {
+          ha: false,
+          haInterval: 10000,
+          replicaSet: 'rs',
+          secondaryAcceptableLatencyMS: 100,
+          connectWithNoPrimary: true,
+          poolSize: 1,
+          socketOptions: {
+            noDelay: false,
+            keepAlive: true,
+            keepAliveInitialDelay: 100,
+            connectTimeoutMS: 444444,
+            socketTimeoutMS: 555555
           }
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
-
-          test.equal(false, db.s.topology.s.clonedOptions.ha);
-          test.equal(10000, db.s.topology.s.clonedOptions.haInterval);
-          test.equal('rs', db.s.topology.s.clonedOptions.setName);
-          test.equal(100, db.s.topology.s.clonedOptions.acceptableLatency);
-          test.equal(true, db.s.topology.s.clonedOptions.secondaryOnlyConnectionAllowed);
-          test.equal(1, db.s.topology.s.clonedOptions.size);
-
-          test.equal(444444, db.s.topology.s.clonedOptions.connectionTimeout);
-          test.equal(555555, db.s.topology.s.clonedOptions.socketTimeout);
-          test.equal(true, db.s.topology.s.clonedOptions.keepAlive);
-          test.equal(100, db.s.topology.s.clonedOptions.keepAliveInitialDelay);
-
-          client.close();
-          done();
         }
-      );
+      });
+
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+
+        test.equal(false, db.s.topology.s.clonedOptions.ha);
+        test.equal(10000, db.s.topology.s.clonedOptions.haInterval);
+        test.equal('rs', db.s.topology.s.clonedOptions.setName);
+        test.equal(100, db.s.topology.s.clonedOptions.acceptableLatency);
+        test.equal(true, db.s.topology.s.clonedOptions.secondaryOnlyConnectionAllowed);
+        test.equal(1, db.s.topology.s.clonedOptions.size);
+
+        test.equal(444444, db.s.topology.s.clonedOptions.connectionTimeout);
+        test.equal(555555, db.s.topology.s.clonedOptions.socketTimeout);
+        test.equal(true, db.s.topology.s.clonedOptions.keepAlive);
+        test.equal(100, db.s.topology.s.clonedOptions.keepAliveInitialDelay);
+
+        client.close();
+        done();
+      });
     }
   });
 
@@ -261,9 +246,8 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect(
-        configuration.url(),
+      const client = configuration.newClient(
+        {},
         {
           ha: false,
           haInterval: 10000,
@@ -276,24 +260,25 @@ describe('MongoClient', function() {
             connectTimeoutMS: 444444,
             socketTimeoutMS: 555555
           }
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
-
-          test.equal(false, db.s.topology.s.clonedOptions.ha);
-          test.equal(10000, db.s.topology.s.clonedOptions.haInterval);
-          test.equal(100, db.s.topology.s.clonedOptions.localThresholdMS);
-          test.equal(1, db.s.topology.s.clonedOptions.poolSize);
-
-          test.equal(444444, db.s.topology.s.clonedOptions.connectionTimeout);
-          test.equal(555555, db.s.topology.s.clonedOptions.socketTimeout);
-          test.equal(true, db.s.topology.s.clonedOptions.keepAlive);
-          test.equal(100, db.s.topology.s.clonedOptions.keepAliveInitialDelay);
-
-          client.close();
-          done();
         }
       );
+
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+
+        test.equal(false, db.s.topology.s.clonedOptions.ha);
+        test.equal(10000, db.s.topology.s.clonedOptions.haInterval);
+        test.equal(100, db.s.topology.s.clonedOptions.localThresholdMS);
+        test.equal(1, db.s.topology.s.clonedOptions.poolSize);
+
+        test.equal(444444, db.s.topology.s.clonedOptions.connectionTimeout);
+        test.equal(555555, db.s.topology.s.clonedOptions.socketTimeout);
+        test.equal(true, db.s.topology.s.clonedOptions.keepAlive);
+        test.equal(100, db.s.topology.s.clonedOptions.keepAliveInitialDelay);
+
+        client.close();
+        done();
+      });
     }
   });
 
@@ -307,14 +292,14 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=100')
           : f('%s?%s', url, 'maxPoolSize=100');
 
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(1, client.topology.connections().length);
         test.equal(100, client.topology.s.coreTopology.s.pool.size);
 
@@ -334,14 +319,14 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=100')
           : f('%s?%s', url, 'maxPoolSize=100');
 
-      MongoClient.connect(url, {}, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.ok(client.topology.connections().length >= 1);
 
         var connections = client.topology.connections();
@@ -353,26 +338,25 @@ describe('MongoClient', function() {
 
         client.close();
 
-        MongoClient.connect(
-          url,
-          {
-            connectTimeoutMS: 15000,
-            socketTimeoutMS: 30000
-          },
-          function(err, client) {
-            test.ok(client.topology.connections().length >= 1);
+        const secondClient = configuration.newClient(url, {
+          connectTimeoutMS: 15000,
+          socketTimeoutMS: 30000
+        });
 
-            var connections = client.topology.connections();
+        secondClient.connect(function(err) {
+          test.equal(null, err);
+          test.ok(client.topology.connections().length >= 1);
 
-            for (var i = 0; i < connections.length; i++) {
-              test.equal(15000, connections[i].connectionTimeout);
-              test.equal(30000, connections[i].socketTimeout);
-            }
+          var connections = secondClient.topology.connections();
 
-            client.close();
-            done();
+          for (var i = 0; i < connections.length; i++) {
+            test.equal(15000, connections[i].connectionTimeout);
+            test.equal(30000, connections[i].socketTimeout);
           }
-        );
+
+          secondClient.close();
+          done();
+        });
       });
     }
   });
@@ -387,14 +371,14 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=100')
           : f('%s?%s', url, 'maxPoolSize=100');
 
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.ok(client.topology.connections().length >= 1);
 
         client.close();
@@ -414,9 +398,9 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
+      const client = configuration.newClient('user:password@localhost:27017/test');
 
-      MongoClient.connect('user:password@localhost:27017/test', function(err) {
+      client.connect(function(err) {
         test.equal(err.message, 'Invalid schema, expected `mongodb` or `mongodb+srv`');
         done();
       });
@@ -434,11 +418,11 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
+      const client = configuration.newClient('user:password@localhost:27017/test', {
+        useNewUrlParser: true
+      });
 
-      MongoClient.connect('user:password@localhost:27017/test', { useNewUrlParser: true }, function(
-        err
-      ) {
+      client.connect(function(err) {
         test.equal(err.message, 'Invalid connection string');
         done();
       });
@@ -448,7 +432,7 @@ describe('MongoClient', function() {
   /**
    * @ignore
    */
-  it('correctly error out when no socket available on MongoClient.connect', {
+  it('correctly error out when no socket available on MongoClient `connect`', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
@@ -456,8 +440,8 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect('mongodb://localhost:27088/test', function(err) {
+      const client = configuration.newClient('mongodb://localhost:27088/test');
+      client.connect(function(err) {
         test.ok(err != null);
 
         done();
@@ -471,8 +455,8 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect('mongodb://%2Ftmp%2Fmongodb-27017.sock/test', function(err) {
+      const client = configuration.newClient('mongodb://%2Ftmp%2Fmongodb-27017.sock/test');
+      client.connect(function(err) {
         test.equal(null, err);
         done();
       });
@@ -482,7 +466,7 @@ describe('MongoClient', function() {
   /**
    * @ignore
    */
-  it('correctly error out when no socket available on MongoClient.connect with domain', {
+  it('correctly error out when no socket available on MongoClient `connect` with domain', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
@@ -490,9 +474,8 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
-      MongoClient.connect('mongodb://test.does.not.exist.com:80/test', function(err) {
+      const client = configuration.newClient('mongodb://test.does.not.exist.com:80/test');
+      client.connect(function(err) {
         test.ok(err != null);
 
         done();
@@ -511,40 +494,34 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
-      MongoClient.connect(
-        configuration.url(),
+      const client = configuration.newClient(
+        {},
         {
           keepAlive: true,
           keepAliveInitialDelay: 100
-        },
-        function(err, client) {
-          test.equal(null, err);
-          var connection = client.topology.connections()[0];
-          test.equal(true, connection.keepAlive);
-          test.equal(100, connection.keepAliveInitialDelay);
-
-          client.close();
-
-          MongoClient.connect(
-            configuration.url(),
-            {
-              keepAlive: false
-            },
-            function(err, client) {
-              test.equal(null, err);
-
-              client.topology.connections().forEach(function(x) {
-                test.equal(false, x.keepAlive);
-              });
-
-              client.close();
-              done();
-            }
-          );
         }
       );
+
+      client.connect(function(err, client) {
+        test.equal(null, err);
+        var connection = client.topology.connections()[0];
+        test.equal(true, connection.keepAlive);
+        test.equal(100, connection.keepAliveInitialDelay);
+
+        client.close();
+
+        const secondClient = configuration.newClient({}, { keepAlive: false });
+        secondClient.connect(function(err) {
+          test.equal(null, err);
+
+          secondClient.topology.connections().forEach(function(x) {
+            test.equal(false, x.keepAlive);
+          });
+
+          secondClient.close();
+          done();
+        });
+      });
     }
   });
 
@@ -559,9 +536,8 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
-      MongoClient.connect(configuration.url(), {}, function(err, client) {
+      const client = configuration.newClient();
+      client.connect(function(err, client) {
         test.equal(null, err);
         client.topology.connections().forEach(function(x) {
           test.equal(true, x.keepAlive);
@@ -583,8 +559,8 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect('mongodb://unknownhost:36363/ddddd', {}, function(err) {
+      const client = configuration.newClient('mongodb://unknownhost:36363/ddddd');
+      client.connect(function(err) {
         test.ok(err != null);
         done();
       });
@@ -601,12 +577,13 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration
         .url()
         .replace('rs_name=rs', '')
         .replace('localhost:31000', 'localhost:31000,localhost:31001');
-      MongoClient.connect(url, function(err) {
+
+      const client = configuration.newClient(url);
+      client.connect(function(err) {
         test.ok(err != null);
         done();
       });
@@ -623,7 +600,6 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       if (url.indexOf('rs_name') !== -1) {
         url = f('%s&appname=hello%20world', configuration.url());
@@ -631,7 +607,8 @@ describe('MongoClient', function() {
         url = f('%s?appname=hello%20world', configuration.url());
       }
 
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
         test.equal('hello world', client.topology.clientInfo.application.name);
 
@@ -651,10 +628,10 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
 
-      MongoClient.connect(url, { appname: 'hello world' }, function(err, db) {
+      const client = configuration.newClient(url, { appname: 'hello world' });
+      client.connect(function(err, db) {
         test.equal(null, err);
         test.equal('hello world', db.topology.clientInfo.application.name);
 
@@ -674,29 +651,29 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect(
-        configuration.url(),
+      const client = configuration.newClient(
+        {},
         {
           socketTimeoutMS: 0,
           connectTimeoutMS: 0
-        },
-        function(err, client) {
-          test.equal(null, err);
-          var db = client.db(configuration.db);
-
-          if (db.s.topology.s.clonedOptions) {
-            test.equal(0, db.s.topology.s.clonedOptions.connectionTimeout);
-            test.equal(0, db.s.topology.s.clonedOptions.socketTimeout);
-          } else {
-            test.equal(0, db.s.topology.s.options.connectionTimeout);
-            test.equal(0, db.s.topology.s.options.socketTimeout);
-          }
-
-          client.close();
-          done();
         }
       );
+
+      client.connect(function(err, client) {
+        test.equal(null, err);
+        var db = client.db(configuration.db);
+
+        if (db.s.topology.s.clonedOptions) {
+          test.equal(0, db.s.topology.s.clonedOptions.connectionTimeout);
+          test.equal(0, db.s.topology.s.clonedOptions.socketTimeout);
+        } else {
+          test.equal(0, db.s.topology.s.options.connectionTimeout);
+          test.equal(0, db.s.topology.s.options.socketTimeout);
+        }
+
+        client.close();
+        done();
+      });
     }
   });
 
@@ -710,10 +687,10 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var uri = f('%s?socketTimeoutMS=120000&connectTimeoutMS=15000', configuration.url());
 
-      MongoClient.connect(uri, {}, function(err, client) {
+      const client = configuration.newClient(uri);
+      client.connect(function(err, client) {
         test.equal(null, err);
         test.equal(120000, client.topology.s.coreTopology.s.options.socketTimeout);
         test.equal(15000, client.topology.s.coreTopology.s.options.connectionTimeout);
@@ -739,9 +716,8 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
-      new MongoClient(configuration.url()).connect(function(err, mongoclient) {
+      const client = configuration.newClient();
+      client.connect(function(err, mongoclient) {
         test.equal(null, err);
 
         mongoclient
@@ -768,9 +744,8 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
-      new MongoClient(configuration.url()).connect().then(function(mongoclient) {
+      const client = configuration.newClient();
+      client.connect().then(function(mongoclient) {
         mongoclient
           .db('integration_tests')
           .collection('new_mongo_client_collection')

--- a/test/functional/mongodb_srv_tests.js
+++ b/test/functional/mongodb_srv_tests.js
@@ -17,6 +17,7 @@ function getTests() {
 describe('mongodb+srv (spec)', function() {
   it('should parse a default database', function(done) {
     parse('mongodb+srv://test5.test.build.10gen.cc/somedb', (err, result) => {
+      expect(err).to.not.exist;
       expect(result.dbName).to.eql('somedb');
       done();
     });

--- a/test/functional/multiple_db_tests.js
+++ b/test/functional/multiple_db_tests.js
@@ -169,8 +169,8 @@ describe('Multiple Databases', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-      MongoClient.connect(configuration.url(), { sslValidate: false }, function(err, client) {
+      const client = configuration.newClient({}, { sslValidate: false });
+      client.connect(function(err, client) {
         for (var i = 0; i < 100; i++) {
           client.db('test');
         }

--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -40,7 +40,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -133,7 +134,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -221,7 +223,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -309,7 +312,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -401,7 +405,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -491,7 +496,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -587,7 +593,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -674,7 +681,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -731,7 +739,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -799,7 +808,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -855,7 +865,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -921,7 +932,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -985,7 +997,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1045,7 +1058,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1105,7 +1119,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1151,7 +1166,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1218,7 +1234,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1286,7 +1303,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1353,7 +1371,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1406,7 +1425,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1458,7 +1478,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1521,7 +1542,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1614,7 +1636,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1674,7 +1697,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1725,7 +1749,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -1791,7 +1816,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2014,7 +2040,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2089,7 +2116,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2161,7 +2189,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2258,7 +2287,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2353,7 +2383,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2411,7 +2442,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2473,7 +2505,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2544,7 +2577,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2613,7 +2647,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2661,7 +2696,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2714,7 +2750,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2776,7 +2813,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2848,7 +2886,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2895,7 +2934,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -2943,7 +2983,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3018,7 +3059,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3086,7 +3128,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3136,7 +3179,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3185,7 +3229,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3300,7 +3345,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3347,7 +3393,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3412,7 +3459,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3467,7 +3515,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3518,7 +3567,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3580,7 +3630,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3632,7 +3683,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3714,7 +3766,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3752,7 +3805,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3808,7 +3862,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3932,7 +3987,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -3991,7 +4047,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4032,7 +4089,8 @@ describe('Operation Examples', function() {
 
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4068,7 +4126,8 @@ describe('Operation Examples', function() {
         test.equal(null, err);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4121,7 +4180,8 @@ describe('Operation Examples', function() {
         test.equal(null, err);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4175,7 +4235,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4238,7 +4299,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4278,7 +4340,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4320,12 +4383,13 @@ describe('Operation Examples', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
+
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4341,15 +4405,16 @@ describe('Operation Examples', function() {
           test.equal(null, err);
           client.close();
 
-          MongoClient.connect('mongodb://user:name@localhost:27017/integration_tests', function(
-            err,
-            client
-          ) {
+          const secondClient = configuration.newClient(
+            'mongodb://user:name@localhost:27017/integration_tests'
+          );
+
+          secondClient.connect(function(err) {
             test.equal(null, err);
-            var db = client.db(configuration.db);
+            var db = secondClient.db(configuration.db);
 
             // Logout the db
-            client.logout(function(err, result) {
+            secondClient.logout(function(err, result) {
               test.equal(true, result);
 
               // Remove the user from the db
@@ -4357,17 +4422,17 @@ describe('Operation Examples', function() {
                 test.ok(result);
                 test.equal(null, err);
 
-                const oldClient = client;
-                // Authenticate
-                MongoClient.connect(
-                  'mongodb://user:name@localhost:27017/integration_tests',
-                  function(err, client) {
-                    expect(err).to.exist;
-                    expect(client).to.not.exist;
-                    oldClient.close();
-                    done();
-                  }
+                const oldClient = secondClient;
+                const thirdClient = configuration.newClient(
+                  'mongodb://user:name@localhost:27017/integration_tests'
                 );
+
+                // Authenticate
+                thirdClient.connect(function(err) {
+                  expect(err).to.exist;
+                  oldClient.close();
+                  done();
+                });
               });
             });
           });
@@ -4396,7 +4461,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4447,7 +4513,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4520,7 +4587,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4562,7 +4630,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4645,7 +4714,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4714,7 +4784,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4781,7 +4852,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4852,7 +4924,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4893,7 +4966,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4970,7 +5044,8 @@ describe('Operation Examples', function() {
         test.equal(null, err);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5007,7 +5082,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5049,7 +5125,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5090,7 +5167,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5143,7 +5221,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5215,7 +5294,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5265,7 +5345,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5306,7 +5387,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5349,7 +5431,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5397,7 +5480,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5436,7 +5520,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5484,7 +5569,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5536,7 +5622,8 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5598,7 +5685,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5649,7 +5737,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5709,7 +5798,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5769,7 +5859,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5836,7 +5927,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5890,7 +5982,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5957,7 +6050,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6015,7 +6109,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6074,7 +6169,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6133,7 +6229,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6220,7 +6317,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6275,7 +6373,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6336,7 +6435,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6403,7 +6503,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6467,7 +6568,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6537,7 +6639,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6589,7 +6692,6 @@ describe('Operation Examples', function() {
    * Example of a simple url connection string to a replicaset, with acknowledgement of writes.
    *
    * @example-class MongoClient
-   * @example-method MongoClient.connect
    * @ignore
    */
   it('Should correctly connect to a replicaset', {
@@ -6598,8 +6700,6 @@ describe('Operation Examples', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var mongo = configuration.require,
-        MongoClient = mongo.MongoClient;
 
       // Create url
       var url = f(
@@ -6611,11 +6711,13 @@ describe('Operation Examples', function() {
         'primary'
       );
 
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6643,7 +6745,6 @@ describe('Operation Examples', function() {
    * Example of a simple url connection string to a shard, with acknowledgement of writes.
    *
    * @example-class MongoClient
-   * @example-method MongoClient.connect
    * @ignore
    */
   it('Should connect to mongos proxies using connectiong string', {
@@ -6652,8 +6753,6 @@ describe('Operation Examples', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
       var url = f(
         'mongodb://%s:%s,%s:%s/sharded_test_db?w=1',
         configuration.host,
@@ -6662,10 +6761,12 @@ describe('Operation Examples', function() {
         configuration.port + 1
       );
 
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -6694,7 +6795,6 @@ describe('Operation Examples', function() {
    * Example of a simple url connection string for a single server connection
    *
    * @example-class MongoClient
-   * @example-method MongoClient.connect
    * @ignore
    */
   it('Should correctly connect using MongoClient to a single server using connect', {
@@ -6705,37 +6805,36 @@ describe('Operation Examples', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
+      const client = configuration.newClient('mongodb://localhost:27017/integration_tests', {
+        native_parser: true
+      });
 
       // DOC_START
       // Connect using the connection string
-      MongoClient.connect(
-        'mongodb://localhost:27017/integration_tests',
-        { native_parser: true },
-        function(err, client) {
-          // LINE var MongoClient = require('mongodb').MongoClient,
-          // LINE   test = require('assert');
-          // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
-          // LINE   var db = client.db('test);
-          // REPLACE configuration.writeConcernMax() WITH {w:1}
-          // REMOVE-LINE restartAndDone
-          // REMOVE-LINE done();
-          // REMOVE-LINE var db = client.db(configuration.db);
-          // BEGIN
-          var db = client.db(configuration.db);
-          test.equal(null, err);
+      client.connect(function(err, client) {
+        // LINE var MongoClient = require('mongodb').MongoClient,
+        // LINE   test = require('assert');
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
+        // LINE   var db = client.db('test);
+        // REPLACE configuration.writeConcernMax() WITH {w:1}
+        // REMOVE-LINE restartAndDone
+        // REMOVE-LINE done();
+        // REMOVE-LINE var db = client.db(configuration.db);
+        // BEGIN
+        var db = client.db(configuration.db);
+        test.equal(null, err);
 
-          db
-            .collection('mongoclient_test')
-            .updateOne({ a: 1 }, { $set: { b: 1 } }, { upsert: true }, function(err, result) {
-              test.equal(null, err);
-              test.equal(1, result.result.n);
+        db
+          .collection('mongoclient_test')
+          .updateOne({ a: 1 }, { $set: { b: 1 } }, { upsert: true }, function(err, result) {
+            test.equal(null, err);
+            test.equal(1, result.result.n);
 
-              client.close();
-              done();
-            });
-        }
-      );
+            client.close();
+            done();
+          });
+      });
       // END
     }
   });
@@ -6980,7 +7079,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7051,7 +7151,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7187,7 +7288,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7239,7 +7341,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7327,7 +7430,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7396,7 +7500,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7456,7 +7561,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7519,7 +7625,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7582,7 +7689,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7652,7 +7760,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7715,7 +7824,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7770,7 +7880,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7822,7 +7933,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7892,7 +8004,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -7944,7 +8057,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8010,7 +8124,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8079,7 +8194,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8134,7 +8250,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8207,7 +8324,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8259,7 +8377,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8330,7 +8449,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8454,7 +8574,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8531,7 +8652,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8584,7 +8706,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8648,7 +8771,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8704,7 +8828,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8784,7 +8909,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8856,7 +8982,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -8944,7 +9071,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9017,7 +9145,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9084,7 +9213,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9159,7 +9289,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9200,7 +9331,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9241,7 +9373,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9283,7 +9416,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9332,7 +9466,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9378,7 +9513,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9426,7 +9562,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9490,7 +9627,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9540,7 +9678,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9598,7 +9737,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -9656,7 +9796,8 @@ describe('Operation Examples', function() {
       client.connect(function(err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect(function(err, client) {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone

--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -2974,7 +2974,7 @@ describe('Operation Examples', function() {
   it('Should correctly execute parallelCollectionScan with multiple cursors using toArray', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
-    metadata: { requires: { mongodb: '>2.5.5', topology: ['single', 'replicaset'] } },
+    metadata: { requires: { mongodb: '>2.5.5 <=4.1.0', topology: ['single', 'replicaset'] } },
 
     // The actual test we wish to run
     test: function(done) {

--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -1805,7 +1805,10 @@ describe('Operation Examples', function() {
    */
   it('shouldCorrectlyExecuteGroupFunction', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      requires: {
+        mongodb: '<=4.1.0',
+        topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
+      }
     },
 
     // The actual test we wish to run
@@ -3850,7 +3853,10 @@ describe('Operation Examples', function() {
    */
   it('shouldCorrectlyExecuteEvalFunctions', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      requires: {
+        topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'],
+        mongodb: '<=4.1.0'
+      }
     },
 
     // The actual test we wish to run
@@ -3976,7 +3982,10 @@ describe('Operation Examples', function() {
    */
   it('shouldCorrectlyDefineSystemLevelFunctionAndExecuteFunction', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      requires: {
+        mongodb: '<=4.1.0',
+        topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
+      }
     },
 
     // The actual test we wish to run

--- a/test/functional/operation_generators_example_tests.js
+++ b/test/functional/operation_generators_example_tests.js
@@ -42,7 +42,12 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -126,7 +131,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -209,7 +216,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -260,7 +269,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -315,7 +326,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -373,7 +386,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -431,7 +446,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -492,7 +509,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -532,7 +551,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -587,7 +608,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -645,7 +668,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -700,7 +725,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -751,7 +778,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -800,7 +829,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -862,7 +893,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -941,7 +974,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -997,7 +1032,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1049,7 +1086,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1106,7 +1145,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1303,7 +1344,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1370,7 +1413,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1435,7 +1480,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1524,7 +1571,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1612,7 +1661,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1661,7 +1712,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1719,7 +1772,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1780,7 +1835,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1839,7 +1896,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1883,7 +1942,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1933,7 +1994,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -1984,7 +2047,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2048,7 +2113,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2096,7 +2163,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2147,7 +2216,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2209,7 +2280,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2266,7 +2339,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2315,7 +2390,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2361,7 +2438,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2466,7 +2545,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2511,7 +2592,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2571,7 +2654,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2622,7 +2707,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2673,7 +2760,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2730,7 +2819,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2780,7 +2871,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2849,7 +2942,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -2904,7 +2999,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3012,7 +3109,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3065,7 +3164,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3118,7 +3219,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3158,7 +3261,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3186,8 +3291,7 @@ describe('Operation (Generators)', function() {
     // The actual test we wish to run
     test: function() {
       var configuration = this.configuration;
-      var co = require('co'),
-        MongoClient = configuration.require.MongoClient;
+      var co = require('co');
 
       return co(function*() {
         // Connect
@@ -3200,7 +3304,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3209,9 +3315,11 @@ describe('Operation (Generators)', function() {
         yield db.addUser('user', 'name');
 
         // Authenticate
-        var client2 = yield MongoClient.connect(
+        var client2 = configuration.newClient(
           'mongodb://user:name@localhost:27017/' + configuration.db
         );
+
+        yield client2.connect();
         client2.close();
 
         // Remove the user from the db
@@ -3219,7 +3327,8 @@ describe('Operation (Generators)', function() {
 
         try {
           // Authenticate
-          yield MongoClient.connect('mongodb://user:name@localhost:27017/admin');
+          const client = configuration.newClient('mongodb://user:name@localhost:27017/admin');
+          yield client.connect();
           test.ok(false);
         } catch (err) {} // eslint-disable-line
 
@@ -3255,7 +3364,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3301,7 +3412,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3358,7 +3471,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3396,7 +3511,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3467,7 +3584,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3527,7 +3646,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3587,7 +3708,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3652,7 +3775,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3691,7 +3816,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3752,7 +3879,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3795,7 +3924,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3839,7 +3970,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3913,7 +4046,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -3974,7 +4109,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4024,7 +4161,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4067,7 +4206,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4112,7 +4253,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4159,7 +4302,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4203,7 +4348,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4254,7 +4401,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4314,7 +4463,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4364,7 +4515,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4413,7 +4566,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4474,7 +4629,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4524,7 +4681,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4588,7 +4747,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4648,7 +4809,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4763,7 +4926,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4814,7 +4979,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4887,7 +5054,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -4946,7 +5115,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5000,7 +5171,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5057,7 +5230,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5117,7 +5292,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5184,7 +5361,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5244,7 +5423,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5297,7 +5478,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5360,7 +5543,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5423,7 +5608,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5489,7 +5676,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5541,7 +5730,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5644,7 +5835,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5712,7 +5905,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5770,7 +5965,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5823,7 +6020,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5897,7 +6096,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -5967,7 +6168,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6043,7 +6246,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6084,7 +6289,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6125,7 +6332,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6167,7 +6376,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6214,7 +6425,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6258,7 +6471,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6304,7 +6519,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6367,7 +6584,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6412,7 +6631,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6467,7 +6688,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN
@@ -6522,7 +6745,9 @@ describe('Operation (Generators)', function() {
         // LINE   test = require('assert');
         // LINE
         // LINE co(function*() {
-        // LINE   var client = yield MongoClient.connect('mongodb://localhost:27017/test');
+        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE   yield client.connect();
+        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN

--- a/test/functional/operation_generators_example_tests.js
+++ b/test/functional/operation_generators_example_tests.js
@@ -45,9 +45,6 @@ describe('Operation (Generators)', function() {
         // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
         // LINE   yield client.connect();
         // LINE
-        // LINE   const client = new MongoClient('mongodb://localhost:27017/test');
-        // LINE   yield client.connect();
-        // LINE
         // LINE   var db = client.db('test');
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // BEGIN

--- a/test/functional/operation_generators_example_tests.js
+++ b/test/functional/operation_generators_example_tests.js
@@ -2198,7 +2198,7 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute parallelCollectionScan with multiple cursors with Generators', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
-    metadata: { requires: { generators: true, mongodb: '>2.5.5', topology: ['single'] } },
+    metadata: { requires: { generators: true, mongodb: '>2.5.5 <=4.1.0', topology: ['single'] } },
 
     // The actual test we wish to run
     test: function() {

--- a/test/functional/operation_generators_example_tests.js
+++ b/test/functional/operation_generators_example_tests.js
@@ -1126,7 +1126,7 @@ describe('Operation (Generators)', function() {
    * @ignore
    */
   it('shouldCorrectlyExecuteGroupFunctionWithGenerators', {
-    metadata: { requires: { generators: true, topology: ['single'] } },
+    metadata: { requires: { generators: true, topology: ['single'], mongodb: '<=4.1.0' } },
 
     // The actual test we wish to run
     test: function() {
@@ -2979,7 +2979,7 @@ describe('Operation (Generators)', function() {
    * @ignore
    */
   it('shouldCorrectlyExecuteEvalFunctionsWithGenerators', {
-    metadata: { requires: { generators: true, topology: ['single'] } },
+    metadata: { requires: { generators: true, topology: ['single'], mongodb: '<=4.1.0' } },
 
     // The actual test we wish to run
     test: function() {
@@ -3090,7 +3090,7 @@ describe('Operation (Generators)', function() {
    * @ignore
    */
   it('shouldCorrectlyDefineSystemLevelFunctionAndExecuteFunctionWithGenerators', {
-    metadata: { requires: { generators: true, topology: ['single'] } },
+    metadata: { requires: { generators: true, topology: ['single'], mongodb: '<=4.1.0' } },
 
     // The actual test we wish to run
     test: function() {

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -1148,7 +1148,7 @@ describe('Operation (Promises)', function() {
    * @ignore
    */
   it('shouldCorrectlyExecuteGroupFunctionWithPromises', {
-    metadata: { requires: { topology: ['single'] } },
+    metadata: { requires: { topology: ['single'], mongodb: '<=4.1.0' } },
 
     // The actual test we wish to run
     test: function() {
@@ -3047,7 +3047,7 @@ describe('Operation (Promises)', function() {
    * @ignore
    */
   it('shouldCorrectlyExecuteEvalFunctionsWithPromises', {
-    metadata: { requires: { topology: ['single'] } },
+    metadata: { requires: { topology: ['single'], mongodb: '<=4.1.0' } },
 
     // The actual test we wish to run
     test: function() {
@@ -3157,7 +3157,7 @@ describe('Operation (Promises)', function() {
    * @ignore
    */
   it('shouldCorrectlyDefineSystemLevelFunctionAndExecuteFunctionWithPromises', {
-    metadata: { requires: { topology: ['single'] } },
+    metadata: { requires: { topology: ['single'], mongodb: '<=4.1.0' } },
 
     // The actual test we wish to run
     test: function() {

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -2240,7 +2240,7 @@ describe('Operation (Promises)', function() {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: {
-      requires: { mongodb: '>2.5.5', topology: ['single', 'replicaset'] }
+      requires: { mongodb: '>2.5.5 <=4.1.0', topology: ['single', 'replicaset'] }
     },
 
     // The actual test we wish to run

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -45,7 +45,10 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -128,7 +131,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
         // BEGIN
@@ -213,7 +217,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -267,7 +272,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -327,7 +333,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -386,7 +393,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -443,7 +451,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -503,7 +512,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -546,7 +556,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -605,7 +616,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -668,7 +680,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -727,7 +740,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -776,7 +790,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -825,7 +840,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -888,7 +904,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -973,7 +990,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1030,7 +1048,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1080,7 +1099,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1141,7 +1161,8 @@ describe('Operation (Promises)', function() {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   Code = require('mongodb').Code,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1349,7 +1370,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1417,7 +1439,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1484,7 +1507,8 @@ describe('Operation (Promises)', function() {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   Code = require('mongodb').Code,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1576,7 +1600,8 @@ describe('Operation (Promises)', function() {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   Code = require('mongodb').Code,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1666,7 +1691,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1720,7 +1746,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1785,7 +1812,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1848,7 +1876,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1908,7 +1937,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -1951,7 +1981,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2000,7 +2031,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2056,7 +2088,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2126,7 +2159,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2169,7 +2203,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2220,7 +2255,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2292,7 +2328,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2353,7 +2390,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2403,7 +2441,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2456,7 +2495,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2580,7 +2620,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2624,7 +2665,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2688,7 +2730,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2738,7 +2781,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2785,7 +2829,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2840,7 +2885,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2885,7 +2931,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -2961,7 +3008,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3015,7 +3063,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3123,7 +3172,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3177,7 +3227,8 @@ describe('Operation (Promises)', function() {
       return client.connect().then(function(client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3213,7 +3264,8 @@ describe('Operation (Promises)', function() {
       return client.connect().then(function(client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3314,7 +3366,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3375,7 +3428,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3412,7 +3466,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3448,13 +3503,14 @@ describe('Operation (Promises)', function() {
     // The actual test we wish to run
     test: function() {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
-      return MongoClient.connect(configuration.url()).then(function(client) {
+      const client = configuration.newClient();
+      return client.connect().then(function(client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3466,8 +3522,11 @@ describe('Operation (Promises)', function() {
           .then(function(result) {
             test.ok(result);
             client.close();
+            const secondClient = configuration.newClient(
+              'mongodb://user3:name@localhost:27017/integration_tests'
+            );
 
-            return MongoClient.connect('mongodb://user3:name@localhost:27017/integration_tests');
+            return secondClient.connect();
           })
           .then(function(client) {
             // Logout the db
@@ -3484,7 +3543,11 @@ describe('Operation (Promises)', function() {
             test.equal(true, result);
 
             // Should error out due to user no longer existing
-            return MongoClient.connect('mongodb://user3:name@localhost:27017/integration_tests');
+            const thirdClient = configuration.newClient(
+              'mongodb://user3:name@localhost:27017/integration_tests'
+            );
+
+            return thirdClient.connect();
           })
           .catch(function(err) {
             test.ok(err);
@@ -3517,7 +3580,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3565,7 +3629,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3630,7 +3695,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3667,7 +3733,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3747,7 +3814,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3813,7 +3881,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3879,7 +3948,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3946,7 +4016,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -3979,7 +4050,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -4049,7 +4121,8 @@ describe('Operation (Promises)', function() {
       return client.connect().then(function() {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4086,7 +4159,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4125,7 +4199,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4164,7 +4239,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4215,7 +4291,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4298,7 +4375,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4366,7 +4444,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4415,7 +4494,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4454,7 +4534,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4499,7 +4580,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4546,7 +4628,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4585,7 +4668,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4656,7 +4740,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4708,7 +4793,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4759,7 +4845,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4810,7 +4897,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4861,7 +4949,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4911,7 +5000,6 @@ describe('Operation (Promises)', function() {
    * Example of a simple url connection string to a replicaset, with acknowledgement of writes using a Promise.
    *
    * @example-class MongoClient
-   * @example-method MongoClient.connect
    * @ignore
    */
   it('Should correctly connect to a replicaset With Promises', {
@@ -4920,10 +5008,6 @@ describe('Operation (Promises)', function() {
     // The actual test we wish to run
     test: function() {
       var configuration = this.configuration;
-      var mongo = configuration.require,
-        MongoClient = mongo.MongoClient;
-
-      // Create url
       var url = f(
         'mongodb://%s,%s/%s?replicaSet=%s&readPreference=%s',
         f('%s:%s', configuration.host, configuration.port),
@@ -4933,11 +5017,13 @@ describe('Operation (Promises)', function() {
         'primary'
       );
 
-      return MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      return client.connect().then(function(client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -4961,7 +5047,6 @@ describe('Operation (Promises)', function() {
    * Example of a simple url connection string to a shard, with acknowledgement of writes using a Promise.
    *
    * @example-class MongoClient
-   * @example-method MongoClient.connect
    * @ignore
    */
   it('Should connect to mongos proxies using connectiong string With Promises', {
@@ -4970,8 +5055,6 @@ describe('Operation (Promises)', function() {
     // The actual test we wish to run
     test: function() {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
       var url = f(
         'mongodb://%s:%s,%s:%s/sharded_test_db?w=1',
         configuration.host,
@@ -4980,11 +5063,13 @@ describe('Operation (Promises)', function() {
         configuration.port + 1
       );
 
-      return MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      return client.connect().then(function(client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5008,7 +5093,6 @@ describe('Operation (Promises)', function() {
    * Example of a simple url connection string for a single server connection
    *
    * @example-class MongoClient
-   * @example-method MongoClient.connect
    * @ignore
    */
   it('Should correctly connect using MongoClient to a single server using connect With Promises', {
@@ -5019,17 +5103,18 @@ describe('Operation (Promises)', function() {
     // The actual test we wish to run
     test: function() {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
+      const client = configuration.newClient('mongodb://localhost:27017/integration_tests', {
+        native_parser: true
+      });
 
       // DOC_START
       // Connect using the connection string
-      return MongoClient.connect('mongodb://localhost:27017/integration_tests', {
-        native_parser: true
-      }).then(function(client) {
+      return client.connect().then(function(client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE restartAndDone
@@ -5076,7 +5161,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5142,7 +5228,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5272,7 +5359,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5325,7 +5413,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5412,7 +5501,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5481,7 +5571,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5536,7 +5627,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5594,7 +5686,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5654,7 +5747,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5721,7 +5815,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5783,7 +5878,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5836,7 +5932,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5905,7 +6002,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -5971,7 +6069,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6043,7 +6142,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6099,7 +6199,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6225,7 +6326,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6305,7 +6407,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6371,7 +6474,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6431,7 +6535,8 @@ describe('Operation (Promises)', function() {
         // LINE   GridStore = require('mongodb').GridStore,
         // LINE   ObjectID = require('mongodb').ObjectID,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6523,7 +6628,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6591,7 +6697,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6665,7 +6772,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6704,7 +6812,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6743,7 +6852,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6783,7 +6893,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6836,7 +6947,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6882,7 +6994,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -6930,7 +7043,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -7024,7 +7138,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -7071,7 +7186,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -7127,7 +7243,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -7184,7 +7301,8 @@ describe('Operation (Promises)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -47,8 +47,6 @@ describe('Operation (Promises)', function() {
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
         // LINE client.connect().then(() => {
-        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
-        // LINE client.connect().then(() => {
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();

--- a/test/functional/promises_collection_tests.js
+++ b/test/functional/promises_collection_tests.js
@@ -18,14 +18,14 @@ describe('Promises (Collection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=100')
           : f('%s?%s', url, 'maxPoolSize=100');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         test.equal(1, client.topology.connections().length);
         var db = client.db(configuration.db);
 
@@ -61,7 +61,9 @@ describe('Promises (Collection)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
+        // LINE
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -108,7 +110,9 @@ describe('Promises (Collection)', function() {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
-        // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+        // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+        // LINE client.connect().then(() => {
+        // LINE
         // LINE   var db = client.db('test);
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
@@ -157,7 +161,9 @@ describe('Promises (Collection)', function() {
           var db = client.db(configuration.db);
           // LINE var MongoClient = require('mongodb').MongoClient,
           // LINE   test = require('assert');
-          // LINE MongoClient.connect('mongodb://localhost:27017/test', function(err, client) {
+          // LINE const client = new MongoClient('mongodb://localhost:27017/test');
+          // LINE client.connect().then(() => {
+          // LINE
           // LINE   var db = client.db('test);
           // REPLACE configuration.writeConcernMax() WITH {w:1}
           // REMOVE-LINE done();
@@ -237,14 +243,14 @@ describe('Promises (Collection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=100')
           : f('%s?%s', url, 'maxPoolSize=100');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         var db = client.db(configuration.db);
         db
           .collection('insertMany_Promise_error')
@@ -270,14 +276,14 @@ describe('Promises (Collection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=100')
           : f('%s?%s', url, 'maxPoolSize=100');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         var db = client.db(configuration.db);
         db
           .collection('insertOne_Promise_error')
@@ -303,14 +309,14 @@ describe('Promises (Collection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=100')
           : f('%s?%s', url, 'maxPoolSize=100');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         var db = client.db(configuration.db);
         var bulk = db.collection('unordered_bulk_promise_form').initializeUnorderedBulkOp({ w: 1 });
         bulk.insert({ a: 1 });
@@ -335,14 +341,14 @@ describe('Promises (Collection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=100')
           : f('%s?%s', url, 'maxPoolSize=100');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         var db = client.db(configuration.db);
         var bulk = db.collection('unordered_bulk_promise_form').initializeOrderedBulkOp({ w: 1 });
         bulk.insert({ a: 1 });

--- a/test/functional/promises_cursor_tests.js
+++ b/test/functional/promises_cursor_tests.js
@@ -18,14 +18,14 @@ describe('Promises (Cursor)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=100')
           : f('%s?%s', url, 'maxPoolSize=100');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         var db = client.db(configuration.db);
         test.equal(1, client.topology.connections().length);
 

--- a/test/functional/promises_db_tests.js
+++ b/test/functional/promises_db_tests.js
@@ -8,7 +8,7 @@ describe('Promises (Db)', function() {
     return setupDatabase(this.configuration);
   });
 
-  it('Should correctly connect with MongoClient.connect using Promise', {
+  it('Should correctly connect with MongoClient `connect` using Promise', {
     metadata: {
       requires: {
         topology: ['single']
@@ -18,14 +18,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=100')
           : f('%s?%s', url, 'maxPoolSize=100');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         test.equal(1, client.topology.connections().length);
 
         client.close();
@@ -62,14 +62,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         // Execute ismaster
         client
           .db(configuration.db)
@@ -94,14 +94,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         // Execute ismaster
         client
           .db(configuration.db)
@@ -127,14 +127,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         client
           .db(configuration.db)
           .createCollection('promiseCollection')
@@ -161,14 +161,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         client
           .db(configuration.db)
           .stats()
@@ -192,14 +192,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         client
           .db(configuration.db)
           .eval('function (x) {return x;}', [3], { nolock: true })
@@ -223,14 +223,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         var db = client.db(configuration.db);
 
         db.createCollection('promiseCollection1').then(function(col) {
@@ -262,14 +262,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         client
           .db(configuration.db)
           .dropDatabase()
@@ -296,14 +296,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         var db = client.db(configuration.db);
 
         db.createCollection('promiseCollectionCollections1').then(function(col) {
@@ -334,14 +334,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         client
           .db(configuration.db)
           .executeDbAdminCommand({ ismaster: true })
@@ -365,14 +365,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         // Create an index
         client
           .db(configuration.db)
@@ -397,14 +397,14 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var url = configuration.url();
       url =
         url.indexOf('?') !== -1
           ? f('%s&%s', url, 'maxPoolSize=5')
           : f('%s?%s', url, 'maxPoolSize=5');
 
-      MongoClient.connect(url).then(function(client) {
+      const client = configuration.newClient(url);
+      client.connect().then(function(client) {
         // Create an index
         client
           .db(configuration.db)
@@ -429,14 +429,13 @@ describe('Promises (Db)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var db = null;
-      var client = null;
       var BlueBird = require('bluebird');
 
-      MongoClient.connect(configuration.url(), { promiseLibrary: BlueBird })
-        .then(function(_client) {
-          client = _client;
+      const client = configuration.newClient({}, { promiseLibrary: BlueBird });
+      client
+        .connect()
+        .then(function() {
           db = client.db(configuration.db);
           return db.createCollection('test');
         })

--- a/test/functional/promote_buffers_tests.js
+++ b/test/functional/promote_buffers_tests.js
@@ -55,34 +55,28 @@ describe('Promote Buffers', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
-      MongoClient.connect(
-        configuration.url(),
-        {
-          promoteBuffers: true
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
+      const client = configuration.newClient({}, { promoteBuffers: true });
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
 
-          db.collection('shouldCorrectlyHonorPromoteBuffer2').insert(
-            {
-              doc: Buffer.alloc(256)
-            },
-            function(err) {
+        db.collection('shouldCorrectlyHonorPromoteBuffer2').insert(
+          {
+            doc: Buffer.alloc(256)
+          },
+          function(err) {
+            test.equal(null, err);
+
+            db.collection('shouldCorrectlyHonorPromoteBuffer2').findOne(function(err, doc) {
               test.equal(null, err);
+              test.ok(doc.doc instanceof Buffer);
 
-              db.collection('shouldCorrectlyHonorPromoteBuffer2').findOne(function(err, doc) {
-                test.equal(null, err);
-                test.ok(doc.doc instanceof Buffer);
-
-                client.close();
-                done();
-              });
-            }
-          );
-        }
-      );
+              client.close();
+              done();
+            });
+          }
+        );
+      });
     }
   });
 
@@ -96,37 +90,31 @@ describe('Promote Buffers', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
-      MongoClient.connect(
-        configuration.url(),
-        {
-          promoteBuffers: true
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
+      const client = configuration.newClient({}, { promoteBuffers: true });
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
 
-          db.collection('shouldCorrectlyHonorPromoteBuffer3').insert(
-            {
-              doc: Buffer.alloc(256)
-            },
-            function(err) {
-              test.equal(null, err);
+        db.collection('shouldCorrectlyHonorPromoteBuffer3').insert(
+          {
+            doc: Buffer.alloc(256)
+          },
+          function(err) {
+            test.equal(null, err);
 
-              db
-                .collection('shouldCorrectlyHonorPromoteBuffer3')
-                .find()
-                .next(function(err, doc) {
-                  test.equal(null, err);
-                  test.ok(doc.doc instanceof Buffer);
+            db
+              .collection('shouldCorrectlyHonorPromoteBuffer3')
+              .find()
+              .next(function(err, doc) {
+                test.equal(null, err);
+                test.ok(doc.doc instanceof Buffer);
 
-                  client.close();
-                  done();
-                });
-            }
-          );
-        }
-      );
+                client.close();
+                done();
+              });
+          }
+        );
+      });
     }
   });
 
@@ -140,9 +128,9 @@ describe('Promote Buffers', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
-      MongoClient.connect(configuration.url(), {}, function(err, client) {
+      const client = configuration.newClient();
+      client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteBuffer4').insert(
           {
@@ -180,9 +168,9 @@ describe('Promote Buffers', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
 
-      MongoClient.connect(configuration.url(), {}, function(err, client) {
+      const client = configuration.newClient();
+      client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteBuffer5').insert(
           {

--- a/test/functional/promote_values_tests.js
+++ b/test/functional/promote_values_tests.js
@@ -67,40 +67,34 @@ describe('Promote Values', function() {
       var configuration = this.configuration;
       var Long = configuration.require.Long,
         Int32 = configuration.require.Int32,
-        Double = configuration.require.Double,
-        MongoClient = configuration.require.MongoClient;
+        Double = configuration.require.Double;
 
-      MongoClient.connect(
-        configuration.url(),
-        {
-          promoteValues: false
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
-          db.collection('shouldCorrectlyHonorPromoteValues').insert(
-            {
-              doc: Long.fromNumber(10),
-              int: 10,
-              double: 2.2222,
-              array: [[Long.fromNumber(10)]]
-            },
-            function(err) {
+      const client = configuration.newClient({}, { promoteValues: false });
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+        db.collection('shouldCorrectlyHonorPromoteValues').insert(
+          {
+            doc: Long.fromNumber(10),
+            int: 10,
+            double: 2.2222,
+            array: [[Long.fromNumber(10)]]
+          },
+          function(err) {
+            test.equal(null, err);
+
+            db.collection('shouldCorrectlyHonorPromoteValues').findOne(function(err, doc) {
               test.equal(null, err);
 
-              db.collection('shouldCorrectlyHonorPromoteValues').findOne(function(err, doc) {
-                test.equal(null, err);
+              test.deepEqual(Long.fromNumber(10), doc.doc);
+              test.deepEqual(new Int32(10), doc.int);
+              test.deepEqual(new Double(2.2222), doc.double);
 
-                test.deepEqual(Long.fromNumber(10), doc.doc);
-                test.deepEqual(new Int32(10), doc.int);
-                test.deepEqual(new Double(2.2222), doc.double);
-
-                client.close();
-                done();
-              });
-            }
-          );
-        }
-      );
+              client.close();
+              done();
+            });
+          }
+        );
+      });
     }
   });
 
@@ -116,43 +110,37 @@ describe('Promote Values', function() {
       var configuration = this.configuration;
       var Long = configuration.require.Long,
         Int32 = configuration.require.Int32,
-        Double = configuration.require.Double,
-        MongoClient = configuration.require.MongoClient;
+        Double = configuration.require.Double;
 
-      MongoClient.connect(
-        configuration.url(),
-        {
-          promoteValues: false
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
-          db.collection('shouldCorrectlyHonorPromoteValues').insert(
-            {
-              doc: Long.fromNumber(10),
-              int: 10,
-              double: 2.2222,
-              array: [[Long.fromNumber(10)]]
-            },
-            function(err) {
-              test.equal(null, err);
+      const client = configuration.newClient({}, { promoteValues: false });
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+        db.collection('shouldCorrectlyHonorPromoteValues').insert(
+          {
+            doc: Long.fromNumber(10),
+            int: 10,
+            double: 2.2222,
+            array: [[Long.fromNumber(10)]]
+          },
+          function(err) {
+            test.equal(null, err);
 
-              db
-                .collection('shouldCorrectlyHonorPromoteValues')
-                .find()
-                .next(function(err, doc) {
-                  test.equal(null, err);
+            db
+              .collection('shouldCorrectlyHonorPromoteValues')
+              .find()
+              .next(function(err, doc) {
+                test.equal(null, err);
 
-                  test.deepEqual(Long.fromNumber(10), doc.doc);
-                  test.deepEqual(new Int32(10), doc.int);
-                  test.deepEqual(new Double(2.2222), doc.double);
+                test.deepEqual(Long.fromNumber(10), doc.doc);
+                test.deepEqual(new Int32(10), doc.int);
+                test.deepEqual(new Double(2.2222), doc.double);
 
-                  client.close();
-                  done();
-                });
-            }
-          );
-        }
-      );
+                client.close();
+                done();
+              });
+          }
+        );
+      });
     }
   });
 
@@ -168,10 +156,10 @@ describe('Promote Values', function() {
       var configuration = this.configuration;
       var Long = configuration.require.Long,
         Int32 = configuration.require.Int32,
-        Double = configuration.require.Double,
-        MongoClient = configuration.require.MongoClient;
+        Double = configuration.require.Double;
 
-      MongoClient.connect(configuration.url(), {}, function(err, client) {
+      const client = configuration.newClient();
+      client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteValues').insert(
           {
@@ -214,10 +202,10 @@ describe('Promote Values', function() {
       var configuration = this.configuration;
       var Long = configuration.require.Long,
         Int32 = configuration.require.Int32,
-        Double = configuration.require.Double,
-        MongoClient = configuration.require.MongoClient;
+        Double = configuration.require.Double;
 
-      MongoClient.connect(configuration.url(), {}, function(err, client) {
+      const client = configuration.newClient();
+      client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteValues2').insert(
           {
@@ -258,10 +246,10 @@ describe('Promote Values', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var Long = configuration.require.Long;
 
-      MongoClient.connect(configuration.url(), function(err, client) {
+      const client = configuration.newClient();
+      client.connect(function(err, client) {
         var docs = new Array(150).fill(0).map(function(_, i) {
           return {
             _id: 'needle_' + i,

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -2,6 +2,7 @@
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 var f = require('util').format;
+const expect = require('chai').expect;
 
 describe('ReadConcern', function() {
   before(function(done) {
@@ -33,14 +34,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'local' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'local' } }
       );
 
       client.connect(function(err, client) {
-        var db = client.db(configuration.db);
+        expect(err).to.not.exist;
 
-        test.equal(null, err);
+        var db = client.db(configuration.db);
         test.deepEqual({ level: 'local' }, db.s.readConcern);
 
         // Get a collection
@@ -79,13 +80,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get a collection
@@ -125,8 +127,9 @@ describe('ReadConcern', function() {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         // Get a collection
         var collection = db.collection('readConcernCollection', {
           readConcern: { level: 'local' }
@@ -166,13 +169,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         // Get a collection
         var collection = db.collection('readConcernCollection', {
           readConcern: { level: 'majority' }
@@ -218,8 +222,9 @@ describe('ReadConcern', function() {
 
       // Connect using mongoclient
       MongoClient.connect(url, function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'local' }, db.s.readConcern);
 
         // Get a collection
@@ -265,8 +270,9 @@ describe('ReadConcern', function() {
 
       // Connect using mongoclient
       MongoClient.connect(url, function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get a collection
@@ -313,8 +319,9 @@ describe('ReadConcern', function() {
 
       // Connect using mongoclient
       MongoClient.connect(url, options, function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get a collection
@@ -354,13 +361,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get a collection
@@ -397,13 +405,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get a collection
@@ -449,13 +458,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get a collection
@@ -514,13 +524,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get the collection
@@ -577,13 +588,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get the collection
@@ -643,13 +655,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get the collection
@@ -709,13 +722,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get the collection
@@ -781,13 +795,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get the collection
@@ -847,13 +862,14 @@ describe('ReadConcern', function() {
       // Get a new instance
       var configuration = this.configuration;
       var client = configuration.newClient(
-        { w: 1, readConcern: { level: 'majority' } },
-        { poolSize: 1 }
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
       client.connect(function(err, client) {
+        expect(err).to.not.exist;
+
         var db = client.db(configuration.db);
-        test.equal(null, err);
         test.deepEqual({ level: 'majority' }, db.s.readConcern);
 
         // Get the collection

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -207,7 +207,6 @@ describe('ReadConcern', function() {
 
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var listener = require('../..').instrument(function(err) {
         test.equal(null, err);
       });
@@ -221,7 +220,8 @@ describe('ReadConcern', function() {
           : f('%s?%s', url, 'readConcernLevel=local');
 
       // Connect using mongoclient
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         expect(err).to.not.exist;
 
         var db = client.db(configuration.db);
@@ -255,7 +255,6 @@ describe('ReadConcern', function() {
 
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var listener = require('../..').instrument(function(err) {
         test.equal(null, err);
       });
@@ -269,7 +268,8 @@ describe('ReadConcern', function() {
           : f('%s?%s', url, 'readConcernLevel=majority');
 
       // Connect using mongoclient
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         expect(err).to.not.exist;
 
         var db = client.db(configuration.db);
@@ -303,7 +303,6 @@ describe('ReadConcern', function() {
 
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var listener = require('../..').instrument(function(err) {
         test.equal(null, err);
       });
@@ -318,7 +317,8 @@ describe('ReadConcern', function() {
       };
 
       // Connect using mongoclient
-      MongoClient.connect(url, options, function(err, client) {
+      const client = configuration.newClient(url, options);
+      client.connect(function(err, client) {
         expect(err).to.not.exist;
 
         var db = client.db(configuration.db);

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -782,7 +782,7 @@ describe('ReadConcern', function() {
   });
 
   it('Should set majority readConcern parallelCollectionScan command', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
+    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0 <=4.1.0' } },
 
     test: function(done) {
       var listener = require('../..').instrument(function(err) {

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -709,7 +709,7 @@ describe('ReadConcern', function() {
   });
 
   it('Should set majority readConcern group command', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
+    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.2.0 <=4.1.0' } },
 
     test: function(done) {
       var listener = require('../..').instrument(function(err) {

--- a/test/functional/reconnect_tests.js
+++ b/test/functional/reconnect_tests.js
@@ -54,52 +54,48 @@ describe('Reconnect', function() {
 
     // The actual test we wish to run
     test: function(done) {
-      var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
-      MongoClient.connect(
-        'mongodb://localhost:27017/test',
-        {
-          db: { native_parser: true, bufferMaxEntries: -1 },
-          server: {
-            poolSize: 20,
-            socketOptions: { autoReconnect: true, keepAlive: true, keepAliveInitialDelay: 50 },
-            reconnectTries: 1000,
-            reconnectInterval: 1000
-          }
-        },
-        function(err, client) {
-          var db = client.db(configuration.db);
-          var col = db.collection('t');
-          var count = 1;
-
-          var execute = function() {
-            if (!done) {
-              col.insertOne({ a: 1, count: count }, function(err) {
-                test.equal(null, err);
-                count = count + 1;
-
-                col.findOne({}, function(err) {
-                  test.equal(null, err);
-                  setTimeout(execute, 500);
-                });
-              });
-            } else {
-              col.insertOne({ a: 1, count: count }, function(err) {
-                test.equal(null, err);
-
-                col.findOne({}, function(err) {
-                  test.equal(null, err);
-                  client.close();
-                  done();
-                });
-              });
-            }
-          };
-
-          setTimeout(execute, 500);
+      const configuration = this.configuration;
+      const client = configuration.newClient('mongodb://localhost:27017/test', {
+        db: { native_parser: true, bufferMaxEntries: -1 },
+        server: {
+          poolSize: 20,
+          socketOptions: { autoReconnect: true, keepAlive: true, keepAliveInitialDelay: 50 },
+          reconnectTries: 1000,
+          reconnectInterval: 1000
         }
-      );
+      });
+
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+        var col = db.collection('t');
+        var count = 1;
+
+        var execute = function() {
+          if (!done) {
+            col.insertOne({ a: 1, count: count }, function(err) {
+              test.equal(null, err);
+              count = count + 1;
+
+              col.findOne({}, function(err) {
+                test.equal(null, err);
+                setTimeout(execute, 500);
+              });
+            });
+          } else {
+            col.insertOne({ a: 1, count: count }, function(err) {
+              test.equal(null, err);
+
+              col.findOne({}, function(err) {
+                test.equal(null, err);
+                client.close();
+                done();
+              });
+            });
+          }
+        };
+
+        setTimeout(execute, 500);
+      });
 
       var count = 2;
 

--- a/test/functional/replicaset_mock_tests.js
+++ b/test/functional/replicaset_mock_tests.js
@@ -62,9 +62,7 @@ describe('ReplSet (mocks)', function() {
 
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        Logger = configuration.require.Logger;
-
+      var Logger = configuration.require.Logger;
       var logger = Logger.currentLogger();
       Logger.setLevel('warn');
       Logger.setCurrentLogger(function(msg, state) {
@@ -74,10 +72,10 @@ describe('ReplSet (mocks)', function() {
         );
       });
 
-      MongoClient.connect(`mongodb://${test.mongos1.uri()},${test.mongos2.uri()}/test`, function(
-        err,
-        client
-      ) {
+      const client = configuration.newClient(
+        `mongodb://${test.mongos1.uri()},${test.mongos2.uri()}/test`
+      );
+      client.connect(function(err, client) {
         Logger.setCurrentLogger(logger);
         Logger.reset();
         expect(err).to.not.exist;
@@ -99,9 +97,7 @@ describe('ReplSet (mocks)', function() {
 
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient,
-        Logger = configuration.require.Logger;
-
+      var Logger = configuration.require.Logger;
       var warnings = [];
       var logger = Logger.currentLogger();
       Logger.setLevel('warn');
@@ -110,10 +106,11 @@ describe('ReplSet (mocks)', function() {
         warnings.push(state);
       });
 
-      MongoClient.connect(`mongodb://${test.mongos1.uri()},${test.mongos2.uri()}/test`, function(
-        err,
-        client
-      ) {
+      const client = configuration.newClient(
+        `mongodb://${test.mongos1.uri()},${test.mongos2.uri()}/test`
+      );
+
+      client.connect(function(err, client) {
         Logger.setCurrentLogger(logger);
         Logger.reset();
 
@@ -155,19 +152,18 @@ describe('ReplSet (mocks)', function() {
 
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
-      MongoClient.connect(
-        `mongodb://${test.mongos1.uri()},${test.mongos2.uri()}/test?socketTimeoutMS=120000&connectTimeoutMS=15000`,
-        function(err, client) {
-          expect(err).to.not.exist;
-          expect(client.topology.s.coreTopology.s.options.connectionTimeout).to.equal(15000);
-          expect(client.topology.s.coreTopology.s.options.socketTimeout).to.equal(120000);
-
-          client.close();
-          done();
-        }
+      const client = configuration.newClient(
+        `mongodb://${test.mongos1.uri()},${test.mongos2.uri()}/test?socketTimeoutMS=120000&connectTimeoutMS=15000`
       );
+
+      client.connect(function(err, client) {
+        expect(err).to.not.exist;
+        expect(client.topology.s.coreTopology.s.options.connectionTimeout).to.equal(15000);
+        expect(client.topology.s.coreTopology.s.options.socketTimeout).to.equal(120000);
+
+        client.close();
+        done();
+      });
     }
   });
 });

--- a/test/functional/replset_connection_tests.js
+++ b/test/functional/replset_connection_tests.js
@@ -59,27 +59,17 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Accounting tests
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server('localhost', 28390),
-          new Server('localhost', 28391),
-          new Server('localhost', 28392)
-        ],
-        { rs_name: configuration.replicasetName }
+      var client = configuration.newClient(
+        'mongodb://localhost:28390,localhost:28391,localhost:38392/test?replicaSet=rs',
+        { w: 0 }
       );
-
-      var client = new MongoClient(replSet, { w: 0 });
       client.connect(function(err) {
         test.ok(err != null);
 
@@ -102,10 +92,7 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Replset start port
@@ -115,17 +102,7 @@ describe.skip('ReplSet (Connection)', function() {
           CoreServer.enableServerAccounting();
           CoreConnection.enableConnectionAccounting();
 
-          // Replica configuration
-          var replSet = new ReplSet(
-            [
-              new Server(configuration.host, configuration.port),
-              new Server(configuration.host, configuration.port + 1),
-              new Server(configuration.host, configuration.port + 2)
-            ],
-            { rs_name: configuration.replicasetName }
-          );
-
-          var client = new MongoClient(replSet, { w: 0 });
+          const client = configuration.newClient({}, { w: 0 });
           client.connect(function(err, client) {
             test.equal(null, err);
             client.close();
@@ -145,10 +122,7 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Replset start port
@@ -158,17 +132,7 @@ describe.skip('ReplSet (Connection)', function() {
           CoreServer.enableServerAccounting();
           CoreConnection.enableConnectionAccounting();
 
-          // Replica configuration
-          var replSet = new ReplSet(
-            [
-              new Server(configuration.host, configuration.port),
-              new Server(configuration.host, configuration.port + 1),
-              new Server(configuration.host, configuration.port + 2)
-            ],
-            {}
-          );
-
-          var client = new MongoClient(replSet, { w: 0 });
+          const client = configuration.newClient({}, { w: 0 });
           client.connect(function(err, client) {
             test.equal(null, err);
             client.close();
@@ -186,30 +150,17 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Accounting tests
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        {
-          socketOptions: { keepAlive: true, keepAliveInitialDelay: 100 },
-          rs_name: configuration.replicasetName
-        }
+      const client = configuration.newClient(
+        {},
+        { w: 0, keepAlive: true, keepAliveInitialDelay: 100 }
       );
 
-      var client = new MongoClient(replSet, { w: 0 });
       client.connect(function(err, client) {
         test.equal(null, err);
         // Get a connection
@@ -228,27 +179,15 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Accounting tests
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName }
-      );
-
-      new MongoClient(replSet, { w: 0 }).connect(function(err, client) {
+      const client = configuration.newClient({}, { w: 0 });
+      client.connect(function(err, client) {
         test.equal(null, err);
         var dbCloseCount = 0;
         client.on('close', function() {
@@ -278,27 +217,15 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Accounting tests
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName }
-      );
-
-      new MongoClient(replSet, { w: 0 }).connect(function(err, client) {
+      const client = configuration.newClient({}, { w: 0 });
+      client.connect(function(err, client) {
         test.equal(null, err);
         var dbCloseCount = 0;
         client.on('close', function() {
@@ -328,21 +255,7 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName + '-wrong' }
-      );
-
-      var client = new MongoClient(replSet, { w: 0 });
+      const client = configuration.newClient({}, { rs_name: 'wrong' });
       client.connect(function(err) {
         test.notEqual(null, err);
         done();
@@ -352,26 +265,12 @@ describe.skip('ReplSet (Connection)', function() {
 
   var retries = 120;
   var ensureConnection = function(configuration, numberOfTries, callback) {
-    var ReplSet = configuration.require.ReplSet,
-      Server = configuration.require.Server,
-      MongoClient = configuration.require.MongoClient;
-
-    // Replica configuration
-    var replSet = new ReplSet(
-      [
-        new Server(configuration.host, configuration.port),
-        new Server(configuration.host, configuration.port + 1),
-        new Server(configuration.host, configuration.port + 2)
-      ],
-      { rs_name: configuration.replicasetName, socketOptions: { connectTimeoutMS: 1000 } }
-    );
-
     if (numberOfTries <= 0) {
       return callback(new Error('could not connect correctly'), null);
     }
 
     // Open the db
-    var client = new MongoClient(replSet, { w: 0 });
+    const client = configuration.newClient({}, { w: 0, connectTimeoutMS: 1000 });
     client.connect(function(err, client) {
       if (err != null) {
         // Wait for a sec and retry
@@ -392,25 +291,12 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Accounting tests
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName }
-      );
 
       // // Step down primary server
       configuration.manager
@@ -420,7 +306,8 @@ describe.skip('ReplSet (Connection)', function() {
           ensureConnection(configuration, retries, function(err) {
             test.equal(null, err);
 
-            new MongoClient(replSet, { w: 0 }).connect(function(err, client) {
+            const client = configuration.newClient({}, { w: 0 });
+            client.connect(function(err, client) {
               test.ok(err == null);
               // Get a connection
               var connection = client.topology.connections()[0];
@@ -441,10 +328,7 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Replset start port
@@ -454,21 +338,12 @@ describe.skip('ReplSet (Connection)', function() {
           CoreServer.enableServerAccounting();
           CoreConnection.enableConnectionAccounting();
 
-          // Replica configuration
-          var replSet = new ReplSet(
-            [
-              new Server(configuration.host, configuration.port),
-              new Server(configuration.host, configuration.port + 1),
-              new Server(configuration.host, configuration.port + 2)
-            ],
-            { rs_name: configuration.replicasetName }
-          );
-
           // Wait for new primary to pop up
           ensureConnection(configuration, retries, function(err) {
             test.equal(null, err);
 
-            new MongoClient(replSet, { w: 0 }).connect(function(err, client) {
+            const client = configuration.newClient({}, { w: 0 });
+            client.connect(function(err, client) {
               test.ok(err == null);
               // Get a connection
               var connection = client.topology.connections()[0];
@@ -490,10 +365,7 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Replset start port
@@ -503,21 +375,12 @@ describe.skip('ReplSet (Connection)', function() {
           CoreServer.enableServerAccounting();
           CoreConnection.enableConnectionAccounting();
 
-          // Replica configuration
-          var replSet = new ReplSet(
-            [
-              new Server(configuration.host, configuration.port),
-              new Server(configuration.host, configuration.port + 1),
-              new Server(configuration.host, configuration.port + 2)
-            ],
-            { rs_name: configuration.replicasetName }
-          );
-
           // Wait for new primary to pop up
           ensureConnection(configuration, retries, function(err) {
             test.equal(null, err);
 
-            new MongoClient(replSet, { w: 0 }).connect(function(err, client) {
+            const client = configuration.newClient({}, { w: 0 });
+            client.connect(function(err, client) {
               test.ok(err == null);
               // Get a connection
               var connection = client.topology.connections()[0];
@@ -539,10 +402,7 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       var openCalled = false;
@@ -550,17 +410,7 @@ describe.skip('ReplSet (Connection)', function() {
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName }
-      );
-
-      var client = new MongoClient(replSet, { w: 0 });
+      const client = configuration.newClient({}, { w: 0 });
       client.once('open', function(_err) {
         test.equal(null, _err);
         openCalled = true;
@@ -595,34 +445,23 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Accounting tests
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
+      const client = configuration.newClient(
+        {},
         {
-          socketOptions: {
-            connectTimeoutMS: 1000,
-            socketTimeoutMS: 3000,
-            noDelay: false
-          },
-          rs_name: configuration.replicasetName
+          w: 0,
+          connectTimeoutMS: 1000,
+          socketTimeoutMS: 3000,
+          noDelay: false
         }
       );
 
-      var client = new MongoClient(replSet, { w: 0 });
       client.connect(function(err, client) {
         test.equal(null, err);
         // Get a connection
@@ -651,28 +490,15 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Accounting tests
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName }
-      );
-
       // Connect to the replicaset
-      var client = new MongoClient(replSet, { w: 0 });
+      const client = configuration.newClient({}, { w: 0 });
       client.connect(function(err, client) {
         // Kill the secondary
         // Replset start port
@@ -694,28 +520,15 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Accounting tests
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName }
-      );
-
       // Connect to the replicaset
-      var client = new MongoClient(replSet, { w: 1, bufferMaxEntries: 0 });
+      const client = configuration.newClient({}, { w: 1, bufferMaxEntries: 0 });
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
 
@@ -752,11 +565,9 @@ describe.skip('ReplSet (Connection)', function() {
 
     // The actual test we wish to run
     test: function(done) {
-      var configuration = this.configuration;
-      var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        CoreServer = configuration.require.CoreServer,
-        CoreConnection = configuration.require.CoreConnection;
+      const configuration = this.configuration;
+      const CoreServer = configuration.require.CoreServer;
+      const CoreConnection = configuration.require.CoreConnection;
 
       var url = f(
         'mongodb://localhost:%s,localhost:%s,localhost:%s/integration_test_?replicaSet=%s',
@@ -770,43 +581,41 @@ describe.skip('ReplSet (Connection)', function() {
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      MongoClient.connect(
-        url,
-        {
-          replSet: {
-            haInterval: 500,
-            socketOptions: {
-              connectTimeoutMS: 500
-            }
+      const client = configuration.newClient(url, {
+        replSet: {
+          haInterval: 500,
+          socketOptions: {
+            connectTimeoutMS: 500
           }
-        },
-        function(err, client) {
-          test.equal(null, err);
-          var db = client.db(configuration.db);
-
-          test.equal(500, client.topology.connections()[0].connectionTimeout);
-          test.equal(360000, client.topology.connections()[0].socketTimeout);
-
-          db
-            .collection('replicaset_mongo_client_collection')
-            .update({ a: 1 }, { b: 1 }, { upsert: true }, function(err, result) {
-              test.equal(null, err);
-              test.equal(1, result.result.n);
-
-              client.close();
-
-              setTimeout(function() {
-                // Connection account tests
-                test.equal(0, Object.keys(CoreConnection.connections()).length);
-                test.equal(0, Object.keys(CoreServer.servers()).length);
-                CoreServer.disableServerAccounting();
-                CoreConnection.disableConnectionAccounting();
-
-                done();
-              }, 200);
-            });
         }
-      );
+      });
+
+      client.connect(function(err, client) {
+        test.equal(null, err);
+        var db = client.db(configuration.db);
+
+        test.equal(500, client.topology.connections()[0].connectionTimeout);
+        test.equal(360000, client.topology.connections()[0].socketTimeout);
+
+        db
+          .collection('replicaset_mongo_client_collection')
+          .update({ a: 1 }, { b: 1 }, { upsert: true }, function(err, result) {
+            test.equal(null, err);
+            test.equal(1, result.result.n);
+
+            client.close();
+
+            setTimeout(function() {
+              // Connection account tests
+              test.equal(0, Object.keys(CoreConnection.connections()).length);
+              test.equal(0, Object.keys(CoreServer.servers()).length);
+              CoreServer.disableServerAccounting();
+              CoreConnection.disableConnectionAccounting();
+
+              done();
+            }, 200);
+          });
+      });
     }
   });
 
@@ -818,11 +627,9 @@ describe.skip('ReplSet (Connection)', function() {
 
     // The actual test we wish to run
     test: function(done) {
-      var configuration = this.configuration;
-      var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        CoreServer = configuration.require.CoreServer,
-        CoreConnection = configuration.require.CoreConnection;
+      const configuration = this.configuration;
+      const CoreServer = configuration.require.CoreServer;
+      const CoreConnection = configuration.require.CoreConnection;
 
       // Create url
       var url = f(
@@ -838,7 +645,8 @@ describe.skip('ReplSet (Connection)', function() {
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         var db = client.db(configuration.db);
 
         db.collection('test_collection').insert({ a: 1 }, function(err) {
@@ -869,9 +677,6 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var mongo = configuration.require,
-        MongoClient = mongo.MongoClient;
-
       var url = f(
         'mongodb://%s,%s/%s?replicaSet=%s&readPreference=%s',
         'nolocalhost:30000',
@@ -881,7 +686,8 @@ describe.skip('ReplSet (Connection)', function() {
         'primary'
       );
 
-      MongoClient.connect(url, function(err) {
+      const client = configuration.newClient(url);
+      client.connect(function(err) {
         test.ok(err != null);
         done();
       });
@@ -900,7 +706,6 @@ describe.skip('ReplSet (Connection)', function() {
       test: function(done) {
         var configuration = this.configuration;
         var mongo = configuration.require,
-          MongoClient = mongo.MongoClient,
           GridStore = mongo.GridStore,
           ObjectID = mongo.ObjectID,
           CoreServer = configuration.require.CoreServer,
@@ -920,7 +725,8 @@ describe.skip('ReplSet (Connection)', function() {
         CoreServer.enableServerAccounting();
         CoreConnection.enableConnectionAccounting();
 
-        MongoClient.connect(url, function(err, client) {
+        const client = configuration.newClient(url);
+        client.connect(function(err, client) {
           var db = client.db(configuration.db);
           var gs = new GridStore(db, new ObjectID());
           test.equal('majority', gs.writeConcern.w);
@@ -950,28 +756,15 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Accounting tests
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, socketTimeoutMS: 5000 }
-      );
-
       // Open the db connection
-      var client = new MongoClient(replSet, { w: 1 });
+      const client = configuration.newClient({}, { w: 1, socketTimeoutMS: 5000 });
       client.on('fullsetup', function(client) {
         var db = client.db(configuration.db);
         db.command({ ismaster: true }, function(err, result) {
@@ -984,7 +777,7 @@ describe.skip('ReplSet (Connection)', function() {
           // Get the arbiters
           var host = secondaries[0].split(':')[0];
           var port = parseInt(secondaries[0].split(':')[1], 10);
-          var client1 = new MongoClient(new Server(host, port), { w: 1 });
+          var client1 = configuration.newClient({}, { host, port, w: 1 });
           var finished = false;
 
           client.topology.on('left', function(t) {
@@ -1039,7 +832,6 @@ describe.skip('ReplSet (Connection)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
         Server = mongo.Server,
         CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -1050,7 +842,8 @@ describe.skip('ReplSet (Connection)', function() {
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
         test.ok(client.topology instanceof Server);
         client.close();
@@ -1097,10 +890,7 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var mongo = configuration.require,
-        Server = mongo.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Replset start port
@@ -1113,7 +903,7 @@ describe.skip('ReplSet (Connection)', function() {
         var host = managers[0].host;
         var port = managers[0].port;
 
-        var client = new MongoClient(new Server(host, port), { w: 1 });
+        var client = configuration.newClient({}, { host, port, w: 1 });
         client.connect(function(err, client) {
           var db = client.db(configuration.db);
           test.equal(null, err);
@@ -1139,10 +929,7 @@ describe.skip('ReplSet (Connection)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var mongo = configuration.require,
-        Server = mongo.Server,
-        MongoClient = configuration.require.MongoClient,
-        CoreServer = configuration.require.CoreServer,
+      var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       configuration.manager.secondaries().then(function(managers) {
@@ -1154,7 +941,7 @@ describe.skip('ReplSet (Connection)', function() {
         var host = managers[0].host;
         var port = managers[0].port;
 
-        var client = new MongoClient(new Server(host, port), { w: 1 });
+        var client = configuration.newClient({}, { host, port, w: 1 });
         client.connect(function(err, client) {
           var db = client.db(configuration.db);
           test.equal(null, err);
@@ -1180,7 +967,6 @@ describe.skip('ReplSet (Connection)', function() {
       var configuration = this.configuration;
       var ReplSet = configuration.require.ReplSet,
         ServerManager = require('mongodb-topology-manager').Server,
-        MongoClient = configuration.require.MongoClient,
         CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
@@ -1213,7 +999,8 @@ describe.skip('ReplSet (Connection)', function() {
                 CoreConnection.enableConnectionAccounting();
 
                 // Attempt to connect using MongoClient uri
-                MongoClient.connect(url, function(err, client) {
+                const client = configuration.newClient(url);
+                client.connect(function(err, client) {
                   test.equal(null, err);
                   test.ok(client.topology instanceof ReplSet);
                   client.close();
@@ -1239,13 +1026,10 @@ describe.skip('ReplSet (Connection)', function() {
 
     // The actual test we wish to run
     test: function(done) {
-      var configuration = this.configuration;
-      var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        CoreServer = configuration.require.CoreServer,
-        CoreConnection = configuration.require.CoreConnection;
-
-      var url = f(
+      const configuration = this.configuration;
+      const CoreServer = configuration.require.CoreServer;
+      const CoreConnection = configuration.require.CoreConnection;
+      const url = f(
         'mongodb://localhost:%s,localhost:%s,localhost:%s/integration_test_?replicaSet=%s',
         configuration.port,
         configuration.port + 1,
@@ -1257,33 +1041,28 @@ describe.skip('ReplSet (Connection)', function() {
       CoreServer.enableServerAccounting();
       CoreConnection.enableConnectionAccounting();
 
-      MongoClient.connect(
-        url,
-        {
-          reconnectTries: 10
-        },
-        function(err, client) {
-          test.equal(null, err);
+      const client = configuration.newClient(url, { reconnectTries: 10 });
+      client.connect(function(err, client) {
+        test.equal(null, err);
 
-          var servers = client.topology.s.coreTopology.s.replicaSetState.allServers();
-          for (var i = 0; i < servers.length; i++) {
-            test.equal(10, servers[i].s.pool.options.reconnectTries);
-          }
-
-          // Destroy the pool
-          client.close();
-
-          setTimeout(function() {
-            // Connection account tests
-            test.equal(0, Object.keys(CoreConnection.connections()).length);
-            test.equal(0, Object.keys(CoreServer.servers()).length);
-            CoreServer.disableServerAccounting();
-            CoreConnection.disableConnectionAccounting();
-
-            done();
-          }, 200);
+        var servers = client.topology.s.coreTopology.s.replicaSetState.allServers();
+        for (var i = 0; i < servers.length; i++) {
+          test.equal(10, servers[i].s.pool.options.reconnectTries);
         }
-      );
+
+        // Destroy the pool
+        client.close();
+
+        setTimeout(function() {
+          // Connection account tests
+          test.equal(0, Object.keys(CoreConnection.connections()).length);
+          test.equal(0, Object.keys(CoreServer.servers()).length);
+          CoreServer.disableServerAccounting();
+          CoreConnection.disableConnectionAccounting();
+
+          done();
+        }, 200);
+      });
     }
   });
 
@@ -1298,9 +1077,6 @@ describe.skip('ReplSet (Connection)', function() {
       // The actual test we wish to run
       test: function(done) {
         var configuration = this.configuration;
-        var mongo = configuration.require,
-          MongoClient = mongo.MongoClient;
-
         var url = f(
           'mongodb://me:secret@localhost:%s,localhost:%s/integration_test_?replicaSet=%s',
           configuration.port + 1,
@@ -1308,22 +1084,20 @@ describe.skip('ReplSet (Connection)', function() {
           configuration.replicasetName
         );
 
-        MongoClient.connect(
-          url,
-          {
-            connectWithNoPrimary: true,
-            bufferMaxEntries: 0
-          },
-          function(err) {
-            test.ok(err);
-            test.ok(
-              err.message.indexOf(
-                'no connection available for operation and number of stored operation'
-              ) === -1
-            );
-            done();
-          }
-        );
+        const client = configuration.newClient(url, {
+          connectWithNoPrimary: true,
+          bufferMaxEntries: 0
+        });
+
+        client.connect(function(err) {
+          test.ok(err);
+          test.ok(
+            err.message.indexOf(
+              'no connection available for operation and number of stored operation'
+            ) === -1
+          );
+          done();
+        });
       }
     }
   );

--- a/test/functional/replset_connection_tests.js
+++ b/test/functional/replset_connection_tests.js
@@ -67,7 +67,7 @@ describe.skip('ReplSet (Connection)', function() {
       CoreConnection.enableConnectionAccounting();
 
       var client = configuration.newClient(
-        'mongodb://localhost:28390,localhost:28391,localhost:38392/test?replicaSet=rs',
+        'mongodb://localhost:28390,localhost:28391,localhost:28392/test?replicaSet=rs',
         { w: 0 }
       );
       client.connect(function(err) {

--- a/test/functional/replset_operations_tests.js
+++ b/test/functional/replset_operations_tests.js
@@ -36,8 +36,6 @@ describe('ReplSet (Operations)', function() {
     // The actual test we wish to run
     test: function(done) {
       const configuration = this.configuration;
-      const mongo = configuration.require,
-        MongoClient = mongo.MongoClient;
 
       // Create url
       const url = format(
@@ -93,7 +91,8 @@ describe('ReplSet (Operations)', function() {
         });
       }
 
-      MongoClient.connect(url, (err, client) => {
+      const client = configuration.newClient(url);
+      client.connect((err, client) => {
         expect(err).to.not.exist;
         const db = client.db(configuration.db);
 
@@ -122,8 +121,6 @@ describe('ReplSet (Operations)', function() {
       // The actual test we wish to run
       test: function(done) {
         const configuration = this.configuration;
-        const mongo = configuration.require,
-          MongoClient = mongo.MongoClient;
 
         // Create url
         const url = format(
@@ -192,7 +189,8 @@ describe('ReplSet (Operations)', function() {
           });
         }
 
-        MongoClient.connect(url, (err, client) => {
+        const client = configuration.newClient(url);
+        client.connect((err, client) => {
           expect(err).to.not.exist;
           const db = client.db(configuration.db);
 
@@ -226,8 +224,6 @@ describe('ReplSet (Operations)', function() {
     // The actual test we wish to run
     test: function(done) {
       const configuration = this.configuration;
-      const mongo = configuration.require,
-        MongoClient = mongo.MongoClient;
 
       // Create url
       const url = format(
@@ -288,7 +284,8 @@ describe('ReplSet (Operations)', function() {
         });
       }
 
-      MongoClient.connect(url, (err, client) => {
+      const client = configuration.newClient(url);
+      client.connect((err, client) => {
         expect(err).to.not.exist;
         const db = client.db(configuration.db);
 
@@ -317,8 +314,6 @@ describe('ReplSet (Operations)', function() {
       // The actual test we wish to run
       test: function(done) {
         const configuration = this.configuration;
-        const mongo = configuration.require,
-          MongoClient = mongo.MongoClient;
 
         // Create url
         const url = format(
@@ -395,7 +390,8 @@ describe('ReplSet (Operations)', function() {
           });
         }
 
-        MongoClient.connect(url, (err, client) => {
+        const client = configuration.newClient(url);
+        client.connect((err, client) => {
           expect(err).to.not.exist;
           const db = client.db(configuration.db);
 
@@ -416,7 +412,6 @@ describe('ReplSet (Operations)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
         ReadPreference = mongo.ReadPreference;
 
       // Create url
@@ -429,7 +424,8 @@ describe('ReplSet (Operations)', function() {
         'primary'
       );
 
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
@@ -474,12 +470,11 @@ describe('ReplSet (Operations)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var mongo = configuration.require,
-        MongoClient = mongo.MongoClient;
-
-      MongoClient.connect(
+      const client = configuration.newClient(
         'mongodb://localhost:31001/integration_test_?replicaSet=rs&readPreference=primaryPreferred'
-      ).then(function(client) {
+      );
+
+      client.connect().then(function(client) {
         var db = client.db(configuration.db);
         var collection = db.collection('ensureIndexWithPrimaryPreferred');
         collection.ensureIndex({ a: 1 }, function(err) {
@@ -500,7 +495,6 @@ describe('ReplSet (Operations)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
         ReadPreference = mongo.ReadPreference;
 
       // Create url
@@ -515,7 +509,8 @@ describe('ReplSet (Operations)', function() {
 
       var manager = configuration.manager;
 
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
@@ -567,7 +562,6 @@ describe('ReplSet (Operations)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
         ReadPreference = mongo.ReadPreference;
 
       // Create url
@@ -580,7 +574,8 @@ describe('ReplSet (Operations)', function() {
         'secondary'
       );
 
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 

--- a/test/functional/replset_read_preference_tests.js
+++ b/test/functional/replset_read_preference_tests.js
@@ -30,23 +30,14 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { secondaryAcceptableLatencyMS: 5, rs_name: configuration.replicasetName, debug: true }
-      );
+        ReadPreference = mongo.ReadPreference;
 
       // Open the database
-      var client = new MongoClient(replSet, { w: 1 });
+      const client = configuration.newClient(
+        {},
+        { secondaryAcceptableLatencyMS: 5, debug: true, w: 1 }
+      );
+
       // Trigger test once whole set is up
       client.on('fullsetup', function(client) {
         var db = client.db(configuration.db);
@@ -171,27 +162,14 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        {
-          readPreference: ReadPreference.NEAREST,
-          rs_name: configuration.replicasetName,
-          debug: true
-        }
-      );
+        ReadPreference = mongo.ReadPreference;
 
       // Open the database
-      var client = new MongoClient(replSet, { w: 1, readPreference: ReadPreference.NEAREST });
+      const client = configuration.newClient(
+        {},
+        { w: 1, readPreference: ReadPreference.NEAREST, debug: true }
+      );
+
       client.on('fullsetup', function() {
         var db = client.db(configuration.db);
         // Servers viewed
@@ -244,23 +222,14 @@ describe.skip('ReplSet (ReadPreference)', function() {
       test: function(done) {
         var configuration = this.configuration;
         var mongo = configuration.require,
-          MongoClient = mongo.MongoClient,
-          ReadPreference = mongo.ReadPreference,
-          ReplSet = mongo.ReplSet,
-          Server = mongo.Server;
-
-        // Replica configuration
-        var replSet = new ReplSet(
-          [
-            new Server(configuration.host, configuration.port),
-            new Server(configuration.host, configuration.port + 1),
-            new Server(configuration.host, configuration.port + 2)
-          ],
-          { rs_name: configuration.replicasetName, debug: true }
-        );
+          ReadPreference = mongo.ReadPreference;
 
         // Open the database
-        var client = new MongoClient(replSet, { w: 1, readPreference: ReadPreference.NEAREST });
+        var client = configuration.newClient(
+          {},
+          { w: 1, readPreference: ReadPreference.NEAREST, debug: true }
+        );
+
         client.on('fullsetup', function() {
           var db = client.db(configuration.db);
           // Servers viewed
@@ -328,29 +297,20 @@ describe.skip('ReplSet (ReadPreference)', function() {
       var configuration = this.configuration;
       var GridStore = configuration.require.GridStore,
         ObjectID = configuration.require.ObjectID,
-        MongoClient = configuration.require.MongoClient,
-        ReadPreference = configuration.require.ReadPreference,
-        ReplSet = configuration.require.ReplSet,
-        Server = configuration.require.Server;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        {
-          readPreference: ReadPreference.NEAREST,
-          rs_name: configuration.replicasetName,
-          debug: true
-        }
-      );
+        ReadPreference = configuration.require.ReadPreference;
 
       // Create an id
       var id = new ObjectID();
       // Open the database
-      var client = new MongoClient(replSet, { w: 1 });
+      var client = configuration.newClient(
+        {},
+        {
+          w: 1,
+          readPreference: ReadPreference.NEAREST,
+          debug: true
+        }
+      );
+
       client.on('fullsetup', function() {
         var db = client.db(configuration.db);
 
@@ -414,23 +374,14 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, debug: true }
-      );
+        ReadPreference = mongo.ReadPreference;
 
       // Create db instance
-      var client = new MongoClient(replSet, { w: 0, readPreference: ReadPreference.PRIMARY });
+      var client = configuration.newClient(
+        {},
+        { w: 0, readPreference: ReadPreference.PRIMARY, debug: true }
+      );
+
       // Logger.setLevel('info');
       // Trigger test once whole set is up
       client.on('fullsetup', function(client) {
@@ -472,23 +423,10 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, debug: true }
-      );
+        ReadPreference = mongo.ReadPreference;
 
       // Create db instance
-      var client = new MongoClient(replSet, { w: 0 });
+      var client = configuration.newClient({}, { w: 0, debug: true });
       // Connect to the db
       client.on('fullsetup', function(client) {
         var db = client.db(configuration.db);
@@ -535,23 +473,10 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, debug: true }
-      );
+        ReadPreference = mongo.ReadPreference;
 
       // Create db instance
-      var client = new MongoClient(replSet, { w: 0 });
+      var client = configuration.newClient({}, { w: 0, debug: true });
       // Connect to the db
       client.on('fullsetup', function() {
         var db = client.db(configuration.db);
@@ -602,23 +527,10 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, debug: true }
-      );
+        ReadPreference = mongo.ReadPreference;
 
       // Create db instance
-      var client = new MongoClient(replSet, { w: 0 });
+      var client = configuration.newClient({}, { w: 0, debug: true });
       // Connect to the db
       client.on('fullsetup', function() {
         var db = client.db(configuration.db);
@@ -665,23 +577,9 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
+        ReadPreference = mongo.ReadPreference;
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, debug: true }
-      );
-
-      // Create db instance
-      var client = new MongoClient(replSet, { w: 0 });
+      const client = configuration.newClient({}, { w: 0, debug: true });
       // Connect to the db
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
@@ -724,26 +622,13 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
+        ReadPreference = mongo.ReadPreference;
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, debug: true }
+      const client = configuration.newClient(
+        {},
+        { w: 0, debug: true, readPreference: new ReadPreference(ReadPreference.SECONDARY) }
       );
 
-      // Create db instance
-      var client = new MongoClient(replSet, {
-        w: 0,
-        readPreference: new ReadPreference(ReadPreference.SECONDARY)
-      });
       // Connect to the db
       client.on('fullsetup', function() {
         var db = client.db(configuration.db);
@@ -787,23 +672,10 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
+        ReadPreference = mongo.ReadPreference;
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, debug: true, haInterval: 100 }
-      );
+      const client = configuration.newClient({}, { w: 0, debug: true, haInterval: 100 });
 
-      // Create db instance
-      var client = new MongoClient(replSet, { w: 0 });
       // Connect to the db
       client.on('fullsetup', function(client) {
         var db = client.db(configuration.db);
@@ -849,26 +721,18 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, debug: true }
-      );
+        ReadPreference = mongo.ReadPreference;
 
       // Open the database
-      var client = new MongoClient(replSet, {
-        w: 0,
-        readPreference: new ReadPreference(ReadPreference.SECONDARY, { loc: 'ny' })
-      });
+      const client = configuration.newClient(
+        {},
+        {
+          w: 0,
+          debug: true,
+          readPreference: new ReadPreference(ReadPreference.SECONDARY, { loc: 'ny' })
+        }
+      );
+
       // Trigger test once whole set is up
       client.on('fullsetup', function() {
         client.topology.replset.once('pickedServer', function(readPreference) {
@@ -903,26 +767,18 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, debug: true }
-      );
+        ReadPreference = mongo.ReadPreference;
 
       // Open the database
-      var client = new MongoClient(replSet, {
-        w: 1,
-        readPreference: new ReadPreference(ReadPreference.NEAREST, { loc: 'ny' })
-      });
+      const client = configuration(
+        {},
+        {
+          w: 1,
+          debug: true,
+          readPreference: new ReadPreference(ReadPreference.NEAREST, { loc: 'ny' })
+        }
+      );
+
       var success = false;
       // Trigger test once whole set is up
       client.on('fullsetup', function(client) {
@@ -960,26 +816,16 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReadPreference = mongo.ReadPreference,
-        ReplSet = mongo.ReplSet,
-        Server = mongo.Server;
-
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        { rs_name: configuration.replicasetName, debug: true }
-      );
+        ReadPreference = mongo.ReadPreference;
 
       // Open the database
-      var client = new MongoClient(replSet, {
-        w: 0,
-        readPreference: new ReadPreference(ReadPreference.SECONDARY_PREFERRED)
-      });
+      const client = configuration.newClient(
+        {},
+        {
+          w: 0,
+          readPreference: new ReadPreference(ReadPreference.SECONDARY_PREFERRED)
+        }
+      );
 
       // Trigger test once whole set is up
       client.on('fullsetup', function(client) {
@@ -1007,27 +853,16 @@ describe.skip('ReplSet (ReadPreference)', function() {
     test: function(done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
-        MongoClient = mongo.MongoClient,
-        ReplSet = mongo.ReplSet,
         Server = mongo.Server,
         ReadPreference = mongo.ReadPreference;
 
-      // Replica configuration
-      var replSet = new ReplSet(
-        [
-          new Server(configuration.host, configuration.port),
-          new Server(configuration.host, configuration.port + 1),
-          new Server(configuration.host, configuration.port + 2)
-        ],
-        {
-          readPreference: ReadPreference.NEAREST,
-          rs_name: configuration.replicasetName,
-          debug: true
-        }
-      );
-
       // Open the database
-      var client = new MongoClient(replSet, { w: 'majority', wtimeout: 10000 });
+      const client = configuration.newClient({
+        w: 'majority',
+        wtimeout: 10000,
+        readPreference: ReadPreference.NEAREST
+      });
+
       client.on('fullsetup', function(client) {
         var db = client.db(configuration.db);
 
@@ -1047,16 +882,17 @@ describe.skip('ReplSet (ReadPreference)', function() {
                 );
 
                 // Connect using the MongoClient
-                MongoClient.connect(url, function(err, client) {
+                const client2 = configuration.newClient(url);
+                client2.connect(url, function(err, client2) {
                   test.equal(null, err);
-                  var db = client.db(configuration.db);
-                  test.ok(client.topology instanceof Server);
+                  var db = client2.db(configuration.db);
+                  test.ok(client2.topology instanceof Server);
 
                   db.collection('direct_secondary_read_test').count(function(err, n) {
                     test.equal(null, err);
                     test.ok(n > 0);
 
-                    client.close();
+                    client2.close();
                     done();
                   });
                 });
@@ -1089,7 +925,8 @@ describe.skip('ReplSet (ReadPreference)', function() {
       var url = format('mongodb://localhost:%s/integration_test_?slaveOk=true', configuration.port);
 
       // Connect using the MongoClient
-      MongoClient.connect(url, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
         test.ok(client != null);
 

--- a/test/functional/replset_read_preference_tests.js
+++ b/test/functional/replset_read_preference_tests.js
@@ -823,6 +823,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
         {},
         {
           w: 0,
+          debug: true,
           readPreference: new ReadPreference(ReadPreference.SECONDARY_PREFERRED)
         }
       );
@@ -860,6 +861,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
       const client = configuration.newClient({
         w: 'majority',
         wtimeout: 10000,
+        debug: true,
         readPreference: ReadPreference.NEAREST
       });
 

--- a/test/functional/retryable_writes_tests.js
+++ b/test/functional/retryable_writes_tests.js
@@ -57,7 +57,6 @@ function loadTestFiles() {
 }
 
 function executeScenarioSetup(scenario, test, config, ctx) {
-  const MongoClient = config.require.MongoClient;
   const url = config.url();
   const options = Object.assign({}, test.clientOptions, {
     haInterval: 100,
@@ -67,7 +66,9 @@ function executeScenarioSetup(scenario, test, config, ctx) {
 
   ctx.failPointName = test.failPoint && test.failPoint.configureFailPoint;
 
-  return MongoClient.connect(url, options)
+  const client = config.newClient(url, options);
+  return client
+    .connect()
     .then(client => (ctx.client = client))
     .then(() => (ctx.db = ctx.client.db(config.db)))
     .then(

--- a/test/functional/scram_sha_256_tests.js
+++ b/test/functional/scram_sha_256_tests.js
@@ -81,13 +81,15 @@ describe('SCRAM-SHA-256 auth', function() {
         metadata: { requires: { mongodb: '>=3.7.3' } },
         test: function() {
           const options = {
-            user: user.username,
-            password: user.password,
+            auth: {
+              user: user.username,
+              password: user.password
+            },
             authMechanism: mechanism,
             authSource: this.configuration.db
           };
 
-          return withClient(this.configuration.newClient(options), client => {
+          return withClient(this.configuration.newClient({}, options), client => {
             return client.db(this.configuration.db).stats();
           });
         }
@@ -118,12 +120,14 @@ describe('SCRAM-SHA-256 auth', function() {
       metadata: { requires: { mongodb: '>=3.7.3' } },
       test: function() {
         const options = {
-          user: user.username,
-          password: user.password,
+          auth: {
+            user: user.username,
+            password: user.password,
+          },
           authSource: this.configuration.db
         };
 
-        return withClient(this.configuration.newClient(options), client => {
+        return withClient(this.configuration.newClient({}, options), client => {
           return client.db(this.configuration.db).stats();
         });
       }
@@ -151,14 +155,16 @@ describe('SCRAM-SHA-256 auth', function() {
     metadata: { requires: { mongodb: '>=3.7.3' } },
     test: function() {
       const options = {
-        user: userMap.both.username,
-        password: userMap.both.password,
+        auth: {
+          user: userMap.both.username,
+          password: userMap.both.password
+        },
         authSource: this.configuration.db
       };
 
       test.sandbox.spy(ScramSHA256.prototype, 'auth');
 
-      return withClient(this.configuration.newClient(options), () => {
+      return withClient(this.configuration.newClient({}, options), () => {
         expect(ScramSHA256.prototype.auth.calledOnce).to.equal(true);
       });
     }
@@ -170,14 +176,16 @@ describe('SCRAM-SHA-256 auth', function() {
     metadata: { requires: { mongodb: '>=3.7.3' } },
     test: function() {
       const options = {
-        user: userMap.sha256.username,
-        password: userMap.sha256.password,
+        auth: {
+          user: userMap.sha256.username,
+          password: userMap.sha256.password
+        },
         authSource: this.configuration.db,
         authMechanism: 'SCRAM-SHA-1'
       };
 
       return withClient(
-        this.configuration.newClient(options),
+        this.configuration.newClient({}, options),
         () => Promise.reject(new Error('This request should have failed to authenticate')),
         err => expect(err).to.not.be.null
       );
@@ -192,20 +200,24 @@ describe('SCRAM-SHA-256 auth', function() {
     metadata: { requires: { mongodb: '>=3.7.3' } },
     test: function() {
       const noUsernameOptions = {
-        user: 'roth',
-        password: 'pencil',
+        auth: {
+          user: 'roth',
+          password: 'pencil',
+        },
         authSource: 'admin'
       };
 
       const badPasswordOptions = {
-        user: 'both',
-        password: 'pencil',
+        auth: {
+          user: 'both',
+          password: 'pencil',
+        },
         authSource: 'admin'
       };
 
       const getErrorMsg = options =>
         withClient(
-          this.configuration.newClient(options),
+          this.configuration.newClient({}, options),
           () => Promise.reject(new Error('This request should have failed to authenticate')),
           err => expect(err).to.be.an.instanceof(MongoError)
         );

--- a/test/functional/scram_sha_256_tests.js
+++ b/test/functional/scram_sha_256_tests.js
@@ -178,7 +178,7 @@ describe('SCRAM-SHA-256 auth', function() {
 
       return withClient(
         this.configuration.newClient(options),
-        () => Promise.reject('This request should have failed to authenticate'),
+        () => Promise.reject(new Error('This request should have failed to authenticate')),
         err => expect(err).to.not.be.null
       );
     }
@@ -206,7 +206,7 @@ describe('SCRAM-SHA-256 auth', function() {
       const getErrorMsg = options =>
         withClient(
           this.configuration.newClient(options),
-          () => Promise.reject('This request should have failed to authenticate'),
+          () => Promise.reject(new Error('This request should have failed to authenticate')),
           err => expect(err).to.be.an.instanceof(MongoError)
         );
 

--- a/test/functional/scram_sha_256_tests.js
+++ b/test/functional/scram_sha_256_tests.js
@@ -122,7 +122,7 @@ describe('SCRAM-SHA-256 auth', function() {
         const options = {
           auth: {
             user: user.username,
-            password: user.password,
+            password: user.password
           },
           authSource: this.configuration.db
         };
@@ -202,7 +202,7 @@ describe('SCRAM-SHA-256 auth', function() {
       const noUsernameOptions = {
         auth: {
           user: 'roth',
-          password: 'pencil',
+          password: 'pencil'
         },
         authSource: 'admin'
       };
@@ -210,7 +210,7 @@ describe('SCRAM-SHA-256 auth', function() {
       const badPasswordOptions = {
         auth: {
           user: 'both',
-          password: 'pencil',
+          password: 'pencil'
         },
         authSource: 'admin'
       };

--- a/test/functional/sdam_tests.js
+++ b/test/functional/sdam_tests.js
@@ -13,7 +13,6 @@ describe('SDAM', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var operations = {
         serverDescriptionChanged: [],
         serverHeartbeatStarted: [],
@@ -25,7 +24,7 @@ describe('SDAM', function() {
         topologyClosed: []
       };
 
-      var client = new MongoClient(configuration.url());
+      var client = configuration.newClient();
       var events = [
         'serverDescriptionChanged',
         'serverHeartbeatStarted',
@@ -61,7 +60,6 @@ describe('SDAM', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var operations = {
         serverDescriptionChanged: [],
         serverHeartbeatStarted: [],
@@ -73,7 +71,7 @@ describe('SDAM', function() {
         topologyClosed: []
       };
 
-      var client = new MongoClient(configuration.url(), { haInterval: 500 });
+      var client = configuration.newClient({}, { haInterval: 500 });
       var events = [
         'serverDescriptionChanged',
         'serverHeartbeatStarted',
@@ -114,7 +112,6 @@ describe('SDAM', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
       var operations = {
         serverDescriptionChanged: [],
         serverOpening: [],
@@ -124,7 +121,7 @@ describe('SDAM', function() {
         topologyClosed: []
       };
 
-      var client = new MongoClient(configuration.url());
+      var client = configuration.newClient();
       var events = [
         'serverDescriptionChanged',
         'serverOpening',

--- a/test/functional/sdam_tests.js
+++ b/test/functional/sdam_tests.js
@@ -44,12 +44,13 @@ describe('SDAM', function() {
       client.connect(function(err) {
         test.equal(null, err);
 
-        client.close(true);
-        for (var name in operations) {
-          test.ok(operations[name].length > 0);
-        }
+        client.close(true, function() {
+          for (var name in operations) {
+            test.ok(operations[name].length > 0);
+          }
 
-        done();
+          done();
+        });
       });
     }
   });

--- a/test/functional/sdam_tests.js
+++ b/test/functional/sdam_tests.js
@@ -2,7 +2,7 @@
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-describe('SDAM', function() {
+describe.skip('SDAM', function() {
   before(function() {
     return setupDatabase(this.configuration);
   });

--- a/test/functional/sdam_tests.js
+++ b/test/functional/sdam_tests.js
@@ -45,11 +45,13 @@ describe('SDAM', function() {
         test.equal(null, err);
 
         client.close(true, function() {
-          for (var name in operations) {
-            test.ok(operations[name].length > 0);
-          }
+          setTimeout(() => {
+            for (var name in operations) {
+              test.ok(operations[name].length > 0);
+            }
 
-          done();
+            done();
+          }, 1000);
         });
       });
     }

--- a/test/functional/sdam_tests.js
+++ b/test/functional/sdam_tests.js
@@ -42,18 +42,15 @@ describe('SDAM', function() {
         });
       });
 
-      client.on('fullsetup', function(topology) {
-        topology.close(true);
+      client.connect(function(err) {
+        test.equal(null, err);
 
+        client.close(true);
         for (var name in operations) {
           test.ok(operations[name].length > 0);
         }
 
         done();
-      });
-
-      client.connect(function(err) {
-        test.equal(null, err);
       });
     }
   });

--- a/test/functional/sharding_failover_tests.js
+++ b/test/functional/sharding_failover_tests.js
@@ -20,8 +20,6 @@ describe.skip('Sharding (Failover)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
       var manager = configuration.manager;
       var url = f(
         'mongodb://%s:%s,%s:%s/sharded_test_db?w=1',
@@ -31,7 +29,8 @@ describe.skip('Sharding (Failover)', function() {
         configuration.port + 1
       );
 
-      MongoClient.connect(url, {}, function(err, client) {
+      const client = configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
@@ -187,8 +186,6 @@ describe.skip('Sharding (Failover)', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var MongoClient = configuration.require.MongoClient;
-
       var manager = configuration.manager;
       var url = f(
         'mongodb://%s:%s,%s:%s/sharded_test_db?w=1',
@@ -198,7 +195,8 @@ describe.skip('Sharding (Failover)', function() {
         configuration.port + 1
       );
 
-      MongoClient.connect(url, {}, function(err, client) {
+      const client = this.configuration.newClient(url);
+      client.connect(function(err, client) {
         test.equal(null, err);
         test.ok(client != null);
         var db = client.db(configuration.db);

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -121,7 +121,9 @@ describe('Transactions (spec)', function() {
             }
 
             // run the actual test
-            testPromise = testPromise.then(() => runTestSuiteTest(testData, testContext));
+            testPromise = testPromise.then(() =>
+              runTestSuiteTest(this.configuration, testData, testContext)
+            );
 
             if (testData.failPoint) {
               testPromise = testPromise.then(() =>
@@ -178,7 +180,7 @@ function disableFailPoint(failPoint, testContext) {
 }
 
 let displayCommands = false;
-function runTestSuiteTest(testData, context) {
+function runTestSuiteTest(configuration, testData, context) {
   const commandEvents = [];
   const clientOptions = translateClientOptions(
     Object.assign({ monitorCommands: true }, testData.clientOptions)
@@ -188,7 +190,7 @@ function runTestSuiteTest(testData, context) {
   clientOptions.autoReconnect = false;
   clientOptions.haInterval = 100;
 
-  const client = this.configuration.newClient(context.url, clientOptions);
+  const client = configuration.newClient(context.url, clientOptions);
   return client.connect().then(client => {
     context.testClient = client;
     client.on('commandStarted', event => {

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const Promise = require('bluebird');
-const mongodb = require('../..');
-const MongoClient = mongodb.MongoClient;
 const path = require('path');
 const fs = require('fs');
 const chai = require('chai');
@@ -100,7 +98,7 @@ describe('Transactions (spec)', function() {
       config.replicasetName
     }`;
 
-    testContext.sharedClient = new MongoClient(testContext.url);
+    testContext.sharedClient = config.newClient(testContext.url);
     return testContext.sharedClient.connect();
   });
 
@@ -190,7 +188,8 @@ function runTestSuiteTest(testData, context) {
   clientOptions.autoReconnect = false;
   clientOptions.haInterval = 100;
 
-  return MongoClient.connect(context.url, clientOptions).then(client => {
+  const client = this.configuration.newClient(context.url, clientOptions);
+  return client.connect().then(client => {
     context.testClient = client;
     client.on('commandStarted', event => {
       if (event.databaseName === context.dbName || isTransactionCommand(event.commandName)) {

--- a/test/functional/view_tests.js
+++ b/test/functional/view_tests.js
@@ -8,9 +8,9 @@ describe('Views', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var self = this,
-        MongoClient = self.configuration.mongo.MongoClient,
-        Long = self.configuration.mongo.Long;
+      var self = this;
+      const configuration = this.configuration;
+      const Long = configuration.mongo.Long;
 
       // Default message fields
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER);
@@ -46,7 +46,8 @@ describe('Views', function() {
         var commandResult = null;
 
         // Connect to the mocks
-        MongoClient.connect(`mongodb://${singleServer.uri()}/test`, function(err, client) {
+        const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
+        client.connect(function(err, client) {
           expect(err).to.not.exist;
           var db = client.db(self.configuration.db);
 

--- a/test/unit/bypass_validation_tests.js
+++ b/test/unit/bypass_validation_tests.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const MongoClient = require('../..').MongoClient;
 const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
 
@@ -14,8 +13,8 @@ describe('bypass document validation', function() {
   afterEach(() => mock.cleanup());
 
   // general test for aggregate function
-  function testAggregate(config, done) {
-    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+  function testAggregate(testConfiguration, config, done) {
+    const client = testConfiguration.newClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
       client.close(() => done(e));
@@ -63,16 +62,16 @@ describe('bypass document validation', function() {
   }
   // aggregate
   it('should only set bypass document validation if strictly true in aggregate', function(done) {
-    testAggregate({ expected: true, actual: true }, done);
+    testAggregate(this.configuration, { expected: true, actual: true }, done);
   });
 
   it('should not set bypass document validation if not strictly true in aggregate', function(done) {
-    testAggregate({ expected: undefined, actual: false }, done);
+    testAggregate(this.configuration, { expected: undefined, actual: false }, done);
   });
 
   // general test for mapReduce function
-  function testMapReduce(config, done) {
-    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+  function testMapReduce(testConfiguration, config, done) {
+    const client = testConfiguration.newClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
       client.close(() => done(e));
@@ -116,16 +115,16 @@ describe('bypass document validation', function() {
   }
   // map reduce
   it('should only set bypass document validation if strictly true in mapReduce', function(done) {
-    testMapReduce({ expected: true, actual: true }, done);
+    testMapReduce(this.configuration, { expected: true, actual: true }, done);
   });
 
   it('should not set bypass document validation if not strictly true in mapReduce', function(done) {
-    testMapReduce({ expected: undefined, actual: false }, done);
+    testMapReduce(this.configuration, { expected: undefined, actual: false }, done);
   });
 
   // general test for findAndModify function
-  function testFindAndModify(config, done) {
-    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+  function testFindAndModify(testConfiguration, config, done) {
+    const client = testConfiguration.newClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
       client.close(() => done(e));
@@ -171,16 +170,16 @@ describe('bypass document validation', function() {
   }
   // find and modify
   it('should only set bypass document validation if strictly true in findAndModify', function(done) {
-    testFindAndModify({ expected: true, actual: true }, done);
+    testFindAndModify(this.configuration, { expected: true, actual: true }, done);
   });
 
   it('should not set bypass document validation if not strictly true in findAndModify', function(done) {
-    testFindAndModify({ expected: undefined, actual: false }, done);
+    testFindAndModify(this.configuration, { expected: undefined, actual: false }, done);
   });
 
   // general test for BlukWrite to test changes made in ordered.js and unordered.js
-  function testBulkWrite(config, done) {
-    const client = new MongoClient(`mongodb://${test.server.uri()}/test`);
+  function testBulkWrite(testConfiguration, config, done) {
+    const client = testConfiguration.newClient(`mongodb://${test.server.uri()}/test`);
     let close = e => {
       close = () => {};
       client.close(() => done(e));
@@ -221,19 +220,19 @@ describe('bypass document validation', function() {
   }
   // ordered bulk write, testing change in ordered.js
   it('should only set bypass document validation if strictly true in ordered bulkWrite', function(done) {
-    testBulkWrite({ expected: true, actual: true, ordered: true }, done);
+    testBulkWrite(this.configuration, { expected: true, actual: true, ordered: true }, done);
   });
 
   it('should not set bypass document validation if not strictly true in ordered bulkWrite', function(done) {
-    testBulkWrite({ expected: undefined, actual: false, ordered: true }, done);
+    testBulkWrite(this.configuration, { expected: undefined, actual: false, ordered: true }, done);
   });
 
   // unordered bulk write, testing change in ordered.js
   it('should only set bypass document validation if strictly true in unordered bulkWrite', function(done) {
-    testBulkWrite({ expected: true, actual: true, ordered: false }, done);
+    testBulkWrite(this.configuration, { expected: true, actual: true, ordered: false }, done);
   });
 
   it('should not set bypass document validation if not strictly true in unordered bulkWrite', function(done) {
-    testBulkWrite({ expected: undefined, actual: false, ordered: false }, done);
+    testBulkWrite(this.configuration, { expected: undefined, actual: false, ordered: false }, done);
   });
 });

--- a/test/unit/change_stream_resume_tests.js
+++ b/test/unit/change_stream_resume_tests.js
@@ -2,7 +2,6 @@
 
 const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
-const MongoClient = require('../../lib/mongo_client');
 const ObjectId = require('../../index').ObjectId;
 const Timestamp = require('../../index').Timestamp;
 const Long = require('../../index').Long;
@@ -183,8 +182,9 @@ describe('Change Stream Resume Tests', function() {
     it(config.description, {
       metadata: { requires: { mongodb: '>=3.6.0' } },
       test: function() {
+        const configuration = this.configuration;
         test.server.setMessageHandler(makeServerHandler(config));
-        client = new MongoClient(`mongodb://${test.server.uri()}`, {
+        client = configuration.newClient(`mongodb://${test.server.uri()}`, {
           socketTimeoutMS: 300
         });
         return client

--- a/test/unit/db_list_collections_tests.js
+++ b/test/unit/db_list_collections_tests.js
@@ -2,7 +2,6 @@
 
 const mock = require('mongodb-mock-server');
 const expect = require('chai').expect;
-const MongoClient = require('../../lib/mongo_client');
 
 describe('db.listCollections', function() {
   const testHarness = {};
@@ -59,7 +58,8 @@ describe('db.listCollections', function() {
     }
   ].forEach(config => {
     function testFn(done) {
-      const client = new MongoClient(`mongodb://${testHarness.server.uri()}/test`, {
+      const configuration = this.configuration;
+      const client = configuration.newClient(`mongodb://${testHarness.server.uri()}/test`, {
         monitorCommands: true
       });
 

--- a/test/unit/sessions/client_tests.js
+++ b/test/unit/sessions/client_tests.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const MongoClient = require('../../..').MongoClient;
 const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
 
@@ -26,7 +25,8 @@ describe('Sessions', function() {
           }
         });
 
-        MongoClient.connect(`mongodb://${test.server.uri()}/test`, function(err, client) {
+        const client = this.configuration.newClient(`mongodb://${test.server.uri()}/test`);
+        client.connect(function(err, client) {
           expect(err).to.not.exist;
           expect(() => {
             client.startSession();
@@ -55,7 +55,8 @@ describe('Sessions', function() {
           }
         });
 
-        MongoClient.connect(`mongodb://${test.server.uri()}/test`, function(err, client) {
+        const client = this.configuration.newClient(`mongodb://${test.server.uri()}/test`);
+        client.connect(function(err, client) {
           expect(err).to.not.exist;
           let session = client.startSession();
           expect(session).to.exist;

--- a/test/unit/sessions/collection_tests.js
+++ b/test/unit/sessions/collection_tests.js
@@ -1,8 +1,7 @@
 'use strict';
-const MongoClient = require('../../..').MongoClient,
-  Timestamp = require('bson').Timestamp,
-  expect = require('chai').expect,
-  mock = require('mongodb-mock-server');
+const Timestamp = require('bson').Timestamp;
+const expect = require('chai').expect;
+const mock = require('mongodb-mock-server');
 
 const test = {};
 describe('Sessions', function() {
@@ -34,7 +33,8 @@ describe('Sessions', function() {
           }
         });
 
-        return MongoClient.connect(`mongodb://${test.server.uri()}/test`).then(client => {
+        const client = this.configuration.newClient(`mongodb://${test.server.uri()}/test`);
+        return client.connect().then(client => {
           const session = client.startSession({ causalConsistency: true });
           const coll = client.db('foo').collection('bar');
 
@@ -66,7 +66,8 @@ describe('Sessions', function() {
           }
         });
 
-        return MongoClient.connect(`mongodb://${test.server.uri()}/test`).then(client => {
+        const client = this.configuration.newClient(`mongodb://${test.server.uri()}/test`);
+        return client.connect().then(client => {
           const coll = client.db('foo').collection('bar');
 
           return coll.count({}, options).then(() => {


### PR DESCRIPTION
These are a set of changes that change the internal implementation of `configuration.newClient` to return `MongoClient`s initialized with connection strings instead of topologies. This ensures we are testing the same way the driver is being used, but also provides a path forward for ensuring compatibility between old and new topology types. 