### PR TITLE
fix(lib): refactor db and collection to prevent multiple rounds of options validation

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -8,11 +8,6 @@ const AggregationCursor = require('./aggregation_cursor');
 const MongoError = require('mongodb-core').MongoError;
 const toError = require('./utils').toError;
 const normalizeHintField = require('./utils').normalizeHintField;
-const handleCallback = require('./utils').handleCallback;
-const decorateCommand = require('./utils').decorateCommand;
-const decorateWithCollation = require('./utils').decorateWithCollation;
-const decorateWithReadConcern = require('./utils').decorateWithReadConcern;
-const formattedOrderClause = require('./utils').formattedOrderClause;
 const ReadPreference = require('mongodb-core').ReadPreference;
 const CommandCursor = require('./command_cursor');
 const unordered = require('./bulk/unordered');
@@ -26,6 +21,7 @@ const validate = require('./options_validator').validate;
 const applyDefaults = require('./options_validator').applyDefaults;
 
 // Operations
+const aggregate = require('./operations/collection_ops').aggregate;
 const bulkWrite = require('./operations/collection_ops').bulkWrite;
 const checkForAtomicOperators = require('./operations/collection_ops').checkForAtomicOperators;
 const count = require('./operations/collection_ops').count;
@@ -39,6 +35,7 @@ const dropCollection = require('./operations/db_ops').dropCollection;
 const dropIndex = require('./operations/collection_ops').dropIndex;
 const dropIndexes = require('./operations/collection_ops').dropIndexes;
 const ensureIndex = require('./operations/collection_ops').ensureIndex;
+const find = require('./operations/collection_ops').find;
 const findAndModify = require('./operations/collection_ops').findAndModify;
 const findAndRemove = require('./operations/collection_ops').findAndRemove;
 const findOne = require('./operations/collection_ops').findOne;
@@ -52,6 +49,7 @@ const indexExists = require('./operations/collection_ops').indexExists;
 const indexInformation = require('./operations/collection_ops').indexInformation;
 const insertOne = require('./operations/collection_ops').insertOne;
 const isCapped = require('./operations/collection_ops').isCapped;
+const listIndexes = require('./operations/collection_ops').listIndexes;
 const mapReduce = require('./operations/collection_ops').mapReduce;
 const optionsOp = require('./operations/collection_ops').optionsOp;
 const parallelCollectionScan = require('./operations/collection_ops').parallelCollectionScan;
@@ -399,62 +397,7 @@ Collection.prototype.find = deprecateOptions(
       }
     );
 
-    let projection = finalOptions.projection || finalOptions.fields;
-
-    if (projection && !Buffer.isBuffer(projection) && Array.isArray(projection)) {
-      projection = projection.length
-        ? projection.reduce((result, field) => {
-            result[field] = 1;
-            return result;
-          }, {})
-        : { _id: 1 };
-    }
-
-    // Set slave ok to true if read preference different from primary
-    if (
-      finalOptions.readPreference != null &&
-      (finalOptions.readPreference !== 'primary' || finalOptions.readPreference.mode !== 'primary')
-    ) {
-      finalOptions.slaveOk = true;
-    }
-
-    // Ensure the query is an object
-    if (selector != null && typeof selector !== 'object') {
-      throw MongoError.create({ message: 'query selector must be an object', driver: true });
-    }
-
-    // Build the find command
-    const findCommand = {
-      find: this.s.namespace,
-      limit: finalOptions.limit,
-      skip: finalOptions.skip,
-      query: selector
-    };
-
-    // Merge in options to command
-    decorateCommand(findCommand, finalOptions, ['session', 'collation']);
-
-    if (projection) findCommand.fields = projection;
-
-    // Sort options
-    if (findCommand.sort) {
-      findCommand.sort = formattedOrderClause(findCommand.sort);
-    }
-
-    // Set the readConcern
-    decorateWithReadConcern(findCommand, this, finalOptions);
-
-    // Decorate find command with collation options
-    try {
-      decorateWithCollation(findCommand, this, finalOptions);
-    } catch (err) {
-      if (typeof callback === 'function') return callback(err, null);
-      throw err;
-    }
-
-    const cursor = this.s.topology.cursor(this.s.namespace, findCommand, finalOptions);
-
-    return typeof callback === 'function' ? handleCallback(callback, null, cursor) : cursor;
+    return find(this, selector, finalOptions, callback);
   }
 );
 
@@ -540,6 +483,7 @@ const insertManySchema = {
   wtimeout: { type: 'number' },
   j: { type: 'boolean' },
   serializeFunctions: { type: 'boolean' },
+  forceServerObjectId: { type: 'boolean' },
   bypassDocumentValidation: { type: 'boolean' },
   ordered: { type: 'boolean', default: true },
   session: { type: ClientSession },
@@ -1549,31 +1493,7 @@ Collection.prototype.listIndexes = function(options) {
     }
   );
 
-  // Cursor options
-  let cursor = options.batchSize ? { batchSize: options.batchSize } : {};
-
-  // We have a list collections command
-  if (this.s.topology.capabilities().hasListIndexesCommand) {
-    // Build the command
-    const command = { listIndexes: this.s.name, cursor: cursor };
-    // Execute the cursor
-    cursor = this.s.topology.cursor(`${this.s.dbName}.$cmd`, command, options);
-    // Do we have a readPreference, apply it
-    if (options.readPreference) cursor.setReadPreference(options.readPreference);
-    // Return the cursor
-    return cursor;
-  }
-
-  // Get the namespace
-  const ns = `${this.s.dbName}.system.indexes`;
-  // Get the query
-  cursor = this.s.topology.cursor(ns, { find: ns, query: { ns: this.s.namespace } }, options);
-  // Do we have a readPreference, apply it
-  if (options.readPreference) cursor.setReadPreference(options.readPreference);
-  // Set the passed in batch size if one was provided
-  if (options.batchSize) cursor = cursor.batchSize(options.batchSize);
-  // Return the cursor
-  return cursor;
+  return listIndexes(this, options);
 };
 
 /**
@@ -1903,7 +1823,8 @@ const findOneAndDeleteSchema = {
   upsert: { overrideOnly: true },
   serializeFunctions: { type: 'boolean' },
   checkKeys: { overrideOnly: true },
-  readPreference: { overrideOnly: true }
+  readPreference: { overrideOnly: true },
+  fsync: { type: 'number' }
 };
 Collection.prototype.findOneAndDelete = function(filter, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -1966,7 +1887,8 @@ const findOneAndReplaceSchema = {
   remove: { overrideOnly: true },
   serializeFunctions: { type: 'boolean' },
   checkKeys: { overrideOnly: true },
-  readPreference: { overrideOnly: true }
+  readPreference: { overrideOnly: true },
+  fsync: { type: 'number' }
 };
 Collection.prototype.findOneAndReplace = function(filter, replacement, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -2039,7 +1961,8 @@ const findOneAndUpdateSchema = {
   remove: { overrideOnly: true },
   serializeFunctions: { type: 'boolean' },
   checkKeys: { overrideOnly: true },
-  readPreference: { overrideOnly: true }
+  readPreference: { overrideOnly: true },
+  fsync: { type: 'number' }
 };
 Collection.prototype.findOneAndUpdate = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -2117,7 +2040,8 @@ const findAndModifySchema = {
   arrayFilters: { type: 'array' },
   readPreference: { overrideOnly: true },
   serializeFunctions: { type: 'boolean' },
-  checkKeys: { overrideOnly: true }
+  checkKeys: { overrideOnly: true },
+  collation: { type: 'object' }
 };
 Collection.prototype.findAndModify = deprecate(function(query, sort, doc, options, callback) {
   const args = Array.prototype.slice.call(arguments, 1);
@@ -2240,6 +2164,9 @@ const aggregateSchema = {
   cursorFactory: { overrideOnly: true },
   optionsValidationLevel: { overrideOnly: true },
   readConcern: { type: 'object' }
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' }
 };
 Collection.prototype.aggregate = function(pipeline, options, callback) {
   if (Array.isArray(pipeline)) {
@@ -2297,78 +2224,7 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
     }
   );
 
-  // If out was specified
-  if (typeof options.out === 'string') {
-    pipeline.push({ $out: options.out });
-    // Ignore read concern
-    ignoreReadConcern = true;
-  } else if (pipeline.length > 0 && pipeline[pipeline.length - 1]['$out']) {
-    ignoreReadConcern = true;
-  }
-
-  // Decorate command with writeConcern if out has been specified
-  if (
-    pipeline.length > 0 &&
-    pipeline[pipeline.length - 1]['$out'] &&
-    this.s.topology.capabilities().commandsTakeWriteConcern
-  ) {
-    applyWriteConcern(command, { db: this.s.db, collection: this }, options);
-  }
-
-  // Have we specified collation
-  try {
-    decorateWithCollation(command, this, options);
-  } catch (err) {
-    if (typeof callback === 'function') return callback(err, null);
-    throw err;
-  }
-
-  // If we have bypassDocumentValidation set
-  if (options.bypassDocumentValidation === true) {
-    command.bypassDocumentValidation = options.bypassDocumentValidation;
-  }
-
-  // Do we have a readConcern specified
-  if (!ignoreReadConcern) {
-    decorateWithReadConcern(command, this, options);
-  }
-
-  // If we have allowDiskUse defined
-  if (options.allowDiskUse) command.allowDiskUse = options.allowDiskUse;
-  if (typeof options.maxTimeMS === 'number') command.maxTimeMS = options.maxTimeMS;
-
-  // If we are giving a hint
-  if (options.hint) command.hint = options.hint;
-
-  // If explain has been specified add it
-  if (options.explain) {
-    if (command.readConcern || command.writeConcern) {
-      throw toError('"explain" cannot be used on an aggregate call with readConcern/writeConcern');
-    }
-    command.explain = options.explain;
-  }
-
-  if (typeof options.comment === 'string') command.comment = options.comment;
-
-  command.cursor = options.cursor;
-  if (options.batchSize) command.cursor.batchSize = options.batchSize;
-
-  if (typeof callback !== 'function') {
-    if (!this.s.topology.capabilities()) {
-      throw new MongoError('cannot connect to server');
-    }
-
-    // Allow disk usage command
-    if (typeof options.allowDiskUse === 'boolean') {
-      command.allowDiskUse = options.allowDiskUse;
-    }
-    if (typeof options.maxTimeMS === 'number') command.maxTimeMS = options.maxTimeMS;
-
-    // Execute the cursor
-    return this.s.topology.cursor(this.s.namespace, command, options);
-  }
-
-  return handleCallback(callback, null, this.s.topology.cursor(this.s.namespace, command, options));
+  return aggregate(this, pipeline, options, callback);
 };
 
 /**
@@ -2634,6 +2490,9 @@ const mapReduceSchema = {
   bypassDocumentValidation: { type: 'boolean' },
   session: { type: ClientSession },
   readConcern: { type: 'object' }
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' }
 };
 Collection.prototype.mapReduce = function(map, reduce, options, callback) {
   if ('function' === typeof options) (callback = options), (options = {});
@@ -2684,7 +2543,8 @@ const initializeUnorderedBulkOpSchema = {
   wtimeout: { type: 'number' },
   j: { type: 'boolean' },
   session: { type: ClientSession },
-  promiseLibrary: { overrideOnly: true }
+  promiseLibrary: { overrideOnly: true },
+  ignoreUndefined: { type: 'boolean' }
 };
 Collection.prototype.initializeUnorderedBulkOp = function(options) {
   validate(initializeUnorderedBulkOpSchema, options, {
@@ -2720,7 +2580,8 @@ const initializeOrderedBulkOpSchema = {
   wtimeout: { type: 'number' },
   j: { type: 'boolean' },
   session: { type: ClientSession },
-  promiseLibrary: { overrideOnly: true }
+  promiseLibrary: { overrideOnly: true },
+  ignoreUndefined: { type: 'boolean' }
 };
 Collection.prototype.initializeOrderedBulkOp = function(options) {
   validate(initializeOrderedBulkOpSchema, options, {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2163,7 +2163,7 @@ const aggregateSchema = {
   promiseLibrary: { type: 'function', overrideOnly: true },
   cursorFactory: { overrideOnly: true },
   optionsValidationLevel: { overrideOnly: true },
-  readConcern: { type: 'object' }
+  readConcern: { type: 'object' },
   w: { type: ['number', 'string'] },
   wtimeout: { type: 'number' },
   j: { type: 'boolean' }
@@ -2203,12 +2203,6 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
     // Left over arguments is the pipeline
     pipeline = args;
   }
-
-  // Ignore readConcern option
-  let ignoreReadConcern = false;
-
-  // Build the command
-  const command = { aggregate: this.s.name, pipeline: pipeline };
 
   validate(aggregateSchema, options, { optionsValidationLevel: this.optionsValidationLevel });
 
@@ -2489,7 +2483,7 @@ const mapReduceSchema = {
   verbose: { type: 'boolean' },
   bypassDocumentValidation: { type: 'boolean' },
   session: { type: ClientSession },
-  readConcern: { type: 'object' }
+  readConcern: { type: 'object' },
   w: { type: ['number', 'string'] },
   wtimeout: { type: 'number' },
   j: { type: 'boolean' }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -16,7 +16,6 @@ const ChangeStream = require('./change_stream');
 const executeOperation = require('./utils').executeOperation;
 const applyWriteConcern = require('./utils').applyWriteConcern;
 const resolveReadPreference = require('./utils').resolveReadPreference;
-const ClientSession = require('mongodb-core').Sessions.ClientSession;
 const validate = require('./options_validator').validate;
 const applyDefaults = require('./options_validator').applyDefaults;
 
@@ -63,6 +62,51 @@ const stats = require('./operations/collection_ops').stats;
 const updateDocuments = require('./operations/collection_ops').updateDocuments;
 const updateMany = require('./operations/collection_ops').updateMany;
 const updateOne = require('./operations/collection_ops').updateOne;
+
+// Schemas
+const aggregateSchema = require('./schemas/collection_schemas').aggregateSchema;
+const bulkWriteSchema = require('./schemas/collection_schemas').bulkWriteSchema;
+const countDocumentsSchema = require('./schemas/collection_schemas').countDocumentsSchema;
+const createIndexSchema = require('./schemas/collection_schemas').createIndexSchema;
+const createIndexesSchema = require('./schemas/collection_schemas').createIndexesSchema;
+const deleteManySchema = require('./schemas/collection_schemas').deleteManySchema;
+const deleteOneSchema = require('./schemas/collection_schemas').deleteOneSchema;
+const distinctSchema = require('./schemas/collection_schemas').distinctSchema;
+const dropSchema = require('./schemas/collection_schemas').dropSchema;
+const dropIndexSchema = require('./schemas/collection_schemas').dropIndexSchema;
+const dropIndexesSchema = require('./schemas/collection_schemas').dropIndexesSchema;
+const estimatedDocumentCountSchema = require('./schemas/collection_schemas')
+  .estimatedDocumentCountSchema;
+const findSchema = require('./schemas/collection_schemas').findSchema;
+const findAndModifySchema = require('./schemas/collection_schemas').findAndModifySchema;
+const findAndRemoveSchema = require('./schemas/collection_schemas').findAndRemoveSchema;
+const findOneSchema = require('./schemas/collection_schemas').findOneSchema;
+const findOneAndDeleteSchema = require('./schemas/collection_schemas').findOneAndDeleteSchema;
+const findOneAndReplaceSchema = require('./schemas/collection_schemas').findOneAndReplaceSchema;
+const findOneAndUpdateSchema = require('./schemas/collection_schemas').findOneAndUpdateSchema;
+const geoHaystackSearchSchema = require('./schemas/collection_schemas').geoHaystackSearchSchema;
+const indexesSchema = require('./schemas/collection_schemas').indexesSchema;
+const indexExistsSchema = require('./schemas/collection_schemas').indexExistsSchema;
+const indexInformationSchema = require('./schemas/collection_schemas').indexInformationSchema;
+const initializeOrderedBulkOpSchema = require('./schemas/collection_schemas')
+  .initializeOrderedBulkOpSchema;
+const initializeUnorderedBulkOpSchema = require('./schemas/collection_schemas')
+  .initializeUnorderedBulkOpSchema;
+const insertManySchema = require('./schemas/collection_schemas').insertManySchema;
+const insertOneSchema = require('./schemas/collection_schemas').insertOneSchema;
+const isCappedSchema = require('./schemas/collection_schemas').isCappedSchema;
+const listIndexesSchema = require('./schemas/collection_schemas').listIndexesSchema;
+const mapReduceSchema = require('./schemas/collection_schemas').mapReduceSchema;
+const optionsSchema = require('./schemas/collection_schemas').optionsSchema;
+const parallelCollectionScanSchema = require('./schemas/collection_schemas')
+  .parallelCollectionScanSchema;
+const reIndexSchema = require('./schemas/collection_schemas').reIndexSchema;
+const renameSchema = require('./schemas/collection_schemas').renameSchema;
+const replaceOneSchema = require('./schemas/collection_schemas').replaceOneSchema;
+const statsSchema = require('./schemas/collection_schemas').statsSchema;
+const updateManySchema = require('./schemas/collection_schemas').updateManySchema;
+const updateOneSchema = require('./schemas/collection_schemas').updateOneSchema;
+const watchSchema = require('./schemas/collection_schemas').watchSchema;
 
 /**
  * @fileOverview The **Collection** class is an internal class that embodies a MongoDB collection
@@ -288,42 +332,6 @@ const DEPRECATED_FIND_OPTIONS = ['maxScan', 'fields', 'snapshot'];
  * @throws {MongoError}
  * @return {Cursor}
  */
