### PR TITLE
refactor: add private `_findAndModify()` function that bypasses deprecation warning for Mongoose

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1587,7 +1587,10 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
  * @return {Promise} returns Promise if no callback passed
  * @deprecated use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead
  */
-Collection.prototype.findAndModify = deprecate(_findAndModify, 'collection.findAndModify is deprecated. Use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead.');
+Collection.prototype.findAndModify = deprecate(
+  _findAndModify,
+  'collection.findAndModify is deprecated. Use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead.'
+);
 
 /**
  * @ignore

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1587,7 +1587,15 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
  * @return {Promise} returns Promise if no callback passed
  * @deprecated use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead
  */
-Collection.prototype.findAndModify = deprecate(function(query, sort, doc, options, callback) {
+Collection.prototype.findAndModify = deprecate(_findAndModify, 'collection.findAndModify is deprecated. Use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead.');
+
+/**
+ * @ignore
+ */
+
+Collection.prototype._findAndModify = _findAndModify;
+
+function _findAndModify(query, sort, doc, options, callback) {
   const args = Array.prototype.slice.call(arguments, 1);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   sort = args.length ? args.shift() || [] : [];
@@ -1607,7 +1615,7 @@ Collection.prototype.findAndModify = deprecate(function(query, sort, doc, option
     options,
     callback
   ]);
-}, 'collection.findAndModify is deprecated. Use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead.');
+}
 
 /**
  * Find and remove a document.


### PR DESCRIPTION
Mongoose has [some trouble with the findAndModify deprecation](https://mongoosejs.com/docs/deprecations.html#-findandmodify-) because Mongoose's [`findOneAndUpdate()` function](https://mongoosejs.com/docs/api.html#model_Model.findOneAndUpdate) pre-dates the driver's `findOneAndUpdate()`, so we still use `findAndModify()` by default to maintain backwards compatibility. Unfortunately, this means if you use `findOneAndUpdate()` with Mongoose, you'll get a very confusing deprecation warning:

```
collection.findAndModify is deprecated. Use findOneAndUpdate, findOneAndReplace or findOneAndDelete instead.
```

I'd like to suppress this warning and add a Mongoose-specific one instead, but there's no good way to suppress one deprecation warning in Node. I hate to suggest this change, and I'm open to other alternatives. Looking forward to your feedback :+1: