### PR TITLE
initializeUnorderedBulkOp to honor ignoreUndefined

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2052,6 +2052,9 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
  */
 Collection.prototype.initializeUnorderedBulkOp = function(options) {
   options = options || {};
+  if (this.s.options.ignoreUndefined) {
+      options.ignoreUndefined = this.s.options.ignoreUndefined;
+  }
   options.promiseLibrary = this.s.promiseLibrary;
   return unordered(this.s.topology, this, options);
 };

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2047,7 +2047,7 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {UnorderedBulkOperation}
  */
@@ -2069,7 +2069,7 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
  * @param {ClientSession} [options.session] optional session to use for this operation
- * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {OrderedBulkOperation} callback The command result callback
  * @return {null}
  */

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2053,7 +2053,7 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
 Collection.prototype.initializeUnorderedBulkOp = function(options) {
   options = options || {};
   if (this.s.options.ignoreUndefined) {
-      options.ignoreUndefined = this.s.options.ignoreUndefined;
+    options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
   options.promiseLibrary = this.s.promiseLibrary;
   return unordered(this.s.topology, this, options);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2047,6 +2047,7 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {UnorderedBulkOperation}
  */
@@ -2068,11 +2069,15 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {OrderedBulkOperation} callback The command result callback
  * @return {null}
  */
 Collection.prototype.initializeOrderedBulkOp = function(options) {
   options = options || {};
+  if (this.s.options.ignoreUndefined) {
+    options.ignoreUndefined = this.s.options.ignoreUndefined;
+  }
   options.promiseLibrary = this.s.promiseLibrary;
   return ordered(this.s.topology, this, options);
 };

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2053,9 +2053,11 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
  */
 Collection.prototype.initializeUnorderedBulkOp = function(options) {
   options = options || {};
-  if (this.s.options.ignoreUndefined) {
+  // Give function's options precedence over session options.
+  if (options.ignoreUndefined == null) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
+
   options.promiseLibrary = this.s.promiseLibrary;
   return unordered(this.s.topology, this, options);
 };
@@ -2075,7 +2077,8 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
  */
 Collection.prototype.initializeOrderedBulkOp = function(options) {
   options = options || {};
-  if (this.s.options.ignoreUndefined) {
+  // Give function's options precedence over session's options.
+  if (options.ignoreUndefined == null) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
   options.promiseLibrary = this.s.promiseLibrary;


### PR DESCRIPTION
All write operations (insertOne,update,updateMany etc...). honor the ignoreUndefined flag defined in the collection scope. Apparently UnorderedBulkOp was left out. This fixes it, makes UnorderedBulkOp honor the flag.