### PR TITLE
fix circular reference between modules db.js and db_ops.js

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const dbConstants = require("./db_constants");
 const EventEmitter = require('events').EventEmitter;
 const inherits = require('util').inherits;
 const getSingleProperty = require('./utils').getSingleProperty;
@@ -532,7 +533,7 @@ Db.prototype.listCollections = function(filter, options) {
   // Return options
   const _options = { transforms: listCollectionsTransforms(this.s.databaseName) };
   // Get the cursor
-  cursor = this.collection(Db.SYSTEM_NAMESPACE_COLLECTION).find(filter, _options);
+  cursor = this.collection(dbConstants.SYSTEM_NAMESPACE_COLLECTION).find(filter, _options);
   // Do we have a readPreference, apply it
   if (options.readPreference) cursor.setReadPreference(options.readPreference);
   // Set the passed in batch size if one was provided
@@ -972,13 +973,5 @@ Db.prototype.getLogger = function() {
  * @event Db#fullsetup
  * @type {Db}
  */
-
-// Constants
-Db.SYSTEM_NAMESPACE_COLLECTION = 'system.namespaces';
-Db.SYSTEM_INDEX_COLLECTION = 'system.indexes';
-Db.SYSTEM_PROFILE_COLLECTION = 'system.profile';
-Db.SYSTEM_USER_COLLECTION = 'system.users';
-Db.SYSTEM_COMMAND_COLLECTION = '$cmd';
-Db.SYSTEM_JS_COLLECTION = 'system.js';
 
 module.exports = Db;

--- a/lib/db_constants.js
+++ b/lib/db_constants.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Constants
+module.exports.SYSTEM_NAMESPACE_COLLECTION = 'system.namespaces';
+module.exports.SYSTEM_INDEX_COLLECTION = 'system.indexes';
+module.exports.SYSTEM_PROFILE_COLLECTION = 'system.profile';
+module.exports.SYSTEM_USER_COLLECTION = 'system.users';
+module.exports.SYSTEM_COMMAND_COLLECTION = '$cmd';
+module.exports.SYSTEM_JS_COLLECTION = 'system.js';

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -1,10 +1,10 @@
 'use strict';
 
+const dbConstants = require("../db_constants");
 const applyWriteConcern = require('../utils').applyWriteConcern;
 const Code = require('mongodb-core').BSON.Code;
 const resolveReadPreference = require('../utils').resolveReadPreference;
 const crypto = require('crypto');
-const Db = require('../db');
 const debugOptions = require('../utils').debugOptions;
 const handleCallback = require('../utils').handleCallback;
 const MongoError = require('mongodb-core').MongoError;
@@ -83,7 +83,7 @@ function addUser(db, username, password, options, callback) {
       const db = options.dbName ? new Db(options.dbName, db.s.topology, db.s.options) : db;
 
       // Fetch a user collection
-      const collection = db.collection(Db.SYSTEM_USER_COLLECTION);
+      const collection = db.collection(dbConstants.SYSTEM_USER_COLLECTION);
 
       // Check if we are inserting the first user
       count(collection, {}, finalOptions, (err, count) => {
@@ -296,7 +296,7 @@ function createIndex(db, name, fieldOrSpec, options, callback) {
     finalOptions.checkKeys = false;
     // Insert document
     db.s.topology.insert(
-      `${db.s.databaseName}.${Db.SYSTEM_INDEX_COLLECTION}`,
+      `${db.s.databaseName}.${dbConstants.SYSTEM_INDEX_COLLECTION}`,
       doc,
       finalOptions,
       (err, result) => {
@@ -638,7 +638,7 @@ function removeUser(db, username, options, callback) {
       const db = options.dbName ? new Db(options.dbName, db.s.topology, db.s.options) : db;
 
       // Fetch a user collection
-      const collection = db.collection(Db.SYSTEM_USER_COLLECTION);
+      const collection = db.collection(dbConstants.SYSTEM_USER_COLLECTION);
 
       // Locate the user
       findOne(collection, { user: username }, finalOptions, (err, user) => {


### PR DESCRIPTION
The db.js module when loaded depends on the db_ops.js module and when the db_ops.js module is loaded, it depends on the db.js module resulting in a circular reference.
The only need that the module db_ops.js has in relation to the module db.js is to have access to the constants Db.SYSTEM_ * (ex: Db.SYSTEM_NAMESPACE_COLLECTION)
This change created a new module to keep the constants called db_constants.js, and the circular dependency between the db.js and db_ops.js modules has been removed.
