### PR TITLE
 feat(mongo_client): add validationLevel as an option to MongoClient

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -179,16 +179,16 @@ function Collection(db, topology, dbName, name, pkFactory, options) {
     // Read Concern
     readConcern: options.readConcern,
     // Write Concern
-    writeConcern: options.writeConcern,
-    // Validation level
-    optionsValidationLevel: db.s.optionsValidationLevel
+    writeConcern: options.writeConcern
   };
 }
 
 Object.defineProperty(Collection.prototype, 'optionsValidationLevel', {
   enumerable: true,
   get: function() {
-    if (this.s && this.s.optionsValidationLevel) return this.s.optionsValidationLevel;
+    if (this.s && this.s.options && this.s.options.optionsValidationLevel) {
+      return this.s.options.optionsValidationLevel;
+    }
     return this.s.db.optionsValidationLevel;
   }
 });
@@ -390,7 +390,7 @@ Collection.prototype.find = deprecateOptions(
         promiseLibrary: this.s.promiseLibrary,
         ignoreUndefined: this.s.options.ignoreUndefined
       },
-      { optionsValidationLevel: this.s.optionsValidationLevel }
+      { optionsValidationLevel: this.optionsValidationLevel }
     );
 
     let projection = finalOptions.projection || finalOptions.fields;
@@ -488,7 +488,7 @@ Collection.prototype.insertOne = function(doc, options, callback) {
     options,
     {},
     { ignoreUndefined: this.s.options.ignoreUndefined },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, insertOne, [this, doc, options, callback]);
@@ -547,7 +547,7 @@ Collection.prototype.insertMany = function(docs, options, callback) {
     options,
     { serializeFunctions: this.s.serializeFunctions },
     { ignoreUndefined: this.s.options.ignoreUndefined },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   if (!Array.isArray(docs) && typeof callback === 'function') {
@@ -651,7 +651,7 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
     options,
     {},
     { ignoreUndefined: this.s.options.ignoreUndefined },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, bulkWrite, [this, operations, options, callback]);
@@ -807,7 +807,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
       ignoreUndefined: this.s.options.ignoreUndefined,
       multi: false
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, updateOne, [this, filter, update, options, callback]);
@@ -851,7 +851,7 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
       ignoreUndefined: this.s.options.ignoreUndefined,
       multi: false
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, replaceOne, [this, filter, doc, options, callback]);
@@ -903,7 +903,7 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
       ignoreUndefined: this.s.options.ignoreUndefined,
       multi: true
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, updateMany, [this, filter, update, options, callback]);
@@ -997,7 +997,7 @@ Collection.prototype.deleteOne = function(filter, options, callback) {
       ignoreUndefined: this.s.options.ignoreUndefined,
       single: true
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, deleteOne, [this, filter, options, callback]);
@@ -1038,7 +1038,7 @@ Collection.prototype.deleteMany = function(filter, options, callback) {
       ignoreUndefined: this.s.options.ignoreUndefined,
       single: false
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, deleteMany, [this, filter, options, callback]);
@@ -1192,7 +1192,7 @@ Collection.prototype.findOne = deprecateOptions(
       findOneSchema,
       options,
       {},
-      { optionsValidationLevel: this.s.optionsValidationLevel }
+      { optionsValidationLevel: this.optionsValidationLevel }
     );
 
     return executeOperation(this.s.topology, findOne, [this, query, options, callback]);
