### PR TITLE
NODE-1941: execute operation with selection

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -18,6 +18,7 @@ const ordered = require('./bulk/ordered');
 const ChangeStream = require('./change_stream');
 const executeOperation = require('./utils').executeOperation;
 const resolveReadPreference = require('./utils').resolveReadPreference;
+const MongoNamespace = require('./utils').MongoNamespace;
 
 // Operations
 const aggregate = require('./operations/aggregate').aggregate;
@@ -181,7 +182,8 @@ function Collection(db, topology, dbName, name, pkFactory, options) {
     // Read Concern
     readConcern: options.readConcern,
     // Write Concern
-    writeConcern: options.writeConcern
+    writeConcern: options.writeConcern,
+    ns: MongoNamespace(namespace)
   };
 }
 
@@ -239,6 +241,13 @@ Object.defineProperty(Collection.prototype, 'hint', {
   },
   set: function(v) {
     this.s.collectionHint = normalizeHintField(v);
+  }
+});
+
+Object.defineProperty(Collection.prototype, 'ns', {
+  enumerable: true,
+  get: function() {
+    return this.s.ns;
   }
 });
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -65,6 +65,7 @@ const UpdateManyOperation = require('./operations/update_many');
 const UpdateOneOperation = require('./operations/update_one');
 
 const executeOperationV2 = require('./operations/execute_operation_v2');
