### PR TITLE
NODE-1883: Insert file with gridfs using session transactions

### DIFF
--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -266,6 +266,9 @@ function init(self) {
   if (self.s.options && self.s.options.skip) {
     findOneOptions.skip = self.s.options.skip;
   }
+  if (self.s.options && self.s.options.session) {
+    findOneOptions.session = self.s.options.session;
+  }
 
   self.s.files.findOne(self.s.filter, findOneOptions, function(error, doc) {
     if (error) {
@@ -307,7 +310,13 @@ function init(self) {
         filter['n'] = { $gte: skip };
       }
     }
-    self.s.cursor = self.s.chunks.find(filter).sort({ n: 1 });
+
+    var findOptions = {};
+    if (self.s.options && self.s.options.session) {
+      findOptions.session = self.s.options.session;
+    }
+
+    self.s.cursor = self.s.chunks.find(filter, findOptions).sort({ n: 1 });
 
     if (self.s.readPreference) {
       self.s.cursor.setReadPreference(self.s.readPreference);

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -142,7 +142,8 @@ GridFSBucket.prototype.openDownloadStream = function(id, options) {
   var filter = { _id: id };
   options = {
     start: options && options.start,
-    end: options && options.end
+    end: options && options.end,
+    session: options && options.session
   };
 
   return new GridFSBucketReadStream(
@@ -161,8 +162,16 @@ GridFSBucket.prototype.openDownloadStream = function(id, options) {
  * @param {GridFSBucket~errorCallback} [callback]
  */
 
-GridFSBucket.prototype.delete = function(id, callback) {
-  return executeOperation(this.s.db.s.topology, _delete, [this, id, callback], {
+/**
+ * Deletes a file with the given id
+ * @method
+ * @param {ObjectId} id The id of the file doc
+ * @param {Object} options
+ * @param {GridFSBucket~errorCallback} [callback]
+ */
+
+GridFSBucket.prototype.delete = function(id, options, callback) {
+  return executeOperation(this.s.db.s.topology, _delete, [this, id, options, callback], {
     skipSessions: true
   });
 };
@@ -171,13 +180,13 @@ GridFSBucket.prototype.delete = function(id, callback) {
  * @ignore
  */
 
-function _delete(_this, id, callback) {
-  _this.s._filesCollection.deleteOne({ _id: id }, function(error, res) {
+function _delete(_this, id, options, callback) {
+  _this.s._filesCollection.deleteOne({ _id: id }, options || {}, function(error, res) {
     if (error) {
       return callback(error);
     }
 
-    _this.s._chunksCollection.deleteMany({ files_id: id }, function(error) {
+    _this.s._chunksCollection.deleteMany({ files_id: id }, options, function(error) {
       if (error) {
         return callback(error);
       }

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -469,6 +469,9 @@ function getWriteOptions(_this) {
     obj.wtimeout = _this.options.writeConcern.wtimeout;
     obj.j = _this.options.writeConcern.j;
   }
+  if (_this.options.session) {
+    obj.session = _this.options.session;
+  }
   return obj;
 }
 


### PR DESCRIPTION
With this change I can upload a new file with gridfs using session transaction.

```javascript
const session = _mongoclient.startSession()
session.startTransaction()
const uploadStream = _gridfs.openUploadStream(file.originalname, { session })
const createReadStream = fs.createReadStream(file.path)
createReadStream.pipe(uploadStream)
uploadStream
  .on('error', async (err) => {
    ...
  })
  .on('finish', async (resultFile) => {
    ...
    await session.commitTransaction()
    session.endSession()
    ...
  })
```