### PR TITLE
fix(asyncIterator): stronger guard against importing async generator

### DIFF
--- a/lib/aggregation_cursor.js
+++ b/lib/aggregation_cursor.js
@@ -5,6 +5,7 @@ const MongoError = require('mongodb-core').MongoError;
 const Readable = require('stream').Readable;
 const CoreCursor = require('./cursor');
 const deprecate = require('util').deprecate;
+const SUPPORTS = require('./utils').SUPPORTS;
 
 /**
  * @fileOverview The **AggregationCursor** class is an internal class that embodies an aggregation cursor on MongoDB
@@ -130,7 +131,7 @@ inherits(AggregationCursor, Readable);
 for (var name in CoreCursor.prototype) {
   AggregationCursor.prototype[name] = CoreCursor.prototype[name];
 }
-if (Symbol.asyncIterator) {
+if (SUPPORTS.ASYNC_ITERATOR) {
   AggregationCursor.prototype[
     Symbol.asyncIterator
   ] = require('./async/async_iterator').asyncIterator;

--- a/lib/command_cursor.js
+++ b/lib/command_cursor.js
@@ -5,6 +5,7 @@ const ReadPreference = require('mongodb-core').ReadPreference;
 const MongoError = require('mongodb-core').MongoError;
 const Readable = require('stream').Readable;
 const CoreCursor = require('./cursor');
+const SUPPORTS = require('./utils').SUPPORTS;
 
 /**
  * @fileOverview The **CommandCursor** class is an internal class that embodies a
@@ -156,7 +157,7 @@ for (var i = 0; i < methodsToInherit.length; i++) {
   CommandCursor.prototype[methodsToInherit[i]] = CoreCursor.prototype[methodsToInherit[i]];
 }
 
-if (Symbol.asyncIterator) {
+if (SUPPORTS.ASYNC_ITERATOR) {
   CommandCursor.prototype[Symbol.asyncIterator] = require('./async/async_iterator').asyncIterator;
 }
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -5,6 +5,7 @@ const PassThrough = require('stream').PassThrough;
 const inherits = require('util').inherits;
 const deprecate = require('util').deprecate;
 const handleCallback = require('./utils').handleCallback;
+const SUPPORTS = require('./utils').SUPPORTS;
 const ReadPreference = require('mongodb-core').ReadPreference;
 const MongoError = require('mongodb-core').MongoError;
 const Readable = require('stream').Readable;
@@ -203,7 +204,7 @@ function Cursor(bson, ns, cmd, options, topology, topologyOptions) {
 // Inherit from Readable
 inherits(Cursor, Readable);
 
-if (Symbol.asyncIterator) {
+if (SUPPORTS.ASYNC_ITERATOR) {
   Cursor.prototype[Symbol.asyncIterator] = require('./async/async_iterator').asyncIterator;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -690,6 +690,15 @@ function deprecateOptions(config, fn) {
   return deprecated;
 }
 
+const SUPPORTS = {};
+// Test asyncIterator support
+try {
+  require('./async/async_iterator');
+  SUPPORTS.ASYNC_ITERATOR = true;
+} catch (e) {
+  SUPPORTS.ASYNC_ITERATOR = false;
+}
+
 module.exports = {
   filterOptions,
   mergeOptions,
@@ -715,5 +724,6 @@ module.exports = {
   isPromiseLike,
   decorateWithCollation,
   decorateWithReadConcern,
-  deprecateOptions
+  deprecateOptions,
+  SUPPORTS
 };


### PR DESCRIPTION
Adds a stronger spot check against importing the async iterator
for cursors. Handles case where other project pollute the known
symbols of the environment.

CC @majorhayes