+const executeOperationV3 = require('./operation').executeOperation;
 
 /**
  * @fileOverview The **Collection** class is an internal class that embodies a MongoDB collection
@@ -1154,8 +1155,7 @@ Collection.prototype.createIndexes = function(indexSpecs, options, callback) {
   if (typeof options.maxTimeMS !== 'number') delete options.maxTimeMS;
 
   const createIndexesOperation = new CreateIndexesOperation(this, indexSpecs, options);
-
-  return executeOperationV2(this.s.topology, createIndexesOperation, callback);
+  return executeOperationV3(this.s.topology, createIndexesOperation, callback);
 };
 
 /**

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -475,8 +475,7 @@ Collection.prototype.insertOne = function(doc, options, callback) {
   }
 
   const insertOneOperation = new InsertOneOperation(this, doc, options);
-
-  return executeOperationV2(this.s.topology, insertOneOperation, callback);
+  return executeOperationV3(this.s.topology, insertOneOperation, callback);
 };
 
 /**

--- a/lib/db.js
+++ b/lib/db.js
@@ -20,6 +20,7 @@ const ChangeStream = require('./change_stream');
 const deprecate = require('util').deprecate;
 const deprecateOptions = require('./utils').deprecateOptions;
 const CONSTANTS = require('./constants');
+const MongoNamespace = require('./utils').MongoNamespace;
 
 // Operations
 const addUser = require('./operations/db_ops').addUser;
@@ -175,7 +176,8 @@ function Db(databaseName, topology, options) {
     // No listener
     noListener: typeof options.noListener === 'boolean' ? options.noListener : false,
     // ReadConcern
-    readConcern: options.readConcern
+    readConcern: options.readConcern,
+    ns: MongoNamespace(databaseName)
   };
 
   // Ensure we have a valid db name
@@ -244,6 +246,13 @@ Object.defineProperty(Db.prototype, 'writeConcern', {
     if (this.s.options.fsync != null) ops.fsync = this.s.options.fsync;
     if (this.s.options.wtimeout != null) ops.wtimeout = this.s.options.wtimeout;
     return ops;
+  }
+});
+
+Object.defineProperty(Db.prototype, 'ns', {
+  enumerable: true,
+  get: function() {
+    return this.s.ns;
   }
 });
 

--- a/lib/operation/command_operation.js
+++ b/lib/operation/command_operation.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const OperationBase = require('./operation_base').OperationBase;
+const MongoError = require('mongodb-core').MongoError;
+const ReadPreference = require('mongodb-core').ReadPreference;
+const debugFields = require('../operations/db_ops').debugFields;
+const debugOptions = require('../utils').debugOptions;
+
+class CommandOperation extends OperationBase {
+  get readPreference() {
+    return ReadPreference.primary;
+  }
+
+  executeCommand(ns, command, server, callback) {
+    // TODO: this check is not necessary for the unified topology, remove when legacy
+    //       topologies are removed.
+    if (server.isDestroyed()) {
+      callback(new MongoError('topology was destroyed'));
+      return;
+    }
+
+    // Debug information
+    if (server.s.logger.isDebug()) {
+      server.s.logger.debug(
+        `executing command ${JSON.stringify(
+          command
+        )} against \`${ns}.$cmd\` with options [${JSON.stringify(
+          debugOptions(debugFields, this.options)
+        )}]`
+      );
+    }
+
+    // TODO: apply write concern, collation, read preference (if needed for sharded), etc.
+    // TODO: `this.options` could (should?) be replaced with a new options object created
+    //        here with _only_ options related to command exectuion
+    server.command(`${ns.database}.$cmd`, command, this.options, (err, result) => {
+      if (err) {
+        callback(err, null);
+        return;
+      }
+
+      callback(null, this.options && this.options.full ? result : result.result);
+    });
+  }
+}
+
+module.exports = { CommandOperation };

--- a/lib/operation/execute_operation.js
+++ b/lib/operation/execute_operation.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const MongoError = require('mongodb-core').MongoError;
+const Aspect = require('./operation_base').Aspect;
+const OperationBase = require('./operation_base').OperationBase;
+const ReadPreference = require('mongodb-core').ReadPreference;
+
+/**
+ * Executes the given operation with provided arguments.
+ *
+ * This method reduces large amounts of duplication in the entire codebase by providing
+ * a single point for determining whether callbacks or promises should be used. Additionally
+ * it allows for a single point of entry to provide features such as implicit sessions, which
+ * are required by the Driver Sessions specification in the event that a ClientSession is
+ * not provided
+ *
+ * @param {object} topology The topology to execute this operation on
+ * @param {Operation} operation The operation to execute
+ * @param {function} callback The command result callback
+ */
+function executeOperation(topology, operation, callback) {
+  if (topology == null) {
+    throw new TypeError('This method requires a valid topology instance');
+  }
+
+  if (!(operation instanceof OperationBase)) {
+    throw new TypeError('This method requires a valid operation instance');
+  }
+
+  const Promise = topology.s.promiseLibrary;
+
+  // The driver sessions spec mandates that we implicitly create sessions for operations
+  // that are not explicitly provided with a session.
+  let session, owner;
+  if (!operation.hasAspect(Aspect.SKIP_SESSION) && topology.hasSessionSupport()) {
+    if (operation.session == null) {
+      owner = Symbol();
+      session = topology.startSession({ owner });
+      operation.session = session;
+    } else if (operation.session.hasEnded) {
+      throw new MongoError('Use of expired sessions is not permitted');
+    }
+  }
+
+  const makeExecuteCallback = (resolve, reject) =>
+    function executeCallback(err, result) {
+      if (session && session.owner === owner) {
+        session.endSession(() => {
+          if (operation.session === session) {
+            operation.clearSession();
+          }
+          if (err) return reject(err);
+          resolve(result);
+        });
+      } else {
+        if (err) return reject(err);
+        resolve(result);
+      }
+    };
+
+  // Execute using callback
+  if (typeof callback === 'function') {
+    const handler = makeExecuteCallback(
+      result => callback(null, result),
+      err => callback(err, null)
+    );
+
+    try {
+      if (operation.hasAspect(Aspect.EXECUTE_WITH_SELECTION)) {
+        executeWithServerSelection(topology, operation, handler);
+      } else {
+        operation.execute(handler);
+      }
+    } catch (e) {
+      handler(e);
+      throw e;
+    }
+
+    return;
+  }
+
+  return new Promise(function(resolve, reject) {
+    const handler = makeExecuteCallback(resolve, reject);
+
+    try {
+      if (operation.hasAspect(Aspect.EXECUTE_WITH_SELECTION)) {
+        executeWithServerSelection(topology, operation, handler);
+      } else {
+        operation.execute(handler);
+      }
+    } catch (e) {
+      handler(e);
+    }
+  });
+}
+
+const MongoNetworkError = require('mongodb-core').MongoNetworkError;
+const RETRYABLE_WIRE_VERSION = 6;
+
+// see: https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst#terms
+const RETRYABLE_ERROR_CODES = new Set([
+  6, // HostUnreachable
+  7, // HostNotFound
+  89, // NetworkTimeout
+  91, // ShutdownInProgress
+  189, // PrimarySteppedDown
+  9001, // SocketException
+  10107, // NotMaster
+  11600, // InterruptedAtShutdown
+  11602, // InterruptedDueToReplStateChange
+  13435, // NotMasterNoSlaveOk
+  13436 // NotMasterOrSecondary
+]);
+
+/**
+ * Determines whether an error is something the driver should attempt to retry
+ *
+ * @param {MongoError|Error} error
+ */
+function isRetryableError(error) {
+  return (
+    RETRYABLE_ERROR_CODES.has(error.code) ||
+    error instanceof MongoNetworkError ||
+    error.message.match(/not master/) ||
+    error.message.match(/node is recovering/)
+  );
+}
+
+function isSingleServer(topology) {
+  if (topology.type && topology.type === 'server') {
+    return true;
+  }
+
+  if (topology.description && topology.description.type === 'Single') {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Determines whether the provided topology supports retryable writes
+ *
+ * @param {*} topology
+ */
+const isRetryabilitySupported = function(topology) {
+  if (isSingleServer(topology)) {
+    return false;
+  }
+
+  const maxWireVersion = topology.lastIsMaster().maxWireVersion;
+  if (maxWireVersion < RETRYABLE_WIRE_VERSION) {
+    return false;
+  }
+
+  if (!topology.logicalSessionTimeoutMinutes) {
+    return false;
+  }
+
+  return true;
+};
+
+function executeWithServerSelection(topology, operation, callback) {
+  const readPreference = operation.readPreference || ReadPreference.primary;
+  const session = operation.session;
+
+  function callbackWithRetry(err, result) {
+    if (err == null) {
+      callback(null, result);
+      return;
+    }
+
+    if (err && isRetryableError(err) && !session.inTransaction()) {
+      // increment and assign txnNumber
+      session.incrementTransactionNumber();
+
+      // select a new server, and attempt to retry the operation
+      topology.selectServer(readPreference, (err, server) => {
+        if (err) {
+          callback(err, null);
+          return;
+        }
+
+        operation.execute(server, callback);
+      });
+
+      return;
+    }
+  }
+
+  // select a server, and execute the operation against it
+  topology.selectServer(readPreference, (err, server) => {
+    if (err) {
+      callback(err, null);
+      return;
+    }
+
+    if (operation.hasAspect(Aspect.RETRY) && isRetryabilitySupported(topology)) {
+      operation.execute(server, callbackWithRetry);
+      return;
+    }
+
+    operation.execute(server, callback);
+  });
+}
+
+module.exports = { executeOperation };

--- a/lib/operation/execute_operation.js
+++ b/lib/operation/execute_operation.js
@@ -49,6 +49,7 @@ function executeOperation(topology, operation, callback) {
           if (operation.session === session) {
             operation.clearSession();
           }
+
           if (err) return reject(err);
           resolve(result);
         });
@@ -168,6 +169,10 @@ function executeWithServerSelection(topology, operation, callback) {
     if (err == null) {
       callback(null, result);
       return;
+    }
+
+    if (!isRetryableError(err)) {
+      return callback(err);
     }
 
     if (err && isRetryableError(err) && !session.inTransaction()) {

--- a/lib/operation/execute_operation.js
+++ b/lib/operation/execute_operation.js
@@ -164,33 +164,33 @@ const isRetryabilitySupported = function(topology) {
 function executeWithServerSelection(topology, operation, callback) {
   const readPreference = operation.readPreference || ReadPreference.primary;
   const session = operation.session;
+  const options = operation.options;
+
+  const willRetryWrite =
+    operation.hasAspect(Aspect.RETRY) &&
+    !!options.retryWrites &&
+    session &&
+    isRetryabilitySupported(topology) &&
+    !options.session.inTransaction();
 
   function callbackWithRetry(err, result) {
     if (err == null) {
-      callback(null, result);
-      return;
+      return callback(null, result);
     }
 
     if (!isRetryableError(err)) {
       return callback(err);
     }
 
-    if (err && isRetryableError(err) && !session.inTransaction()) {
-      // increment and assign txnNumber
-      session.incrementTransactionNumber();
+    // select a new server, and attempt to retry the operation
+    topology.selectServer(readPreference, (err, server) => {
+      if (err) {
+        callback(err, null);
+        return;
+      }
 
-      // select a new server, and attempt to retry the operation
-      topology.selectServer(readPreference, (err, server) => {
-        if (err) {
-          callback(err, null);
-          return;
-        }
-
-        operation.execute(server, callback);
-      });
-
-      return;
-    }
+      operation.execute(server, callback);
+    });
   }
 
   // select a server, and execute the operation against it
@@ -200,7 +200,10 @@ function executeWithServerSelection(topology, operation, callback) {
       return;
     }
 
-    if (operation.hasAspect(Aspect.RETRY) && isRetryabilitySupported(topology)) {
+    if (willRetryWrite) {
+      options.willRetryWrite = true;
+      session.incrementTransactionNumber();
+
       operation.execute(server, callbackWithRetry);
       return;
     }

--- a/lib/operation/index.js
+++ b/lib/operation/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  Aspect: require('./operation_base').Aspect,
+  defineAspects: require('./operation_base').defineAspects,
+  executeOperation: require('./execute_operation').executeOperation,
+  OperationBase: require('./operation_base').OperationBase,
+  CommandOperation: require('./command_operation').CommandOperation
+};

--- a/lib/operation/operation_base.js
+++ b/lib/operation/operation_base.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const Aspect = {
+  SKIP_SESSION: Symbol('SKIP_SESSION')
+};
+
+/**
+ * This class acts as a parent class for any operation and is responsible for setting this.options,
+ * as well as setting and getting a session.
+ * Additionally, this class implements `hasAspect`, which determines whether an operation has
+ * a specific aspect, including `SKIP_SESSION` and other aspects to encode retryability
+ * and other functionality.
+ */
+class OperationBase {
+  constructor(options) {
+    this.options = options || {};
+  }
+
+  hasAspect(aspect) {
+    if (this.constructor.aspects == null) {
+      return false;
+    }
+    return this.constructor.aspects.has(aspect);
+  }
+
+  set session(session) {
+    Object.assign(this.options, { session });
+  }
+
+  get session() {
+    return this.options.session;
+  }
+
+  clearSession() {
+    delete this.options.session;
+  }
+
+  execute() {
+    throw new TypeError('`execute` must be implemented for OperationBase subclasses');
+  }
+}
+
+function defineAspects(operation, aspects) {
+  aspects = new Set(aspects);
+  Object.defineProperty(operation, 'aspects', {
+    value: aspects,
+    writable: false
+  });
+  return aspects;
+}
+
+module.exports = {
+  Aspect,
+  defineAspects,
+  OperationBase
+};

--- a/lib/operations/create_indexes.js
+++ b/lib/operations/create_indexes.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const OperationBase = require('./operation').OperationBase;
-const executeCommand = require('./db_ops').executeCommand;
+const CommandOperation = require('../operation').CommandOperation;
 const MongoError = require('mongodb-core').MongoError;
-const ReadPreference = require('mongodb-core').ReadPreference;
+const Aspect = require('../operation').Aspect;
+const defineAspects = require('../operation').defineAspects;
 
-class CreateIndexesOperation extends OperationBase {
+class CreateIndexesOperation extends CommandOperation {
   constructor(collection, indexSpecs, options) {
     super(options);
 
@@ -13,11 +13,9 @@ class CreateIndexesOperation extends OperationBase {
     this.indexSpecs = indexSpecs;
   }
 
-  execute(callback) {
+  execute(server, callback) {
     const coll = this.collection;
     const indexSpecs = this.indexSpecs;
-    let options = this.options;
-
     const capabilities = coll.s.topology.capabilities();
 
     // Ensure we generate the correct name if the parameter is not set
@@ -39,19 +37,10 @@ class CreateIndexesOperation extends OperationBase {
       }
     }
 
-    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
-
-    // Execute the index
-    executeCommand(
-      coll.s.db,
-      {
-        createIndexes: coll.s.name,
-        indexes: indexSpecs
-      },
-      options,
-      callback
-    );
+    const command = { createIndexes: coll.s.name, indexes: indexSpecs };
+    super.executeCommand(coll.ns, command, server, callback);
   }
 }
 
+defineAspects(CreateIndexesOperation, [Aspect.EXECUTE_WITH_SELECTION]);
 module.exports = CreateIndexesOperation;

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -1002,5 +1002,6 @@ module.exports = {
   profilingLevel,
   removeUser,
   setProfilingLevel,
-  validateDatabaseName
+  validateDatabaseName,
+  debugFields
 };

--- a/lib/operations/execute_operation_v2.js
+++ b/lib/operations/execute_operation_v2.js
@@ -65,18 +65,20 @@ function executeOperationV2(topology, operation, callback) {
     );
 
     try {
-      return operation.execute(handler);
+      operation.execute(handler);
     } catch (e) {
       handler(e);
       throw e;
     }
+
+    return;
   }
 
   return new Promise(function(resolve, reject) {
     const handler = makeExecuteCallback(resolve, reject);
 
     try {
-      return operation.execute(handler);
+      operation.execute(handler);
     } catch (e) {
       handler(e);
     }

--- a/lib/operations/insert_one.js
+++ b/lib/operations/insert_one.js
@@ -4,9 +4,11 @@ const applyRetryableWrites = require('../utils').applyRetryableWrites;
 const applyWriteConcern = require('../utils').applyWriteConcern;
 const handleCallback = require('../utils').handleCallback;
 const MongoError = require('mongodb-core').MongoError;
-const OperationBase = require('./operation').OperationBase;
+const OperationBase = require('../operation').OperationBase;
 const prepareDocs = require('./common_functions').prepareDocs;
 const toError = require('../utils').toError;
+const Aspect = require('../operation').Aspect;
+const defineAspects = require('../operation').defineAspects;
 
 class InsertOneOperation extends OperationBase {
   constructor(collection, doc, options) {
@@ -16,7 +18,7 @@ class InsertOneOperation extends OperationBase {
     this.doc = doc;
   }
 
-  execute(callback) {
+  execute(server, callback) {
     const coll = this.collection;
     const doc = this.doc;
     const options = this.options;
@@ -27,49 +29,33 @@ class InsertOneOperation extends OperationBase {
       );
     }
 
-    insertDocuments(coll, [doc], options, (err, r) => {
-      if (callback == null) return;
-      if (err && callback) return callback(err);
+    // Final options for retryable writes and write concern
+    let finalOptions = Object.assign({}, options);
+    finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
+    finalOptions = applyWriteConcern(finalOptions, { db: coll.s.db, collection: coll }, options);
+
+    // If keep going set unordered
+    if (finalOptions.keepGoing === true) finalOptions.ordered = false;
+    finalOptions.serializeFunctions = options.serializeFunctions || coll.s.serializeFunctions;
+
+    const docs = prepareDocs(coll, [doc], options);
+
+    server.insert(coll.s.namespace, docs, finalOptions, (err, result) => {
+      if (err) return handleCallback(callback, err);
       // Workaround for pre 2.6 servers
-      if (r == null) return callback(null, { result: { ok: 1 } });
-      // Add values to top level to ensure crud spec compatibility
-      r.insertedCount = r.result.n;
-      r.insertedId = doc._id;
-      if (callback) callback(null, r);
+      if (result == null) return handleCallback(callback, null, { result: { ok: 1 } });
+      if (result.result.code) return handleCallback(callback, toError(result.result));
+      if (result.result.writeErrors) {
+        return handleCallback(callback, toError(result.result.writeErrors[0]));
+      }
+
+      result.ops = docs;
+      result.insertedCount = result.result.n;
+      result.insertedId = doc._id;
+      handleCallback(callback, null, result);
     });
   }
 }
 
-function insertDocuments(coll, docs, options, callback) {
-  if (typeof options === 'function') (callback = options), (options = {});
-  options = options || {};
-  // Ensure we are operating on an array op docs
-  docs = Array.isArray(docs) ? docs : [docs];
-
-  // Final options for retryable writes and write concern
-  let finalOptions = Object.assign({}, options);
-  finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
-  finalOptions = applyWriteConcern(finalOptions, { db: coll.s.db, collection: coll }, options);
-
-  // If keep going set unordered
-  if (finalOptions.keepGoing === true) finalOptions.ordered = false;
-  finalOptions.serializeFunctions = options.serializeFunctions || coll.s.serializeFunctions;
-
-  docs = prepareDocs(coll, docs, options);
-
-  // File inserts
-  coll.s.topology.insert(coll.s.namespace, docs, finalOptions, (err, result) => {
-    if (callback == null) return;
-    if (err) return handleCallback(callback, err);
-    if (result == null) return handleCallback(callback, null, null);
-    if (result.result.code) return handleCallback(callback, toError(result.result));
-    if (result.result.writeErrors)
-      return handleCallback(callback, toError(result.result.writeErrors[0]));
-    // Add docs to the list
-    result.ops = docs;
-    // Return the results
-    handleCallback(callback, null, result);
-  });
-}
-
+defineAspects(InsertOneOperation, [Aspect.EXECUTE_WITH_SELECTION]);
 module.exports = InsertOneOperation;

--- a/lib/operations/insert_one.js
+++ b/lib/operations/insert_one.js
@@ -12,7 +12,13 @@ const defineAspects = require('../operation').defineAspects;
 
 class InsertOneOperation extends OperationBase {
   constructor(collection, doc, options) {
-    super(options);
+    // resolve options
+    let finalOptions = Object.assign({}, options);
+    finalOptions = applyRetryableWrites(finalOptions, collection.s.db);
+    finalOptions = applyWriteConcern(finalOptions, { db: collection.s.db, collection }, options);
+    if (finalOptions.keepGoing === true) finalOptions.ordered = false;
+    finalOptions.serializeFunctions = options.serializeFunctions || collection.s.serializeFunctions;
+    super(finalOptions);
 
     this.collection = collection;
     this.doc = doc;
@@ -29,18 +35,8 @@ class InsertOneOperation extends OperationBase {
       );
     }
 
-    // Final options for retryable writes and write concern
-    let finalOptions = Object.assign({}, options);
-    finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
-    finalOptions = applyWriteConcern(finalOptions, { db: coll.s.db, collection: coll }, options);
-
-    // If keep going set unordered
-    if (finalOptions.keepGoing === true) finalOptions.ordered = false;
-    finalOptions.serializeFunctions = options.serializeFunctions || coll.s.serializeFunctions;
-
     const docs = prepareDocs(coll, [doc], options);
-
-    server.insert(coll.s.namespace, docs, finalOptions, (err, result) => {
+    server.insert(coll.s.namespace, docs, this.options, (err, result) => {
       if (err) return handleCallback(callback, err);
       // Workaround for pre 2.6 servers
       if (result == null) return handleCallback(callback, null, { result: { ok: 1 } });
@@ -57,5 +53,5 @@ class InsertOneOperation extends OperationBase {
   }
 }
 
-defineAspects(InsertOneOperation, [Aspect.EXECUTE_WITH_SELECTION]);
+defineAspects(InsertOneOperation, [Aspect.EXECUTE_WITH_SELECTION, Aspect.RETRY]);
 module.exports = InsertOneOperation;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -699,6 +699,19 @@ try {
   SUPPORTS.ASYNC_ITERATOR = false;
 }
 
+function MongoNamespace(ns) {
+  if (typeof ns !== 'string') {
+    return null;
+  }
+
+  const parts = ns.split('.');
+  if (parts.length === 1) {
+    return { database: parts[0] };
+  }
+
+  return { database: parts[0], collection: parts[1] };
+}
+
 module.exports = {
   filterOptions,
   mergeOptions,
@@ -725,5 +738,6 @@ module.exports = {
   decorateWithCollation,
   decorateWithReadConcern,
   deprecateOptions,
-  SUPPORTS
+  SUPPORTS,
+  MongoNamespace
 };


### PR DESCRIPTION
Modifies `executeOperation` to accept a new aspect `EXECUTE_WITH_SELECTION` (should eventually be a default aspect), which integrates server selection into the operation execution. This allows us to move command construction, and dispatch completely into native from core. 