### PR TITLE
fix: allow escaped characters in auth when using mongodb+srv

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -54,7 +54,14 @@ module.exports = function(url, options, callback) {
       }
     }
 
-    let base = result.auth ? `mongodb://${result.auth}@` : `mongodb://`;
+    let base = `mongodb://`;
+
+    if (result.auth) {
+      let authSplit = result.auth.split(':');
+      let escapedAuth = authSplit.map(encodeURIComponent).join(':');
+      base += escapedAuth + '@';
+    }
+
     let connectionStrings = addresses.map(function(address, i) {
       if (i === 0) return `${base}${address.name}:${address.port}`;
       else return `${address.name}:${address.port}`;

--- a/test/functional/url_parser_tests.js
+++ b/test/functional/url_parser_tests.js
@@ -1026,4 +1026,40 @@ describe('Url Parser', function() {
       });
     }
   });
+
+  it('should allow escaped characters in mongodb+srv scheme passwords', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+    test: function(done) {
+      parse(
+        'mongodb+srv://admin:test%24@test5.test.build.10gen.cc/test?retryWrites=true',
+        {},
+        function(err, object) {
+          expect(err).to.be.null;
+          expect(object.auth.user).to.equal('admin');
+          expect(object.auth.password).to.equal('test$');
+          done();
+        }
+      );
+    }
+  });
+
+  it('should allow escaped characters in mongodb+srv scheme usernames', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+    test: function(done) {
+      parse(
+        'mongodb+srv://admin$1:test@test5.test.build.10gen.cc/test?retryWrites=true',
+        {},
+        function(err, object) {
+          expect(err).to.be.null;
+          expect(object.auth.user).to.equal('admin$1');
+          expect(object.auth.password).to.equal('test');
+          done();
+        }
+      );
+    }
+  });
 });


### PR DESCRIPTION
I had problems with certain characters in a password, which led to
finding this, which seems to have been a bug. Fixed for username as
well. Tests added in an attempt to document the issue being
experienced.

Similar to NODE-1588, but no current issues fixed.