### PR TITLE
v2.2: user creation with MongoDB version > 4.0; control digestion

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,13 @@
+<a name="2.2.37"></a>
+## [2.2.37](https://github.com/mongodb/node-mongodb-native/compare/v2.2.37...v2.2.37) (2018-10-22)
+
+
+### Features
+
+* **db, addUser**: Allow user creation with MongoDB versions > 4.0; automatically setting digest parameter and controlling digestion
+
+
+
 <a name="2.2.35"></a>
 ## [2.2.35](https://github.com/mongodb/node-mongodb-native/compare/v2.2.34...v2.2.35) (2018-02-26)
 
@@ -1616,9 +1626,9 @@
 * Reworked socket handling code to emit errors on unparsable messages
 * Added logger option for Db class, lets you pass in a function in the shape
     {
-        log : function(message, object) {},
-        error : function(errorMessage, errorObject) {},
-        debug : function(debugMessage, object) {},
+    ​    log : function(message, object) {},
+    ​    error : function(errorMessage, errorObject) {},
+    ​    debug : function(debugMessage, object) {},
     }
 
   Usage is new Db(new Server(..), {logger: loggerInstance})

--- a/lib/db.js
+++ b/lib/db.js
@@ -1263,22 +1263,28 @@ var _executeAuthCreateUserCommand = function(self, username, password, options, 
     roles = ['dbOwner']
   }
 
+  const lastIsMaster = self.serverConfig.lastIsMaster() || {};
+  const digestPassword = lastIsMaster.maxWireVersion >= 7;
+
   // Build the command to execute
   var command = {
       createUser: username
     , customData: customData
     , roles: roles
-    , digestPassword:false
+    , digestPassword: digestPassword
   }
 
   // Apply write concern to command
   command = writeConcern(command, self, options);
 
-  // Use node md5 generator
-  var md5 = crypto.createHash('md5');
-  // Generate keys used for authentication
-  md5.update(username + ":mongo:" + password);
-  var userPassword = md5.digest('hex');
+  var userPassword = password;
+  if(!digestPassword){
+    // Use node md5 generator
+    var md5 = crypto.createHash('md5');
+    // Generate keys used for authentication
+    md5.update(username + ":mongo:" + password);
+    userPassword = md5.digest('hex');
+  }
 
   // No password
   if(typeof password == 'string') {


### PR DESCRIPTION
**For the v2.2 branch:**

Allow user creation with MongoDB versions > 4.0 and internal digestion with SCRAM-SHA-256; automatically setting digest parameter and controlling digestion.
Taken from [1df6ab0](https://github.com/mongodb/node-mongodb-native/commit/1df6ab0) for minimal changes to the code.

*Applications are still using v2.2 versions as v3 introduces breaking changes, but are not able to add users to new MongoDB instances with versions > 4.0 with the current v2.2 library.*