### PR TITLE
fix(connect): fixed syntax issue in connect error handler

### DIFF
--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -281,10 +281,9 @@ function makeConnection(family, options, _callback) {
   const errorEvents = ['error', 'close', 'timeout', 'parseError', 'connect'];
   function errorHandler(eventName) {
     return err => {
-      if (err == null || err === false) err = true;
       errorEvents.forEach(event => socket.removeAllListeners(event));
       socket.removeListener('connect', connectHandler);
-      callback(new MongoNetworkError(err.message), eventName);
+      callback(connectionFailureError(eventName, err), eventName);
     };
   }
 
@@ -353,6 +352,19 @@ function authenticate(conn, credentials, callback) {
     if (err) return callback(err);
     callback(null, conn);
   });
+}
+
+function connectionFailureError(type, err) {
+  switch (type) {
+    case 'error':
+      return new MongoNetworkError(err);
+    case 'timeout':
+      return new MongoNetworkError(`connection timed out`);
+    case 'close':
+      return new MongoNetworkError(`connection closed`);
+    default:
+      return new MongoNetworkError(`unknown network error`);
+  }
 }
 
 module.exports = connect;


### PR DESCRIPTION
Connect error handler was attempting to read properties off
of an error that had a chance of being null. Removed that,
and replaced the error generation to be more explicit.

Fixes NODE-1960
Fixes NODE-1968