### PR TITLE
Change streams 4.2

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -416,8 +416,16 @@ var buildChangeStreamAggregationCommand = function(self) {
 
   // Map cursor options
   const cursorOptions = {
-    onInitialFetch: result => self.resumeCache.onAggregate(result, self.topology.lastIsMaster()),
-    onGetMore: result => self.resumeCache.onGetMore(result)
+    onInitialFetch: result => {
+      self.resumeCache.onAggregate(result, self.topology.lastIsMaster());
+      // NOTE: This is a private event and is explicitly NOT for external use
+      self.emit('onAggregate', result);
+    },
+    onGetMore: result => {
+      self.resumeCache.onGetMore(result);
+      // NOTE: This is a private event and is explicitly NOT for external use
+      self.emit('onGetMore', result);
+    }
   };
   cursorOptionNames.forEach(function(optionName) {
     if (options[optionName]) {
@@ -526,8 +534,6 @@ function processNewChange(args) {
     if (eventEmitter) {
       return;
     }
-
-    console.log(args);
 
     const error = new MongoError('ChangeStream is closed');
     return typeof callback === 'function'

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -34,6 +34,125 @@ const CHANGE_DOMAIN_TYPES = {
  * @return {ChangeStream} a ChangeStream instance.
  */
 
+class ResumeTokenChangedEvent {
+  constructor(resumeToken) {
+    this.resumeToken = resumeToken;
+  }
+}
+
+class ChangeStreamResumeCache extends EventEmitter {
+  constructor(options) {
+    super();
+    this.options = options;
+    this._init = false;
+  }
+
+  get resumeToken() {
+    return this._resumeToken;
+  }
+
+  set resumeToken(token) {
+    this._resumeToken = token;
+    this.emit('resumeTokenChanged', new ResumeTokenChangedEvent(this._resumeToken));
+  }
+
+  init() {
+    const options = this.options;
+    if (options.startAfter) {
+      this.resumeToken = options.startAfter;
+    } else if (options.resumeAfter) {
+      this.resumeToken = options.resumeAfter;
+    }
+
+    if (options.startAtOperationTime) {
+      this.operationTime = options.startAtOperationTime;
+    }
+    this._init = true;
+  }
+
+  onAggregate(response, ismaster) {
+    if (!response || !response.cursor) {
+      return;
+    }
+
+    const batch = response.cursor.firstBatch || [];
+    const postBatchResumeToken = response.cursor.postBatchResumeToken;
+
+    if (batch.length === 0 && postBatchResumeToken) {
+      if (postBatchResumeToken) {
+        this.resumeToken = postBatchResumeToken;
+      } else if (
+        !this.resumeToken &&
+        !this.operationTime &&
+        ismaster &&
+        ismaster.maxWireVersion >= 7
+      ) {
+        this.operationTime = response.operationTime;
+      }
+    }
+  }
+
+  onGetMore(response) {
+    if (!response || !response.cursor) {
+      return;
+    }
+
+    const batch = response.cursor.nextBatch || [];
+    const postBatchResumeToken = response.cursor.postBatchResumeToken;
+
+    if (batch.length === 0 && postBatchResumeToken) {
+      this.resumeToken = postBatchResumeToken;
+    }
+  }
+
+  onDocReturn(doc, cursor) {
+    if (cursor._needsToRequestMoreDocuments() && cursor.cursorState.postBatchResumeToken) {
+      this.resumeToken = cursor.cursorState.postBatchResumeToken;
+    } else if (doc._id) {
+      this.resumeToken = doc._id;
+    }
+  }
+
+  getResumeToken() {
+    return this.resumeToken;
+  }
+
+  getResumeOptions(ismaster) {
+    if (!this._init) {
+      return this._getPreInitResumeOptions();
+    }
+
+    const resumeAfter = this.getResumeToken();
+
+    if (resumeAfter) {
+      return { resumeAfter };
+    }
+
+    if (this.operationTime && ismaster.maxWireVersion >= 7) {
+      return { startAtOperationTime: this.startAtOperationTime };
+    }
+
+    return {};
+  }
+
+  _getPreInitResumeOptions() {
+    const resumeOptions = {};
+    if (this.options.resumeAfter) {
+      resumeOptions.resumeAfter = this.options.resumeAfter;
+    }
+
+    if (this.options.startAfter) {
+      resumeOptions.startAfter = this.options.startAfter;
+    }
+
+    if (this.options.startAtOperationTime) {
+      resumeOptions.startAtOperationTime;
+    }
+
+    return resumeOptions;
+  }
+}
+
 class ChangeStream extends EventEmitter {
   constructor(changeDomain, pipeline, options) {
     super();
@@ -69,16 +188,11 @@ class ChangeStream extends EventEmitter {
       this.options.readPreference = changeDomain.s.readPreference;
     }
 
-    // We need to get the operationTime as early as possible
-    const isMaster = this.topology.lastIsMaster();
-    if (!isMaster) {
-      throw new MongoError('Topology does not have an ismaster yet.');
-    }
-
-    this.operationTime = isMaster.operationTime;
-
     // Create contained Change Stream cursor
+    this.resumeCache = new ChangeStreamResumeCache(options);
     this.cursor = createChangeStreamCursor(this);
+    this.resumeCache.init();
+    this.resumeCache.on('resumeTokenChanged', e => this.emit('resumeTokenChanged', e));
 
     // Listen for any `change` listeners being added to ChangeStream
     this.on('newListener', eventName => {
@@ -124,8 +238,10 @@ class ChangeStream extends EventEmitter {
 
     return this.cursor
       .next()
-      .then(change => processNewChange({ changeStream: self, change, callback }))
-      .catch(error => processNewChange({ changeStream: self, error, callback }));
+      .then(
+        change => processNewChange({ changeStream: self, change, callback }),
+        error => processNewChange({ changeStream: self, error, callback })
+      );
   }
 
   /**
@@ -212,14 +328,25 @@ class ChangeStream extends EventEmitter {
   resume() {
     return this.cursor.resume();
   }
+
+  /**
+   * Returns the cached resume token that will be used to resume
+   * after the most recently returned change.
+   */
+  getResumeToken() {
+    return this.resumeCache.getResumeToken();
+  }
+
+  /**
+   * @deprecated use ChangeStream#getResumeToken instead
+   */
+  get resumeToken() {
+    return this.getResumeToken();
+  }
 }
 
 // Create a new change stream cursor based on self's configuration
 var createChangeStreamCursor = function(self) {
-  if (self.resumeToken) {
-    self.options.resumeAfter = self.resumeToken;
-  }
-
   var changeStreamCursor = buildChangeStreamAggregationCommand(self);
 
   /**
@@ -276,16 +403,7 @@ var createChangeStreamCursor = function(self) {
   return changeStreamCursor;
 };
 
-function getResumeToken(self) {
-  return self.resumeToken || self.options.resumeAfter;
-}
-
-function getStartAtOperationTime(self) {
-  const isMaster = self.topology.lastIsMaster() || {};
-  return (
-    isMaster.maxWireVersion && isMaster.maxWireVersion >= 7 && self.options.startAtOperationTime
-  );
-}
+// TODO: Throw on changestream error
 
 var buildChangeStreamAggregationCommand = function(self) {
   const topology = self.topology;
@@ -293,22 +411,14 @@ var buildChangeStreamAggregationCommand = function(self) {
   const pipeline = self.pipeline;
   const options = self.options;
 
-  var changeStreamStageOptions = {
-    fullDocument: options.fullDocument || 'default'
-  };
-
-  const resumeToken = getResumeToken(self);
-  const startAtOperationTime = getStartAtOperationTime(self);
-  if (resumeToken) {
-    changeStreamStageOptions.resumeAfter = resumeToken;
-  }
-
-  if (startAtOperationTime) {
-    changeStreamStageOptions.startAtOperationTime = startAtOperationTime;
-  }
+  const changeStreamStageOptions = self.resumeCache.getResumeOptions(topology.lastIsMaster());
+  changeStreamStageOptions.fullDocument = options.fullDocument || 'default';
 
   // Map cursor options
-  var cursorOptions = {};
+  const cursorOptions = {
+    onInitialFetch: result => self.resumeCache.onAggregate(result, self.topology.lastIsMaster()),
+    onGetMore: result => self.resumeCache.onGetMore(result)
+  };
   cursorOptionNames.forEach(function(optionName) {
     if (options[optionName]) {
       cursorOptions[optionName] = options[optionName];
@@ -355,6 +465,53 @@ function waitForTopologyConnected(topology, options, callback) {
   }, 3000); // this is an arbitrary wait time to allow SDAM to transition
 }
 
+function attemptResume(args) {
+  const changeStream = args.changeStream;
+  const callback = args.callback;
+  const eventEmitter = args.eventEmitter || false;
+
+  const topology = changeStream.topology;
+  const options = changeStream.cursor.options;
+
+  changeStream.attemptingResume = true;
+
+  // stop listening to all events from old cursor
+  ['data', 'close', 'end', 'error'].forEach(event => changeStream.cursor.removeAllListeners(event));
+
+  // close internal cursor, ignore errors
+  changeStream.cursor.close();
+
+  // attempt recreating the cursor
+  if (eventEmitter) {
+    waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
+      if (err) return changeStream.emit('error', err);
+      changeStream.cursor = createChangeStreamCursor(changeStream);
+    });
+
+    return;
+  }
+
+  if (callback) {
+    waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
+      if (err) return callback(err, null);
+
+      changeStream.cursor = createChangeStreamCursor(changeStream);
+      changeStream.next(callback);
+    });
+
+    return;
+  }
+
+  return new Promise((resolve, reject) => {
+    waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
+      if (err) return reject(err);
+      resolve();
+    });
+  })
+    .then(() => (changeStream.cursor = createChangeStreamCursor(changeStream)))
+    .then(() => changeStream.next());
+}
+
 // Handle new change events. This method brings together the routes from the callback, event emitter, and promise ways of using ChangeStream.
 function processNewChange(args) {
   const changeStream = args.changeStream;
@@ -370,61 +527,17 @@ function processNewChange(args) {
       return;
     }
 
+    console.log(args);
+
     const error = new MongoError('ChangeStream is closed');
     return typeof callback === 'function'
       ? callback(error, null)
       : changeStream.promiseLibrary.reject(error);
   }
 
-  const topology = changeStream.topology;
-  const options = changeStream.cursor.options;
-
   if (error) {
     if (isResumableError(error) && !changeStream.attemptingResume) {
-      changeStream.attemptingResume = true;
-
-      if (!(getResumeToken(changeStream) || getStartAtOperationTime(changeStream))) {
-        const startAtOperationTime = changeStream.cursor.cursorState.operationTime;
-        changeStream.options = Object.assign({ startAtOperationTime }, changeStream.options);
-      }
-
-      // stop listening to all events from old cursor
-      ['data', 'close', 'end', 'error'].forEach(event =>
-        changeStream.cursor.removeAllListeners(event)
-      );
-
-      // close internal cursor, ignore errors
-      changeStream.cursor.close();
-
-      // attempt recreating the cursor
-      if (eventEmitter) {
-        waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-          if (err) return changeStream.emit('error', err);
-          changeStream.cursor = createChangeStreamCursor(changeStream);
-        });
-
-        return;
-      }
-
-      if (callback) {
-        waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-          if (err) return callback(err, null);
-
-          changeStream.cursor = createChangeStreamCursor(changeStream);
-          changeStream.next(callback);
-        });
-
-        return;
-      }
-
-      return new Promise((resolve, reject) => {
-        waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-          if (err) return reject(err);
-          resolve();
-        });
-      })
-        .then(() => (changeStream.cursor = createChangeStreamCursor(changeStream)))
-        .then(() => changeStream.next());
+      return attemptResume(args);
     }
 
     if (eventEmitter) return changeStream.emit('error', error);
@@ -445,7 +558,7 @@ function processNewChange(args) {
     return changeStream.promiseLibrary.reject(noResumeTokenError);
   }
 
-  changeStream.resumeToken = change._id;
+  changeStream.resumeCache.onDocReturn(change, changeStream.cursor);
 
   // Return the change
   if (eventEmitter) return changeStream.emit('change', change);

--- a/lib/command_cursor.js
+++ b/lib/command_cursor.js
@@ -157,7 +157,8 @@ var methodsToInherit = [
   'isNotified',
   'isKilled',
   '_endSession',
-  '_initImplicitSession'
+  '_initImplicitSession',
+  '_needsToRequestMoreDocuments'
 ];
 
 // Only inherit the types we need

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -123,6 +123,14 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
     this.cursorState.cursorId = cmd;
     this.cursorState.lastCursorId = cmd;
   }
+
+  // Hooks that allow callbacks for wire protocol responses
+  if (options.onInitialFetch) {
+    this.cursorState._onInitialFetch = options.onInitialFetch;
+  }
+  if (options.onGetMore) {
+    this.cursorState._onGetMore = options.onGetMore;
+  }
 };
 
 Cursor.prototype.setCursorBatchSize = function(value) {
@@ -330,6 +338,13 @@ Cursor.prototype.rewind = function() {
   }
 };
 
+Cursor.prototype._needsToRequestMoreDocuments = function() {
+  return (
+    this.cursorState.cursorIndex === this.cursorState.documents.length &&
+    !Long.ZERO.equals(this.cursorState.cursorId)
+  );
+};
+
 /**
  * Validate if the pool is dead and return error
  */
@@ -434,10 +449,7 @@ var nextFunction = function(self, callback) {
     self.kill();
     // Set cursor in dead and notified state
     return setCursorDeadAndNotified(self, callback);
-  } else if (
-    self.cursorState.cursorIndex === self.cursorState.documents.length &&
-    !Long.ZERO.equals(self.cursorState.cursorId)
-  ) {
+  } else if (self._needsToRequestMoreDocuments()) {
     // Ensure an empty cursor state
     self.cursorState.documents = [];
     self.cursorState.cursorIndex = 0;
@@ -604,7 +616,10 @@ function initializeCursor(cursor, callback) {
       return callback(new MongoError(`server ${cursor.server.name} does not support collation`));
     }
 
-    function done() {
+    function done(result) {
+      if (cursor.cursorState._onInitialFetch) {
+        cursor.cursorState._onInitialFetch(result);
+      }
       if (
         cursor.cursorState.cursorId &&
         cursor.cursorState.cursorId.isZero() &&
@@ -670,8 +685,14 @@ function initializeCursor(cursor, callback) {
             cursor.cursorState.documents = result.documents[0].cursor.firstBatch; //.reverse();
           }
 
+          // Store postBatchResumeToken for changeStreams
+          if (result.documents[0].cursor.postBatchResumeToken) {
+            cursor.cursorState.postBatchResumeToken =
+              result.documents[0].cursor.postBatchResumeToken;
+          }
+
           // Return after processing command cursor
-          return done(result);
+          return done(result.documents[0]);
         }
 
         if (Array.isArray(result.documents[0].result)) {

--- a/lib/core/wireprotocol/get_more.js
+++ b/lib/core/wireprotocol/get_more.js
@@ -51,6 +51,17 @@ function getMore(server, ns, cursorState, batchSize, options, callback) {
     cursorState.documents = response.documents[0].cursor.nextBatch;
     cursorState.cursorId = cursorId;
 
+    // Store postBatchResumeToken for changeStreams
+    if (response.documents[0].cursor.postBatchResumeToken) {
+      cursorState.postBatchResumeToken = response.documents[0].cursor.postBatchResumeToken;
+    } else {
+      delete cursorState.postBatchResumeToken;
+    }
+
+    if (cursorState._onGetMore) {
+      cursorState._onGetMore(response.documents[0]);
+    }
+
     callback(null, response.documents[0], response.connection);
   }
 

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -1774,7 +1774,7 @@ describe('Change Streams', function() {
     });
   });
 
-  describe('4.2 Prose Tests', function() {
+  describe('getResumeToken', function() {
     class MockServerManager {
       constructor(config, commandIterators) {
         this.config = config;
@@ -1801,6 +1801,52 @@ describe('Change Streams', function() {
             }
             request.reply(this.applyOpTime(response));
           });
+
+          this.client = this.config.newClient(this.mongodbURI, { monitorCommands: true });
+          return this.client.connect().then(() => {
+            this.apm = { started: [], succeeded: [], failed: [] };
+            [
+              ['commandStared', this.apm.started],
+              ['commandSucceeded', this.apm.succeeded],
+              ['commandFailed', this.apm.failed]
+            ].forEach(opts => {
+              const eventName = opts[0];
+              const target = opts[1];
+
+              this.client.on(eventName, e => {
+                if (e.commandName === 'aggregate' || e.commandName === 'getMore') {
+                  target.push(e);
+                }
+              });
+            });
+          });
+        });
+      }
+
+      makeChangeStream(options) {
+        this.changeStream = this.client
+          .db(this.database)
+          .collection(this.collection)
+          .watch(options);
+        this.resumeTokenChangedEvents = [];
+
+        this.changeStream.on('resumeTokenChanged', e => this.resumeTokenChangedEvents.push(e));
+
+        return this.changeStream;
+      }
+
+      teardown(e) {
+        let promise = Promise.resolve();
+        if (this.changeStream) {
+          promise = promise.then(() => this.changeStream.close()).catch();
+        }
+        if (this.client) {
+          promise = promise.then(() => this.client.close()).catch();
+        }
+        return promise.then(function() {
+          if (e) {
+            throw e;
+          }
         });
       }
 
@@ -1921,72 +1967,533 @@ describe('Change Streams', function() {
     //   The batch is empty or has been iterated to the last document.
     // Expected result:
     //   getResumeToken must return the postBatchResumeToken from the current command response.
-    it('should properly store postBatchResumeToken when batch is empty', function() {
-      const manager = new MockServerManager(this.configuration, {
-        aggregate: (function*() {
-          yield { numDocuments: 0, postBatchResumeToken: true };
-        })(),
-        getMore: (function*() {
-          yield { numDocuments: 1, postBatchResumeToken: false };
-        })()
-      });
-      let client;
-      let changeStream;
-      const commandSucceededEvents = [];
-      const resumeTokenChangedEvents = [];
-
-      function cleanup(err, r) {
-        return Promise.resolve()
-          .then(() => changeStream && changeStream.close())
-          .then(() => client && client.close())
-          .catch()
-          .then(() => {
-            if (err) {
-              throw err;
-            }
-            return r;
-          });
-      }
-
-      return manager
-        .ready()
-        .then(() => {
-          client = this.configuration.newClient(manager.mongodbURI, { monitorCommands: true });
-          return client.connect();
-        })
-        .then(() => {
-          client.on('commandSucceeded', e => {
-            if (e.commandName === 'aggregate' || e.commandName === 'getMore') {
-              commandSucceededEvents.push(e);
-            }
-          });
-          changeStream = client
-            .db(manager.database)
-            .collection(manager.collection)
-            .watch();
-
-          changeStream.on('resumeTokenChanged', e => resumeTokenChangedEvents.push(e));
-          return changeStream.next();
-        })
-        .then(() => cleanup(), err => cleanup(err))
-        .then(() => {
-          expect(commandSucceededEvents).to.have.a.lengthOf(2);
-          expect(resumeTokenChangedEvents).to.have.a.lengthOf(2);
-
-          expect(commandSucceededEvents[0])
-            .to.have.a.nested.property('reply.cursor.postBatchResumeToken')
-            .that.deep.equals(resumeTokenChangedEvents[0].resumeToken);
-          expect(commandSucceededEvents[0])
-            .to.have.a.nested.property('reply.cursor.postBatchResumeToken')
-            .that.does.not.deep.equal(resumeTokenChangedEvents[1].resumeToken);
-
-          expect(commandSucceededEvents[1])
-            .to.have.a.nested.property('reply.cursor.nextBatch[0]._id')
-            .that.does.not.deep.equal(resumeTokenChangedEvents[0].resumeToken);
-          expect(commandSucceededEvents[1])
-            .to.have.a.nested.property('reply.cursor.nextBatch[0]._id')
-            .that.deep.equal(resumeTokenChangedEvents[1].resumeToken);
+    describe('for emptied batch on server >= 4.0.7', function() {
+      it('must return the postBatchResumeToken from the current command response', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: true };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 1, postBatchResumeToken: true };
+          })()
         });
+
+        return manager
+          .ready()
+          .then(() => {
+            return manager.makeChangeStream().next();
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            const tokens = manager.resumeTokenChangedEvents.map(e => e.resumeToken);
+            const successes = manager.apm.succeeded.map(e => {
+              try {
+                return e.reply.cursor;
+              } catch (e) {
+                return {};
+              }
+            });
+
+            expect(successes).to.have.a.lengthOf(2);
+            expect(successes[0]).to.have.a.property('postBatchResumeToken');
+            expect(successes[1]).to.have.a.property('postBatchResumeToken');
+            expect(successes[1]).to.have.a.nested.property('nextBatch[0]._id');
+
+            expect(tokens).to.have.a.lengthOf(2);
+            expect(tokens[0]).to.deep.equal(successes[0].postBatchResumeToken);
+            expect(tokens[1])
+              .to.deep.equal(successes[1].postBatchResumeToken)
+              .and.to.not.deep.equal(successes[1].nextBatch[0]._id);
+          });
+      });
+    });
+
+    // For a ChangeStream under these conditions:
+    //   Running against a server <4.0.7.
+    //   The batch is empty or has been iterated to the last document.
+    // Expected result:
+    //   getResumeToken must return the _id of the last document returned if one exists.
+    //   getResumeToken must return startAfter from the initial aggregate if the option was specified.
+    //   getResumeToken must return resumeAfter from the initial aggregate if the option was specified.
+    //   If neither the startAfter nor resumeAfter options were specified, the getResumeToken result must be empty.
+    describe('for emptied batch on server <= 4.0.7', function() {
+      it('must return the _id of the last document returned if one exists', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 1, postBatchResumeToken: false };
+          })()
+        });
+
+        return manager
+          .ready()
+          .then(() => {
+            return manager.makeChangeStream().next();
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            const tokens = manager.resumeTokenChangedEvents.map(e => e.resumeToken);
+            const successes = manager.apm.succeeded.map(e => {
+              try {
+                return e.reply.cursor;
+              } catch (e) {
+                return {};
+              }
+            });
+
+            expect(successes).to.have.a.lengthOf(2);
+            expect(successes[1]).to.have.a.nested.property('nextBatch[0]._id');
+
+            expect(tokens).to.have.a.lengthOf(1);
+            expect(tokens[0]).to.deep.equal(successes[1].nextBatch[0]._id);
+          });
+      });
+      it('must return startAfter from the initial aggregate if the option was specified', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })()
+        });
+        let token;
+        const startAfter = manager.resumeToken();
+        const resumeAfter = manager.resumeToken();
+
+        return manager
+          .ready()
+          .then(() => {
+            return new Promise(resolve => {
+              const changeStream = manager.makeChangeStream({ startAfter, resumeAfter });
+              changeStream.once('onGetMore', () => {
+                token = changeStream.getResumeToken();
+                resolve();
+              });
+
+              // Note: this is expected to fail
+              changeStream.next().catch(() => {});
+            });
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            expect(token)
+              .to.deep.equal(startAfter)
+              .and.to.not.deep.equal(resumeAfter);
+          });
+      });
+      it('must return resumeAfter from the initial aggregate if the option was specified', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })()
+        });
+        let token;
+        const resumeAfter = manager.resumeToken();
+
+        return manager
+          .ready()
+          .then(() => {
+            return new Promise(resolve => {
+              const changeStream = manager.makeChangeStream({ resumeAfter });
+              changeStream.once('onGetMore', () => {
+                token = changeStream.getResumeToken();
+                resolve();
+              });
+
+              // Note: this is expected to fail
+              changeStream.next().catch(() => {});
+            });
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            expect(token).to.deep.equal(resumeAfter);
+          });
+      });
+      it('must be empty if neither the startAfter nor resumeAfter options were specified', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })()
+        });
+        let token;
+
+        return manager
+          .ready()
+          .then(() => {
+            return new Promise(resolve => {
+              const changeStream = manager.makeChangeStream();
+              changeStream.once('onGetMore', () => {
+                token = changeStream.getResumeToken();
+                resolve();
+              });
+
+              // Note: this is expected to fail
+              changeStream.next().catch(() => {});
+            });
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            expect(token).to.not.exist;
+          });
+      });
+    });
+
+    // For a ChangeStream under these conditions:
+    //   The batch is not empty.
+    //   The batch has been iterated up to but not including the last element.
+    // Expected result:
+    //   getResumeToken must return the _id of the previous document returned.
+    describe('for non-empty batch iterated up to but not including the last element', function() {
+      it('must return the _id of the previous document returned', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 2, postBatchResumeToken: true };
+          })(),
+          getMore: (function*() {})()
+        });
+
+        return manager
+          .ready()
+          .then(() => {
+            return manager.makeChangeStream().next();
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            const tokens = manager.resumeTokenChangedEvents.map(e => e.resumeToken);
+            const successes = manager.apm.succeeded.map(e => {
+              try {
+                return e.reply.cursor;
+              } catch (e) {
+                return {};
+              }
+            });
+
+            expect(successes).to.have.a.lengthOf(1);
+            expect(successes[0]).to.have.a.nested.property('firstBatch[0]._id');
+            expect(successes[0]).to.have.a.property('postBatchResumeToken');
+
+            expect(tokens).to.have.a.lengthOf(1);
+            expect(tokens[0])
+              .to.deep.equal(successes[0].firstBatch[0]._id)
+              .and.to.not.deep.equal(successes[0].postBatchResumeToken);
+          });
+      });
+    });
+
+    // For a ChangeStream under these conditions:
+    //   The batch is not empty.
+    //   The batch hasn’t been iterated at all.
+    //   Only the initial aggregate command has been executed.
+    // Expected result:
+    //   getResumeToken must return startAfter from the initial aggregate if the option was specified.
+    //   getResumeToken must return resumeAfter from the initial aggregate if the option was specified.
+    //   If neither the startAfter nor resumeAfter options were specified, the getResumeToken result must be empty.
+    describe('for non-empty non-iterated batch where only the initial aggregate command has been executed', function() {
+      it('must return startAfter from the initial aggregate if the option was specified', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })()
+        });
+        let token;
+        const startAfter = manager.resumeToken();
+        const resumeAfter = manager.resumeToken();
+
+        return manager
+          .ready()
+          .then(() => {
+            return new Promise(resolve => {
+              const changeStream = manager.makeChangeStream({ startAfter, resumeAfter });
+              changeStream.once('onAggregate', () => {
+                token = changeStream.getResumeToken();
+                resolve();
+              });
+
+              // Note: this is expected to fail
+              changeStream.next().catch(() => {});
+            });
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            expect(token)
+              .to.deep.equal(startAfter)
+              .and.to.not.deep.equal(resumeAfter);
+          });
+      });
+      it('must return resumeAfter from the initial aggregate if the option was specified', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })()
+        });
+        let token;
+        const resumeAfter = manager.resumeToken();
+
+        return manager
+          .ready()
+          .then(() => {
+            return new Promise(resolve => {
+              const changeStream = manager.makeChangeStream({ resumeAfter });
+              changeStream.once('onAggregate', () => {
+                token = changeStream.getResumeToken();
+                resolve();
+              });
+
+              // Note: this is expected to fail
+              changeStream.next().catch(() => {});
+            });
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            expect(token).to.deep.equal(resumeAfter);
+          });
+      });
+      it('must be empty if neither the startAfter nor resumeAfter options were specified', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })()
+        });
+        let token;
+
+        return manager
+          .ready()
+          .then(() => {
+            return new Promise(resolve => {
+              const changeStream = manager.makeChangeStream();
+              changeStream.once('onAggregate', () => {
+                token = changeStream.getResumeToken();
+                resolve();
+              });
+
+              // Note: this is expected to fail
+              changeStream.next().catch(() => {});
+            });
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            expect(token).to.not.exist;
+          });
+      });
+    });
+
+    // For a ChangeStream under these conditions:
+    //   Running against a server >=4.0.7.
+    //   The batch is not empty.
+    //   The batch hasn’t been iterated at all.
+    //   The stream has iterated beyond a previous batch and a getMore command has just been executed.
+    // Expected result:
+    //   getResumeToken must return the postBatchResumeToken from the previous command response.
+    describe('for non-empty non-iterated batch where getMore has just been executed against server >=4.0.7', function() {
+      it('must return the postBatchResumeToken from the previous command response', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 1, postBatchResumeToken: true };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 1, postBatchResumeToken: true };
+          })()
+        });
+        let token;
+        const startAfter = manager.resumeToken();
+        const resumeAfter = manager.resumeToken();
+
+        return manager
+          .ready()
+          .then(() => {
+            return manager.makeChangeStream({ startAfter, resumeAfter }).next();
+          })
+          .then(() => {
+            manager.changeStream.once('onGetMore', () => {
+              token = manager.changeStream.getResumeToken();
+            });
+
+            // Note: this is expected to fail
+            return manager.changeStream.next();
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            const successes = manager.apm.succeeded.map(e => {
+              try {
+                return e.reply.cursor;
+              } catch (e) {
+                return {};
+              }
+            });
+
+            expect(successes).to.have.a.lengthOf(2);
+            expect(successes[0]).to.have.a.property('postBatchResumeToken');
+            expect(successes[0]).to.have.a.nested.property('firstBatch[0]._id');
+
+            expect(token)
+              .to.deep.equal(successes[0].postBatchResumeToken)
+              .and.to.not.deep.equal(successes[0].firstBatch[0]._id)
+              .and.to.not.deep.equal(startAfter)
+              .and.to.not.deep.equal(resumeAfter);
+          });
+      });
+    });
+
+    // For a ChangeStream under these conditions:
+    //   Running against a server <4.0.7.
+    //   The batch is not empty.
+    //   The batch hasn’t been iterated at all.
+    //   The stream has iterated beyond a previous batch and a getMore command has just been executed.
+    // Expected result:
+    //   getResumeToken must return the _id of the previous document returned if one exists.
+    //   getResumeToken must return startAfter from the initial aggregate if the option was specified.
+    //   getResumeToken must return resumeAfter from the initial aggregate if the option was specified.
+    //   If neither the startAfter nor resumeAfter options were specified, the getResumeToken result must be empty.
+    describe('for non-empty non-iterated batch where getMore has just been executed against server < 4.0.7', function() {
+      it('must return the _id of the previous document returned if one exists', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 1, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 1, postBatchResumeToken: false };
+          })()
+        });
+        let token;
+        const startAfter = manager.resumeToken();
+        const resumeAfter = manager.resumeToken();
+
+        return manager
+          .ready()
+          .then(() => {
+            return manager.makeChangeStream({ startAfter, resumeAfter }).next();
+          })
+          .then(() => {
+            manager.changeStream.once('onGetMore', () => {
+              token = manager.changeStream.getResumeToken();
+            });
+
+            // Note: this is expected to fail
+            return manager.changeStream.next();
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            const successes = manager.apm.succeeded.map(e => {
+              try {
+                return e.reply.cursor;
+              } catch (e) {
+                return {};
+              }
+            });
+
+            expect(successes).to.have.a.lengthOf(2);
+            expect(successes[0]).to.have.a.nested.property('firstBatch[0]._id');
+
+            expect(token)
+              .to.deep.equal(successes[0].firstBatch[0]._id)
+              .and.to.not.deep.equal(startAfter)
+              .and.to.not.deep.equal(resumeAfter);
+          });
+      });
+      it('must return startAfter from the initial aggregate if the option was specified', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 1, postBatchResumeToken: false };
+          })()
+        });
+        let token;
+        const startAfter = manager.resumeToken();
+        const resumeAfter = manager.resumeToken();
+
+        return manager
+          .ready()
+          .then(() => {
+            const changeStream = manager.makeChangeStream({ startAfter, resumeAfter });
+            changeStream.once('onGetMore', () => {
+              token = changeStream.getResumeToken();
+            });
+
+            // Note: this is expected to fail
+            return changeStream.next();
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            expect(token)
+              .to.deep.equal(startAfter)
+              .and.to.not.deep.equal(resumeAfter);
+          });
+      });
+      it('must return resumeAfter from the initial aggregate if the option was specified', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 1, postBatchResumeToken: false };
+          })()
+        });
+        let token;
+        const resumeAfter = manager.resumeToken();
+
+        return manager
+          .ready()
+          .then(() => {
+            const changeStream = manager.makeChangeStream({ resumeAfter });
+            changeStream.once('onGetMore', () => {
+              token = changeStream.getResumeToken();
+            });
+
+            // Note: this is expected to fail
+            return changeStream.next();
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            expect(token).to.deep.equal(resumeAfter);
+          });
+      });
+      it('must be empty if neither the startAfter nor resumeAfter options were specified', function() {
+        const manager = new MockServerManager(this.configuration, {
+          aggregate: (function*() {
+            yield { numDocuments: 0, postBatchResumeToken: false };
+          })(),
+          getMore: (function*() {
+            yield { numDocuments: 1, postBatchResumeToken: false };
+          })()
+        });
+        let token;
+
+        return manager
+          .ready()
+          .then(() => {
+            const changeStream = manager.makeChangeStream();
+            changeStream.once('onGetMore', () => {
+              token = changeStream.getResumeToken();
+            });
+
+            // Note: this is expected to fail
+            return changeStream.next();
+          })
+          .then(() => manager.teardown(), err => manager.teardown(err))
+          .then(() => {
+            expect(token).to.not.exist;
+          });
+      });
     });
   });
 });

