### PR TITLE
fix(sessions): ensure an error is thrown when attempting sharded transactions

### DIFF
--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -16,6 +16,7 @@ const ReadPreference = require('./topologies/read_preference');
 const isTransactionCommand = require('./transactions').isTransactionCommand;
 const resolveClusterTime = require('./topologies/shared').resolveClusterTime;
 const isSharded = require('./wireprotocol/shared').isSharded;
+const maxWireVersion = require('./utils').maxWireVersion;
 
 const MAX_FOR_TRANSACTIONS = 7;
 
@@ -191,8 +192,8 @@ class ClientSession extends EventEmitter {
       throw new MongoError('Transaction already in progress');
     }
 
-    const maxWireVersion = this.topology.lastIsMaster().maxWireVersion || {};
-    if (isSharded(this.topology) || maxWireVersion < MAX_FOR_TRANSACTIONS) {
+    const topologyMaxWireVersion = maxWireVersion(this.topology);
+    if (isSharded(this.topology) || topologyMaxWireVersion < MAX_FOR_TRANSACTIONS) {
       throw new MongoError('Transactions are not supported on sharded clusters in MongoDB < 4.2.');
     }
 

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -193,7 +193,7 @@ class ClientSession extends EventEmitter {
 
     const maxWireVersion = this.topology.lastIsMaster().maxWireVersion;
     if (isSharded(this.topology) || maxWireVersion < MAX_FOR_TRANSACTIONS) {
-      throw new MongoError('Transactions are not supported.');
+      throw new MongoError('Transactions are not supported on sharded clusters in MongoDB < 4.2.');
     }
 
     // increment txnNumber

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -191,7 +191,7 @@ class ClientSession extends EventEmitter {
       throw new MongoError('Transaction already in progress');
     }
 
-    const maxWireVersion = this.topology.lastIsMaster().maxWireVersion;
+    const maxWireVersion = this.topology.lastIsMaster().maxWireVersion || {};
     if (isSharded(this.topology) || maxWireVersion < MAX_FOR_TRANSACTIONS) {
       throw new MongoError('Transactions are not supported on sharded clusters in MongoDB < 4.2.');
     }

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -193,7 +193,10 @@ class ClientSession extends EventEmitter {
     }
 
     const topologyMaxWireVersion = maxWireVersion(this.topology);
-    if (isSharded(this.topology) || topologyMaxWireVersion < MAX_FOR_TRANSACTIONS) {
+    if (
+      isSharded(this.topology) ||
+      (topologyMaxWireVersion != null && topologyMaxWireVersion < MAX_FOR_TRANSACTIONS)
+    ) {
       throw new MongoError('Transactions are not supported on sharded clusters in MongoDB < 4.2.');
     }
 

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -15,6 +15,9 @@ const isPromiseLike = require('./utils').isPromiseLike;
 const ReadPreference = require('./topologies/read_preference');
 const isTransactionCommand = require('./transactions').isTransactionCommand;
 const resolveClusterTime = require('./topologies/shared').resolveClusterTime;
+const isSharded = require('./wireprotocol/shared').isSharded;
+
+const MAX_FOR_TRANSACTIONS = 7;
 
 function assertAlive(session, callback) {
   if (session.serverSession == null) {
@@ -186,6 +189,11 @@ class ClientSession extends EventEmitter {
     assertAlive(this);
     if (this.inTransaction()) {
       throw new MongoError('Transaction already in progress');
+    }
+
+    const maxWireVersion = this.topology.lastIsMaster().maxWireVersion;
+    if (isSharded(this.topology) || maxWireVersion < MAX_FOR_TRANSACTIONS) {
+      throw new MongoError('Transactions are not supported.');
     }
 
     // increment txnNumber

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -222,8 +222,9 @@ describe('Transactions', function() {
           'Transactions are not supported on sharded clusters in MongoDB < 4.2.'
         );
 
-        session.endSession(done);
-        sessionPool.endAllPooledSessions();
+        session.endSession(() => {
+          sessionPool.endAllPooledSessions(done);
+        });
       }
     });
 
@@ -242,8 +243,9 @@ describe('Transactions', function() {
           'Transactions are not supported on sharded clusters in MongoDB < 4.2.'
         );
 
-        session.endSession(done);
-        sessionPool.endAllPooledSessions();
+        session.endSession(() => {
+          sessionPool.endAllPooledSessions(done);
+        });
       }
     });
   });

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -210,41 +210,23 @@ describe('Transactions', function() {
     it('should error if transactions are not supported', {
       metadata: { requires: { topology: ['sharded'], mongodb: '>4.0.0' } },
       test: function(done) {
-        if (this.configuration.usingUnifiedTopology()) {
-          return this.skip();
-        }
+        const configuration = this.configuration;
+        const client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-        const topology = new core.Mongos();
-        const sessionPool = new sessions.ServerSessionPool(topology);
-        const session = new sessions.ClientSession(topology, sessionPool);
+        client.connect((err, client) => {
+          const session = client.startSession();
+          const db = client.db(configuration.db);
+          const coll = db.collection('transaction_error_test');
+          coll.insertOne({ a: 1 }, err => {
+            expect(err).to.not.exist;
+            expect(() => session.startTransaction()).to.throw(
+              'Transactions are not supported on sharded clusters in MongoDB < 4.2.'
+            );
 
-        expect(() => session.startTransaction()).to.throw(
-          'Transactions are not supported on sharded clusters in MongoDB < 4.2.'
-        );
-
-        session.endSession(() => {
-          sessionPool.endAllPooledSessions(done);
-        });
-      }
-    });
-
-    it('should error if transactions are not supported (unified topology)', {
-      metadata: { requires: { topology: ['sharded'], mongodb: '>4.0.0' } },
-      test: function(done) {
-        if (!this.configuration.usingUnifiedTopology()) {
-          return this.skip();
-        }
-
-        const topology = new core.Topology();
-        const sessionPool = new sessions.ServerSessionPool(topology);
-        const session = new sessions.ClientSession(topology, sessionPool);
-
-        expect(() => session.startTransaction()).to.throw(
-          'Transactions are not supported on sharded clusters in MongoDB < 4.2.'
-        );
-
-        session.endSession(() => {
-          sessionPool.endAllPooledSessions(done);
+            session.endSession(() => {
+              client.close(done);
+            });
+          });
         });
       }
     });

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -210,7 +210,7 @@ describe('Transactions', function() {
     it('should error if transactions are not supported', {
       metadata: { requires: { topology: ['sharded'], mongodb: '>4.0.0' } },
       test: function(done) {
-         if (this.configuration.usingUnifiedTopology()) {
+        if (this.configuration.usingUnifiedTopology()) {
           return this.skip();
         }
 
@@ -218,7 +218,9 @@ describe('Transactions', function() {
         const sessionPool = new sessions.ServerSessionPool(topology);
         const session = new sessions.ClientSession(topology, sessionPool);
 
-        expect(() => session.startTransaction()).to.throw('Transactions are not supported.');
+        expect(() => session.startTransaction()).to.throw(
+          'Transactions are not supported on sharded clusters in MongoDB < 4.2.'
+        );
 
         session.endSession(done);
         sessionPool.endAllPooledSessions();
@@ -228,7 +230,7 @@ describe('Transactions', function() {
     it('should error if transactions are not supported (unified topology)', {
       metadata: { requires: { topology: ['sharded'], mongodb: '>4.0.0' } },
       test: function(done) {
-         if (!this.configuration.usingUnifiedTopology()) {
+        if (!this.configuration.usingUnifiedTopology()) {
           return this.skip();
         }
 
@@ -236,7 +238,9 @@ describe('Transactions', function() {
         const sessionPool = new sessions.ServerSessionPool(topology);
         const session = new sessions.ClientSession(topology, sessionPool);
 
-        expect(() => session.startTransaction()).to.throw('Transactions are not supported.');
+        expect(() => session.startTransaction()).to.throw(
+          'Transactions are not supported on sharded clusters in MongoDB < 4.2.'
+        );
 
         session.endSession(done);
         sessionPool.endAllPooledSessions();

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -205,6 +205,28 @@ describe('Transactions', function() {
       }
     });
   });
+
+  describe('startTransaction', function() {
+    let session, sessionPool;
+    beforeEach(() => {
+      const topology = new core.Mongos();
+      sessionPool = new sessions.ServerSessionPool(topology);
+      session = new sessions.ClientSession(topology, sessionPool);
+    });
+
+    afterEach(() => {
+      sessionPool.endAllPooledSessions();
+    });
+
+    it('should error if transactions are not supported', {
+      metadata: { requires: { topology: ['sharded'], mongodb: '>4.0.0' } },
+      test: function(done) {
+        expect(() => session.startTransaction()).to.throw('Transactions are not supported.');
+
+        session.endSession(done);
+      }
+    });
+  });
 });
 
 function parseTopologies(topologies) {


### PR DESCRIPTION
Fixes NODE-1931

# Description
According to the 4.0 transaction spec, startTransaction SHOULD report an error if the driver can detect that transactions are not supported by the deployment. A deployment does not support transactions when the deployment does not support sessions, or maxWireVersion < 7, or the topology type is Sharded. This PR throws a new `MongoError` for sharded topologies and topologies with `maxWireVersion < 7`.

**What changed?**
`ClientSession.startTransaction` will throw a new `MongoError` when it is called on a sharded topology or on a topology where `maxWireVersion` is less than 7.
The test in `transactions_tests.js` shows that the error is thrown for a sharded topology.
