### PR TITLE
test(arrayFilter): Ability to use array filters with bulk operations

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -564,6 +564,23 @@ class FindOperators {
   }
 
   /**
+   * selects which array elements to modify based on array of filters
+   *
+   * @method
+   * @param {object} arrayOfFilterDocuments array of filters
+   * @throws {MongoError}
+   **/
+  arrayFilters(arrayOfFilterDocuments) {
+    if (!arrayOfFilterDocuments) {
+      throw toError('Must specify an array of filter documents');
+    }
+    arrayOfFilterDocuments.foreach(function (filter) {
+      this = this.find(filter)
+    })
+    return new FindOperators(this)
+  }
+
+  /**
    * Add a single update document to the bulk operation
    *
    * @method

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -564,23 +564,6 @@ class FindOperators {
   }
 
   /**
-   * selects which array elements to modify based on array of filters
-   *
-   * @method
-   * @param {object} arrayOfFilterDocuments array of filters
-   * @throws {MongoError}
-   **/
-  arrayFilters(arrayOfFilterDocuments) {
-    if (!arrayOfFilterDocuments) {
-      throw toError('Must specify an array of filter documents');
-    }
-    arrayOfFilterDocuments.foreach(function (filter) {
-      this = this.find(filter)
-    })
-    return new FindOperators(this)
-  }
-
-  /**
    * Add a single update document to the bulk operation
    *
    * @method

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -771,7 +771,7 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
   }
 
   options = Object.assign({}, options);
-  
+
   // Add ignoreUndefined
   if (this.s.options.ignoreUndefined) {
     options = Object.assign({}, options);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -526,6 +526,8 @@ Collection.prototype.insertMany = function(docs, options, callback) {
  *
  *  { updateMany: { filter: {a:2}, update: {$set: {a:2}}, upsert:true } }
  *
+ *  { updateMany: { filter: {}, update: {$set: {"a.$[i].x": 5}}, arrayFilters: [{ "i.x": 5 }]} }
+ *
  *  { deleteOne: { filter: {c:1} } }
  *
  *  { deleteMany: { filter: {c:1} } }
@@ -769,7 +771,6 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
   }
 
   options = Object.assign({}, options);
-
   // Add ignoreUndefined
   if (this.s.options.ignoreUndefined) {
     options = Object.assign({}, options);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -771,6 +771,7 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
   }
 
   options = Object.assign({}, options);
+  
   // Add ignoreUndefined
   if (this.s.options.ignoreUndefined) {
     options = Object.assign({}, options);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -541,6 +541,7 @@ Collection.prototype.insertMany = function(docs, options, callback) {
  * @method
  * @param {object[]} operations Bulk operations to perform.
  * @param {object} [options] Optional settings.
+ * @param {object[]} [options.arrayFilters] Determines which array elements to modify for update operation in MongoDB 3.6 or higher.
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -73,27 +73,31 @@ describe('Bulk', function() {
     }
   });
 
-  it('should use arrayFilters for updateMany', function(done) {
-    const configuration = this.configuration;
-    const client = configuration.newClient({}, { w: 1 });
+  it('should use arrayFilters for updateMany', {
+    metadata: { requires: { mongodb: '>=3.6.x' } },
+    test: function(done) {
+      const configuration = this.configuration;
+      const client = configuration.newClient({}, { w: 1 });
 
-    client.connect((err, client) => {
-      const db = client.db(configuration.db);
-      const collection = db.collection('arrayfilterstest');
-      const docs = [{ a: [{ x: 1 }, { x: 2 }] }, { a: [{ x: 3 }, { x: 4 }] }];
-      const close = e => client.close(() => done(e));
-      collection.insertMany(docs).then(() =>
-        collection.updateMany(
-          {},
-          { $set: { 'a.$[i].x': 5 } },
-          { arrayFilters: [{ 'i.x': 5 }] },
-          (err, data) => {
-            expect(data.matchedCount).to.equal(2);
-            close(err);
-          }
-        )
-      );
-    });
+      client.connect((err, client) => {
+        const db = client.db(configuration.db);
+        const collection = db.collection('arrayfilterstest');
+        const docs = [{ a: [{ x: 1 }, { x: 2 }] }, { a: [{ x: 3 }, { x: 4 }] }];
+        const close = e => client.close(() => done(e));
+        collection.insertMany(docs).then(() =>
+          collection.updateMany(
+            {},
+            { $set: { 'a.$[i].x': 5 } },
+            { arrayFilters: [{ 'i.x': 5 }] },
+            (err, data) => {
+              expect(err).to.not.exist;
+              expect(data.matchedCount).to.equal(2);
+              close(err);
+            }
+          )
+        );
+      });
+    }
   });
 
   it('should ignore undefined values in unordered bulk operation if `ignoreUndefined` specified', {

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -73,6 +73,7 @@ describe('Bulk', function() {
     }
   });
 
+<<<<<<< HEAD
   it('should use arrayFilters for updateOne', function(done) {
     const configuration = this.configuration;
     const client = configuration.newClient({}, { w: 1 });
@@ -94,6 +95,68 @@ describe('Bulk', function() {
         )
       );
     });
+=======
+  it('Should be able to use array filters in unordered operation', {
+    metadata: { //not sure about metadata
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    test: function(done) {
+      var self = this;
+      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
+        poolSize: 1
+      });
+
+      client.connect(function(err, client) {
+        var db = client.db(self.configuration.db);
+        var bulk = db.collection('batch_write_unordered_ops_1')
+        bulk.insert({ a: 1, b: 2});
+        bulk.insert({ a: 3, b: 4});
+        bulk.find({}).arrayFilters([{a: {"$gt": 2}}]).updateOne({$set: {a: 3}});
+        bulk.execute();
+        bulk.then(() => bulk.find({}).toArray())
+          .then(docs => {
+            expect(docs[0]['a']).to.equal(3);
+            expect(docs[0]['b']).to.equal(2);
+            expect(docs[1]['a']).to.equal(3);
+            expect(docs[1]['b']).to.equal(4);
+          });
+        client.close();
+        done();
+      });
+    }
+  });
+
+  it('Should be able to use array filters in ordered operation', {
+    metadata: { //not sure about metadata
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    test: function(done) {
+      var self = this;
+      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
+        poolSize: 1
+      });
+
+      client.connect(function(err, client) {
+        var db = client.db(self.configuration.db);
+        var bulk = db.collection('batch_write_ordered_ops_1')
+        bulk.insert({ a: 1, b: 2});
+        bulk.insert({ a: 3, b: 4});
+        bulk.find({}).arrayFilters([{a: {"$gt": 2}}]).updateOne({$set: {a: 3}});
+        bulk.execute();
+        bulk.then(() => bulk.find({}).toArray())
+          .then(docs => {
+            expect(docs[0]['a']).to.equal(3);
+            expect(docs[0]['b']).to.equal(2);
+            expect(docs[1]['a']).to.equal(3);
+            expect(docs[1]['b']).to.equal(4);
+          });
+        client.close();
+        done();
+      });
+    }
+>>>>>>> feat(arryFilter): Ability to use array filters with bulk operations
   });
 
   it('should ignore undefined values in unordered bulk operation if `ignoreUndefined` specified', {

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -73,7 +73,6 @@ describe('Bulk', function() {
     }
   });
 
-<<<<<<< HEAD
   it('should use arrayFilters for updateOne', function(done) {
     const configuration = this.configuration;
     const client = configuration.newClient({}, { w: 1 });
@@ -95,68 +94,6 @@ describe('Bulk', function() {
         )
       );
     });
-=======
-  it('Should be able to use array filters in unordered operation', {
-    metadata: { //not sure about metadata
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-        var bulk = db.collection('batch_write_unordered_ops_1')
-        bulk.insert({ a: 1, b: 2});
-        bulk.insert({ a: 3, b: 4});
-        bulk.find({}).arrayFilters([{a: {"$gt": 2}}]).updateOne({$set: {a: 3}});
-        bulk.execute();
-        bulk.then(() => bulk.find({}).toArray())
-          .then(docs => {
-            expect(docs[0]['a']).to.equal(3);
-            expect(docs[0]['b']).to.equal(2);
-            expect(docs[1]['a']).to.equal(3);
-            expect(docs[1]['b']).to.equal(4);
-          });
-        client.close();
-        done();
-      });
-    }
-  });
-
-  it('Should be able to use array filters in ordered operation', {
-    metadata: { //not sure about metadata
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-        var bulk = db.collection('batch_write_ordered_ops_1')
-        bulk.insert({ a: 1, b: 2});
-        bulk.insert({ a: 3, b: 4});
-        bulk.find({}).arrayFilters([{a: {"$gt": 2}}]).updateOne({$set: {a: 3}});
-        bulk.execute();
-        bulk.then(() => bulk.find({}).toArray())
-          .then(docs => {
-            expect(docs[0]['a']).to.equal(3);
-            expect(docs[0]['b']).to.equal(2);
-            expect(docs[1]['a']).to.equal(3);
-            expect(docs[1]['b']).to.equal(4);
-          });
-        client.close();
-        done();
-      });
-    }
->>>>>>> feat(arryFilter): Ability to use array filters with bulk operations
   });
 
   it('should ignore undefined values in unordered bulk operation if `ignoreUndefined` specified', {

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -73,11 +73,11 @@ describe('Bulk', function() {
     }
   });
 
-  it('should use arrayFilters for updateOne', function(done) {
+  it('should use arrayFilters for updateMany', function(done) {
     const configuration = this.configuration;
     const client = configuration.newClient({}, { w: 1 });
 
-    client.connect(function(err, client) {
+    client.connect((err, client) => {
       const db = client.db(configuration.db);
       const collection = db.collection('arrayfilterstest');
       const docs = [{ a: [{ x: 1 }, { x: 2 }] }, { a: [{ x: 3 }, { x: 4 }] }];

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -73,21 +73,25 @@ describe('Bulk', function() {
     }
   });
 
-    it('should use arrayFilters for updateOne', function(done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient({}, { w: 1 });
+  it('should use arrayFilters for updateOne', function(done) {
+    const configuration = this.configuration;
+    const client = configuration.newClient({}, { w: 1 });
 
-      client.connect(function(err, client) {
-        const db = client.db(configuration.db);
-        const collection = db.collection('arrayfilterstest');
-        const docs = [{ a: [ { x: 1 }, { x: 2 }] }, { a: [ { x: 3 }, { x: 4 }] }];
-        const close = e => client.close(() => done(e));
-        collection.insertMany(docs).then(() =>
-          collection.updateMany({}, {}, { arrayFilters: [{ x: { $gte: 1 } }] } (err, data) => {
-            console.log(data);
-            expect(data).to.equal(1);
+    client.connect(function(err, client) {
+      const db = client.db(configuration.db);
+      const collection = db.collection('arrayfilterstest');
+      const docs = [{ a: [{ x: 1 }, { x: 2 }] }, { a: [{ x: 3 }, { x: 4 }] }];
+      const close = e => client.close(() => done(e));
+      collection.insertMany(docs).then(() =>
+        collection.updateMany(
+          {},
+          { $set: { 'a.$[i].x': 5 } },
+          { arrayFilters: [{ 'i.x': 5 }] },
+          (err, data) => {
+            expect(data.matchedCount).to.equal(2);
             close(err);
-        })
+          }
+        )
       );
     });
   });

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -73,6 +73,25 @@ describe('Bulk', function() {
     }
   });
 
+    it('should use arrayFilters for updateOne', function(done) {
+      const configuration = this.configuration;
+      const client = configuration.newClient({}, { w: 1 });
+
+      client.connect(function(err, client) {
+        const db = client.db(configuration.db);
+        const collection = db.collection('arrayfilterstest');
+        const docs = [{ a: [ { x: 1 }, { x: 2 }] }, { a: [ { x: 3 }, { x: 4 }] }];
+        const close = e => client.close(() => done(e));
+        collection.insertMany(docs).then(() =>
+          collection.updateMany({}, {}, { arrayFilters: [{ x: { $gte: 1 } }] } (err, data) => {
+            console.log(data);
+            expect(data).to.equal(1);
+            close(err);
+        })
+      );
+    });
+  });
+
   it('should ignore undefined values in unordered bulk operation if `ignoreUndefined` specified', {
     metadata: {
       requires: { topology: ['single'] }


### PR DESCRIPTION
Fixes NODE-1911

# Description
Made an arrayFilters method for FindOperators which matches the documentation of the method here: https://docs.mongodb.com/manual/reference/method/Bulk.find.arrayFilters/
Created two tests for ordered and unordered operations with arrayFilters.

**What changed?**
Made a 'Should be able to use array filters in unordered operation' and  'Should be able to use array filters in ordered operation' test. Created an arrayFilters method in the FindOperators class which calls the find method on each filter in the filter array.
