### PR TITLE
feat(options_validator): implement OperationBuilder

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -21,7 +21,7 @@ const executeOperation = require('./utils').executeOperation;
 const applyWriteConcern = require('./utils').applyWriteConcern;
 const resolveReadPreference = require('./utils').resolveReadPreference;
 const ClientSession = require('mongodb-core').Sessions.ClientSession;
-const createValidationFunction = require('./options_validator').createValidationFunction;
+const validate = require('./options_validator').validate;
 const assertArity = require('./options_validator').assertArity;
 
 // Operations
@@ -94,7 +94,7 @@ const mergeKeys = ['ignoreUndefined'];
 /**
  * Options schema for insertOne
  */
-const insertOneValidation = createValidationFunction({
+const insertOneSchema = {
   w: { type: ['number', 'string'] },
   wtimeout: { type: 'number' },
   j: { type: 'boolean' },
@@ -103,7 +103,7 @@ const insertOneValidation = createValidationFunction({
   bypassDocumentValidation: { type: 'boolean' },
   session: { type: ClientSession },
   ignoreUndefined: { type: 'boolean' }
-});
+};
 
 /**
  * Create a new Collection instance (INTERNAL TYPE, do not instantiate directly)
@@ -473,7 +473,8 @@ Collection.prototype.insertOne = function(doc, options, callback) {
 
   assertArity(arguments, 1);
 
-  const finalOptions = insertOneValidation(
+  const finalOptions = validate(
+    insertOneSchema,
     options,
     { ignoreUndefined: this.s.options.ignoreUndefined },
     { validationLevel: 'error' }

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -146,6 +146,65 @@ class OperationBuilder {
     this.requiredArity = -1;
     this.validationSchema = {};
   }
+
+  /**
+   * Set an operation's required arity.
+   *
+   * @method
+   * @param {number} requiredArity The operation to validate.
+   * @return {OperationBuilder} An operation builder with a set requiredArity.
+   */
+  arity(requiredArity) {
+    this.requiredArity = requiredArity;
+    return this;
+  }
+
+  /**
+   * Set an OperationBuilder's validationSchema.
+   *
+   * @method
+   * @param {object} validationSchema The schema against which to validate options.
+   * @return {OperationBuilder} An operation builder that will validate options.
+   */
+  options(validationSchema) {
+    this.validationSchema = validationSchema;
+    return this;
+  }
+
+  /**
+   * Build an operation by checking its arity and validating its options.
+   *
+   * @method
+   * @param {function} operationToBuild The operation to validate.
+   * @return {function} The operation with validated options.
+   */
+  build(operationToBuild, overrideOptions, validationOptions) {
+    const operationBuilder = this;
+
+    function buildOperation() {
+      assertArity(arguments, operationBuilder.requiredArity);
+
+      const args = Array.prototype.slice.call(arguments);
+
+      // validate options
+      const optionsIndex =
+        typeof args[args.length - 1] === 'function' ? args.length - 2 : args.length - 1;
+
+      const verifiedOptions = validationFunction(
+        operationBuilder.validationSchema,
+        args[optionsIndex],
+        overrideOptions,
+        validationOptions
+      );
+
+      args[optionsIndex] = verifiedOptions;
+
+      // call original function with validated options
+      return operationToBuild.apply(this, args);
+    }
+
+    return buildOperation;
+  }
 }
 
 /**
@@ -159,57 +218,5 @@ function arity(requiredArity) {
   const operationBuilder = new OperationBuilder(requiredArity);
   return operationBuilder.arity(requiredArity);
 }
-
-OperationBuilder.prototype.arity = function(requiredArity) {
-  this.requiredArity = requiredArity;
-  return this;
-};
-
-/**
- * Set an OperationBuilder's validationSchema.
- *
- * @method
- * @param {object} validationSchema The schema against which to validate options.
- * @return {OperationBuilder} An operation builder that will validate options.
- */
-OperationBuilder.prototype.options = function(validationSchema) {
-  this.validationSchema = validationSchema;
-  return this;
-};
-
-/**
- * Build an operation by checking its arity and validating its options.
- *
- * @method
- * @param {function} operationToBuild The operation to validate.
- * @return {function} The operation with validated options.
- */
-OperationBuilder.prototype.build = function(operationToBuild, overrideOptions, validationOptions) {
-  const operationBuilder = this;
-
-  function buildOperation() {
-    assertArity(arguments, operationBuilder.requiredArity);
-
-    const args = Array.prototype.slice.call(arguments);
-
-    // validate options
-    const optionsIndex =
-      typeof args[args.length - 1] === 'function' ? args.length - 2 : args.length - 1;
-
-    const verifiedOptions = validationFunction(
-      operationBuilder.validationSchema,
-      args[optionsIndex],
-      overrideOptions,
-      validationOptions
-    );
-
-    args[optionsIndex] = verifiedOptions;
-
-    // call original function with validated options
-    return operationToBuild.apply(this, args);
-  }
-
-  return buildOperation;
-};
 
 module.exports = { arity, assertArity, createValidationFunction };

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -138,4 +138,78 @@ function invalidate(validationLevel, message, logger) {
   }
 }
 
