### PR TITLE
fix(bulk): fix error propagation in empty bulk.execute

### DIFF
--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -114,6 +114,11 @@ class OrderedBulkOperation extends BulkOperationBase {
    */
   execute(_writeConcern, options, callback) {
     const ret = this.bulkExecute(_writeConcern, options, callback);
+
+    if (!(ret && ret.options && ret.callback)) {
+      return ret;
+    }
+
     options = ret.options;
     callback = ret.callback;
 

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -126,6 +126,11 @@ class UnorderedBulkOperation extends BulkOperationBase {
    */
   execute(_writeConcern, options, callback) {
     const ret = this.bulkExecute(_writeConcern, options, callback);
+
+    if (!(ret && ret.options && ret.callback)) {
+      return ret;
+    }
+
     options = ret.options;
     callback = ret.callback;
 


### PR DESCRIPTION
Executing an empty bulk write is supposed to return a detailed
MongoError, but we were not properly returning the error object,
resulting in a cryptic error.

Fixes NODE-1822