### PR TITLE
doc(connect): 'Connecting' example code returns a deprecation warning

### DIFF
--- a/docs/reference/content/reference/ecmascriptnext/connecting.md
+++ b/docs/reference/content/reference/ecmascriptnext/connecting.md
@@ -21,7 +21,7 @@ const assert = require('assert');
   const url = 'mongodb://localhost:27017/myproject';
   // Database Name
   const dbName = 'myproject';
-  const client = new MongoClient(url, {useNewUrlParser: true});
+  const client = new MongoClient(url, { useNewUrlParser: true });
 
   try {
     // Use connect method to connect to the Server

--- a/docs/reference/content/reference/ecmascriptnext/connecting.md
+++ b/docs/reference/content/reference/ecmascriptnext/connecting.md
@@ -21,7 +21,7 @@ const assert = require('assert');
   const url = 'mongodb://localhost:27017/myproject';
   // Database Name
   const dbName = 'myproject';
-  const client = new MongoClient(url);
+  const client = new MongoClient(url, {useNewUrlParser: true});
 
   try {
     // Use connect method to connect to the Server


### PR DESCRIPTION
Fixes NODE-1849

# Description
By way of: https://twitter.com/mikemaccana/status/1090328293243527168
Previous demo code was returning an error. By adding this useNewURLParser argument, the demo code works. 
**What changed?**
Added correct argument to MongoClient()