-module.exports = { createValidationFunction };
+/**
+ * This is a class to build an operation by checking its arity and validating its options.
+ */
+class OperationBuilder {
+  constructor() {
+    this.requiredArity = -1;
+    this.validationSchema = {};
+  }
+}
+
+/**
+ * Build an OperationBuilder given an operation's required arity.
+ *
+ * @method
+ * @param {number} requiredArity The required arity of the operation to build.
+ * @return {OperationBuilder} An operation builder that will validate options.
+ */
+function arity(requiredArity) {
+  const operationBuilder = new OperationBuilder(requiredArity);
+  return operationBuilder.arity(requiredArity);
+}
+
+OperationBuilder.prototype.arity = function(requiredArity) {
+  this.requiredArity = requiredArity;
+  return this;
+};
+
+/**
+ * Set an OperationBuilder's validationSchema.
+ *
+ * @method
+ * @param {object} validationSchema The schema against which to validate options.
+ * @return {OperationBuilder} An operation builder that will validate options.
+ */
+OperationBuilder.prototype.options = function(validationSchema) {
+  this.validationSchema = validationSchema;
+  return this;
+};
+
+/**
+ * Build an operation by checking its arity and validating its options.
+ *
+ * @method
+ * @param {function} operationToBuild The operation to validate.
+ * @return {function} The operation with validated options.
+ */
+OperationBuilder.prototype.build = function(operationToBuild, overrideOptions, validationOptions) {
+  const operationBuilder = this;
+
+  function buildOperation() {
+    assertArity(arguments, operationBuilder.requiredArity);
+
+    const args = Array.prototype.slice.call(arguments);
+
+    // validate options
+    const optionsIndex =
+      typeof args[args.length - 1] === 'function' ? args.length - 2 : args.length - 1;
+
+    const verifiedOptions = validationFunction(
+      operationBuilder.validationSchema,
+      args[optionsIndex],
+      overrideOptions,
+      validationOptions
+    );
+
+    args[optionsIndex] = verifiedOptions;
+
+    // call original function with validated options
+    return operationToBuild.apply(this, args);
+  }
+
+  return buildOperation;
+};
+
+module.exports = { arity, assertArity, createValidationFunction };

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -176,6 +176,14 @@ class OperationBuilder {
     return this;
   }
 