@@ -1230,7 +1230,7 @@ Collection.prototype.rename = function(newName, options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, rename, [this, newName, options, callback]);
@@ -1263,7 +1263,7 @@ Collection.prototype.drop = function(options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   // Command to execute
@@ -1294,7 +1294,7 @@ Collection.prototype.options = function(opts, callback) {
     optionsSchema,
     opts,
     {},
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, optionsOp, [this, finalOpts, callback]);
@@ -1319,7 +1319,7 @@ Collection.prototype.isCapped = function(options, callback) {
     isCappedSchema,
     options,
     {},
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, isCapped, [this, options, callback]);
@@ -1374,7 +1374,7 @@ Collection.prototype.createIndex = function(fieldOrSpec, options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, createIndex, [this, fieldOrSpec, options, callback]);
@@ -1411,7 +1411,7 @@ Collection.prototype.createIndexes = function(indexSpecs, options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, createIndexes, [this, indexSpecs, options, callback]);
@@ -1448,7 +1448,7 @@ Collection.prototype.dropIndex = function(indexName, options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, dropIndex, [this, indexName, options, callback]);
@@ -1480,7 +1480,7 @@ Collection.prototype.dropIndexes = function(options, callback) {
     dropIndexesSchema,
     options,
     {},
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, dropIndexes, [this, options, callback]);
@@ -1517,7 +1517,7 @@ Collection.prototype.reIndex = function(options, callback) {
     reIndexSchema,
     options,
     {},
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, reIndex, [this, options, callback]);
@@ -1554,7 +1554,7 @@ Collection.prototype.listIndexes = function(options) {
       cursorFactory: CommandCursor,
       promiseLibrary: this.s.promiseLibrary
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   // Cursor options
@@ -1634,7 +1634,7 @@ Collection.prototype.indexExists = function(indexes, options, callback) {
     indexExistsSchema,
     options,
     {},
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, indexExists, [this, indexes, options, callback]);
@@ -1661,7 +1661,7 @@ Collection.prototype.indexInformation = function(options, callback) {
     indexInformationSchema,
     options,
     {},
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, indexInformation, [this, options, callback]);
@@ -1718,7 +1718,7 @@ Collection.prototype.estimatedDocumentCount = function(options, callback) {
     estimatedDocumentCountSchema,
     options,
     {},
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, count, [this, null, options, callback]);
@@ -1772,7 +1772,7 @@ Collection.prototype.countDocuments = function(query, options, callback) {
     countDocumentsSchema,
     options,
     {},
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, countDocuments, [this, query, options, callback]);
@@ -1808,7 +1808,7 @@ Collection.prototype.distinct = function(key, query, options, callback) {
     optionsOption,
     {},
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, distinct, [this, key, queryOption, options, callback]);
@@ -1837,7 +1837,7 @@ Collection.prototype.indexes = function(options, callback) {
     indexesSchema,
     options,
     {},
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, indexes, [this, options, callback]);
@@ -1868,7 +1868,7 @@ Collection.prototype.stats = function(options, callback) {
     options,
     {},
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, stats, [this, options, callback]);
@@ -1926,7 +1926,7 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
       fields: options ? options.projection : null,
       remove: true
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, findOneAndDelete, [this, filter, options, callback]);
@@ -1981,7 +1981,7 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
       update: true,
       new: options ? (options.returnOriginal !== void 0 ? !options.returnOriginal : false) : null
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, findOneAndReplace, [
@@ -2050,7 +2050,7 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
       update: true,
       new: options ? (options.returnOriginal !== void 0 ? !options.returnOriginal : false) : null
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, findOneAndUpdate, [
@@ -2221,7 +2221,7 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
       promiseLibrary: this.s.promiseLibrary,
       cursorFactory: AggregationCursor
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   // If out was specified
@@ -2338,7 +2338,7 @@ Collection.prototype.watch = function(pipeline, options) {
     options,
     {},
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return new ChangeStream(this, pipeline, options);
@@ -2384,7 +2384,7 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
       promiseLibrary: this.s.promiseLibrary,
       session: undefined
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, parallelCollectionScan, [this, options, callback], {
@@ -2424,7 +2424,7 @@ Collection.prototype.geoHaystackSearch = function(x, y, options, callback) {
     options,
     {},
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, geoHaystackSearch, [this, x, y, options, callback]);
@@ -2567,7 +2567,7 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
       finalize:
         typeof options.finalize === 'function' ? options.finalize.toString() : options.finalize
     },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, mapReduce, [this, map, reduce, options, callback]);
@@ -2599,7 +2599,7 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
     options,
     {},
     { promiseLibrary: this.s.promiseLibrary },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return unordered(this.s.topology, this, options);
@@ -2632,7 +2632,7 @@ Collection.prototype.initializeOrderedBulkOp = function(options) {
     options,
     {},
     { promiseLibrary: this.s.promiseLibrary },
-    { optionsValidationLevel: this.s.optionsValidationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return ordered(this.s.topology, this, options);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -185,6 +185,14 @@ function Collection(db, topology, dbName, name, pkFactory, options) {
   };
 }
 
+Object.defineProperty(Collection.prototype, 'optionsValidationLevel', {
+  enumerable: true,
+  get: function() {
+    if (this.s && this.s.optionsValidationLevel) return this.s.optionsValidationLevel;
+    return this.s.db.optionsValidationLevel;
+  }
+});
+
 Object.defineProperty(Collection.prototype, 'dbName', {
   enumerable: true,
   get: function() {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -65,8 +65,6 @@ const updateDocuments = require('./operations/collection_ops').updateDocuments;
 const updateMany = require('./operations/collection_ops').updateMany;
 const updateOne = require('./operations/collection_ops').updateOne;
 
-const DEFAULT_VALIDATION = 'error';
-
 /**
  * @fileOverview The **Collection** class is an internal class that embodies a MongoDB collection
  * allowing for insert/update/remove/find and other command operation on that MongoDB collection.
@@ -181,7 +179,9 @@ function Collection(db, topology, dbName, name, pkFactory, options) {
     // Read Concern
     readConcern: options.readConcern,
     // Write Concern
-    writeConcern: options.writeConcern
+    writeConcern: options.writeConcern,
+    // Validation level
+    optionsValidationLevel: db.s.optionsValidationLevel
   };
 }
 
@@ -382,7 +382,7 @@ Collection.prototype.find = deprecateOptions(
         promiseLibrary: this.s.promiseLibrary,
         ignoreUndefined: this.s.options.ignoreUndefined
       },
-      { validationLevel: DEFAULT_VALIDATION }
+      { optionsValidationLevel: this.s.optionsValidationLevel }
     );
 
     let projection = finalOptions.projection || finalOptions.fields;
@@ -480,7 +480,7 @@ Collection.prototype.insertOne = function(doc, options, callback) {
     options,
     {},
     { ignoreUndefined: this.s.options.ignoreUndefined },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, insertOne, [this, doc, options, callback]);
@@ -539,7 +539,7 @@ Collection.prototype.insertMany = function(docs, options, callback) {
     options,
     { serializeFunctions: this.s.serializeFunctions },
     { ignoreUndefined: this.s.options.ignoreUndefined },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   if (!Array.isArray(docs) && typeof callback === 'function') {
@@ -643,7 +643,7 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
     options,
     {},
     { ignoreUndefined: this.s.options.ignoreUndefined },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, bulkWrite, [this, operations, options, callback]);
@@ -799,7 +799,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
       ignoreUndefined: this.s.options.ignoreUndefined,
       multi: false
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, updateOne, [this, filter, update, options, callback]);
@@ -843,7 +843,7 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
       ignoreUndefined: this.s.options.ignoreUndefined,
       multi: false
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, replaceOne, [this, filter, doc, options, callback]);
@@ -895,7 +895,7 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
       ignoreUndefined: this.s.options.ignoreUndefined,
       multi: true
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, updateMany, [this, filter, update, options, callback]);
@@ -989,7 +989,7 @@ Collection.prototype.deleteOne = function(filter, options, callback) {
       ignoreUndefined: this.s.options.ignoreUndefined,
       single: true
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, deleteOne, [this, filter, options, callback]);
@@ -1030,7 +1030,7 @@ Collection.prototype.deleteMany = function(filter, options, callback) {
       ignoreUndefined: this.s.options.ignoreUndefined,
       single: false
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, deleteMany, [this, filter, options, callback]);
@@ -1180,7 +1180,12 @@ Collection.prototype.findOne = deprecateOptions(
     if (typeof options === 'function') (callback = options), (options = {});
     query = query || {};
 
-    options = validate(findOneSchema, options, {}, { validationLevel: DEFAULT_VALIDATION });
+    options = validate(
+      findOneSchema,
+      options,
+      {},
+      { optionsValidationLevel: this.s.optionsValidationLevel }
+    );
 
     return executeOperation(this.s.topology, findOne, [this, query, options, callback]);
   }
@@ -1217,7 +1222,7 @@ Collection.prototype.rename = function(newName, options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, rename, [this, newName, options, callback]);
@@ -1250,7 +1255,7 @@ Collection.prototype.drop = function(options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   // Command to execute
@@ -1277,7 +1282,12 @@ const optionsSchema = {
 Collection.prototype.options = function(opts, callback) {
   if (typeof opts === 'function') (callback = opts), (opts = {});
 
-  const finalOpts = validate(optionsSchema, opts, {}, { validationLevel: DEFAULT_VALIDATION });
+  const finalOpts = validate(
+    optionsSchema,
+    opts,
+    {},
+    { optionsValidationLevel: this.s.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, optionsOp, [this, finalOpts, callback]);
 };
@@ -1297,7 +1307,12 @@ const isCappedSchema = {
 Collection.prototype.isCapped = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
-  options = validate(isCappedSchema, options, {}, { validationLevel: DEFAULT_VALIDATION });
+  options = validate(
+    isCappedSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.s.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, isCapped, [this, options, callback]);
 };
@@ -1351,7 +1366,7 @@ Collection.prototype.createIndex = function(fieldOrSpec, options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, createIndex, [this, fieldOrSpec, options, callback]);
@@ -1388,7 +1403,7 @@ Collection.prototype.createIndexes = function(indexSpecs, options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, createIndexes, [this, indexSpecs, options, callback]);
@@ -1425,7 +1440,7 @@ Collection.prototype.dropIndex = function(indexName, options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, dropIndex, [this, indexName, options, callback]);
@@ -1453,7 +1468,12 @@ const dropIndexesSchema = {
 Collection.prototype.dropIndexes = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
-  options = validate(dropIndexesSchema, options, {}, { validationLevel: DEFAULT_VALIDATION });
+  options = validate(
+    dropIndexesSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.s.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, dropIndexes, [this, options, callback]);
 };
@@ -1485,7 +1505,12 @@ const reIndexSchema = {
 Collection.prototype.reIndex = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
-  options = validate(reIndexSchema, options, {}, { validationLevel: DEFAULT_VALIDATION });
+  options = validate(
+    reIndexSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.s.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, reIndex, [this, options, callback]);
 };
@@ -1521,7 +1546,7 @@ Collection.prototype.listIndexes = function(options) {
       cursorFactory: CommandCursor,
       promiseLibrary: this.s.promiseLibrary
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   // Cursor options
@@ -1597,7 +1622,12 @@ const indexExistsSchema = {
 Collection.prototype.indexExists = function(indexes, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
-  options = validate(indexExistsSchema, options, {}, { validationLevel: DEFAULT_VALIDATION });
+  options = validate(
+    indexExistsSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.s.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, indexExists, [this, indexes, options, callback]);
 };
@@ -1619,7 +1649,12 @@ Collection.prototype.indexInformation = function(options, callback) {
   const args = Array.prototype.slice.call(arguments, 0);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
 
-  options = validate(indexInformationSchema, options, {}, { validationLevel: DEFAULT_VALIDATION });
+  options = validate(
+    indexInformationSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.s.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, indexInformation, [this, options, callback]);
 };
@@ -1675,7 +1710,7 @@ Collection.prototype.estimatedDocumentCount = function(options, callback) {
     estimatedDocumentCountSchema,
     options,
     {},
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, count, [this, null, options, callback]);
@@ -1725,7 +1760,12 @@ Collection.prototype.countDocuments = function(query, options, callback) {
   query = args.length ? args.shift() || {} : {};
   options = args.length ? args.shift() || {} : {};
 
-  options = validate(countDocumentsSchema, options, {}, { validationLevel: DEFAULT_VALIDATION });
+  options = validate(
+    countDocumentsSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.s.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, countDocuments, [this, query, options, callback]);
 };
@@ -1760,7 +1800,7 @@ Collection.prototype.distinct = function(key, query, options, callback) {
     optionsOption,
     {},
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, distinct, [this, key, queryOption, options, callback]);
@@ -1785,7 +1825,12 @@ const indexesSchema = {
 Collection.prototype.indexes = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
-  options = validate(indexesSchema, options, {}, { validationLevel: DEFAULT_VALIDATION });
+  options = validate(
+    indexesSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.s.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, indexes, [this, options, callback]);
 };
@@ -1815,7 +1860,7 @@ Collection.prototype.stats = function(options, callback) {
     options,
     {},
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, stats, [this, options, callback]);
@@ -1873,7 +1918,7 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
       fields: options ? options.projection : null,
       remove: true
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, findOneAndDelete, [this, filter, options, callback]);
@@ -1928,7 +1973,7 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
       update: true,
       new: options ? (options.returnOriginal !== void 0 ? !options.returnOriginal : false) : null
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, findOneAndReplace, [
@@ -1997,7 +2042,7 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
       update: true,
       new: options ? (options.returnOriginal !== void 0 ? !options.returnOriginal : false) : null
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, findOneAndUpdate, [
@@ -2168,7 +2213,7 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
       promiseLibrary: this.s.promiseLibrary,
       cursorFactory: AggregationCursor
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   // If out was specified
@@ -2285,7 +2330,7 @@ Collection.prototype.watch = function(pipeline, options) {
     options,
     {},
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return new ChangeStream(this, pipeline, options);
@@ -2331,7 +2376,7 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
       promiseLibrary: this.s.promiseLibrary,
       session: undefined
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, parallelCollectionScan, [this, options, callback], {
@@ -2371,7 +2416,7 @@ Collection.prototype.geoHaystackSearch = function(x, y, options, callback) {
     options,
     {},
     { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, geoHaystackSearch, [this, x, y, options, callback]);
@@ -2514,7 +2559,7 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
       finalize:
         typeof options.finalize === 'function' ? options.finalize.toString() : options.finalize
     },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, mapReduce, [this, map, reduce, options, callback]);
@@ -2546,7 +2591,7 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
     options,
     {},
     { promiseLibrary: this.s.promiseLibrary },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return unordered(this.s.topology, this, options);
@@ -2579,7 +2624,7 @@ Collection.prototype.initializeOrderedBulkOp = function(options) {
     options,
     {},
     { promiseLibrary: this.s.promiseLibrary },
-    { validationLevel: DEFAULT_VALIDATION }
+    { optionsValidationLevel: this.s.optionsValidationLevel }
   );
 
   return ordered(this.s.topology, this, options);

--- a/lib/db.js
+++ b/lib/db.js
@@ -88,7 +88,8 @@ const legalOptionNames = [
   'promoteLongs',
   'promoteValues',
   'compression',
-  'retryWrites'
+  'retryWrites',
+  'optionsValidationLevel'
 ];
 
 /**
@@ -145,9 +146,6 @@ function Db(databaseName, topology, options) {
   // Get the promiseLibrary
   const promiseLibrary = options.promiseLibrary || Promise;
 
-  // Get the optionsValidationLevel
-  const optionsValidationLevel = options.optionsValidationLevel;
-
   // Filter the options
   options = filterOptions(options, legalOptionNames);
 
@@ -185,10 +183,7 @@ function Db(databaseName, topology, options) {
     // No listener
     noListener: typeof options.noListener === 'boolean' ? options.noListener : false,
     // ReadConcern
-    readConcern: options.readConcern,
-
-    // TODO: temporary until NODE-1733 is merged
-    validationLevel: 'error'
+    readConcern: options.readConcern
   };
 
   // Ensure we have a valid db name
@@ -217,8 +212,10 @@ function Db(databaseName, topology, options) {
 Object.defineProperty(Db.prototype, 'optionsValidationLevel', {
   enumerable: true,
   get: function() {
-    if (this.s && this.s.optionsValidationLevel) return this.s.optionsValidationLevel;
-    return this.s.client.optionsValidationLevel;
+    if (this.s && this.s.options && this.s.options.optionsValidationLevel) {
+      return this.s.options.optionsValidationLevel;
+    }
+    return 'warn';
   }
 });
 
@@ -284,7 +281,12 @@ const commandSchema = {
 };
 Db.prototype.command = function(command, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
-  options = validate(commandSchema, options, {}, { validationLevel: this.s.validationLevel });
+  options = validate(
+    commandSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, executeCommand, [this, command, options, callback]);
 };
@@ -363,7 +365,7 @@ Db.prototype.collection = function(name, options, callback) {
       readPreference: resolveReadPreference(options, { db: this }),
       ignoreUndefined: this.s.options.ignoreUndefined ? this.s.options.ignoreUndefined : null
     },
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   // Merge in all needed options and ensure correct writeConcern merging from db level
@@ -486,7 +488,7 @@ Db.prototype.createCollection = function(name, options, callback) {
     createCollectionSchema,
     options,
     { promiseLibrary: this.s.promiseLibrary },
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, createCollection, [this, name, options, callback]);
@@ -516,7 +518,7 @@ Db.prototype.stats = function(options, callback) {
     options,
     {},
     { readPreference: resolveReadPreference(options, { db: this }) },
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
   // Build command object
   const commandObject = { dbStats: true };
@@ -559,7 +561,7 @@ Db.prototype.listCollections = function(filter, options) {
         ? CommandCursor
         : null
     },
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   // Cursor options
@@ -665,7 +667,7 @@ Db.prototype.renameCollection = function(fromCollection, toCollection, options, 
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   const collection = this.collection(fromCollection);
@@ -697,7 +699,7 @@ Db.prototype.dropCollection = function(name, options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   // Command to execute
@@ -733,7 +735,7 @@ Db.prototype.dropDatabase = function(options, callback) {
     options,
     {},
     { readPreference: ReadPreference.primary },
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
   // Drop database command
   const cmd = { dropDatabase: 1 };
@@ -764,7 +766,12 @@ const collectionsSchema = {
 };
 Db.prototype.collections = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
-  options = validate(collectionsSchema, options, {}, { validationLevel: this.s.validationLevel });
+  options = validate(
+    collectionsSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, collections, [this, options, callback]);
 };
@@ -790,7 +797,7 @@ Db.prototype.executeDbAdminCommand = function(selector, options, callback) {
     options,
     {},
     { readPreference: resolveReadPreference(options) },
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, executeDbAdminCommand, [
@@ -844,7 +851,12 @@ const createIndexSchema = {
 };
 Db.prototype.createIndex = function(name, fieldOrSpec, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
-  options = validate(createIndexSchema, options, {}, { validationLevel: this.s.validationLevel });
+  options = validate(
+    createIndexSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, createIndex, [
     this,
@@ -927,7 +939,12 @@ const addUserSchema = {
 };
 Db.prototype.addUser = function(username, password, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
-  options = validate(addUserSchema, options, {}, { validationLevel: this.s.validationLevel });
+  options = validate(
+    addUserSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, addUser, [this, username, password, options, callback]);
 };
@@ -952,7 +969,12 @@ const removeUserSchema = {
 };
 Db.prototype.removeUser = function(username, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
-  options = validate(removeUserSchema, options, {}, { validationLevel: this.s.validationLevel });
+  options = validate(
+    removeUserSchema,
+    options,
+    {},
+    { optionsValidationLevel: this.optionsValidationLevel }
+  );
 
   return executeOperation(this.s.topology, removeUser, [this, username, options, callback]);
 };
@@ -975,7 +997,7 @@ Db.prototype.setProfilingLevel = function(level, options, callback) {
     setProfilingLevelSchema,
     options,
     {},
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, setProfilingLevel, [this, level, options, callback]);
@@ -1014,7 +1036,7 @@ Db.prototype.profilingLevel = function(options, callback) {
     profilingLevelSchema,
     options,
     {},
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, profilingLevel, [this, options, callback]);
@@ -1045,7 +1067,7 @@ Db.prototype.indexInformation = function(name, options, callback) {
     indexInformationSchema,
     options,
     {},
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return executeOperation(this.s.topology, indexInformation, [this, name, options, callback]);
@@ -1099,7 +1121,7 @@ Db.prototype.watch = function(pipeline, options) {
     options,
     {},
     { readPreference: resolveReadPreference(options, { db: this }) },
-    { validationLevel: this.s.validationLevel }
+    { optionsValidationLevel: this.optionsValidationLevel }
   );
 
   return new ChangeStream(this, pipeline, options);

--- a/lib/db.js
+++ b/lib/db.js
@@ -145,6 +145,9 @@ function Db(databaseName, topology, options) {
   // Get the promiseLibrary
   const promiseLibrary = options.promiseLibrary || Promise;
 
+  // Get the optionsValidationLevel
+  const optionsValidationLevel = options.optionsValidationLevel;
+
   // Filter the options
   options = filterOptions(options, legalOptionNames);
 
@@ -433,7 +436,6 @@ Db.prototype.collection = function(name, options, callback) {
  * @param {number} [options.flags] Optional. Available for the MMAPv1 storage engine only to set the usePowerOf2Sizes and the noPadding flag.
  * @param {object} [options.storageEngine] Allows users to specify configuration to the storage engine on a per-collection basis when creating a collection on MongoDB 3.0 or higher.
  * @param {object} [options.validator] Allows users to specify validation rules or expressions for the collection. For more information, see Document Validation on MongoDB 3.2 or higher.
- * @param {string} [options.validationLevel] Determines how strictly MongoDB applies the validation rules to existing documents during an update on MongoDB 3.2 or higher.
  * @param {string} [options.validationAction] Determines whether to error on invalid documents or just warn about the violations but allow invalid documents to be inserted on MongoDB 3.2 or higher.
  * @param {object} [options.indexOptionDefaults] Allows users to specify a default configuration for indexes when creating a collection on MongoDB 3.2 or higher.
  * @param {string} [options.viewOn] The name of the source collection or view from which to create the view. The name is not the full namespace of the collection or view; i.e. does not include the database name and implies the same database as the view to create on MongoDB 3.4 or higher.

--- a/lib/db.js
+++ b/lib/db.js
@@ -209,6 +209,8 @@ function Db(databaseName, topology, options) {
   topology.on('reconnect', createListener(this, 'reconnect', this));
 }
 
+inherits(Db, EventEmitter);
+
 Object.defineProperty(Db.prototype, 'optionsValidationLevel', {
   enumerable: true,
   get: function() {
@@ -218,8 +220,6 @@ Object.defineProperty(Db.prototype, 'optionsValidationLevel', {
     return 'warn';
   }
 });
-
-inherits(Db, EventEmitter);
 
 // Topology
 Object.defineProperty(Db.prototype, 'topology', {

--- a/lib/db.js
+++ b/lib/db.js
@@ -214,6 +214,14 @@ function Db(databaseName, topology, options) {
   topology.on('reconnect', createListener(this, 'reconnect', this));
 }
 
+Object.defineProperty(Db.prototype, 'optionsValidationLevel', {
+  enumerable: true,
+  get: function() {
+    if (this.s && this.s.optionsValidationLevel) return this.s.optionsValidationLevel;
+    return this.s.client.optionsValidationLevel;
+  }
+});
+
 inherits(Db, EventEmitter);
 
 // Topology
@@ -436,6 +444,7 @@ Db.prototype.collection = function(name, options, callback) {
  * @param {number} [options.flags] Optional. Available for the MMAPv1 storage engine only to set the usePowerOf2Sizes and the noPadding flag.
  * @param {object} [options.storageEngine] Allows users to specify configuration to the storage engine on a per-collection basis when creating a collection on MongoDB 3.0 or higher.
  * @param {object} [options.validator] Allows users to specify validation rules or expressions for the collection. For more information, see Document Validation on MongoDB 3.2 or higher.
+ * @param {string} [options.validationLevel] Determines how strictly MongoDB applies the validation rules to existing documents during an update on MongoDB 3.2 or higher.
  * @param {string} [options.validationAction] Determines whether to error on invalid documents or just warn about the violations but allow invalid documents to be inserted on MongoDB 3.2 or higher.
  * @param {object} [options.indexOptionDefaults] Allows users to specify a default configuration for indexes when creating a collection on MongoDB 3.2 or higher.
  * @param {string} [options.viewOn] The name of the source collection or view from which to create the view. The name is not the full namespace of the collection or view; i.e. does not include the database name and implies the same database as the view to create on MongoDB 3.4 or higher.

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -13,6 +13,8 @@ const connectOp = require('./operations/mongo_client_ops').connectOp;
 const logout = require('./operations/mongo_client_ops').logout;
 const validOptions = require('./operations/mongo_client_ops').validOptions;
 
+const DEFAULT_VALIDATION_LEVEL = 'warn';
+
 /**
  * @fileOverview The **MongoClient** class is a class that allows for making Connections to MongoDB.
  *
@@ -110,6 +112,7 @@ const validOptions = require('./operations/mongo_client_ops').validOptions;
  * @param {boolean} [options.monitorCommands=false] Enable command monitoring for this client
  * @param {number} [options.minSize] If present, the connection pool will be initialized with minSize connections, and will never dip below minSize connections
  * @param {boolean} [options.useNewUrlParser=false] Determines whether or not to use the new url parser
+ * @param {string} [options.optionsValidationLevel] Sets the optionsValidationLevel for options validation: 'none', 'warn', or 'error'
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {MongoClient} a MongoClient instance
  */
@@ -124,7 +127,11 @@ function MongoClient(url, options) {
     options: options || {},
     promiseLibrary: null,
     dbCache: {},
-    sessions: []
+    sessions: [],
+    optionsValidationLevel:
+      options && options.optionsValidationLevel
+        ? options.optionsValidationLevel
+        : DEFAULT_VALIDATION_LEVEL
   };
 
   // Get the promiseLibrary

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -13,8 +13,6 @@ const connectOp = require('./operations/mongo_client_ops').connectOp;
 const logout = require('./operations/mongo_client_ops').logout;
 const validOptions = require('./operations/mongo_client_ops').validOptions;
 
-const DEFAULT_VALIDATION_LEVEL = 'warn';
-
 /**
  * @fileOverview The **MongoClient** class is a class that allows for making Connections to MongoDB.
  *
@@ -112,7 +110,7 @@ const DEFAULT_VALIDATION_LEVEL = 'warn';
  * @param {boolean} [options.monitorCommands=false] Enable command monitoring for this client
  * @param {number} [options.minSize] If present, the connection pool will be initialized with minSize connections, and will never dip below minSize connections
  * @param {boolean} [options.useNewUrlParser=false] Determines whether or not to use the new url parser
- * @param {string} [options.optionsValidationLevel] Sets the optionsValidationLevel for options validation: 'none', 'warn', or 'error'
+ * @param {string} [options.optionsValidationLevel] Sets the output level for options validation, one of: 'none', 'warn', or 'error'. The default is 'warn'.
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {MongoClient} a MongoClient instance
  */
@@ -127,11 +125,7 @@ function MongoClient(url, options) {
     options: options || {},
     promiseLibrary: null,
     dbCache: {},
-    sessions: [],
-    optionsValidationLevel:
-      options && options.optionsValidationLevel
-        ? options.optionsValidationLevel
-        : DEFAULT_VALIDATION_LEVEL
+    sessions: []
   };
 
   // Get the promiseLibrary
@@ -144,6 +138,16 @@ function MongoClient(url, options) {
     this.s.options.readPreference = resolveReadPreference(this.s.options);
   }
 }
+
+Object.defineProperty(MongoClient.prototype, 'optionsValidationLevel', {
+  enumerable: true,
+  get: function() {
+    if (this.s && this.s.options && this.s.options.optionsValidationLevel) {
+      return this.s.options.optionsValidationLevel;
+    }
+    return 'warn';
+  }
+});
 
 /**
  * @ignore

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -139,6 +139,11 @@ function MongoClient(url, options) {
   }
 }
 
+/**
+ * @ignore
+ */
+inherits(MongoClient, EventEmitter);
+
 Object.defineProperty(MongoClient.prototype, 'optionsValidationLevel', {
   enumerable: true,
   get: function() {
@@ -148,11 +153,6 @@ Object.defineProperty(MongoClient.prototype, 'optionsValidationLevel', {
     return 'warn';
   }
 });
-
-/**
- * @ignore
- */
-inherits(MongoClient, EventEmitter);
 
 /**
  * The callback format for results

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -102,7 +102,8 @@ const validOptionNames = [
   'monitorCommands',
   'retryWrites',
   'useNewUrlParser',
-  'useUnifiedTopology'
+  'useUnifiedTopology',
+  'optionsValidationLevel'
 ];
 
 function addListeners(mongoClient, topology) {

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -41,7 +41,7 @@ function assertArity(args, requiredArity) {
 /**
  * Validate all options passed into an operation by checking type, applying defaults, and checking deprecation.
  *
- * This function works by first setting the validationLevel to 'none', 'warn', or 'error' and setting a logger if one is provided.
+ * This function works by first setting the optionsValidationLevel to 'none', 'warn', or 'error' and setting a logger if one is provided.
  * It then makes a copy of the options provided by the user (providedOptions) and iterates through each option in optionsSchema.
  *
  * During this iteration, the following occurs:
@@ -65,7 +65,7 @@ function assertArity(args, requiredArity) {
  * @param {object} [overrideOptions] The values for options that will override any user-provided value, like { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) }.
  * @param {object} [validationOptions] Options for the validation itself.
  * @param {Logger} [validationOptions.logger] A logger instance to use if validation fails.
- * @param {string} [validationOptions.validationLevel] The level at which to validate the providedOptions ('none', 'warn', or 'error').
+ * @param {string} [validationOptions.optionsValidationLevel] The level at which to validate the providedOptions ('none', 'warn', or 'error').
  * @return {object} returns a frozen object of validated options
  */
 function validate(
@@ -75,7 +75,7 @@ function validate(
   overrideOptions,
   validationOptions
 ) {
-  let validationLevel = VALIDATION_LEVEL_WARN;
+  let optionsValidationLevel = VALIDATION_LEVEL_WARN;
   let logger;
 
   if (validationOptions == null) {
@@ -84,8 +84,8 @@ function validate(
   }
 
   if (validationOptions) {
-    if (validationOptions.validationLevel) {
-      validationLevel = validationOptions.validationLevel;
+    if (validationOptions.optionsValidationLevel) {
+      optionsValidationLevel = validationOptions.optionsValidationLevel;
     }
     if (validationOptions.logger) {
       logger = validationOptions.logger;
@@ -142,13 +142,13 @@ function validate(
       emitDeprecationWarning(deprecationMessage);
     }
 
-    if (validationLevel !== VALIDATION_LEVEL_NONE) {
+    if (optionsValidationLevel !== VALIDATION_LEVEL_NONE) {
       if (verifiedOptions[optionName] && optionFromSchema.type != null) {
         if (!checkType(optionFromSchema.type, verifiedOptions[optionName])) {
           const invalidateMessageType = `${optionName} should be of type ${
             optionFromSchema.type
           }, but is of type ${typeof verifiedOptions[optionName]}.`;
-          invalidate(validationLevel, invalidateMessageType, logger);
+          invalidate(optionsValidationLevel, invalidateMessageType, logger);
         }
       }
     }
@@ -180,21 +180,21 @@ function checkType(requiredType, providedValue) {
  * Warn or error if an option fails validation.
  *
  * @method
- * @param {string} validationLevel The level at which to validate the providedOptions ('warn' or 'error').
+ * @param {string} optionsValidationLevel The level at which to validate the providedOptions ('warn' or 'error').
  * @param {string} message The message to warn or error.
  * @param {Logger} [logger] A logger instance.
  */
-function invalidate(validationLevel, message, logger) {
+function invalidate(optionsValidationLevel, message, logger) {
   if (logger) {
-    if (validationLevel === VALIDATION_LEVEL_WARN) {
+    if (optionsValidationLevel === VALIDATION_LEVEL_WARN) {
       logger.warn(message);
-    } else if (validationLevel === VALIDATION_LEVEL_ERROR) {
+    } else if (optionsValidationLevel === VALIDATION_LEVEL_ERROR) {
       logger.error(message);
     }
   } else {
-    if (validationLevel === VALIDATION_LEVEL_WARN) {
+    if (optionsValidationLevel === VALIDATION_LEVEL_WARN) {
       console.warn(message);
-    } else if (validationLevel === VALIDATION_LEVEL_ERROR) {
+    } else if (optionsValidationLevel === VALIDATION_LEVEL_ERROR) {
       throw new Error(message);
     }
   }
@@ -250,9 +250,9 @@ class OperationBuilder {
 
       const args = Array.prototype.slice.call(arguments);
 
-      let validationOptions = { validationLevel: VALIDATION_LEVEL_WARN };
-      if (this.s && this.s.options && this.s.options.validationLevel) {
-        validationOptions = { validationLevel: this.s.options.validationLevel };
+      let validationOptions = { optionsValidationLevel: VALIDATION_LEVEL_WARN };
+      if (this.s && this.s.options && this.s.options.optionsValidationLevel) {
+        validationOptions = { optionsValidationLevel: this.s.options.optionsValidationLevel };
       }
 
       const callback =

--- a/test/functional/aggregation_tests.js
+++ b/test/functional/aggregation_tests.js
@@ -877,6 +877,7 @@ describe('Aggregation', function() {
     test: function(done) {
       var databaseName = this.configuration.db;
       var client = this.configuration.newClient(this.configuration.writeConcernMax(), {
+        optionsValidationLevel: 'error',
         poolSize: 1
       });
 

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -1870,4 +1870,37 @@ describe('Collection', function() {
       }
     });
   });
+
+  it('should inherit config options from MongoClient', {
+    metadata: { requires: { topology: 'single' } },
+    test: function() {
+      const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
+        optionsValidationLevel: 'error',
+        poolSize: 1
+      });
+
+      return client.connect().then(() => {
+        const db = client.db('inherit_test');
+        expect(db.optionsValidationLevel).to.equal('error');
+        const collection = db.collection('inheritTest');
+        expect(collection.optionsValidationLevel).to.equal('error');
+      });
+    }
+  });
+
+  it('should inherit config options from Db', {
+    metadata: { requires: { topology: 'single' } },
+    test: function() {
+      const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
+        poolSize: 1
+      });
+
+      return client.connect().then(() => {
+        const db = client.db('inherit_test', { optionsValidationLevel: 'error' });
+        expect(db.optionsValidationLevel).to.equal('error');
+        const collection = db.collection('inheritTest');
+        expect(collection.optionsValidationLevel).to.equal('error');
+      });
+    }
+  });
 });

--- a/test/functional/db_tests.js
+++ b/test/functional/db_tests.js
@@ -1,6 +1,8 @@
 'use strict';
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
+const chai = require('chai');
+const expect = chai.expect;
 
 describe('Db', function() {
   before(function() {
@@ -684,6 +686,21 @@ describe('Db', function() {
           done();
         });
         items.push(2);
+      });
+    }
+  });
+
+  it('should inherit config options from MongoClient', {
+    metadata: { requires: { topology: 'single' } },
+    test: function() {
+      const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
+        optionsValidationLevel: 'error',
+        poolSize: 1
+      });
+
+      return client.connect().then(() => {
+        const db = client.db('inherit_test');
+        expect(db.optionsValidationLevel).to.equal('error');
       });
     }
   });

--- a/test/functional/insert_tests.js
+++ b/test/functional/insert_tests.js
@@ -2893,7 +2893,10 @@ describe('Insert', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1,
+        optionsValidationLevel: 'error'
+      });
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
         expect(err).to.be.null;

--- a/test/unit/options_validator_tests.js
+++ b/test/unit/options_validator_tests.js
@@ -24,7 +24,7 @@ describe('Options Validation', function() {
       validationSchema,
       testObject,
       {},
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
 
     expect(validatedObject).to.deep.equal({ a: 1 });
@@ -40,7 +40,7 @@ describe('Options Validation', function() {
       validationSchema,
       testObject,
       {},
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
 
     expect(validatedObject).to.deep.equal(testObject);
@@ -56,7 +56,7 @@ describe('Options Validation', function() {
       validationSchema,
       testObject1,
       {},
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
 
     expect(validatedObject1).to.deep.equal(testObject1);
@@ -66,7 +66,7 @@ describe('Options Validation', function() {
       validationSchema,
       testObject2,
       {},
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
 
     expect(validatedObject2).to.deep.equal(testObject2);
@@ -84,7 +84,7 @@ describe('Options Validation', function() {
       validationSchema,
       testObject,
       {},
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
 
     expect(validatedObject).to.deep.equal(testObject);
@@ -100,13 +100,13 @@ describe('Options Validation', function() {
       validationSchema,
       testObject,
       {},
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
 
     expect(validatedObject).to.deep.equal(testObject);
   });
 
-  it('Should use default validationLevel', function() {
+  it('Should use default optionsValidationLevel', function() {
     const validationSchema = {
       a: { type: 'boolean' }
     };
@@ -117,18 +117,23 @@ describe('Options Validation', function() {
     expect(validatedObject).to.deep.equal(testObject);
   });
 
-  it('Should skip validation if validationLevel is none', function() {
+  it('Should skip validation if optionsValidationLevel is none', function() {
     const validationSchema = {
       a: { type: 'boolean' }
     };
 
     const testObject = { a: 45 };
-    const validatedObject = validate(validationSchema, testObject, {}, { validationLevel: 'none' });
+    const validatedObject = validate(
+      validationSchema,
+      testObject,
+      {},
+      { optionsValidationLevel: 'none' }
+    );
 
     expect(validatedObject).to.deep.equal(testObject);
   });
 
-  it('Should set defaults, set overrides, and emit deprecation notices if validationLevel is none', function() {
+  it('Should set defaults, set overrides, and emit deprecation notices if optionsValidationLevel is none', function() {
     const stub = process.emitWarning
       ? sinon.stub(process, 'emitWarning')
       : sinon.stub(console, 'error');
@@ -147,7 +152,7 @@ describe('Options Validation', function() {
       testObject,
       { d: 2 },
       { e: 0 },
-      { validationLevel: 'none' }
+      { optionsValidationLevel: 'none' }
     );
 
     expect(stub).to.have.been.calledOnce;
@@ -164,24 +169,29 @@ describe('Options Validation', function() {
 
     const testObject = {};
     expect(() => {
-      validate(validationSchema, testObject, {}, { validationLevel: 'none' });
+      validate(validationSchema, testObject, {}, { optionsValidationLevel: 'none' });
     }).to.throw('required option [a] was not found.');
     expect(() => {
-      validate(validationSchema, testObject, {}, { validationLevel: 'warn' });
+      validate(validationSchema, testObject, {}, { optionsValidationLevel: 'warn' });
     }).to.throw('required option [a] was not found.');
     expect(() => {
-      validate(validationSchema, testObject, {}, { validationLevel: 'error' });
+      validate(validationSchema, testObject, {}, { optionsValidationLevel: 'error' });
     }).to.throw('required option [a] was not found.');
   });
 
-  it('Should warn if validationLevel is warn', function() {
+  it('Should warn if optionsValidationLevel is warn', function() {
     const stub = sinon.stub(console, 'warn');
     const validationSchema = {
       a: { type: 'boolean' }
     };
 
     const testObject = { a: 45 };
-    const validatedObject = validate(validationSchema, testObject, {}, { validationLevel: 'warn' });
+    const validatedObject = validate(
+      validationSchema,
+      testObject,
+      {},
+      { optionsValidationLevel: 'warn' }
+    );
 
     expect(stub).to.have.been.calledOnce;
     expect(stub).to.have.been.calledWith('a should be of type boolean, but is of type number.');
@@ -190,7 +200,7 @@ describe('Options Validation', function() {
     console.warn.restore();
   });
 
-  it('Should error if validationLevel is error', function() {
+  it('Should error if optionsValidationLevel is error', function() {
     const validationSchema = {
       a: { type: 'boolean' }
     };
@@ -201,7 +211,7 @@ describe('Options Validation', function() {
         validationSchema,
         testObject,
         {},
-        { validationLevel: 'error' }
+        { optionsValidationLevel: 'error' }
       );
       expect(validatedObject).to.deep.equal(testObject);
     } catch (err) {
@@ -220,7 +230,7 @@ describe('Options Validation', function() {
       validationSchema,
       testObject,
       {},
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
 
     expect(validatedObject).to.deep.equal(testObject);
@@ -238,7 +248,7 @@ describe('Options Validation', function() {
         validationSchema,
         testObject,
         {},
-        { validationLevel: testValidationLevel }
+        { optionsValidationLevel: testValidationLevel }
       );
       expect(validatedObject).to.deep.equal(testObject);
     } catch (err) {
@@ -258,7 +268,7 @@ describe('Options Validation', function() {
       validationSchema,
       testObject,
       {},
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
     expect(validatedObject.a).to.equal(true);
     expect(validatedObject.b).to.equal(3);
@@ -279,7 +289,7 @@ describe('Options Validation', function() {
       validationSchema,
       testObject,
       {},
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
     expect(stub).to.have.been.calledOnce;
     expect(stub).to.have.been.calledWith(
@@ -309,7 +319,7 @@ describe('Options Validation', function() {
       testObject,
       {},
       { a: customObject.a, b: customObject.b },
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
 
     expect(validatedObject).to.deep.equal({ a: 'custom', b: 'override' });
@@ -319,7 +329,7 @@ describe('Options Validation', function() {
       testObject,
       {},
       { a: customObject.a, b: customObject.b },
-      { validationLevel: 'none' }
+      { optionsValidationLevel: 'none' }
     );
 
     expect(validatedObject2).to.deep.equal({ a: 'custom', b: 'override' });
@@ -340,7 +350,7 @@ describe('Options Validation', function() {
       testObject,
       {},
       { a: customObject.a },
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
 
     expect(validatedObject).to.deep.equal({ a: 'custom' });
@@ -363,7 +373,7 @@ describe('Options Validation', function() {
       testObject,
       {},
       { a: customObject.a },
-      { validationLevel: testValidationLevel }
+      { optionsValidationLevel: testValidationLevel }
     );
 
     expect(stub).have.been.calledOnce;
@@ -448,7 +458,7 @@ describe('Options Validation', function() {
   it('Should validate options using OperationBuilder', function() {
     class TestClass {
       constructor() {
-        this.s = { options: { validationLevel: 'error' } };
+        this.s = { options: { optionsValidationLevel: 'error' } };
       }
     }
 
@@ -472,7 +482,7 @@ describe('Options Validation', function() {
   it('Should override options using OperationBuilder', function() {
     class TestClass {
       constructor() {
-        this.s = { options: { validationLevel: 'error' } };
+        this.s = { options: { optionsValidationLevel: 'error' } };
       }
     }
 
@@ -501,7 +511,7 @@ describe('Options Validation', function() {
   it('Should properly validate when no options are provided', function() {
     class TestClass {
       constructor() {
-        this.s = { options: { validationLevel: 'error' } };
+        this.s = { options: { optionsValidationLevel: 'error' } };
       }
     }
 
@@ -528,7 +538,7 @@ describe('Options Validation', function() {
   it('Should fail with an object in the options position', function() {
     class TestClass {
       constructor() {
-        this.s = { options: { validationLevel: 'error' } };
+        this.s = { options: { optionsValidationLevel: 'error' } };
       }
     }
 
@@ -548,7 +558,7 @@ describe('Options Validation', function() {
   it('Should correctly handle a promise', function() {
     class TestClass {
       constructor() {
-        this.s = { options: { validationLevel: 'error' } };
+        this.s = { options: { optionsValidationLevel: 'error' } };
       }
     }
 
@@ -584,7 +594,7 @@ describe('Options Validation', function() {
   it('Should allow a boolean default', function() {
     class TestClass {
       constructor() {
-        this.s = { options: { validationLevel: 'error' } };
+        this.s = { options: { optionsValidationLevel: 'error' } };
       }
     }
 


### PR DESCRIPTION
Fixes [NODE-1733](https://jira.mongodb.org/browse/NODE-1733)

I also changed `validationLevel` to `optionsValidationLevel` because `validationLevel` is a Mongo option for `createCollection`.