### PR TITLE
docs(connect): fixing errors in client.connect documentation

### DIFF
--- a/docs/reference/content/quick-start/quick-start.md
+++ b/docs/reference/content/quick-start/quick-start.md
@@ -109,7 +109,7 @@ const dbName = 'myproject';
 const client = new MongoClient(url);
 
 // Use connect method to connect to the server
-client.connect(url, function(err) {
+client.connect(function(err) {
   assert.equal(null, err);
   console.log("Connected successfully to server");
 

--- a/docs/reference/content/reference/faq/index.md
+++ b/docs/reference/content/reference/faq/index.md
@@ -111,10 +111,9 @@ This can occur if the connection pool is too large.
 
 ```js
 const client = new MongoClient('mongodb://localhost:27017/test?maxPoolSize=5000');
-client.connect('mongodb://localhost:27017/test?maxPoolSize=5000',
-  function(err) {
-    // connection
-  });
+client.connect(function(err) {
+	// connection
+});
 ```
 If this operation causes an `ECONNRESET` error, you may have run into
 the file descriptor limit for your Node.js process.

--- a/docs/reference/content/reference/management/sdam-monitoring.md
+++ b/docs/reference/content/reference/management/sdam-monitoring.md
@@ -85,7 +85,7 @@ client.on('topologyDescriptionChanged', function(event) {
   console.log(JSON.stringify(event, null, 2));
 });
 
-client.connect(url, function(err, client) {
+client.connect(function(err, client) {
   if(err) throw err;
 });
 ```

--- a/docs/reference/layouts/shortcodes/js6-connect.html
+++ b/docs/reference/layouts/shortcodes/js6-connect.html
@@ -10,6 +10,6 @@ const client = new MongoClient(url);
 
 (async function() {
   try {
-    await client.connect(url);
+    await client.connect();
     console.log("Connected correctly to server");
     const db = client.db(dbName);

--- a/docs/reference/layouts/shortcodes/myproject-connect.html
+++ b/docs/reference/layouts/shortcodes/myproject-connect.html
@@ -11,7 +11,7 @@ const dbName = 'myproject';
 const client = new MongoClient(url);
 
 // Use connect method to connect to the Server
-client.connect(url, function(err, client) {
+client.connect(function(err, client) {
   assert.equal(null, err);
   console.log("Connected correctly to server");
 


### PR DESCRIPTION
We were incorrectly stating that client.connect took a url
parameter.

Fixes NODE-1716