### PR TITLE
NODE-1778: fix batch-size calculations

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -695,10 +695,16 @@ class BulkOperationBase {
     // Handle to the bson serializer, used to calculate running sizes
     const bson = topology.bson;
 
+    // Reserved Command Buffer Bytes
+    const reservedCommandBufferBytes = 256;
+
     // Set max byte size
     const isMaster = topology.lastIsMaster();
-    const maxBatchSizeBytes =
+    let maxBatchSizeBytes =
       isMaster && isMaster.maxBsonObjectSize ? isMaster.maxBsonObjectSize : 1024 * 1024 * 16;
+    if (maxBatchSizeBytes > reservedCommandBufferBytes) {
+      maxBatchSizeBytes = maxBatchSizeBytes - reservedCommandBufferBytes;
+    }
     const maxWriteBatchSize =
       isMaster && isMaster.maxWriteBatchSize ? isMaster.maxWriteBatchSize : 1000;
 

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -83,6 +83,10 @@ function addToOperationsList(bulkOperation, docType, document) {
   bulkOperation.s.currentBatch.size = bulkOperation.s.currentBatch.size + 1;
   bulkOperation.s.currentBatch.sizeBytes = bulkOperation.s.currentBatch.sizeBytes + bsonSize;
 
+  // Consider the bytes of array indexes
+  bulkOperation.s.currentBatch.sizeBytes +=
+    ('' + (bulkOperation.s.currentBatch.size - 1)).length + 2;
+
   // Return bulkOperation
   return bulkOperation;
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/NODE-1778
BSON parser treats array indexes as strings, see BSON parser: https://github.com/mongodb/js-bson/blob/v1.1.0/lib/bson/parser/serializer.js#L699, a batch is an array whose indexes bytes needs to be accumulated.