### PR TITLE
NODE-1603: add async_hooks support

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -103,12 +103,12 @@ Admin.prototype.command = function(command, options, callback) {
     { readPreference: resolveReadPreference(options) }
   );
 
-  return executeOperation(this.s.db.s.topology, executeDbAdminCommand.bind(this.s.db), [
-    this.s.db,
-    command,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.db.s.topology,
+    executeDbAdminCommand.bind(this.s.db),
+    [this.s.db, command, options, callback],
+    { asyncResource: this.s.db.s.asyncResource }
+  );
 };
 
 /**
@@ -138,12 +138,12 @@ Admin.prototype.buildInfo = function(options, callback) {
   );
 
   const cmd = { buildinfo: 1 };
-  return executeOperation(this.s.db.s.topology, executeDbAdminCommand.bind(this.s.db), [
-    this.s.db,
-    cmd,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.db.s.topology,
+    executeDbAdminCommand.bind(this.s.db),
+    [this.s.db, cmd, options, callback],
+    { asyncResource: this.s.db.s.asyncResource }
+  );
 };
 
 /**
@@ -173,12 +173,12 @@ Admin.prototype.serverInfo = function(options, callback) {
   );
 
   const cmd = { buildinfo: 1 };
-  return executeOperation(this.s.db.s.topology, executeDbAdminCommand.bind(this.s.db), [
-    this.s.db,
-    cmd,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.db.s.topology,
+    executeDbAdminCommand.bind(this.s.db),
+    [this.s.db, cmd, options, callback],
+    { asyncResource: this.s.db.s.asyncResource }
+  );
 };
 
 /**
@@ -199,7 +199,9 @@ Admin.prototype.serverStatus = function(options, callback) {
 
   options = applyDefaults(serverStatusSchema, options, {});
 
-  return executeOperation(this.s.db.s.topology, serverStatus, [this, options, callback]);
+  return executeOperation(this.s.db.s.topology, serverStatus, [this, options, callback], {
+    asyncResource: this.s.db.s.asyncResource
+  });
 };
 
 /**
@@ -226,12 +228,12 @@ Admin.prototype.ping = function(options, callback) {
   );
 
   const cmd = { ping: 1 };
-  return executeOperation(this.s.db.s.topology, executeDbAdminCommand.bind(this.s.db), [
-    this.s.db,
-    cmd,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.db.s.topology,
+    executeDbAdminCommand.bind(this.s.db),
+    [this.s.db, cmd, options, callback],
+    { asyncResource: this.s.db.s.asyncResource }
+  );
 };
 
 /**
@@ -280,13 +282,12 @@ Admin.prototype.addUser = function(username, password, options, callback) {
   // Set the db name to admin
   options.dbName = 'admin';
 
-  return executeOperation(this.s.db.s.topology, addUser, [
-    this.s.db,
-    username,
-    password,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.db.s.topology,
+    addUser,
+    [this.s.db, username, password, options, callback],
+    { asyncResource: this.s.db.s.asyncResource }
+  );
 };
 
 /**
@@ -323,12 +324,12 @@ Admin.prototype.removeUser = function(username, options, callback) {
   // Set the db name
   options.dbName = 'admin';
 
-  return executeOperation(this.s.db.s.topology, removeUser, [
-    this.s.db,
-    username,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.db.s.topology,
+    removeUser,
+    [this.s.db, username, options, callback],
+    { asyncResource: this.s.db.s.asyncResource }
+  );
 };
 
 /**
@@ -352,12 +353,12 @@ Admin.prototype.validateCollection = function(collectionName, options, callback)
 
   options = applyDefaults(validateCollectionSchema, options, {});
 
-  return executeOperation(this.s.db.s.topology, validateCollection, [
-    this,
-    collectionName,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.db.s.topology,
+    validateCollection,
+    [this, collectionName, options, callback],
+    { asyncResource: this.s.db.s.asyncResource }
+  );
 };
 
 /**
@@ -389,12 +390,12 @@ Admin.prototype.listDatabases = function(options, callback) {
 
   const cmd = { listDatabases: 1 };
   if (options.nameOnly) cmd.nameOnly = Number(cmd.nameOnly);
-  return executeOperation(this.s.db.s.topology, executeDbAdminCommand.bind(this.s.db), [
-    this.s.db,
-    cmd,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.db.s.topology,
+    executeDbAdminCommand.bind(this.s.db),
+    [this.s.db, cmd, options, callback],
+    { asyncResource: this.s.db.s.asyncResource }
+  );
 };
 
 /**
@@ -417,7 +418,9 @@ Admin.prototype.replSetGetStatus = function(options, callback) {
 
   options = applyDefaults(replSetGetStatusSchema, options, {});
 
-  return executeOperation(this.s.db.s.topology, replSetGetStatus, [this, options, callback]);
+  return executeOperation(this.s.db.s.topology, replSetGetStatus, [this, options, callback], {
+    asyncResource: this.s.db.s.asyncResource
+  });
 };
 
 module.exports = Admin;

--- a/lib/aggregation_cursor.js
+++ b/lib/aggregation_cursor.js
@@ -4,6 +4,7 @@ const inherits = require('util').inherits;
 const MongoError = require('mongodb-core').MongoError;
 const Readable = require('stream').Readable;
 const CoreCursor = require('./cursor');
+const AsyncResource = require('async_hooks').AsyncResource;
 
 /**
  * @fileOverview The **AggregationCursor** class is an internal class that embodies an aggregation cursor on MongoDB
@@ -90,7 +91,8 @@ var AggregationCursor = function(bson, ns, cmd, options, topology, topologyOptio
     // Promise library
     promiseLibrary: promiseLibrary,
     // Optional ClientSession
-    session: options.session
+    session: options.session,
+    asyncResource: new AsyncResource('mongodb:AggregationCursor')
   };
 };
 

--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -12,6 +12,7 @@ const executeOperation = utils.executeOperation;
 const MongoWriteConcernError = require('mongodb-core').MongoWriteConcernError;
 const handleMongoWriteConcernError = require('./common').handleMongoWriteConcernError;
 const bson = common.bson;
+const AsyncResource = require('async_hooks').AsyncResource;
 
 /**
  * Add to internal list of Operations
@@ -90,6 +91,7 @@ class OrderedBulkOperation extends BulkOperationBase {
     options = Object.assign(options, { addToOperationsList });
 
     super(topology, collection, options, true);
+    this.s.asyncResource = new AsyncResource('mongodb:OrderedBulkOperation');
   }
 
   /**
@@ -117,7 +119,9 @@ class OrderedBulkOperation extends BulkOperationBase {
     options = ret.options;
     callback = ret.callback;
 
-    return executeOperation(this.s.topology, executeCommands, [this, options, callback]);
+    return executeOperation(this.s.topology, executeCommands, [this, options, callback], {
+      asyncResource: this.s.asyncResource
+    });
   }
 }
 

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -12,6 +12,7 @@ const executeOperation = utils.executeOperation;
 const MongoWriteConcernError = require('mongodb-core').MongoWriteConcernError;
 const handleMongoWriteConcernError = require('./common').handleMongoWriteConcernError;
 const bson = common.bson;
+const AsyncResource = require('async_hooks').AsyncResource;
 
 /**
  * Add to internal list of Operations
@@ -102,6 +103,7 @@ class UnorderedBulkOperation extends BulkOperationBase {
     options = Object.assign(options, { addToOperationsList });
 
     super(topology, collection, options, false);
+    this.s.asyncResource = new AsyncResource('mongodb:UnorderedBulkOperation');
   }
 
   /**
@@ -129,7 +131,9 @@ class UnorderedBulkOperation extends BulkOperationBase {
     options = ret.options;
     callback = ret.callback;
 
-    return executeOperation(this.s.topology, executeBatches, [this, options, callback]);
+    return executeOperation(this.s.topology, executeBatches, [this, options, callback], {
+      asyncResource: this.s.asyncResource
+    });
   }
 }
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -24,6 +24,7 @@ const resolveReadPreference = require('./utils').resolveReadPreference;
 const ClientSession = require('mongodb-core').Sessions.ClientSession;
 const validate = require('./options_validator').validate;
 const applyDefaults = require('./options_validator').applyDefaults;
+const AsyncResource = require('async_hooks').AsyncResource;
 
 // Operations
 const bulkWrite = require('./operations/collection_ops').bulkWrite;
@@ -180,7 +181,8 @@ function Collection(db, topology, dbName, name, pkFactory, options) {
     // Read Concern
     readConcern: options.readConcern,
     // Write Concern
-    writeConcern: options.writeConcern
+    writeConcern: options.writeConcern,
+    asyncResource: new AsyncResource('mongodb:Collection')
   };
 }
 
@@ -498,7 +500,9 @@ Collection.prototype.insertOne = function(doc, options, callback) {
     { ignoreUndefined: this.s.options.ignoreUndefined }
   );
 
-  return executeOperation(this.s.topology, insertOne, [this, doc, options, callback]);
+  return executeOperation(this.s.topology, insertOne, [this, doc, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 function mapInsertManyResults(docs, r) {
@@ -580,6 +584,7 @@ Collection.prototype.insertMany = function(docs, options, callback) {
   ];
 
   return executeOperation(this.s.topology, bulkWrite, [this, operations, options, callback], {
+    asyncResource: this.s.asyncResource,
     resultMutator: result => mapInsertManyResults(docs, result)
   });
 };
@@ -663,7 +668,9 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
     { ignoreUndefined: this.s.options.ignoreUndefined }
   );
 
-  return executeOperation(this.s.topology, bulkWrite, [this, operations, options, callback]);
+  return executeOperation(this.s.topology, bulkWrite, [this, operations, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -820,7 +827,9 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
     }
   );
 
-  return executeOperation(this.s.topology, updateOne, [this, filter, update, options, callback]);
+  return executeOperation(this.s.topology, updateOne, [this, filter, update, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -865,7 +874,9 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
     }
   );
 
-  return executeOperation(this.s.topology, replaceOne, [this, filter, doc, options, callback]);
+  return executeOperation(this.s.topology, replaceOne, [this, filter, doc, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -918,7 +929,9 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
     }
   );
 
-  return executeOperation(this.s.topology, updateMany, [this, filter, update, options, callback]);
+  return executeOperation(this.s.topology, updateMany, [this, filter, update, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -950,14 +963,12 @@ Collection.prototype.update = deprecate(function(selector, update, options, call
     options = Object.assign({}, options);
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
-
-  return executeOperation(this.s.topology, updateDocuments, [
-    this,
-    selector,
-    update,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.topology,
+    updateDocuments,
+    [this, selector, update, options, callback],
+    { asyncResource: this.s.asyncResource }
+  );
 }, 'collection.update is deprecated. Use updateOne, updateMany, or bulkWrite instead.');
 
 /**
@@ -1013,7 +1024,9 @@ Collection.prototype.deleteOne = function(filter, options, callback) {
     }
   );
 
-  return executeOperation(this.s.topology, deleteOne, [this, filter, options, callback]);
+  return executeOperation(this.s.topology, deleteOne, [this, filter, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 Collection.prototype.removeOne = Collection.prototype.deleteOne;
@@ -1055,7 +1068,9 @@ Collection.prototype.deleteMany = function(filter, options, callback) {
     }
   );
 
-  return executeOperation(this.s.topology, deleteMany, [this, filter, options, callback]);
+  return executeOperation(this.s.topology, deleteMany, [this, filter, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 Collection.prototype.removeMany = Collection.prototype.deleteMany;
@@ -1084,7 +1099,9 @@ Collection.prototype.remove = deprecate(function(selector, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  return executeOperation(this.s.topology, removeDocuments, [this, selector, options, callback]);
+  return executeOperation(this.s.topology, removeDocuments, [this, selector, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 }, 'collection.remove is deprecated. Use deleteOne, deleteMany, or bulkWrite instead.');
 
 /**
@@ -1111,7 +1128,9 @@ Collection.prototype.save = deprecate(function(doc, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  return executeOperation(this.s.topology, save, [this, doc, options, callback]);
+  return executeOperation(this.s.topology, save, [this, doc, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 }, 'collection.save is deprecated. Use insertOne, insertMany, updateOne, or updateMany instead.');
 
 /**
@@ -1206,7 +1225,9 @@ Collection.prototype.findOne = deprecateOptions(
 
     options = applyDefaults(findOneSchema, options, {});
 
-    return executeOperation(this.s.topology, findOne, [this, query, options, callback]);
+    return executeOperation(this.s.topology, findOne, [this, query, options, callback], {
+      asyncResource: this.s.asyncResource
+    });
   }
 );
 
@@ -1240,7 +1261,9 @@ Collection.prototype.rename = function(newName, options, callback) {
 
   options = applyDefaults(renameSchema, options, {}, { readPreference: ReadPreference.primary });
 
-  return executeOperation(this.s.topology, rename, [this, newName, options, callback]);
+  return executeOperation(this.s.topology, rename, [this, newName, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1275,7 +1298,9 @@ Collection.prototype.drop = function(options, callback) {
   // Decorate with write concern
   applyWriteConcern(cmd, { db: this }, options);
 
-  return executeOperation(this.s.topology, dropCollection, [this.s.db, cmd, options, callback]);
+  return executeOperation(this.s.topology, dropCollection, [this.s.db, cmd, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1297,7 +1322,9 @@ Collection.prototype.options = function(opts, callback) {
 
   const finalOpts = applyDefaults(optionsSchema, opts, {});
 
-  return executeOperation(this.s.topology, optionsOp, [this, finalOpts, callback]);
+  return executeOperation(this.s.topology, optionsOp, [this, finalOpts, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1319,7 +1346,9 @@ Collection.prototype.isCapped = function(options, callback) {
 
   options = applyDefaults(isCappedSchema, options, {});
 
-  return executeOperation(this.s.topology, isCapped, [this, options, callback]);
+  return executeOperation(this.s.topology, isCapped, [this, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1375,7 +1404,9 @@ Collection.prototype.createIndex = function(fieldOrSpec, options, callback) {
     { readPreference: ReadPreference.primary }
   );
 
-  return executeOperation(this.s.topology, createIndex, [this, fieldOrSpec, options, callback]);
+  return executeOperation(this.s.topology, createIndex, [this, fieldOrSpec, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1413,7 +1444,9 @@ Collection.prototype.createIndexes = function(indexSpecs, options, callback) {
     { readPreference: ReadPreference.primary }
   );
 
-  return executeOperation(this.s.topology, createIndexes, [this, indexSpecs, options, callback]);
+  return executeOperation(this.s.topology, createIndexes, [this, indexSpecs, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1446,7 +1479,9 @@ Collection.prototype.dropIndex = function(indexName, options, callback) {
 
   options = applyDefaults(dropIndexSchema, options, {}, { readPreference: ReadPreference.primary });
 
-  return executeOperation(this.s.topology, dropIndex, [this, indexName, options, callback]);
+  return executeOperation(this.s.topology, dropIndex, [this, indexName, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1475,7 +1510,9 @@ Collection.prototype.dropIndexes = function(options, callback) {
 
   options = applyDefaults(dropIndexesSchema, options, {});
 
-  return executeOperation(this.s.topology, dropIndexes, [this, options, callback]);
+  return executeOperation(this.s.topology, dropIndexes, [this, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1509,7 +1546,9 @@ Collection.prototype.reIndex = function(options, callback) {
 
   options = applyDefaults(reIndexSchema, options, {});
 
-  return executeOperation(this.s.topology, reIndex, [this, options, callback]);
+  return executeOperation(this.s.topology, reIndex, [this, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1603,7 +1642,9 @@ Collection.prototype.ensureIndex = deprecate(function(fieldOrSpec, options, call
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  return executeOperation(this.s.topology, ensureIndex, [this, fieldOrSpec, options, callback]);
+  return executeOperation(this.s.topology, ensureIndex, [this, fieldOrSpec, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 }, 'collection.ensureIndex is deprecated. Use createIndexes instead.');
 
 /**
@@ -1626,7 +1667,9 @@ Collection.prototype.indexExists = function(indexes, options, callback) {
 
   options = applyDefaults(indexExistsSchema, options, {});
 
-  return executeOperation(this.s.topology, indexExists, [this, indexes, options, callback]);
+  return executeOperation(this.s.topology, indexExists, [this, indexes, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1652,7 +1695,9 @@ Collection.prototype.indexInformation = function(options, callback) {
 
   options = applyDefaults(indexInformationSchema, options, {});
 
-  return executeOperation(this.s.topology, indexInformation, [this, options, callback]);
+  return executeOperation(this.s.topology, indexInformation, [this, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1683,7 +1728,9 @@ Collection.prototype.count = deprecate(function(query, options, callback) {
   query = args.length ? args.shift() || {} : {};
   options = args.length ? args.shift() || {} : {};
 
-  return executeOperation(this.s.topology, count, [this, query, options, callback]);
+  return executeOperation(this.s.topology, count, [this, query, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 }, 'collection.count is deprecated, and will be removed in a future version.' +
   ' Use collection.countDocuments or collection.estimatedDocumentCount instead');
 
@@ -1710,7 +1757,9 @@ Collection.prototype.estimatedDocumentCount = function(options, callback) {
 
   options = applyDefaults(estimatedDocumentCountSchema, options, {});
 
-  return executeOperation(this.s.topology, count, [this, null, options, callback]);
+  return executeOperation(this.s.topology, count, [this, null, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1802,7 +1851,9 @@ Collection.prototype.distinct = function(key, query, options, callback) {
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) }
   );
 
-  return executeOperation(this.s.topology, distinct, [this, key, queryOption, options, callback]);
+  return executeOperation(this.s.topology, distinct, [this, key, queryOption, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1828,7 +1879,9 @@ Collection.prototype.indexes = function(options, callback) {
 
   options = applyDefaults(indexesSchema, options, {});
 
-  return executeOperation(this.s.topology, indexes, [this, options, callback]);
+  return executeOperation(this.s.topology, indexes, [this, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1860,7 +1913,9 @@ Collection.prototype.stats = function(options, callback) {
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) }
   );
 
-  return executeOperation(this.s.topology, stats, [this, options, callback]);
+  return executeOperation(this.s.topology, stats, [this, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1930,7 +1985,9 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
     }
   );
 
-  return executeOperation(this.s.topology, findOneAndDelete, [this, filter, options, callback]);
+  return executeOperation(this.s.topology, findOneAndDelete, [this, filter, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1995,13 +2052,12 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
     }
   );
 
-  return executeOperation(this.s.topology, findOneAndReplace, [
-    this,
-    filter,
-    replacement,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.topology,
+    findOneAndReplace,
+    [this, filter, replacement, options, callback],
+    { asyncResource: this.s.asyncResource }
+  );
 };
 
 /**
@@ -2074,13 +2130,12 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
     }
   );
 
-  return executeOperation(this.s.topology, findOneAndUpdate, [
-    this,
-    filter,
-    update,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.topology,
+    findOneAndUpdate,
+    [this, filter, update, options, callback],
+    { asyncResource: this.s.asyncResource }
+  );
 };
 
 /**
@@ -2136,14 +2191,14 @@ Collection.prototype.findAndModify = deprecate(function(query, sort, doc, option
     { readPreference: ReadPreference.primary, checkKeys: false }
   );
 
-  return executeOperation(this.s.topology, findAndModify, [
-    this,
-    query,
-    sort,
-    doc,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.topology,
+    findAndModify,
+    [this, query, sort, doc, options, callback],
+    {
+      asyncResource: this.s.asyncResource
+    }
+  );
 }, 'collection.findAndModify is deprecated. Use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead.');
 
 /**
@@ -2193,7 +2248,9 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
     }
   );
 
-  return executeOperation(this.s.topology, findAndRemove, [this, query, sort, options, callback]);
+  return executeOperation(this.s.topology, findAndRemove, [this, query, sort, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 }, 'collection.findAndRemove is deprecated. Use findOneAndDelete instead.');
 
 /**
@@ -2473,6 +2530,7 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
   );
 
   return executeOperation(this.s.topology, parallelCollectionScan, [this, options, callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: true
   });
 };
@@ -2517,7 +2575,9 @@ Collection.prototype.geoHaystackSearch = function(x, y, options, callback) {
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) }
   );
 
-  return executeOperation(this.s.topology, geoHaystackSearch, [this, x, y, options, callback]);
+  return executeOperation(this.s.topology, geoHaystackSearch, [this, x, y, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -2580,17 +2640,14 @@ Collection.prototype.group = deprecate(function(
   // Set up the command as default
   command = command == null ? true : command;
 
-  return executeOperation(this.s.topology, group, [
-    this,
-    keys,
-    condition,
-    initial,
-    reduce,
-    finalize,
-    command,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.topology,
+    group,
+    [this, keys, condition, initial, reduce, finalize, command, options, callback],
+    {
+      asyncResource: this.s.asyncResource
+    }
+  );
 },
 'MongoDB 3.6 or higher no longer supports the group command. We recommend rewriting using the aggregation framework.');
 
@@ -2663,7 +2720,9 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
     }
   );
 
-  return executeOperation(this.s.topology, mapReduce, [this, map, reduce, options, callback]);
+  return executeOperation(this.s.topology, mapReduce, [this, map, reduce, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**

--- a/lib/command_cursor.js
+++ b/lib/command_cursor.js
@@ -5,6 +5,7 @@ const ReadPreference = require('mongodb-core').ReadPreference;
 const MongoError = require('mongodb-core').MongoError;
 const Readable = require('stream').Readable;
 const CoreCursor = require('./cursor');
+const AsyncResource = require('async_hooks').AsyncResource;
 
 /**
  * @fileOverview The **CommandCursor** class is an internal class that embodies a
@@ -90,7 +91,8 @@ var CommandCursor = function(bson, ns, cmd, options, topology, topologyOptions) 
     // Promise library
     promiseLibrary: promiseLibrary,
     // Optional ClientSession
-    session: options.session
+    session: options.session,
+    asyncResource: new AsyncResource('mongodb:CommandCursor')
   };
 };
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -14,6 +14,7 @@ const executeOperation = require('./utils').executeOperation;
 const validate = require('./options_validator').validate;
 const ClientSession = require('mongodb-core').Sessions.ClientSession;
 const applyDefaults = require('./options_validator').applyDefaults;
+const AsyncResource = require('async_hooks').AsyncResource;
 
 const count = require('./operations/cursor_ops').count;
 const each = require('./operations/cursor_ops').each;
@@ -147,7 +148,8 @@ function Cursor(bson, ns, cmd, options, topology, topologyOptions) {
     // Current doc
     currentDoc: null,
     // explicitlyIgnoreSession
-    explicitlyIgnoreSession: options.explicitlyIgnoreSession
+    explicitlyIgnoreSession: options.explicitlyIgnoreSession,
+    asyncResource: new AsyncResource('mongodb:Cursor')
   };
 
   // Optional ClientSession
@@ -251,6 +253,7 @@ Cursor.prototype._endSession = function() {
  */
 Cursor.prototype.hasNext = function(callback) {
   return executeOperation(this.s.topology, hasNext, [this, callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: true
   });
 };
