### PR TITLE
fix(cursor): do not truncate an existing Long

### DIFF
--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -683,7 +683,7 @@ function initializeCursor(cursor, callback) {
 
       // Otherwise fall back to regular find path
       const cursorId = result.cursorId || 0;
-      cursor.cursorState.cursorId = Long.fromNumber(cursorId);
+      cursor.cursorState.cursorId = cursorId instanceof Long ? cursorId : Long.fromNumber(cursorId);
       cursor.cursorState.documents = result.documents;
       cursor.cursorState.lastCursorId = result.cursorId;
 


### PR DESCRIPTION
Port of mongodb-js/mongodb-core#441 to native.

# Description

Fixes a cursor issue where a cursor id could get truncated if it was larger than `Number.MAX_SAFE_INT`.

**What changed?**

Minor change to `lib/core/cursor.js`

**Are there any files to ignore?**
nope