### PR TITLE
Remove unnecessary information for estimatedDocumentCount

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1376,28 +1376,11 @@ Collection.prototype.count = deprecate(function(query, options, callback) {
 /**
  * Gets an estimate of the count of documents in a collection using collection metadata.
  *
- * **Note**: When migrating from {@link Collection#count count} to {@link Collection#estimatedDocumentCount estimatedDocumentCount}
- * the following query operators must be replaced:
- *
- * | Operator | Replacement |
- * | -------- | ----------- |
- * | `$where`   | [`$expr`][1] |
- * | `$near`    | [`$geoWithin`][2] with [`$center`][3] |
- * | `$nearSphere` | [`$geoWithin`][2] with [`$centerSphere`][4] |
- *
- * [1]: https://docs.mongodb.com/manual/reference/operator/query/expr/
- * [2]: https://docs.mongodb.com/manual/reference/operator/query/geoWithin/
- * [3]: https://docs.mongodb.com/manual/reference/operator/query/center/#op._S_center
- * [4]: https://docs.mongodb.com/manual/reference/operator/query/centerSphere/#op._S_centerSphere
  * @method
  * @param {object} [options] Optional settings.
  * @param {number} [options.maxTimeMS] The maximum amount of time to allow the operation to run.
  * @param {Collection~countCallback} [callback] The command result callback.
  * @return {Promise} returns Promise if no callback passed.
- * @see https://docs.mongodb.com/manual/reference/operator/query/expr/
- * @see https://docs.mongodb.com/manual/reference/operator/query/geoWithin/
- * @see https://docs.mongodb.com/manual/reference/operator/query/center/#op._S_center
- * @see https://docs.mongodb.com/manual/reference/operator/query/centerSphere/#op._S_centerSphere
  */
 Collection.prototype.estimatedDocumentCount = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});


### PR DESCRIPTION
These docs should be valid only for `countDocuments`
`estimatedDocumentCount` doesn't have `query` parameter so no need to add these migration guide.

It seems this is a copy & paste docs from `countDocuments` issue.