### PR TITLE
The MongoClient.close `force` param is optional

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -147,11 +147,11 @@ inherits(MongoClient, EventEmitter);
  */
 
 /**
- * Connect to MongoDB using a URL as documented at
+ * Connect to MongoDB using a url as documented at
  *
- *  https://docs.mongodb.com/manual/reference/connection-string/
+ *  docs.mongodb.org/manual/reference/connection-string/
  *
- * Note that for replicasets, the replicaSet query parameter is required in the 2.0 driver.
+ * Note that for replicasets the replicaSet query parameter is required in the 2.0 driver
  *
  * @method
  * @param {MongoClient~connectCallback} [callback] The command result callback

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -147,11 +147,11 @@ inherits(MongoClient, EventEmitter);
  */
 
 /**
- * Connect to MongoDB using a url as documented at
+ * Connect to MongoDB using a URL as documented at
  *
- *  docs.mongodb.org/manual/reference/connection-string/
+ *  https://docs.mongodb.com/manual/reference/connection-string/
  *
- * Note that for replicasets the replicaSet query parameter is required in the 2.0 driver
+ * Note that for replicasets, the replicaSet query parameter is required in the 2.0 driver.
  *
  * @method
  * @param {MongoClient~connectCallback} [callback] The command result callback
@@ -193,7 +193,7 @@ MongoClient.prototype.logout = function(options, callback) {
 /**
  * Close the db and its underlying connections
  * @method
- * @param {boolean} force Force close, emitting no events
+ * @param {boolean} [force=false] Force close, emitting no events
  * @param {Db~noResultCallback} [callback] The result callback
  * @return {Promise} returns Promise if no callback passed
  */


### PR DESCRIPTION
The `client.close()` calls at http://mongodb.github.io/node-mongodb-native/3.1/api/index.html don't pass a `force` parameter. The parameter not being documented as optional triggers linting errors:

![image](https://user-images.githubusercontent.com/33569/51432354-e2084200-1bea-11e9-9db5-7ab30aa5d895.png)
