### PR TITLE
fix(options_validator): use validationOptions instead of magic boolean

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -219,7 +219,10 @@ function MongoClient(url, options) {
   EventEmitter.call(this);
 
   options = options || {};
-  validate(connectSchema, options, { optionsValidationLevel: this.optionsValidationLevel }, true);
+  validate(connectSchema, options, {
+    optionsValidationLevel: this.optionsValidationLevel,
+    warnOnUnknownOptions: true
+  });
 
   options = applyDefaults(connectSchema, options, {
     autoReconnect: options && options.socketOptions ? options.socketOptions.autoReconnect : true,
@@ -547,7 +550,10 @@ MongoClient.connect = function(url, options, callback) {
   options = args.length ? args.shift() : null;
   options = options || {};
 
-  validate(connectSchema, options, { optionsValidationLevel: this.optionsValidationLevel }, true);
+  validate(connectSchema, options, {
+    optionsValidationLevel: this.optionsValidationLevel,
+    warnOnUnknownOptions: true
+  });
 
   options = applyDefaults(connectSchema, options, {
     autoReconnect: options && options.socketOptions ? options.socketOptions.autoReconnect : true,

--- a/lib/options_validator.js
+++ b/lib/options_validator.js
@@ -64,10 +64,10 @@ function assertArity(args, requiredArity) {
  * @param {object} [validationOptions] Options for the validation itself.
  * @param {Logger} [validationOptions.logger] A logger instance to use if validation fails.
  * @param {string} [validationOptions.optionsValidationLevel] The level at which to validate the providedOptions ('none', 'warn', or 'error').
- * @param {boolean} [warnOnUnknownOptions=false] If true, warn on any option that is not in the schema.
+ * @param {boolean} [validationOptions.warnOnUnknownOptions] If true, warn on any option that is not in the schema.
  * @return {object} returns a frozen object of validated options
  */
-function validate(optionsSchema, providedOptions, validationOptions, warnOnUnknownOptions) {
+function validate(optionsSchema, providedOptions, validationOptions) {
   let optionsValidationLevel = VALIDATION_LEVEL_WARN;
   let logger;
 
@@ -78,15 +78,14 @@ function validate(optionsSchema, providedOptions, validationOptions, warnOnUnkno
     if (validationOptions.logger) {
       logger = validationOptions.logger;
     }
-  }
-
-  if (warnOnUnknownOptions) {
-    const optionSchemaNames = Object.keys(optionsSchema);
-    Object.keys(providedOptions).forEach(providedOption => {
-      if (optionSchemaNames.indexOf(providedOption) === -1) {
-        console.warn(`provided option [${providedOption}] is an unknown option`);
-      }
-    });
+    if (validationOptions.warnOnUnknownOptions) {
+      const optionSchemaNames = Object.keys(optionsSchema);
+      Object.keys(providedOptions).forEach(providedOption => {
+        if (optionSchemaNames.indexOf(providedOption) === -1) {
+          console.warn(`provided option [${providedOption}] is an unknown option`);
+        }
+      });
+    }
   }
 
   Object.keys(optionsSchema).forEach(optionName => {

--- a/test/unit/options_validator_tests.js
+++ b/test/unit/options_validator_tests.js
@@ -519,7 +519,10 @@ describe('Options Validation', function() {
     };
 
     const testObject = { a: true, b: 45 };
-    validate(validationSchema, testObject, { optionsValidationLevel: 'warn' }, true);
+    validate(validationSchema, testObject, {
+      optionsValidationLevel: 'warn',
+      warnOnUnknownOptions: true
+    });
 
     expect(stub).to.have.been.calledOnce;
     expect(stub).to.have.been.calledWith('provided option [b] is an unknown option');


### PR DESCRIPTION
This PR fixes the magic boolean I added to `validate()` in [this commit](https://github.com/mongodb/node-mongodb-native/commit/18e187a1b140fa6f888bbbef1135fb898b628bd3).