### PR TITLE
fix(changestream): removes all event listeners on close

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -154,6 +154,7 @@ class ChangeStream extends EventEmitter {
 
     // Tidy up the existing cursor
     var cursor = this.cursor;
+    ['data', 'close', 'end', 'error'].forEach(event => this.cursor.removeAllListeners(event));
     delete this.cursor;
     return cursor.close(callback);
   }

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -42,7 +42,6 @@ describe('Change Streams', function() {
 
     // The actual test we wish to run
     test: function(done) {
-      /*
       let closed = false;
       const close = _err => {
         if (closed) {
@@ -71,37 +70,7 @@ describe('Change Streams', function() {
         setTimeout(() => coll.insertOne({ x: 1 }));
         changeStream.on('error', err => close(err));
       });
-      */
-
-
-      const configuration = this.configuration;
-      const client = configuration.newClient();
-      let closed = false;
-      const close = _err => {
-        if (closed) {
-          return;
-        }
-        closed = true;
-        return done(_err);
-      };
-
-      client.connect((err, client) => {
-        const coll = client.db('integration_tests').collection('listenertest');
-        const changeStream = coll.watch();
-        changeStream.on('change', () => {
-          console.log("changeStream.on change")
-          const internalCursor = changeStream.cursor;
-          expect(internalCursor.listenerCount('data')).to.equal(1);
-          // Close the change stream
-          changeStream.close(err => {
-              expect(internalCursor.listenerCount('data')).to.equal(0);
-              close(err)
-          });
-        });
-        setTimeout(() => coll.insertOne({ x: 1 }));
-        changeStream.on('error', err => close(err));
-      });
-  }
+    }
   });
 
   it('Should create a Change Stream on a collection and emit `change` events', {

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -37,7 +37,6 @@ describe('Change Streams', function() {
   });
 
   it('Should close the listeners after the cursor is closed', {
-
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.5.10' } },
 
     // The actual test we wish to run

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -52,14 +52,13 @@ describe('Change Streams', function() {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
-      client.connect(function(err, client) {
+      client.connect((err, client) => {
         expect(err).to.not.exist;
         const coll = client.db('integration_tests').collection('listenertest');
         const changeStream = coll.watch();
         changeStream.on('change', () => {
           const internalCursor = changeStream.cursor;
           expect(internalCursor.listenerCount('data')).to.equal(1);
-          // Close the change stream
           changeStream.close(err => {
             expect(internalCursor.listenerCount('data')).to.equal(0);
             close(err);

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -57,7 +57,6 @@ describe('Change Streams', function() {
         const coll = client.db('integration_tests').collection('listenertest');
         const changeStream = coll.watch();
         changeStream.on('change', () => {
-          console.log('changeStream.on change');
           const internalCursor = changeStream.cursor;
           expect(internalCursor.listenerCount('data')).to.equal(1);
           // Close the change stream

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -36,6 +36,74 @@ describe('Change Streams', function() {
       .then(() => client.close(), () => client.close());
   });
 
+  it('Should close the listeners after the cursor is closed', {
+
+    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.5.10' } },
+
+    // The actual test we wish to run
+    test: function(done) {
+      /*
+      let closed = false;
+      const close = _err => {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        return done(_err);
+      };
+      const configuration = this.configuration;
+      const client = configuration.newClient();
+
+      client.connect(function(err, client) {
+        expect(err).to.not.exist;
+        const coll = client.db('integration_tests').collection('listenertest');
+        const changeStream = coll.watch();
+        changeStream.on('change', () => {
+          console.log('changeStream.on change');
+          const internalCursor = changeStream.cursor;
+          expect(internalCursor.listenerCount('data')).to.equal(1);
+          // Close the change stream
+          changeStream.close(err => {
+            expect(internalCursor.listenerCount('data')).to.equal(0);
+            close(err);
+          });
+        });
+        setTimeout(() => coll.insertOne({ x: 1 }));
+        changeStream.on('error', err => close(err));
+      });
+      */
+
+
+      const configuration = this.configuration;
+      const client = configuration.newClient();
+      let closed = false;
+      const close = _err => {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        return done(_err);
+      };
+
+      client.connect((err, client) => {
+        const coll = client.db('integration_tests').collection('listenertest');
+        const changeStream = coll.watch();
+        changeStream.on('change', () => {
+          console.log("changeStream.on change")
+          const internalCursor = changeStream.cursor;
+          expect(internalCursor.listenerCount('data')).to.equal(1);
+          // Close the change stream
+          changeStream.close(err => {
+              expect(internalCursor.listenerCount('data')).to.equal(0);
+              close(err)
+          });
+        });
+        setTimeout(() => coll.insertOne({ x: 1 }));
+        changeStream.on('error', err => close(err));
+      });
+  }
+  });
+
   it('Should create a Change Stream on a collection and emit `change` events', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.5.10' } },
 

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -47,7 +47,7 @@ describe('Change Streams', function() {
           return;
         }
         closed = true;
-        return done(_err);
+        return client.close(() => done(_err));
       };
       const configuration = this.configuration;
       const client = configuration.newClient();


### PR DESCRIPTION
Fixes Node-1727

# Description

Closes the 'data', 'close', 'end', and 'error' listeners when the ChangeStream's cursor is closed.

**What changed?**

This change closes event listeners when the cursor is closed. Before, when `ChangeStream.prototype.close` was called, the event listeners would remain, which led to memory leaks and made bugs hard to understand.