-const findSchema = {
-  limit: { type: 'number', default: 0 },
-  sort: { type: ['array', 'object', 'string'] },
-  projection: { type: 'object' },
-  fields: { type: 'object' },
-  skip: { type: 'number', default: 0 },
-  hint: { type: ['string', 'object'] },
-  explain: { type: 'boolean' },
-  snapshot: { type: 'boolean' },
-  timeout: { type: 'boolean' },
-  tailable: { type: 'boolean' },
-  batchSize: { type: 'number' },
-  returnKey: { type: 'boolean' },
-  maxScan: { type: 'number' },
-  min: { type: 'number' },
-  max: { type: 'number' },
-  showDiskLoc: { type: 'boolean' },
-  showRecordId: { type: 'boolean' },
-  comment: { type: 'string' },
-  raw: { type: 'boolean' },
-  promoteLongs: { type: 'boolean' },
-  promoteValues: { type: 'boolean' },
-  promoteBuffers: { type: 'boolean' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  partial: { type: 'boolean' },
-  maxTimeMS: { type: 'number' },
-  collation: { type: 'object' },
-  session: { type: ClientSession },
-  promiseLibrary: { overrideOnly: true },
-  slaveOk: { type: 'boolean' },
-  awaitData: { type: 'boolean' },
-  noCursorTimeout: { type: 'boolean', overrideOnly: true },
-  ignoreUndefined: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true },
-  readConcern: { type: 'object' }
-};
 Collection.prototype.find = deprecateOptions(
   {
     name: 'collection.find',
@@ -419,16 +427,6 @@ Collection.prototype.find = deprecateOptions(
  * @param {Collection~insertOneWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const insertOneSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  serializeFunctions: { type: 'boolean' },
-  forceServerObjectId: { type: 'boolean' },
-  bypassDocumentValidation: { type: 'boolean' },
-  session: { type: ClientSession },
-  ignoreUndefined: { type: 'boolean', overrideOnly: true }
-};
 Collection.prototype.insertOne = function(doc, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -478,17 +476,6 @@ function mapInsertManyResults(docs, r) {
  * @param {Collection~insertWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const insertManySchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  serializeFunctions: { type: 'boolean' },
-  forceServerObjectId: { type: 'boolean' },
-  bypassDocumentValidation: { type: 'boolean' },
-  ordered: { type: 'boolean', default: true },
-  session: { type: ClientSession },
-  ignoreUndefined: { overrideOnly: true }
-};
 Collection.prototype.insertMany = function(docs, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options ? Object.assign({}, options) : { ordered: true };
@@ -581,16 +568,6 @@ Collection.prototype.insertMany = function(docs, options, callback) {
  * @param {Collection~bulkWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const bulkWriteSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  serializeFunctions: { type: 'boolean' },
-  ordered: { type: 'boolean', default: true },
-  bypassDocumentValidation: { type: 'boolean' },
-  ignoreUndefined: { overrideOnly: true },
-  session: { type: ClientSession }
-};
 Collection.prototype.bulkWrite = function(operations, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -731,18 +708,6 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const updateOneSchema = {
-  upsert: { type: 'boolean' },
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  bypassDocumentValidation: { type: 'boolean' },
-  arrayFilters: { type: 'array' },
-  collation: { type: 'object' },
-  ignoreUndefined: { type: 'boolean', overrideOnly: true },
-  session: { type: ClientSession },
-  multi: { overrideOnly: true }
-};
 Collection.prototype.updateOne = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -783,17 +748,6 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise<Collection~updatewriteOpResultObject>} returns Promise if no callback passed
  */
-const replaceOneSchema = {
-  upsert: { type: 'boolean' },
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  bypassDocumentValidation: { type: 'boolean' },
-  collation: { type: 'object' },
-  ignoreUndefined: { type: 'boolean', overrideOnly: true },
-  session: { type: ClientSession },
-  multi: { overrideOnly: true }
-};
 Collection.prototype.replaceOne = function(filter, doc, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -829,18 +783,6 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise<Collection~updateWriteOpResultObject>} returns Promise if no callback passed
  */
-const updateManySchema = {
-  upsert: { type: 'boolean' },
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  arrayFilters: { type: 'array' },
-  bypassDocumentValidation: { type: 'boolean' },
-  collation: { type: 'object' },
-  session: { type: ClientSession },
-  ignoreUndefined: { type: 'boolean', overrideOnly: true },
-  multi: { overrideOnly: true }
-};
 Collection.prototype.updateMany = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -933,15 +875,6 @@ Collection.prototype.update = deprecate(function(selector, update, options, call
  * @param {Collection~deleteWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const deleteOneSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  collation: { type: 'object' },
-  session: { type: ClientSession },
-  ignoreUndefined: { type: 'boolean', overrideOnly: true },
-  single: { overrideOnly: true }
-};
 Collection.prototype.deleteOne = function(filter, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -975,15 +908,6 @@ Collection.prototype.removeOne = Collection.prototype.deleteOne;
  * @param {Collection~deleteWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const deleteManySchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  collation: { type: 'object' },
-  session: { type: ClientSession },
-  ignoreUndefined: { type: 'boolean', overrideOnly: true },
-  single: { overrideOnly: true }
-};
 Collection.prototype.deleteMany = function(filter, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1104,32 +1028,6 @@ Collection.prototype.save = deprecate(function(doc, options, callback) {
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const findOneSchema = {
-  projection: { type: 'object' },
-  fields: { type: 'object' },
-  hint: { type: ['string', 'object'] },
-  explain: { type: 'boolean' },
-  snapshot: { type: 'boolean' },
-  timeout: { type: 'boolean' },
-  tailable: { type: 'boolean' },
-  batchSize: { type: 'number' },
-  returnKey: { type: 'boolean' },
-  maxScan: { type: 'number' },
-  min: { type: 'number' },
-  max: { type: 'number' },
-  showDiskLoc: { type: 'boolean' },
-  showRecordId: { type: 'boolean' },
-  comment: { type: 'string' },
-  raw: { type: 'boolean' },
-  promoteLongs: { type: 'boolean' },
-  promoteValues: { type: 'boolean' },
-  promoteBuffers: { type: 'boolean' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  partial: { type: 'boolean' },
-  maxTimeMS: { type: 'number' },
-  collation: { type: 'object' },
-  session: { type: ClientSession }
-};
 Collection.prototype.findOne = deprecateOptions(
   {
     name: 'collection.find',
@@ -1172,11 +1070,6 @@ Collection.prototype.findOne = deprecateOptions(
  * @param {Collection~collectionResultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
  */
-const renameSchema = {
-  dropTarget: { type: 'boolean', default: false },
-  readPreference: { type: [ReadPreference, 'string', 'object'], overrideOnly: true },
-  session: { type: ClientSession }
-};
 Collection.prototype.rename = function(newName, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1199,13 +1092,6 @@ Collection.prototype.rename = function(newName, options, callback) {
  * @param {Collection~resultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
  */
-const dropSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  readPreference: { type: [ReadPreference, 'string', 'object'], overrideOnly: true },
-  session: { type: ClientSession }
-};
 Collection.prototype.drop = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1231,9 +1117,6 @@ Collection.prototype.drop = function(options, callback) {
  * @param {Collection~resultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
  */
-const optionsSchema = {
-  session: { type: ClientSession }
-};
 Collection.prototype.options = function(opts, callback) {
   if (typeof opts === 'function') (callback = opts), (opts = {});
 
@@ -1253,9 +1136,6 @@ Collection.prototype.options = function(opts, callback) {
  * @param {Collection~resultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
  */
-const isCappedSchema = {
-  session: { type: ClientSession }
-};
 Collection.prototype.isCapped = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1289,24 +1169,6 @@ Collection.prototype.isCapped = function(options, callback) {
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const createIndexSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  unique: { type: 'boolean', default: false },
-  sparse: { type: 'boolean' },
-  background: { type: 'boolean' },
-  dropDups: { type: 'boolean' },
-  min: { type: 'number' },
-  max: { type: 'number' },
-  v: { type: 'number' },
-  expireAfterSeconds: { type: 'number' },
-  name: { type: 'string' },
-  partialFilterExpression: { type: 'object' },
-  collation: { type: 'object' },
-  session: { type: ClientSession },
-  readPreference: { overrideOnly: true }
-};
 Collection.prototype.createIndex = function(fieldOrSpec, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1337,14 +1199,6 @@ Collection.prototype.createIndex = function(fieldOrSpec, options, callback) {
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const createIndexesSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  maxTimeMS: { type: 'number' },
-  readPreference: { overrideOnly: true },
-  session: { type: ClientSession }
-};
 Collection.prototype.createIndexes = function(indexSpecs, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1373,14 +1227,6 @@ Collection.prototype.createIndexes = function(indexSpecs, options, callback) {
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const dropIndexSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  readPreference: { type: [ReadPreference, 'string', 'object'], overrideOnly: true },
-  maxTimeMS: { type: 'number' },
-  session: { type: ClientSession }
-};
 Collection.prototype.dropIndex = function(indexName, options, callback) {
   const args = Array.prototype.slice.call(arguments, 1);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
@@ -1405,13 +1251,6 @@ Collection.prototype.dropIndex = function(indexName, options, callback) {
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const dropIndexesSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  maxTimeMS: { type: 'number' },
-  session: { type: ClientSession }
-};
 Collection.prototype.dropIndexes = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1443,9 +1282,6 @@ Collection.prototype.dropAllIndexes = deprecate(
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const reIndexSchema = {
-  session: { type: ClientSession }
-};
 Collection.prototype.reIndex = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1466,14 +1302,6 @@ Collection.prototype.reIndex = function(options, callback) {
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {CommandCursor}
  */
-const listIndexesSchema = {
-  batchSize: { type: 'number' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  session: { type: ClientSession },
-  cursorFactory: { type: 'function', overrideOnly: true },
-  promiseLibrary: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true }
-};
 Collection.prototype.listIndexes = function(options) {
   if (!this.s.topology.capabilities()) {
     throw new MongoError('cannot connect to server');
@@ -1535,10 +1363,6 @@ Collection.prototype.ensureIndex = deprecate(function(fieldOrSpec, options, call
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const indexExistsSchema = {
-  session: { type: ClientSession },
-  full: { type: 'boolean', default: false }
-};
 Collection.prototype.indexExists = function(indexes, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1558,10 +1382,6 @@ Collection.prototype.indexExists = function(indexes, options, callback) {
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const indexInformationSchema = {
-  full: { type: 'boolean', default: false },
-  session: { type: ClientSession }
-};
 Collection.prototype.indexInformation = function(options, callback) {
   const args = Array.prototype.slice.call(arguments, 0);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
@@ -1617,10 +1437,6 @@ Collection.prototype.count = deprecate(function(query, options, callback) {
  * @param {Collection~countCallback} [callback] The command result callback.
  * @return {Promise} returns Promise if no callback passed.
  */
-const estimatedDocumentCountSchema = {
-  maxTimeMS: { type: 'number' },
-  readConcern: { type: 'object' }
-};
 Collection.prototype.estimatedDocumentCount = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1665,14 +1481,6 @@ Collection.prototype.estimatedDocumentCount = function(options, callback) {
  * @see https://docs.mongodb.com/manual/reference/operator/query/center/#op._S_center
  * @see https://docs.mongodb.com/manual/reference/operator/query/centerSphere/#op._S_centerSphere
  */
-const countDocumentsSchema = {
-  collation: { type: 'object' },
-  hint: { type: ['string', 'object'] },
-  limit: { type: 'number' },
-  maxTimeMS: { type: 'number' },
-  skip: { type: 'number' },
-  readConcern: { type: 'object' }
-};
 Collection.prototype.countDocuments = function(query, options, callback) {
   const args = Array.prototype.slice.call(arguments, 0);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
@@ -1700,13 +1508,6 @@ Collection.prototype.countDocuments = function(query, options, callback) {
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const distinctSchema = {
-  collation: { type: 'object' },
-  readPreference: { type: [ReadPreference, 'string', 'object'] },
-  maxTimeMS: { type: 'number' },
-  session: { type: ClientSession },
-  readConcern: { type: 'object' }
-};
 Collection.prototype.distinct = function(key, query, options, callback) {
   const args = Array.prototype.slice.call(arguments, 1);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
@@ -1735,12 +1536,6 @@ Collection.prototype.distinct = function(key, query, options, callback) {
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const indexesSchema = {
-  batchSize: { type: 'number' },
-  readPreference: { type: [ReadPreference, 'string', 'object'] },
-  session: { type: ClientSession },
-  full: { type: 'boolean', default: true }
-};
 Collection.prototype.indexes = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1762,11 +1557,6 @@ Collection.prototype.indexes = function(options, callback) {
  * @param {Collection~resultCallback} [callback] The collection result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const statsSchema = {
-  readPreference: { type: [ReadPreference, 'string', 'object'] },
-  scale: { type: 'number' },
-  session: { type: ClientSession }
-};
 Collection.prototype.stats = function(options, callback) {
   const args = Array.prototype.slice.call(arguments, 0);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
@@ -1811,21 +1601,6 @@ Collection.prototype.stats = function(options, callback) {
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
  * @return {Promise<Collection~findAndModifyWriteOpResultObject>} returns Promise if no callback passed
  */
-const findOneAndDeleteSchema = {
-  collation: { type: 'object' },
-  projection: { type: 'object' },
-  sort: { type: ['object', 'string'] },
-  maxTimeMS: { type: 'number' },
-  session: { type: ClientSession },
-  fields: { overrideOnly: true },
-  remove: { overrideOnly: true },
-  new: { overrideOnly: true },
-  upsert: { overrideOnly: true },
-  serializeFunctions: { type: 'boolean' },
-  checkKeys: { overrideOnly: true },
-  readPreference: { overrideOnly: true },
-  fsync: { type: 'number' }
-};
 Collection.prototype.findOneAndDelete = function(filter, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1872,24 +1647,6 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
  * @return {Promise<Collection~findAndModifyWriteOpResultObject>} returns Promise if no callback passed
  */
-const findOneAndReplaceSchema = {
-  bypassDocumentValidation: { type: 'boolean' },
-  collation: { type: 'object' },
-  projection: { type: 'object' },
-  sort: { type: ['object', 'string'] },
-  maxTimeMS: { type: 'number' },
-  upsert: { type: 'boolean', default: false },
-  returnOriginal: { type: 'boolean' },
-  session: { type: ClientSession },
-  fields: { overrideOnly: true },
-  update: { overrideOnly: true },
-  new: { overrideOnly: true },
-  remove: { overrideOnly: true },
-  serializeFunctions: { type: 'boolean' },
-  checkKeys: { overrideOnly: true },
-  readPreference: { overrideOnly: true },
-  fsync: { type: 'number' }
-};
 Collection.prototype.findOneAndReplace = function(filter, replacement, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1945,25 +1702,6 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
  * @return {Promise<Collection~findAndModifyWriteOpResultObject>} returns Promise if no callback passed
  */
-const findOneAndUpdateSchema = {
-  bypassDocumentValidation: { type: 'boolean' },
-  collation: { type: 'object' },
-  projection: { type: 'object' },
-  sort: { type: ['object', 'string'] },
-  maxTimeMS: { type: 'number' },
-  upsert: { type: 'boolean', default: false },
-  returnOriginal: { type: 'boolean' },
-  session: { type: ClientSession },
-  arrayFilters: { type: 'array' },
-  fields: { overrideOnly: true },
-  update: { overrideOnly: true },
-  new: { overrideOnly: true },
-  remove: { overrideOnly: true },
-  serializeFunctions: { type: 'boolean' },
-  checkKeys: { overrideOnly: true },
-  readPreference: { overrideOnly: true },
-  fsync: { type: 'number' }
-};
 Collection.prototype.findOneAndUpdate = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -2027,22 +1765,6 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
  * @return {Promise} returns Promise if no callback passed
  * @deprecated use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead
  */
-const findAndModifySchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  remove: { type: 'boolean', default: false },
-  upsert: { type: 'boolean', default: false },
-  new: { type: 'boolean', default: false },
-  projection: { type: 'object' },
-  fields: { type: 'object' },
-  session: { type: ClientSession },
-  arrayFilters: { type: 'array' },
-  readPreference: { overrideOnly: true },
-  serializeFunctions: { type: 'boolean' },
-  checkKeys: { overrideOnly: true },
-  collation: { type: 'object' }
-};
 Collection.prototype.findAndModify = deprecate(function(query, sort, doc, options, callback) {
   const args = Array.prototype.slice.call(arguments, 1);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
@@ -2084,18 +1806,6 @@ Collection.prototype.findAndModify = deprecate(function(query, sort, doc, option
  * @return {Promise} returns Promise if no callback passed
  * @deprecated use findOneAndDelete instead
  */
-const findAndRemoveSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  session: { type: ClientSession },
-  remove: { overrideOnly: true },
-  readPreference: { overrideOnly: true },
-  serializeFunctions: { type: 'boolean' },
-  checkKeys: { overrideOnly: true },
-  upsert: { overrideOnly: true },
-  new: { overrideOnly: true }
-};
 Collection.prototype.findAndRemove = deprecate(function(query, sort, options, callback) {
   const args = Array.prototype.slice.call(arguments, 1);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
@@ -2144,30 +1854,6 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
  * @param {Collection~aggregationCallback} callback The command result callback
  * @return {(null|AggregationCursor)}
  */
-const aggregateSchema = {
-  readPreference: { type: [ReadPreference, 'string', 'object'] },
-  cursor: { type: 'object', default: {} },
-  batchSize: { type: 'number' },
-  explain: { type: 'boolean' },
-  allowDiskUse: { type: 'boolean' },
-  maxTimeMS: { type: 'number' },
-  bypassDocumentValidation: { type: 'boolean' },
-  raw: { type: 'boolean' },
-  promoteLongs: { type: 'boolean' },
-  promoteValues: { type: 'boolean' },
-  promoteBuffers: { type: 'boolean' },
-  collation: { type: 'object' },
-  comment: { type: 'string' },
-  hint: { type: ['object', 'string'] },
-  session: { type: ClientSession },
-  promiseLibrary: { type: 'function', overrideOnly: true },
-  cursorFactory: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true },
-  readConcern: { type: 'object' },
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' }
-};
 Collection.prototype.aggregate = function(pipeline, options, callback) {
   if (Array.isArray(pipeline)) {
     // Set up callback if one is provided
@@ -2237,17 +1923,6 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {ChangeStream} a ChangeStream instance.
  */
-const watchSchema = {
-  fullDocument: { type: 'string', default: 'default' },
-  resumeAfter: { type: 'object' },
-  maxAwaitTimeMS: { type: 'number' },
-  batchSize: { type: 'number' },
-  collation: { type: 'object' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  startAtClusterTime: { type: 'Timestamp' },
-  session: { type: ClientSession },
-  optionsValidationLevel: { overrideOnly: true }
-};
 Collection.prototype.watch = function(pipeline, options) {
   pipeline = pipeline || [];
 
@@ -2293,16 +1968,6 @@ Collection.prototype.watch = function(pipeline, options) {
  * @param {Collection~parallelCollectionScanCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const parallelCollectionScanSchema = {
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  batchSize: { type: 'number', default: 1000 },
-  numCursors: { type: 'number', default: 1 },
-  raw: { type: 'boolean', default: false },
-  promiseLibrary: { overrideOnly: true },
-  session: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true },
-  readConcern: { type: 'object' }
-};
 Collection.prototype.parallelCollectionScan = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = { numCursors: 1 });
 
@@ -2343,14 +2008,6 @@ Collection.prototype.parallelCollectionScan = function(options, callback) {
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const geoHaystackSearchSchema = {
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  maxDistance: { type: 'number' },
-  search: { type: 'object' },
-  limit: { type: 'number' },
-  session: { type: ClientSession },
-  readConcern: { type: 'object' }
-};
 Collection.prototype.geoHaystackSearch = function(x, y, options, callback) {
   const args = Array.prototype.slice.call(arguments, 2);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
@@ -2469,25 +2126,6 @@ Collection.prototype.group = deprecate(function(
  * @throws {MongoError}
  * @return {Promise} returns Promise if no callback passed
  */
-const mapReduceSchema = {
-  collation: { type: 'object' },
-  readPreference: { type: [ReadPreference, 'string', 'object'] },
-  out: { type: ['string', 'object'], required: true },
-  query: { type: 'object' },
-  sort: { type: 'object' },
-  limit: { type: 'number' },
-  keeptemp: { type: 'boolean' },
-  finalize: { type: ['function', 'string'] },
-  scope: { type: 'object' },
-  jsMode: { type: 'boolean' },
-  verbose: { type: 'boolean' },
-  bypassDocumentValidation: { type: 'boolean' },
-  session: { type: ClientSession },
-  readConcern: { type: 'object' },
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' }
-};
 Collection.prototype.mapReduce = function(map, reduce, options, callback) {
   if ('function' === typeof options) (callback = options), (options = {});
 
@@ -2531,15 +2169,6 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {UnorderedBulkOperation}
  */
-const initializeUnorderedBulkOpSchema = {
-  bypassDocumentValidation: { type: 'boolean' },
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  session: { type: ClientSession },
-  promiseLibrary: { overrideOnly: true },
-  ignoreUndefined: { type: 'boolean' }
-};
 Collection.prototype.initializeUnorderedBulkOp = function(options) {
   validate(initializeUnorderedBulkOpSchema, options, {
     optionsValidationLevel: this.optionsValidationLevel
@@ -2568,15 +2197,6 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
  * @param {OrderedBulkOperation} callback The command result callback
  * @return {null}
  */
-const initializeOrderedBulkOpSchema = {
-  bypassDocumentValidation: { type: 'boolean' },
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  session: { type: ClientSession },
-  promiseLibrary: { overrideOnly: true },
-  ignoreUndefined: { type: 'boolean' }
-};
 Collection.prototype.initializeOrderedBulkOp = function(options) {
   validate(initializeOrderedBulkOpSchema, options, {
     optionsValidationLevel: this.optionsValidationLevel

--- a/lib/db.js
+++ b/lib/db.js
@@ -14,7 +14,6 @@ const applyWriteConcern = require('./utils').applyWriteConcern;
 const resolveReadPreference = require('./utils').resolveReadPreference;
 const ChangeStream = require('./change_stream');
 const deprecate = require('util').deprecate;
-const ClientSession = require('mongodb-core').Sessions.ClientSession;
 const validate = require('./options_validator').validate;
 const applyDefaults = require('./options_validator').applyDefaults;
 const CONSTANTS = require('./constants');
@@ -40,6 +39,25 @@ const removeUser = require('./operations/db_ops').removeUser;
 const rename = require('./operations/collection_ops').rename;
 const setProfilingLevel = require('./operations/db_ops').setProfilingLevel;
 const validateDatabaseName = require('./operations/db_ops').validateDatabaseName;
+
+// Schemas
+const addUserSchema = require('./schemas/db_schemas').addUserSchema;
+const collectionSchema = require('./schemas/db_schemas').collectionSchema;
+const collectionsSchema = require('./schemas/db_schemas').collectionsSchema;
+const commandSchema = require('./schemas/db_schemas').commandSchema;
+const createCollectionSchema = require('./schemas/db_schemas').createCollectionSchema;
+const createIndexSchema = require('./schemas/db_schemas').createIndexSchema;
+const dropCollectionSchema = require('./schemas/db_schemas').dropCollectionSchema;
+const dropDatabaseSchema = require('./schemas/db_schemas').dropDatabaseSchema;
+const executeDbAdminCommandSchema = require('./schemas/db_schemas').executeDbAdminCommandSchema;
+const indexInformationSchema = require('./schemas/db_schemas').indexInformationSchema;
+const listCollectionsSchema = require('./schemas/db_schemas').listCollectionsSchema;
+const profilingLevelSchema = require('./schemas/db_schemas').profilingLevelSchema;
+const removeUserSchema = require('./schemas/db_schemas').removeUserSchema;
+const renameCollectionSchema = require('./schemas/db_schemas').renameCollectionSchema;
+const setProfilingLevelSchema = require('./schemas/db_schemas').setProfilingLevelSchema;
+const statsSchema = require('./schemas/db_schemas').statsSchema;
+const watchSchema = require('./schemas/db_schemas').watchSchema;
 
 /**
  * @fileOverview The **Db** class is a class that represents a MongoDB Database.
@@ -282,10 +300,6 @@ Object.defineProperty(Db.prototype, 'writeConcern', {
  * @param {Db~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const commandSchema = {
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  session: { type: ClientSession }
-};
 Db.prototype.command = function(command, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -333,20 +347,6 @@ Db.prototype.admin = function() {
  * @param {Db~collectionResultCallback} [callback] The collection result callback
  * @return {Collection} return the new Collection instance if not in strict mode
  */
-const collectionSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  raw: { type: 'boolean' },
-  pkFactory: { type: 'object' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  serializeFunctions: { type: 'boolean' },
-  strict: { type: 'boolean' },
-  readConcern: { type: 'object' },
-  promiseLibrary: { overrideOnly: true },
-  ignoreUndefined: { overrideOnly: true },
-  fsync: { type: 'number' }
-};
 Db.prototype.collection = function(name, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -399,31 +399,6 @@ Db.prototype.collection = function(name, options, callback) {
  * @param {Db~collectionResultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
  */
-const createCollectionSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  raw: { type: 'boolean' },
-  pkFactory: { type: 'object' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  serializeFunctions: { type: 'boolean' },
-  strict: { type: 'boolean' },
-  capped: { type: 'boolean' },
-  autoIndexId: { type: 'boolean', deprecated: true },
-  size: { type: 'number' },
-  max: { type: 'number' },
-  flags: { type: 'number' },
-  storageEngine: { type: 'object' },
-  validator: { type: 'object' },
-  validationLevel: { type: 'string' },
-  validationAction: { type: 'string' },
-  indexOptionDefaults: { type: 'object' },
-  viewOn: { type: 'string' },
-  pipeline: { type: 'array' },
-  collation: { type: 'object' },
-  session: { type: ClientSession },
-  promiseLibrary: { type: 'function' }
-};
 Db.prototype.createCollection = function(name, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -449,11 +424,6 @@ Db.prototype.createCollection = function(name, options, callback) {
  * @param {Db~resultCallback} [callback] The collection result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const statsSchema = {
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  scale: { type: 'number' },
-  session: { type: ClientSession }
-};
 Db.prototype.stats = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -486,14 +456,6 @@ Db.prototype.stats = function(options, callback) {
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {CommandCursor}
  */
-const listCollectionsSchema = {
-  nameOnly: { type: 'boolean', default: false },
-  batchSize: { type: 'number' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  session: { type: ClientSession },
-  cursorFactory: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true }
-};
 Db.prototype.listCollections = function(filter, options) {
   filter = filter || {};
 
@@ -551,14 +513,6 @@ Db.prototype.eval = deprecate(function(code, parameters, options, callback) {
  * @param {Db~collectionResultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
  */
-const renameCollectionSchema = {
-  dropTarget: { type: 'boolean', default: false },
-  session: { type: ClientSession },
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  readPreference: { type: [ReadPreference, 'string', 'object'], overrideOnly: true }
-};
 Db.prototype.renameCollection = function(fromCollection, toCollection, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -593,13 +547,6 @@ Db.prototype.renameCollection = function(fromCollection, toCollection, options, 
  * @param {Db~resultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
  */
-const dropCollectionSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  session: { type: ClientSession },
-  readPreference: { overrideOnly: true }
-};
 Db.prototype.dropCollection = function(name, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -631,14 +578,6 @@ Db.prototype.dropCollection = function(name, options, callback) {
  * @param {Db~resultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
  */
-const dropDatabaseSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  session: { type: ClientSession },
-  readPreference: { overrideOnly: true },
-  writeConcern: { type: 'object' }
-};
 Db.prototype.dropDatabase = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -671,12 +610,6 @@ Db.prototype.dropDatabase = function(options, callback) {
  * @param {Db~collectionsResultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
  */
-const collectionsSchema = {
-  nameOnly: { type: 'boolean', default: false },
-  batchSize: { type: 'number' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  session: { type: ClientSession }
-};
 Db.prototype.collections = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -697,10 +630,6 @@ Db.prototype.collections = function(options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const executeDbAdminCommandSchema = {
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  session: { type: ClientSession }
-};
 Db.prototype.executeDbAdminCommand = function(selector, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -747,23 +676,6 @@ Db.prototype.executeDbAdminCommand = function(selector, options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const createIndexSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  unique: { type: 'boolean', default: false },
-  sparse: { type: 'boolean' },
-  background: { type: 'boolean' },
-  dropDups: { type: 'boolean' },
-  min: { type: 'number' },
-  max: { type: 'number' },
-  v: { type: 'number' },
-  expireAfterSeconds: { type: 'number' },
-  name: { type: 'number' },
-  partialFilterExpression: { type: 'object' },
-  collation: { type: 'object' },
-  session: { type: ClientSession }
-};
 Db.prototype.createIndex = function(name, fieldOrSpec, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -839,17 +751,6 @@ Db.prototype.addChild = function(db) {
  * @param {Db~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const addUserSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  customData: { type: 'object' },
-  roles: { type: 'object' },
-  authenticationRestrictions: { type: 'array' },
-  mechanisms: { type: 'array' },
-  passwordDigestor: { type: 'string' },
-  session: { type: ClientSession }
-};
 Db.prototype.addUser = function(username, password, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -872,12 +773,6 @@ Db.prototype.addUser = function(username, password, options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const removeUserSchema = {
-  w: { type: ['number', 'string'] },
-  wtimeout: { type: 'number' },
-  j: { type: 'boolean' },
-  session: { type: ClientSession }
-};
 Db.prototype.removeUser = function(username, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -897,9 +792,6 @@ Db.prototype.removeUser = function(username, options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback.
  * @return {Promise} returns Promise if no callback passed
  */
-const setProfilingLevelSchema = {
-  session: { type: ClientSession }
-};
 Db.prototype.setProfilingLevel = function(level, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -936,9 +828,6 @@ Db.prototype.profilingInfo = deprecate(function(options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const profilingLevelSchema = {
-  session: { type: ClientSession }
-};
 Db.prototype.profilingLevel = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -962,12 +851,6 @@ Db.prototype.profilingLevel = function(options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const indexInformationSchema = {
-  batchSize: { type: 'number' },
-  full: { type: 'boolean', default: false },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  session: { type: ClientSession }
-};
 Db.prototype.indexInformation = function(name, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -1004,17 +887,6 @@ Db.prototype.unref = function() {
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {ChangeStream} a ChangeStream instance.
  */
-const watchSchema = {
-  fullDocument: { type: 'string', default: 'default' },
-  resumeAfter: { type: 'object' },
-  maxAwaitTimeMS: { type: 'number' },
-  batchSize: { type: 'number' },
-  collation: { type: 'object' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  startAtClusterTime: { type: 'Timestamp' },
-  session: { type: ClientSession },
-  optionsValidationLevel: { overrideOnly: true }
-};
 Db.prototype.watch = function(pipeline, options) {
   pipeline = pipeline || [];
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -4,15 +4,11 @@ const EventEmitter = require('events').EventEmitter;
 const inherits = require('util').inherits;
 const getSingleProperty = require('./utils').getSingleProperty;
 const CommandCursor = require('./command_cursor');
-const handleCallback = require('./utils').handleCallback;
 const filterOptions = require('./utils').filterOptions;
-const toError = require('./utils').toError;
 const ReadPreference = require('mongodb-core').ReadPreference;
 const MongoError = require('mongodb-core').MongoError;
 const ObjectID = require('mongodb-core').ObjectID;
 const Logger = require('mongodb-core').Logger;
-const Collection = require('./collection');
-const mergeOptionsAndWriteConcern = require('./utils').mergeOptionsAndWriteConcern;
 const executeOperation = require('./utils').executeOperation;
 const applyWriteConcern = require('./utils').applyWriteConcern;
 const resolveReadPreference = require('./utils').resolveReadPreference;
@@ -25,6 +21,7 @@ const CONSTANTS = require('./constants');
 
 // Operations
 const addUser = require('./operations/db_ops').addUser;
+const collection = require('./operations/db_ops').collection;
 const collections = require('./operations/db_ops').collections;
 const createCollection = require('./operations/db_ops').createCollection;
 const createIndex = require('./operations/db_ops').createIndex;
@@ -36,7 +33,7 @@ const evaluate = require('./operations/db_ops').evaluate;
 const executeCommand = require('./operations/db_ops').executeCommand;
 const executeDbAdminCommand = require('./operations/db_ops').executeDbAdminCommand;
 const indexInformation = require('./operations/db_ops').indexInformation;
-const listCollectionsTransforms = require('./operations/db_ops').listCollectionsTransforms;
+const listCollections = require('./operations/db_ops').listCollections;
 const profilingInfo = require('./operations/db_ops').profilingInfo;
 const profilingLevel = require('./operations/db_ops').profilingLevel;
 const removeUser = require('./operations/db_ops').removeUser;
@@ -317,18 +314,6 @@ Db.prototype.admin = function() {
  * @param {Collection} collection The collection instance.
  */
 
-const collectionKeys = [
-  'pkFactory',
-  'readPreference',
-  'serializeFunctions',
-  'strict',
-  'readConcern',
-  'ignoreUndefined',
-  'promoteValues',
-  'promoteBuffers',
-  'promoteLongs'
-];
-
 /**
  * Fetch a specific collection (containing the actual collection information). If the application does not use strict mode you
  * can use it without a callback in the following way: `const collection = db.collection('mycollection');`
@@ -359,7 +344,8 @@ const collectionSchema = {
   strict: { type: 'boolean' },
   readConcern: { type: 'object' },
   promiseLibrary: { overrideOnly: true },
-  ignoreUndefined: { overrideOnly: true }
+  ignoreUndefined: { overrideOnly: true },
+  fsync: { type: 'number' }
 };
 Db.prototype.collection = function(name, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -377,60 +363,7 @@ Db.prototype.collection = function(name, options, callback) {
     }
   );
 
-  // Merge in all needed options and ensure correct writeConcern merging from db level
-  options = mergeOptionsAndWriteConcern(options, this.s.options, collectionKeys, true);
-
-  // Execute
-  if (options == null || !options.strict) {
-    try {
-      const collection = new Collection(
-        this,
-        this.s.topology,
-        this.s.databaseName,
-        name,
-        this.s.pkFactory,
-        options
-      );
-      if (callback) callback(null, collection);
-      return collection;
-    } catch (err) {
-      if (err instanceof MongoError && callback) return callback(err);
-      throw err;
-    }
-  }
-
-  // Strict mode
-  if (typeof callback !== 'function') {
-    throw toError(`A callback is required in strict mode. While getting collection ${name}`);
-  }
-
-  // Did the user destroy the topology
-  if (this.serverConfig && this.serverConfig.isDestroyed()) {
-    return callback(new MongoError('topology was destroyed'));
-  }
-
-  const listCollectionOptions = Object.assign({}, options, { nameOnly: true });
-
-  // Strict mode
-  this.listCollections({ name: name }, listCollectionOptions).toArray((err, collections) => {
-    if (err != null) return handleCallback(callback, err, null);
-    if (collections.length === 0)
-      return handleCallback(
-        callback,
-        toError(`Collection ${name} does not exist. Currently in strict mode.`),
-        null
-      );
-
-    try {
-      return handleCallback(
-        callback,
-        null,
-        new Collection(this, this.s.topology, this.s.databaseName, name, this.s.pkFactory, options)
-      );
-    } catch (err) {
-      return handleCallback(callback, err, null);
-    }
-  });
+  return collection(this, name, options, callback);
 };
 
 /**
@@ -580,57 +513,7 @@ Db.prototype.listCollections = function(filter, options) {
     }
   );
 
-  // Cursor options
-  let cursor = options.batchSize ? { batchSize: options.batchSize } : {};
-
-  // We have a list collections command
-  if (this.serverConfig.capabilities().hasListCollectionsCommand) {
-    // Build the command
-    const command = { listCollections: true, filter, cursor, nameOnly: options.nameOnly };
-    // Create the cursor
-    cursor = this.s.topology.cursor(`${this.s.databaseName}.$cmd`, command, options);
-    // Do we have a readPreference, apply it
-    if (options.readPreference) {
-      cursor.setReadPreference(options.readPreference);
-    }
-    // Return the cursor
-    return cursor;
-  }
-
-  // We cannot use the listCollectionsCommand
-  if (!this.serverConfig.capabilities().hasListCollectionsCommand) {
-    // If we have legacy mode and have not provided a full db name filter it
-    if (
-      typeof filter.name === 'string' &&
-      !new RegExp('^' + this.databaseName + '\\.').test(filter.name)
-    ) {
-      filter = Object.assign({}, filter);
-      filter.name = `${this.s.databaseName}.${filter.name}`;
-    }
-  }
-
-  // No filter, filter by current database
-  if (filter == null) {
-    filter.name = `/${this.s.databaseName}/`;
-  }
-
-  // Rewrite the filter to use $and to filter out indexes
-  if (filter.name) {
-    filter = { $and: [{ name: filter.name }, { name: /^((?!\$).)*$/ }] };
-  } else {
-    filter = { name: /^((?!\$).)*$/ };
-  }
-
-  // Return options
-  const _options = { transforms: listCollectionsTransforms(this.s.databaseName) };
-  // Get the cursor
-  cursor = this.collection(CONSTANTS.SYSTEM_NAMESPACE_COLLECTION).find(filter, _options);
-  // Do we have a readPreference, apply it
-  if (options.readPreference) cursor.setReadPreference(options.readPreference);
-  // Set the passed in batch size if one was provided
-  if (options.batchSize) cursor = cursor.batchSize(options.batchSize);
-  // We have a fallback mode using legacy systems collections
-  return cursor;
+  return listCollections(this, filter, options);
 };
 
 /**
@@ -690,8 +573,13 @@ Db.prototype.renameCollection = function(fromCollection, toCollection, options, 
     { readPreference: ReadPreference.primary }
   );
 
-  const collection = this.collection(fromCollection);
-  return executeOperation(this.s.topology, rename, [collection, toCollection, options, callback]);
+  const oldCollection = collection(this, fromCollection);
+  return executeOperation(this.s.topology, rename, [
+    oldCollection,
+    toCollection,
+    options,
+    callback
+  ]);
 };
 
 /**
@@ -748,7 +636,8 @@ const dropDatabaseSchema = {
   wtimeout: { type: 'number' },
   j: { type: 'boolean' },
   session: { type: ClientSession },
-  readPreference: { overrideOnly: true }
+  readPreference: { overrideOnly: true },
+  writeConcern: { type: 'object' }
 };
 Db.prototype.dropDatabase = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});

--- a/lib/db.js
+++ b/lib/db.js
@@ -59,7 +59,13 @@ const setProfilingLevelSchema = require('./schemas/db_schemas').setProfilingLeve
 const statsSchema = require('./schemas/db_schemas').statsSchema;
 const watchSchema = require('./schemas/db_schemas').watchSchema;
 
-const loadAdmin = makeLazyLoader(`${__dirname}/./admin`);
+let Admin;
+function loadAdmin() {
+  if (!Admin) {
+    Admin = require('./admin');
+  }
+  return Admin;
+}
 
 /**
  * @fileOverview The **Db** class is a class that represents a MongoDB Database.

--- a/lib/db.js
+++ b/lib/db.js
@@ -59,6 +59,8 @@ const setProfilingLevelSchema = require('./schemas/db_schemas').setProfilingLeve
 const statsSchema = require('./schemas/db_schemas').statsSchema;
 const watchSchema = require('./schemas/db_schemas').watchSchema;
 
+const loadAdmin = makeLazyLoader(`${__dirname}/./admin`);
+
 /**
  * @fileOverview The **Db** class is a class that represents a MongoDB Database.
  *
@@ -316,7 +318,7 @@ Db.prototype.command = function(command, options, callback) {
  * @return {Admin} return the new Admin db instance
  */
 Db.prototype.admin = function() {
-  const Admin = require('./admin');
+  let Admin = loadAdmin();
 
   return new Admin(this, this.s.topology, this.s.promiseLibrary);
 };

--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -47,6 +47,10 @@ const inherits = util.inherits;
 const Duplex = require('stream').Duplex;
 const executeOperation = require('../utils').executeOperation;
 const deprecate = require('util').deprecate;
+const findOne = require('../operations/collection_ops').findOne;
+const remove = require('../operations/collection_ops').removeDocuments;
+const find = require('../operations/collection_ops').find;
+const ensureIndex = require('../operations/collection_ops').ensureIndex;
 
 var REFERENCE_BY_FILENAME = 0,
   REFERENCE_BY_ID = 1;
@@ -216,14 +220,14 @@ var open = function(self, options, callback) {
     // Get files collection
     var collection = self.collection();
     // Put index on filename
-    collection.ensureIndex([['filename', 1]], writeConcern, function() {
+    ensureIndex(collection, [['filename', 1]], writeConcern, function() {
       // Get chunk collection
       var chunkCollection = self.chunkCollection();
       // Make an unique index for compatibility with mongo-cxx-driver:legacy
       let chunkIndexOptions = Object.assign({}, writeConcern);
       chunkIndexOptions.unique = true;
       // Ensure index on chunk collection
-      chunkCollection.ensureIndex([['files_id', 1], ['n', 1]], chunkIndexOptions, function() {
+      ensureIndex(chunkCollection, [['files_id', 1], ['n', 1]], chunkIndexOptions, function() {
         // Open the connection
         _open(self, writeConcern, function(err, r) {
           if (err) return callback(err);
@@ -593,7 +597,7 @@ var unlink = function(self, options, callback) {
         return callback(err);
       }
 
-      collection.remove({ _id: self.fileId }, self.writeConcern, function(err) {
+      remove(collection, { _id: self.fileId }, self.writeConcern, function(err) {
         callback(err, self);
       });
     });
@@ -910,7 +914,7 @@ var _open = function(self, options, callback) {
 
   // Fetch the chunks
   if (query != null) {
-    collection.findOne(query, options, function(err, doc) {
+    findOne(collection, query, options, function(err, doc) {
       if (err) {
         return error(err);
       }
@@ -1186,14 +1190,16 @@ var nthChunk = function(self, chunkNumber, options, callback) {
   options = options || self.writeConcern;
   options.readPreference = self.readPreference;
   // Get the nth chunk
-  self
-    .chunkCollection()
-    .findOne({ files_id: self.fileId, n: chunkNumber }, options, function(err, chunk) {
-      if (err) return callback(err);
+  const chunkCollection = self.chunkCollection();
+  findOne(chunkCollection, { files_id: self.fileId, n: chunkNumber }, options, function(
+    err,
+    chunk
+  ) {
+    if (err) return callback(err);
 
-      var finalChunk = chunk == null ? {} : chunk;
-      callback(null, new Chunk(self, finalChunk, self.writeConcern));
-    });
+    var finalChunk = chunk == null ? {} : chunk;
+    callback(null, new Chunk(self, finalChunk, self.writeConcern));
+  });
 };
 
 /**
@@ -1217,7 +1223,8 @@ var deleteChunks = function(self, options, callback) {
   options = options || self.writeConcern;
 
   if (self.fileId != null) {
-    self.chunkCollection().remove({ files_id: self.fileId }, options, function(err) {
+    const chunkCollection = self.chunkCollection();
+    remove(chunkCollection, { files_id: self.fileId }, options, function(err) {
       if (err) return callback(err, false);
       callback(null, true);
     });
@@ -1318,7 +1325,7 @@ var exists = function(db, fileIdObject, rootCollection, options, callback) {
     }
 
     // Check if the entry exists
-    collection.findOne(query, { readPreference: readPreference }, function(err, item) {
+    findOne(collection, query, { readPreference: readPreference }, function(err, item) {
       if (err) return callback(err);
       callback(null, item == null ? false : true);
     });
@@ -1370,7 +1377,7 @@ var list = function(db, rootCollection, options, callback) {
   db.collection(rootCollectionFinal + '.files', function(err, collection) {
     if (err) return callback(err);
 
-    collection.find({}, { readPreference: readPreference }, function(err, cursor) {
+    find(collection, {}, { readPreference: readPreference }, function(err, cursor) {
       if (err) return callback(err);
 
       cursor.each(function(err, item) {
@@ -1532,7 +1539,7 @@ var unlinkStatic = function(self, db, names, options, callback) {
         if (err) return callback(err);
         gridStore.collection(function(err, collection) {
           if (err) return callback(err);
-          collection.remove({ _id: gridStore.fileId }, writeConcern, function(err) {
+          remove(collection, { _id: gridStore.fileId }, writeConcern, function(err) {
             callback(err, self);
           });
         });

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -2,13 +2,11 @@
 
 const applyDefaults = require('./options_validator').applyDefaults;
 const ChangeStream = require('./change_stream');
-const ClientSession = require('mongodb-core').Sessions.ClientSession;
 const Db = require('./db');
 const EventEmitter = require('events').EventEmitter;
 const executeOperation = require('./utils').executeOperation;
 const inherits = require('util').inherits;
 const MongoError = require('mongodb-core').MongoError;
-const ReadPreference = require('mongodb-core').ReadPreference;
 const resolveReadPreference = require('./utils').resolveReadPreference;
 const validate = require('./options_validator').validate;
 
@@ -16,89 +14,14 @@ const validate = require('./options_validator').validate;
 const connectOp = require('./operations/mongo_client_ops').connectOp;
 const logout = require('./operations/mongo_client_ops').logout;
 
-const connectSchema = {
-  appname: { type: 'string' },
-  authMechanism: { type: 'string' },
-  authMechanismProperties: { type: 'array' },
-  authSource: { type: 'string' },
-  compression: { type: 'string', alias: 'compressors' },
-  connectTimeoutMS: { type: 'number', default: 30000 },
-  heartbeatFrequencyMS: { type: 'number', default: 60000 },
-  j: { type: 'boolean', alias: 'journal' },
-  secondaryAcceptableLatencyMS: { type: 'number', default: 15, alias: 'localThresholdMS' },
-  maxIdleTimeMS: { type: 'number' },
-  maxPoolSize: { type: 'number', default: 5, alias: 'poolSize' },
-  poolSize: { type: 'number' },
-  maxStalenessSeconds: { type: 'number' },
-  readConcernLevel: { type: 'string', alias: 'readConcern.level' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  readPreferenceTags: { type: 'object' },
-  replicaSet: { type: 'string' },
-  retryWrites: { type: 'boolean', default: false },
-  serverSelectionTimeoutMS: { type: 'number', default: 30000 },
-  serverSelectionTryOnce: { type: 'boolean', default: true },
-  socketTimeoutMS: { type: 'number', default: 360000 },
-  ssl: { type: 'boolean', default: false },
-  tls: { type: 'boolean', default: false },
-  tlsAllowInvalidCertificates: { type: 'boolean', default: false },
-  tlsAllowInvalidHostnames: { type: 'boolean', default: false },
-  tlsCAFile: { type: 'string' },
-  tlsCertificateKeyFile: { type: 'string' },
-  tlsCertificateKeyFilePassword: { type: 'string' },
-  tlsInsecure: { type: 'boolean', default: false },
-  w: { type: 'number' },
-  wtimeout: { type: 'number', alias: 'wTimeoutMS' },
-  zlibCompressionLevel: { type: 'number', default: -1 },
-  // TODO: check these old options
-  sslCA: { type: 'string' },
-  sslCert: { type: 'string' },
-  sslValidate: { type: 'boolean', default: true },
-  sslKey: { type: 'buffer' },
-  sslPass: { type: 'string' },
-  sslCRL: { type: 'buffer' },
-  autoReconnect: { type: 'boolean', default: true },
-  auto_reconnect: { type: 'boolean', default: true },
-  noDelay: { type: 'boolean', default: true },
-  keepAlive: { type: 'boolean', default: true },
-  keepAliveInitialDelay: { type: 'number', default: 30000 },
-  family: { type: 'number' },
-  reconnectTries: { type: 'number', default: 30 },
-  reconnectInterval: { type: 'number', default: 1000 },
-  ha: { type: 'boolean', default: true },
-  haInterval: { type: 'number', default: 10000 },
-  acceptableLatencyMS: { type: 'number', default: 15 },
-  connectWithNoPrimary: { type: 'boolean', default: false },
-  forceServerObjectId: { type: 'boolean', default: false },
-  serializeFunctions: { type: 'boolean', default: false },
-  ignoreUndefined: { type: 'boolean', default: false },
-  raw: { type: 'boolean', default: false },
-  bufferMaxEntries: { type: 'number', default: -1 },
-  pkFactory: { type: ['object', 'function'] },
-  promiseLibrary: { type: ['object', 'function'] },
-  readConcern: { type: 'object' },
-  'readConcern.level': { type: 'string' },
-  loggerLevel: { type: 'string' },
-  logger: { type: ['object', 'function'] },
-  promoteValues: { type: 'boolean' },
-  promoteBuffers: { type: 'boolean' },
-  promoteLongs: { type: 'boolean' },
-  domainsEnabled: { type: 'boolean', default: false },
-  validateOptions: { type: 'boolean', default: false, deprecated: 'unknownOptionsWarningLevel' },
-  checkServerIdentity: { type: ['boolean', 'function'], default: true },
-  'auth.user': { type: 'string' },
-  'auth.password': { type: 'string' },
-  fsync: { type: 'boolean' },
-  numberOfRetries: { type: 'number', default: 5 },
-  minSize: { type: 'number' },
-  emitError: { type: 'boolean', default: true },
-  monitorCommands: { type: 'boolean', default: false },
-  useNewUrlParser: { type: 'boolean' },
-  useUnifiedTopology: { type: 'boolean' },
-  optionsValidationLevel: { type: 'string' },
-  unknownOptionsWarningLevel: { type: 'string' },
-  host: { type: 'string' },
-  auth: { type: 'object' }
-};
+// Schemas
+const connectSchema = require('./schemas/mongo_client_schemas').connectSchema;
+const dbSchema = require('./schemas/mongo_client_schemas').dbSchema;
+const isConnectedSchema = require('./schemas/mongo_client_schemas').isConnectedSchema;
+const logoutSchema = require('./schemas/mongo_client_schemas').logoutSchema;
+const startSessionSchema = require('./schemas/mongo_client_schemas').startSessionSchema;
+const watchSchema = require('./schemas/mongo_client_schemas').watchSchema;
+const withSessionSchema = require('./schemas/mongo_client_schemas').withSessionSchema;
 
 /**
  * @fileOverview The **MongoClient** class is a class that allows for making Connections to MongoDB.
@@ -340,9 +263,6 @@ MongoClient.prototype.connect = function(callback) {
  * @param {MongoClient~logoutCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-const logoutSchema = {
-  dbName: { type: 'string' }
-};
 MongoClient.prototype.logout = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
 
@@ -415,13 +335,6 @@ MongoClient.prototype.close = function(force, callback) {
  * @param {boolean} [options.returnNonCachedInstance] Control if you want to return a cached instance or have a new one created
  * @return {Db}
  */
-const dbSchema = {
-  noListener: { type: 'boolean', default: false },
-  returnNonCachedInstance: { type: 'boolean' },
-  readPreference: { overrideOnly: true },
-  promiseLibrary: { overrideOnly: true },
-  optionsValidationLevel: { type: 'string' }
-};
 MongoClient.prototype.db = function(dbName, options) {
   validate(dbSchema, options, { optionsValidationLevel: this.optionsValidationLevel });
 
@@ -471,10 +384,6 @@ MongoClient.prototype.db = function(dbName, options) {
  * @param {boolean} [options.returnNonCachedInstance] Control if you want to return a cached instance or have a new one created
  * @return {boolean}
  */
-const isConnectedSchema = {
-  noListener: { type: 'boolean', default: false },
-  returnNonCachedInstance: { type: 'boolean' }
-};
 MongoClient.prototype.isConnected = function(options) {
   validate(isConnectedSchema, options, { optionsValidationLevel: this.optionsValidationLevel });
 
@@ -611,10 +520,6 @@ MongoClient.connect = function(url, options, callback) {
  * @param {SessionOptions} [options] optional settings for a driver session
  * @return {ClientSession} the newly established session
  */
-const startSessionSchema = {
-  explicit: { overrideOnly: true },
-  causalConsistency: { type: 'boolean' }
-};
 MongoClient.prototype.startSession = function(options) {
   validate(startSessionSchema, options, { optionsValidationLevel: this.optionsValidationLevel });
 
@@ -641,9 +546,6 @@ MongoClient.prototype.startSession = function(options) {
  * @param {Function} operation An operation to execute with an implicitly created session. The signature of this MUST be `(session) => {}`
  * @return {Promise}
  */
-const withSessionSchema = {
-  causalConsistency: { type: 'boolean' }
-};
 MongoClient.prototype.withSession = function(options, operation) {
   if (typeof options === 'function') (operation = options), (options = undefined);
   const session = this.startSession(options);
@@ -693,17 +595,6 @@ MongoClient.prototype.withSession = function(options, operation) {
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {ChangeStream} a ChangeStream instance.
  */
-const watchSchema = {
-  fullDocument: { type: 'string', default: 'default' },
-  resumeAfter: { type: 'object' },
-  maxAwaitTimeMS: { type: 'number' },
-  batchSize: { type: 'number' },
-  collation: { type: 'object' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  startAtClusterTime: { type: 'Timestamp' },
-  session: { type: ClientSession },
-  optionsValidationLevel: { overrideOnly: true }
-};
 MongoClient.prototype.watch = function(pipeline, options) {
   pipeline = pipeline || [];
 

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -419,7 +419,8 @@ const dbSchema = {
   noListener: { type: 'boolean', default: false },
   returnNonCachedInstance: { type: 'boolean' },
   readPreference: { overrideOnly: true },
-  promiseLibrary: { overrideOnly: true }
+  promiseLibrary: { overrideOnly: true },
+  optionsValidationLevel: { type: 'string' }
 };
 MongoClient.prototype.db = function(dbName, options) {
   validate(dbSchema, options, { optionsValidationLevel: this.optionsValidationLevel });
@@ -611,7 +612,8 @@ MongoClient.connect = function(url, options, callback) {
  * @return {ClientSession} the newly established session
  */
 const startSessionSchema = {
-  explicit: { overrideOnly: true }
+  explicit: { overrideOnly: true },
+  causalConsistency: { type: 'boolean' }
 };
 MongoClient.prototype.startSession = function(options) {
   validate(startSessionSchema, options, { optionsValidationLevel: this.optionsValidationLevel });
@@ -639,7 +641,9 @@ MongoClient.prototype.startSession = function(options) {
  * @param {Function} operation An operation to execute with an implicitly created session. The signature of this MUST be `(session) => {}`
  * @return {Promise}
  */
-const withSessionSchema = {};
+const withSessionSchema = {
+  causalConsistency: { type: 'boolean' }
+};
 MongoClient.prototype.withSession = function(options, operation) {
   if (typeof options === 'function') (operation = options), (options = undefined);
   const session = this.startSession(options);

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const applyDefaults = require('../options_validator').applyDefaults;
 const applyWriteConcern = require('../utils').applyWriteConcern;
 const applyRetryableWrites = require('../utils').applyRetryableWrites;
 const checkCollectionName = require('../utils').checkCollectionName;
+const ClientSession = require('mongodb-core').Sessions.ClientSession;
 const Code = require('mongodb-core').BSON.Code;
 const createIndexDb = require('./db_ops').createIndex;
 const decorateCommand = require('../utils').decorateCommand;
@@ -20,7 +22,11 @@ const isObject = require('../utils').isObject;
 const Long = require('mongodb-core').BSON.Long;
 const makeLazyLoader = require('../utils').makeLazyLoader;
 const MongoError = require('mongodb-core').MongoError;
+const normalizeHintField = require('../utils').normalizeHintField;
+const ordered = require('../bulk/ordered');
+const ReadPreference = require('mongodb-core').ReadPreference;
 const toError = require('../utils').toError;
+const unordered = require('../bulk/unordered');
 
 const loadCollection = makeLazyLoader(`${__dirname}/../collection`);
 const loadDb = makeLazyLoader(`${__dirname}/../db`);
@@ -60,6 +66,118 @@ const groupFunction =
   'function () {\nvar c = db[ns].find(condition);\nvar map = new Map();\nvar reduce_function = reduce;\n\nwhile (c.hasNext()) {\nvar obj = c.next();\nvar key = {};\n\nfor (var i = 0, len = keys.length; i < len; ++i) {\nvar k = keys[i];\nkey[k] = obj[k];\n}\n\nvar aggObj = map.get(key);\n\nif (aggObj == null) {\nvar newObj = Object.extend({}, key);\naggObj = Object.extend(newObj, initial);\nmap.put(key, aggObj);\n}\n\nreduce_function(obj, aggObj);\n}\n\nreturn { "result": map.values() };\n}';
 
 /**
+ * Perform an aggregate operation. See Collection.prototype.aggregate for more information.
+ *
+ * @method
+ * @param {Collection} a Collection instance.
+ * @param {object} [pipeline=[]] Array containing all the aggregation framework commands for the execution.
+ * @param {object} [options] Optional settings. See Collection.prototype.aggregate for a list of options.
+ * @param {Collection~aggregationCallback} callback The command result callback
+ */
+const aggregateSchema = {
+  readPreference: { type: [ReadPreference, 'string', 'object'] },
+  cursor: { type: 'object', default: {} },
+  batchSize: { type: 'number' },
+  explain: { type: 'boolean' },
+  allowDiskUse: { type: 'boolean' },
+  maxTimeMS: { type: 'number' },
+  bypassDocumentValidation: { type: 'boolean' },
+  raw: { type: 'boolean' },
+  promoteLongs: { type: 'boolean' },
+  promoteValues: { type: 'boolean' },
+  promoteBuffers: { type: 'boolean' },
+  collation: { type: 'object' },
+  comment: { type: 'string' },
+  hint: { type: ['object', 'string'] },
+  session: { type: ClientSession },
+  promiseLibrary: { type: 'function', overrideOnly: true },
+  cursorFactory: { overrideOnly: true },
+  optionsValidationLevel: { overrideOnly: true }
+};
+function aggregate(coll, pipeline, options, callback) {
+  options = applyDefaults(aggregateSchema, options, {});
+
+  // Ignore readConcern option
+  let ignoreReadConcern = false;
+
+  // Build the command
+  const command = { aggregate: coll.s.name, pipeline: pipeline };
+
+  // If out was specified
+  if (typeof options.out === 'string') {
+    pipeline.push({ $out: options.out });
+    // Ignore read concern
+    ignoreReadConcern = true;
+  } else if (pipeline.length > 0 && pipeline[pipeline.length - 1]['$out']) {
+    ignoreReadConcern = true;
+  }
+
+  // Decorate command with writeConcern if out has been specified
+  if (
+    pipeline.length > 0 &&
+    pipeline[pipeline.length - 1]['$out'] &&
+    coll.s.topology.capabilities().commandsTakeWriteConcern
+  ) {
+    applyWriteConcern(command, { db: coll.s.db, collection: coll }, options);
+  }
+
+  // Have we specified collation
+  try {
+    decorateWithCollation(command, coll, options);
+  } catch (err) {
+    if (typeof callback === 'function') return callback(err, null);
+    throw err;
+  }
+
+  // If we have bypassDocumentValidation set
+  if (options.bypassDocumentValidation === true) {
+    command.bypassDocumentValidation = options.bypassDocumentValidation;
+  }
+
+  // Do we have a readConcern specified
+  if (!ignoreReadConcern) {
+    decorateWithReadConcern(command, coll, options);
+  }
+
+  // If we have allowDiskUse defined
+  if (options.allowDiskUse) command.allowDiskUse = options.allowDiskUse;
+  if (typeof options.maxTimeMS === 'number') command.maxTimeMS = options.maxTimeMS;
+
+  // If we are giving a hint
+  if (options.hint) command.hint = options.hint;
+
+  // If explain has been specified add it
+  if (options.explain) {
+    if (command.readConcern || command.writeConcern) {
+      throw toError('"explain" cannot be used on an aggregate call with readConcern/writeConcern');
+    }
+    command.explain = options.explain;
+  }
+
+  if (typeof options.comment === 'string') command.comment = options.comment;
+
+  command.cursor = options.cursor;
+  if (options.batchSize) command.cursor.batchSize = options.batchSize;
+
+  if (typeof callback !== 'function') {
+    if (!coll.s.topology.capabilities()) {
+      throw new MongoError('cannot connect to server');
+    }
+
+    // Allow disk usage command
+    if (typeof options.allowDiskUse === 'boolean') {
+      command.allowDiskUse = options.allowDiskUse;
+    }
+    if (typeof options.maxTimeMS === 'number') command.maxTimeMS = options.maxTimeMS;
+
+    // Execute the cursor
+    return coll.s.topology.cursor(coll.s.namespace, command, options);
+  }
+
+  return handleCallback(callback, null, coll.s.topology.cursor(coll.s.namespace, command, options));
+}
+
+/**
  * Perform a bulkWrite operation. See Collection.prototype.bulkWrite for more information.
  *
  * @method
@@ -72,8 +190,8 @@ function bulkWrite(coll, operations, options, callback) {
   // Create the bulk operation
   const bulk =
     options.ordered === true
-      ? coll.initializeOrderedBulkOp(options)
-      : coll.initializeUnorderedBulkOp(options);
+      ? ordered(coll.s.topology, coll, options)
+      : unordered(coll.s.topology, coll, options);
 
   // Do we have a collation
   let collation = false;
@@ -193,6 +311,15 @@ function count(coll, query, options, callback) {
   });
 }
 
+/**
+ * Gets the number of documents matching the filter.
+ *
+ * @param {Collection} a Collection instance.
+ * @param {object} [query] the query for the count
+ * @param {object} [options] Optional settings.
+ * @param {Collection~countCallback} [callback] The command result callback.
+ * @return {Promise} returns Promise if no callback passed.
+ */
 function countDocuments(coll, query, options, callback) {
   const skip = options.skip;
   const limit = options.limit;
@@ -214,9 +341,7 @@ function countDocuments(coll, query, options, callback) {
   delete options.limit;
   delete options.skip;
 
-  decorateWithReadConcern(options, coll, options);
-
-  coll.aggregate(pipeline, options).toArray((err, docs) => {
+  aggregate(coll, pipeline, options).toArray((err, docs) => {
     if (err) return handleCallback(callback, err);
     handleCallback(callback, null, docs.length ? docs[0].n : 0);
   });
@@ -453,6 +578,171 @@ function ensureIndex(coll, fieldOrSpec, options, callback) {
 }
 
 /**
+ * Creates a cursor for a query that can be used to iterate over results from MongoDB
+ *
+ * @method
+ * @param {object} [query={}] The cursor query object.
+ * @param {object} [options] Optional settings. See Collection.prototype.find for a list of options.
+ * @throws {MongoError}
+ * @return {Cursor}
+ */
+const findSchema = {
+  limit: { type: 'number', default: 0 },
+  sort: { type: ['array', 'object', 'string'] },
+  projection: { type: 'object' },
+  fields: { type: 'object' },
+  skip: { type: 'number', default: 0 },
+  hint: { type: ['string', 'object'] },
+  explain: { type: 'boolean' },
+  snapshot: { type: 'boolean' },
+  timeout: { type: 'boolean' },
+  tailable: { type: 'boolean' },
+  batchSize: { type: 'number' },
+  returnKey: { type: 'boolean' },
+  maxScan: { type: 'number' },
+  min: { type: 'number' },
+  max: { type: 'number' },
+  showDiskLoc: { type: 'boolean' },
+  showRecordId: { type: 'boolean' },
+  comment: { type: 'string' },
+  raw: { type: 'boolean' },
+  promoteLongs: { type: 'boolean' },
+  promoteValues: { type: 'boolean' },
+  promoteBuffers: { type: 'boolean' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  partial: { type: 'boolean' },
+  maxTimeMS: { type: 'number' },
+  collation: { type: 'object' },
+  session: { type: ClientSession },
+  promiseLibrary: { overrideOnly: true },
+  slaveOk: { type: 'boolean' },
+  awaitData: { type: 'boolean' },
+  noCursorTimeout: { type: 'boolean', overrideOnly: true },
+  ignoreUndefined: { overrideOnly: true },
+  optionsValidationLevel: { overrideOnly: true }
+};
+function find(coll, query, options, callback) {
+  if (typeof callback === 'object') {
+    // TODO(MAJOR): throw in the future
+    console.warn('Third parameter to `find()` must be a callback or undefined');
+  }
+
+  let selector = query;
+  // figuring out arguments
+  if (typeof callback !== 'function') {
+    if (typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    } else if (options == null) {
+      callback = typeof selector === 'function' ? selector : undefined;
+      selector = typeof selector === 'object' ? selector : undefined;
+    }
+  }
+
+  // Ensure selector is not null
+  selector = selector == null ? {} : selector;
+  // Validate correctness off the selector
+  const object = selector;
+  if (Buffer.isBuffer(object)) {
+    const object_size = object[0] | (object[1] << 8) | (object[2] << 16) | (object[3] << 24);
+    if (object_size !== object.length) {
+      const error = new Error(
+        'query selector raw message size does not match message header size [' +
+          object.length +
+          '] != [' +
+          object_size +
+          ']'
+      );
+      error.name = 'MongoError';
+      throw error;
+    }
+  }
+
+  // Check special case where we are using an objectId
+  if (selector != null && selector._bsontype === 'ObjectID') {
+    selector = { _id: selector };
+  }
+
+  const finalOptions = applyDefaults(
+    findSchema,
+    options,
+    {
+      raw: coll.s.raw,
+      promoteLongs: coll.s.promoteLongs,
+      promoteValues: coll.s.promoteValues,
+      promoteBuffers: coll.s.promoteBuffers,
+      slaveOk: coll.s.db.slaveOk
+    },
+    {
+      readPreference: resolveReadPreference(options, { db: coll.s.db, collection: coll }),
+      hint:
+        options && options.hint != null ? normalizeHintField(options.hint) : coll.s.collectionHint,
+      noCursorTimeout: options ? options.timeout : null,
+      promiseLibrary: coll.s.promiseLibrary,
+      ignoreUndefined: coll.s.options.ignoreUndefined,
+      optionsValidationLevel: coll.optionsValidationLevel
+    }
+  );
+
+  let projection = finalOptions.projection || finalOptions.fields;
+
+  if (projection && !Buffer.isBuffer(projection) && Array.isArray(projection)) {
+    projection = projection.length
+      ? projection.reduce((result, field) => {
+          result[field] = 1;
+          return result;
+        }, {})
+      : { _id: 1 };
+  }
+
+  // Set slave ok to true if read preference different from primary
+  if (
+    finalOptions.readPreference != null &&
+    (finalOptions.readPreference !== 'primary' || finalOptions.readPreference.mode !== 'primary')
+  ) {
+    finalOptions.slaveOk = true;
+  }
+
+  // Ensure the query is an object
+  if (selector != null && typeof selector !== 'object') {
+    throw MongoError.create({ message: 'query selector must be an object', driver: true });
+  }
+
+  // Build the find command
+  const findCommand = {
+    find: coll.s.namespace,
+    limit: finalOptions.limit,
+    skip: finalOptions.skip,
+    query: selector
+  };
+
+  // Merge in options to command
+  decorateCommand(findCommand, finalOptions, ['session', 'collation']);
+
+  if (projection) findCommand.fields = projection;
+
+  // Sort options
+  if (findCommand.sort) {
+    findCommand.sort = formattedOrderClause(findCommand.sort);
+  }
+
+  // Set the readConcern
+  decorateWithReadConcern(findCommand, coll, finalOptions);
+
+  // Decorate find command with collation options
+  try {
+    decorateWithCollation(findCommand, coll, finalOptions);
+  } catch (err) {
+    if (typeof callback === 'function') return callback(err, null);
+    throw err;
+  }
+
+  const cursor = coll.s.topology.cursor(coll.s.namespace, findCommand, finalOptions);
+
+  return typeof callback === 'function' ? handleCallback(callback, null, cursor) : cursor;
+}
+
+/**
  * Find and update a document.
  *
  * @method
@@ -555,8 +845,7 @@ function findAndRemove(coll, query, sort, options, callback) {
  * @param {Collection~resultCallback} [callback] The command result callback
  */
 function findOne(coll, query, options, callback) {
-  const cursor = coll
-    .find(query, options)
+  const cursor = find(coll, query, options)
     .limit(-1)
     .batchSize(1);
 
@@ -850,6 +1139,42 @@ function isCapped(coll, options, callback) {
     if (err) return handleCallback(callback, err);
     handleCallback(callback, null, !!(document && document.capped));
   });
+}
+
+/**
+ * Get the list of all indexes information for the collection.
+ *
+ * @method
+ * @param {Collection} a Collection instance.
+ * @param {object} [options] Optional settings. See Collection.prototype.listIndexes for a list of options.
+ * @param {Collection~resultCallback} [callback] The command result callback
+ */
+function listIndexes(coll, options) {
+  // Cursor options
+  let cursor = options.batchSize ? { batchSize: options.batchSize } : {};
+
+  // We have a list collections command
+  if (coll.s.topology.capabilities().hasListIndexesCommand) {
+    // Build the command
+    const command = { listIndexes: coll.s.name, cursor: cursor };
+    // Execute the cursor
+    cursor = coll.s.topology.cursor(`${coll.s.dbName}.$cmd`, command, options);
+    // Do we have a readPreference, apply it
+    if (options.readPreference) cursor.setReadPreference(options.readPreference);
+    // Return the cursor
+    return cursor;
+  }
+
+  // Get the namespace
+  const ns = `${coll.s.dbName}.system.indexes`;
+  // Get the query
+  cursor = coll.s.topology.cursor(ns, { find: ns, query: { ns: coll.s.namespace } }, options);
+  // Do we have a readPreference, apply it
+  if (options.readPreference) cursor.setReadPreference(options.readPreference);
+  // Set the passed in batch size if one was provided
+  if (options.batchSize) cursor = cursor.batchSize(options.batchSize);
+  // Return the cursor
+  return cursor;
 }
 
 /**
@@ -1383,6 +1708,7 @@ function updateOne(coll, filter, update, options, callback) {
 }
 
 module.exports = {
+  aggregate,
   bulkWrite,
   checkForAtomicOperators,
   count,
@@ -1396,6 +1722,7 @@ module.exports = {
   dropIndex,
   dropIndexes,
   ensureIndex,
+  find,
   findAndModify,
   findAndRemove,
   findOne,
@@ -1409,6 +1736,7 @@ module.exports = {
   indexInformation,
   insertOne,
   isCapped,
+  listIndexes,
   mapReduce,
   optionsOp,
   parallelCollectionScan,

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -23,10 +23,10 @@ const Long = require('mongodb-core').BSON.Long;
 const makeLazyLoader = require('../utils').makeLazyLoader;
 const MongoError = require('mongodb-core').MongoError;
 const normalizeHintField = require('../utils').normalizeHintField;
-const ordered = require('../bulk/ordered');
+const initializeOrderedBulkOp = require('../bulk/ordered');
 const ReadPreference = require('mongodb-core').ReadPreference;
 const toError = require('../utils').toError;
-const unordered = require('../bulk/unordered');
+const initializeUnorderedBulkOp = require('../bulk/unordered');
 
 const loadCollection = makeLazyLoader(`${__dirname}/../collection`);
 const loadDb = makeLazyLoader(`${__dirname}/../db`);
@@ -190,8 +190,8 @@ function bulkWrite(coll, operations, options, callback) {
   // Create the bulk operation
   const bulk =
     options.ordered === true
-      ? ordered(coll.s.topology, coll, options)
-      : unordered(coll.s.topology, coll, options);
+      ? initializeOrderedBulkOp(coll.s.topology, coll, options)
+      : initializeUnorderedBulkOp(coll.s.topology, coll, options);
 
   // Do we have a collation
   let collation = false;

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -19,7 +19,6 @@ const handleCallback = require('../utils').handleCallback;
 const indexInformationDb = require('./db_ops').indexInformation;
 const isObject = require('../utils').isObject;
 const Long = require('mongodb-core').BSON.Long;
-const makeLazyLoader = require('../utils').makeLazyLoader;
 const MongoError = require('mongodb-core').MongoError;
 const normalizeHintField = require('../utils').normalizeHintField;
 const initializeOrderedBulkOp = require('../bulk/ordered');
@@ -29,8 +28,20 @@ const initializeUnorderedBulkOp = require('../bulk/unordered');
 const aggregateOperationSchema = require('../schemas/collection_schemas').aggregateOperationSchema;
 const findOperationSchema = require('../schemas/collection_schemas').findOperationSchema;
 
-const loadCollection = makeLazyLoader(`${__dirname}/../collection`);
-const loadDb = makeLazyLoader(`${__dirname}/../db`);
+let collection;
+function loadCollection() {
+  if (!collection) {
+    collection = require('../collection');
+  }
+  return collection;
+}
+let db;
+function loadDb() {
+  if (!db) {
+    db = require('../db');
+  }
+  return db;
+}
 
 /**
  * Group function helper

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -4,7 +4,6 @@ const applyDefaults = require('../options_validator').applyDefaults;
 const applyWriteConcern = require('../utils').applyWriteConcern;
 const applyRetryableWrites = require('../utils').applyRetryableWrites;
 const checkCollectionName = require('../utils').checkCollectionName;
-const ClientSession = require('mongodb-core').Sessions.ClientSession;
 const Code = require('mongodb-core').BSON.Code;
 const createIndexDb = require('./db_ops').createIndex;
 const decorateCommand = require('../utils').decorateCommand;
@@ -24,9 +23,11 @@ const makeLazyLoader = require('../utils').makeLazyLoader;
 const MongoError = require('mongodb-core').MongoError;
 const normalizeHintField = require('../utils').normalizeHintField;
 const initializeOrderedBulkOp = require('../bulk/ordered');
-const ReadPreference = require('mongodb-core').ReadPreference;
 const toError = require('../utils').toError;
 const initializeUnorderedBulkOp = require('../bulk/unordered');
+
+const aggregateOperationSchema = require('../schemas/collection_schemas').aggregateOperationSchema;
+const findOperationSchema = require('../schemas/collection_schemas').findOperationSchema;
 
 const loadCollection = makeLazyLoader(`${__dirname}/../collection`);
 const loadDb = makeLazyLoader(`${__dirname}/../db`);
@@ -74,28 +75,8 @@ const groupFunction =
  * @param {object} [options] Optional settings. See Collection.prototype.aggregate for a list of options.
  * @param {Collection~aggregationCallback} callback The command result callback
  */
-const aggregateSchema = {
-  readPreference: { type: [ReadPreference, 'string', 'object'] },
-  cursor: { type: 'object', default: {} },
-  batchSize: { type: 'number' },
-  explain: { type: 'boolean' },
-  allowDiskUse: { type: 'boolean' },
-  maxTimeMS: { type: 'number' },
-  bypassDocumentValidation: { type: 'boolean' },
-  raw: { type: 'boolean' },
-  promoteLongs: { type: 'boolean' },
-  promoteValues: { type: 'boolean' },
-  promoteBuffers: { type: 'boolean' },
-  collation: { type: 'object' },
-  comment: { type: 'string' },
-  hint: { type: ['object', 'string'] },
-  session: { type: ClientSession },
-  promiseLibrary: { type: 'function', overrideOnly: true },
-  cursorFactory: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true }
-};
 function aggregate(coll, pipeline, options, callback) {
-  options = applyDefaults(aggregateSchema, options, {});
+  options = applyDefaults(aggregateOperationSchema, options, {});
 
   // Ignore readConcern option
   let ignoreReadConcern = false;
@@ -586,41 +567,6 @@ function ensureIndex(coll, fieldOrSpec, options, callback) {
  * @throws {MongoError}
  * @return {Cursor}
  */
-const findSchema = {
-  limit: { type: 'number', default: 0 },
-  sort: { type: ['array', 'object', 'string'] },
-  projection: { type: 'object' },
-  fields: { type: 'object' },
-  skip: { type: 'number', default: 0 },
-  hint: { type: ['string', 'object'] },
-  explain: { type: 'boolean' },
-  snapshot: { type: 'boolean' },
-  timeout: { type: 'boolean' },
-  tailable: { type: 'boolean' },
-  batchSize: { type: 'number' },
-  returnKey: { type: 'boolean' },
-  maxScan: { type: 'number' },
-  min: { type: 'number' },
-  max: { type: 'number' },
-  showDiskLoc: { type: 'boolean' },
-  showRecordId: { type: 'boolean' },
-  comment: { type: 'string' },
-  raw: { type: 'boolean' },
-  promoteLongs: { type: 'boolean' },
-  promoteValues: { type: 'boolean' },
-  promoteBuffers: { type: 'boolean' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  partial: { type: 'boolean' },
-  maxTimeMS: { type: 'number' },
-  collation: { type: 'object' },
-  session: { type: ClientSession },
-  promiseLibrary: { overrideOnly: true },
-  slaveOk: { type: 'boolean' },
-  awaitData: { type: 'boolean' },
-  noCursorTimeout: { type: 'boolean', overrideOnly: true },
-  ignoreUndefined: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true }
-};
 function find(coll, query, options, callback) {
   if (typeof callback === 'object') {
     // TODO(MAJOR): throw in the future
@@ -664,7 +610,7 @@ function find(coll, query, options, callback) {
   }
 
   const finalOptions = applyDefaults(
-    findSchema,
+    findOperationSchema,
     options,
     {
       raw: coll.s.raw,

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -1443,7 +1443,7 @@ function removeDocuments(coll, selector, options, callback) {
  * @param {Collection~collectionResultCallback} [callback] The results callback
  */
 function rename(coll, newName, options, callback) {
-  let Collection = loadCollection();
+  const Collection = loadCollection();
   // Check the collection name
   checkCollectionName(newName);
   // Build the command

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -28,19 +28,19 @@ const initializeUnorderedBulkOp = require('../bulk/unordered');
 const aggregateOperationSchema = require('../schemas/collection_schemas').aggregateOperationSchema;
 const findOperationSchema = require('../schemas/collection_schemas').findOperationSchema;
 
-let collection;
+let Collection;
 function loadCollection() {
-  if (!collection) {
-    collection = require('../collection');
+  if (!Collection) {
+    Collection = require('../collection');
   }
-  return collection;
+  return Collection;
 }
-let db;
+let Db;
 function loadDb() {
-  if (!db) {
-    db = require('../db');
+  if (!Db) {
+    Db = require('../db');
   }
-  return db;
+  return Db;
 }
 
 /**

--- a/lib/operations/cursor_ops.js
+++ b/lib/operations/cursor_ops.js
@@ -3,11 +3,16 @@
 const buildCountCommand = require('./collection_ops').buildCountCommand;
 const formattedOrderClause = require('../utils').formattedOrderClause;
 const handleCallback = require('../utils').handleCallback;
-const makeLazyLoader = require('../utils').makeLazyLoader;
 const MongoError = require('mongodb-core').MongoError;
 const push = Array.prototype.push;
 
-const loadCursor = makeLazyLoader(`${__dirname}/../cursor`);
+let cursor;
+function loadCursor() {
+  if (!cursor) {
+    cursor = require('../cursor');
+  }
+  return cursor;
+}
 
 /**
  * Get the count of documents for this cursor.

--- a/lib/operations/cursor_ops.js
+++ b/lib/operations/cursor_ops.js
@@ -6,12 +6,12 @@ const handleCallback = require('../utils').handleCallback;
 const MongoError = require('mongodb-core').MongoError;
 const push = Array.prototype.push;
 
-let cursor;
+let Cursor;
 function loadCursor() {
-  if (!cursor) {
-    cursor = require('../cursor');
+  if (!Cursor) {
+    Cursor = require('../cursor');
   }
-  return cursor;
+  return Cursor;
 }
 
 /**

--- a/lib/operations/cursor_ops.js
+++ b/lib/operations/cursor_ops.js
@@ -68,7 +68,7 @@ function count(cursor, applySkipLimit, opts, callback) {
  * @param {Cursor~resultCallback} callback The result callback.
  */
 function each(cursor, callback) {
-  let Cursor = loadCursor();
+  const Cursor = loadCursor();
 
   if (!callback) throw MongoError.create({ message: 'callback is mandatory', driver: true });
   if (cursor.isNotified()) return;
@@ -108,7 +108,7 @@ function each(cursor, callback) {
  * @param {Cursor~resultCallback} [callback] The result callback.
  */
 function hasNext(cursor, callback) {
-  let Cursor = loadCursor();
+  const Cursor = loadCursor();
 
   if (cursor.s.currentDoc) {
     return callback(null, true);
@@ -159,7 +159,7 @@ function next(cursor, callback) {
 
 // Get the next available document from the cursor, returns null if no more documents are available.
 function nextObject(cursor, callback) {
-  let Cursor = loadCursor();
+  const Cursor = loadCursor();
 
   if (cursor.s.state === Cursor.CLOSED || (cursor.isDead && cursor.isDead()))
     return handleCallback(
@@ -190,7 +190,7 @@ function nextObject(cursor, callback) {
  * @param {Cursor~toArrayResultCallback} [callback] The result callback.
  */
 function toArray(cursor, callback) {
-  let Cursor = loadCursor();
+  const Cursor = loadCursor();
 
   const items = [];
 

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -2,13 +2,13 @@
 
 const applyDefaults = require('../options_validator').applyDefaults;
 const applyWriteConcern = require('../utils').applyWriteConcern;
-const ClientSession = require('mongodb-core').Sessions.ClientSession;
 const Code = require('mongodb-core').BSON.Code;
 const resolveReadPreference = require('../utils').resolveReadPreference;
 const crypto = require('crypto');
 const debugOptions = require('../utils').debugOptions;
 const handleCallback = require('../utils').handleCallback;
 const makeLazyLoader = require('../utils').makeLazyLoader;
+const mergeOptionsAndWriteConcern = require('../utils').mergeOptionsAndWriteConcern;
 const MongoError = require('mongodb-core').MongoError;
 const parseIndexOptions = require('../utils').parseIndexOptions;
 const ReadPreference = require('mongodb-core').ReadPreference;
@@ -20,8 +20,22 @@ const findOne = require('./collection_ops').findOne;
 const remove = require('./collection_ops').remove;
 const updateOne = require('./collection_ops').updateOne;
 
+const listCollectionsSchema = require('./schemas/collection_schemas').listCollectionsSchema;
+
 const loadCollection = makeLazyLoader(`${__dirname}/../collection`);
 const loadDb = makeLazyLoader(`${__dirname}/../db`);
+
+const collectionKeys = [
+  'pkFactory',
+  'readPreference',
+  'serializeFunctions',
+  'strict',
+  'readConcern',
+  'ignoreUndefined',
+  'promoteValues',
+  'promoteBuffers',
+  'promoteLongs'
+];
 
 const debugFields = [
   'authSource',
@@ -130,7 +144,7 @@ function addUser(db, username, password, options, callback) {
 }
 
 function collection(db, name, options, callback) {
-  const Collection = require('../collection');
+  let Collection = loadCollection();
 
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
@@ -319,7 +333,7 @@ function createCollection(db, name, options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  */
 function createIndex(db, name, fieldOrSpec, options, callback) {
-  const Db = require('../db');
+  let Db = loadDb();
   // Get the write concern options
   let finalOptions = Object.assign({}, { readPreference: ReadPreference.primary }, options);
   finalOptions = applyWriteConcern(finalOptions, { db }, options);
@@ -640,16 +654,8 @@ function indexInformation(db, name, options, callback) {
  * @param {object} [options] Optional settings. See Db.prototype.listCollections for a list of options.
  * @return {CommandCursor}
  */
-const listCollectionsSchema = {
-  nameOnly: { type: 'boolean', default: false },
-  batchSize: { type: 'number' },
-  readPreference: { type: [ReadPreference, 'object', 'string'] },
-  session: { type: ClientSession },
-  cursorFactory: { overrideOnly: true },
-  optionsValidationLevel: { overrideOnly: true }
-};
 function listCollections(db, filter, options) {
-  const Db = require('../db');
+  let Db = loadDb();
   const find = require('./collection_ops').find;
   options = options || {};
   options = applyDefaults(listCollectionsSchema, options, {});

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -7,7 +7,6 @@ const resolveReadPreference = require('../utils').resolveReadPreference;
 const crypto = require('crypto');
 const debugOptions = require('../utils').debugOptions;
 const handleCallback = require('../utils').handleCallback;
-const makeLazyLoader = require('../utils').makeLazyLoader;
 const mergeOptionsAndWriteConcern = require('../utils').mergeOptionsAndWriteConcern;
 const MongoError = require('mongodb-core').MongoError;
 const parseIndexOptions = require('../utils').parseIndexOptions;
@@ -23,10 +22,6 @@ const updateOne = require('./collection_ops').updateOne;
 const listCollectionsOperationSchema = require('../schemas/db_schemas')
   .listCollectionsOperationSchema;
 
-const loadCollection = makeLazyLoader(`${__dirname}/../collection`);
-const loadDb = makeLazyLoader(`${__dirname}/../db`);
-const loadCollectionOps = makeLazyLoader(`${__dirname}/./collection_ops`);
-
 const collectionKeys = [
   'pkFactory',
   'readPreference',
@@ -38,6 +33,21 @@ const collectionKeys = [
   'promoteBuffers',
   'promoteLongs'
 ];
+
+let collection;
+function loadCollection() {
+  if (!collection) {
+    collection = require('../collection');
+  }
+  return collection;
+}
+let db;
+function loadDb() {
+  if (!db) {
+    db = require('../db');
+  }
+  return db;
+}
 
 const debugFields = [
   'authSource',

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -20,7 +20,7 @@ const findOne = require('./collection_ops').findOne;
 const remove = require('./collection_ops').remove;
 const updateOne = require('./collection_ops').updateOne;
 
-const listCollectionsSchema = require('./schemas/collection_schemas').listCollectionsSchema;
+const listCollectionsSchema = require('../schemas/collection_schemas').listCollectionsSchema;
 
 const loadCollection = makeLazyLoader(`${__dirname}/../collection`);
 const loadDb = makeLazyLoader(`${__dirname}/../db`);

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -1,12 +1,14 @@
 'use strict';
 
+const applyDefaults = require('../options_validator').applyDefaults;
 const applyWriteConcern = require('../utils').applyWriteConcern;
+const ClientSession = require('mongodb-core').Sessions.ClientSession;
 const Code = require('mongodb-core').BSON.Code;
 const resolveReadPreference = require('../utils').resolveReadPreference;
 const crypto = require('crypto');
 const debugOptions = require('../utils').debugOptions;
 const handleCallback = require('../utils').handleCallback;
-const makeLazyLoader = require('../utils').makeLazyLoader;
+const mergeOptionsAndWriteConcern = require('../utils').mergeOptionsAndWriteConcern;
 const MongoError = require('mongodb-core').MongoError;
 const parseIndexOptions = require('../utils').parseIndexOptions;
 const ReadPreference = require('mongodb-core').ReadPreference;
@@ -18,8 +20,17 @@ const findOne = require('./collection_ops').findOne;
 const remove = require('./collection_ops').remove;
 const updateOne = require('./collection_ops').updateOne;
 
-const loadCollection = makeLazyLoader(`${__dirname}/../collection`);
-const loadDb = makeLazyLoader(`${__dirname}/../db`);
+const collectionKeys = [
+  'pkFactory',
+  'readPreference',
+  'serializeFunctions',
+  'strict',
+  'readConcern',
+  'ignoreUndefined',
+  'promoteValues',
+  'promoteBuffers',
+  'promoteLongs'
+];
 
 const debugFields = [
   'authSource',
@@ -89,7 +100,7 @@ function addUser(db, username, password, options, callback) {
       const db = options.dbName ? new Db(options.dbName, db.s.client, db.s.options) : db;
 
       // Fetch a user collection
-      const collection = db.collection(CONSTANTS.SYSTEM_USER_COLLECTION);
+      const collection = collection(CONSTANTS.SYSTEM_USER_COLLECTION);
 
       // Check if we are inserting the first user
       count(collection, {}, finalOptions, (err, count) => {
@@ -127,6 +138,68 @@ function addUser(db, username, password, options, callback) {
   });
 }
 
+function collection(db, name, options, callback) {
+  const Collection = require('../collection');
+
+  if (typeof options === 'function') (callback = options), (options = {});
+  options = options || {};
+
+  // Merge in all needed options and ensure correct writeConcern merging from db level
+  options = mergeOptionsAndWriteConcern(options, db.s.options, collectionKeys, true);
+
+  // Execute
+  if (options == null || !options.strict) {
+    try {
+      const collection = new Collection(
+        db,
+        db.s.topology,
+        db.s.databaseName,
+        name,
+        db.s.pkFactory,
+        options
+      );
+      if (callback) callback(null, collection);
+      return collection;
+    } catch (err) {
+      if (err instanceof MongoError && callback) return callback(err);
+      throw err;
+    }
+  }
+
+  // Strict mode
+  if (typeof callback !== 'function') {
+    throw toError(`A callback is required in strict mode. While getting collection ${name}`);
+  }
+
+  // Did the user destroy the topology
+  if (db.serverConfig && db.serverConfig.isDestroyed()) {
+    return callback(new MongoError('topology was destroyed'));
+  }
+
+  const listCollectionOptions = Object.assign({}, options, { nameOnly: true });
+
+  // Strict mode
+  listCollections(db, { name: name }, listCollectionOptions).toArray((err, collections) => {
+    if (err != null) return handleCallback(callback, err, null);
+    if (collections.length === 0)
+      return handleCallback(
+        callback,
+        toError(`Collection ${name} does not exist. Currently in strict mode.`),
+        null
+      );
+
+    try {
+      return handleCallback(
+        callback,
+        null,
+        new Collection(db, db.s.topology, db.s.databaseName, name, db.s.pkFactory, options)
+      );
+    } catch (err) {
+      return handleCallback(callback, err, null);
+    }
+  });
+}
+
 /**
  * Fetch all collections for the current db.
  *
@@ -140,7 +213,7 @@ function collections(db, options, callback) {
 
   options = Object.assign({}, options, { nameOnly: true });
   // Let's get the collection names
-  db.listCollections({}, options).toArray((err, documents) => {
+  listCollections(db, {}, options).toArray((err, documents) => {
     if (err != null) return handleCallback(callback, err, null);
     // Filter collections removing any illegal ones
     documents = documents.filter(doc => {
@@ -189,8 +262,7 @@ function createCollection(db, name, options, callback) {
   const listCollectionOptions = Object.assign({}, finalOptions, { nameOnly: true });
 
   // Check if we have the name
-  db
-    .listCollections({ name }, listCollectionOptions)
+  listCollections(db, { name }, listCollectionOptions)
     .setReadPreference(ReadPreference.primary)
     .toArray((err, collections) => {
       if (err != null) return handleCallback(callback, err, null);
@@ -532,6 +604,8 @@ function executeDbAdminCommand(db, command, options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  */
 function indexInformation(db, name, options, callback) {
+  const listIndexes = require('./collection_ops').listIndexes;
+
   // If we specified full information
   const full = options['full'] == null ? false : options['full'];
 
@@ -556,15 +630,89 @@ function indexInformation(db, name, options, callback) {
   }
 
   // Get the list of indexes of the specified collection
-  db
-    .collection(name)
-    .listIndexes(options)
-    .toArray((err, indexes) => {
-      if (err) return callback(toError(err));
-      if (!Array.isArray(indexes)) return handleCallback(callback, null, []);
-      if (full) return handleCallback(callback, null, indexes);
-      handleCallback(callback, null, processResults(indexes));
-    });
+  const coll = collection(db, name);
+  listIndexes(coll, options).toArray((err, indexes) => {
+    if (err) return callback(toError(err));
+    if (!Array.isArray(indexes)) return handleCallback(callback, null, []);
+    if (full) return handleCallback(callback, null, indexes);
+    handleCallback(callback, null, processResults(indexes));
+  });
+}
+
+/**
+ * Get the list of all collection information for the specified db.
+ *
+ * @method
+ * @param {Db} db The Db instance on which to retrieve the collections info.
+ * @param {object} [filter={}] Query by which to filter collections
+ * @param {object} [options] Optional settings. See Db.prototype.listCollections for a list of options.
+ * @return {CommandCursor}
+ */
+const listCollectionsSchema = {
+  nameOnly: { type: 'boolean', default: false },
+  batchSize: { type: 'number' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  session: { type: ClientSession },
+  cursorFactory: { overrideOnly: true },
+  optionsValidationLevel: { overrideOnly: true }
+};
+function listCollections(db, filter, options) {
+  const find = require('./collection_ops').find;
+  options = options || {};
+  options = applyDefaults(listCollectionsSchema, options, {});
+
+  // Cursor options
+  let cursor = options.batchSize ? { batchSize: options.batchSize } : {};
+
+  // We have a list collections command
+  if (db.serverConfig.capabilities().hasListCollectionsCommand) {
+    // Build the command
+    const command = { listCollections: true, filter, cursor, nameOnly: options.nameOnly };
+    // Create the cursor
+    cursor = db.s.topology.cursor(`${db.s.databaseName}.$cmd`, command, options);
+    // Do we have a readPreference, apply it
+    if (options.readPreference) {
+      cursor.setReadPreference(options.readPreference);
+    }
+    // Return the cursor
+    return cursor;
+  }
+
+  // We cannot use the listCollectionsCommand
+  if (!db.serverConfig.capabilities().hasListCollectionsCommand) {
+    // If we have legacy mode and have not provided a full db name filter it
+    if (
+      typeof filter.name === 'string' &&
+      !new RegExp('^' + db.databaseName + '\\.').test(filter.name)
+    ) {
+      filter = Object.assign({}, filter);
+      filter.name = `${db.s.databaseName}.${filter.name}`;
+    }
+  }
+
+  // No filter, filter by current database
+  if (filter == null) {
+    filter.name = `/${db.s.databaseName}/`;
+  }
+
+  // Rewrite the filter to use $and to filter out indexes
+  if (filter.name) {
+    filter = { $and: [{ name: filter.name }, { name: /^((?!\$).)*$/ }] };
+  } else {
+    filter = { name: /^((?!\$).)*$/ };
+  }
+
+  // Return options
+  const _options = { transforms: listCollectionsTransforms(db.s.databaseName) };
+  // Get the cursor
+  const coll = collection(db, CONSTANTS.SYSTEM_NAMESPACE_COLLECTION);
+  cursor = find(coll, filter, _options);
+  // Do we have a readPreference, apply it
+  if (options.readPreference) cursor.setReadPreference(options.readPreference);
+  // Set the passed in batch size if one was provided
+  if (options.batchSize) cursor = cursor.batchSize(options.batchSize);
+  // We have a fallback mode using legacy systems collections
+  return cursor;
 }
 
 // Transformation methods for cursor results
@@ -594,11 +742,10 @@ function listCollectionsTransforms(databaseName) {
  * @deprecated Query the system.profile collection directly.
  */
 function profilingInfo(db, options, callback) {
+  const find = require('./collection_ops').find;
   try {
-    db
-      .collection('system.profile')
-      .find({}, options)
-      .toArray(callback);
+    const coll = collection(db, 'system.profile');
+    find(coll, {}, options).toArray(callback);
   } catch (err) {
     return callback(err, null);
   }
@@ -646,7 +793,7 @@ function removeUser(db, username, options, callback) {
       const db = options.dbName ? new Db(options.dbName, db.s.client, db.s.options) : db;
 
       // Fetch a user collection
-      const collection = db.collection(CONSTANTS.SYSTEM_USER_COLLECTION);
+      const collection = collection(Db.SYSTEM_USER_COLLECTION);
 
       // Locate the user
       findOne(collection, { user: username }, finalOptions, (err, user) => {
@@ -970,6 +1117,7 @@ function executeAuthRemoveUserCommand(db, username, options, callback) {
 
 module.exports = {
   addUser,
+  collection,
   collections,
   createCollection,
   createListener,
@@ -980,6 +1128,7 @@ module.exports = {
   evaluate,
   executeCommand,
   executeDbAdminCommand,
+  listCollections,
   listCollectionsTransforms,
   indexInformation,
   profilingInfo,

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -328,6 +328,7 @@ function createCollection(db, name, options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  */
 function createIndex(db, name, fieldOrSpec, options, callback) {
+  const Db = require('../db');
   // Get the write concern options
   let finalOptions = Object.assign({}, { readPreference: ReadPreference.primary }, options);
   finalOptions = applyWriteConcern(finalOptions, { db }, options);
@@ -657,6 +658,7 @@ const listCollectionsSchema = {
   optionsValidationLevel: { overrideOnly: true }
 };
 function listCollections(db, filter, options) {
+  const Db = require('../db');
   const find = require('./collection_ops').find;
   options = options || {};
   options = applyDefaults(listCollectionsSchema, options, {});

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -34,19 +34,26 @@ const collectionKeys = [
   'promoteLongs'
 ];
 
-let collection;
+let Collection;
 function loadCollection() {
-  if (!collection) {
-    collection = require('../collection');
+  if (!Collection) {
+    Collection = require('../collection');
   }
-  return collection;
+  return Collection;
 }
-let db;
+let Db;
 function loadDb() {
-  if (!db) {
-    db = require('../db');
+  if (!Db) {
+    Db = require('../db');
   }
-  return db;
+  return Db;
+}
+let CollectionOps;
+function loadCollectionOps() {
+  if (!CollectionOps) {
+    CollectionOps = require('../operations/collection_ops');
+  }
+  return CollectionOps;
 }
 
 const debugFields = [
@@ -345,7 +352,6 @@ function createCollection(db, name, options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  */
 function createIndex(db, name, fieldOrSpec, options, callback) {
-  let Db = loadDb();
   // Get the write concern options
   let finalOptions = Object.assign({}, { readPreference: ReadPreference.primary }, options);
   finalOptions = applyWriteConcern(finalOptions, { db }, options);
@@ -667,7 +673,6 @@ function indexInformation(db, name, options, callback) {
  * @return {CommandCursor}
  */
 function listCollections(db, filter, options) {
-  let Db = loadDb();
   let find = loadCollectionOps().find;
   options = options || {};
   options = applyDefaults(listCollectionsOperationSchema, options, {});

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -20,10 +20,12 @@ const findOne = require('./collection_ops').findOne;
 const remove = require('./collection_ops').remove;
 const updateOne = require('./collection_ops').updateOne;
 
-const listCollectionsSchema = require('../schemas/collection_schemas').listCollectionsSchema;
+const listCollectionsOperationSchema = require('../schemas/db_schemas')
+  .listCollectionsOperationSchema;
 
 const loadCollection = makeLazyLoader(`${__dirname}/../collection`);
 const loadDb = makeLazyLoader(`${__dirname}/../db`);
+const loadCollectionOps = makeLazyLoader(`${__dirname}/./collection_ops`);
 
 const collectionKeys = [
   'pkFactory',
@@ -610,7 +612,7 @@ function executeDbAdminCommand(db, command, options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  */
 function indexInformation(db, name, options, callback) {
-  const listIndexes = require('./collection_ops').listIndexes;
+  let listIndexes = loadCollectionOps().listIndexes;
 
   // If we specified full information
   const full = options['full'] == null ? false : options['full'];
@@ -656,9 +658,9 @@ function indexInformation(db, name, options, callback) {
  */
 function listCollections(db, filter, options) {
   let Db = loadDb();
-  const find = require('./collection_ops').find;
+  let find = loadCollectionOps().find;
   options = options || {};
-  options = applyDefaults(listCollectionsSchema, options, {});
+  options = applyDefaults(listCollectionsOperationSchema, options, {});
 
   // Cursor options
   let cursor = options.batchSize ? { batchSize: options.batchSize } : {};
@@ -741,7 +743,7 @@ function listCollectionsTransforms(databaseName) {
  * @deprecated Query the system.profile collection directly.
  */
 function profilingInfo(db, options, callback) {
-  const find = require('./collection_ops').find;
+  let find = loadCollectionOps().find;
   try {
     const coll = collection(db, 'system.profile');
     find(coll, {}, options).toArray(callback);

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -8,7 +8,7 @@ const resolveReadPreference = require('../utils').resolveReadPreference;
 const crypto = require('crypto');
 const debugOptions = require('../utils').debugOptions;
 const handleCallback = require('../utils').handleCallback;
-const mergeOptionsAndWriteConcern = require('../utils').mergeOptionsAndWriteConcern;
+const makeLazyLoader = require('../utils').makeLazyLoader;
 const MongoError = require('mongodb-core').MongoError;
 const parseIndexOptions = require('../utils').parseIndexOptions;
 const ReadPreference = require('mongodb-core').ReadPreference;
@@ -20,17 +20,8 @@ const findOne = require('./collection_ops').findOne;
 const remove = require('./collection_ops').remove;
 const updateOne = require('./collection_ops').updateOne;
 
-const collectionKeys = [
-  'pkFactory',
-  'readPreference',
-  'serializeFunctions',
-  'strict',
-  'readConcern',
-  'ignoreUndefined',
-  'promoteValues',
-  'promoteBuffers',
-  'promoteLongs'
-];
+const loadCollection = makeLazyLoader(`${__dirname}/../collection`);
+const loadDb = makeLazyLoader(`${__dirname}/../db`);
 
 const debugFields = [
   'authSource',

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -103,7 +103,7 @@ const illegalCommandFields = [
  * @param {Db~resultCallback} [callback] The command result callback
  */
 function addUser(db, username, password, options, callback) {
-  let Db = loadDb();
+  const Db = loadDb();
 
   // Did the user destroy the topology
   if (db.serverConfig && db.serverConfig.isDestroyed())
@@ -163,7 +163,7 @@ function addUser(db, username, password, options, callback) {
 }
 
 function collection(db, name, options, callback) {
-  let Collection = loadCollection();
+  const Collection = loadCollection();
 
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
@@ -233,7 +233,7 @@ function collection(db, name, options, callback) {
  * @param {Db~collectionsResultCallback} [callback] The results callback
  */
 function collections(db, options, callback) {
-  let Collection = loadCollection();
+  const Collection = loadCollection();
 
   options = Object.assign({}, options, { nameOnly: true });
   // Let's get the collection names
@@ -273,7 +273,7 @@ function collections(db, options, callback) {
  * @param {Db~collectionResultCallback} [callback] The results callback
  */
 function createCollection(db, name, options, callback) {
-  let Collection = loadCollection();
+  const Collection = loadCollection();
 
   // Get the write concern options
   const finalOptions = applyWriteConcern(Object.assign({}, options), { db }, options);
@@ -799,7 +799,7 @@ function profilingLevel(db, options, callback) {
  * @param {Db~resultCallback} [callback] The command result callback
  */
 function removeUser(db, username, options, callback) {
-  let Db = loadDb();
+  const Db = loadDb();
 
   // Attempt to execute command
   executeAuthRemoveUserCommand(db, username, options, (err, result) => {

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -3,7 +3,6 @@
 const generateCredentials = require('../authenticate').generateCredentials;
 const deprecate = require('util').deprecate;
 const Logger = require('mongodb-core').Logger;
-const makeLazyLoader = require('../utils').makeLazyLoader;
 const MongoError = require('mongodb-core').MongoError;
 const Mongos = require('../topologies/mongos');
 const parse = require('mongodb-core').parseConnectionString;
@@ -13,7 +12,13 @@ const Server = require('../topologies/server');
 const ServerSessionPool = require('mongodb-core').Sessions.ServerSessionPool;
 const NativeTopology = require('../topologies/native_topology');
 
-const loadClient = makeLazyLoader(`${__dirname}/../mongo_client`);
+let client;
+function loadClient() {
+  if (!client) {
+    client = require('../mongo_client');
+  }
+  return client;
+}
 
 const monitoringEvents = [
   'timeout',

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -150,7 +150,7 @@ function clearAllEvents(topology) {
 
 // Collect all events in order from SDAM
 function collectEvents(mongoClient, topology) {
-  let MongoClient = loadClient();
+  const MongoClient = loadClient();
   const collectedEvents = [];
 
   if (mongoClient instanceof MongoClient) {

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -197,10 +197,6 @@ function applyDefaults(optionsSchema, providedOptions, optionDefaults, overrideO
       }
     }
 
-    if (optionFromSchema.required && !verifiedOptions.hasOwnProperty(optionName)) {
-      throw new Error(`required option [${optionName}] was not found.`);
-    }
-
     if (
       optionFromSchema.hasOwnProperty('default') &&
       !verifiedOptions.hasOwnProperty(optionName) &&

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -197,55 +197,6 @@ function applyDefaults(optionsSchema, providedOptions, optionDefaults, overrideO
       }
     }
 
-    if (
-      optionFromSchema.hasOwnProperty('default') &&
-      !verifiedOptions.hasOwnProperty(optionName) &&
-      optionFromSchema.default != null
-    ) {
-      verifiedOptions[optionName] = optionFromSchema.default;
-    }
-  });
-
-  return verifiedOptions;
-}
-
-/**
- * This function applies defaults without validating options.
- * It returns an options object with defaults from optionDefaults and overrideOptions.
- *
- * @method
- * @param {object} optionsSchema A schema specifying possible options and their types, defaults,
- *   deprecation status, and whether or not they are required.
- * @param {object} providedOptions The options passed into the operation.
- * @param {object} optionDefaults The dynamic defaults for options in optionsSchema. If there are no dynamic defaults, null should be passed in.
- * @param {object} [overrideOptions] The values for options that will override any user-provided value, like { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) }.
- * @return {object} returns an object of options with defaults set
- */
-function applyDefaults(optionsSchema, providedOptions, optionDefaults, overrideOptions) {
-  const verifiedOptions = Object.assign({}, providedOptions);
-
-  Object.keys(optionsSchema).forEach(optionName => {
-    const optionFromSchema = optionsSchema[optionName];
-
-    if (optionDefaults && optionDefaults.hasOwnProperty(optionName)) {
-      if (!verifiedOptions.hasOwnProperty(optionName)) {
-        verifiedOptions[optionName] = optionDefaults[optionName];
-      }
-    }
-
-    if (overrideOptions && overrideOptions.hasOwnProperty(optionName)) {
-      verifiedOptions[optionName] = overrideOptions[optionName];
-
-      if (
-        (optionFromSchema && optionFromSchema.hasOwnProperty('default')) ||
-        (optionDefaults && optionDefaults.hasOwnProperty(optionName))
-      ) {
-        console.warn(
-          `A default value and override value were provided for option [${optionName}]. The override value will be used.`
-        );
-      }
-    }
-
     if (optionFromSchema.required && !verifiedOptions.hasOwnProperty(optionName)) {
       throw new Error(`required option [${optionName}] was not found.`);
     }

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -210,6 +210,59 @@ function applyDefaults(optionsSchema, providedOptions, optionDefaults, overrideO
 }
 
 /**
+ * This function applies defaults without validating options.
+ * It returns an options object with defaults from optionDefaults and overrideOptions.
+ *
+ * @method
+ * @param {object} optionsSchema A schema specifying possible options and their types, defaults,
+ *   deprecation status, and whether or not they are required.
+ * @param {object} providedOptions The options passed into the operation.
+ * @param {object} optionDefaults The dynamic defaults for options in optionsSchema. If there are no dynamic defaults, null should be passed in.
+ * @param {object} [overrideOptions] The values for options that will override any user-provided value, like { readPreference: resolveReadPreference(options, { db: this.s.db, collection: this }) }.
+ * @return {object} returns an object of options with defaults set
+ */
+function applyDefaults(optionsSchema, providedOptions, optionDefaults, overrideOptions) {
+  const verifiedOptions = Object.assign({}, providedOptions);
+
+  Object.keys(optionsSchema).forEach(optionName => {
+    const optionFromSchema = optionsSchema[optionName];
+
+    if (optionDefaults && optionDefaults.hasOwnProperty(optionName)) {
+      if (!verifiedOptions.hasOwnProperty(optionName)) {
+        verifiedOptions[optionName] = optionDefaults[optionName];
+      }
+    }
+
+    if (overrideOptions && overrideOptions.hasOwnProperty(optionName)) {
+      verifiedOptions[optionName] = overrideOptions[optionName];
+
+      if (
+        (optionFromSchema && optionFromSchema.hasOwnProperty('default')) ||
+        (optionDefaults && optionDefaults.hasOwnProperty(optionName))
+      ) {
+        console.warn(
+          `A default value and override value were provided for option [${optionName}]. The override value will be used.`
+        );
+      }
+    }
+
+    if (optionFromSchema.required && !verifiedOptions.hasOwnProperty(optionName)) {
+      throw new Error(`required option [${optionName}] was not found.`);
+    }
+
+    if (
+      optionFromSchema.hasOwnProperty('default') &&
+      !verifiedOptions.hasOwnProperty(optionName) &&
+      optionFromSchema.default != null
+    ) {
+      verifiedOptions[optionName] = optionFromSchema.default;
+    }
+  });
+
+  return verifiedOptions;
+}
+
+/**
  * Warn or error if an option fails validation.
  *
  * @method

--- a/lib/schemas/collection_schemas.js
+++ b/lib/schemas/collection_schemas.js
@@ -1,0 +1,508 @@
+'use strict';
+const ReadPreference = require('mongodb-core').ReadPreference;
+const ClientSession = require('mongodb-core').Sessions.ClientSession;
+
+const aggregateSchema = {
+  readPreference: { type: [ReadPreference, 'string', 'object'] },
+  cursor: { type: 'object', default: {} },
+  batchSize: { type: 'number' },
+  explain: { type: 'boolean' },
+  allowDiskUse: { type: 'boolean' },
+  maxTimeMS: { type: 'number' },
+  bypassDocumentValidation: { type: 'boolean' },
+  raw: { type: 'boolean' },
+  promoteLongs: { type: 'boolean' },
+  promoteValues: { type: 'boolean' },
+  promoteBuffers: { type: 'boolean' },
+  collation: { type: 'object' },
+  comment: { type: 'string' },
+  hint: { type: ['object', 'string'] },
+  session: { type: ClientSession },
+  promiseLibrary: { type: 'function', overrideOnly: true },
+  cursorFactory: { overrideOnly: true },
+  optionsValidationLevel: { overrideOnly: true },
+  readConcern: { type: 'object' },
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' }
+};
+
+const bulkWriteSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  serializeFunctions: { type: 'boolean' },
+  ordered: { type: 'boolean', default: true },
+  bypassDocumentValidation: { type: 'boolean' },
+  ignoreUndefined: { overrideOnly: true },
+  session: { type: ClientSession }
+};
+
+const countDocumentsSchema = {
+  collation: { type: 'object' },
+  hint: { type: ['string', 'object'] },
+  limit: { type: 'number' },
+  maxTimeMS: { type: 'number' },
+  skip: { type: 'number' },
+  readConcern: { type: 'object' }
+};
+
+const createIndexSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  unique: { type: 'boolean', default: false },
+  sparse: { type: 'boolean' },
+  background: { type: 'boolean' },
+  dropDups: { type: 'boolean' },
+  min: { type: 'number' },
+  max: { type: 'number' },
+  v: { type: 'number' },
+  expireAfterSeconds: { type: 'number' },
+  name: { type: 'string' },
+  partialFilterExpression: { type: 'object' },
+  collation: { type: 'object' },
+  session: { type: ClientSession },
+  readPreference: { overrideOnly: true }
+};
+
+const createIndexesSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  maxTimeMS: { type: 'number' },
+  readPreference: { overrideOnly: true },
+  session: { type: ClientSession }
+};
+
+const deleteManySchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  collation: { type: 'object' },
+  session: { type: ClientSession },
+  ignoreUndefined: { type: 'boolean', overrideOnly: true },
+  single: { overrideOnly: true }
+};
+
+const deleteOneSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  collation: { type: 'object' },
+  session: { type: ClientSession },
+  ignoreUndefined: { type: 'boolean', overrideOnly: true },
+  single: { overrideOnly: true }
+};
+
+const distinctSchema = {
+  collation: { type: 'object' },
+  readPreference: { type: [ReadPreference, 'string', 'object'] },
+  maxTimeMS: { type: 'number' },
+  session: { type: ClientSession },
+  readConcern: { type: 'object' }
+};
+
+const dropSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  readPreference: { type: [ReadPreference, 'string', 'object'], overrideOnly: true },
+  session: { type: ClientSession }
+};
+
+const dropIndexSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  readPreference: { type: [ReadPreference, 'string', 'object'], overrideOnly: true },
+  maxTimeMS: { type: 'number' },
+  session: { type: ClientSession }
+};
+
+const dropIndexesSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  maxTimeMS: { type: 'number' },
+  session: { type: ClientSession }
+};
+
+const estimatedDocumentCountSchema = {
+  maxTimeMS: { type: 'number' },
+  readConcern: { type: 'object' }
+};
+
+const findSchema = {
+  limit: { type: 'number', default: 0 },
+  sort: { type: ['array', 'object', 'string'] },
+  projection: { type: 'object' },
+  fields: { type: 'object' },
+  skip: { type: 'number', default: 0 },
+  hint: { type: ['string', 'object'] },
+  explain: { type: 'boolean' },
+  snapshot: { type: 'boolean' },
+  timeout: { type: 'boolean' },
+  tailable: { type: 'boolean' },
+  batchSize: { type: 'number' },
+  returnKey: { type: 'boolean' },
+  maxScan: { type: 'number' },
+  min: { type: 'number' },
+  max: { type: 'number' },
+  showDiskLoc: { type: 'boolean' },
+  showRecordId: { type: 'boolean' },
+  comment: { type: 'string' },
+  raw: { type: 'boolean' },
+  promoteLongs: { type: 'boolean' },
+  promoteValues: { type: 'boolean' },
+  promoteBuffers: { type: 'boolean' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  partial: { type: 'boolean' },
+  maxTimeMS: { type: 'number' },
+  collation: { type: 'object' },
+  session: { type: ClientSession },
+  promiseLibrary: { overrideOnly: true },
+  slaveOk: { type: 'boolean' },
+  awaitData: { type: 'boolean' },
+  noCursorTimeout: { type: 'boolean', overrideOnly: true },
+  ignoreUndefined: { overrideOnly: true },
+  optionsValidationLevel: { overrideOnly: true },
+  readConcern: { type: 'object' }
+};
+
+const findAndModifySchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  remove: { type: 'boolean', default: false },
+  upsert: { type: 'boolean', default: false },
+  new: { type: 'boolean', default: false },
+  projection: { type: 'object' },
+  fields: { type: 'object' },
+  session: { type: ClientSession },
+  arrayFilters: { type: 'array' },
+  readPreference: { overrideOnly: true },
+  serializeFunctions: { type: 'boolean' },
+  checkKeys: { overrideOnly: true },
+  collation: { type: 'object' }
+};
+
+const findAndRemoveSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  session: { type: ClientSession },
+  remove: { overrideOnly: true },
+  readPreference: { overrideOnly: true },
+  serializeFunctions: { type: 'boolean' },
+  checkKeys: { overrideOnly: true },
+  upsert: { overrideOnly: true },
+  new: { overrideOnly: true }
+};
+
+const findOneSchema = {
+  projection: { type: 'object' },
+  fields: { type: 'object' },
+  hint: { type: ['string', 'object'] },
+  explain: { type: 'boolean' },
+  snapshot: { type: 'boolean' },
+  timeout: { type: 'boolean' },
+  tailable: { type: 'boolean' },
+  batchSize: { type: 'number' },
+  returnKey: { type: 'boolean' },
+  maxScan: { type: 'number' },
+  min: { type: 'number' },
+  max: { type: 'number' },
+  showDiskLoc: { type: 'boolean' },
+  showRecordId: { type: 'boolean' },
+  comment: { type: 'string' },
+  raw: { type: 'boolean' },
+  promoteLongs: { type: 'boolean' },
+  promoteValues: { type: 'boolean' },
+  promoteBuffers: { type: 'boolean' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  partial: { type: 'boolean' },
+  maxTimeMS: { type: 'number' },
+  collation: { type: 'object' },
+  session: { type: ClientSession }
+};
+
+const findOneAndDeleteSchema = {
+  collation: { type: 'object' },
+  projection: { type: 'object' },
+  sort: { type: ['object', 'string'] },
+  maxTimeMS: { type: 'number' },
+  session: { type: ClientSession },
+  fields: { overrideOnly: true },
+  remove: { overrideOnly: true },
+  new: { overrideOnly: true },
+  upsert: { overrideOnly: true },
+  serializeFunctions: { type: 'boolean' },
+  checkKeys: { overrideOnly: true },
+  readPreference: { overrideOnly: true },
+  fsync: { type: 'number' }
+};
+
+const findOneAndReplaceSchema = {
+  bypassDocumentValidation: { type: 'boolean' },
+  collation: { type: 'object' },
+  projection: { type: 'object' },
+  sort: { type: ['object', 'string'] },
+  maxTimeMS: { type: 'number' },
+  upsert: { type: 'boolean', default: false },
+  returnOriginal: { type: 'boolean' },
+  session: { type: ClientSession },
+  fields: { overrideOnly: true },
+  update: { overrideOnly: true },
+  new: { overrideOnly: true },
+  remove: { overrideOnly: true },
+  serializeFunctions: { type: 'boolean' },
+  checkKeys: { overrideOnly: true },
+  readPreference: { overrideOnly: true },
+  fsync: { type: 'number' }
+};
+
+const findOneAndUpdateSchema = {
+  bypassDocumentValidation: { type: 'boolean' },
+  collation: { type: 'object' },
+  projection: { type: 'object' },
+  sort: { type: ['object', 'string'] },
+  maxTimeMS: { type: 'number' },
+  upsert: { type: 'boolean', default: false },
+  returnOriginal: { type: 'boolean' },
+  session: { type: ClientSession },
+  arrayFilters: { type: 'array' },
+  fields: { overrideOnly: true },
+  update: { overrideOnly: true },
+  new: { overrideOnly: true },
+  remove: { overrideOnly: true },
+  serializeFunctions: { type: 'boolean' },
+  checkKeys: { overrideOnly: true },
+  readPreference: { overrideOnly: true },
+  fsync: { type: 'number' }
+};
+
+const geoHaystackSearchSchema = {
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  maxDistance: { type: 'number' },
+  search: { type: 'object' },
+  limit: { type: 'number' },
+  session: { type: ClientSession },
+  readConcern: { type: 'object' }
+};
+
+const indexesSchema = {
+  batchSize: { type: 'number' },
+  readPreference: { type: [ReadPreference, 'string', 'object'] },
+  session: { type: ClientSession },
+  full: { type: 'boolean', default: true }
+};
+
+const indexExistsSchema = {
+  session: { type: ClientSession },
+  full: { type: 'boolean', default: false }
+};
+
+const indexInformationSchema = {
+  full: { type: 'boolean', default: false },
+  session: { type: ClientSession }
+};
+
+const initializeOrderedBulkOpSchema = {
+  bypassDocumentValidation: { type: 'boolean' },
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  session: { type: ClientSession },
+  promiseLibrary: { overrideOnly: true },
+  ignoreUndefined: { type: 'boolean' }
+};
+
+const initializeUnorderedBulkOpSchema = {
+  bypassDocumentValidation: { type: 'boolean' },
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  session: { type: ClientSession },
+  promiseLibrary: { overrideOnly: true },
+  ignoreUndefined: { type: 'boolean' }
+};
+
+const insertManySchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  serializeFunctions: { type: 'boolean' },
+  forceServerObjectId: { type: 'boolean' },
+  bypassDocumentValidation: { type: 'boolean' },
+  ordered: { type: 'boolean', default: true },
+  session: { type: ClientSession },
+  ignoreUndefined: { overrideOnly: true }
+};
+
+const insertOneSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  serializeFunctions: { type: 'boolean' },
+  forceServerObjectId: { type: 'boolean' },
+  bypassDocumentValidation: { type: 'boolean' },
+  session: { type: ClientSession },
+  ignoreUndefined: { type: 'boolean', overrideOnly: true }
+};
+
+const isCappedSchema = {
+  session: { type: ClientSession }
+};
+
+const listIndexesSchema = {
+  batchSize: { type: 'number' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  session: { type: ClientSession },
+  cursorFactory: { overrideOnly: true },
+  promiseLibrary: { overrideOnly: true },
+  optionsValidationLevel: { overrideOnly: true }
+};
+
+const mapReduceSchema = {
+  collation: { type: 'object' },
+  readPreference: { type: [ReadPreference, 'string', 'object'] },
+  out: { type: ['string', 'object'], required: true },
+  query: { type: 'object' },
+  sort: { type: 'object' },
+  limit: { type: 'number' },
+  keeptemp: { type: 'boolean' },
+  finalize: { type: ['function', 'string'] },
+  scope: { type: 'object' },
+  jsMode: { type: 'boolean' },
+  verbose: { type: 'boolean' },
+  bypassDocumentValidation: { type: 'boolean' },
+  session: { type: ClientSession },
+  readConcern: { type: 'object' },
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' }
+};
+
+const optionsSchema = {
+  session: { type: ClientSession }
+};
+
+const parallelCollectionScanSchema = {
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  batchSize: { type: 'number', default: 1000 },
+  numCursors: { type: 'number', default: 1 },
+  raw: { type: 'boolean', default: false },
+  promiseLibrary: { overrideOnly: true },
+  session: { overrideOnly: true },
+  optionsValidationLevel: { overrideOnly: true },
+  readConcern: { type: 'object' }
+};
+
+const reIndexSchema = {
+  session: { type: ClientSession }
+};
+
+const renameSchema = {
+  dropTarget: { type: 'boolean', default: false },
+  readPreference: { type: [ReadPreference, 'string', 'object'], overrideOnly: true },
+  session: { type: ClientSession }
+};
+
+const replaceOneSchema = {
+  upsert: { type: 'boolean' },
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  bypassDocumentValidation: { type: 'boolean' },
+  collation: { type: 'object' },
+  ignoreUndefined: { type: 'boolean', overrideOnly: true },
+  session: { type: ClientSession },
+  multi: { overrideOnly: true }
+};
+
+const statsSchema = {
+  readPreference: { type: [ReadPreference, 'string', 'object'] },
+  scale: { type: 'number' },
+  session: { type: ClientSession }
+};
+
+const updateManySchema = {
+  upsert: { type: 'boolean' },
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  arrayFilters: { type: 'array' },
+  bypassDocumentValidation: { type: 'boolean' },
+  collation: { type: 'object' },
+  session: { type: ClientSession },
+  ignoreUndefined: { type: 'boolean', overrideOnly: true },
+  multi: { overrideOnly: true }
+};
+
+const updateOneSchema = {
+  upsert: { type: 'boolean' },
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  bypassDocumentValidation: { type: 'boolean' },
+  arrayFilters: { type: 'array' },
+  collation: { type: 'object' },
+  ignoreUndefined: { type: 'boolean', overrideOnly: true },
+  session: { type: ClientSession },
+  multi: { overrideOnly: true }
+};
+
+const watchSchema = {
+  fullDocument: { type: 'string', default: 'default' },
+  resumeAfter: { type: 'object' },
+  maxAwaitTimeMS: { type: 'number' },
+  batchSize: { type: 'number' },
+  collation: { type: 'object' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  startAtClusterTime: { type: 'Timestamp' },
+  session: { type: ClientSession },
+  optionsValidationLevel: { overrideOnly: true }
+};
+
+module.exports = {
+  aggregateSchema,
+  bulkWriteSchema,
+  countDocumentsSchema,
+  createIndexSchema,
+  createIndexesSchema,
+  deleteManySchema,
+  deleteOneSchema,
+  distinctSchema,
+  dropSchema,
+  dropIndexSchema,
+  dropIndexesSchema,
+  estimatedDocumentCountSchema,
+  findSchema,
+  findAndModifySchema,
+  findAndRemoveSchema,
+  findOneSchema,
+  findOneAndDeleteSchema,
+  findOneAndReplaceSchema,
+  findOneAndUpdateSchema,
+  geoHaystackSearchSchema,
+  indexesSchema,
+  indexExistsSchema,
+  indexInformationSchema,
+  initializeOrderedBulkOpSchema,
+  initializeUnorderedBulkOpSchema,
+  insertManySchema,
+  insertOneSchema,
+  isCappedSchema,
+  listIndexesSchema,
+  mapReduceSchema,
+  optionsSchema,
+  parallelCollectionScanSchema,
+  reIndexSchema,
+  renameSchema,
+  replaceOneSchema,
+  statsSchema,
+  updateManySchema,
+  updateOneSchema,
+  watchSchema
+};

--- a/lib/schemas/collection_schemas.js
+++ b/lib/schemas/collection_schemas.js
@@ -27,6 +27,31 @@ const aggregateSchema = {
   j: { type: 'boolean' }
 };
 
+const aggregateOperationSchema = {
+  readPreference: { type: [ReadPreference, 'string', 'object'] },
+  cursor: { type: 'object', default: {} },
+  batchSize: { type: 'number' },
+  explain: { type: 'boolean' },
+  allowDiskUse: { type: 'boolean' },
+  maxTimeMS: { type: 'number' },
+  bypassDocumentValidation: { type: 'boolean' },
+  raw: { type: 'boolean' },
+  promoteLongs: { type: 'boolean' },
+  promoteValues: { type: 'boolean' },
+  promoteBuffers: { type: 'boolean' },
+  collation: { type: 'object' },
+  comment: { type: 'string' },
+  hint: { type: ['object', 'string'] },
+  session: { type: ClientSession },
+  promiseLibrary: { type: 'function' },
+  cursorFactory: { type: 'function' },
+  optionsValidationLevel: { type: 'string' },
+  readConcern: { type: 'object' },
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' }
+};
+
 const bulkWriteSchema = {
   w: { type: ['number', 'string'] },
   wtimeout: { type: 'number' },
@@ -167,6 +192,43 @@ const findSchema = {
   noCursorTimeout: { type: 'boolean', overrideOnly: true },
   ignoreUndefined: { overrideOnly: true },
   optionsValidationLevel: { overrideOnly: true },
+  readConcern: { type: 'object' }
+};
+
+const findOperationSchema = {
+  limit: { type: 'number', default: 0 },
+  sort: { type: ['array', 'object', 'string'] },
+  projection: { type: 'object' },
+  fields: { type: 'object' },
+  skip: { type: 'number', default: 0 },
+  hint: { type: ['string', 'object'] },
+  explain: { type: 'boolean' },
+  snapshot: { type: 'boolean' },
+  timeout: { type: 'boolean' },
+  tailable: { type: 'boolean' },
+  batchSize: { type: 'number' },
+  returnKey: { type: 'boolean' },
+  maxScan: { type: 'number' },
+  min: { type: 'number' },
+  max: { type: 'number' },
+  showDiskLoc: { type: 'boolean' },
+  showRecordId: { type: 'boolean' },
+  comment: { type: 'string' },
+  raw: { type: 'boolean' },
+  promoteLongs: { type: 'boolean' },
+  promoteValues: { type: 'boolean' },
+  promoteBuffers: { type: 'boolean' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  partial: { type: 'boolean' },
+  maxTimeMS: { type: 'number' },
+  collation: { type: 'object' },
+  session: { type: ClientSession },
+  promiseLibrary: { type: 'function' },
+  slaveOk: { type: 'boolean' },
+  awaitData: { type: 'boolean' },
+  noCursorTimeout: { type: 'boolean' },
+  ignoreUndefined: { type: 'boolean' },
+  optionsValidationLevel: { type: 'string' },
   readConcern: { type: 'object' }
 };
 
@@ -467,6 +529,7 @@ const watchSchema = {
 
 module.exports = {
   aggregateSchema,
+  aggregateOperationSchema,
   bulkWriteSchema,
   countDocumentsSchema,
   createIndexSchema,
@@ -479,6 +542,7 @@ module.exports = {
   dropIndexesSchema,
   estimatedDocumentCountSchema,
   findSchema,
+  findOperationSchema,
   findAndModifySchema,
   findAndRemoveSchema,
   findOneSchema,

--- a/lib/schemas/db_schemas.js
+++ b/lib/schemas/db_schemas.js
@@ -1,0 +1,186 @@
+'use strict';
+const ClientSession = require('mongodb-core').Sessions.ClientSession;
+const ReadPreference = require('mongodb-core').ReadPreference;
+
+const addUserSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  customData: { type: 'object' },
+  roles: { type: 'object' },
+  authenticationRestrictions: { type: 'array' },
+  mechanisms: { type: 'array' },
+  passwordDigestor: { type: 'string' },
+  session: { type: ClientSession }
+};
+
+const collectionSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  raw: { type: 'boolean' },
+  pkFactory: { type: 'object' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  serializeFunctions: { type: 'boolean' },
+  strict: { type: 'boolean' },
+  readConcern: { type: 'object' },
+  promiseLibrary: { overrideOnly: true },
+  ignoreUndefined: { overrideOnly: true },
+  fsync: { type: 'number' }
+};
+
+const collectionsSchema = {
+  nameOnly: { type: 'boolean', default: false },
+  batchSize: { type: 'number' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  session: { type: ClientSession }
+};
+
+const commandSchema = {
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  session: { type: ClientSession }
+};
+
+const createCollectionSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  raw: { type: 'boolean' },
+  pkFactory: { type: 'object' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  serializeFunctions: { type: 'boolean' },
+  strict: { type: 'boolean' },
+  capped: { type: 'boolean' },
+  autoIndexId: { type: 'boolean', deprecated: true },
+  size: { type: 'number' },
+  max: { type: 'number' },
+  flags: { type: 'number' },
+  storageEngine: { type: 'object' },
+  validator: { type: 'object' },
+  validationLevel: { type: 'string' },
+  validationAction: { type: 'string' },
+  indexOptionDefaults: { type: 'object' },
+  viewOn: { type: 'string' },
+  pipeline: { type: 'array' },
+  collation: { type: 'object' },
+  session: { type: ClientSession },
+  promiseLibrary: { type: 'function' }
+};
+
+const createIndexSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  unique: { type: 'boolean', default: false },
+  sparse: { type: 'boolean' },
+  background: { type: 'boolean' },
+  dropDups: { type: 'boolean' },
+  min: { type: 'number' },
+  max: { type: 'number' },
+  v: { type: 'number' },
+  expireAfterSeconds: { type: 'number' },
+  name: { type: 'number' },
+  partialFilterExpression: { type: 'object' },
+  collation: { type: 'object' },
+  session: { type: ClientSession }
+};
+
+const dropCollectionSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  session: { type: ClientSession },
+  readPreference: { overrideOnly: true }
+};
+
+const dropDatabaseSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  session: { type: ClientSession },
+  readPreference: { overrideOnly: true },
+  writeConcern: { type: 'object' }
+};
+
+const executeDbAdminCommandSchema = {
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  session: { type: ClientSession }
+};
+
+const indexInformationSchema = {
+  batchSize: { type: 'number' },
+  full: { type: 'boolean', default: false },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  session: { type: ClientSession }
+};
+
+const listCollectionsSchema = {
+  nameOnly: { type: 'boolean', default: false },
+  batchSize: { type: 'number' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  session: { type: ClientSession },
+  cursorFactory: { overrideOnly: true },
+  optionsValidationLevel: { overrideOnly: true }
+};
+
+const profilingLevelSchema = {
+  session: { type: ClientSession }
+};
+
+const removeUserSchema = {
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  session: { type: ClientSession }
+};
+
+const renameCollectionSchema = {
+  dropTarget: { type: 'boolean', default: false },
+  session: { type: ClientSession },
+  w: { type: ['number', 'string'] },
+  wtimeout: { type: 'number' },
+  j: { type: 'boolean' },
+  readPreference: { type: [ReadPreference, 'string', 'object'], overrideOnly: true }
+};
+
+const setProfilingLevelSchema = {
+  session: { type: ClientSession }
+};
+
+const statsSchema = {
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  scale: { type: 'number' },
+  session: { type: ClientSession }
+};
+
+const watchSchema = {
+  fullDocument: { type: 'string', default: 'default' },
+  resumeAfter: { type: 'object' },
+  maxAwaitTimeMS: { type: 'number' },
+  batchSize: { type: 'number' },
+  collation: { type: 'object' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  startAtClusterTime: { type: 'Timestamp' },
+  session: { type: ClientSession },
+  optionsValidationLevel: { overrideOnly: true }
+};
+
+module.exports = {
+  addUserSchema,
+  collectionSchema,
+  collectionsSchema,
+  commandSchema,
+  createCollectionSchema,
+  createIndexSchema,
+  dropCollectionSchema,
+  dropDatabaseSchema,
+  executeDbAdminCommandSchema,
+  indexInformationSchema,
+  listCollectionsSchema,
+  profilingLevelSchema,
+  removeUserSchema,
+  renameCollectionSchema,
+  setProfilingLevelSchema,
+  statsSchema,
+  watchSchema
+};

--- a/lib/schemas/db_schemas.js
+++ b/lib/schemas/db_schemas.js
@@ -123,6 +123,15 @@ const listCollectionsSchema = {
   optionsValidationLevel: { overrideOnly: true }
 };
 
+const listCollectionsOperationSchema = {
+  nameOnly: { type: 'boolean', default: false },
+  batchSize: { type: 'number' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  session: { type: ClientSession },
+  cursorFactory: { type: 'function' },
+  optionsValidationLevel: { type: 'string' }
+};
+
 const profilingLevelSchema = {
   session: { type: ClientSession }
 };
@@ -177,6 +186,7 @@ module.exports = {
   executeDbAdminCommandSchema,
   indexInformationSchema,
   listCollectionsSchema,
+  listCollectionsOperationSchema,
   profilingLevelSchema,
   removeUserSchema,
   renameCollectionSchema,

--- a/lib/schemas/mongo_client_schemas.js
+++ b/lib/schemas/mongo_client_schemas.js
@@ -1,0 +1,135 @@
+'use strict';
+const ClientSession = require('mongodb-core').Sessions.ClientSession;
+const ReadPreference = require('mongodb-core').ReadPreference;
+
+const connectSchema = {
+  appname: { type: 'string' },
+  authMechanism: { type: 'string' },
+  authMechanismProperties: { type: 'array' },
+  authSource: { type: 'string' },
+  compression: { type: 'string', alias: 'compressors' },
+  connectTimeoutMS: { type: 'number', default: 30000 },
+  heartbeatFrequencyMS: { type: 'number', default: 60000 },
+  j: { type: 'boolean', alias: 'journal' },
+  secondaryAcceptableLatencyMS: { type: 'number', default: 15, alias: 'localThresholdMS' },
+  maxIdleTimeMS: { type: 'number' },
+  maxPoolSize: { type: 'number', default: 5, alias: 'poolSize' },
+  poolSize: { type: 'number' },
+  maxStalenessSeconds: { type: 'number' },
+  readConcernLevel: { type: 'string', alias: 'readConcern.level' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  readPreferenceTags: { type: 'object' },
+  replicaSet: { type: 'string' },
+  retryWrites: { type: 'boolean', default: false },
+  serverSelectionTimeoutMS: { type: 'number', default: 30000 },
+  serverSelectionTryOnce: { type: 'boolean', default: true },
+  socketTimeoutMS: { type: 'number', default: 360000 },
+  ssl: { type: 'boolean', default: false },
+  tls: { type: 'boolean', default: false },
+  tlsAllowInvalidCertificates: { type: 'boolean', default: false },
+  tlsAllowInvalidHostnames: { type: 'boolean', default: false },
+  tlsCAFile: { type: 'string' },
+  tlsCertificateKeyFile: { type: 'string' },
+  tlsCertificateKeyFilePassword: { type: 'string' },
+  tlsInsecure: { type: 'boolean', default: false },
+  w: { type: 'number' },
+  wtimeout: { type: 'number', alias: 'wTimeoutMS' },
+  zlibCompressionLevel: { type: 'number', default: -1 },
+  // TODO: check these old options
+  sslCA: { type: 'string' },
+  sslCert: { type: 'string' },
+  sslValidate: { type: 'boolean', default: true },
+  sslKey: { type: 'buffer' },
+  sslPass: { type: 'string' },
+  sslCRL: { type: 'buffer' },
+  autoReconnect: { type: 'boolean', default: true },
+  auto_reconnect: { type: 'boolean', default: true },
+  noDelay: { type: 'boolean', default: true },
+  keepAlive: { type: 'boolean', default: true },
+  keepAliveInitialDelay: { type: 'number', default: 30000 },
+  family: { type: 'number' },
+  reconnectTries: { type: 'number', default: 30 },
+  reconnectInterval: { type: 'number', default: 1000 },
+  ha: { type: 'boolean', default: true },
+  haInterval: { type: 'number', default: 10000 },
+  acceptableLatencyMS: { type: 'number', default: 15 },
+  connectWithNoPrimary: { type: 'boolean', default: false },
+  forceServerObjectId: { type: 'boolean', default: false },
+  serializeFunctions: { type: 'boolean', default: false },
+  ignoreUndefined: { type: 'boolean', default: false },
+  raw: { type: 'boolean', default: false },
+  bufferMaxEntries: { type: 'number', default: -1 },
+  pkFactory: { type: ['object', 'function'] },
+  promiseLibrary: { type: ['object', 'function'] },
+  readConcern: { type: 'object' },
+  'readConcern.level': { type: 'string' },
+  loggerLevel: { type: 'string' },
+  logger: { type: ['object', 'function'] },
+  promoteValues: { type: 'boolean' },
+  promoteBuffers: { type: 'boolean' },
+  promoteLongs: { type: 'boolean' },
+  domainsEnabled: { type: 'boolean', default: false },
+  validateOptions: { type: 'boolean', default: false, deprecated: 'unknownOptionsWarningLevel' },
+  checkServerIdentity: { type: ['boolean', 'function'], default: true },
+  'auth.user': { type: 'string' },
+  'auth.password': { type: 'string' },
+  fsync: { type: 'boolean' },
+  numberOfRetries: { type: 'number', default: 5 },
+  minSize: { type: 'number' },
+  emitError: { type: 'boolean', default: true },
+  monitorCommands: { type: 'boolean', default: false },
+  useNewUrlParser: { type: 'boolean' },
+  useUnifiedTopology: { type: 'boolean' },
+  optionsValidationLevel: { type: 'string' },
+  unknownOptionsWarningLevel: { type: 'string' },
+  host: { type: 'string' },
+  auth: { type: 'object' }
+};
+
+const dbSchema = {
+  noListener: { type: 'boolean', default: false },
+  returnNonCachedInstance: { type: 'boolean' },
+  readPreference: { overrideOnly: true },
+  promiseLibrary: { overrideOnly: true },
+  optionsValidationLevel: { type: 'string' }
+};
+
+const isConnectedSchema = {
+  noListener: { type: 'boolean', default: false },
+  returnNonCachedInstance: { type: 'boolean' }
+};
+
+const logoutSchema = {
+  dbName: { type: 'string' }
+};
+
+const startSessionSchema = {
+  explicit: { overrideOnly: true },
+  causalConsistency: { type: 'boolean' }
+};
+
+const watchSchema = {
+  fullDocument: { type: 'string', default: 'default' },
+  resumeAfter: { type: 'object' },
+  maxAwaitTimeMS: { type: 'number' },
+  batchSize: { type: 'number' },
+  collation: { type: 'object' },
+  readPreference: { type: [ReadPreference, 'object', 'string'] },
+  startAtClusterTime: { type: 'Timestamp' },
+  session: { type: ClientSession },
+  optionsValidationLevel: { overrideOnly: true }
+};
+
+const withSessionSchema = {
+  causalConsistency: { type: 'boolean' }
+};
+
+module.exports = {
+  connectSchema,
+  dbSchema,
+  isConnectedSchema,
+  logoutSchema,
+  startSessionSchema,
+  watchSchema,
+  withSessionSchema
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -711,16 +711,6 @@ function deprecateOptions(config, fn) {
   return deprecated;
 }
 
-function makeLazyLoader(modulePath) {
-  let mod;
-  return function lazyLoad() {
-    if (!mod) {
-      mod = require(modulePath);
-    }
-    return mod;
-  };
-}
-
 module.exports = {
   filterOptions,
   mergeOptions,
@@ -747,6 +737,5 @@ module.exports = {
   decorateWithCollation,
   decorateWithReadConcern,
   deprecateOptions,
-  emitDeprecationWarning,
-  makeLazyLoader
+  emitDeprecationWarning
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
       "dev": true,
       "requires": {
-        "array-from": "2.1.1"
+        "array-from": "^2.1.1"
       }
     },
     "JSONStream": {
@@ -28,8 +28,8 @@
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abbrev": {
@@ -41,7 +41,7 @@
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk=",
       "dev": true
     },
     "acorn-jsx": {
@@ -67,10 +67,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -92,21 +92,21 @@
       "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
       "dev": true,
       "requires": {
-        "ampersand-version": "1.0.2",
-        "lodash": "4.17.11"
+        "ampersand-version": "^1.0.2",
+        "lodash": "^4.6.1"
       }
     },
     "ampersand-state": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
-      "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
+      "integrity": "sha1-M0AupgQ3WvZKJJ9mSgMSwRYNpHU=",
       "dev": true,
       "requires": {
-        "ampersand-events": "2.0.2",
-        "ampersand-version": "1.0.2",
-        "array-next": "0.0.1",
-        "key-tree-store": "1.3.0",
-        "lodash": "4.17.11"
+        "ampersand-events": "^2.0.1",
+        "ampersand-version": "^1.0.0",
+        "array-next": "~0.0.1",
+        "key-tree-store": "^1.3.0",
+        "lodash": "^4.12.0"
       }
     },
     "ampersand-version": {
@@ -115,8 +115,8 @@
       "integrity": "sha1-/489TOrE0yzNg/a9Zpc5f3tZ4sA=",
       "dev": true,
       "requires": {
-        "find-root": "0.1.2",
-        "through2": "0.6.5"
+        "find-root": "^0.1.1",
+        "through2": "^0.6.3"
       }
     },
     "ansi": {
@@ -128,7 +128,7 @@
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "integrity": "sha1-9zIHu4EgfXX9bIPxJa8m7qN4yjA=",
       "dev": true
     },
     "ansi-regex": {
@@ -146,26 +146,26 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-find-index": {
@@ -198,7 +198,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -216,10 +216,10 @@
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
@@ -231,7 +231,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "async": {
@@ -255,7 +255,7 @@
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
       "dev": true
     },
     "babel-code-frame": {
@@ -264,15 +264,15 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babylon": {
       "version": "7.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-      "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+      "integrity": "sha1-6SjH6AfpcOBTaweKs+DEj54FJQM=",
       "dev": true
     },
     "balanced-match": {
@@ -293,7 +293,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bindings": {
@@ -305,11 +305,11 @@
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "bluebird": {
@@ -330,16 +330,16 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -352,7 +352,7 @@
     "bson": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
-      "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
+      "integrity": "sha1-vuV9H7aodxNHGvTjK8rjbegUtbA="
     },
     "buffer": {
       "version": "3.6.0",
@@ -368,17 +368,17 @@
     "buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "1.1.0",
-        "buffer-fill": "1.0.0"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
       "dev": true
     },
     "buffer-crc32": {
@@ -396,7 +396,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "builtin-modules": {
@@ -411,7 +411,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -432,9 +432,9 @@
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "map-obj": "2.0.0",
-        "quick-lru": "1.1.0"
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
       }
     },
     "caseless": {
@@ -449,19 +449,19 @@
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
-        "underscore-contrib": "0.3.0"
+        "underscore-contrib": "~0.3.0"
       }
     },
     "caw": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
-      "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+      "integrity": "sha1-bDygcfwZRyCIPC3F2psHS/x+npU=",
       "dev": true,
       "requires": {
-        "get-proxy": "2.1.0",
-        "isurl": "1.0.0",
-        "tunnel-agent": "0.6.0",
-        "url-to-options": "1.0.1"
+        "get-proxy": "^2.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "tunnel-agent": "^0.6.0",
+        "url-to-options": "^1.0.1"
       },
       "dependencies": {
         "tunnel-agent": {
@@ -470,7 +470,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -478,15 +478,15 @@
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chai-subset": {
@@ -526,34 +526,34 @@
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "dev": true,
       "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.2",
-        "htmlparser2": "3.10.0",
-        "lodash.assignin": "4.2.0",
-        "lodash.bind": "4.2.1",
-        "lodash.defaults": "4.2.0",
-        "lodash.filter": "4.6.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.foreach": "4.5.0",
-        "lodash.map": "4.6.0",
-        "lodash.merge": "4.6.1",
-        "lodash.pick": "4.4.0",
-        "lodash.reduce": "4.6.0",
-        "lodash.reject": "4.6.0",
-        "lodash.some": "4.6.0"
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash.assignin": "^4.0.9",
+        "lodash.bind": "^4.1.4",
+        "lodash.defaults": "^4.0.1",
+        "lodash.filter": "^4.4.0",
+        "lodash.flatten": "^4.2.0",
+        "lodash.foreach": "^4.3.0",
+        "lodash.map": "^4.4.0",
+        "lodash.merge": "^4.4.0",
+        "lodash.pick": "^4.2.1",
+        "lodash.reduce": "^4.4.0",
+        "lodash.reject": "^4.4.0",
+        "lodash.some": "^4.4.0"
       }
     },
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ=",
       "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli-cursor": {
@@ -562,7 +562,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -577,9 +577,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -588,7 +588,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -597,9 +597,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -619,7 +619,7 @@
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -634,10 +634,10 @@
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "integrity": "sha1-LR0kMXr7ir6V1tLAsHtXgTU52Cg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -652,8 +652,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "1.0.0",
-        "dot-prop": "3.0.0"
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
       }
     },
     "concat-map": {
@@ -665,23 +665,23 @@
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "config-chain": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "integrity": "sha1-D96NCRIA616AjK8l/mGMAvSOTvo=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "console-control-strings": {
@@ -699,69 +699,69 @@
     "conventional-changelog": {
       "version": "1.1.24",
       "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
-      "integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
+      "integrity": "sha1-PZTCnJYPUmHAAmeDFbdWzdPX0fA=",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.6.6",
-        "conventional-changelog-atom": "0.2.8",
-        "conventional-changelog-codemirror": "0.3.8",
-        "conventional-changelog-core": "2.0.11",
-        "conventional-changelog-ember": "0.3.12",
-        "conventional-changelog-eslint": "1.0.9",
-        "conventional-changelog-express": "0.3.6",
-        "conventional-changelog-jquery": "0.1.0",
-        "conventional-changelog-jscs": "0.1.0",
-        "conventional-changelog-jshint": "0.3.8",
-        "conventional-changelog-preset-loader": "1.1.8"
+        "conventional-changelog-angular": "^1.6.6",
+        "conventional-changelog-atom": "^0.2.8",
+        "conventional-changelog-codemirror": "^0.3.8",
+        "conventional-changelog-core": "^2.0.11",
+        "conventional-changelog-ember": "^0.3.12",
+        "conventional-changelog-eslint": "^1.0.9",
+        "conventional-changelog-express": "^0.3.6",
+        "conventional-changelog-jquery": "^0.1.0",
+        "conventional-changelog-jscs": "^0.1.0",
+        "conventional-changelog-jshint": "^0.3.8",
+        "conventional-changelog-preset-loader": "^1.1.8"
       }
     },
     "conventional-changelog-angular": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
-      "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+      "integrity": "sha1-sn8rMVwW0KHyPrGBMJ0OakaY6g8=",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-atom": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
-      "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
+      "integrity": "sha1-gDdpNFWZDjJW8pcyCkX6R+5VOhQ=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-codemirror": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
-      "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
+      "integrity": "sha1-oZgsgpH07k1vL2KBfGsuzSxLe0c=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-core": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
-      "integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
+      "integrity": "sha1-GbX71VqWl3c+1mYfTjIDDtfjAoc=",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "3.0.9",
-        "conventional-commits-parser": "2.1.7",
-        "dateformat": "3.0.3",
-        "get-pkg-repo": "1.4.0",
-        "git-raw-commits": "1.3.6",
-        "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.3.6",
-        "lodash": "4.17.11",
-        "normalize-package-data": "2.4.0",
-        "q": "1.5.1",
-        "read-pkg": "1.1.0",
-        "read-pkg-up": "1.0.1",
-        "through2": "2.0.4"
+        "conventional-changelog-writer": "^3.0.9",
+        "conventional-commits-parser": "^2.1.7",
+        "dateformat": "^3.0.0",
+        "get-pkg-repo": "^1.0.0",
+        "git-raw-commits": "^1.3.6",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^1.3.6",
+        "lodash": "^4.2.1",
+        "normalize-package-data": "^2.3.5",
+        "q": "^1.5.1",
+        "read-pkg": "^1.1.0",
+        "read-pkg-up": "^1.0.1",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -770,8 +770,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -793,7 +793,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -802,9 +802,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -813,9 +813,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -824,8 +824,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -834,7 +834,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "through2": {
@@ -843,8 +843,8 @@
           "integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "2 || 3",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -852,28 +852,28 @@
     "conventional-changelog-ember": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
-      "integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
+      "integrity": "sha1-t9MYUXVtD8tJsDHf/ravqTsgJAA=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-eslint": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
-      "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
+      "integrity": "sha1-sTzH5LRyyBlFDt4DH/GnXA49B9M=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-express": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
-      "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
+      "integrity": "sha1-SmKVyxF4UFn7CSAhgNDlnDWLnCw=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-jquery": {
@@ -882,7 +882,7 @@
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jscs": {
@@ -891,41 +891,41 @@
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jshint": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
-      "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
+      "integrity": "sha1-kFHBrAdnq69iox900v6HkOisxsg=",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-preset-loader": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
-      "integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
+      "integrity": "sha1-QLsPFCzSfRaDnsbHTujbQYCZs3M=",
       "dev": true
     },
     "conventional-changelog-writer": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
-      "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
+      "integrity": "sha1-Suzf7zP/KlO7DPO4BxziHw6ZRjQ=",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.1.6",
-        "dateformat": "3.0.3",
-        "handlebars": "4.0.12",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.11",
-        "meow": "4.0.1",
-        "semver": "5.6.0",
-        "split": "1.0.1",
-        "through2": "2.0.4"
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^1.1.6",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "semver": "^5.5.0",
+        "split": "^1.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "through2": {
@@ -934,8 +934,8 @@
           "integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "2 || 3",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -943,26 +943,26 @@
     "conventional-commits-filter": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
-      "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
+      "integrity": "sha1-Q4nNjlj+iXUMC1+1jx1/DMitODE=",
       "dev": true,
       "requires": {
-        "is-subset": "0.1.1",
-        "modify-values": "1.0.1"
+        "is-subset": "^0.1.1",
+        "modify-values": "^1.0.0"
       }
     },
     "conventional-commits-parser": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
-      "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+      "integrity": "sha1-7KRe1hQNcrqXIu5BMmdNY55kTo4=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.5",
-        "is-text-path": "1.0.1",
-        "lodash": "4.17.11",
-        "meow": "4.0.1",
-        "split2": "2.2.0",
-        "through2": "2.0.4",
-        "trim-off-newlines": "1.0.1"
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
       },
       "dependencies": {
         "through2": {
@@ -971,8 +971,8 @@
           "integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "2 || 3",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -983,13 +983,13 @@
       "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "conventional-commits-filter": "1.1.6",
-        "conventional-commits-parser": "2.1.7",
-        "git-raw-commits": "1.3.6",
-        "git-semver-tags": "1.3.6",
-        "meow": "3.7.0",
-        "object-assign": "4.1.1"
+        "concat-stream": "^1.4.10",
+        "conventional-commits-filter": "^1.1.1",
+        "conventional-commits-parser": "^2.1.1",
+        "git-raw-commits": "^1.3.0",
+        "git-semver-tags": "^1.3.0",
+        "meow": "^3.3.0",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -1004,8 +1004,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "find-up": {
@@ -1014,8 +1014,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "indent-string": {
@@ -1024,7 +1024,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -1033,11 +1033,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "map-obj": {
@@ -1052,16 +1052,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "path-exists": {
@@ -1070,7 +1070,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -1079,9 +1079,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -1090,9 +1090,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -1101,8 +1101,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "redent": {
@@ -1111,8 +1111,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "strip-bom": {
@@ -1121,7 +1121,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -1130,7 +1130,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "trim-newlines": {
@@ -1150,7 +1150,7 @@
     "coveralls": {
       "version": "2.13.3",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
-      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
+      "integrity": "sha1-mtfCrlJ0F/Nh6LYmSD9I7pLdK8c=",
       "dev": true,
       "requires": {
         "js-yaml": "3.6.1",
@@ -1166,9 +1166,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -1177,7 +1177,7 @@
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "css-select": {
@@ -1186,10 +1186,10 @@
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.2",
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.2"
+        "nth-check": "~1.0.1"
       }
     },
     "css-what": {
@@ -1204,7 +1204,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "dargs": {
@@ -1213,7 +1213,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "dashdash": {
@@ -1222,7 +1222,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1236,7 +1236,7 @@
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4=",
       "dev": true
     },
     "debug": {
@@ -1245,7 +1245,7 @@
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.1.1"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -1260,8 +1260,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "map-obj": {
@@ -1278,14 +1278,14 @@
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "decompress-tarbz2": "4.1.1",
-        "decompress-targz": "4.1.1",
-        "decompress-unzip": "4.0.1",
-        "graceful-fs": "4.1.15",
-        "make-dir": "1.3.0",
-        "pify": "2.3.0",
-        "strip-dirs": "2.1.0"
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
       }
     },
     "decompress-response": {
@@ -1294,37 +1294,37 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.1"
+        "mimic-response": "^1.0.0"
       }
     },
     "decompress-tar": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "integrity": "sha1-cYy9P8sWIJcW5womuE57pFkuWvE=",
       "dev": true,
       "requires": {
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0",
-        "tar-stream": "1.6.2"
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
       }
     },
     "decompress-tarbz2": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "integrity": "sha1-MIKluIDqQEOBY0nzeLVsUWvho5s=",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "6.2.0",
-        "is-stream": "1.1.0",
-        "seek-bzip": "1.0.5",
-        "unbzip2-stream": "1.3.1"
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
       },
       "dependencies": {
         "file-type": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+          "integrity": "sha1-5QzXXTVv/tTjBtxPW89Sp5kDqRk=",
           "dev": true
         }
       }
@@ -1332,12 +1332,12 @@
     "decompress-targz": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "integrity": "sha1-wJvDXE0R894J8tLaU+neI+fOHu4=",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0"
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
       }
     },
     "decompress-unzip": {
@@ -1346,10 +1346,10 @@
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
       "requires": {
-        "file-type": "3.9.0",
-        "get-stream": "2.3.1",
-        "pify": "2.3.0",
-        "yauzl": "2.10.0"
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
       },
       "dependencies": {
         "file-type": {
@@ -1364,8 +1364,8 @@
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -1373,16 +1373,16 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
       "dev": true
     },
     "deep-is": {
@@ -1397,13 +1397,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -1439,10 +1439,10 @@
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom-serializer": {
@@ -1451,8 +1451,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.2"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -1472,10 +1472,10 @@
     "domhandler": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.2.1"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -1484,8 +1484,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.2.1"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -1494,7 +1494,7 @@
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "dotgitignore": {
@@ -1503,8 +1503,8 @@
       "integrity": "sha512-eu5XjSstm0WXQsARgo6kPjkINYZlOUW+z/KtAAIBjHa5mUpMPrxJytbPIndWz6GubBuuuH5ljtVcXKnVnH5q8w==",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "minimatch": "3.0.4"
+        "find-up": "^2.1.0",
+        "minimatch": "^3.0.4"
       }
     },
     "downcache": {
@@ -1513,13 +1513,13 @@
       "integrity": "sha1-eQuwQkaJE2EVzpPyqhWUbG2AbQ4=",
       "dev": true,
       "requires": {
-        "extend": "3.0.2",
-        "graceful-fs": "4.1.15",
-        "limiter": "1.1.3",
-        "mkdirp": "0.5.1",
-        "npmlog": "2.0.4",
-        "request": "2.79.0",
-        "rimraf": "2.6.2"
+        "extend": "^3.0.0",
+        "graceful-fs": "^4.1.3",
+        "limiter": "^1.1.0",
+        "mkdirp": "^0.5.1",
+        "npmlog": "^2.0.3",
+        "request": "^2.69.0",
+        "rimraf": "^2.5.2"
       },
       "dependencies": {
         "gauge": {
@@ -1528,11 +1528,11 @@
           "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "2.0.1",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
+            "ansi": "^0.3.0",
+            "has-unicode": "^2.0.0",
+            "lodash.pad": "^4.1.0",
+            "lodash.padend": "^4.1.0",
+            "lodash.padstart": "^4.1.0"
           }
         },
         "npmlog": {
@@ -1541,9 +1541,9 @@
           "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.5",
-            "gauge": "1.2.7"
+            "ansi": "~0.3.1",
+            "are-we-there-yet": "~1.1.2",
+            "gauge": "~1.2.5"
           }
         }
       }
@@ -1551,20 +1551,20 @@
     "download": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
-      "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
+      "integrity": "sha1-rNalQuTNC7Qspwz8mMnkOwcDlxQ=",
       "dev": true,
       "requires": {
-        "caw": "2.0.1",
-        "content-disposition": "0.5.2",
-        "decompress": "4.2.0",
-        "ext-name": "5.0.0",
+        "caw": "^2.0.0",
+        "content-disposition": "^0.5.2",
+        "decompress": "^4.0.0",
+        "ext-name": "^5.0.0",
         "file-type": "5.2.0",
-        "filenamify": "2.1.0",
-        "get-stream": "3.0.0",
-        "got": "7.1.0",
-        "make-dir": "1.3.0",
-        "p-event": "1.3.0",
-        "pify": "3.0.0"
+        "filenamify": "^2.0.0",
+        "get-stream": "^3.0.0",
+        "got": "^7.0.0",
+        "make-dir": "^1.0.0",
+        "p-event": "^1.0.0",
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -1587,17 +1587,17 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "entities": {
@@ -1609,19 +1609,19 @@
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -1636,11 +1636,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -1765,34 +1765,34 @@
       "integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
       "dev": true,
       "requires": {
-        "fast-diff": "1.2.0",
-        "jest-docblock": "21.2.0"
+        "fast-diff": "^1.1.1",
+        "jest-docblock": "^21.0.0"
       }
     },
     "eslint-scope": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "integrity": "sha1-u1ByANPRf2AkdjYWC0gmKEsQhTU=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
       "dev": true
     },
     "espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -1804,19 +1804,19 @@
     "esquery": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -1837,13 +1837,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-template": {
@@ -1855,26 +1855,26 @@
     "ext-list": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
-      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "integrity": "sha1-C5jmTtgvWs8PKTG6v2khLvUt3Tc=",
       "dev": true,
       "requires": {
-        "mime-db": "1.37.0"
+        "mime-db": "^1.28.0"
       }
     },
     "ext-name": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
-      "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "integrity": "sha1-cHgZgdGD7hXROZPIgiBFxQbI8KY=",
       "dev": true,
       "requires": {
-        "ext-list": "2.2.2",
-        "sort-keys-length": "1.0.1"
+        "ext-list": "^2.0.0",
+        "sort-keys-length": "^1.0.0"
       }
     },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true
     },
     "external-editor": {
@@ -1924,7 +1924,7 @@
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -1933,7 +1933,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -1942,8 +1942,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-type": {
@@ -1961,12 +1961,12 @@
     "filenamify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
-      "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+      "integrity": "sha1-iPr0lfsbR6v9YSMAACoWIoxnfuk=",
       "dev": true,
       "requires": {
-        "filename-reserved-regex": "2.0.0",
-        "strip-outer": "1.0.1",
-        "trim-repeated": "1.0.0"
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
       }
     },
     "find-root": {
@@ -1981,7 +1981,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -1990,10 +1990,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.15",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "forever-agent": {
@@ -2008,9 +2008,9 @@
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.7",
-        "mime-types": "2.1.21"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fs-access": {
@@ -2019,24 +2019,24 @@
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "1.0.0"
+        "null-check": "^1.0.0"
       }
     },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
       "dev": true
     },
     "fs-extra": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "integrity": "sha1-DYUhIuW8W+tFP7Ao6cDJvzY0DJQ=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -2057,14 +2057,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -2073,7 +2073,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -2082,9 +2082,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -2092,10 +2092,10 @@
     "generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "integrity": "sha1-8GlhdpDBDIaOc7hGV0Z2T5fDR58=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.2"
       }
     },
     "generate-object-property": {
@@ -2104,13 +2104,13 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
       "dev": true
     },
     "get-func-name": {
@@ -2125,9 +2125,9 @@
       "integrity": "sha512-z6uvzkaB+bGrH/Hi57hI0e3fyzKW0B4v355Hzv24IfKkJSC6H1+2pb6rs03j6lLRxyXgsQiKhU0uuQnrouDmiw==",
       "dev": true,
       "requires": {
-        "lodash.startswith": "4.2.1",
-        "minimist": "1.2.0",
-        "which": "1.3.1"
+        "lodash.startswith": "^4.2.1",
+        "minimist": "^1.1.1",
+        "which": "^1.1.1"
       }
     },
     "get-pkg-repo": {
@@ -2136,11 +2136,11 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "meow": "3.7.0",
-        "normalize-package-data": "2.4.0",
-        "parse-github-repo-url": "1.4.1",
-        "through2": "2.0.4"
+        "hosted-git-info": "^2.1.4",
+        "meow": "^3.3.0",
+        "normalize-package-data": "^2.3.0",
+        "parse-github-repo-url": "^1.3.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2155,8 +2155,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "find-up": {
@@ -2165,8 +2165,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "indent-string": {
@@ -2175,7 +2175,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -2203,16 +2203,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "path-exists": {
@@ -2221,7 +2221,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -2230,9 +2230,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -2241,9 +2241,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -2252,8 +2252,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "redent": {
@@ -2262,8 +2262,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "strip-bom": {
@@ -2272,7 +2272,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -2281,7 +2281,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "through2": {
@@ -2290,8 +2290,8 @@
           "integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "2 || 3",
+            "xtend": "~4.0.1"
           }
         },
         "trim-newlines": {
@@ -2305,10 +2305,10 @@
     "get-proxy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
-      "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+      "integrity": "sha1-NJ8rTZHUTE1NTpy6KtkBQ/rF75M=",
       "dev": true,
       "requires": {
-        "npm-conf": "1.1.3"
+        "npm-conf": "^1.1.0"
       }
     },
     "get-stdin": {
@@ -2329,7 +2329,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2343,14 +2343,14 @@
     "git-raw-commits": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
-      "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
+      "integrity": "sha1-J8NaMqZ3d8Hs1BKiOabBnXG5Wv8=",
       "dev": true,
       "requires": {
-        "dargs": "4.1.0",
-        "lodash.template": "4.4.0",
-        "meow": "4.0.1",
-        "split2": "2.2.0",
-        "through2": "2.0.4"
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "through2": {
@@ -2359,8 +2359,8 @@
           "integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "2 || 3",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -2371,18 +2371,18 @@
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "1.0.0",
-        "pify": "2.3.0"
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
       }
     },
     "git-semver-tags": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
-      "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
+      "integrity": "sha1-NX6gH3KAeU/gkn8oBr7mQU0sq6U=",
       "dev": true,
       "requires": {
-        "meow": "4.0.1",
-        "semver": "5.6.0"
+        "meow": "^4.0.0",
+        "semver": "^5.5.0"
       }
     },
     "gitconfiglocal": {
@@ -2391,7 +2391,7 @@
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.2"
       }
     },
     "github-from-package": {
@@ -2403,15 +2403,15 @@
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -2426,34 +2426,34 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.3",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+      "integrity": "sha1-BUUP2ECU5rvqVvRRpDqcKJFmOFo=",
       "dev": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-plain-obj": "1.1.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "isurl": "1.0.0",
-        "lowercase-keys": "1.0.1",
-        "p-cancelable": "0.3.0",
-        "p-timeout": "1.2.1",
-        "safe-buffer": "5.1.2",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "1.0.0",
-        "url-to-options": "1.0.1"
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
+        "url-to-options": "^1.0.1"
       }
     },
     "graceful-fs": {
@@ -2477,28 +2477,28 @@
     "handlebars": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "integrity": "sha1-LBXIqW1G2l4mZwBRi6jLjZGdW8U=",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "optimist": "0.6.1",
-        "source-map": "0.6.1",
-        "uglify-js": "3.4.9"
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
         "async": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
           "dev": true,
           "requires": {
-            "lodash": "4.17.11"
+            "lodash": "^4.17.10"
           }
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -2509,10 +2509,10 @@
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.19.0",
-        "is-my-json-valid": "2.19.0",
-        "pinkie-promise": "2.0.1"
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -2521,7 +2521,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -2533,16 +2533,16 @@
     "has-symbol-support-x": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+      "integrity": "sha1-FAn5i8ACR9pF2mfO4KNvKC/yZFU=",
       "dev": true
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "integrity": "sha1-oEWrOD17SyASoAFIqwql8pAETU0=",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "1.4.2"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-unicode": {
@@ -2557,10 +2557,10 @@
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "he": {
@@ -2578,7 +2578,7 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
       "dev": true
     },
     "htmlparser2": {
@@ -2587,12 +2587,12 @@
       "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.2",
-        "domutils": "1.5.1",
-        "entities": "1.1.2",
-        "inherits": "2.0.3",
-        "readable-stream": "3.0.6"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.6"
       },
       "dependencies": {
         "domelementtype": {
@@ -2607,9 +2607,9 @@
           "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -2620,30 +2620,30 @@
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.15.2"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "integrity": "sha1-UL8k5bnIu5ivSWTJQc2wkY2ntgs=",
       "dev": true
     },
     "ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
       "dev": true
     },
     "imurmurhash": {
@@ -2664,8 +2664,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2677,29 +2677,29 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
       "dev": true
     },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.11",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2711,10 +2711,10 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -2723,9 +2723,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "strip-ansi": {
@@ -2734,16 +2734,16 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -2775,7 +2775,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -2787,20 +2787,20 @@
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
       "dev": true
     },
     "is-my-json-valid": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
+      "integrity": "sha1-j9bkA2PNBrlj+od9REv7Xt3GIXU=",
       "dev": true,
       "requires": {
-        "generate-function": "2.3.1",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-natural-number": {
@@ -2833,7 +2833,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -2842,7 +2842,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -2866,7 +2866,7 @@
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
     "is-retry-allowed": {
@@ -2893,7 +2893,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "1.9.0"
+        "text-extensions": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -2932,20 +2932,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.12",
-        "js-yaml": "3.6.1",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.1",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -2954,11 +2954,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -2973,7 +2973,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -2981,17 +2981,17 @@
     "isurl": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "integrity": "sha1-sn9PSfPNqj6kSgpbfzRi5u3DnWc=",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "jest-docblock": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "integrity": "sha1-UVKcOzDV/RWdpgwnzu3Blfr41BQ=",
       "dev": true
     },
     "js-tokens": {
@@ -3006,8 +3006,8 @@
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
       }
     },
     "js2xmlparser": {
@@ -3016,7 +3016,7 @@
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
       "dev": true,
       "requires": {
-        "xmlcreate": "1.0.2"
+        "xmlcreate": "^1.0.1"
       }
     },
     "jsbn": {
@@ -3028,27 +3028,27 @@
     "jsdoc": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
-      "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+      "integrity": "sha1-SEUhsSboGQTWMv+D7JqqCWcI+k0=",
       "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
-        "bluebird": "3.5.0",
-        "catharsis": "0.8.9",
-        "escape-string-regexp": "1.0.5",
-        "js2xmlparser": "3.0.0",
-        "klaw": "2.0.0",
-        "marked": "0.3.19",
-        "mkdirp": "0.5.1",
-        "requizzle": "0.2.1",
-        "strip-json-comments": "2.0.1",
+        "bluebird": "~3.5.0",
+        "catharsis": "~0.8.9",
+        "escape-string-regexp": "~1.0.5",
+        "js2xmlparser": "~3.0.0",
+        "klaw": "~2.0.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
         "taffydb": "2.6.2",
-        "underscore": "1.8.3"
+        "underscore": "~1.8.3"
       }
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema": {
@@ -3087,7 +3087,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonparse": {
@@ -3134,9 +3134,9 @@
       "integrity": "sha512-N+CeRTi0f6ov85Fx+w/epVPTBy6bovoWjUCD6pvXoHWBWeqI6+ViV2psdoSc4CRtiZfJkhvYO3b47I4hJfOu7Q==",
       "dev": true,
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.11.1",
-        "prebuild-install": "5.2.1"
+        "bindings": "^1.3.0",
+        "nan": "^2.10.0",
+        "prebuild-install": "^5.0.0"
       }
     },
     "key-tree-store": {
@@ -3151,7 +3151,7 @@
       "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lcid": {
@@ -3160,7 +3160,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -3175,14 +3175,14 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "limiter": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
-      "integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw==",
+      "integrity": "sha1-MuLrVbIyQHaUPl0EwRhf+zh5aO8=",
       "dev": true
     },
     "load-json-file": {
@@ -3203,14 +3203,14 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
       "dev": true
     },
     "lodash._baseassign": {
@@ -3219,8 +3219,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -3277,9 +3277,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.defaults": {
@@ -3336,9 +3336,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.map": {
@@ -3350,7 +3350,7 @@
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "integrity": "sha1-rcJdnLmbk5HFliTzefu6YNcRHVQ=",
       "dev": true
     },
     "lodash.pad": {
@@ -3407,8 +3407,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -3417,7 +3417,7 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "~3.0.0"
       }
     },
     "log-driver": {
@@ -3429,7 +3429,7 @@
     "lolex": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+      "integrity": "sha1-ETAB1Wv8fgLVbjYpHMXEE9GqBzM=",
       "dev": true
     },
     "loud-rejection": {
@@ -3438,14 +3438,14 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
       "dev": true
     },
     "lru-cache": {
@@ -3454,17 +3454,17 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -3493,30 +3493,30 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memory-pager": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.1.0.tgz",
-      "integrity": "sha512-Mf9OHV/Y7h6YWDxTzX/b4ZZ4oh9NSXblQL8dtPCOomOtZciEHxePR78+uHFLLlsk01A6jVHhHsQZZ/WcIPpnzg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "optional": true
     },
     "meow": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-      "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+      "integrity": "sha1-1IWY9vSxRy81v2MXqVlFrONH+XU=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "4.2.0",
-        "decamelize-keys": "1.1.0",
-        "loud-rejection": "1.6.0",
-        "minimist": "1.2.0",
-        "minimist-options": "3.0.2",
-        "normalize-package-data": "2.4.0",
-        "read-pkg-up": "3.0.0",
-        "redent": "2.0.0",
-        "trim-newlines": "2.0.0"
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist": "^1.1.3",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0"
       },
       "dependencies": {
         "load-json-file": {
@@ -3525,10 +3525,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "parse-json": {
@@ -3537,17 +3537,17 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -3562,9 +3562,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -3573,8 +3573,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         }
       }
@@ -3582,10 +3582,10 @@
     "metamocha": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/metamocha/-/metamocha-1.3.2.tgz",
-      "integrity": "sha512-GQj+vxauCtP5o9hxGJm7tZIwwCpDJUW7KLBqqLJyhnpKdxDWxfUTwjgbMfLdGs/BQiFvVP2b3JmGobBkUQPvtg==",
+      "integrity": "sha1-E3A96v1Twa134b+tN/IZbMPOysA=",
       "dev": true,
       "requires": {
-        "mocha": "3.5.3"
+        "mocha": "^3.5.3"
       }
     },
     "mime-db": {
@@ -3600,28 +3600,28 @@
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.37.0"
+        "mime-db": "~1.37.0"
       }
     },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
       "dev": true
     },
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -3633,11 +3633,11 @@
     "minimist-options": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "integrity": "sha1-+6TIGRM54T7PTWG+sD8HAQPz2VQ=",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "is-plain-obj": "1.1.0"
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
       }
     },
     "mkdirp": {
@@ -3660,7 +3660,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -3701,12 +3701,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -3727,7 +3727,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -3741,16 +3741,17 @@
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "integrity": "sha1-s5OfpgVUZHTj4+PGPWS9Q7TuYCI=",
       "dev": true
     },
     "mongodb-core": {
-      "version": "github:mongodb-js/mongodb-core#36ab60285a8f9945828131484e8ac29d277d470f",
+      "version": "github:mongodb-js/mongodb-core#5024c8aff8044ef36ef5fd44c297b0b26501a87d",
+      "from": "github:mongodb-js/mongodb-core#next",
       "requires": {
-        "bson": "1.1.0",
-        "require_optional": "1.0.1",
-        "safe-buffer": "5.1.2",
-        "saslprep": "1.0.2"
+        "bson": "^1.1.0",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
       }
     },
     "mongodb-download-url": {
@@ -3759,28 +3760,28 @@
       "integrity": "sha512-BSlCy2+fDkVjnEKPgKEKqF5mj1tZ8luyACOCZl8rN4E7xc9Jq7GlTZdWVJtZ9RpUx+2o5cEHlCPpduDK3Zf3bg==",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "debug": "2.6.9",
-        "lodash.defaults": "4.2.0",
-        "minimist": "1.2.0",
-        "mongodb-version-list": "1.0.0",
-        "request": "2.79.0",
-        "semver": "5.6.0"
+        "async": "^2.1.2",
+        "debug": "^2.2.0",
+        "lodash.defaults": "^4.0.0",
+        "minimist": "^1.2.0",
+        "mongodb-version-list": "^1.0.0",
+        "request": "^2.65.0",
+        "semver": "^5.0.3"
       },
       "dependencies": {
         "async": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
           "dev": true,
           "requires": {
-            "lodash": "4.17.11"
+            "lodash": "^4.17.10"
           }
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -3797,16 +3798,16 @@
     "mongodb-extjson": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/mongodb-extjson/-/mongodb-extjson-2.1.4.tgz",
-      "integrity": "sha512-AYGhTnrMoPW3JXdtY2QkP3kPBNrUqcTW4tQaW1rQ/JO41QCiMqIq5RWf5e3lhs4McGx9rIXHKPYGDH6TDp8RHg==",
+      "integrity": "sha1-x+riO77qlka48sMCdkqpVAwg/lY=",
       "dev": true,
       "requires": {
-        "bson": "2.0.8"
+        "bson": "^2.0.7"
       },
       "dependencies": {
         "bson": {
           "version": "2.0.8",
           "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.8.tgz",
-          "integrity": "sha512-0F0T3gHeOwJzHWcN60BZomqj5hCBDRk4b3fANuruvDTnyJJ8sggABKSaePM2F34THNZZSIlB2P1mk2nQWgBr9w==",
+          "integrity": "sha1-47zBFeSGvcsiLedWjEOwtDKSdh4=",
           "dev": true
         }
       }
@@ -3817,34 +3818,34 @@
       "integrity": "sha1-bewhLSLMEWz9IlfI+b4/pN00Ej0=",
       "dev": true,
       "requires": {
-        "snappy": "6.1.1"
+        "snappy": "^6.0.1"
       }
     },
     "mongodb-test-runner": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/mongodb-test-runner/-/mongodb-test-runner-1.3.4.tgz",
-      "integrity": "sha512-Ubfi6nfhEHFCaF0cIg7e8jZBYbjpjTa7GhOS5dWkYTwtVcNMmL0TeQAaea4i3dVl85VdoI5I4WNFpDpu8Ye58Q==",
+      "integrity": "sha1-Y9/ao1dJnwf1CHVw0P3G7zBRJrQ=",
       "dev": true,
       "requires": {
-        "metamocha": "1.3.2",
-        "mongodb-topology-manager": "2.1.0",
-        "mongodb-version-manager": "1.3.0",
-        "semver": "5.6.0",
-        "yargs": "8.0.2"
+        "metamocha": "^1.2.5",
+        "mongodb-topology-manager": "^2.0.0",
+        "mongodb-version-manager": "^1.0.7",
+        "semver": "^5.4.1",
+        "yargs": "^8.0.2"
       }
     },
     "mongodb-topology-manager": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mongodb-topology-manager/-/mongodb-topology-manager-2.1.0.tgz",
-      "integrity": "sha512-s2PelP303LsyJIsReIDUyHhdGPN1xoBY5RynfDKpgT2Wz/D0vaQZN+x0AK6lzj7ro7c8hPFzvHyGA5bJ7JWUug==",
+      "integrity": "sha1-Xe4NUX0UdPMAPZbMIMekHqnSY+k=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.2",
-        "co": "4.6.0",
-        "kerberos": "1.1.2",
-        "mkdirp": "0.5.1",
-        "mongodb-core": "github:mongodb-js/mongodb-core#36ab60285a8f9945828131484e8ac29d277d470f",
-        "rimraf": "2.6.2"
+        "bluebird": "^3.5.1",
+        "co": "^4.6.0",
+        "kerberos": "^1.0.0",
+        "mkdirp": "^0.5.1",
+        "mongodb-core": "^3.1.2",
+        "rimraf": "^2.6.2"
       },
       "dependencies": {
         "bluebird": {
@@ -3861,18 +3862,18 @@
       "integrity": "sha1-8lAxz83W8UWx3o/OKk6+wCiLtKQ=",
       "dev": true,
       "requires": {
-        "cheerio": "0.22.0",
-        "debug": "2.6.9",
-        "downcache": "0.0.9",
-        "fs-extra": "1.0.0",
-        "minimist": "1.2.0",
-        "semver": "5.6.0"
+        "cheerio": "^0.22.0",
+        "debug": "^2.2.0",
+        "downcache": "^0.0.9",
+        "fs-extra": "^1.0.0",
+        "minimist": "^1.1.1",
+        "semver": "^5.0.1"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -3884,9 +3885,9 @@
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
           }
         },
         "jsonfile": {
@@ -3904,7 +3905,7 @@
           "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15"
+            "graceful-fs": "^4.1.9"
           }
         },
         "ms": {
@@ -3921,40 +3922,40 @@
       "integrity": "sha512-0KfymtjnxPCLOgoqoHyEquhimFxxMLoE0+9zy4Y7X8czZ5fYmmhwtoetMmTYgy4yjBEG3friA4FLXTbGB4EIAg==",
       "dev": true,
       "requires": {
-        "ampersand-state": "5.0.3",
-        "async": "2.6.1",
-        "chalk": "2.4.1",
-        "debug": "3.2.6",
-        "docopt": "0.6.2",
-        "download": "6.2.5",
-        "figures": "2.0.0",
-        "fs-extra": "4.0.3",
-        "get-mongodb-version": "2.0.0",
-        "lodash.defaults": "4.2.0",
-        "lodash.difference": "4.5.0",
-        "mongodb-download-url": "0.4.2",
-        "mongodb-version-list": "1.0.0",
-        "semver": "5.6.0",
-        "tildify": "1.2.0",
-        "untildify": "3.0.3"
+        "ampersand-state": "^5.0.3",
+        "async": "^2.1.2",
+        "chalk": "^2.1.0",
+        "debug": ">= 2.6.9 < 3.0.0 || >= ^3.1.0",
+        "docopt": "^0.6.2",
+        "download": "^6.2.5",
+        "figures": "^2.0.0",
+        "fs-extra": "^4.0.2",
+        "get-mongodb-version": "^2.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.1.1",
+        "mongodb-download-url": "^0.4.2",
+        "mongodb-version-list": "^1.0.0",
+        "semver": "^5.3.0",
+        "tildify": "^1.2.0",
+        "untildify": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "async": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
           "dev": true,
           "requires": {
-            "lodash": "4.17.11"
+            "lodash": "^4.17.10"
           }
         },
         "chalk": {
@@ -3963,18 +3964,18 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -3982,7 +3983,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
       "dev": true
     },
     "mute-stream": {
@@ -4016,10 +4017,10 @@
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "3.0.0",
-        "just-extend": "3.0.0",
-        "lolex": "2.7.5",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "just-extend": "^3.0.0",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       },
       "dependencies": {
         "@sinonjs/formatio": {
@@ -4039,7 +4040,7 @@
       "integrity": "sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==",
       "dev": true,
       "requires": {
-        "semver": "5.6.0"
+        "semver": "^5.4.1"
       }
     },
     "noop-logger": {
@@ -4054,29 +4055,29 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.6.0",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "npm-conf": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
-      "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+      "integrity": "sha1-JWzEe9DiGMJZxOlVC/QTvCGSr/k=",
       "dev": true,
       "requires": {
-        "config-chain": "1.1.12",
-        "pify": "3.0.0"
+        "config-chain": "^1.1.11",
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -4093,19 +4094,19 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -4114,7 +4115,7 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "null-check": {
@@ -4147,7 +4148,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -4156,7 +4157,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -4165,8 +4166,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -4189,12 +4190,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-homedir": {
@@ -4206,12 +4207,12 @@
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -4223,7 +4224,7 @@
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+      "integrity": "sha1-ueEjgAvOu3rBOkeb4ZW1B7mNMPo=",
       "dev": true
     },
     "p-event": {
@@ -4232,7 +4233,7 @@
       "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
       "dev": true,
       "requires": {
-        "p-timeout": "1.2.1"
+        "p-timeout": "^1.1.1"
       }
     },
     "p-finally": {
@@ -4244,10 +4245,10 @@
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -4256,7 +4257,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-timeout": {
@@ -4265,7 +4266,7 @@
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -4286,7 +4287,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -4336,7 +4337,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
     },
     "pathval": {
@@ -4369,13 +4370,13 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
       "dev": true
     },
     "prebuild-install": {
@@ -4384,22 +4385,22 @@
       "integrity": "sha512-9DAccsInWHB48TBQi2eJkLPE049JuAI6FjIH0oIrij4bpDVEbX6JvlWRAcAAlUqBHhjgq0jNqA3m3bBXWm9v6w==",
       "dev": true,
       "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.1",
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "napi-build-utils": "1.0.1",
-        "node-abi": "2.5.0",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.8",
-        "simple-get": "2.8.1",
-        "tar-fs": "1.16.3",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.2.7",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
       },
       "dependencies": {
         "tunnel-agent": {
@@ -4408,7 +4409,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -4434,7 +4435,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
       "dev": true
     },
     "progress": {
@@ -4464,11 +4465,11 @@
     "pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -4498,13 +4499,13 @@
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "read-pkg": {
@@ -4513,9 +4514,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -4524,8 +4525,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -4549,14 +4550,14 @@
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
-        "indent-string": "3.2.0",
-        "strip-indent": "2.0.0"
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "regexpp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "integrity": "sha1-DjUW3Qt5BPQT0tQZPc5GGMOmias=",
       "dev": true
     },
     "repeating": {
@@ -4565,7 +4566,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -4614,8 +4615,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -4631,8 +4632,8 @@
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
       "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.6.0"
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
       }
     },
     "requizzle": {
@@ -4641,7 +4642,7 @@
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
       "requires": {
-        "underscore": "1.6.0"
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "underscore": {
@@ -4669,8 +4670,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
@@ -4679,7 +4680,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -4688,7 +4689,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -4703,24 +4704,24 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
     },
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
       "dev": true
     },
     "saslprep": {
@@ -4729,7 +4730,7 @@
       "integrity": "sha512-4cDsYuAjXssUSjxHKRe4DTZC0agDwsCqcMqtJAQPzC74nJ7LfAJflAtC1Zed5hMzEQKj82d3tuzqdGNRsLJ4Gw==",
       "optional": true,
       "requires": {
-        "sparse-bitfield": "3.0.3"
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "seek-bzip": {
@@ -4738,7 +4739,7 @@
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
       "requires": {
-        "commander": "2.8.1"
+        "commander": "~2.8.1"
       },
       "dependencies": {
         "commander": {
@@ -4769,7 +4770,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -4793,12 +4794,12 @@
     "simple-get": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "integrity": "sha1-DiLpHUV12HYgYgvJEwjVenf0S10=",
       "dev": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "sinon": {
@@ -4836,10 +4837,10 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "snappy": {
@@ -4848,9 +4849,9 @@
       "integrity": "sha512-QTv+NJUVWfDMq1edGhmIgn/8TI3Pc+G2sxHOoV8NU0gDMeHaYgnyhIq/U6W+mv6wGmbdhq+bRyXggIoDUSjQng==",
       "dev": true,
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.11.1",
-        "prebuild-install": "5.2.1"
+        "bindings": "^1.3.0",
+        "nan": "^2.11.0",
+        "prebuild-install": "^5.1.0"
       }
     },
     "sntp": {
@@ -4859,7 +4860,7 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "sort-keys": {
@@ -4868,7 +4869,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "sort-keys-length": {
@@ -4877,7 +4878,7 @@
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
       "requires": {
-        "sort-keys": "1.1.2"
+        "sort-keys": "^1.0.0"
       }
     },
     "source-map": {
@@ -4887,7 +4888,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "sparse-bitfield": {
@@ -4896,7 +4897,7 @@
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
       "optional": true,
       "requires": {
-        "memory-pager": "1.1.0"
+        "memory-pager": "^1.0.2"
       }
     },
     "spdx-correct": {
@@ -4905,8 +4906,8 @@
       "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.2"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -4918,11 +4919,11 @@
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.2"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -4934,19 +4935,19 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
       "dev": true,
       "requires": {
-        "through2": "2.0.4"
+        "through2": "^2.0.2"
       },
       "dependencies": {
         "through2": {
@@ -4955,8 +4956,8 @@
           "integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "2 || 3",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -4973,15 +4974,15 @@
       "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -4998,14 +4999,14 @@
       "integrity": "sha512-jJ8FZhnmh9xJRQLnaXiGRLaAUNItIH29lOQZGpL5fd4+jUHto9Ij6SPCYN86h6ZNNXkYq2TYiIVVF7gVyC+pcQ==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "conventional-changelog": "1.1.24",
-        "conventional-recommended-bump": "1.2.1",
-        "dotgitignore": "1.0.3",
-        "figures": "1.7.0",
-        "fs-access": "1.0.1",
-        "semver": "5.6.0",
-        "yargs": "8.0.2"
+        "chalk": "^1.1.3",
+        "conventional-changelog": "^1.1.0",
+        "conventional-recommended-bump": "^1.0.0",
+        "dotgitignore": "^1.0.3",
+        "figures": "^1.5.0",
+        "fs-access": "^1.0.0",
+        "semver": "^5.1.0",
+        "yargs": "^8.0.1"
       },
       "dependencies": {
         "figures": {
@@ -5014,8 +5015,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         }
       }
@@ -5023,11 +5024,11 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5042,7 +5043,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -5050,16 +5051,16 @@
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI=",
       "dev": true
     },
     "strip-ansi": {
@@ -5068,7 +5069,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -5080,10 +5081,10 @@
     "strip-dirs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "integrity": "sha1-SYdzYmT8NEzyD2w0rKnRPR1O1sU=",
       "dev": true,
       "requires": {
-        "is-natural-number": "4.0.1"
+        "is-natural-number": "^4.0.1"
       }
     },
     "strip-eof": {
@@ -5107,10 +5108,10 @@
     "strip-outer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "supports-color": {
@@ -5122,24 +5123,24 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.4.1",
-        "lodash": "4.17.11",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5148,18 +5149,18 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5173,23 +5174,23 @@
     "tar-fs": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "integrity": "sha1-lmpiiEHaLEAQQGqCFny9Xgxy1Qk=",
       "dev": true,
       "requires": {
-        "chownr": "1.1.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.6.2"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       },
       "dependencies": {
         "pump": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "integrity": "sha1-Xf6DEcM7v2/BgmH580cCxHwIqVQ=",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -5197,16 +5198,16 @@
     "tar-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
       "dev": true,
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.2.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
       }
     },
     "text-encoding": {
@@ -5239,8 +5240,8 @@
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "4.0.1"
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       },
       "dependencies": {
         "isarray": {
@@ -5275,7 +5276,7 @@
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "timed-out": {
@@ -5287,25 +5288,25 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
       "dev": true
     },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim-newlines": {
@@ -5326,7 +5327,7 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "tunnel-agent": {
@@ -5347,13 +5348,13 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "typedarray": {
@@ -5365,25 +5366,25 @@
     "uglify-js": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "integrity": "sha1-rwLxgMEgfXZDLkc+0koo9KeCuuM=",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.17.1",
-        "source-map": "0.6.1"
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
           "version": "2.17.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
           "dev": true,
           "optional": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true,
           "optional": true
         }
@@ -5395,8 +5396,8 @@
       "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
       "dev": true,
       "requires": {
-        "buffer": "3.6.0",
-        "through": "2.3.8"
+        "buffer": "^3.0.1",
+        "through": "^2.3.6"
       }
     },
     "underscore": {
@@ -5425,13 +5426,13 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
       "dev": true
     },
     "untildify": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
+      "integrity": "sha1-HntCsUC8/ZIrIucMoSZb/jY0x8k=",
       "dev": true
     },
     "url-parse-lax": {
@@ -5440,7 +5441,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-to-options": {
@@ -5458,17 +5459,17 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.2",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -5477,9 +5478,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -5493,10 +5494,10 @@
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -5514,10 +5515,10 @@
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "wordwrap": {
@@ -5529,10 +5530,10 @@
     "worker-farm": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-      "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+      "integrity": "sha1-rsxAWXb6talVJhgIRvDboojzpKA=",
       "dev": true,
       "requires": {
-        "errno": "0.1.7"
+        "errno": "~0.1.7"
       }
     },
     "wrap-ansi": {
@@ -5579,7 +5580,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "xmlcreate": {
@@ -5612,19 +5613,19 @@
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.3",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
       }
     },
     "yargs-parser": {
@@ -5633,7 +5634,7 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       }
     },
     "yauzl": {
@@ -5642,8 +5643,8 @@
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.1.0"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }


### PR DESCRIPTION
This PR is an update to #1876 since `applyDefaults` is now merged to `next`.