### PR TITLE
fix(aggregate): do not send batchSize for aggregation with $out

### DIFF
--- a/lib/operations/aggregate.js
+++ b/lib/operations/aggregate.js
@@ -25,13 +25,13 @@ function aggregate(db, coll, pipeline, options, callback) {
   const isDbAggregate = typeof coll === 'string';
   const target = isDbAggregate ? db : coll;
   const topology = target.s.topology;
-  let ignoreReadConcern = false;
+  let hasOutStage = false;
 
   if (typeof options.out === 'string') {
     pipeline = pipeline.concat({ $out: options.out });
-    ignoreReadConcern = true;
+    hasOutStage = true;
   } else if (pipeline.length > 0 && pipeline[pipeline.length - 1]['$out']) {
-    ignoreReadConcern = true;
+    hasOutStage = true;
   }
 
   let command;
@@ -52,7 +52,7 @@ function aggregate(db, coll, pipeline, options, callback) {
 
   const takesWriteConcern = topology.capabilities().commandsTakeWriteConcern;
 
-  if (!ignoreReadConcern) {
+  if (!hasOutStage) {
     decorateWithReadConcern(command, target, options);
   }
 
@@ -96,7 +96,7 @@ function aggregate(db, coll, pipeline, options, callback) {
   }
 
   options.cursor = options.cursor || {};
-  if (options.batchSize) options.cursor.batchSize = options.batchSize;
+  if (options.batchSize && !hasOutStage) options.cursor.batchSize = options.batchSize;
   command.cursor = options.cursor;
 
   // promiseLibrary


### PR DESCRIPTION
Sending a batchSize of 0 will break the cursor, and in general we
should not be sending batchSize for aggregation pipelines
that contain a $out stage.

Fixes NODE-1850