### PR TITLE
Node 1854/enable client encryption in client

### DIFF
--- a/lib/core/wireprotocol/command.js
+++ b/lib/core/wireprotocol/command.js
@@ -9,6 +9,10 @@ const databaseNamespace = require('./shared').databaseNamespace;
 const isTransactionCommand = require('../transactions').isTransactionCommand;
 const applySession = require('../sessions').applySession;
 
+function isClientEncryptionEnabled(server) {
+  return server && server.s && server.s.options && server.s.options.autoEncrypter;
+}
+
 function command(server, ns, cmd, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
@@ -17,6 +21,15 @@ function command(server, ns, cmd, options, callback) {
     return callback(new MongoError(`command ${JSON.stringify(cmd)} does not return a cursor`));
   }
 
+  if (!isClientEncryptionEnabled(server)) {
+    _command(server, ns, cmd, options, callback);
+    return;
+  }
+
+  _cryptCommand(server, ns, cmd, options, callback);
+}
+
+function _command(server, ns, cmd, options, callback) {
   const bson = server.s.bson;
   const pool = server.s.pool;
   const readPreference = getReadPreference(cmd, options);
@@ -116,6 +129,42 @@ function supportsOpMsg(topologyOrServer) {
   }
 
   return description.maxWireVersion >= 6 && description.__nodejs_mock_server__ == null;
+}
+
+function _cryptCommand(server, ns, cmd, options, callback) {
+  const shouldBypassAutoEncryption = !!server.s.options.bypassAutoEncryption;
+  const autoEncrypter = server.s.options.autoEncrypter;
+  function commandResponseHandler(err, response) {
+    if (err || response == null) {
+      callback(err, response);
+      return;
+    }
+
+    autoEncrypter.decrypt(response.result, (err, decrypted) => {
+      if (err) {
+        callback(err, null);
+        return;
+      }
+
+      response.result = decrypted;
+      response.message.documents = [decrypted];
+      callback(null, response);
+    });
+  }
+
+  if (shouldBypassAutoEncryption) {
+    _command(server, ns, cmd, options, commandResponseHandler);
+    return;
+  }
+
+  autoEncrypter.encrypt(ns, cmd, (err, encrypted) => {
+    if (err) {
+      callback(err, null);
+      return;
+    }
+
+    _command(server, ns, encrypted, options, commandResponseHandler);
+  });
 }
 
 module.exports = command;

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -54,6 +54,22 @@ const closeOperation = require('./operations/mongo_client_ops').closeOperation;
  */
 
 /**
+ * Configuration options for a automatic client encryption
+ *
+ * @typedef {Object} AutoEncryptionOptions
+ * @property {MongoClient} [keyVaultClient] A `MongoClient` used to fetch keys from a key vault
+ * @property {string} [keyVaultNamespace] The namespace where keys are stored in the key vault
+ * @property {object} [kmsProviders] Provider details for the desired Key Management Service to use for encryption
+ * @property {object} [kmsProviders.aws] Optional settings for the AWS KMS provider
+ * @property {string} [kmsProviders.aws.accessKeyId] The access key used for the AWS KMS provider
+ * @property {string} [kmsProviders.aws.secretAccessKey] The secret access key used for the AWS KMS provider
+ * @property {object} [kmsProviders.local] Optional settings for the local KMS provider
+ * @property {string} [kmsProviders.local.key] The master key used to encrypt/decrypt data keys
+ * @property {object} [schemaMap] A map of namespaces to a local JSON schema for encryption
+ * @property {boolean} [bypassAutoEncryption] Allows the user to bypass auto encryption, maintaining implicit decryption
+ */
+
+/**
  * Creates a new MongoClient instance
  * @class
  * @param {string} url The connection URI string
@@ -118,6 +134,7 @@ const closeOperation = require('./operations/mongo_client_ops').closeOperation;
  * @param {number} [options.minSize] If present, the connection pool will be initialized with minSize connections, and will never dip below minSize connections
  * @param {boolean} [options.useNewUrlParser=false] Determines whether or not to use the new url parser. Enables the new, spec-compliant, url parser shipped in the core driver. This url parser fixes a number of problems with the original parser, and aims to outright replace that parser in the near future.
  * @param {boolean} [options.useUnifiedTopology] Enables the new unified topology layer
+ * @param {AutoEncryptionOptions} [options.autoEncryption] Optionally enable client side auto encryption
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {MongoClient} a MongoClient instance
  */

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -12,6 +12,7 @@ const ServerSessionPool = require('../core').Sessions.ServerSessionPool;
 const NativeTopology = require('../topologies/native_topology');
 const MongoCredentials = require('../core').MongoCredentials;
 const ReadConcern = require('../read_concern');
+const os = require('os');
 
 let client;
 function loadClient() {
@@ -416,6 +417,43 @@ function createTopology(mongoClient, topologyType, options, callback) {
     }
 
     assignTopology(mongoClient, newTopology);
+    if (options.autoEncryption == null) {
+      callback(null, newTopology);
+      return;
+    }
+
+    // setup for client side encryption
+    let AutoEncrypter;
+    try {
+      AutoEncrypter = require('mongodb-client-encryption').AutoEncrypter;
+    } catch (err) {
+      callback(
+        new MongoError(
+          'Auto-encryption requested, but the module is not installed. Please add `mongodb-client-encryption` as a dependency of your project'
+        )
+      );
+
+      return;
+    }
+
+    const MongoClient = loadClient();
+    const connectionString =
+      os.platform() === 'win32'
+        ? 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000'
+        : 'mongodb://%2Ftmp%2Fmongocryptd.sock/?serverSelectionTimeoutMS=1000';
+
+    const mongocryptdClient = new MongoClient(connectionString, { useUnifiedTopology: true });
+    mongocryptdClient.connect(err => {
+      if (err) return callback(err, null);
+
+      const mongoCryptOptions = Object.assign({}, options.autoEncryption, {
+        mongocryptdClient
+      });
+
+      topology.s.options.autoEncrypter = new AutoEncrypter(mongoClient, mongoCryptOptions);
+      callback(null, newTopology);
+    });
+
     callback(null, newTopology);
   });
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "peerOptionalDependencies": {
     "kerberos": "^1.0.0",
+    "mongodb-client-encryption": "^1.0.0",
     "mongodb-extjson": "^2.1.2",
     "snappy": "^6.1.1",
     "bson-ext": "^2.0.0"
@@ -25,8 +26,7 @@
   "dependencies": {
     "bson": "^1.1.1",
     "require_optional": "^1.0.1",
-    "safe-buffer": "^5.1.2",
-    "mongodb-client-encryption": "^1.0.0"
+    "safe-buffer": "^5.1.2"
   },
   "devDependencies": {
     "bluebird": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "bson": "^1.1.1",
     "require_optional": "^1.0.1",
-    "safe-buffer": "^5.1.2"
+    "safe-buffer": "^5.1.2",
+    "mongodb-client-encryption": "^1.0.0"
   },
   "devDependencies": {
     "bluebird": "3.5.0",


### PR DESCRIPTION
# Description
This is the client component to Client Encryption. Primarily we are allowing users to specify a new option `autoEncryption` to the `MongoClient` constructor to enable auto encryption. The actual work is implemented in the `command` wire protocol method. **NOTE:** This feature only works with the unified topology.

**What changed?**
The big change is that the `command` wire protocol method now conditionally autoencrypts if the feature was requested. It's supported in a non-ideal way, because our wire protocol methods are not easily decorated. If, instead, they were defined on a `Connection`, then we could potentially provide a `CryptoConnection` - alas it's not possible with the current design. 

**Are there any files to ignore?**
No
