### PR TITLE
fix(server): emit "first connect" error if initial connect fails due to ECONNREFUSED

### DIFF
--- a/lib/core/topologies/server.js
+++ b/lib/core/topologies/server.js
@@ -421,7 +421,7 @@ var eventHandler = function(self, event) {
 
       // On first connect fail
       if (
-        self.s.pool.state === 'disconnected' &&
+        ['disconnected', 'connecting'].indexOf(self.s.pool.state) !== -1 &&
         self.initialConnect &&
         ['close', 'timeout', 'error', 'parseError'].indexOf(event) !== -1
       ) {


### PR DESCRIPTION
Same thing as https://github.com/mongodb-js/mongodb-core/pull/438, but for the `next` branch as per https://github.com/mongodb-js/mongodb-core/pull/438#issuecomment-499844609