### PR TITLE
docs(BulkWrite): document when errors are thrown

### DIFF
--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -114,7 +114,8 @@ class OrderedBulkOperation extends BulkOperationBase {
    * @param {boolean} [options.j=false] Specify a journal write concern.
    * @param {boolean} [options.fsync=false] Specify a file sync write concern.
    * @param {OrderedBulkOperation~resultCallback} [callback] The result callback
-   * @throws {MongoError}
+   * @throws {MongoError} Throws error if the bulk object has already been executed
+   * @throws {MongoError} Throws error if the bulk object does not have any operations
    * @return {Promise} returns Promise if no callback passed
    */
   execute(_writeConcern, options, callback) {

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -126,7 +126,8 @@ class UnorderedBulkOperation extends BulkOperationBase {
    * @param {boolean} [options.j=false] Specify a journal write concern.
    * @param {boolean} [options.fsync=false] Specify a file sync write concern.
    * @param {UnorderedBulkOperation~resultCallback} [callback] The result callback
-   * @throws {MongoError}
+   * @throws {MongoError} Throws error if the bulk object has already been executed
+   * @throws {MongoError} Throws error if the bulk object does not have any operations
    * @return {Promise} returns Promise if no callback passed
    */
   execute(_writeConcern, options, callback) {


### PR DESCRIPTION
Documents the two errors that can be thrown by a bulkWrite execution:
- throws if the bulk object has already been executed
- throws if the bulk object does not have any operations

Fixes NODE-1914

CC @dandv 