### PR TITLE
fix(collection): add support for `readConcern` on every eligible operation

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -285,6 +285,7 @@ const DEPRECATED_FIND_OPTIONS = ['maxScan', 'fields', 'snapshot'];
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {boolean} [options.awaitData] Sets the cursor to block and await data for a while rather than returning no data
+ * @param {object} [options.readConcern] Specify a read concern for the operation. (only MongoDB 3.2 or higher supported)
  * @throws {MongoError}
  * @return {Cursor}
  */
@@ -321,7 +322,8 @@ const findSchema = {
   awaitData: { type: 'boolean' },
   noCursorTimeout: { type: 'boolean', overrideOnly: true },
   ignoreUndefined: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true }
+  optionsValidationLevel: { overrideOnly: true },
+  readConcern: { type: 'object' }
 };
 Collection.prototype.find = deprecateOptions(
   {
@@ -1709,11 +1711,13 @@ Collection.prototype.count = deprecate(function(query, options, callback) {
  * @method
  * @param {object} [options] Optional settings.
  * @param {number} [options.maxTimeMS] The maximum amount of time to allow the operation to run.
+ * @param {object} [options.readConcern] Specify a read concern for the operation. (only MongoDB 3.2 or higher supported)
  * @param {Collection~countCallback} [callback] The command result callback.
  * @return {Promise} returns Promise if no callback passed.
  */
 const estimatedDocumentCountSchema = {
-  maxTimeMS: { type: 'number' }
+  maxTimeMS: { type: 'number' },
+  readConcern: { type: 'object' }
 };
 Collection.prototype.estimatedDocumentCount = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -1752,6 +1756,7 @@ Collection.prototype.estimatedDocumentCount = function(options, callback) {
  * @param {number} [options.limit] The maximum number of document to count.
  * @param {number} [options.maxTimeMS] The maximum amount of time to allow the operation to run.
  * @param {number} [options.skip] The number of documents to skip before counting.
+ * @param {object} [options.readConcern] Specify a read concern for the operation. (only MongoDB 3.2 or higher supported)
  * @param {Collection~countCallback} [callback] The command result callback.
  * @return {Promise} returns Promise if no callback passed.
  * @see https://docs.mongodb.com/manual/reference/operator/query/expr/
@@ -1764,7 +1769,8 @@ const countDocumentsSchema = {
   hint: { type: ['string', 'object'] },
   limit: { type: 'number' },
   maxTimeMS: { type: 'number' },
-  skip: { type: 'number' }
+  skip: { type: 'number' },
+  readConcern: { type: 'object' }
 };
 Collection.prototype.countDocuments = function(query, options, callback) {
   const args = Array.prototype.slice.call(arguments, 0);
@@ -1792,6 +1798,7 @@ Collection.prototype.countDocuments = function(query, options, callback) {
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  * @param {number} [options.maxTimeMS] Number of milliseconds to wait before aborting the query.
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {object} [options.readConcern] Specify a read concern for the operation. (only MongoDB 3.2 or higher supported)
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
@@ -1799,7 +1806,8 @@ const distinctSchema = {
   collation: { type: 'object' },
   readPreference: { type: [ReadPreference, 'string', 'object'] },
   maxTimeMS: { type: 'number' },
-  session: { type: ClientSession }
+  session: { type: ClientSession },
+  readConcern: { type: 'object' }
 };
 Collection.prototype.distinct = function(key, query, options, callback) {
   const args = Array.prototype.slice.call(arguments, 1);
@@ -2220,6 +2228,7 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
  * @param {string} [options.comment] Add a comment to an aggregation command
  * @param {object|string} [options.hint] Tell the query to use specific indexes in the query. Object of indexes to use, {'_id':1}
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {object} [options.readConcern] Specify a read concern for the operation. (only MongoDB 3.2 or higher supported)
  * @param {Collection~aggregationCallback} callback The command result callback
  * @return {(null|AggregationCursor)}
  */
@@ -2241,7 +2250,8 @@ const aggregateSchema = {
   session: { type: ClientSession },
   promiseLibrary: { type: 'function', overrideOnly: true },
   cursorFactory: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true }
+  optionsValidationLevel: { overrideOnly: true },
+  readConcern: { type: 'object' }
 };
 Collection.prototype.aggregate = function(pipeline, options, callback) {
   if (Array.isArray(pipeline)) {
@@ -2439,6 +2449,7 @@ Collection.prototype.watch = function(pipeline, options) {
  * @param {number} [options.batchSize] Set the batchSize for the getMoreCommand when iterating over the query results.
  * @param {number} [options.numCursors=1] The maximum number of parallel command cursors to return (the number of returned cursors will be in the range 1:numCursors)
  * @param {boolean} [options.raw=false] Return all BSON documents as Raw Buffer documents.
+ * @param {object} [options.readConcern] Specify a read concern for the operation. (only MongoDB 3.2 or higher supported)
  * @param {Collection~parallelCollectionScanCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
@@ -2449,7 +2460,8 @@ const parallelCollectionScanSchema = {
   raw: { type: 'boolean', default: false },
   promiseLibrary: { overrideOnly: true },
   session: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true }
+  optionsValidationLevel: { overrideOnly: true },
+  readConcern: { type: 'object' }
 };
 Collection.prototype.parallelCollectionScan = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = { numCursors: 1 });
@@ -2484,6 +2496,7 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
  * @param {object} [options.search] Filter the results by a query.
  * @param {number} [options.limit] Max number of results to return.
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {object} [options.readConcern] Specify a read concern for the operation. (only MongoDB 3.2 or higher supported)
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
@@ -2492,7 +2505,8 @@ const geoHaystackSearchSchema = {
   maxDistance: { type: 'number' },
   search: { type: 'object' },
   limit: { type: 'number' },
-  session: { type: ClientSession }
+  session: { type: ClientSession },
+  readConcern: { type: 'object' }
 };
 Collection.prototype.geoHaystackSearch = function(x, y, options, callback) {
   const args = Array.prototype.slice.call(arguments, 2);
@@ -2604,6 +2618,7 @@ Collection.prototype.group = deprecate(function(
  * @param {boolean} [options.verbose] Provide statistics on job execution time.
  * @param {boolean} [options.bypassDocumentValidation] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {object} [options.readConcern] Specify a read concern for the operation. (only MongoDB 3.2 or higher supported)
  * @param {Collection~resultCallback} [callback] The command result callback
  * @throws {MongoError}
  * @return {Promise} returns Promise if no callback passed
@@ -2621,7 +2636,8 @@ const mapReduceSchema = {
   jsMode: { type: 'boolean' },
   verbose: { type: 'boolean' },
   bypassDocumentValidation: { type: 'boolean' },
-  session: { type: ClientSession }
+  session: { type: ClientSession },
+  readConcern: { type: 'object' }
 };
 Collection.prototype.mapReduce = function(map, reduce, options, callback) {
   if ('function' === typeof options) (callback = options), (options = {});

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -181,6 +181,8 @@ function count(coll, query, options, callback) {
     return callback(err);
   }
 
+  decorateWithReadConcern(cmd, coll, options);
+
   executeCommand(coll.s.db, cmd, options, (err, result) => {
     if (err) return handleCallback(callback, err);
     handleCallback(callback, null, result.n);
@@ -207,6 +209,8 @@ function countDocuments(coll, query, options, callback) {
 
   delete options.limit;
   delete options.skip;
+
+  decorateWithReadConcern(options, coll, options);
 
   coll.aggregate(pipeline, options).toArray((err, docs) => {
     if (err) return handleCallback(callback, err);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -608,7 +608,10 @@ function decorateWithCollation(command, target, options) {
  * @param {Collection} coll the parent collection of the operation calling this method
  */
 function decorateWithReadConcern(command, coll, options) {
-  let readConcern = Object.assign({}, command.readConcern || (options ? options.readConcern : {}));
+  let readConcern = Object.assign(
+    {},
+    command.readConcern || (options ? options.readConcern : undefined)
+  );
   if (coll.s.readConcern) {
     Object.assign(readConcern, coll.s.readConcern);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -607,8 +607,8 @@ function decorateWithCollation(command, target, options) {
  * @param {object} command the command on which to apply the read concern
  * @param {Collection} coll the parent collection of the operation calling this method
  */
-function decorateWithReadConcern(command, coll) {
-  let readConcern = Object.assign({}, command.readConcern || {});
+function decorateWithReadConcern(command, coll, options) {
+  let readConcern = Object.assign({}, command.readConcern || (options ? options.readConcern : {}));
   if (coll.s.readConcern) {
     Object.assign(readConcern, coll.s.readConcern);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -606,6 +606,7 @@ function decorateWithCollation(command, target, options) {
  *
  * @param {object} command the command on which to apply the read concern
  * @param {Collection} coll the parent collection of the operation calling this method
+ * @param {object} [options] options the object passed by the operation, which contains the readConcern option
  */
 function decorateWithReadConcern(command, coll, options) {
   let readConcern = Object.assign(

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -444,6 +444,55 @@ describe('ReadConcern', function() {
     }
   });
 
+  it('Should set majority readConcern option for aggregate command', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
+
+    test: function(done) {
+      const listener = require('../..').instrument(function(err) {
+        expect(err).to.be.null;
+      });
+
+      // Contains all the apm events
+      const started = [];
+      const succeeded = [];
+      // Get a new instance
+      const configuration = this.configuration;
+      const client = configuration.newClient({ w: 1 }, { poolSize: 1 });
+
+      client.connect(function(err, client) {
+        expect(err).to.be.null;
+
+        const db = client.db(configuration.db);
+
+        // Get a collection
+        const collection = db.collection('readConcernCollectionAggregate');
+
+        // Listen to apm events
+        listener.on('started', function(event) {
+          if (event.commandName === 'aggregate') started.push(event);
+        });
+        listener.on('succeeded', function(event) {
+          if (event.commandName === 'aggregate') succeeded.push(event);
+        });
+
+        // Execute find
+        collection
+          .aggregate([{ $match: {} }], { readConcern: { level: 'majority' } })
+          .toArray(function(err) {
+            expect(err).to.be.null;
+            expect(started.length).to.equal(1);
+            expect(started[0].commandName).to.equal('aggregate');
+            expect(succeeded[0].commandName).to.equal('aggregate');
+            expect(started[0].command.readConcern).to.deep.equal({ level: 'majority' });
+
+            listener.uninstrument();
+            client.close();
+            done();
+          });
+      });
+    }
+  });
+
   it('Should set majority readConcern aggregate command but ignore due to out', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
 
@@ -500,6 +549,73 @@ describe('ReadConcern', function() {
                 test.equal('aggregate', started[1].commandName);
                 test.equal('aggregate', succeeded[1].commandName);
                 test.equal(undefined, started[1].command.readConcern);
+
+                listener.uninstrument();
+                client.close();
+                done();
+              });
+          });
+      });
+    }
+  });
+
+  it('Should set majority readConcern option for aggregate command but ignore due to out', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
+
+    test: function(done) {
+      const listener = require('../..').instrument(function(err) {
+        expect(err).to.be.null;
+      });
+
+      // Contains all the apm events
+      const started = [];
+      const succeeded = [];
+      // Get a new instance
+      const configuration = this.configuration;
+      const client = configuration.newClient({ w: 1 }, { poolSize: 1 });
+
+      client.connect(function(err, client) {
+        expect(err).to.be.null;
+
+        const db = client.db(configuration.db);
+
+        // Get a collection
+        const collection = db.collection('readConcernCollectionAggregate1');
+        // Validate readConcern
+
+        // Listen to apm events
+        listener.on('started', function(event) {
+          if (event.commandName === 'aggregate') started.push(event);
+        });
+        listener.on('succeeded', function(event) {
+          if (event.commandName === 'aggregate') succeeded.push(event);
+        });
+
+        // Execute find
+        collection
+          .aggregate([{ $match: {} }, { $out: 'readConcernCollectionAggregate1Output' }], {
+            readConcern: { level: 'majority' }
+          })
+          .toArray(function(err) {
+            expect(err).to.be.null;
+            expect(started.length).to.equal(1);
+            expect(started[0].commandName).to.equal('aggregate');
+            expect(succeeded[0].commandName).to.equal('aggregate');
+            expect(started[0].command.readConcern).to.deep.equal(undefined);
+
+            // Execute find
+            collection
+              .aggregate(
+                [{ $match: {} }],
+                { out: 'readConcernCollectionAggregate2Output' },
+                { readConcern: { level: 'majority' } }
+              )
+              .toArray(function(err) {
+                expect(err).to.be.null;
+                expect(started.length).to.equal(2);
+                expect(started[1].commandName).to.equal('aggregate');
+                expect(succeeded[1].commandName).to.equal('aggregate');
+                expect(started[1].command.readConcern).to.equal(undefined);
 
                 listener.uninstrument();
                 client.close();
@@ -574,6 +690,70 @@ describe('ReadConcern', function() {
     }
   });
 
+  // NOTE: skip until NODE-1804 is resolved
+  it.skip('Should set majority readConcern option for mapReduce command but be ignored', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
+
+    test: function(done) {
+      const listener = require('../..').instrument(function(err) {
+        expect(err).to.be.null;
+      });
+
+      // Contains all the apm events
+      const started = [];
+      const succeeded = [];
+      // Get a new instance
+      const configuration = this.configuration;
+      const client = configuration.newClient({ w: 1 }, { poolSize: 1 });
+
+      client.connect(function(err, client) {
+        expect(err).to.be.null;
+
+        const db = client.db(configuration.db);
+
+        // Get the collection
+        const collection = db.collection('test_map_reduce_read_concern');
+        collection.insert(
+          [{ user_id: 1 }, { user_id: 2 }],
+          configuration.writeConcernMax(),
+          function(err) {
+            expect(err).to.be.null;
+            // String functions
+            const map = 'function() { emit(this.user_id, 1); }';
+            const reduce = 'function(k,vals) { return 1; }';
+
+            // Listen to apm events
+            listener.on('started', function(event) {
+              if (event.commandName === 'mapreduce') started.push(event);
+            });
+            listener.on('succeeded', function(event) {
+              if (event.commandName === 'mapreduce') succeeded.push(event);
+            });
+
+            // Execute mapReduce
+            collection.mapReduce(
+              map,
+              reduce,
+              { out: { replace: 'tempCollection' }, readConcern: { level: 'majority' } },
+              function(err) {
+                expect(err).to.be.null;
+                expect(err).to.be.null;
+                expect(started.length).to.equal(1);
+                expect(started[0].commandName).to.equal('mapreduce');
+                expect(succeeded[0].commandName).to.equal('mapreduce');
+                expect(started[0].command.readConcern).to.deep.equal(undefined);
+
+                listener.uninstrument();
+                client.close();
+                done();
+              }
+            );
+          }
+        );
+      });
+    }
+  });
+
   it('Should set majority readConcern distinct command', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
 
@@ -641,6 +821,69 @@ describe('ReadConcern', function() {
     }
   });
 
+  it('Should set majority readConcern option for distinct command', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
+
+    test: function(done) {
+      const listener = require('../..').instrument(function(err) {
+        expect(err).to.be.null;
+      });
+
+      // Contains all the apm events
+      const started = [];
+      const succeeded = [];
+      // Get a new instance
+      const configuration = this.configuration;
+      const client = configuration.newClient({ w: 1 }, { poolSize: 1 });
+
+      client.connect(function(err, client) {
+        expect(err).to.be.null;
+
+        const db = client.db(configuration.db);
+
+        // Get the collection
+        const collection = db.collection('test_distinct_read_concern');
+        // Insert documents to perform distinct against
+        collection.insertMany(
+          [
+            { a: 0, b: { c: 'a' } },
+            { a: 1, b: { c: 'b' } },
+            { a: 1, b: { c: 'c' } },
+            { a: 2, b: { c: 'a' } },
+            { a: 3 },
+            { a: 3 }
+          ],
+          configuration.writeConcernMax(),
+          function(err) {
+            expect(err).to.be.null;
+
+            // Listen to apm events
+            listener.on('started', function(event) {
+              if (event.commandName === 'distinct') started.push(event);
+            });
+            listener.on('succeeded', function(event) {
+              if (event.commandName === 'distinct') succeeded.push(event);
+            });
+
+            // Perform a distinct query against the a field
+            collection.distinct('a', {}, { readConcern: { level: 'majority' } }, function(err) {
+              expect(err).to.be.null;
+              expect(started.length).to.equal(1);
+              expect(succeeded.length).to.equal(1);
+              expect(started[0].commandName).to.equal('distinct');
+              expect(succeeded[0].commandName).to.equal('distinct');
+              expect(started[0].command.readConcern).to.deep.equal({ level: 'majority' });
+
+              listener.uninstrument();
+              client.close();
+              done();
+            });
+          }
+        );
+      });
+    }
+  });
+
   it('Should set majority readConcern count command', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
 
@@ -697,6 +940,69 @@ describe('ReadConcern', function() {
               test.equal('count', started[0].commandName);
               test.equal('count', succeeded[0].commandName);
               test.deepEqual({ level: 'majority' }, started[0].command.readConcern);
+
+              listener.uninstrument();
+              client.close();
+              done();
+            });
+          }
+        );
+      });
+    }
+  });
+
+  it('Should set majority readConcern option for count command', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
+
+    test: function(done) {
+      const listener = require('../..').instrument(function(err) {
+        expect(err).to.be.null;
+      });
+
+      // Contains all the apm events
+      const started = [];
+      const succeeded = [];
+      // Get a new instance
+      const configuration = this.configuration;
+      const client = configuration.newClient({ w: 1 }, { poolSize: 1 });
+
+      client.connect(function(err, client) {
+        expect(err).to.be.null;
+
+        const db = client.db(configuration.db);
+
+        // Get the collection
+        const collection = db.collection('test_count_read_concern');
+        // Insert documents to perform distinct against
+        collection.insertMany(
+          [
+            { a: 0, b: { c: 'a' } },
+            { a: 1, b: { c: 'b' } },
+            { a: 1, b: { c: 'c' } },
+            { a: 2, b: { c: 'a' } },
+            { a: 3 },
+            { a: 3 }
+          ],
+          configuration.writeConcernMax(),
+          function(err) {
+            expect(err).to.be.null;
+
+            // Listen to apm events
+            listener.on('started', function(event) {
+              if (event.commandName === 'count') started.push(event);
+            });
+            listener.on('succeeded', function(event) {
+              if (event.commandName === 'count') succeeded.push(event);
+            });
+
+            // Perform a distinct query against the a field
+            collection.count({ a: 1 }, { readConcern: { level: 'majority' } }, function(err) {
+              expect(err).to.be.null;
+              expect(started.length).to.equal(1);
+              expect(succeeded.length).to.equal(1);
+              expect(started[0].commandName).to.equal('count');
+              expect(succeeded[0].commandName).to.equal('count');
+              expect(started[0].command.readConcern).to.deep.equal({ level: 'majority' });
 
               listener.uninstrument();
               client.close();
@@ -848,6 +1154,72 @@ describe('ReadConcern', function() {
     }
   });
 
+  it('Should set majority readConcern option for parallelCollectionScan command', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0 <=4.1.0' } },
+
+    test: function(done) {
+      const listener = require('../..').instrument(function(err) {
+        expect(err).to.be.null;
+      });
+
+      // Contains all the apm events
+      const started = [];
+      const succeeded = [];
+      // Get a new instance
+      const configuration = this.configuration;
+      const client = configuration.newClient({ w: 1 }, { poolSize: 1 });
+
+      client.connect(function(err, client) {
+        expect(err).to.be.null;
+
+        const db = client.db(configuration.db);
+
+        // Get the collection
+        const collection = db.collection('test_parallel_collection_scan_read_concern');
+        // Insert documents to perform distinct against
+        collection.insertMany(
+          [
+            { a: 0, b: { c: 'a' } },
+            { a: 1, b: { c: 'b' } },
+            { a: 1, b: { c: 'c' } },
+            { a: 2, b: { c: 'a' } },
+            { a: 3 },
+            { a: 3 }
+          ],
+          configuration.writeConcernMax(),
+          function(err) {
+            expect(err).to.be.null;
+
+            // Listen to apm events
+            listener.on('started', function(event) {
+              if (event.commandName === 'parallelCollectionScan') started.push(event);
+            });
+            listener.on('succeeded', function(event) {
+              if (event.commandName === 'parallelCollectionScan') succeeded.push(event);
+            });
+
+            // Execute parallelCollectionScan command
+            collection.parallelCollectionScan(
+              { numCursors: 1, readConcern: { level: 'majority' } },
+              function(err) {
+                expect(err).to.be.null;
+                expect(started.length).to.equal(1);
+                expect(succeeded.length).to.equal(1);
+                expect(started[0].commandName).to.equal('parallelCollectionScan');
+                expect(succeeded[0].commandName).to.equal('parallelCollectionScan');
+                expect(started[0].command.readConcern).to.deep.equal({ level: 'majority' });
+
+                listener.uninstrument();
+                client.close();
+                done();
+              }
+            );
+          }
+        );
+      });
+    }
+  });
+
   it('Should set majority readConcern geoSearch command', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
 
@@ -913,6 +1285,124 @@ describe('ReadConcern', function() {
               );
             }
           );
+        });
+      });
+    }
+  });
+
+  it('Should set majority readConcern option for geoSearch command', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
+
+    test: function(done) {
+      const listener = require('../..').instrument(function(err) {
+        expect(err).to.be.null;
+      });
+
+      // Contains all the apm events
+      const started = [];
+      const succeeded = [];
+      // Get a new instance
+      const configuration = this.configuration;
+      const client = configuration.newClient({ w: 1 }, { poolSize: 1 });
+
+      client.connect(function(err, client) {
+        expect(err).to.be.null;
+
+        const db = client.db(configuration.db);
+
+        // Get the collection
+        const collection = db.collection('test_geo_search_read_concern');
+
+        // Listen to apm events
+        listener.on('started', function(event) {
+          if (event.commandName === 'geoSearch') started.push(event);
+        });
+        listener.on('succeeded', function(event) {
+          if (event.commandName === 'geoSearch') succeeded.push(event);
+        });
+
+        // Add a location based index
+        collection.ensureIndex({ loc: 'geoHaystack', type: 1 }, { bucketSize: 1 }, function(err) {
+          expect(err).to.be.null;
+          // Save a new location tagged document
+          collection.insertMany(
+            [{ a: 1, loc: [50, 30] }, { a: 1, loc: [30, 50] }],
+            configuration.writeConcernMax(),
+            function(err) {
+              expect(err).to.be.null;
+
+              // Use geoHaystackSearch command to find document
+              collection.geoHaystackSearch(
+                50,
+                50,
+                {
+                  search: { a: 1 },
+                  limit: 1,
+                  maxDistance: 100,
+                  readConcern: { level: 'majority' }
+                },
+                function(err) {
+                  expect(err).to.be.null;
+                  expect(started.length).to.equal(1);
+                  expect(succeeded.length).to.equal(1);
+                  expect(started[0].commandName).to.equal('geoSearch');
+                  expect(succeeded[0].commandName).to.equal('geoSearch');
+                  expect(started[0].command.readConcern).to.deep.equal({ level: 'majority' });
+
+                  listener.uninstrument();
+                  client.close();
+                  done();
+                }
+              );
+            }
+          );
+        });
+      });
+    }
+  });
+
+  it('Should set majority readConcern option for find command', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2.0' } },
+
+    test: function(done) {
+      const listener = require('../..').instrument(function(err) {
+        expect(err).to.be.null;
+      });
+
+      // Contains all the apm events
+      const started = [];
+      const succeeded = [];
+      // Get a new instance
+      const configuration = this.configuration;
+      const client = configuration.newClient({ w: 1 }, { poolSize: 1 });
+
+      client.connect(function(err, client) {
+        expect(err).to.be.null;
+
+        const db = client.db(configuration.db);
+
+        // Get a collection
+        const collection = db.collection('readConcernCollectionFind');
+
+        // Listen to apm events
+        listener.on('started', function(event) {
+          if (event.commandName === 'find') started.push(event);
+        });
+        listener.on('succeeded', function(event) {
+          if (event.commandName === 'find') succeeded.push(event);
+        });
+
+        // Execute find
+        collection.find({}, { readConcern: { level: 'majority' } }).toArray(function(err) {
+          expect(err).to.be.null;
+          expect(started.length).to.equal(1);
+          expect(started[0].commandName).to.equal('find');
+          expect(succeeded[0].commandName).to.equal('find');
+          expect(started[0].command.readConcern).to.deep.equal({ level: 'majority' });
+
+          listener.uninstrument();
+          client.close();
+          done();
         });
       });
     }


### PR DESCRIPTION
Fixes [NODE-1532](https://jira.mongodb.org/browse/NODE-1532)