### PR TITLE
fix(connect): add condition for close topology if it is available

### DIFF
--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -413,7 +413,7 @@ function createTopology(mongoClient, topologyType, options, callback) {
   // Open the connection
   topology.connect(options, (err, newTopology) => {
     if (err) {
-      topology.close(true);
+      if (topology) topology.close();
       return callback(err);
     }
 


### PR DESCRIPTION
Added fix for correctly closing topology instance on the callback.

For instance, if call the method `connect` in the file _"mongodb/lib/topologies/mongos.js"_,
the other method `connectErrorHandler` won't return the callback correctly.