### PR TITLE
fix(cursor): remove deprecated notice on forEach

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -729,8 +729,14 @@ Cursor.prototype.each = deprecate(function(callback) {
  * @return {Promise} if no callback supplied
  */
 Cursor.prototype.forEach = function(iterator, callback) {
+  // Rewind cursor state
+  this.rewind();
+
+  // Set current cursor to INIT
+  this.s.state = Cursor.INIT;
+
   if (typeof callback === 'function') {
-    this.each((err, doc) => {
+    each(this, (err, doc) => {
       if (err) {
         callback(err);
         return false;
@@ -748,7 +754,7 @@ Cursor.prototype.forEach = function(iterator, callback) {
     });
   } else {
     return new this.s.promiseLibrary((fulfill, reject) => {
-      this.each((err, doc) => {
+      each(this, (err, doc) => {
         if (err) {
           reject(err);
           return false;


### PR DESCRIPTION
Also, sort of unrelated, but the docs show that AggregationCursor's base is "Readable" and the `@types/mongodb` package reflects that and is missing a lot of methods for the AggregationCursor.