### PR TITLE
fix(options_validator): add options if they do not exist

### DIFF
--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -27,7 +27,9 @@ function assertArity(args, requiredArity) {
   if (
     args.length < requiredArity ||
     args.length > requiredArity + 2 ||
-    (typeof args[args.length - 1] !== 'function' && args.length > requiredArity + 1)
+    (typeof args[args.length - 1] !== 'function' &&
+      typeof args[args.length - 1] !== 'undefined' &&
+      args.length > requiredArity + 1)
   ) {
     const invalidateMessageArity = `This operation has a required arity of ${requiredArity}, but ${
       args.length
@@ -93,7 +95,10 @@ function validate(optionsSchema, providedOptions, overrideOptions, validationOpt
         invalidate(validationLevel, invalidateMessageRequired, logger);
       }
 
-      if (optionFromSchema.default && !verifiedOptions.hasOwnProperty(optionName)) {
+      if (
+        optionFromSchema.hasOwnProperty('default') &&
+        !verifiedOptions.hasOwnProperty(optionName)
+      ) {
         verifiedOptions[optionName] = optionFromSchema.default;
       }
 
@@ -209,7 +214,10 @@ class OperationBuilder {
         validationOptions = { validationLevel: this.s.options.validationLevel };
       }
 
-      const callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
+      const callback =
+        typeof args[args.length - 1] === 'function' || typeof args[args.length - 1] === 'undefined'
+          ? args.pop()
+          : undefined;
       const options = typeof args[operationBuilder.requiredArity] === 'object' ? args.pop() : {};
 
       const optionsIndex = args.length;

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -209,9 +209,15 @@ class OperationBuilder {
         validationOptions = { validationLevel: this.s.options.validationLevel };
       }
 
-      // validate options
-      const optionsIndex =
-        typeof args[args.length - 1] === 'function' ? args.length - 2 : args.length - 1;
+      const callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
+      const options = typeof args[operationBuilder.requiredArity] === 'object' ? args.pop() : {};
+
+      const optionsIndex = args.length;
+      args.push(options);
+
+      if (callback) {
+        args.push(callback);
+      }
 
       const verifiedOptions = validate(
         operationBuilder.validationSchema,
@@ -225,7 +231,6 @@ class OperationBuilder {
       // call original function with validated options
       return operationToBuild.apply(this, args);
     }
-
     return operation;
   }
 }


### PR DESCRIPTION
While working on [NODE-1671](https://jira.mongodb.org/browse/NODE-1671), I realized that I was not handling the case where an operation is called without any options.

If `insertOne(doc, callback)` is called before this fix, the `doc` will be treated as `options` in `build()`. This fix ensures that a new options object is created if one is not passed in.