--- a/test/functional/spec/change-stream/README.rst
+++ b/test/functional/spec/change-stream/README.rst
@@ -33,7 +33,7 @@ Each YAML file has the following keys:
   - ``description``: The name of the test.
   - ``minServerVersion``: The minimum server version to run this test against. If not present, assume there is no minimum server version.
   - ``maxServerVersion``: Reserved for later use
-  - ``failPoint``: Reserved for later use
+  - ``failPoint``(optional): The configureFailPoint command document to run to configure a fail point on the primary server.
   - ``target``: The entity on which to run the change stream. Valid values are:
   
     - ``collection``: Watch changes on collection ``database_name.collection_name``
@@ -44,10 +44,11 @@ Each YAML file has the following keys:
   - ``changeStreamPipeline``: An array of additional aggregation pipeline stages to add to the change stream
   - ``changeStreamOptions``: Additional options to add to the changeStream
   - ``operations``: Array of documents, each describing an operation. Each document has the following fields:
+
     - ``database``: Database against which to run the operation
     - ``collection``: Collection against which to run the operation
-    - ``commandName``: Name of the command to run
-    - ``arguments``: Object of arguments for the command (ex: document to insert)
+    - ``name``: Name of the command to run
+    - ``arguments`` (optional): Object of arguments for the command (ex: document to insert)
 
   - ``expectations``: Optional list of command-started events in Extended JSON format
   - ``result``: Document with ONE of the following fields:
