### PR TITLE
test(bulk_tests): fix 'should correctly handle multiple unordered batch API'

### DIFF
--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -663,18 +663,6 @@ describe('Bulk', function() {
 
         // Add some operations to be executed in order
         batch.insert({ b: 1, a: 1 });
-        batch
-          .find({ b: 2 })
-          .upsert()
-          .updateOne({ $set: { a: 1 } });
-        batch
-          .find({ b: 3 })
-          .upsert()
-          .updateOne({ $set: { a: 2 } });
-        batch
-          .find({ b: 2 })
-          .upsert()
-          .updateOne({ $set: { a: 1 } });
         batch.insert({ b: 4, a: 3 });
         batch.insert({ b: 5, a: 1 });
 

--- a/test/functional/bulk_tests.js
+++ b/test/functional/bulk_tests.js
@@ -663,7 +663,6 @@ describe('Bulk', function() {
 
         // Add some operations to be executed in order
         batch.insert({ b: 1, a: 1 });
-        batch.insert({ b: 4, a: 3 });
         batch.insert({ b: 5, a: 1 });
 
         // Execute the operations
@@ -673,7 +672,7 @@ describe('Bulk', function() {
 
           // Basic properties check
           result = err.result;
-          expect(result.nInserted).to.equal(2);
+          expect(result.nInserted).to.equal(1);
           expect(result.hasWriteErrors()).to.equal(true);
           expect(result.getWriteErrorCount()).to.equal(1);
 


### PR DESCRIPTION
NODE-1994

# Description
The test originally had a `test.ok(...)` that checked if any WriteErrors were generated, but left extraneous code and asserts that would never be checked.

**What changed?**
Updated 'should correctly handle multiple unordered batch API' to adhere to current testing specifications and generate 1 `WriteError` consistently.