### PR TITLE
feat(Update): add the ability to specify a pipeline to an update command

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -686,7 +686,10 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  const err = checkForAtomicOperators(update);
+  const err = Array.isArray(update)
+    ? update.forEach(checkForAtomicOperators)
+    : checkForAtomicOperators(update);
+
   if (err) {
     if (typeof callback === 'function') return callback(err);
     return this.s.promiseLibrary.reject(err);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -686,9 +686,14 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  const err = Array.isArray(update)
-    ? update.forEach(checkForAtomicOperators)
-    : checkForAtomicOperators(update);
+  let err;
+  if (Array.isArray(update)) {
+    for (let i = 0; !err && i < update.length; i++) {
+      err = checkForAtomicOperators(update[i]);
+    }
+  } else {
+    err = checkForAtomicOperators(update);
+  }
 
   if (err) {
     if (typeof callback === 'function') return callback(err);

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -1901,10 +1901,7 @@ describe('Collection', function() {
 
   it('should correctly update with pipeline', {
     metadata: {
-      requires: {
-        topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'],
-        mongodb: '>=4.2.0'
-      }
+      requires: { mongodb: '>=4.2.0' }
     },
 
     // The actual test we wish to run
@@ -1923,7 +1920,7 @@ describe('Collection', function() {
             [{ $set: { a: 1 } }, { $set: { b: 1 } }, { $set: { d: 1 } }],
             configuration.writeConcernMax(),
             (err, r) => {
-              expect(err).to.equal(null);
+              expect(err).to.not.exist;
               expect(r.result.n).to.equal(0);
 
               client.close(done);

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -1898,4 +1898,36 @@ describe('Collection', function() {
       }
     });
   });
+
+  it('should correctly update with array of docs', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    // The actual test we wish to run
+    test: function(done) {
+      const configuration = this.configuration;
+      const client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1
+      });
+
+      client.connect((err, client) => {
+        const db = client.db(configuration.db);
+
+        db.createCollection('test_should_correctly_do_update_with_docs_array', (err, collection) => {
+          collection.updateOne(
+            {},
+            [{ $set: { a: 1 } }, { $set: { b: 1 } }, { $set: { d: 1 } }],
+            configuration.writeConcernMax(),
+            (err, r) => {
+              expect(err).to.equal(null);
+              expect(r.result.n).to.equal(0);
+
+              client.close(done);
+            }
+          );
+        });
+      });
+    }
+  });
 });

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -1899,7 +1899,7 @@ describe('Collection', function() {
     });
   });
 
-  it('should correctly update with array of docs', {
+  it('should correctly update with pipeline', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
@@ -1914,7 +1914,7 @@ describe('Collection', function() {
       client.connect((err, client) => {
         const db = client.db(configuration.db);
 
-        db.createCollection('test_should_correctly_do_update_with_docs_array', (err, collection) => {
+        db.createCollection('test_should_correctly_do_update_with_pipeline', (err, collection) => {
           collection.updateOne(
             {},
             [{ $set: { a: 1 } }, { $set: { b: 1 } }, { $set: { d: 1 } }],

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -1901,7 +1901,10 @@ describe('Collection', function() {
 
   it('should correctly update with pipeline', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      requires: {
+        topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'],
+        mongodb: '>=4.2.0'
+      }
     },
 
     // The actual test we wish to run


### PR DESCRIPTION
Fixes NODE-1920

# Description
This provides extended functionality for the `update` command by allowing the specification of a pipeline. `update` can now take in an object or an array.

**What changed?**
To allow the user to pass in an array to `update` in addition to preserving the functionality of providing an object, the corresponding argument in the `updateOne` function was modified to check for atomic operators on each element in the array, if passed in as such.