### PR TITLE
fix(Bulk): change BulkWriteError message to first item from writeErrors

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -1119,7 +1119,7 @@ class BulkOperationBase {
         callback,
         new BulkWriteError(
           toError({
-            message: 'write operation failed',
+            message: this.s.bulkResult.writeErrors[0].errmsg,
             code: this.s.bulkResult.writeErrors[0].code,
             writeErrors: this.s.bulkResult.writeErrors
           }),

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -1115,11 +1115,15 @@ class BulkOperationBase {
         return true;
       }
 
+      const msg = this.s.bulkResult.writeErrors[0].errmsg
+        ? this.s.bulkResult.writeErrors[0].errmsg
+        : 'write operation failed';
+
       handleCallback(
         callback,
         new BulkWriteError(
           toError({
-            message: this.s.bulkResult.writeErrors[0].errmsg,
+            message: msg,
             code: this.s.bulkResult.writeErrors[0].code,
             writeErrors: this.s.bulkResult.writeErrors
           }),

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -943,7 +943,7 @@ describe('Bulk', function() {
       poolSize: 1
     });
 
-    client.connect(function(err, client) {
+    client.connect((err, client) => {
       const db = client.db(configuration.db);
       const col = db.collection('err_batch_write_unordered_ops_legacy_6');
 
@@ -983,8 +983,7 @@ describe('Bulk', function() {
             expect(error.errmsg).to.exist;
             expect(err.message).to.equal(error.errmsg);
 
-            client.close();
-            done();
+            client.close(done);
           });
         }
       );

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -956,7 +956,7 @@ describe('Bulk', function() {
             unique: true
           }
         ],
-        function(err) {
+        err => {
           expect(err).to.not.exist;
 
           // Initialize the unordered Batch
@@ -967,7 +967,7 @@ describe('Bulk', function() {
           batch.insert({ a: 1 });
 
           // Execute the operations
-          batch.execute(configuration.writeConcernMax(), function(err, result) {
+          batch.execute(configuration.writeConcernMax(), (err, result) => {
             expect(err).to.exist;
             expect(result).to.not.exist;
 


### PR DESCRIPTION
Fixes NODE-1965

# Description
An unspecific `BulkWriteError: write operation failed` message was changed to the first item from `writeErrors`. 

**What changed?**
A user requested to make the error more specific and suggested to use the first item from `writeErrors`. A change was made to the `MongoError` message field to reflect this error message.
