### PR TITLE
test(txns): ensure `local` read concern used for outcome testing

### DIFF
--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -300,7 +300,7 @@ function validateExpectations(commandEvents, testData, testContext, operationCon
       return testContext.sharedClient
         .db()
         .collection(testContext.collectionName)
-        .find({})
+        .find({}, { readPreference: 'primary', readConcern: { level: 'local' } })
         .toArray()
         .then(docs => {
           expect(docs).to.eql(testData.outcome.collection.data);


### PR DESCRIPTION
Ensure the find remains causally consistent with previous operations by using a "local" read concern level while reading the latest data on the primary.

NODE-1793