@@ -103,6 +104,9 @@ For each YAML file, for each element in ``tests``:
   - Drop the database ``database2_name``
   - Create the database ``database_name`` and the collection ``database_name.collection_name``
   - Create the database ``database2_name`` and the collection ``database2_name.collection2_name``
+  - If the the ``failPoint`` field is present, configure the fail point on the primary server. See
+    `Server Fail Point <../../transactions/tests#server-fail-point>`_ in the
+    Transactions spec test documentation for more information.
 
 - Create a new MongoClient ``client``
 - Begin monitoring all APM events for ``client``. (If the driver uses global listeners, filter out all events that do not originate with ``client``). Filter out any "internal" commands (e.g. ``isMaster``)
@@ -117,12 +121,12 @@ For each YAML file, for each element in ``tests``:
 - If there was an error:
 
   - Assert that an error was expected for the test.
-  - Assert that the error MATCHES ``results.error``
+  - Assert that the error MATCHES ``result.error``
 
 - Else:
 
   - Assert that no error was expected for the test
-  - Assert that the changes received from ``changeStream`` MATCH the results in ``results.success``
+  - Assert that the changes received from ``changeStream`` MATCH the results in ``result.success``
 
 - If there are any ``expectations``
 
@@ -144,12 +148,56 @@ Prose Tests
 
 The following tests have not yet been automated, but MUST still be tested
 
