### PR TITLE
readPreference is respected on GridFSBucket.find()

### DIFF
--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -212,8 +212,8 @@ GridFSBucket.prototype.find = function(filter, options) {
   options = options || {};
 
   var cursor = this.s._filesCollection.find(filter);
-  
-  if(this.s.options.readPreference){
+
+  if (this.s.options.readPreference) {
     cursor.setReadPreference(this.s.options.readPreference);
   }
 

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -212,6 +212,10 @@ GridFSBucket.prototype.find = function(filter, options) {
   options = options || {};
 
   var cursor = this.s._filesCollection.find(filter);
+  
+  if(this.s.options.readPreference){
+    cursor.setReadPreference(this.s.options.readPreference);
+  }
 
   if (options.batchSize != null) {
     cursor.batchSize(options.batchSize);


### PR DESCRIPTION
Currently, there is no way to specify readPreference on GridFSBucket.find(). This change makes`.find()` use readPreference set on Bucket.