### PR TITLE
test: make sure bulk tests catch all errors

### DIFF
--- a/test/functional/promises_collection_tests.js
+++ b/test/functional/promises_collection_tests.js
@@ -320,13 +320,16 @@ describe('Promises (Collection)', function() {
         var db = client.db(configuration.db);
         var bulk = db.collection('unordered_bulk_promise_form').initializeUnorderedBulkOp({ w: 1 });
         bulk.insert({ a: 1 });
-        bulk.execute().then(function(r) {
-          test.ok(r);
-          test.deepEqual({ w: 1 }, bulk.s.writeConcern);
+        return bulk
+          .execute()
+          .then(function(r) {
+            test.ok(r);
+            test.deepEqual({ w: 1 }, bulk.s.writeConcern);
 
-          client.close();
-          done();
-        });
+            client.close();
+            done();
+          })
+          .catch(done);
       });
     }
   });
@@ -352,13 +355,16 @@ describe('Promises (Collection)', function() {
         var db = client.db(configuration.db);
         var bulk = db.collection('unordered_bulk_promise_form').initializeOrderedBulkOp({ w: 1 });
         bulk.insert({ a: 1 });
-        bulk.execute().then(function(r) {
-          test.ok(r);
-          test.deepEqual({ w: 1 }, bulk.s.writeConcern);
+        return bulk
+          .execute()
+          .then(function(r) {
+            test.ok(r);
+            test.deepEqual({ w: 1 }, bulk.s.writeConcern);
 
-          client.close();
-          done();
-        });
+            client.close();
+            done();
+          })
+          .catch(done);
       });
     }
   });


### PR DESCRIPTION
Won't change the actual result of the test, but makes sure errors
cause a quick error rather than an uncaught error causing a stall