### PR TITLE
fix(mongo_client_schemas): remove default for deprecated option validateOptions

### DIFF
--- a/lib/schemas/mongo_client_schemas.js
+++ b/lib/schemas/mongo_client_schemas.js
@@ -68,7 +68,7 @@ const connectSchema = {
   promoteBuffers: { type: 'boolean' },
   promoteLongs: { type: 'boolean' },
   domainsEnabled: { type: 'boolean', default: false },
-  validateOptions: { type: 'boolean', default: false, deprecated: 'unknownOptionsWarningLevel' },
+  validateOptions: { type: 'boolean', deprecated: 'unknownOptionsWarningLevel' },
   checkServerIdentity: { type: ['boolean', 'function'], default: true },
   fsync: { type: 'boolean' },
   numberOfRetries: { type: 'number', default: 5 },


### PR DESCRIPTION
The default value for `validateOptions` was causing a lot of annoying deprecation notices. This removes the unnecessary default and the annoying deprecation notices.