### PR TITLE
fix(documentation): Documentation for countDocuments mentions estimatedDocumentCount

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1380,7 +1380,7 @@ Collection.prototype.estimatedDocumentCount = function(options, callback) {
 
 /**
  * Gets the number of documents matching the filter.
- *
+ * For a fast count of the total documents in a collection see estimatedDocumentCount
  * **Note**: When migrating from {@link Collection#count count} to {@link Collection#countDocuments countDocuments}
  * the following query operators must be replaced:
  *

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1380,7 +1380,7 @@ Collection.prototype.estimatedDocumentCount = function(options, callback) {
 
 /**
  * Gets the number of documents matching the filter.
- * For a fast count of the total documents in a collection see estimatedDocumentCount: {@link Collection#estimatedDocumentCount estimatedDocumentCount}.
+ * For a fast count of the total documents in a collection see {@link Collection#estimatedDocumentCount estimatedDocumentCount}.
  * **Note**: When migrating from {@link Collection#count count} to {@link Collection#countDocuments countDocuments}
  * the following query operators must be replaced:
  *

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1380,7 +1380,7 @@ Collection.prototype.estimatedDocumentCount = function(options, callback) {
 
 /**
  * Gets the number of documents matching the filter.
- * For a fast count of the total documents in a collection see estimatedDocumentCount
+ * For a fast count of the total documents in a collection see estimatedDocumentCount: {@link Collection#estimatedDocumentCount estimatedDocumentCount}.
  * **Note**: When migrating from {@link Collection#count count} to {@link Collection#countDocuments countDocuments}
  * the following query operators must be replaced:
  *


### PR DESCRIPTION
fixes Node-1981
# Description
This comment navigates developers from countDocument to estimateDocumentCount, since estimatedDocumentCount is not easily discoverable by developers in their IDE.
**What changed?**
Added a comment line to the collections documentation for countDocuments, that refers people to estimatedDocumentCount
