### PR TITLE
Fixed deprecation warning.

### DIFF
--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -277,7 +277,7 @@ function checkDone(_this, callback) {
       return false;
     }
 
-    _this.files.insert(filesDoc, getWriteOptions(_this), function(error) {
+    _this.files.insertOne(filesDoc, getWriteOptions(_this), function(error) {
       if (error) {
         return __handleError(_this, error, callback);
       }
@@ -430,7 +430,7 @@ function doWrite(_this, chunk, encoding, callback) {
         return false;
       }
 
-      _this.chunks.insert(doc, getWriteOptions(_this), function(error) {
+      _this.chunks.insertOne(doc, getWriteOptions(_this), function(error) {
         if (error) {
           return __handleError(_this, error);
         }
@@ -514,7 +514,7 @@ function writeRemnant(_this, callback) {
     return false;
   }
 
-  _this.chunks.insert(doc, getWriteOptions(_this), function(error) {
+  _this.chunks.insertOne(doc, getWriteOptions(_this), function(error) {
     if (error) {
       return __handleError(_this, error);
     }


### PR DESCRIPTION
Fixes deprecation warning:  `DeprecationWarning: collection.insert is deprecated. Use insertOne, insertMany or bulkWrite instead.`