+  /**
+   *
+   * Set the overrideOptions for an operationBuilder.
+   * The overrideOptions are dynamic defaults for options that can inherit their values, like readPreference.
+   *
+   * @param {object} overrideOptions The options and their override values.
+   * @return {OperationBuilder} An operation builder that will validate options.
+   */
   overrides(overrideOptions) {
     this.overrideOptions = overrideOptions;
     return this;

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -8,6 +8,35 @@ const VALIDATION_LEVEL_WARN = 'warn';
 const VALIDATION_LEVEL_ERROR = 'error';
 
 /**
+ * Checks that arguments provided to an operation match that operation's arity.
+ * An error will be thrown if the operation is called with an incorrect number of arguments.
+ *
+ * @method
+ * @param {object} args Arguments supplied to the operation that is calling assertArity.
+ * @param {number} requiredArity The correct arity of the operation.
+ */
+function assertArity(args, requiredArity) {
+  // acceptable values for arity are 0, 1, and 2
+  if (requiredArity < 0 || requiredArity > 2) {
+    throw new Error('The arity of an operation can only be 0, 1, or 2.');
+  }
+
+  // requiredArity is the minimum number of arguments allowed
+  // requiredArity + 2 is the maximum number of arguments allowed if there are options and a callback
+  // requiredArity + 1 i s the maximum number of arguments allowed if there is no callback
+  if (
+    args.length < requiredArity ||
+    args.length > requiredArity + 2 ||
+    (typeof args[args.length - 1] !== 'function' && args.length > requiredArity + 1)
+  ) {
+    const invalidateMessageArity = `This operation has a required arity of ${requiredArity}, but ${
+      args.length
+    } arguments were provided.`;
+    invalidate(VALIDATION_LEVEL_ERROR, invalidateMessageArity);
+  }
+}
+
+/**
  * Create a validation function given an options schema.
  *
  * @method

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -37,19 +37,6 @@ function assertArity(args, requiredArity) {
 }
 
 /**
- * Create a validation function given an options schema.
- *
- * @method
- * @param {object} optionsSchema A schema specifying possible options and their types, defaults,
- *   deprecation status, and whether or not they are required.
- * @return {function} returns a validation function
- */
-function createValidationFunction(optionsSchema) {
-  return (providedOptions, overrideOptions, validationOptions) =>
-    validationFunction(optionsSchema, providedOptions, overrideOptions, validationOptions);
-}
-
-/**
  * Validate all options passed into an operation by checking type, applying defaults, and checking deprecation.
  *
  * @method
@@ -62,7 +49,7 @@ function createValidationFunction(optionsSchema) {
  * @param {string} [validationOptions.validationLevel] The level at which to validate the providedOptions ('none', 'warn', or 'error').
  * @return {object} returns a frozen object of validated options
  */
-function validationFunction(optionsSchema, providedOptions, overrideOptions, validationOptions) {
+function validate(optionsSchema, providedOptions, overrideOptions, validationOptions) {
   let validationLevel = VALIDATION_LEVEL_WARN;
   let logger;
 
@@ -174,6 +161,7 @@ class OperationBuilder {
   constructor() {
     this.requiredArity = -1;
     this.validationSchema = {};
+    this.overrideOptions = {};
   }
 
   /**
@@ -200,6 +188,11 @@ class OperationBuilder {
     return this;
   }
 
+  overrides(overrideOptions) {
+    this.overrideOptions = overrideOptions;
+    return this;
+  }
+
   /**
    * Build an operation by checking its arity and validating its options.
    *
@@ -207,7 +200,7 @@ class OperationBuilder {
    * @param {function} operationToBuild The operation to validate.
    * @return {function} The operation with validated options.
    */
-  build(operationToBuild, overrideOptions, validationOptions) {
+  build(operationToBuild) {
     const operationBuilder = this;
 
     function buildOperation() {
@@ -215,14 +208,19 @@ class OperationBuilder {
 
       const args = Array.prototype.slice.call(arguments);
 
+      let validationOptions = { validationLevel: VALIDATION_LEVEL_WARN };
+      if (this.s.options.validationLevel) {
+        validationOptions = { validationLevel: this.s.options.validationLevel };
+      }
+
       // validate options
       const optionsIndex =
         typeof args[args.length - 1] === 'function' ? args.length - 2 : args.length - 1;
 
-      const verifiedOptions = validationFunction(
+      const verifiedOptions = validate(
         operationBuilder.validationSchema,
         args[optionsIndex],
-        overrideOptions,
+        operationBuilder.overrideOptions,
         validationOptions
       );
 
@@ -237,15 +235,39 @@ class OperationBuilder {
 }
 
 /**
- * Build an OperationBuilder given an operation's required arity.
+ * Build an OperationBuilder with a required arity of zero.
  *
  * @method
  * @param {number} requiredArity The required arity of the operation to build.
  * @return {OperationBuilder} An operation builder that will validate options.
  */
-function arity(requiredArity) {
-  const operationBuilder = new OperationBuilder(requiredArity);
-  return operationBuilder.arity(requiredArity);
+function arityZero() {
+  const operationBuilder = new OperationBuilder(0);
+  return operationBuilder.arity(0);
 }
 
-module.exports = { arity, assertArity, createValidationFunction };
+/**
+ * Build an OperationBuilder with a required arity of one.
+ *
+ * @method
+ * @param {number} requiredArity The required arity of the operation to build.
+ * @return {OperationBuilder} An operation builder that will validate options.
+ */
+function arityOne() {
+  const operationBuilder = new OperationBuilder(1);
+  return operationBuilder.arity(1);
+}
+
+/**
+ * Build an OperationBuilder with a required arity of two.
+ *
+ * @method
+ * @param {number} requiredArity The required arity of the operation to build.
+ * @return {OperationBuilder} An operation builder that will validate options.
+ */
+function arityTwo() {
+  const operationBuilder = new OperationBuilder(2);
+  return operationBuilder.arity(2);
+}
+
+module.exports = { arityZero, arityOne, arityTwo, assertArity, validate };

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -158,22 +158,10 @@ function invalidate(validationLevel, message, logger) {
  * This is a class to build an operation by checking its arity and validating its options.
  */
 class OperationBuilder {
-  constructor() {
-    this.requiredArity = -1;
+  constructor(requiredArity) {
+    this.requiredArity = requiredArity;
     this.validationSchema = {};
     this.overrideOptions = {};
-  }
-
-  /**
-   * Set an operation's required arity.
-   *
-   * @method
-   * @param {number} requiredArity The operation to validate.
-   * @return {OperationBuilder} An operation builder with a set requiredArity.
-   */
-  arity(requiredArity) {
-    this.requiredArity = requiredArity;
-    return this;
   }
 
   /**
@@ -203,13 +191,13 @@ class OperationBuilder {
   build(operationToBuild) {
     const operationBuilder = this;
 
-    function buildOperation() {
+    function operation() {
       assertArity(arguments, operationBuilder.requiredArity);
 
       const args = Array.prototype.slice.call(arguments);
 
       let validationOptions = { validationLevel: VALIDATION_LEVEL_WARN };
-      if (this.s.options.validationLevel) {
+      if (this.s && this.s.options && this.s.options.validationLevel) {
         validationOptions = { validationLevel: this.s.options.validationLevel };
       }
 
@@ -230,7 +218,7 @@ class OperationBuilder {
       return operationToBuild.apply(this, args);
     }
 
-    return buildOperation;
+    return operation;
   }
 }
 
@@ -242,8 +230,7 @@ class OperationBuilder {
  * @return {OperationBuilder} An operation builder that will validate options.
  */
 function arityZero() {
-  const operationBuilder = new OperationBuilder(0);
-  return operationBuilder.arity(0);
+  return new OperationBuilder(0);
 }
 
 /**
@@ -254,8 +241,7 @@ function arityZero() {
  * @return {OperationBuilder} An operation builder that will validate options.
  */
 function arityOne() {
-  const operationBuilder = new OperationBuilder(1);
-  return operationBuilder.arity(1);
+  return new OperationBuilder(1);
 }
 
 /**
@@ -266,8 +252,7 @@ function arityOne() {
  * @return {OperationBuilder} An operation builder that will validate options.
  */
 function arityTwo() {
-  const operationBuilder = new OperationBuilder(2);
-  return operationBuilder.arity(2);
+  return new OperationBuilder(2);
 }
 
 module.exports = { arityZero, arityOne, arityTwo, assertArity, validate };

--- a/test/unit/options_validator_tests.js
+++ b/test/unit/options_validator_tests.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const expect = require('chai').expect;
+const arity = require('../../lib/options_validator').arity;
+const assertArity = require('../../lib/options_validator').assertArity;
 const createValidationFunction = require('../../lib/options_validator').createValidationFunction;
+const expect = require('chai').expect;
 const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
 const chai = require('chai');
@@ -295,5 +297,208 @@ describe('Options Validation', function() {
     expect(validatedObject).to.be.frozen;
 
     console.warn.restore();
+  });
+
+  it('Should error if too many arguments are provided', function() {
+    /* eslint-disable-next-line no-unused-vars */
+    function failArity0(optionalArgument1, optionalArgument2) {
+      assertArity(arguments, 0);
+    }
+
+    try {
+      failArity0('optional', 'optional', 'extraArgument');
+    } catch (err) {
+      expect(err).to.not.be.null;
+      expect(err.message).to.equal(
+        'This operation has a required arity of 0, but 3 arguments were provided.'
+      );
+    }
+
+    /* eslint-disable-next-line no-unused-vars */
+    function failArity1(requiredArgument, optionalArgument1, optionalArgument2) {
+      assertArity(arguments, 1);
+    }
+
+    try {
+      failArity1('required', 'optional', 'optional', 'extraArgument');
+    } catch (err) {
+      expect(err).to.not.be.null;
+      expect(err.message).to.equal(
+        'This operation has a required arity of 1, but 4 arguments were provided.'
+      );
+    }
+
+    /* eslint-disable no-unused-vars */
+    function failArity2(
+      requiredArgument1,
+      requiredArgument2,
+      optionalArgument1,
+      optionalArgument2
+    ) {
+      assertArity(arguments, 2);
+    }
+    /* eslint-disable no-unused-vars */
+
+    try {
+      failArity2('required', 'required', 'optional', 'optional', 'extraArgument');
+    } catch (err) {
+      expect(err).to.not.be.null;
+      expect(err.message).to.equal(
+        'This operation has a required arity of 2, but 5 arguments were provided.'
+      );
+    }
+  });
+
+  it('Should error if too few arguments are provided', function() {
+    /* eslint-disable-next-line no-unused-vars */
+    function failArity1(requiredArgument, optionalArgument1, optionalArgument2) {
+      assertArity(arguments, 1);
+    }
+
+    try {
+      failArity1();
+    } catch (err) {
+      expect(err).to.not.be.null;
+      expect(err.message).to.equal(
+        'This operation has a required arity of 1, but 0 arguments were provided.'
+      );
+    }
+
+    /* eslint-disable no-unused-vars */
+    function failArity2(
+      requiredArgument1,
+      requiredArgument2,
+      optionalArgument1,
+      optionalArgument2
+    ) {
+      assertArity(arguments, 2);
+    }
+    /* eslint-disable no-unused-vars */
+
+    try {
+      failArity2('required');
+    } catch (err) {
+      expect(err).to.not.be.null;
+      expect(err.message).to.equal(
+        'This operation has a required arity of 2, but 1 arguments were provided.'
+      );
+    }
+  });
+
+  it('Should assert arity of 0', function() {
+    /* eslint-disable-next-line no-unused-vars */
+    function passArity0(optionalArgument1, optionalArgument2) {
+      assertArity(arguments, 0);
+    }
+
+    try {
+      passArity0({ option1: false });
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+    try {
+      passArity0(callback => {
+        console.log(callback);
+      });
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+    try {
+      passArity0({ option1: false }, callback => {
+        console.log(callback);
+      });
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+  });
+
+  it('Should assert arity of 1', function() {
+    /* eslint-disable-next-line no-unused-vars */
+    function passArity1(requiredArgument, optionalArgument1, optionalArgument2) {
+      assertArity(arguments, 1);
+    }
+
+    try {
+      passArity1('required');
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+    try {
+      passArity1('required', { option1: false });
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+    try {
+      passArity1('required', callback => {
+        console.log(callback);
+      });
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+    try {
+      passArity1('required', { option1: false }, callback => {
+        console.log(callback);
+      });
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+  });
+
+  it('Should assert arity of 2', function() {
+    /* eslint-disable no-unused-vars */
+    function passArity2(
+      requiredArgument1,
+      requiredArgument2,
+      optionalArgument1,
+      optionalArgument2
+    ) {
+      assertArity(arguments, 2);
+    }
+    /* eslint-disable no-unused-vars */
+
+    try {
+      passArity2('required1', 'required2');
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+    try {
+      passArity2('required1', 'required2', { option1: false });
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+    try {
+      passArity2('required', 'required2', callback => {
+        console.log(callback);
+      });
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+    try {
+      passArity2('required', 'required2', { option1: false }, callback => {
+        console.log(callback);
+      });
+    } catch (err) {
+      expect(err).to.be.null;
+    }
+  });
+
+  it('Should validate options using OperationBuilder', function() {
+    const testOperationBuilder = arity(1)
+      .options({ a: { type: 'boolean' } })
+      .build(
+        function(a) {
+          return a;
+        },
+        { validationLevel: 'error' }
+      );
+
+    const testObject = { a: 3 };
+
+    try {
+      testOperationBuilder(testObject);
+    } catch (err) {
+      expect(err).to.not.be.null;
+      expect(err.message).to.equal('a should be of type boolean, but is of type number.');
+    }
   });
 });

--- a/test/unit/options_validator_tests.js
+++ b/test/unit/options_validator_tests.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const arity = require('../../lib/options_validator').arity;
+const arityOne = require('../../lib/options_validator').arityOne;
 const assertArity = require('../../lib/options_validator').assertArity;
-const createValidationFunction = require('../../lib/options_validator').createValidationFunction;
+const validate = require('../../lib/options_validator').validate;
 const expect = require('chai').expect;
 const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
@@ -13,42 +13,50 @@ describe('Options Validation', function() {
   const testValidationLevel = 'error';
 
   it('Should validate a basic object with type number', function() {
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: 'number' }
-    });
+    };
 
     const testObject = { a: 1 };
-    const validatedObject = objectValidator(testObject, { validationLevel: testValidationLevel });
+    const validatedObject = validate(validationSchema, testObject, {
+      validationLevel: testValidationLevel
+    });
 
     expect(validatedObject).to.deep.equal({ a: 1 });
     expect(validatedObject).to.be.frozen;
   });
 
   it('Should validate a basic object with type object', function() {
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: 'object' }
-    });
+    };
 
     const testObject = { a: { b: 1 } };
-    const validatedObject = objectValidator(testObject, { validationLevel: testValidationLevel });
+    const validatedObject = validate(validationSchema, testObject, {
+      validationLevel: testValidationLevel
+    });
 
     expect(validatedObject).to.deep.equal(testObject);
     expect(validatedObject).to.be.frozen;
   });
 
   it('Should validate a basic object with array of types', function() {
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: ['number', 'object'] }
-    });
+    };
 
     const testObject1 = { a: 1 };
-    const validatedObject1 = objectValidator(testObject1, { validationLevel: testValidationLevel });
+    const validatedObject1 = validate(validationSchema, testObject1, {
+      validationLevel: testValidationLevel
+    });
 
     expect(validatedObject1).to.deep.equal(testObject1);
     expect(validatedObject1).to.be.frozen;
 
     const testObject2 = { a: { b: true } };
-    const validatedObject2 = objectValidator(testObject2, { validationLevel: testValidationLevel });
+    const validatedObject2 = validate(validationSchema, testObject2, {
+      validationLevel: testValidationLevel
+    });
 
     expect(validatedObject2).to.deep.equal(testObject2);
     expect(validatedObject2).to.be.frozen;
@@ -59,46 +67,50 @@ describe('Options Validation', function() {
       this.type = 'custom';
     }
 
-    const objectValidator = createValidationFunction({ a: { type: CustomType } });
+    const validationSchema = { a: { type: CustomType } };
 
     const testObject = { a: new CustomType() };
-    const validatedObject = objectValidator(testObject, { validationLevel: testValidationLevel });
+    const validatedObject = validate(validationSchema, testObject, {
+      validationLevel: testValidationLevel
+    });
 
     expect(validatedObject).to.deep.equal(testObject);
     expect(validatedObject).to.be.frozen;
   });
 
   it('Should ignore fields not in schema', function() {
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: 'boolean' }
-    });
+    };
 
     const testObject = { b: 1 };
-    const validatedObject = objectValidator(testObject, { validationLevel: testValidationLevel });
+    const validatedObject = validate(validationSchema, testObject, {
+      validationLevel: testValidationLevel
+    });
 
     expect(validatedObject).to.deep.equal(testObject);
     expect(validatedObject).to.be.frozen;
   });
 
   it('Should use default validationLevel', function() {
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: 'boolean' }
-    });
+    };
 
     const testObject = { b: 1 };
-    const validatedObject = objectValidator(testObject);
+    const validatedObject = validate(validationSchema, testObject);
 
     expect(validatedObject).to.deep.equal(testObject);
     expect(validatedObject).to.be.frozen;
   });
 
   it('Should skip validation if validationLevel is none', function() {
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: 'boolean' }
-    });
+    };
 
     const testObject = { a: 45 };
-    const validatedObject = objectValidator(testObject, { validationLevel: 'none' });
+    const validatedObject = validate(validationSchema, testObject, { validationLevel: 'none' });
 
     expect(validatedObject).to.deep.equal(testObject);
     expect(validatedObject).to.be.frozen;
@@ -106,12 +118,12 @@ describe('Options Validation', function() {
 
   it('Should warn if validationLevel is warn', function() {
     const stub = sinon.stub(console, 'warn');
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: 'boolean' }
-    });
+    };
 
     const testObject = { a: 45 };
-    const validatedObject = objectValidator(testObject, { validationLevel: 'warn' });
+    const validatedObject = validate(validationSchema, testObject, { validationLevel: 'warn' });
 
     expect(stub).to.have.been.calledOnce;
     expect(stub).to.have.been.calledWith('a should be of type boolean, but is of type number.');
@@ -122,13 +134,13 @@ describe('Options Validation', function() {
   });
 
   it('Should error if validationLevel is error', function() {
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: 'boolean' }
-    });
+    };
 
     const testObject = { a: 45 };
     try {
-      const validatedObject = objectValidator(testObject, { validationLevel: 'error' });
+      const validatedObject = validate(validationSchema, testObject, { validationLevel: 'error' });
       expect(validatedObject).to.deep.equal(testObject);
       expect(validatedObject).to.be.frozen;
     } catch (err) {
@@ -139,12 +151,12 @@ describe('Options Validation', function() {
 
   it('Should fail validation if required option is not present', function() {
     const stub = sinon.stub(console, 'warn');
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { required: true }
-    });
+    };
 
     const testObject = { b: 45 };
-    const validatedObject = objectValidator(testObject, { validationLevel: 'warn' });
+    const validatedObject = validate(validationSchema, testObject, { validationLevel: 'warn' });
 
     expect(stub).to.have.been.calledOnce;
     expect(stub).to.have.been.calledWith('required option [a] was not found.');
@@ -155,26 +167,30 @@ describe('Options Validation', function() {
   });
 
   it('Should validate an object with required and type fields', function() {
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: 'boolean', required: true }
-    });
+    };
 
     const testObject = { a: true };
