### PR TITLE
feat(Aggregate): support ReadConcern in aggregate with $out

### DIFF
--- a/lib/operations/aggregate.js
+++ b/lib/operations/aggregate.js
@@ -11,6 +11,8 @@ const toError = require('../utils').toError;
 
 const DB_AGGREGATE_COLLECTION = 1;
 
+const MIN_WIRE_VERSION_$OUT_READ_CONCERN_SUPPORT = 8;
+
 /**
  * Perform an aggregate operation. See Collection.prototype.aggregate or Db.prototype.aggregate for more information.
  *
@@ -51,8 +53,9 @@ function aggregate(db, coll, pipeline, options, callback) {
   }
 
   const takesWriteConcern = topology.capabilities().commandsTakeWriteConcern;
+  const ismaster = topology.lastIsMaster() || {};
 
-  if (!hasOutStage) {
+  if (!hasOutStage || ismaster.maxWireVersion >= MIN_WIRE_VERSION_$OUT_READ_CONCERN_SUPPORT) {
     decorateWithReadConcern(command, target, options);
   }
 


### PR DESCRIPTION
# Description
Adds support for adding a ReadConcern to aggregates with $out against
4.2 servers. Some ReadConcerns (like linearizable) are still
not supported by the server, but will still be added on to
the outbound request.

Fixes NODE-1880

**What changed?**

- Small change to `lib/operations/aggregate.js` to properly attach ReadConcern against 4.2 servers.
- Adds test in `test/functional/readconcern_tests.js` to verify changes

**Are there any files to ignore?**
None

**Note:** there are spec tests in `test/functional/spec/crud/v2` that will give full coverage to the proper results, but since the `v2` test runner is not implemented they are not being run atm.