-1. ``ChangeStream`` must continuously track the last seen ``resumeToken``
-2. ``ChangeStream`` will throw an exception if the server response is missing the resume token
-3. ``ChangeStream`` will automatically resume one time on a resumable error (including `not master`) with the initial pipeline and options, except for the addition/update of a ``resumeToken``.
-4. ``ChangeStream`` will not attempt to resume on a server error
-5. ``ChangeStream`` will perform server selection before attempting to resume, using initial ``readPreference``
-6. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
-7. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
-8. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a changestream.
-9. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.
+#. ``ChangeStream`` must continuously track the last seen ``resumeToken``
+#. ``ChangeStream`` will throw an exception if the server response is missing the resume token (if wire version is < 8)
+#. ``ChangeStream`` will automatically resume one time on a resumable error (including `not master`) with the initial pipeline and options, except for the addition/update of a ``resumeToken``.
+#. ``ChangeStream`` will not attempt to resume on any error encountered while executing an ``aggregate`` command.
+#. ``ChangeStream`` will not attempt to resume after encountering error code 11601 (Interrupted), 136 (CappedPositionLost), or 237 (CursorKilled) while executing a ``getMore`` command.
+#. ``ChangeStream`` will perform server selection before attempting to resume, using initial ``readPreference``
+#. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
+#. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
+#. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` and ``<4.0.7`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a changestream.
+#. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.
+#. - For a ``ChangeStream`` under these conditions:
+      - Running against a server ``>=4.0.7``.
+      - The batch is empty or has been iterated to the last document.
+   - Expected result: 
+       - ``getResumeToken`` must return the ``postBatchResumeToken`` from the current command response.
+#. - For a ``ChangeStream`` under these conditions:
+      - Running against a server ``<4.0.7``.
+      - The batch is empty or has been iterated to the last document.
+   - Expected result: 
+      - ``getResumeToken`` must return the ``_id`` of the last document returned if one exists.
+      - ``getResumeToken`` must return ``startAfter`` from the initial aggregate if the option was specified.
+      - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
+      - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.
+#. - For a ``ChangeStream`` under these conditions:
+      - The batch is not empty.
+      - The batch has been iterated up to but not including the last element.
+   - Expected result:
+      - ``getResumeToken`` must return the ``_id`` of the previous document returned.
+#. - For a ``ChangeStream`` under these conditions:
+      - The batch is not empty.
+      - The batch hasn’t been iterated at all.
+      - Only the initial ``aggregate`` command has been executed.
+   - Expected result:
+      - ``getResumeToken`` must return ``startAfter`` from the initial aggregate if the option was specified.
+      - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
+      - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.
+#. - For a ``ChangeStream`` under these conditions:
+      - Running against a server ``>=4.0.7``.
+      - The batch is not empty.
+      - The batch hasn’t been iterated at all.
+      - The stream has iterated beyond a previous batch and a ``getMore`` command has just been executed.
+   - Expected result:
+      - ``getResumeToken`` must return the ``postBatchResumeToken`` from the previous command response.
+#. - For a ``ChangeStream`` under these conditions:
+      - Running against a server ``<4.0.7``.
+      - The batch is not empty.
+      - The batch hasn’t been iterated at all.
+      - The stream has iterated beyond a previous batch and a ``getMore`` command has just been executed.
+   - Expected result:
+      - ``getResumeToken`` must return the ``_id`` of the previous document returned if one exists.
+      - ``getResumeToken`` must return ``startAfter`` from the initial aggregate if the option was specified.
+      - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
+      - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.