-    const validatedObject = objectValidator(testObject, { validationLevel: testValidationLevel });
+    const validatedObject = validate(validationSchema, testObject, {
+      validationLevel: testValidationLevel
+    });
 
     expect(validatedObject).to.deep.equal(testObject);
     expect(validatedObject).to.be.frozen;
   });
 
   it('Should fail validation if required or type fails', function() {
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: 'boolean', required: true }
-    });
+    };
 
     const testObject = { b: 1 };
 
     try {
-      const validatedObject = objectValidator(testObject, { validationLevel: testValidationLevel });
+      const validatedObject = validate(validationSchema, testObject, {
+        validationLevel: testValidationLevel
+      });
       expect(validatedObject).to.deep.equal(testObject);
       expect(validatedObject).to.be.frozen;
     } catch (err) {
@@ -184,13 +200,15 @@ describe('Options Validation', function() {
   });
 
   it('Should set defaults', function() {
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { default: true }
-    });
+    };
 
     const testObject = { b: 3 };
 
-    const validatedObject = objectValidator(testObject, { validationLevel: testValidationLevel });
+    const validatedObject = validate(validationSchema, testObject, {
+      validationLevel: testValidationLevel
+    });
     expect(validatedObject.a).to.equal(true);
     expect(validatedObject.b).to.equal(3);
     expect(validatedObject).to.be.frozen;
