### PR TITLE
fix(unified-topology): only clone pool size if provided

### DIFF
--- a/lib/topologies/native_topology.js
+++ b/lib/topologies/native_topology.js
@@ -14,9 +14,10 @@ class NativeTopology extends Topology {
       {
         cursorFactory: Cursor,
         reconnect: false,
-        emitError: options.emitError,
-        size: options.poolSize,
-        monitorCommands: options.monitorCommands
+        emitError: typeof options.emitError === 'boolean' ? options.emitError : true,
+        size: typeof options.poolSize === 'number' ? options.poolSize : 5,
+        monitorCommands:
+          typeof options.monitorCommands === 'boolean' ? options.monitorCommands : false
       }
     );
 


### PR DESCRIPTION
I know the ticket says something about session leaks, but that's because I was forcing a constant pool size of 5, where most of our tests actually set it to 1. 