### PR TITLE
test: stop session leak tests from cascading

### DIFF
--- a/test/functional/session_leak_test.js
+++ b/test/functional/session_leak_test.js
@@ -106,6 +106,9 @@ afterEach('Session Leak After Each - ensure no leaks', function() {
       `client close failed to clean up ${pooledSessions.size} pooled sessions`
     ).to.equal(0);
   } catch (e) {
+    activeSessions.clear();
+    pooledSessions.clear();
+    activeSessionsBeforeClose.clear();
     this.test.error(e);
   }
 });


### PR DESCRIPTION
Clear all of the session tracking if a test fails, b/c otherwise
those can cause every subsequent test to fail