### PR TITLE
refactor(connect): modify the rules for determining auth from uri

### DIFF
--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -248,6 +248,7 @@ function connect(mongoClient, url, options, callback) {
       );
     }
   });
+
   function connectCallback(err, topology) {
     const warningMessage = `seed list contains no mongos proxies, replicaset connections requires the parameter replicaSet to be supplied in the URI or options object, mongodb://server:port/db?replicaSet=name`;
     if (err && err.message === 'no mongos proxies found in seed list') {
@@ -580,11 +581,14 @@ function transformUrlOptions(_object) {
     }
   }
 
-  if (_object.auth) {
+  const hasUsername = _object.auth && _object.auth.username;
+  const hasAuthMechanism = _object.options && _object.options.authMechanism;
+  if (hasUsername || hasAuthMechanism) {
     object.auth = Object.assign({}, _object.auth);
     if (object.auth.db) {
       object.authSource = object.authSource || object.auth.db;
     }
+
     if (object.auth.username) {
       object.auth.user = object.auth.username;
     }

--- a/test/functional/uri_tests.js
+++ b/test/functional/uri_tests.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const expect = require('chai').expect;
+const sinon = require('sinon');
+const ReplSet = require('../../lib/topologies/replset');
 
 describe('URI', function() {
   /**
@@ -180,6 +182,24 @@ describe('URI', function() {
         expect(client.s.options.replicaSet).to.exist.and.equal(config.replicasetName);
         done();
       });
+    }
+  });
+
+  it('should generate valid credentials with X509 and the new parser', {
+    metadata: { requires: { topology: 'single' } },
+    test: function(done) {
+      function validateConnect(options /*, callback */) {
+        expect(options).to.have.property('credentials');
+        expect(options.credentials.mechanism).to.eql('x509');
+
+        connectStub.restore();
+        done();
+      }
+
+      const connectStub = sinon.stub(ReplSet.prototype, 'connect').callsFake(validateConnect);
+      const uri = 'mongodb://some-hostname/test?ssl=true&authMechanism=MONGODB-X509&replicaSet=rs0';
+      const client = this.configuration.newClient(uri, { useNewUrlParser: true });
+      client.connect();
     }
   });
 });


### PR DESCRIPTION
This slightly modifies @kvwalker 's work from last week to support x509 without any username/password provided in a URI. We need to be careful not to always create an `auth` object, because that will result in `MongoCredentials` being created in cases where no auth is desired. This also includes a unit test to validate the behavior in the future. 