@@ -264,6 +267,7 @@ Cursor.prototype.hasNext = function(callback) {
  */
 Cursor.prototype.next = function(callback) {
   return executeOperation(this.s.topology, next, [this, callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: true
   });
 };
@@ -835,6 +839,7 @@ Cursor.prototype.toArray = function(callback) {
   }
 
   return executeOperation(this.s.topology, toArray, [this, callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: true
   });
 };
@@ -887,6 +892,7 @@ Cursor.prototype.count = function(applySkipLimit, opts, callback) {
   }
 
   return executeOperation(this.s.topology, count, [this, applySkipLimit, opts, callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: !!this.s.session
   });
 };
@@ -916,8 +922,8 @@ Cursor.prototype.close = function(options, callback) {
   }
 
   const completeClose = () => {
-    // Emit the close event for the cursor
     this.emit('close');
+    this.s.asyncResource.emitDestroy();
 
     // Callback if provided
     if (typeof callback === 'function') {
@@ -1040,6 +1046,7 @@ Cursor.prototype.explain = function(callback) {
   }
 
   return executeOperation(this.s.topology, this._next.bind(this), [callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: true
   });
 };

--- a/lib/db.js
+++ b/lib/db.js
@@ -22,6 +22,7 @@ const ClientSession = require('mongodb-core').Sessions.ClientSession;
 const validate = require('./options_validator').validate;
 const applyDefaults = require('./options_validator').applyDefaults;
 const CONSTANTS = require('./constants');
+const AsyncResource = require('async_hooks').AsyncResource;
 
 // Operations
 const addUser = require('./operations/db_ops').addUser;
@@ -196,7 +197,8 @@ function Db(databaseName, client, options) {
     // No listener
     noListener: options.noListener,
     // ReadConcern
-    readConcern: options.readConcern
+    readConcern: options.readConcern,
+    asyncResource: new AsyncResource('mongodb:Database')
   };
 
   // Add a read Only property
@@ -296,7 +298,9 @@ Db.prototype.command = function(command, options, callback) {
 
   options = applyDefaults(commandSchema, options, {});
 
-  return executeOperation(this.s.topology, executeCommand, [this, command, options, callback]);
+  return executeOperation(this.s.topology, executeCommand, [this, command, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -502,7 +506,9 @@ Db.prototype.createCollection = function(name, options, callback) {
     promiseLibrary: this.s.promiseLibrary
   });
 
-  return executeOperation(this.s.topology, createCollection, [this, name, options, callback]);
+  return executeOperation(this.s.topology, createCollection, [this, name, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -652,7 +658,9 @@ Db.prototype.eval = deprecate(function(code, parameters, options, callback) {
   parameters = args.length ? args.shift() : parameters;
   options = args.length ? args.shift() || {} : {};
 
-  return executeOperation(this.s.topology, evaluate, [this, code, parameters, options, callback]);
+  return executeOperation(this.s.topology, evaluate, [this, code, parameters, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 }, 'Db.eval is deprecated as of MongoDB version 3.2');
 
 /**
@@ -691,7 +699,9 @@ Db.prototype.renameCollection = function(fromCollection, toCollection, options, 
   );
 
   const collection = this.collection(fromCollection);
-  return executeOperation(this.s.topology, rename, [collection, toCollection, options, callback]);
+  return executeOperation(this.s.topology, rename, [collection, toCollection, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -730,7 +740,9 @@ Db.prototype.dropCollection = function(name, options, callback) {
   // Decorate with write concern
   applyWriteConcern(cmd, { db: this }, options);
 
-  return executeOperation(this.s.topology, dropCollection, [this, cmd, options, callback]);
+  return executeOperation(this.s.topology, dropCollection, [this, cmd, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -767,7 +779,9 @@ Db.prototype.dropDatabase = function(options, callback) {
   // Decorate with write concern
   applyWriteConcern(cmd, { db: this }, options);
 
-  return executeOperation(this.s.topology, dropDatabase, [this, cmd, options, callback]);
+  return executeOperation(this.s.topology, dropDatabase, [this, cmd, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -795,7 +809,9 @@ Db.prototype.collections = function(options, callback) {
 
   options = applyDefaults(collectionsSchema, options, {});
 
-  return executeOperation(this.s.topology, collections, [this, options, callback]);
+  return executeOperation(this.s.topology, collections, [this, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -826,12 +842,14 @@ Db.prototype.executeDbAdminCommand = function(selector, options, callback) {
     { readPreference: resolveReadPreference(options) }
   );
 
-  return executeOperation(this.s.topology, executeDbAdminCommand, [
-    this,
-    selector,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.topology,
+    executeDbAdminCommand,
+    [this, selector, options, callback],
+    {
+      asyncResource: this.s.asyncResource
+    }
+  );
 };
 
 /**
@@ -882,13 +900,14 @@ Db.prototype.createIndex = function(name, fieldOrSpec, options, callback) {
 
   options = applyDefaults(createIndexSchema, options, {});
 
-  return executeOperation(this.s.topology, createIndex, [
-    this,
-    name,
-    fieldOrSpec,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.topology,
+    createIndex,
+    [this, name, fieldOrSpec, options, callback],
+    {
+      asyncResource: this.s.asyncResource
+    }
+  );
 };
 
 /**
@@ -918,13 +937,14 @@ Db.prototype.ensureIndex = deprecate(function(name, fieldOrSpec, options, callba
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  return executeOperation(this.s.topology, ensureIndex, [
-    this,
-    name,
-    fieldOrSpec,
-    options,
-    callback
-  ]);
+  return executeOperation(
+    this.s.topology,
+    ensureIndex,
+    [this, name, fieldOrSpec, options, callback],
+    {
+      asyncResource: this.s.asyncResource
+    }
+  );
 }, 'Db.ensureIndex is deprecated as of MongoDB version 3.0 / driver version 2.0');
 
 Db.prototype.addChild = function(db) {
@@ -968,7 +988,9 @@ Db.prototype.addUser = function(username, password, options, callback) {
 
   options = applyDefaults(addUserSchema, options, {});
 
-  return executeOperation(this.s.topology, addUser, [this, username, password, options, callback]);
+  return executeOperation(this.s.topology, addUser, [this, username, password, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -996,7 +1018,9 @@ Db.prototype.removeUser = function(username, options, callback) {
 
   options = applyDefaults(removeUserSchema, options, {});
 
-  return executeOperation(this.s.topology, removeUser, [this, username, options, callback]);
+  return executeOperation(this.s.topology, removeUser, [this, username, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1020,7 +1044,9 @@ Db.prototype.setProfilingLevel = function(level, options, callback) {
 
   options = applyDefaults(setProfilingLevelSchema, options, {});
 
-  return executeOperation(this.s.topology, setProfilingLevel, [this, level, options, callback]);
+  return executeOperation(this.s.topology, setProfilingLevel, [this, level, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1036,7 +1062,9 @@ Db.prototype.profilingInfo = deprecate(function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  return executeOperation(this.s.topology, profilingInfo, [this, options, callback]);
+  return executeOperation(this.s.topology, profilingInfo, [this, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 }, 'Db.profilingInfo is deprecated. Query the system.profile collection directly.');
 
 /**
@@ -1057,7 +1085,9 @@ Db.prototype.profilingLevel = function(options, callback) {
 
   options = applyDefaults(profilingLevelSchema, options, {});
 
-  return executeOperation(this.s.topology, profilingLevel, [this, options, callback]);
+  return executeOperation(this.s.topology, profilingLevel, [this, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**
@@ -1088,7 +1118,9 @@ Db.prototype.indexInformation = function(name, options, callback) {
 
   options = applyDefaults(indexInformationSchema, options, {});
 
-  return executeOperation(this.s.topology, indexInformation, [this, name, options, callback]);
+  return executeOperation(this.s.topology, indexInformation, [this, name, options, callback], {
+    asyncResource: this.s.asyncResource
+  });
 };
 
 /**

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -8,6 +8,7 @@ const GridFSBucketWriteStream = require('./upload');
 const toError = require('../utils').toError;
 const util = require('util');
 const validate = require('../options_validator').validate;
+const AsyncResource = require('async_hooks').AsyncResource;
 
 var DEFAULT_GRIDFS_BUCKET_OPTIONS = {
   bucketName: 'fs',
@@ -52,7 +53,8 @@ function GridFSBucket(db, options) {
     _filesCollection: db.collection(options.bucketName + '.files'),
     checkedIndexes: false,
     calledOpenUploadStream: false,
-    promiseLibrary: db.s.promiseLibrary || Promise
+    promiseLibrary: db.s.promiseLibrary || Promise,
+    asyncResource: new AsyncResource('mongodb:GridFSBucket')
   };
 }
 
@@ -181,6 +183,7 @@ GridFSBucket.prototype.openDownloadStream = function(id, options) {
 
 GridFSBucket.prototype.delete = function(id, callback) {
   return executeOperation(this.s.db.s.topology, _delete, [this, id, callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: true
   });
 };
@@ -328,6 +331,7 @@ GridFSBucket.prototype.openDownloadStreamByName = function(filename, options) {
 
 GridFSBucket.prototype.rename = function(id, filename, callback) {
   return executeOperation(this.s.db.s.topology, _rename, [this, id, filename, callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: true
   });
 };
@@ -358,6 +362,7 @@ function _rename(_this, id, filename, callback) {
 
 GridFSBucket.prototype.drop = function(callback) {
   return executeOperation(this.s.db.s.topology, _drop, [this, callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: true
   });
 };

--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -47,6 +47,7 @@ const inherits = util.inherits;
 const Duplex = require('stream').Duplex;
 const executeOperation = require('../utils').executeOperation;
 const deprecate = require('util').deprecate;
+const AsyncResource = require('async_hooks').AsyncResource;
 
 var REFERENCE_BY_FILENAME = 0,
   REFERENCE_BY_ID = 1;
@@ -144,6 +145,7 @@ var GridStore = function GridStore(db, id, filename, mode, options) {
 
   // Set the promiseLibrary
   this.promiseLibrary = promiseLibrary;
+  this.asyncResource = new AsyncResource('mongodb:GridStore');
 
   Object.defineProperty(this, 'chunkSize', {
     enumerable: true,
@@ -203,6 +205,7 @@ GridStore.prototype.open = function(options, callback) {
   }
 
   return executeOperation(this.db.s.topology, open, [this, options, callback], {
+    asyncResource: this.asyncResource,
     skipSessions: true
   });
 };
@@ -275,6 +278,7 @@ GridStore.prototype.getc = function(options, callback) {
   options = options || {};
 
   return executeOperation(this.db.s.topology, getc, [this, options, callback], {
+    asyncResource: this.asyncResource,
     skipSessions: true
   });
 };
@@ -315,7 +319,10 @@ GridStore.prototype.puts = function(string, options, callback) {
     this.db.s.topology,
     this.write.bind(this),
     [finalString, options, callback],
-    { skipSessions: true }
+    {
+      asyncResource: this.asyncResource,
+      skipSessions: true
+    }
   );
 };
 
@@ -350,7 +357,10 @@ GridStore.prototype.write = function write(data, close, options, callback) {
     this.db.s.topology,
     _writeNormal,
     [this, data, close, options, callback],
-    { skipSessions: true }
+    {
+      asyncResource: this.asyncResource,
+      skipSessions: true
+    }
   );
 };
 
@@ -388,6 +398,7 @@ GridStore.prototype.writeFile = function(file, options, callback) {
   options = options || {};
 
   return executeOperation(this.db.s.topology, writeFile, [this, file, options, callback], {
+    asyncResource: this.asyncResource,
     skipSessions: true
   });
 };
@@ -473,6 +484,7 @@ GridStore.prototype.close = function(options, callback) {
   options = options || {};
 
   return executeOperation(this.db.s.topology, close, [this, options, callback], {
+    asyncResource: this.asyncResource,
     skipSessions: true
   });
 };
@@ -576,6 +588,7 @@ GridStore.prototype.unlink = function(options, callback) {
   options = options || {};
 
   return executeOperation(this.db.s.topology, unlink, [this, options, callback], {
+    asyncResource: this.asyncResource,
     skipSessions: true
   });
 };
@@ -639,6 +652,7 @@ GridStore.prototype.readlines = function(separator, options, callback) {
   options = args.length ? args.shift() : {};
 
   return executeOperation(this.db.s.topology, readlines, [this, separator, options, callback], {
+    asyncResource: this.asyncResource,
     skipSessions: true
   });
 };
@@ -673,6 +687,7 @@ GridStore.prototype.rewind = function(options, callback) {
   options = options || {};
 
   return executeOperation(this.db.s.topology, rewind, [this, options, callback], {
+    asyncResource: this.asyncResource,
     skipSessions: true
   });
 };
@@ -735,6 +750,7 @@ GridStore.prototype.read = function(length, buffer, options, callback) {
   options = args.length ? args.shift() : {};
 
   return executeOperation(this.db.s.topology, read, [this, length, buffer, options, callback], {
+    asyncResource: this.asyncResource,
     skipSessions: true
   });
 };
@@ -854,7 +870,10 @@ GridStore.prototype.seek = function(position, seekLocation, options, callback) {
     this.db.s.topology,
     seek,
     [this, position, seekLocation, options, callback],
-    { skipSessions: true }
+    {
+      asyncResource: this.asyncResource,
+      skipSessions: true
+    }
   );
 };
 
@@ -1288,7 +1307,10 @@ GridStore.exist = function(db, fileIdObject, rootCollection, options, callback) 
     db.s.topology,
     exists,
     [db, fileIdObject, rootCollection, options, callback],
-    { skipSessions: true }
+    {
+      asyncResource: this.asyncResource,
+      skipSessions: true
+    }
   );
 };
 
@@ -1348,6 +1370,7 @@ GridStore.list = function(db, rootCollection, options, callback) {
   options = options || {};
 
   return executeOperation(db.s.topology, list, [db, rootCollection, options, callback], {
+    asyncResource: this.asyncResource,
     skipSessions: true
   });
 };
@@ -1420,7 +1443,10 @@ GridStore.read = function(db, name, length, offset, options, callback) {
     db.s.topology,
     readStatic,
     [db, name, length, offset, options, callback],
-    { skipSessions: true }
+    {
+      asyncResource: this.asyncResource,
+      skipSessions: true
+    }
   );
 };
 
@@ -1473,7 +1499,10 @@ GridStore.readlines = function(db, name, separator, options, callback) {
     db.s.topology,
     readlinesStatic,
     [db, name, separator, options, callback],
-    { skipSessions: true }
+    {
+      asyncResource: this.asyncResource,
+      skipSessions: true
+    }
   );
 };
 
@@ -1506,6 +1535,7 @@ GridStore.unlink = function(db, names, options, callback) {
   options = options || {};
 
   return executeOperation(db.s.topology, unlinkStatic, [this, db, names, options, callback], {
+    asyncResource: this.asyncResource,
     skipSessions: true
   });
 };

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -11,6 +11,7 @@ const MongoError = require('mongodb-core').MongoError;
 const ReadPreference = require('mongodb-core').ReadPreference;
 const resolveReadPreference = require('./utils').resolveReadPreference;
 const validate = require('./options_validator').validate;
+const AsyncResource = require('async_hooks').AsyncResource;
 
 // Operations
 const connectOp = require('./operations/mongo_client_ops').connectOp;
@@ -237,7 +238,8 @@ function MongoClient(url, options) {
     options: options || {},
     promiseLibrary: null,
     dbCache: {},
-    sessions: []
+    sessions: [],
+    asyncResource: new AsyncResource('mongodb:Client')
   };
 
   // Get the promiseLibrary
@@ -293,6 +295,7 @@ MongoClient.prototype.connect = function(callback) {
   }
 
   return executeOperation(this, connectOp, [this, err, callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: true
   });
 };
@@ -326,6 +329,7 @@ MongoClient.prototype.logout = function(options, callback) {
   const dbName = this.s.options.authSource ? this.s.options.authSource : this.s.options.dbName;
 
   return executeOperation(this, logout, [this, dbName, callback], {
+    asyncResource: this.s.asyncResource,
     skipSessions: true
   });
 };
@@ -349,6 +353,8 @@ MongoClient.prototype.close = function(force, callback) {
       for (const name in this.s.dbCache) {
         this.s.dbCache[name].emit('close');
       }
+
+      this.s.asyncResource.emitDestroy();
 
       // Remove listeners after emit
       this.removeAllListeners('close');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -438,7 +438,9 @@ function executeOperation(topology, operation, args, options) {
 
   return new Promise(function(resolve, reject) {
     const handler = makeExecuteCallback(resolve, reject);
-    args[args.length - 1] = handler;
+    args[args.length - 1] = asyncResource
+      ? asyncResource.runInAsyncScope.bind(asyncResource, handler, undefined)
+      : handler;
 
     try {
       return operation.apply(null, args);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -360,9 +360,10 @@ var mergeOptionsAndWriteConcern = function(targetOptions, sourceOptions, keys, m
  * @param {function} operation The operation to execute
  * @param {array} args Arguments to apply the provided operation
  * @param {object} [options] Options that modify the behavior of the method
+ * @param {AsyncResource} [options.asyncResource] An optional AsyncResource to run the operation in the scope of
  * @param {function]} [options.resultMutator] Allows for the result of the operation to be changed for custom return types
  */
-const executeOperation = (topology, operation, args, options) => {
+function executeOperation(topology, operation, args, options) {
   if (topology == null) {
     throw new TypeError('This method requires a valid topology instance');
   }
@@ -373,7 +374,8 @@ const executeOperation = (topology, operation, args, options) => {
 
   options = options || {};
   const Promise = topology.s.promiseLibrary;
-  let resultMutator = options.resultMutator;
+  const asyncResource = options.asyncResource;
+  const resultMutator = options.resultMutator;
   let callback = args[args.length - 1];
 
   // The driver sessions spec mandates that we implicitly create sessions for operations
@@ -414,7 +416,12 @@ const executeOperation = (topology, operation, args, options) => {
       result => callback(null, result),
       err => callback(err, null)
     );
-    args.push(handler);
+
+    args.push(
+      asyncResource
+        ? asyncResource.runInAsyncScope.bind(asyncResource, handler, undefined)
+        : handler
+    );
 
     try {
       return operation.apply(null, args);
@@ -439,7 +446,7 @@ const executeOperation = (topology, operation, args, options) => {
       handler(e);
     }
   });
-};
+}
 
 /**
  * Applies retryWrites: true to a command if retryWrites is set on the command's database.


### PR DESCRIPTION
This is a basic initial implementation of `async_hooks` support for the native driver. I will put some notes inline, but it should be generally understood that this work is incomplete. Specifically:
  - this assumes `async_hooks` exists
  - this assumes support for `runInAsyncScope`

I just wanted to get the conversation started about the approach. 

/cc @mcollina @mafintosh 