### PR TITLE
fix(docs): correctly document that default for `sslValidate` is false

### DIFF
--- a/docs/reference/content/reference/connecting/connection-settings.md
+++ b/docs/reference/content/reference/connecting/connection-settings.md
@@ -41,7 +41,7 @@ The table below shows all settings and what topology they affect.
 | :----------| :------------------ | :------ | :------ |:------------- |
 | **poolSize** | Server, ReplicaSet, Mongos | integer | 5 | Set the maximum poolSize for each individual server or proxy connection.|
 | **ssl** | Server, ReplicaSet, Mongos | boolean | false | Use ssl connection |
-| **sslValidate** | Server, ReplicaSet, Mongos | boolean | true | Validate mongod server certificate against ca |
+| **sslValidate** | Server, ReplicaSet, Mongos | boolean | false | Validate mongod server certificate against ca |
 | **sslCA** | Server, ReplicaSet, Mongos | Array | null | Array of valid certificates either as Buffers or Strings |
 | **sslCert** | Server, ReplicaSet, Mongos | Buffer/String | null | String or buffer containing the certificate we wish to present |
 | **sslKey** | Server, ReplicaSet, Mongos | Buffer/String | null | String or buffer containing the certificate private key we wish to present |

--- a/docs/reference/content/tutorials/connect/ssl.md
+++ b/docs/reference/content/tutorials/connect/ssl.md
@@ -145,7 +145,7 @@ The following TLS/SSL options are available.
 | Parameter | Type | Description |
 | :----------| :------------- | :------------- |
 | `ssl` | {Boolean, default: false} | Use ssl connection |
-| `sslValidate` | {Boolean, default: true} | Validate server certificate against certificate authority. |
+| `sslValidate` | {Boolean, default: false} | Validate server certificate against certificate authority. |
 | `sslCA` | {Buffer[]\|string[], default: null} | Array of valid certificates for Certificate Authority either as Buffers or Strings. |
 | `sslCRL` | {Buffer[]\|string[], default: null} | Array of revocation certificates as Buffers or Strings. |
 | `sslCert` | {Buffer\|string, default: null} | String or buffer containing the client certificate. |

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -53,7 +53,7 @@ const closeOperation = require('./operations/mongo_client_ops').closeOperation;
  * @param {object} [options] Optional settings
  * @param {number} [options.poolSize=5] The maximum size of the individual server pool
  * @param {boolean} [options.ssl=false] Enable SSL connection.
- * @param {boolean} [options.sslValidate=true] Validate mongod server certificate against Certificate Authority
+ * @param {boolean} [options.sslValidate=false] Validate mongod server certificate against Certificate Authority
  * @param {buffer} [options.sslCA=undefined] SSL Certificate store binary buffer
  * @param {buffer} [options.sslCert=undefined] SSL Certificate binary buffer
  * @param {buffer} [options.sslKey=undefined] SSL Key file binary buffer
@@ -265,7 +265,7 @@ MongoClient.prototype.isConnected = function(options) {
  * @param {object} [options] Optional settings
  * @param {number} [options.poolSize=5] The maximum size of the individual server pool
  * @param {boolean} [options.ssl=false] Enable SSL connection.
- * @param {boolean} [options.sslValidate=true] Validate mongod server certificate against Certificate Authority
+ * @param {boolean} [options.sslValidate=false] Validate mongod server certificate against Certificate Authority
  * @param {buffer} [options.sslCA=undefined] SSL Certificate store binary buffer
  * @param {buffer} [options.sslCert=undefined] SSL Certificate binary buffer
  * @param {buffer} [options.sslKey=undefined] SSL Key file binary buffer

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -70,7 +70,7 @@ var legalOptionNames = [
  * @param {number} [options.acceptableLatencyMS=15] Cutoff latency point in MS for MongoS proxy selection
  * @param {boolean} [options.ssl=false] Use ssl connection (needs to have a mongod server with ssl support)
  * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
- * @param {boolean} [options.sslValidate=true] Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher)
+ * @param {boolean} [options.sslValidate=false] Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher)
  * @param {array} [options.sslCA] Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support, 2.4 or higher)
  * @param {array} [options.sslCRL] Array of revocation certificates either as Buffers or Strings (needs to have a mongod server with ssl support, 2.4 or higher)
  * @param {string} [options.ciphers] Passed directly through to tls.createSecureContext. See https://nodejs.org/dist/latest-v9.x/docs/api/tls.html#tls_tls_createsecurecontext_options for more info.

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -80,7 +80,7 @@ var legalOptionNames = [
  * @param {number} [options.poolSize=5] Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
  * @param {boolean} [options.ssl=false] Use ssl connection (needs to have a mongod server with ssl support)
  * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
- * @param {boolean} [options.sslValidate=true] Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher)
+ * @param {boolean} [options.sslValidate=false] Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher)
  * @param {array} [options.sslCA] Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support, 2.4 or higher)
  * @param {array} [options.sslCRL] Array of revocation certificates either as Buffers or Strings (needs to have a mongod server with ssl support, 2.4 or higher)
  * @param {(Buffer|string)} [options.sslCert] String or buffer containing the certificate we wish to present (needs to have a mongod server with ssl support, 2.4 or higher.

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -70,7 +70,7 @@ var legalOptionNames = [
  * @param {object} [options] Optional settings.
  * @param {number} [options.poolSize=5] Number of connections in the connection pool for each server instance, set to 5 as default for legacy reasons.
  * @param {boolean} [options.ssl=false] Use ssl connection (needs to have a mongod server with ssl support)
- * @param {boolean} [options.sslValidate=true] Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher)
+ * @param {boolean} [options.sslValidate=false] Validate mongod server certificate against ca (needs to have a mongod server with ssl support, 2.4 or higher)
  * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
  * @param {array} [options.sslCA] Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support, 2.4 or higher)
  * @param {array} [options.sslCRL] Array of revocation certificates either as Buffers or Strings (needs to have a mongod server with ssl support, 2.4 or higher)


### PR DESCRIPTION
Fixes NODE-1918