@@ -201,13 +219,15 @@ describe('Options Validation', function() {
       ? sinon.stub(process, 'emitWarning')
       : sinon.stub(console, 'error');
 
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { deprecated: true }
-    });
+    };
 
     const testObject = { a: 3 };
 
-    const validatedObject = objectValidator(testObject, { validationLevel: testValidationLevel });
+    const validatedObject = validate(validationSchema, testObject, {
+      validationLevel: testValidationLevel
+    });
     expect(stub).to.have.been.calledOnce;
     expect(stub).to.have.been.calledWith(
       'option [a] is deprecated and will be removed in a later version.'
@@ -225,14 +245,15 @@ describe('Options Validation', function() {
     }
     const customObject = new CustomObject();
 
-    const objectValidator = createValidationFunction({
+    const validationSchema = {
       a: { type: 'string' },
       b: { type: 'string' }
-    });
+    };
 
     const testObject = {};
 
-    const validatedObject = objectValidator(
+    const validatedObject = validate(
+      validationSchema,
       testObject,
       { a: customObject.a, b: customObject.b },
       { validationLevel: testValidationLevel }
@@ -241,7 +262,8 @@ describe('Options Validation', function() {
     expect(validatedObject).to.deep.equal({ a: 'custom', b: 'override' });
     expect(validatedObject).to.be.frozen;
 
-    const validatedObject2 = objectValidator(
+    const validatedObject2 = validate(
+      validationSchema,
       testObject,
       { a: customObject.a, b: customObject.b },
       { validationLevel: 'none' }
@@ -257,11 +279,12 @@ describe('Options Validation', function() {
     }
     const customObject = new CustomObject();
 
-    const objectValidator = createValidationFunction({ a: { type: 'string' } });
+    const validationSchema = { a: { type: 'string' } };
 
     const testObject = { a: 'hello' };
 
-    const validatedObject = objectValidator(
+    const validatedObject = validate(
+      validationSchema,
       testObject,
       { a: customObject.a },
       { validationLevel: testValidationLevel }
@@ -279,11 +302,12 @@ describe('Options Validation', function() {
     }
     const customObject = new CustomObject();
 
-    const objectValidator = createValidationFunction({ a: { type: 'string', default: 'default' } });
+    const validationSchema = { a: { type: 'string', default: 'default' } };
 
     const testObject = {};
 
-    const validatedObject = objectValidator(
+    const validatedObject = validate(
+      validationSchema,
       testObject,
       { a: customObject.a },
       { validationLevel: testValidationLevel }
@@ -370,22 +394,55 @@ describe('Options Validation', function() {
   });
 
   it('Should validate options using OperationBuilder', function() {
-    const testOperationBuilder = arity(1)
+    class TestClass {
+      constructor() {
+        this.s = { options: { validationLevel: 'error' } };
+      }
+    }
+
+    TestClass.prototype.testOperation = arityOne()
       .options({ a: { type: 'boolean' } })
-      .build(
-        function(a) {
-          return a;
-        },
-        { validationLevel: 'error' }
-      );
+      .build(function(a) {
+        return a;
+      });
 
     const testObject = { a: 3 };
 
+    const testClass = new TestClass();
     try {
-      testOperationBuilder(testObject);
+      testClass.testOperation(testObject);
     } catch (err) {
       expect(err).to.not.be.null;
       expect(err.message).to.equal('a should be of type boolean, but is of type number.');
     }
+  });
+
+  it('Should override options using OperationBuilder', function() {
+    class TestClass {
+      constructor() {
+        this.s = { options: { validationLevel: 'error' } };
+      }
+    }
+
+    class CustomObject {
+      constructor() {
+        this.a = 'override';
+      }
+    }
+
+    const customObject = new CustomObject();
+
+    TestClass.prototype.testOperation = arityOne()
+      .options({ a: { type: 'string' } })
+      .overrides({ a: customObject.a })
+      .build(function(a) {
+        return a;
+      });
+
+    const testObject = {};
+
+    const testClass = new TestClass();
+    const validatedObject = testClass.testOperation(testObject);
+    expect(validatedObject).to.deep.equal({ a: 'override' });
   });
 });

--- a/test/unit/options_validator_tests.js
+++ b/test/unit/options_validator_tests.js
@@ -299,189 +299,6 @@ describe('Options Validation', function() {
     console.warn.restore();
   });
 
-  it('Should error if too many arguments are provided', function() {
-    /* eslint-disable-next-line no-unused-vars */
-    function failArity0(optionalArgument1, optionalArgument2) {
-      assertArity(arguments, 0);
-    }
-
-    try {
-      failArity0('optional', 'optional', 'extraArgument');
-    } catch (err) {
-      expect(err).to.not.be.null;
-      expect(err.message).to.equal(
-        'This operation has a required arity of 0, but 3 arguments were provided.'
-      );
-    }
-
-    /* eslint-disable-next-line no-unused-vars */
-    function failArity1(requiredArgument, optionalArgument1, optionalArgument2) {
-      assertArity(arguments, 1);
-    }
-
-    try {
-      failArity1('required', 'optional', 'optional', 'extraArgument');
-    } catch (err) {
-      expect(err).to.not.be.null;
-      expect(err.message).to.equal(
-        'This operation has a required arity of 1, but 4 arguments were provided.'
-      );
-    }
-
-    /* eslint-disable no-unused-vars */
-    function failArity2(
-      requiredArgument1,
-      requiredArgument2,
-      optionalArgument1,
-      optionalArgument2
-    ) {
-      assertArity(arguments, 2);
-    }
-    /* eslint-disable no-unused-vars */
-
-    try {
-      failArity2('required', 'required', 'optional', 'optional', 'extraArgument');
-    } catch (err) {
-      expect(err).to.not.be.null;
-      expect(err.message).to.equal(
-        'This operation has a required arity of 2, but 5 arguments were provided.'
-      );
-    }
-  });
-
-  it('Should error if too few arguments are provided', function() {
-    /* eslint-disable-next-line no-unused-vars */
-    function failArity1(requiredArgument, optionalArgument1, optionalArgument2) {
-      assertArity(arguments, 1);
-    }
-
-    try {
-      failArity1();
-    } catch (err) {
-      expect(err).to.not.be.null;
-      expect(err.message).to.equal(
-        'This operation has a required arity of 1, but 0 arguments were provided.'
-      );
-    }
-
-    /* eslint-disable no-unused-vars */
-    function failArity2(
-      requiredArgument1,
-      requiredArgument2,
-      optionalArgument1,
-      optionalArgument2
-    ) {
-      assertArity(arguments, 2);
-    }
-    /* eslint-disable no-unused-vars */
-
-    try {
-      failArity2('required');
-    } catch (err) {
-      expect(err).to.not.be.null;
-      expect(err.message).to.equal(
-        'This operation has a required arity of 2, but 1 arguments were provided.'
-      );
-    }
-  });
-
-  it('Should assert arity of 0', function() {
-    /* eslint-disable-next-line no-unused-vars */
-    function passArity0(optionalArgument1, optionalArgument2) {
-      assertArity(arguments, 0);
-    }
-
-    try {
-      passArity0({ option1: false });
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-    try {
-      passArity0(callback => {
-        console.log(callback);
-      });
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-    try {
-      passArity0({ option1: false }, callback => {
-        console.log(callback);
-      });
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-  });
-
-  it('Should assert arity of 1', function() {
-    /* eslint-disable-next-line no-unused-vars */
-    function passArity1(requiredArgument, optionalArgument1, optionalArgument2) {
-      assertArity(arguments, 1);
-    }
-
-    try {
-      passArity1('required');
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-    try {
-      passArity1('required', { option1: false });
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-    try {
-      passArity1('required', callback => {
-        console.log(callback);
-      });
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-    try {
-      passArity1('required', { option1: false }, callback => {
-        console.log(callback);
-      });
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-  });
-
-  it('Should assert arity of 2', function() {
-    /* eslint-disable no-unused-vars */
-    function passArity2(
-      requiredArgument1,
-      requiredArgument2,
-      optionalArgument1,
-      optionalArgument2
-    ) {
-      assertArity(arguments, 2);
-    }
-    /* eslint-disable no-unused-vars */
-
-    try {
-      passArity2('required1', 'required2');
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-    try {
-      passArity2('required1', 'required2', { option1: false });
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-    try {
-      passArity2('required', 'required2', callback => {
-        console.log(callback);
-      });
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-    try {
-      passArity2('required', 'required2', { option1: false }, callback => {
-        console.log(callback);
-      });
-    } catch (err) {
-      expect(err).to.be.null;
-    }
-  });
-
   it('Should validate options using OperationBuilder', function() {
     const testOperationBuilder = arity(1)
       .options({ a: { type: 'boolean' } })
@@ -500,5 +317,75 @@ describe('Options Validation', function() {
       expect(err).to.not.be.null;
       expect(err.message).to.equal('a should be of type boolean, but is of type number.');
     }
+  });
+
+  [
+    {
+      description: 'Should fail arity 0 if too many arguments are provided',
+      func: args => assertArity(args, 0),
+      numberOfArgs: 2,
+      errorMessageMatch: /This operation has a required arity of 0, but 2 arguments were provided./
+    },
+    {
+      description: 'Should fail arity 1 if too many arguments are provided',
+      func: args => assertArity(args, 1),
+      numberOfArgs: 3,
+      errorMessageMatch: /This operation has a required arity of 1, but 3 arguments were provided./
+    },
+    {
+      description: 'Should fail arity 2 if too many arguments are provided',
+      func: args => assertArity(args, 2),
+      numberOfArgs: 4,
+      errorMessageMatch: /This operation has a required arity of 2, but 4 arguments were provided./
+    },
+    {
+      description: 'Should fail arity 1 if too few arguments are provided',
+      func: args => assertArity(args, 1),
+      numberOfArgs: 0,
+      errorMessageMatch: /This operation has a required arity of 1, but 0 arguments were provided./
+    },
+    {
+      description: 'Should fail arity 2 if too few arguments are provided',
+      func: args => assertArity(args, 2),
+      numberOfArgs: 1,
+      errorMessageMatch: /This operation has a required arity of 2, but 1 arguments were provided./
+    },
+    {
+      description: 'Should pass arity 0',
+      func: args => assertArity(args, 0),
+      numberOfArgs: 0
+    },
+    {
+      description: 'Should pass arity 1',
+      func: args => assertArity(args, 1),
+      numberOfArgs: 1
+    },
+    {
+      description: 'Should pass arity 2',
+      func: args => assertArity(args, 2),
+      numberOfArgs: 2
+    }
+  ].forEach(test => {
+    it(test.description, function() {
+      let args = [];
+      if (test.errorMessageMatch) {
+        for (let i = 0; i < test.numberOfArgs; i++) {
+          args.push(i);
+        }
+        expect(() => test.func(args)).to.throw(test.errorMessageMatch);
+      } else {
+        // test that it passes with only the required arguments
+        for (let i = 0; i < test.numberOfArgs; i++) {
+          args.push(i);
+        }
+        expect(() => test.func(args)).to.not.throw;
+        // test that it passes with one optional argument (options)
+        args.push(test.numberOfArgs);
+        expect(() => test.func(args)).to.not.throw;
+        // test that it passes with a callback and an optional argument
+        args.push(() => console.log('callback'));
+        expect(() => test.func(args)).to.not.throw;
+      }
+    });
   });
 });

--- a/test/unit/options_validator_tests.js
+++ b/test/unit/options_validator_tests.js
@@ -299,26 +299,6 @@ describe('Options Validation', function() {
     console.warn.restore();
   });
 
-  it('Should validate options using OperationBuilder', function() {
-    const testOperationBuilder = arity(1)
-      .options({ a: { type: 'boolean' } })
-      .build(
-        function(a) {
-          return a;
-        },
-        { validationLevel: 'error' }
-      );
-
-    const testObject = { a: 3 };
-
-    try {
-      testOperationBuilder(testObject);
-    } catch (err) {
-      expect(err).to.not.be.null;
-      expect(err.message).to.equal('a should be of type boolean, but is of type number.');
-    }
-  });
-
   [
     {
       description: 'Should fail arity 0 if too many arguments are provided',
@@ -387,5 +367,25 @@ describe('Options Validation', function() {
         expect(() => test.func(args)).to.not.throw;
       }
     });
+  });
+
+  it('Should validate options using OperationBuilder', function() {
+    const testOperationBuilder = arity(1)
+      .options({ a: { type: 'boolean' } })
+      .build(
+        function(a) {
+          return a;
+        },
+        { validationLevel: 'error' }
+      );
+
+    const testObject = { a: 3 };
+
+    try {
+      testOperationBuilder(testObject);
+    } catch (err) {
+      expect(err).to.not.be.null;
+      expect(err.message).to.equal('a should be of type boolean, but is of type number.');
+    }
   });
 });


### PR DESCRIPTION
Fixes [NODE-1670](https://jira.mongodb.org/browse/NODE-1670)

This PR depends on the `assertArity` implementation [PR](https://github.com/mongodb/node-mongodb-native/pull/1837).

This is the implementation of `OperationBuilder`, which is responsible for building a function that checks the arity of an operation, validates its options, and calls the original function. 