### PR TITLE
fix(bulkWrite): always count undefined values in bson size for bulk

### DIFF
--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -25,7 +25,11 @@ const isPromiseLike = require('../utils').isPromiseLike;
 function addToOperationsList(bulkOperation, docType, document) {
   // Get the bsonSize
   const bsonSize = bson.calculateObjectSize(document, {
-    checkKeys: false
+    checkKeys: false,
+
+    // Since we don't know what the user selected for BSON options here,
+    // err on the safe side, and check the size with ignoreUndefined: false.
+    ignoreUndefined: false
   });
 
   // Throw error if the doc is bigger than the max BSON size

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -25,7 +25,11 @@ const isPromiseLike = require('../utils').isPromiseLike;
 function addToOperationsList(bulkOperation, docType, document) {
   // Get the bsonSize
   const bsonSize = bson.calculateObjectSize(document, {
-    checkKeys: false
+    checkKeys: false,
+
+    // Since we don't know what the user selected for BSON options here,
+    // err on the safe side, and check the size with ignoreUndefined: false.
+    ignoreUndefined: false
   });
   // Throw error if the doc is bigger than the max BSON size
   if (bsonSize >= bulkOperation.s.maxBatchSizeBytes)


### PR DESCRIPTION
Bulk Writes use bson.calculateObjectSize to determine the size of
batches. However, it was not respecting user or default option
values like ignoreUndefined, which lead to bulkWrite errors in
some edge cases. To be safe, it now always sets ignoreUndefined to
false.

Fixes NODE-1898