### PR TITLE
ChangeStream support for 4.2

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -42,6 +42,12 @@ class ResumeTokenTracker extends EventEmitter {
     this._postBatchResumeToken = undefined;
   }
 
+  set resumeToken(token) {
+    this._resumeToken = token;
+    // NOTE: Event is for internal use only, and is not part of public API
+    this.emit('tokenChange');
+  }
+
   get resumeToken() {
     return this._resumeToken;
   }
@@ -55,8 +61,8 @@ class ResumeTokenTracker extends EventEmitter {
   resumeInfo() {
     const resumeInfo = {};
 
-    if (this._init && this._resumeToken) {
-      resumeInfo.resumeAfter = this._resumeToken;
+    if (this._init && this.resumeToken) {
+      resumeInfo.resumeAfter = this.resumeToken;
     } else if (this._init && this._operationTime) {
       resumeInfo.startAtOperationTime = this._operationTime;
     } else {
@@ -83,20 +89,20 @@ class ResumeTokenTracker extends EventEmitter {
     const cursor = this.changeStream.cursor;
     if (!postBatchResumeToken) {
       if (
-        !(this._resumeToken || this._operationTime || cursor.bufferedCount()) &&
+        !(this.resumeToken || this._operationTime || cursor.bufferedCount()) &&
         cursor.server &&
         cursor.server.ismaster.maxWireVersion >= 7
       ) {
         this._operationTime = operationTime;
       }
-      return;
     } else {
       this._postBatchResumeToken = postBatchResumeToken;
       if (cursor.cursorState.documents.length === 0) {
-        this._resumeToken = this._postBatchResumeToken;
+        this.resumeToken = this._postBatchResumeToken;
       }
     }
 
+    // NOTE: Event is for internal use only, and is not part of public API
     this.emit('response');
   }
 
@@ -105,9 +111,9 @@ class ResumeTokenTracker extends EventEmitter {
       return;
     }
     if (this._postBatchResumeToken && this.changeStream.cursor.bufferedCount() === 0) {
-      this._resumeToken = this._postBatchResumeToken;
+      this.resumeToken = this._postBatchResumeToken;
     } else {
-      this._resumeToken = doc._id;
+      this.resumeToken = doc._id;
     }
   }
 }

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -105,13 +105,13 @@ class ResumeTokenTracker extends EventEmitter {
 
 /**
  * @typedef OperationTime
- * @description Represents a specific point in time on a server. Can be retrieve by using {@link Db#command}
+ * @description Represents a specific point in time on a server. Can be retrieved by using {@link Db#command}
  * @see https://docs.mongodb.com/manual/reference/method/db.runCommand/#response
  */
 
 /**
  * @typedef ChangeStreamOptions
- * @description Options that can be passed to a ChangeSream. Note that startAfter, resumeAfter, and startAtOperationTime are all mutually exclusive, and the server will error if more than one is specified.
+ * @description Options that can be passed to a ChangeStream. Note that startAfter, resumeAfter, and startAtOperationTime are all mutually exclusive, and the server will error if more than one is specified.
  * @property {string} [fullDocument='default'] Allowed values: ‘default’, ‘updateLookup’. When set to ‘updateLookup’, the change stream will include both a delta describing the changes to the document, as well as a copy of the entire document that was changed from some time after the change occurred.
  * @property {number} [maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a change stream query.
  * @property {ResumeToken} [resumeAfter] Allows you to start a changeStream after a specified event. See {@link https://docs.mongodb.com/master/changeStreams/#resumeafter-for-change-streams|ChangeStream documentation}.

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -34,6 +34,84 @@ const CHANGE_DOMAIN_TYPES = {
  * @return {ChangeStream} a ChangeStream instance.
  */
 
+class ResumeTokenTracker extends EventEmitter {
+  constructor(changeStream, options) {
+    super();
+    this.changeStream = changeStream;
+    this.options = options;
+    this._postBatchResumeToken = undefined;
+  }
+
+  get resumeToken() {
+    return this._resumeToken;
+  }
+
+  init() {
+    this._resumeToken = this.options.startAfter || this.options.resumeAfter;
+    this._operationTime = this.options.startAtOperationTime;
+    this._init = true;
+  }
+
+  resumeInfo() {
+    const resumeInfo = {};
+
+    if (this._init && this._resumeToken) {
+      resumeInfo.resumeAfter = this._resumeToken;
+    } else if (this._init && this._operationTime) {
+      resumeInfo.startAtOperationTime = this._operationTime;
+    } else {
+      if (this.options.startAfter) {
+        resumeInfo.startAfter = this.options.startAfter;
+      }
+
+      if (this.options.resumeAfter) {
+        resumeInfo.resumeAfter = this.options.resumeAfter;
+      }
+
+      if (this.options.startAtOperationTime) {
+        resumeInfo.startAtOperationTime = this.options.startAtOperationTime;
+      }
+    }
+
+    return resumeInfo;
+  }
+
+  onResponse(postBatchResumeToken, operationTime) {
+    if (this.changeStream.isClosed()) {
+      return;
+    }
+    const cursor = this.changeStream.cursor;
+    if (!postBatchResumeToken) {
+      if (
+        !(this._resumeToken || this._operationTime || cursor.bufferedCount()) &&
+        cursor.server &&
+        cursor.server.ismaster.maxWireVersion >= 7
+      ) {
+        this._operationTime = operationTime;
+      }
+      return;
+    } else {
+      this._postBatchResumeToken = postBatchResumeToken;
+      if (cursor.cursorState.documents.length === 0) {
+        this._resumeToken = this._postBatchResumeToken;
+      }
+    }
+
+    this.emit('response');
+  }
+
+  onNext(doc) {
+    if (this.changeStream.isClosed()) {
+      return;
+    }
+    if (this._postBatchResumeToken && this.changeStream.cursor.bufferedCount() === 0) {
+      this._resumeToken = this._postBatchResumeToken;
+    } else {
+      this._resumeToken = doc._id;
+    }
+  }
+}
+
 class ChangeStream extends EventEmitter {
   constructor(changeDomain, pipeline, options) {
     super();
@@ -69,16 +147,12 @@ class ChangeStream extends EventEmitter {
       this.options.readPreference = changeDomain.s.readPreference;
     }
 
-    // We need to get the operationTime as early as possible
-    const isMaster = this.topology.lastIsMaster();
-    if (!isMaster) {
-      throw new MongoError('Topology does not have an ismaster yet.');
-    }
-
-    this.operationTime = isMaster.operationTime;
+    this._resumeTokenTracker = new ResumeTokenTracker(this, options);
 
     // Create contained Change Stream cursor
     this.cursor = createChangeStreamCursor(this);
+
+    this._resumeTokenTracker.init();
 
     // Listen for any `change` listeners being added to ChangeStream
     this.on('newListener', eventName => {
@@ -95,6 +169,14 @@ class ChangeStream extends EventEmitter {
         this.cursor.removeAllListeners('data');
       }
     });
+  }
+
+  /**
+   * The cached resume token that will be used to resume
+   * after the most recently returned change.
+   */
+  get resumeToken() {
+    return this._resumeTokenTracker.resumeToken;
   }
 
   /**
@@ -217,10 +299,6 @@ class ChangeStream extends EventEmitter {
 
 // Create a new change stream cursor based on self's configuration
 var createChangeStreamCursor = function(self) {
-  if (self.resumeToken) {
-    self.options.resumeAfter = self.resumeToken;
-  }
-
   var changeStreamCursor = buildChangeStreamAggregationCommand(self);
 
   /**
@@ -277,39 +355,20 @@ var createChangeStreamCursor = function(self) {
   return changeStreamCursor;
 };
 
-function getResumeToken(self) {
-  return self.resumeToken || self.options.resumeAfter;
-}
-
-function getStartAtOperationTime(self) {
-  const isMaster = self.topology.lastIsMaster() || {};
-  return (
-    isMaster.maxWireVersion && isMaster.maxWireVersion >= 7 && self.options.startAtOperationTime
-  );
-}
-
 var buildChangeStreamAggregationCommand = function(self) {
   const topology = self.topology;
   const namespace = self.namespace;
   const pipeline = self.pipeline;
   const options = self.options;
+  const resumeTokenTracker = self._resumeTokenTracker;
 
-  var changeStreamStageOptions = {
-    fullDocument: options.fullDocument || 'default'
-  };
-
-  const resumeToken = getResumeToken(self);
-  const startAtOperationTime = getStartAtOperationTime(self);
-  if (resumeToken) {
-    changeStreamStageOptions.resumeAfter = resumeToken;
-  }
-
-  if (startAtOperationTime) {
-    changeStreamStageOptions.startAtOperationTime = startAtOperationTime;
-  }
+  const changeStreamStageOptions = Object.assign(
+    { fullDocument: options.fullDocument || 'default' },
+    resumeTokenTracker.resumeInfo()
+  );
 
   // Map cursor options
-  var cursorOptions = {};
+  var cursorOptions = { resumeTokenTracker };
   cursorOptionNames.forEach(function(optionName) {
     if (options[optionName]) {
       cursorOptions[optionName] = options[optionName];
@@ -384,11 +443,6 @@ function processNewChange(args) {
     if (isResumableError(error) && !changeStream.attemptingResume) {
       changeStream.attemptingResume = true;
 
-      if (!(getResumeToken(changeStream) || getStartAtOperationTime(changeStream))) {
-        const startAtOperationTime = changeStream.cursor.cursorState.operationTime;
-        changeStream.options = Object.assign({ startAtOperationTime }, changeStream.options);
-      }
-
       // stop listening to all events from old cursor
       ['data', 'close', 'end', 'error'].forEach(event =>
         changeStream.cursor.removeAllListeners(event)
@@ -446,7 +500,7 @@ function processNewChange(args) {
     return changeStream.promiseLibrary.reject(noResumeTokenError);
   }
 
-  changeStream.resumeToken = change._id;
+  changeStream._resumeTokenTracker.onNext(change);
 
   // Return the change
   if (eventEmitter) return changeStream.emit('change', change);

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -13,27 +13,6 @@ const CHANGE_DOMAIN_TYPES = {
   DATABASE: Symbol('Database'),
   CLUSTER: Symbol('Cluster')
 };
-
-/**
- * Creates a new Change Stream instance. Normally created using {@link Collection#watch|Collection.watch()}.
- * @class ChangeStream
- * @since 3.0.0
- * @param {(MongoClient|Db|Collection)} changeDomain The domain against which to create the change stream
- * @param {Array} pipeline An array of {@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/|aggregation pipeline stages} through which to pass change stream documents
- * @param {object} [options] Optional settings
- * @param {string} [options.fullDocument='default'] Allowed values: ‘default’, ‘updateLookup’. When set to ‘updateLookup’, the change stream will include both a delta describing the changes to the document, as well as a copy of the entire document that was changed from some time after the change occurred.
- * @param {number} [options.maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a change stream query
- * @param {object} [options.resumeAfter] Specifies the logical starting point for the new change stream. This should be the _id field from a previously returned change stream document.
- * @param {number} [options.batchSize] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
- * @param {object} [options.collation] Specify collation settings for operation. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
- * @param {ReadPreference} [options.readPreference] The read preference. Defaults to the read preference of the database or collection. See {@link https://docs.mongodb.com/manual/reference/read-preference|read preference documentation}.
- * @fires ChangeStream#close
- * @fires ChangeStream#change
- * @fires ChangeStream#end
- * @fires ChangeStream#error
- * @return {ChangeStream} a ChangeStream instance.
- */
-
 class ResumeTokenTracker extends EventEmitter {
   constructor(changeStream, options) {
     super();
@@ -118,6 +97,44 @@ class ResumeTokenTracker extends EventEmitter {
   }
 }
 
+/**
+ * @typedef ResumeToken
+ * @description Represents the logical starting point for a new or resuming {@link ChangeStream} on the server.
+ * @see https://docs.mongodb.com/master/changeStreams/#change-stream-resume-token
+ */
+
+/**
+ * @typedef OperationTime
+ * @description Represents a specific point in time on a server. Can be retrieve by using {@link Db#command}
+ * @see https://docs.mongodb.com/manual/reference/method/db.runCommand/#response
+ */
+
+/**
+ * @typedef ChangeStreamOptions
+ * @description Options that can be passed to a ChangeSream. Note that startAfter, resumeAfter, and startAtOperationTime are all mutually exclusive, and the server will error if more than one is specified.
+ * @property {string} [fullDocument='default'] Allowed values: ‘default’, ‘updateLookup’. When set to ‘updateLookup’, the change stream will include both a delta describing the changes to the document, as well as a copy of the entire document that was changed from some time after the change occurred.
+ * @property {number} [maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a change stream query.
+ * @property {ResumeToken} [resumeAfter] Allows you to start a changeStream after a specified event. See {@link https://docs.mongodb.com/master/changeStreams/#resumeafter-for-change-streams|ChangeStream documentation}.
+ * @property {ResumeToken} [startAfter] Similar to resumeAfter, but will allow you to start after an invalidated event. See {@link https://docs.mongodb.com/master/changeStreams/#startafter-for-change-streams|ChangeStream documentation}.
+ * @property {OperationTime} [startAtOperationTime] Will start the changeStream after the specified operationTime.
+ * @property {number} [batchSize] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
+ * @property {object} [collation] Specify collation settings for operation. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
+ * @property {ReadPreference} [readPreference] The read preference. Defaults to the read preference of the database or collection. See {@link https://docs.mongodb.com/manual/reference/read-preference|read preference documentation}.
+ */
+
+/**
+ * Creates a new Change Stream instance. Normally created using {@link Collection#watch|Collection.watch()}.
+ * @class ChangeStream
+ * @since 3.0.0
+ * @param {(MongoClient|Db|Collection)} changeDomain The domain against which to create the change stream
+ * @param {Array} pipeline An array of {@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/|aggregation pipeline stages} through which to pass change stream documents
+ * @param {ChangeStreamOptions} [options] Optional settings
+ * @fires ChangeStream#close
+ * @fires ChangeStream#change
+ * @fires ChangeStream#end
+ * @fires ChangeStream#error
+ * @return {ChangeStream} a ChangeStream instance.
+ */
 class ChangeStream extends EventEmitter {
   constructor(changeDomain, pipeline, options) {
     super();
@@ -178,6 +195,7 @@ class ChangeStream extends EventEmitter {
   }
 
   /**
+   * @property {ResumeToken} resumeToken
    * The cached resume token that will be used to resume
    * after the most recently returned change.
    */

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -79,7 +79,8 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
     currentLimit: 0,
     // Result field name if not a cursor (contains the array of results)
     transforms: options.transforms,
-    raw: options.raw || (cmd && cmd.raw)
+    raw: options.raw || (cmd && cmd.raw),
+    resumeTokenTracker: options.resumeTokenTracker
   };
 
   if (typeof options.session === 'object') {
@@ -462,6 +463,10 @@ var nextFunction = function(self, callback) {
         return handleCallback(callback, err);
       }
 
+      if (self.cursorState.resumeTokenTracker) {
+        self.cursorState.resumeTokenTracker.onResponse(doc.cursor.postBatchResumeToken);
+      }
+
       if (self.cursorState.cursorId && self.cursorState.cursorId.isZero() && self._endSession) {
         self._endSession();
       }
@@ -668,6 +673,13 @@ function initializeCursor(cursor, callback) {
           // If we have a firstBatch set it
           if (Array.isArray(result.documents[0].cursor.firstBatch)) {
             cursor.cursorState.documents = result.documents[0].cursor.firstBatch; //.reverse();
+          }
+
+          if (cursor.cursorState.resumeTokenTracker) {
+            cursor.cursorState.resumeTokenTracker.onResponse(
+              result.documents[0].cursor.postBatchResumeToken,
+              result.documents[0].operationTime
+            );
           }
 
           // Return after processing command cursor

--- a/lib/error.js
+++ b/lib/error.js
@@ -9,15 +9,15 @@ const GET_MORE_NON_RESUMABLE_CODES = new Set([
   11601 // Interrupted
 ]);
 
-// From spec@https://github.com/mongodb/specifications/blob/35e466ddf25059cb30e4113de71cdebd3754657f/source/change-streams.rst#resumable-error:
+// From spec@https://github.com/mongodb/specifications/blob/7a2e93d85935ee4b1046a8d2ad3514c657dc74fa/source/change-streams/change-streams.rst#resumable-error:
 //
 // An error is considered resumable if it meets any of the following criteria:
 // - any error encountered which is not a server error (e.g. a timeout error or network error)
-// - any server error response from a getMore command excluding those containing the following error codes
+// - any server error response from a getMore command excluding those containing the error label
+//   NonRetryableChangeStreamError and those containing the following error codes:
 //   - Interrupted: 11601
 //   - CappedPositionLost: 136
 //   - CursorKilled: 237
-// - a server error response with an error message containing the substring "not master" or "node is recovering"
 //
 // An error on an aggregate command is not a resumable error. Only errors on a getMore command may be considered resumable errors.
 
@@ -32,11 +32,13 @@ function isResumableError(error) {
     return false;
   }
 
-  return !!(
-    error instanceof MongoNetworkError ||
-    !GET_MORE_NON_RESUMABLE_CODES.has(error.code) ||
-    error.message.match(/not master/) ||
-    error.message.match(/node is recovering/)
+  if (error instanceof MongoNetworkError) {
+    return true;
+  }
+
+  return !(
+    GET_MORE_NON_RESUMABLE_CODES.has(error.code) ||
+    error.hasErrorLabel('NonRetryableChangeStreamError')
   );
 }
 


### PR DESCRIPTION
# Description

Adds support for the 4.2 features of ChangeStreams:

- Adds support for the new startAfter option ([NODE-1824](https://jira.mongodb.org/browse/NODE-1824))
- Adds the ability to parse postBatchResumeTokens off of aggregate/getMore responses and leverage them when resuming. ([NODE-1866](https://jira.mongodb.org/browse/NODE-1866))
- Replaces property resumeToken with accessor resumeToken that will always have the most up to date resume token. (can be considered to satisfy [NODE-1979](https://jira.mongodb.org/browse/NODE-1979)
- We are already satisfying [NODE-1951](https://jira.mongodb.org/browse/NODE-1951)

**What changed?**

- `lib/core/cursor.js` now has a `resumeTokenTracker` that caches the `postBatchResumeToken` and `operationTime` from wire responses.
- `lib/change_stream.js` has the implementation fo `resumeTokenTracker`, and is refactored to leverage the `resumeTokenTracker` as the SSOT for resume tokens.
- `test/functional/change_stream_tests.js` has an updated `startAtOperationTime` test , and also includes an updated test that was behaving non-deterministically.

**Are there any files to ignore?**
Everything in `test/functional/spec/change-stream` is just syncing the specs.

**Additional Work that needs to happen**
- ~Reimplement the prose tests that were implemented [here](https://github.com/mongodb/node-mongodb-native/pull/2009/files?file-filters%5B%5D=.js&owned-by%5B%5D=#diff-193705f022e19ef91444aa63b824b8bd)~
- ~Document `startAfter` and `resumeToken`~