### PR TITLE
Ignore prototype methods in config validation

### DIFF
--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -590,7 +590,7 @@ function validOptions(options) {
   const _validOptions = validOptionNames.concat(legacyOptionNames);
 
   for (const name in options) {
-    if (ignoreOptionNames.indexOf(name) !== -1) {
+    if (ignoreOptionNames.indexOf(name) !== -1 || !options.hasOwnProperty(name)) {
       continue;
     }
 


### PR DESCRIPTION
# Description

This pull request fixes the unnecessary `the options [x] is not supported` warnings when extending the `Object.prototype` object for custom functions. For example, using the following code:
```js
Object.prototype.custom = function () { return true; };
```

... would report this to console when you try to create a new Mongo client:

`the options [custom] is not supported`

**What changed?**
On line 593 of the file that validates config files, it checks to make sure that the key it is checking is an actual property within the object, instead of prototype function.

**Are there any files to ignore?**
Nope