### PR TITLE
chore(evergreen): port atlas connectivity tests to native

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -317,6 +317,13 @@ tasks:
         vars:
           VERSION: '2.6'
           TOPOLOGY: sharded_cluster
+  - name: test-atlas-connectivity
+    tags:
+      - atlas-connect
+    commands:
+      - func: run atlas tests
+        vars:
+          VERSION: latest
 buildvariants:
   - name: linux-64-amzn-test-carbon
     display_name: Amazon Linux (Enterprise) Node Carbon
@@ -345,6 +352,7 @@ buildvariants:
       - test-2.6-server
       - test-2.6-replica_set
       - test-2.6-sharded_cluster
+      - test-atlas-connectivity
   - name: linux-64-amzn-test-boron
     display_name: Amazon Linux (Enterprise) Node Boron
     run_on: linux-64-amzn-test
@@ -468,6 +476,7 @@ buildvariants:
       - test-3.2-server
       - test-3.2-replica_set
       - test-3.2-sharded_cluster
+      - test-atlas-connectivity
   - name: ubuntu-16.04-boron
     display_name: Ubuntu 16.04 Node Boron
     run_on: ubuntu1604-test
@@ -534,6 +543,7 @@ buildvariants:
       - test-3.4-server
       - test-3.4-replica_set
       - test-3.4-sharded_cluster
+      - test-atlas-connectivity
   - name: debian81-test-boron
     display_name: Debian 8.1 Node Boron
     run_on: debian81-test

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -155,6 +155,19 @@ MONGODB_VERSIONS.forEach(mongoVersion => {
   });
 });
 
+TASKS.push({
+  name: 'test-atlas-connectivity',
+  tags: ['atlas-connect'],
+  commands: [
+    {
+      func: 'run atlas tests',
+      vars: {
+        VERSION: 'latest'
+      }
+    }
+  ]
+})
+
 const BUILD_VARIANTS = [];
 
 const getTaskList = (() => {

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -o errexit  # Exit the script with error if any of the commands fail
+
+export PROJECT_DIRECTORY="$(pwd)"
+NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
+export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+ATLAS_REPL="$ATLAS_REPL" ATLAS_SHRD="$ATLAS_SHRD" ATLAS_FREE="$ATLAS_FREE" ATLAS_TLS11="$ATLAS_TLS11" ATLAS_TLS12="$ATLAS_TLS12" npm run atlas

--- a/package-lock.json
+++ b/package-lock.json
@@ -3755,6 +3755,20 @@
       "requires": {
         "mongodb-core": "3.1.5",
         "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "mongodb-core": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.5.tgz",
+          "integrity": "sha512-emT/tM4ZBinqd6RZok+EzDdtN4LjYJIckv71qQVOEFmvXgT5cperZegVmTgox/1cx4XQu6LJ5ZuIwipP/eKdQg==",
+          "dev": true,
+          "requires": {
+            "bson": "^1.1.0",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        }
       }
     },
     "mongodb-core": {
@@ -3866,6 +3880,18 @@
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
           "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
           "dev": true
+        },
+        "mongodb-core": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.5.tgz",
+          "integrity": "sha512-emT/tM4ZBinqd6RZok+EzDdtN4LjYJIckv71qQVOEFmvXgT5cperZegVmTgox/1cx4XQu6LJ5ZuIwipP/eKdQg==",
+          "dev": true,
+          "requires": {
+            "bson": "^1.1.0",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "url": "https://github.com/mongodb/node-mongodb-native/issues"
   },
   "scripts": {
+    "atlas": "node ./test/atlas_connectivity_tests.js",
     "test": "npm run lint && mongodb-test-runner -t 60000 test/unit test/functional",
     "coverage": "istanbul cover mongodb-test-runner -- -t 60000  test/unit test/functional",
     "lint": "eslint lib test",

--- a/test/atlas_connectivity_tests.js
+++ b/test/atlas_connectivity_tests.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const MongoClient = require('../').MongoClient;
+
+const CONFIGS = ['ATLAS_REPL', 'ATLAS_SHRD', 'ATLAS_FREE', 'ATLAS_TLS11', 'ATLAS_TLS12'].map(
+  name => {
+    return {
+      name,
+      url: process.env[name]
+    };
+  }
+);
+
+function runConnectionTest(config) {
+  const client = new MongoClient(config.url, {
+    useNewUrlParser: true,
+    // TODO: We should test both the unified and not-unified cases
+    useUnifiedTopology: false
+  });
+  return Promise.resolve()
+    .then(() => console.log(`testing ${config.name}`))
+    .then(() => client.connect())
+    .then(() => client.db('admin').command({ ismaster: 1 }))
+    .then(() =>
+      client
+        .db('test')
+        .collection('test')
+        .findOne({})
+    )
+    .then(() => client.close())
+    .then(() => console.log(`${config.name} passed`))
+    .catch(e => {
+      console.log(`${config.name} failed`);
+      throw e;
+    });
+}
+
+CONFIGS.reduce((p, config) => p.then(() => runConnectionTest(config)), Promise.resolve())
+  .then(() => {
+    console.log('all tests passed');
+    process.exit(0);
+  })
+  .catch(() => {
+    console.log('test failed');
+    process.exit(1);
+  });


### PR DESCRIPTION
These tests were originally in core, but they actually make more
sense in the native driver, as it becomes a full e2e test