--- a/test/functional/spec/change-stream/change-streams-errors.json
+++ b/test/functional/spec/change-stream/change-streams-errors.json
@@ -73,6 +73,43 @@
           "code": 40324
         }
       }
+    },
+    {
+      "description": "Change Stream should error when _id is projected out",
+      "minServerVersion": "4.1.11",
+      "target": "collection",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ],
+      "changeStreamPipeline": [
+        {
+          "$project": {
+            "_id": 0
+          }
+        }
+      ],
+      "changeStreamOptions": {},
+      "operations": [
+        {
+          "database": "change-stream-tests",
+          "collection": "test",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "z": 3
+            }
+          }
+        }
+      ],
+      "result": {
+        "error": {
+          "code": 280,
+          "errorLabels": [
+            "NonResumableChangeStreamError"
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/functional/spec/change-stream/change-streams-errors.yml
+++ b/test/functional/spec/change-stream/change-streams-errors.yml
@@ -51,3 +51,26 @@ tests:
     result:
       error:
         code: 40324
+  -
+    description: Change Stream should error when _id is projected out
+    minServerVersion: "4.1.11"
+    target: collection
+    topology:
+      - replicaset
+      - sharded
+    changeStreamPipeline:
+      -
+        $project: { _id: 0 }
+    changeStreamOptions: {}
+    operations:
+      -
+        database: *database_name
+        collection: *collection_name
+        name: insertOne
+        arguments:
+          document:
+            z: 3
+    result:
+      error:
+        code: 280
+        errorLabels: [ "NonResumableChangeStreamError" ]

--- a/test/functional/spec/change-stream/change-streams.json
+++ b/test/functional/spec/change-stream/change-streams.json
@@ -675,6 +675,123 @@
           }
         ]
       }
