### PR TITLE
refactor(auth): remove `authenticate`, push authentication to core

### DIFF
--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const handleCallback = require('./utils').handleCallback;
 const MongoError = require('mongodb-core').MongoError;
-
 const MongoCredentials = require('mongodb-core').MongoCredentials;
 
 // TODO: I feel like these sets should be somewhere else.
@@ -15,17 +13,6 @@ const VALID_AUTH_MECHANISMS = new Set([
   'SCRAM-SHA-1',
   'SCRAM-SHA-256',
   'GSSAPI'
-]);
-
-const VALID_AUTH_MECHANISMS_INTERNAL = new Set([
-  'default',
-  'mongocr',
-  'plain',
-  'x509',
-  'scram-sha-1',
-  'scram-sha-256',
-  'gssapi',
-  'sspi'
 ]);
 
 const AUTH_MECHANISM_INTERNAL_MAP = {
@@ -75,59 +62,4 @@ function generateCredentials(options) {
   });
 }
 
-function _authenticate(client, credentials, callback) {
-  // Did the user destroy the topology
-  if (client.topology && client.topology.isDestroyed())
-    return callback(new MongoError('topology was destroyed'));
-
-  // Callback
-  var _callback = function(err, result) {
-    if (client.listeners('authenticated').length > 0) {
-      client.emit('authenticated', err, result);
-    }
-
-    // Return to caller
-    handleCallback(callback, err, result);
-  };
-
-  client.topology.auth(credentials, function(err) {
-    if (err) return handleCallback(callback, err, false);
-    _callback(null, true);
-  });
-}
-
-function authenticate(self, credentials, callback) {
-  if (!VALID_AUTH_MECHANISMS_INTERNAL.has(credentials.mechanism)) {
-    return handleCallback(
-      callback,
-      MongoError.create({
-        message:
-          'only DEFAULT, GSSAPI, PLAIN, MONGODB-X509, or SCRAM-SHA-1 is supported by authMechanism',
-        driver: true
-      })
-    );
-  }
-
-  // If we have a callback fallback
-  if (typeof callback === 'function')
-    return _authenticate(self, credentials, function(err, r) {
-      // Support failed auth method
-      if (err && err.message && err.message.indexOf('saslStart') !== -1) err.code = 59;
-      // Reject error
-      if (err) return callback(err, r);
-      callback(null, r);
-    });
-
-  // Return a promise
-  return new self.s.promiseLibrary(function(resolve, reject) {
-    _authenticate(self, credentials, function(err, r) {
-      // Support failed auth method
-      if (err && err.message && err.message.indexOf('saslStart') !== -1) err.code = 59;
-      // Reject error
-      if (err) return reject(err);
-      resolve(r);
-    });
-  });
-}
-
-module.exports = { generateCredentials, authenticate };
+module.exports = { generateCredentials };

--- a/lib/db.js
+++ b/lib/db.js
@@ -453,10 +453,7 @@ Db.prototype.stats = function(options, callback) {
   // Check if we have the scale value
   if (options['scale'] != null) commandObject['scale'] = options['scale'];
 
-  // If we have a readPreference set
-  if (options.readPreference == null && this.s.readPreference) {
-    options.readPreference = this.s.readPreference;
-  }
+  options.readPreference = resolveReadPreference(options, { db: this });
 
   // Execute the command
   return this.command(commandObject, options, callback);

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const authenticate = require('../authenticate').authenticate;
 const generateCredentials = require('../authenticate').generateCredentials;
 const deprecate = require('util').deprecate;
 const Logger = require('mongodb-core').Logger;
@@ -268,11 +267,15 @@ function connect(mongoClient, url, options, callback) {
   }
 }
 
