### PR TITLE
fix(ClientSessions): initialize clientOptions and cluster time

### DIFF
--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -83,7 +83,7 @@ class ClientSession extends EventEmitter {
         typeof options.causalConsistency !== 'undefined' ? options.causalConsistency : true
     };
 
-    this.clusterTime = options.initialClusterTime != null ? options.initialClusterTime : null;
+    this.clusterTime = options.initialClusterTime;
 
     this.operationTime = null;
     this.explicit = !!options.explicit;

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -70,6 +70,8 @@ class ClientSession extends EventEmitter {
     }
 
     options = options || {};
+    clientOptions = clientOptions || {};
+
     this.topology = topology;
     this.sessionPool = sessionPool;
     this.hasEnded = false;
@@ -81,12 +83,7 @@ class ClientSession extends EventEmitter {
         typeof options.causalConsistency !== 'undefined' ? options.causalConsistency : true
     };
 
-    options = options || {};
-    if (typeof options.initialClusterTime !== 'undefined') {
-      this.clusterTime = options.initialClusterTime;
-    } else {
-      this.clusterTime = null;
-    }
+    this.clusterTime = options.initialClusterTime != null ? options.initialClusterTime : null;
 
     this.operationTime = null;
     this.explicit = !!options.explicit;


### PR DESCRIPTION
Fixes NODE-1557

# Description
`clientOptions` was not initialized in the `ClientSession` constructor. The `clusterTime` initialization was cleaned up.