### PR TITLE
Lazy load cursor in cursor_ops.

### DIFF
--- a/lib/operations/cursor_ops.js
+++ b/lib/operations/cursor_ops.js
@@ -6,6 +6,9 @@ const handleCallback = require('../utils').handleCallback;
 const MongoError = require('mongodb-core').MongoError;
 const push = Array.prototype.push;
 
+// lazy loading of Cursor
+let Cursor = null;
+
 /**
  * Get the count of documents for this cursor.
  *
@@ -74,7 +77,9 @@ function count(cursor, applySkipLimit, opts, callback) {
  * @param {Cursor~resultCallback} callback The result callback.
  */
 function each(cursor, callback) {
-  const Cursor = require('../cursor');
+  if (Cursor === null) {
+    Cursor = require('../cursor');
+  }
 
   if (!callback) throw MongoError.create({ message: 'callback is mandatory', driver: true });
   if (cursor.isNotified()) return;
@@ -114,7 +119,9 @@ function each(cursor, callback) {
  * @param {Cursor~resultCallback} [callback] The result callback.
  */
 function hasNext(cursor, callback) {
-  const Cursor = require('../cursor');
+  if (Cursor === null) {
+    Cursor = require('../cursor');
+  }
 
   if (cursor.s.currentDoc) {
     return callback(null, true);
@@ -165,7 +172,9 @@ function next(cursor, callback) {
 
 // Get the next available document from the cursor, returns null if no more documents are available.
 function nextObject(cursor, callback) {
-  const Cursor = require('../cursor');
+  if (Cursor === null) {
+    Cursor = require('../cursor');
+  }
 
   if (cursor.s.state === Cursor.CLOSED || (cursor.isDead && cursor.isDead()))
     return handleCallback(
@@ -196,7 +205,9 @@ function nextObject(cursor, callback) {
  * @param {Cursor~toArrayResultCallback} [callback] The result callback.
  */
 function toArray(cursor, callback) {
-  const Cursor = require('../cursor');
+  if (Cursor === null) {
+    Cursor = require('../cursor');
+  }
 
   const items = [];
 


### PR DESCRIPTION
Calling require in a hot path is typically a bottleneck.

Here is a flamegraph without this patch: https://upload.clinicjs.org/public/1662f151d0c5fe1f92d8457f0055515abb29074724f1728cf9b80f25331ab324/40058.clinic-flame.html.

Note that `normalizePath` is the only part of `require()` that is not getting inlined.

---

An alternative approach of this PR would be to load `Cursor` at the top. I kept the lazy-loading, as I though it was there for a reason.