### PR TITLE
fix(options_validator): warn on unknown options and use hasOwnProperty for type check

### DIFF
--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -94,6 +94,13 @@ function validate(
 
   const verifiedOptions = Object.assign({}, providedOptions);
 
+  const optionSchemaNames = Object.keys(optionsSchema);
+  Object.keys(verifiedOptions).forEach(providedOption => {
+    if (optionSchemaNames.indexOf(providedOption) === -1) {
+      console.warn(`provided option [${providedOption}] is an unknown option`);
+    }
+  });
+
   Object.keys(optionsSchema).forEach(optionName => {
     const optionFromSchema = optionsSchema[optionName];
 
@@ -143,9 +150,9 @@ function validate(
     }
 
     if (optionsValidationLevel !== VALIDATION_LEVEL_NONE) {
-      if (verifiedOptions[optionName] && optionFromSchema.type != null) {
+      if (verifiedOptions.hasOwnProperty(optionName) && optionFromSchema.type != null) {
         if (!checkType(optionFromSchema.type, verifiedOptions[optionName])) {
-          const invalidateMessageType = `${optionName} should be of type ${
+          const invalidateMessageType = `option [${optionName}] should be of type ${
             optionFromSchema.type
           }, but is of type ${typeof verifiedOptions[optionName]}.`;
           invalidate(optionsValidationLevel, invalidateMessageType, logger);

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -165,6 +165,9 @@ function validate(
 }
 
 function checkType(requiredType, providedValue) {
+  if (typeof providedValue === 'undefined') {
+    return true;
+  }
   if (typeof requiredType === 'string') {
     if (requiredType === 'object') {
       return isObject(providedValue);

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -165,7 +165,7 @@ function validate(
 }
 
 function checkType(requiredType, providedValue) {
-  if (typeof providedValue === 'undefined') {
+  if (providedValue == null) {
     return true;
   }
   if (typeof requiredType === 'string') {

--- a/test/functional/insert_tests.js
+++ b/test/functional/insert_tests.js
@@ -2907,7 +2907,7 @@ describe('Insert', function() {
         } catch (err) {
           expect(err).to.not.be.null;
           expect(err.message).to.equal(
-            'forceServerObjectId should be of type boolean, but is of type number.'
+            'option [forceServerObjectId] should be of type boolean, but is of type number.'
           );
         }
         client.close();

--- a/test/unit/options_validator_tests.js
+++ b/test/unit/options_validator_tests.js
@@ -90,7 +90,9 @@ describe('Options Validation', function() {
     expect(validatedObject).to.deep.equal(testObject);
   });
 
-  it('Should ignore fields not in schema', function() {
+  it('Should warn for fields not in schema', function() {
+    const stub = sinon.stub(console, 'warn');
+
     const validationSchema = {
       a: { type: 'boolean' }
     };
@@ -103,18 +105,30 @@ describe('Options Validation', function() {
       { optionsValidationLevel: testValidationLevel }
     );
 
+    expect(stub).to.have.been.calledOnce;
+    expect(stub).to.have.been.calledWith('provided option [b] is an unknown option');
     expect(validatedObject).to.deep.equal(testObject);
+
+    console.warn.restore();
   });
 
   it('Should use default optionsValidationLevel', function() {
+    const stub = sinon.stub(console, 'warn');
+
     const validationSchema = {
       a: { type: 'boolean' }
     };
 
-    const testObject = { b: 1 };
+    const testObject = { a: 1 };
     const validatedObject = validate(validationSchema, testObject, {});
 
+    expect(stub).to.have.been.calledOnce;
+    expect(stub).to.have.been.calledWith(
+      'option [a] should be of type boolean, but is of type number.'
+    );
     expect(validatedObject).to.deep.equal(testObject);
+
+    console.warn.restore();
   });
 
   it('Should skip validation if optionsValidationLevel is none', function() {
@@ -194,7 +208,9 @@ describe('Options Validation', function() {
     );
 
     expect(stub).to.have.been.calledOnce;
-    expect(stub).to.have.been.calledWith('a should be of type boolean, but is of type number.');
+    expect(stub).to.have.been.calledWith(
+      'option [a] should be of type boolean, but is of type number.'
+    );
     expect(validatedObject).to.deep.equal(testObject);
 
     console.warn.restore();
@@ -216,7 +232,7 @@ describe('Options Validation', function() {
       expect(validatedObject).to.deep.equal(testObject);
     } catch (err) {
       expect(err).to.not.be.null;
-      expect(err.message).to.equal('a should be of type boolean, but is of type number.');
+      expect(err.message).to.equal('option [a] should be of type boolean, but is of type number.');
     }
   });
 
@@ -607,5 +623,26 @@ describe('Options Validation', function() {
     const testClass = new TestClass();
     const testResult = testClass.testOperation();
     expect(testResult).to.deep.equal({ a: false });
+  });
+
+  it('Should warn on unknown option', function() {
+    const stub = sinon.stub(console, 'warn');
+    const validationSchema = {
+      a: { type: 'boolean' }
+    };
+
+    const testObject = { a: true, b: 45 };
+    const validatedObject = validate(
+      validationSchema,
+      testObject,
+      {},
+      { optionsValidationLevel: 'warn' }
+    );
+
+    expect(stub).to.have.been.calledOnce;
+    expect(stub).to.have.been.calledWith('provided option [b] is an unknown option');
+    expect(validatedObject).to.deep.equal(testObject);
+
+    console.warn.restore();
   });
 });


### PR DESCRIPTION
Fixes [NODE-1381](https://jira.mongodb.org/browse/NODE-1381)

This PR adds warning for unknown options so we will probably see lots of unknown options being logged in tests due to some operations calling other operations, which causes options validation to be performed twice. I'm currently working on removing as much of that as possible.

The other main change in this PR is using `hasOwnProperty` to check for options that need to be type-checked. This was a bug with the original implementation that I just discovered so we may see some warnings in the tests about options that are the wrong type, especially options that are inherited like `readConcern: this.s.readConcern`, which may be `undefined`.