### PR TITLE
Change Stream 4.2 work

### DIFF
--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -79,7 +79,8 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
     currentLimit: 0,
     // Result field name if not a cursor (contains the array of results)
     transforms: options.transforms,
-    raw: options.raw || (cmd && cmd.raw)
+    raw: options.raw || (cmd && cmd.raw),
+    initialQueryResponse: null
   };
 
   if (typeof options.session === 'object') {
@@ -330,6 +331,33 @@ Cursor.prototype.rewind = function() {
   }
 };
 
+Cursor.prototype._ensureInit = function(callback) {
+  // We have notified about it
+  if (this.cursorState.notified) {
+    return callback(new Error('cursor is exhausted'));
+  }
+
+  // Cursor is killed return null
+  if (isCursorKilled(this, callback)) return;
+
+  // Cursor is dead but not marked killed, return null
+  if (isCursorDeadButNotkilled(this, callback)) return;
+
+  // We have a dead and killed cursor, attempting to call next should error
+  if (isCursorDeadAndKilled(this, callback)) return;
+
+  // We have just started the cursor
+  if (!this.cursorState.init) {
+    return initializeCursor(this, (err, response) => {
+      this.cursorState.initialQueryResponse = response;
+
+      callback(err, response);
+    });
+  }
+
+  callback(null, this.cursorState.initialQueryResponse);
+};
+
 /**
  * Validate if the pool is dead and return error
  */
@@ -426,7 +454,38 @@ var nextFunction = function(self, callback) {
 
   // We have just started the cursor
   if (!self.cursorState.init) {
-    return initializeCursor(self, callback);
+    return initializeCursor(self, function(err, initialQueryResponse) {
+      if (err) {
+        if (self.disconnectHandler && err[mongoErrorContextSymbol].legacyDisconnectHandle) {
+          return self.disconnectHandler.addObjectAndMethod(
+            'cursor',
+            self,
+            'next',
+            [callback],
+            callback
+          );
+        }
+        return callback(err);
+      }
+
+      self.cursorState.initialQueryResponse = initialQueryResponse;
+
+      if (self.cursorState.cursorId && self.cursorState.cursorId.isZero() && self._endSession) {
+        self._endSession();
+      }
+
+      if (
+        self.cursorState.documents.length === 0 &&
+        self.cursorState.cursorId &&
+        self.cursorState.cursorId.isZero() &&
+        !self.cmd.tailable &&
+        !self.cmd.awaitData
+      ) {
+        return setCursorNotified(self, callback);
+      }
+
+      nextFunction(self, callback);
+    });
   }
 
   if (self.cursorState.limit > 0 && self.cursorState.currentLimit >= self.cursorState.limit) {
@@ -569,13 +628,10 @@ function initializeCursor(cursor, callback) {
         return callback(new MongoError('Topology was destroyed'));
       }
 
-      return cursor.disconnectHandler.addObjectAndMethod(
-        'cursor',
-        cursor,
-        'next',
-        [callback],
-        callback
-      );
+      // TODO: Remove this once we get rid of disconnect handler
+      const err = new MongoError('no connection available');
+      err[mongoErrorContextSymbol].legacyDisconnectHandle = true;
+      return callback(err);
     }
   }
 
@@ -590,11 +646,8 @@ function initializeCursor(cursor, callback) {
 
   return cursor.topology.selectServer(serverSelectOptions, (err, server) => {
     if (err) {
-      const disconnectHandler = cursor.disconnectHandler;
-      if (disconnectHandler != null) {
-        return disconnectHandler.addObjectAndMethod('cursor', cursor, 'next', [callback], callback);
-      }
-
+      // TODO: Remove this once we get rid of disconnect handler
+      err[mongoErrorContextSymbol].legacyDisconnectHandle = true;
       return callback(err);
     }
 
@@ -604,31 +657,9 @@ function initializeCursor(cursor, callback) {
       return callback(new MongoError(`server ${cursor.server.name} does not support collation`));
     }
 
-    function done() {
-      if (
-        cursor.cursorState.cursorId &&
-        cursor.cursorState.cursorId.isZero() &&
-        cursor._endSession
-      ) {
-        cursor._endSession();
-      }
-
-      if (
-        cursor.cursorState.documents.length === 0 &&
-        cursor.cursorState.cursorId &&
-        cursor.cursorState.cursorId.isZero() &&
-        !cursor.cmd.tailable &&
-        !cursor.cmd.awaitData
-      ) {
-        return setCursorNotified(cursor, callback);
-      }
-
-      nextFunction(cursor, callback);
-    }
-
     // NOTE: this is a special internal method for cloning a cursor, consider removing
     if (cursor.cursorState.cursorId != null) {
-      return done();
+      return callback(null, null);
     }
 
     const queryCallback = (err, r) => {
@@ -671,13 +702,13 @@ function initializeCursor(cursor, callback) {
           }
 
           // Return after processing command cursor
-          return done(result);
+          return callback(null, result);
         }
 
         if (Array.isArray(result.documents[0].result)) {
           cursor.cursorState.documents = result.documents[0].result;
           cursor.cursorState.cursorId = Long.ZERO;
-          return done(result);
+          return callback(null, result);
         }
       }
 
@@ -696,7 +727,7 @@ function initializeCursor(cursor, callback) {
       }
 
       // Return callback
-      done(result);
+      callback(null, result);
     };
 
     if (cursor.logger.isDebug()) {


### PR DESCRIPTION
# Description

Exposes the ability to fire the initial query attempt in a cursor without firing additional getMores. Necessary for postBatchResumeToken work

**What changed?**

+ in `lib/core/cursor.js`, the functions `initializeCursor` and `nextFunction` have been refactored such that `initializeCursor` doesn't immediately call `nextFunction` when done. This makes it possible to run `nextFunction` without going into `nextFunction`'s perpetual loop of `getMore`s. Added the function `_ensureInit` that would callback once `initializeCursor` finished.