+    },
+    {
+      "description": "Test consecutive resume",
+      "minServerVersion": "4.1.7",
+      "target": "collection",
+      "topology": [
+        "replicaset"
+      ],
+      "changeStreamPipeline": [],
+      "changeStreamOptions": {
+        "batchSize": 1
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "getMore"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "database": "change-stream-tests",
+          "collection": "test",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "database": "change-stream-tests",
+          "collection": "test",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "x": 2
+            }
+          }
+        },
+        {
+          "database": "change-stream-tests",
+          "collection": "test",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "x": 3
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "cursor": {
+                "batchSize": 1
+              },
+              "pipeline": [
+                {
+                  "$changeStream": {
+                    "fullDocument": "default"
+                  }
+                }
+              ]
+            },
+            "command_name": "aggregate",
+            "database_name": "change-stream-tests"
+          }
+        }
+      ],
+      "result": {
+        "success": [
+          {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "x": {
+                "$numberInt": "1"
+              }
+            }
+          },
+          {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "x": {
+                "$numberInt": "2"
+              }
+            }
+          },
+          {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "x": {
+                "$numberInt": "3"
+              }
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/test/functional/spec/change-stream/change-streams.yml
+++ b/test/functional/spec/change-stream/change-streams.yml
@@ -456,3 +456,79 @@ tests:
             coll: *collection_name
         -
           operationType: invalidate
+  # Test that resume logic works correctly even after consecutive retryable failures of a getMore command,
+  # with no intervening events.  This is ensured by setting the batch size of the change stream to 1,
+  -
+    description: Test consecutive resume
+    minServerVersion: "4.1.7"
+    target: collection
+    topology:
+      - replicaset
+    changeStreamPipeline: []
+    changeStreamOptions: { batchSize: 1}
+    failPoint:
+      configureFailPoint: failCommand
+      mode: {times: 2}
+      data:
+          failCommands: ["getMore"]
+          closeConnection: true
+    operations:
+      -
+        database: *database_name
+        collection: *collection_name
+        name: insertOne
+        arguments:
+          document:
+            x: 1
+      -
+        database: *database_name
+        collection: *collection_name
+        name: insertOne
+        arguments:
+          document:
+            x: 2
+      -
+        database: *database_name
+        collection: *collection_name
+        name: insertOne
+        arguments:
+          document:
+            x: 3
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            cursor: {batchSize: 1}
+            pipeline:
+              -
+                $changeStream:
+                  fullDocument: default
+          command_name: aggregate
+          database_name: *database_name
+    result:
+      success:
+        -
+          operationType: insert
+          ns:
+            db: *database_name
+            coll: *collection_name
+          fullDocument:
+            x:
+              $numberInt: "1"
+        -
+          operationType: insert
+          ns:
+            db: *database_name
+            coll: *collection_name
+          fullDocument:
+            x:
+              $numberInt: "2"
+        -
+          operationType: insert
+          ns:
+            db: *database_name
+            coll: *collection_name
+          fullDocument:
+            x:
+              $numberInt: "3"


### PR DESCRIPTION
# Description

ChangeStream's now need to support both the user-provided `startAfter` and the `postBatchResumeToken`. Because of the way that `postBatchResumeToken` is collected, this involved a few low-level plumbing changes inside the core cursor / wireprotocol.

**What changed?**

+ `lib/core/cursor.js` and `lib/core/wireprotocol/get_more.js`: Added two hooks to the `cursorState` that are called whenever a fetch or getMore return with valid results. The hook is used by `changeStream` to ensure that when a postBatchResumeToken returns with an empty batch, the value can be captured. Also created a helper method `_needsToRequestMoreDocuments` on the cursor since that check needs to be used by `changeStream`
+ `lib/change_stream.js`:
  + Added support for the `startAfter` field
    + **TODO: Needs to be documented**
  + Consolidates all logic involving resume tokens / values (`startAfter`, `resumeAfter`, `startAtOperationTime`, `postBatchResumeToken`, etc.) into a class `ChangeStreamResumeCache` that acts as the state machine for what the resume token is at any given moment.
  + Added a new event `resumeTokenChanged` that emits whenever the resume token has changed.
    + **TODO: Needs to be documented**
  + Added accessor method `getResumeToken` to synchronously get the resume token at any given time.
+ `test/functional/change_stream_tests.js`: Added a big helper object `MockServerManager` to help with mock tests for change streams. Used it to implement one of the new prose tests
  + **TODO: Implement the remaining prose tests**

**Are there any files to ignore?**
Everything in `test/functional/spec/` is just resyncing tests and can be ignored

**Specific things I'd like feedback on in addition to review**
+ `ChangeStreamResumeCache#onGetMore` winds up reaching deep into the cursor, which is kind of disappointing. Ideally, I'd like to remove the coreCursor as a source of truth for resume tokens, probably via another hook. I'd love some thoughts on the issue.
+ `MockServerManager` is a monstrosity, but the functionality it performs is necessary to properly control the state of the change stream tests. I am thinking of a few things:
  1. Moving all these mock tests to a separate file, and essentially making a single test runner for these specific tests.
  2. Making a generic version of `MockServerManager` to use in other tests that use the mock server.

This PR will wind up resolving:
+ [NODE-1824](https://jira.mongodb.org/browse/NODE-1824)
+ [NODE-1866](https://jira.mongodb.org/browse/NODE-1866)
+ [NODE-1949](https://jira.mongodb.org/browse/NODE-1949)
+ [NODE-1979](https://jira.mongodb.org/browse/NODE-1979)