-function connectHandler(callback) {
+function connectHandler(client, options, callback) {
   return (err, topology) => {
     if (err) {
       if (topology) topology.close();
       return handleConnectCallback(err, topology, callback);
+    }
+
+    if (options.credentials != null) {
+      client.emit('authenticated');
     }
 
     handleConnectCallback(null, topology, callback);
@@ -329,20 +332,7 @@ function connectWithUrl(mongoClient, url, options, connectCallback) {
   }
 
   // Connect
-  return url.connect(
-    finalOptions,
-    connectHandler((err, topology) => {
-      if (err) return connectCallback(err, topology);
-      if (isDoingAuth) {
-        return authenticate(mongoClient, finalOptions.credentials, err => {
-          if (err) return connectCallback(err, topology);
-          connectCallback(err, topology);
-        });
-      }
-
-      connectCallback(err, topology);
-    })
-  );
+  return url.connect(finalOptions, connectHandler(mongoClient, finalOptions, connectCallback));
 }
 
 function createListener(mongoClient, event) {

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -268,27 +268,14 @@ function connect(mongoClient, url, options, callback) {
   }
 }
 
-function connectHandler(client, options, callback) {
+function connectHandler(callback) {
   return (err, topology) => {
     if (err) {
+      if (topology) topology.close();
       return handleConnectCallback(err, topology, callback);
     }
 
-    // No authentication just reconnect
-    if (!options.credentials) {
-      return handleConnectCallback(err, topology, callback);
-    }
-
-    // Authenticate
-    authenticate(client, options.credentials, (err, success) => {
-      if (success) {
-        handleConnectCallback(null, topology, callback);
-      } else {
-        if (topology) topology.close();
-        const authError = err ? err : new Error('Could not authenticate user ' + options.auth[0]);
-        handleConnectCallback(authError, topology, callback);
-      }
-    });
+    handleConnectCallback(null, topology, callback);
   };
 }
 
@@ -344,7 +331,7 @@ function connectWithUrl(mongoClient, url, options, connectCallback) {
   // Connect
   return url.connect(
     finalOptions,
-    connectHandler(mongoClient, finalOptions, (err, topology) => {
+    connectHandler((err, topology) => {
       if (err) return connectCallback(err, topology);
       if (isDoingAuth) {
         return authenticate(mongoClient, finalOptions.credentials, err => {

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -333,7 +333,6 @@ function connectWithUrl(mongoClient, url, options, connectCallback) {
   }
 
   const isDoingAuth = finalOptions.user || finalOptions.password || finalOptions.authMechanism;
-
   if (isDoingAuth && !finalOptions.credentials) {
     try {
       finalOptions.credentials = generateCredentials(finalOptions);

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -55,7 +55,8 @@ var legalOptionNames = [
   'promoteValues',
   'promoteBuffers',
   'promiseLibrary',
-  'monitorCommands'
+  'monitorCommands',
+  'credentials'
 ];
 
 /**

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -261,7 +261,7 @@ class Mongos extends TopologyBase {
     };
 
     // Connect handler
-    var connectHandler = function() {
+    var connectHandler = err => {
       // Clear out all the current handlers left over
       var events = ['timeout', 'error', 'close', 'fullsetup'];
       events.forEach(function(e) {
@@ -279,11 +279,11 @@ class Mongos extends TopologyBase {
       });
 
       // Emit open event
-      self.emit('open', null, self);
+      self.emit('open', err, self);
 
       // Return correctly
       try {
-        callback(null, self);
+        callback(err, self);
       } catch (err) {
         process.nextTick(function() {
           throw err;

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -279,7 +279,7 @@ class Mongos extends TopologyBase {
       });
 
       // Emit open event
-      self.emit('open', err, self);
+      self.emit('open', self, err);
 
       // Return correctly
       try {

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -261,7 +261,7 @@ class Mongos extends TopologyBase {
     };
 
     // Connect handler
-    var connectHandler = err => {
+    var connectHandler = (_, err) => {
       // Clear out all the current handlers left over
       var events = ['timeout', 'error', 'close', 'fullsetup'];
       events.forEach(function(e) {

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -330,18 +330,18 @@ class ReplSet extends TopologyBase {
     });
 
     // Connect handler
-    var connectHandler = function() {
+    var connectHandler = err => {
       // Set up listeners
       self.s.coreTopology.once('timeout', errorHandler('timeout'));
       self.s.coreTopology.once('error', errorHandler('error'));
       self.s.coreTopology.once('close', errorHandler('close'));
 
       // Emit open event
-      self.emit('open', null, self);
+      self.emit('open', err, self);
 
       // Return correctly
       try {
-        callback(null, self);
+        callback(err, self);
       } catch (err) {
         process.nextTick(function() {
           throw err;

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -63,7 +63,8 @@ var legalOptionNames = [
   'maxStalenessSeconds',
   'promiseLibrary',
   'minSize',
-  'monitorCommands'
+  'monitorCommands',
+  'credentials'
 ];
 
 /**

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -330,14 +330,14 @@ class ReplSet extends TopologyBase {
     });
 
     // Connect handler
-    var connectHandler = err => {
+    var connectHandler = (_, err) => {
       // Set up listeners
       self.s.coreTopology.once('timeout', errorHandler('timeout'));
       self.s.coreTopology.once('error', errorHandler('error'));
       self.s.coreTopology.once('close', errorHandler('close'));
 
       // Emit open event
-      self.emit('open', err, self);
+      self.emit('open', self, err);
 
       // Return correctly
       try {

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -278,7 +278,7 @@ class Server extends TopologyBase {
     };
 
     // Connect handler
-    var connectHandler = function() {
+    var connectHandler = err => {
       // Clear out all the current handlers left over
       ['timeout', 'error', 'close', 'destroy'].forEach(function(e) {
         self.s.coreTopology.removeAllListeners(e);
@@ -292,11 +292,11 @@ class Server extends TopologyBase {
       self.s.coreTopology.on('destroy', destroyHandler);
 
       // Emit open event
-      self.emit('open', null, self);
+      self.emit('open', err, self);
 
       // Return correctly
       try {
-        callback(null, self);
+        callback(err, self);
       } catch (err) {
         process.nextTick(function() {
           throw err;

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -58,7 +58,8 @@ var legalOptionNames = [
   'promoteBuffers',
   'compression',
   'promiseLibrary',
-  'monitorCommands'
+  'monitorCommands',
+  'credentials'
 ];
 
 /**

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -292,7 +292,7 @@ class Server extends TopologyBase {
       self.s.coreTopology.on('destroy', destroyHandler);
 
       // Emit open event
-      self.emit('open', err, self);
+      self.emit('open', self, err);
 
       // Return correctly
       try {

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -278,7 +278,7 @@ class Server extends TopologyBase {
     };
 
     // Connect handler
-    var connectHandler = err => {
+    var connectHandler = (_, err) => {
       // Clear out all the current handlers left over
       ['timeout', 'error', 'close', 'destroy'].forEach(function(e) {
         self.s.coreTopology.removeAllListeners(e);

--- a/lib/topologies/topology_base.js
+++ b/lib/topologies/topology_base.js
@@ -370,11 +370,6 @@ class TopologyBase extends EventEmitter {
     return this.s.coreTopology.unref();
   }
 
-  auth() {
-    var args = Array.prototype.slice.call(arguments, 0);
-    this.s.coreTopology.auth.apply(this.s.coreTopology, args);
-  }
-
   logout() {
     var args = Array.prototype.slice.call(arguments, 0);
     this.s.coreTopology.logout.apply(this.s.coreTopology, args);

--- a/test/functional/scram_sha_256_tests.js
+++ b/test/functional/scram_sha_256_tests.js
@@ -191,7 +191,7 @@ describe('SCRAM-SHA-256 auth', function() {
       applyEnvironment(options, this.configuration.environment);
       test.sandbox.spy(ScramSHA256.prototype, 'auth');
       return withClient(this.configuration.newClient({}, options), () => {
-        expect(ScramSHA256.prototype.auth.calledOnce).to.equal(true);
+        expect(ScramSHA256.prototype.auth.called).to.equal(true);
       });
     }
   });


### PR DESCRIPTION
This is the companion to https://github.com/mongodb-js/mongodb-core/pull/361, effectively moving all authentication to the core driver. The majority of the changes here relate to making sure that credentials that are passed in the options to the topology proxy classes are not filtered out when instantiating the mongodb-core versions of the topologies. 

As mentioned in the companion PR, this is more work than we ever intended to put into these types we soon hope to get rid of, but it is a crucial step towards making that transition much smoother. 

**NOTE:** This builds on the previous PR related to running SCRAM-SHA-256 tests against replica sets, so the change set will look bigger until that is merged. 