### PR TITLE
fix(db_ops): ensure we async resolve errors in createCollection

### DIFF
--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -248,11 +248,16 @@ function createCollection(db, name, options, callback) {
       // Execute command
       executeCommand(db, cmd, finalOptions, err => {
         if (err) return handleCallback(callback, err);
-        handleCallback(
-          callback,
-          null,
-          new Collection(db, db.s.topology, db.s.databaseName, name, db.s.pkFactory, options)
-        );
+
+        try {
+          return handleCallback(
+            callback,
+            null,
+            new Collection(db, db.s.topology, db.s.databaseName, name, db.s.pkFactory, options)
+          );
+        } catch (err) {
+          return handleCallback(callback, err);
+        }
       });
     });
 }

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -497,6 +497,34 @@ describe('Collection', function() {
     }
   });
 
+  it('should return invalid collection name error by callback for createCollection', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    test: function(done) {
+      const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
+        poolSize: 1
+      });
+
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+
+        const db = client.db('test_crate_collection');
+
+        db.dropDatabase(err => {
+          expect(err).to.not.exist;
+
+          db.createCollection('test/../', err => {
+            expect(err).to.exist;
+            client.close();
+            done();
+          });
+        });
+      });
+    }
+  });
+
   /**
    * @ignore
    */


### PR DESCRIPTION
Passing in a name which does not pass collection name validation
when a database does not exist will result in throwing an
uncatchable error from the driver, resulting in application failure.
We need to catch and return these errors asynchronously.

NODE-1839