### PR TITLE
NODE-1741: implement convenient transaction api (native)

### DIFF
--- a/test/functional/spec/transactions/convenient-api/README.rst
+++ b/test/functional/spec/transactions/convenient-api/README.rst
@@ -1,0 +1,174 @@
+=====================================
+Convenient API for Transactions Tests
+=====================================
+
+.. contents::
+
+----
+
+Introduction
+============
+
+The YAML and JSON files in this directory are platform-independent tests that
+drivers can use to prove their conformance to the Convenient API for
+Transactions spec.  They are designed with the intention of sharing some
+test-runner code with the CRUD, Command Monitoring, and Transaction spec tests.
+
+Several prose tests, which are not easily expressed in YAML, are also presented
+in this file. Those tests will need to be manually implemented by each driver.
+
+Server Fail Point
+=================
+
+See: `Server Fail Point <../../transactions/tests#server-fail-point>`_ in the
+Transactions spec test suite.
+
+Test Format
+===========
+
+Each YAML file has the following keys:
+
+- ``database_name`` and ``collection_name``: The database and collection to use
+  for testing.
+
+- ``data``: The data that should exist in the collection under test before each
+  test run.
+
+- ``minServerVersion`` (optional): The minimum server version (inclusive)
+  required to successfully run the test. If this field is not present, it should
+  be assumed that there is no lower bound on the required server version.
+
+- ``tests``: An array of tests that are to be run independently of each other.
+  Each test will have some or all of the following fields:
+
+  - ``description``: The name of the test.
+
+  - ``skipReason`` (optional): If present, the test should be skipped and the
+    string value will specify a reason.
+
+  - ``failPoint`` (optional): The ``configureFailPoint`` command document to run
+    to configure a fail point on the primary server.
+
+  - ``clientOptions`` (optional): Names and values of options to pass to
+    ``MongoClient()``.
+
+  - ``sessionOptions`` (optional): Names and values of options to pass to
+    ``MongoClient.startSession()``.
+
+  - ``operations``: Array of documents, each describing an operation to be
+    executed. Each document has the following fields:
+
+    - ``name``: The name of the operation on ``object``.
+
+    - ``object``: The name of the object on which to perform the operation. The
+      value will be either "collection" or "session0".
+
+    - ``arguments`` (optional): Names and values of arguments to pass to the
+      operation.
+
+    - ``error`` (optional): If ``true``, the test should expect the operation
+      to emit an error or exception. If ``false`` or omitted, drivers MUST
+      assert that no error occurred.
+
+    - ``result`` (optional): The return value from the operation. This will
+      correspond to an operation's result object as defined in the CRUD
+      specification. If the operation is expected to return an error, the
+      ``result`` is a single document that has one or more of the following
+      fields:
+
+      - ``errorContains``: A substring of the expected error message.
+
+      - ``errorCodeName``: The expected "codeName" field in the server
+        error response.
+
+      - ``errorLabelsContain``: A list of error label strings that the
+        error is expected to have.
+
+      - ``errorLabelsOmit``: A list of error label strings that the
+        error is expected not to have.
+
+  - ``expectations`` (optional): List of command-started events.
+
+  - ``outcome``: Document describing the return value and/or expected state of
+    the collection after the operation is executed. Contains the following
+    fields:
+
+    - ``collection``:
+
+      - ``data``: The data that should exist in the collection after the
+        operations have run.
+
+Use as Integration Tests
+========================
+
+Testing against a replica set will require server version 4.0.0 or later. The
+replica set should include a primary, a secondary, and an arbiter. Including a
+secondary ensures that server selection in a transaction works properly.
+Including an arbiter helps ensure that no new bugs have been introduced related
+to arbiters.
+
+Testing against a sharded cluster will require server version 4.1.6 or later.
+A driver that implements support for sharded transactions MUST also run these
+tests against a MongoDB sharded cluster with multiple mongoses. Including
+multiple mongoses (and initializing the MongoClient with multiple mongos seeds!)
+ensures that mongos transaction pinning works properly.
+
+See: `Use as Integration Tests <../../transactions/tests#use-as-integration-tests>`_
+in the Transactions spec test suite for instructions on executing each test.
+
+Take note of the following:
+
+- Most tests will consist of a single "withTransaction" operation to be invoked
+  on the "session0" object. The ``callback`` argument of that operation will
+  resemble the ``operations`` array found in transaction spec tests.
+
+Command-Started Events
+``````````````````````
+
+See: `Command-Started Events <../../transactions/tests#command-started-events>`_
+in the Transactions spec test suite for instructions on asserting
+command-started events.
+
+Prose Tests
+===========
+
+Callback Raises a Custom Error
+``````````````````````````````
+
+Write a callback that raises a custom exception or error that does not include
+either UnknownTransactionCommitResult or TransientTransactionError error labels.
+Execute this callback using ``withTransaction`` and assert that the callback's
+error bypasses any retry logic within ``withTransaction`` and is propagated to
+the caller of ``withTransaction``.
+
+Callback Returns a Value
+````````````````````````
+
+Write a callback that returns a custom value (e.g. boolean, string, object).
+Execute this callback using ``withTransaction`` and assert that the callback's
+return value is propagated to the caller of ``withTransaction``.
+
+Retry Timeout is Enforced
+`````````````````````````
+
+Drivers should test that ``withTransaction`` enforces a non-configurable timeout
+before retrying both commits and entire transactions. Specifically, three cases
+should be checked:
+
+ * If the callback raises an error with the TransientTransactionError label and
+   the retry timeout has been exceeded, ``withTransaction`` should propagate the
+   error to its caller.
+ * If committing raises an error with the UnknownTransactionCommitResult label,
+   the error is not a write concern timeout, and the retry timeout has been
+   exceeded, ``withTransaction`` should propagate the error to its caller.
+ * If committing raises an error with the TransientTransactionError label and
+   the retry timeout has been exceeded, ``withTransaction`` should propagate the
+   error to its caller. This case may occur if the commit was internally retried
+   against a new primary after a failover and the second primary returned a
+   NoSuchTransaction error response.
+   
+ If possible, drivers should implement these tests without requiring the test
+ runner to block for the full duration of the retry timeout. This might be done
+ by internally modifying the timeout value used by ``withTransaction`` with some
+ private API or using a mock timer.
+ 

--- a/test/functional/spec/transactions/convenient-api/README.rst
+++ b/test/functional/spec/transactions/convenient-api/README.rst
@@ -98,6 +98,24 @@ Each YAML file has the following keys:
       - ``data``: The data that should exist in the collection after the
         operations have run.
 
+``withTransaction`` Operation
+`````````````````````````````
+
+These tests introduce a ``withTransaction`` operation, which may have the
+following fields:
+
+- ``callback``: Document containing the following field:
+
+  - ``operations``: Array of documents, each describing an operation to be
+    executed. Elements in this array will follow the same structure as the
+    ``operations`` field defined above (and in the CRUD and Transactions specs).
+
+    Note that drivers are expected to evaluate ``error` and ``result``
+    assertions when executing operations within ``callback.operations``.
+
+- ``options`` (optional): Names and values of options to pass to
+  ``withTransaction()``, which will in turn be used for ``startTransaction()``.
+
 Use as Integration Tests
 ========================
 
@@ -166,9 +184,9 @@ should be checked:
    error to its caller. This case may occur if the commit was internally retried
    against a new primary after a failover and the second primary returned a
    NoSuchTransaction error response.
-   
+
  If possible, drivers should implement these tests without requiring the test
  runner to block for the full duration of the retry timeout. This might be done
  by internally modifying the timeout value used by ``withTransaction`` with some
  private API or using a mock timer.
- 
+

--- a/test/functional/spec/transactions/convenient-api/callback-aborts.json
+++ b/test/functional/spec/transactions/convenient-api/callback-aborts.json
@@ -1,0 +1,221 @@
+{
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "withTransaction succeeds if callback aborts",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              },
+              {
+                "name": "abortTransaction",
+                "object": "session0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "withTransaction succeeds if callback aborts with no ops",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "abortTransaction",
+                "object": "session0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "withTransaction still succeeds if callback aborts and runs extra op",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              },
+              {
+                "name": "abortTransaction",
+                "object": "session0"
+              },
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 2
+                  }
+                },
+                "result": {
+                  "insertedId": 2
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "autocommit": null,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/transactions/convenient-api/callback-aborts.json
+++ b/test/functional/spec/transactions/convenient-api/callback-aborts.json
@@ -9,26 +9,28 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
                 },
-                "result": {
-                  "insertedId": 1
+                {
+                  "name": "abortTransaction",
+                  "object": "session0"
                 }
-              },
-              {
-                "name": "abortTransaction",
-                "object": "session0"
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -86,13 +88,15 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "abortTransaction",
-                "object": "session0"
-              }
-            ]
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "abortTransaction",
+                  "object": "session0"
+                }
+              ]
+            }
           }
         }
       ],
@@ -109,39 +113,41 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
                 },
-                "result": {
-                  "insertedId": 1
-                }
-              },
-              {
-                "name": "abortTransaction",
-                "object": "session0"
-              },
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 2
-                  }
+                {
+                  "name": "abortTransaction",
+                  "object": "session0"
                 },
-                "result": {
-                  "insertedId": 2
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 2
+                    }
+                  },
+                  "result": {
+                    "insertedId": 2
+                  }
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],

--- a/test/functional/spec/transactions/convenient-api/callback-aborts.yml
+++ b/test/functional/spec/transactions/convenient-api/callback-aborts.yml
@@ -11,19 +11,20 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
-            -
-              name: abortTransaction
-              object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: abortTransaction
+                object: session0
     expectations:
       -
         command_started_event:
@@ -64,11 +65,12 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: abortTransaction
-              object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: abortTransaction
+                object: session0
     expectations: []
     outcome:
       collection:
@@ -80,27 +82,28 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
-            -
-              name: abortTransaction
-              object: session0
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 2 }
-              result:
-                insertedId: 2
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: abortTransaction
+                object: session0
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 2 }
+                result:
+                  insertedId: 2
     expectations:
       -
         command_started_event:

--- a/test/functional/spec/transactions/convenient-api/callback-aborts.yml
+++ b/test/functional/spec/transactions/convenient-api/callback-aborts.yml
@@ -1,0 +1,156 @@
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    # Session state will be ABORTED when callback returns to withTransaction
+    description: withTransaction succeeds if callback aborts
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+            -
+              name: abortTransaction
+              object: session0
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: abortTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data: []
+  -
+    # Session state will be ABORTED when callback returns to withTransaction
+    description: withTransaction succeeds if callback aborts with no ops
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: abortTransaction
+              object: session0
+    expectations: []
+    outcome:
+      collection:
+        data: []
+  -
+    # Session state will be NO_TXN when callback returns to withTransaction
+    description: withTransaction still succeeds if callback aborts and runs extra op
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+            -
+              name: abortTransaction
+              object: session0
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 2 }
+              result:
+                insertedId: 2
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: abortTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            # This test is agnostic about retryWrites, so we do not assert the
+            # txnNumber. If retryWrites=true, the txnNumber will be incremented
+            # from the value used in the previous transaction; otherwise, the
+            # field will not be present at all.
+            insert: *collection_name
+            documents:
+              - { _id: 2 }
+            ordered: true
+            lsid: session0
+            # omitted fields
+            autocommit: ~
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+    outcome:
+      collection:
+        data:
+          - { _id: 2 }

--- a/test/functional/spec/transactions/convenient-api/callback-commits.json
+++ b/test/functional/spec/transactions/convenient-api/callback-commits.json
@@ -1,0 +1,283 @@
+{
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "withTransaction succeeds if callback commits",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              },
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 2
+                  }
+                },
+                "result": {
+                  "insertedId": 2
+                }
+              },
+              {
+                "name": "commitTransaction",
+                "object": "session0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction still succeeds if callback commits and runs extra op",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              },
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 2
+                  }
+                },
+                "result": {
+                  "insertedId": 2
+                }
+              },
+              {
+                "name": "commitTransaction",
+                "object": "session0"
+              },
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 3
+                  }
+                },
+                "result": {
+                  "insertedId": 3
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "autocommit": null,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/transactions/convenient-api/callback-commits.json
+++ b/test/functional/spec/transactions/convenient-api/callback-commits.json
@@ -9,39 +9,41 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
                 },
-                "result": {
-                  "insertedId": 1
-                }
-              },
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 2
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 2
+                    }
+                  },
+                  "result": {
+                    "insertedId": 2
                   }
                 },
-                "result": {
-                  "insertedId": 2
+                {
+                  "name": "commitTransaction",
+                  "object": "session0"
                 }
-              },
-              {
-                "name": "commitTransaction",
-                "object": "session0"
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -129,52 +131,54 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
                 },
-                "result": {
-                  "insertedId": 1
-                }
-              },
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 2
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 2
+                    }
+                  },
+                  "result": {
+                    "insertedId": 2
                   }
                 },
-                "result": {
-                  "insertedId": 2
-                }
-              },
-              {
-                "name": "commitTransaction",
-                "object": "session0"
-              },
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 3
-                  }
+                {
+                  "name": "commitTransaction",
+                  "object": "session0"
                 },
-                "result": {
-                  "insertedId": 3
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 3
+                    }
+                  },
+                  "result": {
+                    "insertedId": 3
+                  }
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],

--- a/test/functional/spec/transactions/convenient-api/callback-commits.yml
+++ b/test/functional/spec/transactions/convenient-api/callback-commits.yml
@@ -1,0 +1,192 @@
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    # Session state will be COMMITTED when callback returns to withTransaction
+    description: withTransaction succeeds if callback commits
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 2 }
+              result:
+                insertedId: 2
+            -
+              name: commitTransaction
+              object: session0
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 2 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+          - { _id: 2 }
+  -
+    # Session state will be NO_TXN when callback returns to withTransaction
+    description: withTransaction still succeeds if callback commits and runs extra op
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 2 }
+              result:
+                insertedId: 2
+            -
+              name: commitTransaction
+              object: session0
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 3 }
+              result:
+                insertedId: 3
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 2 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            # This test is agnostic about retryWrites, so we do not assert the
+            # txnNumber. If retryWrites=true, the txnNumber will be incremented
+            # from the value used in the previous transaction; otherwise, the
+            # field will not be present at all.
+            insert: *collection_name
+            documents:
+              - { _id: 3 }
+            ordered: true
+            lsid: session0
+            # omitted fields
+            autocommit: ~
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+          - { _id: 2 }
+          - { _id: 3 }

--- a/test/functional/spec/transactions/convenient-api/callback-commits.yml
+++ b/test/functional/spec/transactions/convenient-api/callback-commits.yml
@@ -11,27 +11,28 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 2 }
-              result:
-                insertedId: 2
-            -
-              name: commitTransaction
-              object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 2 }
+                result:
+                  insertedId: 2
+              -
+                name: commitTransaction
+                object: session0
     expectations:
       -
         command_started_event:
@@ -90,35 +91,36 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 2 }
-              result:
-                insertedId: 2
-            -
-              name: commitTransaction
-              object: session0
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 3 }
-              result:
-                insertedId: 3
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 2 }
+                result:
+                  insertedId: 2
+              -
+                name: commitTransaction
+                object: session0
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 3 }
+                result:
+                  insertedId: 3
     expectations:
       -
         command_started_event:

--- a/test/functional/spec/transactions/convenient-api/callback-retry.json
+++ b/test/functional/spec/transactions/convenient-api/callback-retry.json
@@ -21,19 +21,21 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
                   }
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -179,39 +181,41 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
                 },
-                "result": {
-                  "insertedId": 1
-                }
-              },
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "errorCodeName": "DuplicateKey",
+                    "errorLabelsOmit": [
+                      "TransientTransactionError",
+                      "UnknownTransactionCommitResult"
+                    ]
                   }
-                },
-                "result": {
-                  "errorCodeName": "DuplicateKey",
-                  "errorLabelsOmit": [
-                    "TransientTransactionError",
-                    "UnknownTransactionCommitResult"
-                  ]
                 }
-              }
-            ]
+              ]
+            }
           },
           "result": {
             "errorCodeName": "DuplicateKey",

--- a/test/functional/spec/transactions/convenient-api/callback-retry.json
+++ b/test/functional/spec/transactions/convenient-api/callback-retry.json
@@ -1,0 +1,297 @@
+{
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "callback succeeds after multiple connection errors",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "callback is not retried after non-transient error (DuplicateKeyError)",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              },
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "errorCodeName": "DuplicateKey",
+                  "errorLabelsOmit": [
+                    "TransientTransactionError",
+                    "UnknownTransactionCommitResult"
+                  ]
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorCodeName": "DuplicateKey",
+            "errorLabelsOmit": [
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/transactions/convenient-api/callback-retry.yml
+++ b/test/functional/spec/transactions/convenient-api/callback-retry.yml
@@ -16,18 +16,19 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              # We do not assert the result here, as insertOne will fail for the
-              # first two executions of the callback before ultimately
-              # succeeding and returning a result. Asserting the state of the
-              # output collection after the test is sufficient.
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
+        arguments:
+          callback:
+            operations:
+              -
+                # We do not assert the result here, as insertOne will fail for
+                # the first two executions of the callback before ultimately
+                # succeeding and returning a result. Asserting the state of the
+                # output collection after the test is sufficient.
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
     expectations:
       -
         command_started_event:
@@ -130,25 +131,26 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                errorCodeName: DuplicateKey
-                errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  errorCodeName: DuplicateKey
+                  errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
         result:
           errorCodeName: DuplicateKey
           errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]

--- a/test/functional/spec/transactions/convenient-api/callback-retry.yml
+++ b/test/functional/spec/transactions/convenient-api/callback-retry.yml
@@ -1,0 +1,203 @@
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    description: callback succeeds after multiple connection errors
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["insert"]
+          closeConnection: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              # We do not assert the result here, as insertOne will fail for the
+              # first two executions of the callback before ultimately
+              # succeeding and returning a result. Asserting the state of the
+              # output collection after the test is sufficient.
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: abortTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # second transaction will be causally consistent with the first
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "2" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "2" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: abortTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # third transaction will be causally consistent with the second
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "3" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "3" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: callback is not retried after non-transient error (DuplicateKeyError)
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                errorCodeName: DuplicateKey
+                errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+        result:
+          errorCodeName: DuplicateKey
+          errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: abortTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data: []

--- a/test/functional/spec/transactions/convenient-api/commit-retry.json
+++ b/test/functional/spec/transactions/convenient-api/commit-retry.json
@@ -1,0 +1,402 @@
+{
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "commitTransaction succeeds after multiple connection errors",
+      "skipReason": "SPEC-1185 Drivers should use majority write concern when retrying commitTransaction",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction retry only overwrites write concern w option",
+      "skipReason": "SPEC-1185 Drivers should use majority write concern when retrying commitTransaction",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          },
+          "transactionOptions": {
+            "writeConcern": {
+              "w": 2,
+              "j": true,
+              "wtimeout": 5000
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 2,
+                "j": true,
+                "wtimeout": 5000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "j": true,
+                "wtimeout": 5000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "j": true,
+                "wtimeout": 5000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commit is retried after commitTransaction UnknownTransactionCommitResult (NotMaster)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 10107,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/transactions/convenient-api/commit-retry.json
+++ b/test/functional/spec/transactions/convenient-api/commit-retry.json
@@ -5,7 +5,6 @@
   "tests": [
     {
       "description": "commitTransaction succeeds after multiple connection errors",
-      "skipReason": "SPEC-1185 Drivers should use majority write concern when retrying commitTransaction",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -22,22 +21,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -92,7 +93,8 @@
               },
               "autocommit": false,
               "writeConcern": {
-                "w": "majority"
+                "w": "majority",
+                "wtimeout": 10000
               },
               "readConcern": null,
               "startTransaction": null
@@ -111,7 +113,8 @@
               },
               "autocommit": false,
               "writeConcern": {
-                "w": "majority"
+                "w": "majority",
+                "wtimeout": 10000
               },
               "readConcern": null,
               "startTransaction": null
@@ -133,7 +136,6 @@
     },
     {
       "description": "commitTransaction retry only overwrites write concern w option",
-      "skipReason": "SPEC-1185 Drivers should use majority write concern when retrying commitTransaction",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -150,28 +152,30 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
+              ]
+            },
+            "options": {
+              "writeConcern": {
+                "w": 2,
+                "j": true,
+                "wtimeout": 5000
               }
-            ]
-          },
-          "transactionOptions": {
-            "writeConcern": {
-              "w": 2,
-              "j": true,
-              "wtimeout": 5000
             }
           }
         }
@@ -293,22 +297,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -362,9 +368,12 @@
                 "$numberLong": "1"
               },
               "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
               "readConcern": null,
-              "startTransaction": null,
-              "writeConcern": null
+              "startTransaction": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -379,9 +388,12 @@
                 "$numberLong": "1"
               },
               "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
               "readConcern": null,
-              "startTransaction": null,
-              "writeConcern": null
+              "startTransaction": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"

--- a/test/functional/spec/transactions/convenient-api/commit-retry.yml
+++ b/test/functional/spec/transactions/convenient-api/commit-retry.yml
@@ -1,0 +1,261 @@
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    description: commitTransaction succeeds after multiple connection errors
+    skipReason: SPEC-1185 Drivers should use majority write concern when retrying commitTransaction
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          closeConnection: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: commitTransaction retry only overwrites write concern w option
+    skipReason: SPEC-1185 Drivers should use majority write concern when retrying commitTransaction
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          closeConnection: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+        transactionOptions:
+          writeConcern: { w: 2, j: true, wtimeout: 5000 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 2, j: true, wtimeout: 5000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, j: true, wtimeout: 5000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, j: true, wtimeout: 5000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: commit is retried after commitTransaction UnknownTransactionCommitResult (NotMaster)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 10107 # NotMaster
+          closeConnection: false
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1 }

--- a/test/functional/spec/transactions/convenient-api/commit-retry.yml
+++ b/test/functional/spec/transactions/convenient-api/commit-retry.yml
@@ -6,7 +6,6 @@ data: []
 tests:
   -
     description: commitTransaction succeeds after multiple connection errors
-    skipReason: SPEC-1185 Drivers should use majority write concern when retrying commitTransaction
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 2 }
@@ -17,16 +16,17 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
     expectations:
       -
         command_started_event:
@@ -65,7 +65,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             autocommit: false
             # commitTransaction applies w:majority on retries (SPEC-1185)
-            writeConcern: { w: majority }
+            writeConcern: { w: majority, wtimeout: 10000 }
             # omitted fields
             readConcern: ~
             startTransaction: ~
@@ -79,7 +79,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             autocommit: false
             # commitTransaction applies w:majority on retries (SPEC-1185)
-            writeConcern: { w: majority }
+            writeConcern: { w: majority, wtimeout: 10000 }
             # omitted fields
             readConcern: ~
             startTransaction: ~
@@ -91,7 +91,6 @@ tests:
           - { _id: 1 }
   -
     description: commitTransaction retry only overwrites write concern w option
-    skipReason: SPEC-1185 Drivers should use majority write concern when retrying commitTransaction
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 2 }
@@ -102,18 +101,19 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
-        transactionOptions:
-          writeConcern: { w: 2, j: true, wtimeout: 5000 }
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+          options:
+            writeConcern: { w: 2, j: true, wtimeout: 5000 }
     expectations:
       -
         command_started_event:
@@ -189,16 +189,17 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
     expectations:
       -
         command_started_event:
@@ -236,10 +237,11 @@ tests:
             lsid: session0
             txnNumber: { $numberLong: "1" }
             autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, wtimeout: 10000 }
             # omitted fields
             readConcern: ~
             startTransaction: ~
-            writeConcern: ~
           command_name: commitTransaction
           database_name: admin
       -
@@ -249,10 +251,11 @@ tests:
             lsid: session0
             txnNumber: { $numberLong: "1" }
             autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, wtimeout: 10000 }
             # omitted fields
             readConcern: ~
             startTransaction: ~
-            writeConcern: ~
           command_name: commitTransaction
           database_name: admin
     outcome: &outcome

--- a/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror-4.2.json
+++ b/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror-4.2.json
@@ -1,0 +1,182 @@
+{
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "minServerVersion": "4.1.6",
+  "data": [],
+  "tests": [
+    {
+      "description": "transaction is retried after commitTransaction TransientTransactionError (PreparedTransactionInProgress)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 267,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror-4.2.json
+++ b/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror-4.2.json
@@ -23,22 +23,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],

--- a/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror-4.2.yml
+++ b/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror-4.2.yml
@@ -24,17 +24,18 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback: &callback
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
-    expectations: &expectations
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+    expectations:
       -
         command_started_event:
           command:

--- a/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror-4.2.yml
+++ b/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror-4.2.yml
@@ -1,0 +1,132 @@
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+minServerVersion: '4.1.6'
+
+data: []
+
+# These tests use error codes where the TransientTransactionError label will be
+# applied to the error response for commitTransaction. This will cause the
+# entire transaction to be retried instead of commitTransaction.
+#
+# See: https://github.com/mongodb/mongo/blob/r4.1.6/src/mongo/db/handle_request_response.cpp
+tests:
+  -
+    description: transaction is retried after commitTransaction TransientTransactionError (PreparedTransactionInProgress)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 267 # PreparedTransactionInProgress
+          closeConnection: false
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback: &callback
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+    expectations: &expectations
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # second transaction will be causally consistent with the first
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "2" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "2" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # third transaction will be causally consistent with the second
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "3" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "3" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1 }

--- a/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror.json
+++ b/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror.json
@@ -1,0 +1,703 @@
+{
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "transaction is retried after commitTransaction TransientTransactionError (LockTimeout)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 24,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "transaction is retried after commitTransaction TransientTransactionError (WriteConflict)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 112,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "transaction is retried after commitTransaction TransientTransactionError (SnapshotUnavailable)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 246,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "transaction is retried after commitTransaction TransientTransactionError (NoSuchTransaction)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 251,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror.json
+++ b/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror.json
@@ -22,22 +22,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -196,22 +198,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -370,22 +374,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -544,22 +550,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],

--- a/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror.yml
+++ b/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror.yml
@@ -1,0 +1,178 @@
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+# These tests use error codes where the TransientTransactionError label will be
+# applied to the error response for commitTransaction. This will cause the
+# entire transaction to be retried instead of commitTransaction.
+#
+# See: https://github.com/mongodb/mongo/blob/r4.1.6/src/mongo/db/handle_request_response.cpp
+tests:
+  -
+    description: transaction is retried after commitTransaction TransientTransactionError (LockTimeout)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 24 # LockTimeout
+          closeConnection: false
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback: &callback
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+    expectations: &expectations
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # second transaction will be causally consistent with the first
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "2" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "2" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # third transaction will be causally consistent with the second
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "3" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "3" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: transaction is retried after commitTransaction TransientTransactionError (WriteConflict)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 112 # WriteConflict
+          closeConnection: false
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback: *callback
+    expectations: *expectations
+    outcome: *outcome
+  -
+    description: transaction is retried after commitTransaction TransientTransactionError (SnapshotUnavailable)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 246 # SnapshotUnavailable
+          closeConnection: false
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback: *callback
+    expectations: *expectations
+    outcome: *outcome
+  -
+    description: transaction is retried after commitTransaction TransientTransactionError (NoSuchTransaction)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 251 # NoSuchTransaction
+          closeConnection: false
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback: *callback
+    expectations: *expectations
+    outcome: *outcome

--- a/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror.yml
+++ b/test/functional/spec/transactions/convenient-api/commit-transienttransactionerror.yml
@@ -22,16 +22,17 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback: &callback
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
+        arguments: &arguments
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
     expectations: &expectations
       -
         command_started_event:
@@ -141,7 +142,7 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback: *callback
+        arguments: *arguments
     expectations: *expectations
     outcome: *outcome
   -
@@ -157,7 +158,7 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback: *callback
+        arguments: *arguments
     expectations: *expectations
     outcome: *outcome
   -
@@ -173,6 +174,6 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback: *callback
+        arguments: *arguments
     expectations: *expectations
     outcome: *outcome

--- a/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.json
+++ b/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.json
@@ -1,0 +1,446 @@
+{
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "commitTransaction is not retried after WriteConcernFailed timeout error",
+      "skipReason": "SPEC-1197 Drivers should not retry commit after wtimeout error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 64,
+            "codeName": "WriteConcernFailed",
+            "errmsg": "waiting for replication timed out",
+            "errInfo": {
+              "wtimeout": true
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorCodeName": "WriteConcernFailed",
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction is retried after WriteConcernFailed non-timeout error",
+      "skipReason": "SPEC-1185 Drivers should use majority write concern when retrying commitTransaction",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "closeConnection": false,
+          "writeConcernError": {
+            "code": 64,
+            "codeName": "WriteConcernFailed",
+            "errmsg": "waiting for replication did not time out"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction is not retried after UnknownReplWriteConcern error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 79,
+            "codeName": "UnknownReplWriteConcern",
+            "errmsg": "No write concern mode named 'foo' found in replica set configuration"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorCodeName": "UnknownReplWriteConcern",
+            "errorLabelsOmit": [
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction is not retried after UnsatisfiableWriteConcern error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 100,
+            "codeName": "UnsatisfiableWriteConcern",
+            "errmsg": "Not enough data-bearing nodes"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          },
+          "result": {
+            "errorCodeName": "UnsatisfiableWriteConcern",
+            "errorLabelsOmit": [
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.json
+++ b/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.json
@@ -5,7 +5,6 @@
   "tests": [
     {
       "description": "commitTransaction is not retried after WriteConcernFailed timeout error",
-      "skipReason": "SPEC-1197 Drivers should not retry commit after wtimeout error",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -29,22 +28,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           },
           "result": {
             "errorCodeName": "WriteConcernFailed",
@@ -111,7 +112,6 @@
     },
     {
       "description": "commitTransaction is retried after WriteConcernFailed non-timeout error",
-      "skipReason": "SPEC-1185 Drivers should use majority write concern when retrying commitTransaction",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -121,11 +121,10 @@
           "failCommands": [
             "commitTransaction"
           ],
-          "closeConnection": false,
           "writeConcernError": {
             "code": 64,
             "codeName": "WriteConcernFailed",
-            "errmsg": "waiting for replication did not time out"
+            "errmsg": "multiple errors reported"
           }
         }
       },
@@ -133,22 +132,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -203,7 +204,8 @@
               },
               "autocommit": false,
               "writeConcern": {
-                "w": "majority"
+                "w": "majority",
+                "wtimeout": 10000
               },
               "readConcern": null,
               "startTransaction": null
@@ -222,7 +224,8 @@
               },
               "autocommit": false,
               "writeConcern": {
-                "w": "majority"
+                "w": "majority",
+                "wtimeout": 10000
               },
               "readConcern": null,
               "startTransaction": null
@@ -264,22 +267,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           },
           "result": {
             "errorCodeName": "UnknownReplWriteConcern",
@@ -364,22 +369,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           },
           "result": {
             "errorCodeName": "UnsatisfiableWriteConcern",

--- a/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.yml
+++ b/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.yml
@@ -1,0 +1,269 @@
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    description: commitTransaction is not retried after WriteConcernFailed timeout error
+    skipReason: SPEC-1197 Drivers should not retry commit after wtimeout error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          # Do not specify closeConnection: false, since that would conflict
+          # with writeConcernError (likely a server bug)
+          writeConcernError:
+            code: 64
+            codeName: WriteConcernFailed
+            errmsg: "waiting for replication timed out"
+            errInfo: { wtimeout: true }
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback: &callback
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+        result:
+          errorCodeName: WriteConcernFailed
+          # Per transactions spec, drivers add UnknownTransactionCommitResult
+          # label for WriteConcernFailed errors
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    # The write operation is still applied despite the write concern error
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    # This test configures the fail point to return a contrived error that
+    # is WriteConcernFailed but omits the errInfo field that would identify it
+    # as a wtimeout error. This tests that drivers do not assume that all
+    # WriteConcernFailed errors are due to a replication timeout.
+    description: commitTransaction is retried after WriteConcernFailed non-timeout error
+    skipReason: SPEC-1185 Drivers should use majority write concern when retrying commitTransaction
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          closeConnection: false
+          writeConcernError:
+            code: 64
+            codeName: WriteConcernFailed
+            errmsg: "waiting for replication did not time out"
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: commitTransaction is not retried after UnknownReplWriteConcern error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 79
+            codeName: UnknownReplWriteConcern
+            errmsg: "No write concern mode named 'foo' found in replica set configuration"
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback: *callback
+        result:
+          errorCodeName: UnknownReplWriteConcern
+          errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome
+  -
+    description: commitTransaction is not retried after UnsatisfiableWriteConcern error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 100
+            codeName: UnsatisfiableWriteConcern
+            errmsg: "Not enough data-bearing nodes"
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback: *callback
+        result:
+          errorCodeName: UnsatisfiableWriteConcern
+          errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome

--- a/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.yml
+++ b/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.yml
@@ -6,14 +6,13 @@ data: []
 tests:
   -
     description: commitTransaction is not retried after WriteConcernFailed timeout error
-    skipReason: SPEC-1197 Drivers should not retry commit after wtimeout error
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 1 }
       data:
           failCommands: ["commitTransaction"]
           # Do not specify closeConnection: false, since that would conflict
-          # with writeConcernError (likely a server bug)
+          # with writeConcernError (see: SERVER-39292)
           writeConcernError:
             code: 64
             codeName: WriteConcernFailed
@@ -23,20 +22,22 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback: &callback
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
+        arguments: &arguments
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
         result:
           errorCodeName: WriteConcernFailed
           # Per transactions spec, drivers add UnknownTransactionCommitResult
-          # label for WriteConcernFailed errors
+          # label for WriteConcernFailed errors; however, neither the driver
+          # nor withTransaction() will retry the commit in this case.
           errorLabelsContain: ["UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
     expectations:
@@ -75,36 +76,27 @@ tests:
         data:
           - { _id: 1 }
   -
-    # This test configures the fail point to return a contrived error that
-    # is WriteConcernFailed but omits the errInfo field that would identify it
-    # as a wtimeout error. This tests that drivers do not assume that all
+    # This test configures the fail point to return an error with the
+    # WriteConcernFailed code but without errInfo that would identify it as a
+    # wtimeout error. This tests that drivers do not assume that all
     # WriteConcernFailed errors are due to a replication timeout.
     description: commitTransaction is retried after WriteConcernFailed non-timeout error
-    skipReason: SPEC-1185 Drivers should use majority write concern when retrying commitTransaction
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
           failCommands: ["commitTransaction"]
-          closeConnection: false
+          # Do not specify closeConnection: false, since that would conflict
+          # with writeConcernError (see: SERVER-39292)
           writeConcernError:
             code: 64
             codeName: WriteConcernFailed
-            errmsg: "waiting for replication did not time out"
+            errmsg: "multiple errors reported"
     operations:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
+        arguments: *arguments
     expectations:
       -
         command_started_event:
@@ -143,7 +135,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             autocommit: false
             # commitTransaction applies w:majority on retries (SPEC-1185)
-            writeConcern: { w: majority }
+            writeConcern: { w: majority, wtimeout: 10000 }
             # omitted fields
             readConcern: ~
             startTransaction: ~
@@ -157,7 +149,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             autocommit: false
             # commitTransaction applies w:majority on retries (SPEC-1185)
-            writeConcern: { w: majority }
+            writeConcern: { w: majority, wtimeout: 10000 }
             # omitted fields
             readConcern: ~
             startTransaction: ~
@@ -182,7 +174,7 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback: *callback
+        arguments: *arguments
         result:
           errorCodeName: UnknownReplWriteConcern
           errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
@@ -232,7 +224,7 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback: *callback
+        arguments: *arguments
         result:
           errorCodeName: UnsatisfiableWriteConcern
           errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]

--- a/test/functional/spec/transactions/convenient-api/commit.json
+++ b/test/functional/spec/transactions/convenient-api/commit.json
@@ -1,0 +1,266 @@
+{
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "withTransaction commits after callback returns",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              },
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 2
+                  }
+                },
+                "result": {
+                  "insertedId": 2
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction commits after callback returns (second transaction)",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              },
+              {
+                "name": "commitTransaction",
+                "object": "session0"
+              },
+              {
+                "name": "startTransaction",
+                "object": "session0"
+              },
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 2
+                  }
+                },
+                "result": {
+                  "insertedId": 2
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/transactions/convenient-api/commit.json
+++ b/test/functional/spec/transactions/convenient-api/commit.json
@@ -9,35 +9,37 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
                 },
-                "result": {
-                  "insertedId": 1
-                }
-              },
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 2
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 2
+                    }
+                  },
+                  "result": {
+                    "insertedId": 2
                   }
-                },
-                "result": {
-                  "insertedId": 2
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -125,43 +127,45 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
                 },
-                "result": {
-                  "insertedId": 1
-                }
-              },
-              {
-                "name": "commitTransaction",
-                "object": "session0"
-              },
-              {
-                "name": "startTransaction",
-                "object": "session0"
-              },
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 2
-                  }
+                {
+                  "name": "commitTransaction",
+                  "object": "session0"
                 },
-                "result": {
-                  "insertedId": 2
+                {
+                  "name": "startTransaction",
+                  "object": "session0"
+                },
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 2
+                    }
+                  },
+                  "result": {
+                    "insertedId": 2
+                  }
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],

--- a/test/functional/spec/transactions/convenient-api/commit.yml
+++ b/test/functional/spec/transactions/convenient-api/commit.yml
@@ -10,24 +10,25 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 2 }
-              result:
-                insertedId: 2
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 2 }
+                result:
+                  insertedId: 2
     expectations:
       -
         command_started_event:
@@ -89,30 +90,31 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
-            -
-              name: commitTransaction
-              object: session0
-            -
-              name: startTransaction
-              object: session0
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 2 }
-              result:
-                insertedId: 2
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: commitTransaction
+                object: session0
+              -
+                name: startTransaction
+                object: session0
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 2 }
+                result:
+                  insertedId: 2
     expectations:
       -
         command_started_event:

--- a/test/functional/spec/transactions/convenient-api/commit.yml
+++ b/test/functional/spec/transactions/convenient-api/commit.yml
@@ -1,0 +1,181 @@
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    description: withTransaction commits after callback returns
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 2 }
+              result:
+                insertedId: 2
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 2 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+          - { _id: 2 }
+  -
+    # In this scenario, the callback commits the transaction originally started
+    # by withTransaction and starts a second transaction before returning. Since
+    # withTransaction only examines the session's state, it should commit that
+    # second transaction after the callback returns.
+    description: withTransaction commits after callback returns (second transaction)
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+            -
+              name: commitTransaction
+              object: session0
+            -
+              name: startTransaction
+              object: session0
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 2 }
+              result:
+                insertedId: 2
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 2 }
+            ordered: true
+            lsid: session0
+            # second transaction will be causally consistent with the first
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented for the second transaction
+            txnNumber: { $numberLong: "2" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "2" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+          - { _id: 2 }

--- a/test/functional/spec/transactions/convenient-api/transaction-options.json
+++ b/test/functional/spec/transactions/convenient-api/transaction-options.json
@@ -1,0 +1,545 @@
+{
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "withTransaction and no transaction options set",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction inherits transaction options from client",
+      "clientOptions": {
+        "readConcernLevel": "local",
+        "w": 1
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "local"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 1
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction inherits transaction options from defaultTransactionOptions",
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "snapshot"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 1
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction explicit transaction options",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          },
+          "transactionOptions": {
+            "readConcern": {
+              "level": "snapshot"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 1
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction explicit transaction options override defaultTransactionOptions",
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "majority"
+            },
+            "writeConcern": {
+              "w": "majority"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          },
+          "transactionOptions": {
+            "readConcern": {
+              "level": "snapshot"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 1
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction explicit transaction options override client options",
+      "clientOptions": {
+        "readConcernLevel": "majority",
+        "w": "majority"
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "callback": {
+            "operations": [
+              {
+                "name": "insertOne",
+                "object": "collection",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "result": {
+                  "insertedId": 1
+                }
+              }
+            ]
+          },
+          "transactionOptions": {
+            "readConcern": {
+              "level": "snapshot"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 1
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/transactions/convenient-api/transaction-options.json
+++ b/test/functional/spec/transactions/convenient-api/transaction-options.json
@@ -9,22 +9,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -90,22 +92,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -183,22 +187,24 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ],
@@ -264,29 +270,31 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
-          },
-          "transactionOptions": {
-            "readConcern": {
-              "level": "snapshot"
+              ]
             },
-            "writeConcern": {
-              "w": 1
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": {
+                "w": 1
+              }
             }
           }
         }
@@ -365,29 +373,31 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
-          },
-          "transactionOptions": {
-            "readConcern": {
-              "level": "snapshot"
+              ]
             },
-            "writeConcern": {
-              "w": 1
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": {
+                "w": 1
+              }
             }
           }
         }
@@ -458,29 +468,31 @@
         {
           "name": "withTransaction",
           "object": "session0",
-          "callback": {
-            "operations": [
-              {
-                "name": "insertOne",
-                "object": "collection",
-                "arguments": {
-                  "session": "session0",
-                  "document": {
-                    "_id": 1
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
                   }
-                },
-                "result": {
-                  "insertedId": 1
                 }
-              }
-            ]
-          },
-          "transactionOptions": {
-            "readConcern": {
-              "level": "snapshot"
+              ]
             },
-            "writeConcern": {
-              "w": 1
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": {
+                "w": 1
+              }
             }
           }
         }

--- a/test/functional/spec/transactions/convenient-api/transaction-options.yml
+++ b/test/functional/spec/transactions/convenient-api/transaction-options.yml
@@ -1,0 +1,258 @@
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    description: withTransaction and no transaction options set
+    operations: &operations
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: withTransaction inherits transaction options from client
+    clientOptions:
+      readConcernLevel: local
+      w: 1
+    operations: *operations
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            readConcern: { level: local }
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 1 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome
+  -
+    description: withTransaction inherits transaction options from defaultTransactionOptions
+    sessionOptions:
+      session0:
+        defaultTransactionOptions:
+          readConcern: { level: snapshot }
+          writeConcern: { w: 1 }
+    operations: *operations
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            readConcern: { level: snapshot }
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 1 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome
+  -
+    description: withTransaction explicit transaction options
+    operations: &operations_explicit_transactionOptions
+      -
+        name: withTransaction
+        object: session0
+        callback:
+          operations:
+            -
+              name: insertOne
+              object: collection
+              arguments:
+                session: session0
+                document: { _id: 1 }
+              result:
+                insertedId: 1
+        transactionOptions:
+          readConcern: { level: snapshot }
+          writeConcern: { w: 1 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            readConcern: { level: snapshot }
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 1 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome
+  -
+    description: withTransaction explicit transaction options override defaultTransactionOptions
+    sessionOptions:
+      session0:
+        defaultTransactionOptions:
+          readConcern: { level: majority }
+          writeConcern: { w: majority }
+    operations: *operations_explicit_transactionOptions
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            readConcern: { level: snapshot }
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 1 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome
+  -
+    description: withTransaction explicit transaction options override client options
+    clientOptions:
+      readConcernLevel: majority
+      w: majority
+    operations: *operations_explicit_transactionOptions
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            readConcern: { level: snapshot }
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 1 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome

--- a/test/functional/spec/transactions/convenient-api/transaction-options.yml
+++ b/test/functional/spec/transactions/convenient-api/transaction-options.yml
@@ -10,16 +10,17 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
     expectations:
       -
         command_started_event:
@@ -136,19 +137,20 @@ tests:
       -
         name: withTransaction
         object: session0
-        callback:
-          operations:
-            -
-              name: insertOne
-              object: collection
-              arguments:
-                session: session0
-                document: { _id: 1 }
-              result:
-                insertedId: 1
-        transactionOptions:
-          readConcern: { level: snapshot }
-          writeConcern: { w: 1 }
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+          options:
+            readConcern: { level: snapshot }
+            writeConcern: { w: 1 }
     expectations:
       -
         command_started_event:

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -537,7 +537,7 @@ function testOperation(operation, obj, context, options) {
 
           if (errorLabelsOmit) {
             if (err.errorLabels && Array.isArray(err.errorLabels) && err.errorLabels.length !== 0) {
-              // expect(errorLabelsOmit).to.not.include.members(err.errorLabels);
+              expect(errorLabelsOmit).to.not.include.members(err.errorLabels);
             }
           }
 

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -137,7 +137,7 @@ describe('Transactions', function() {
     });
   });
 
-  describe.only('convenient api', function() {
+  describe('convenient api', function() {
     const testContext = {};
     const testSuites = fs
       .readdirSync(`${__dirname}/spec/transactions/convenient-api`)
@@ -319,7 +319,6 @@ function validateExpectations(commandEvents, testData, testContext, operationCon
     );
 
     const expectedEvents = normalizeCommandShapes(rawExpectedEvents);
-    console.dir({ actualEvents }, { depth: 10 });
     expect(actualEvents).to.have.length(expectedEvents.length);
 
     expectedEvents.forEach((expected, idx) => {
@@ -444,24 +443,12 @@ function testOperation(operation, obj, context, options) {
   const args = [];
   const operationName = translateOperationName(operation.name);
 
-  // NOTE: move after #459 is merged
-  if (operation.callback) {
-    args.push(() => testOperations(operation.callback, context, { swallowOperationErrors: false }));
-
-    if (operation.transactionOptions) {
-      args.push(operation.transactionOptions);
-    }
-  }
-
   if (operation.arguments) {
     Object.keys(operation.arguments).forEach(key => {
       if (key === 'callback') {
-        args.push(() => testOperations(operation.arguments.callback, context));
-        return;
-      }
-
-      if (key === 'transactionOptions') {
-        args.push(operation.arguments[key]);
+        args.push(() =>
+          testOperations(operation.arguments.callback, context, { swallowOperationErrors: false })
+        );
         return;
       }
 
@@ -521,7 +508,6 @@ function testOperation(operation, obj, context, options) {
     const cursor = obj[operationName].apply(obj, args);
     opPromise = cursor.toArray();
   } else {
-    console.log('running operation: ', operationName);
     // wrap this in a `Promise.try` because some operations might throw
     opPromise = Promise.try(() => obj[operationName].apply(obj, args));
   }
@@ -551,7 +537,7 @@ function testOperation(operation, obj, context, options) {
 
           if (errorLabelsOmit) {
             if (err.errorLabels && Array.isArray(err.errorLabels) && err.errorLabels.length !== 0) {
-              expect(err.errorLabels).to.not.include.members(errorLabelsOmit);
+              // expect(errorLabelsOmit).to.not.include.members(err.errorLabels);
             }
           }
 


### PR DESCRIPTION
This is the native component to NODE-1741. Considering the helper is hung off a `ClientSession`, this PR is mostly concerned with importing and syncing the YAML tests and providing a test runner for said tests.