### PR TITLE
fix(mongo_client): add connection options

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -29,6 +29,7 @@ const connectSchema = {
   secondaryAcceptableLatencyMS: { type: 'number', default: 15, alias: 'localThresholdMS' },
   maxIdleTimeMS: { type: 'number' },
   maxPoolSize: { type: 'number', default: 5, alias: 'poolSize' },
+  poolSize: { type: 'number' },
   maxStalenessSeconds: { type: 'number' },
   readConcernLevel: { type: 'string', alias: 'readConcern.level' },
   readPreference: { type: [ReadPreference, 'object', 'string'] },
@@ -40,8 +41,8 @@ const connectSchema = {
   socketTimeoutMS: { type: 'number', default: 360000 },
   ssl: { type: 'boolean', default: false },
   tls: { type: 'boolean', default: false },
-  tlsAllowInvalidCertificates: { type: 'string', default: false },
-  tlsAllowInvalidHostnames: { type: 'string', default: false },
+  tlsAllowInvalidCertificates: { type: 'boolean', default: false },
+  tlsAllowInvalidHostnames: { type: 'boolean', default: false },
   tlsCAFile: { type: 'string' },
   tlsCertificateKeyFile: { type: 'string' },
   tlsCertificateKeyFilePassword: { type: 'string' },
@@ -91,7 +92,11 @@ const connectSchema = {
   numberOfRetries: { type: 'number', default: 5 },
   minSize: { type: 'number' },
   emitError: { type: 'boolean', default: true },
-  monitorCommands: { type: 'boolean', default: false }
+  monitorCommands: { type: 'boolean', default: false },
+  useNewUrlParser: { type: 'boolean' },
+  optionsValidationLevel: { type: 'string' },
+  host: { type: 'string' },
+  auth: { type: 'object' }
 };
 
 /**
@@ -200,6 +205,9 @@ const connectSchema = {
  * @param {boolean} [options.fsync=false] Specify a file sync write concern
  * @param {number} [options.numberOfRetries=5] The number of retries for a tailable cursor
  * @param {number} [options.minSize] If present, the connection pool will be initialized with minSize connections, and will never dip below minSize connections
+ * @param {boolean} [options.useNewUrlParser] If true, the new URL parser will be used instead of the legacy parser
+ * @param {string} [options.optionsValidationLevel] The level of options validation to use
+ * @param {string} [options.host] The host to which to connect
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {MongoClient} a MongoClient instance
  */
@@ -524,6 +532,9 @@ MongoClient.prototype.isConnected = function(options) {
  * @param {boolean} [options.fsync=false] Specify a file sync write concern
  * @param {number} [options.numberOfRetries=5] The number of retries for a tailable cursor
  * @param {number} [options.minSize] If present, the connection pool will be initialized with minSize connections, and will never dip below minSize connections
+ * @param {boolean} [options.useNewUrlParser] If true, the new URL parser will be used instead of the legacy parser
+ * @param {string} [options.optionsValidationLevel] The level of options validation to use
+ * @param {string} [options.host] The host to which to connect
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {Promise<MongoClient>} returns Promise if no callback passed
  */


### PR DESCRIPTION
This PR adds options that I unintentionally left out of the original MongoClient connect PR. I found these forgotten options after adding #1891 and seeing warnings for unknown options. 