### PR TITLE
NODE-2004: Finer Grained Updates from Aggregation via `$merge`

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -686,15 +686,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  let err;
-  if (Array.isArray(update)) {
-    for (let i = 0; !err && i < update.length; i++) {
-      err = checkForAtomicOperators(update[i]);
-    }
-  } else {
-    err = checkForAtomicOperators(update);
-  }
-
+  const err = checkForAtomicOperators(update);
   if (err) {
     if (typeof callback === 'function') return callback(err);
     return this.s.promiseLibrary.reject(err);

--- a/lib/operations/aggregate.js
+++ b/lib/operations/aggregate.js
@@ -8,9 +8,9 @@ const handleCallback = require('../utils').handleCallback;
 const MongoError = require('../core').MongoError;
 const resolveReadPreference = require('../utils').resolveReadPreference;
 const toError = require('../utils').toError;
+const ReadPreference = require('../core').ReadPreference;
 
 const DB_AGGREGATE_COLLECTION = 1;
-
 const MIN_WIRE_VERSION_$OUT_READ_CONCERN_SUPPORT = 8;
 
 /**
@@ -27,13 +27,16 @@ function aggregate(db, coll, pipeline, options, callback) {
   const isDbAggregate = typeof coll === 'string';
   const target = isDbAggregate ? db : coll;
   const topology = target.s.topology;
-  let hasOutStage = false;
+  let hasWriteStage = false;
 
   if (typeof options.out === 'string') {
     pipeline = pipeline.concat({ $out: options.out });
-    hasOutStage = true;
-  } else if (pipeline.length > 0 && pipeline[pipeline.length - 1]['$out']) {
-    hasOutStage = true;
+    hasWriteStage = true;
+  } else if (pipeline.length > 0) {
+    const finalStage = pipeline[pipeline.length - 1];
+    if (finalStage.$out || finalStage.$merge) {
+      hasWriteStage = true;
+    }
   }
 
   let command;
@@ -55,11 +58,11 @@ function aggregate(db, coll, pipeline, options, callback) {
   const takesWriteConcern = topology.capabilities().commandsTakeWriteConcern;
   const ismaster = topology.lastIsMaster() || {};
 
-  if (!hasOutStage || ismaster.maxWireVersion >= MIN_WIRE_VERSION_$OUT_READ_CONCERN_SUPPORT) {
+  if (!hasWriteStage || ismaster.maxWireVersion >= MIN_WIRE_VERSION_$OUT_READ_CONCERN_SUPPORT) {
     decorateWithReadConcern(command, target, options);
   }
 
-  if (pipeline.length > 0 && pipeline[pipeline.length - 1]['$out'] && takesWriteConcern) {
+  if (hasWriteStage && takesWriteConcern) {
     applyWriteConcern(command, optionSources, options);
   }
 
@@ -82,7 +85,9 @@ function aggregate(db, coll, pipeline, options, callback) {
   options = Object.assign({}, options);
 
   // Ensure we have the right read preference inheritance
-  options.readPreference = resolveReadPreference(isDbAggregate ? db : coll, options);
+  options.readPreference = hasWriteStage
+    ? ReadPreference.primary
+    : resolveReadPreference(isDbAggregate ? db : coll, options);
 
   if (options.explain) {
     if (command.readConcern || command.writeConcern) {
@@ -99,7 +104,10 @@ function aggregate(db, coll, pipeline, options, callback) {
   }
 
   options.cursor = options.cursor || {};
-  if (options.batchSize && !hasOutStage) options.cursor.batchSize = options.batchSize;
+  if (options.batchSize && !hasWriteStage) {
+    options.cursor.batchSize = options.batchSize;
+  }
+
   command.cursor = options.cursor;
 
   // promiseLibrary

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -156,14 +156,17 @@ function bulkWrite(coll, operations, options, callback) {
 
 // Check the update operation to ensure it has atomic operators.
 function checkForAtomicOperators(update) {
-  const keys = Object.keys(update);
+  const keys = Array.isArray(update)
+    ? update.reduce((keys, u) => keys.concat(Object.keys(u)), [])
+    : Object.keys(update);
 
   // same errors as the server would give for update doc lacking atomic operators
   if (keys.length === 0) {
     return toError('The update operation document must contain at least one atomic operator.');
   }
 
-  if (keys[0][0] !== '$') {
+  const foundInvalid = keys.some(key => key[0] !== '$');
+  if (foundInvalid) {
     return toError('the update operation document must contain atomic operators.');
   }
 }

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -156,17 +156,18 @@ function bulkWrite(coll, operations, options, callback) {
 
 // Check the update operation to ensure it has atomic operators.
 function checkForAtomicOperators(update) {
-  const keys = Array.isArray(update)
-    ? update.reduce((keys, u) => keys.concat(Object.keys(u)), [])
-    : Object.keys(update);
+  if (Array.isArray(update)) {
+    return update.reduce((err, u) => err || checkForAtomicOperators(u), null);
+  }
+
+  const keys = Object.keys(update);
 
   // same errors as the server would give for update doc lacking atomic operators
   if (keys.length === 0) {
     return toError('The update operation document must contain at least one atomic operator.');
   }
 
-  const foundInvalid = keys.some(key => key[0] !== '$');
-  if (foundInvalid) {
+  if (keys[0][0] !== '$') {
     return toError('the update operation document must contain atomic operators.');
   }
 }

--- a/test/functional/crud_spec_tests.js
+++ b/test/functional/crud_spec_tests.js
@@ -8,6 +8,10 @@ chai.use(require('chai-subset'));
 
 const BulkWriteError = require('../../lib/bulk/common').BulkWriteError;
 
+const TestRunnerContext = require('./runner').TestRunnerContext;
+const gatherTestSuites = require('./runner').gatherTestSuites;
+const generateTopologyTests = require('./runner').generateTopologyTests;
+
 function findScenarios() {
   const route = [__dirname, 'spec', 'crud'].concat(Array.from(arguments));
   return fs
@@ -466,4 +470,15 @@ describe('CRUD spec', function() {
         }
       });
   }
+});
+
+describe('CRUD v2', function() {
+  const testContext = new TestRunnerContext();
+  const testSuites = gatherTestSuites(path.join(__dirname, 'spec', 'crud', 'v2'));
+  after(() => testContext.teardown());
+  before(function() {
+    return testContext.setup(this.configuration);
+  });
+
+  generateTopologyTests(testSuites, testContext);
 });

--- a/test/functional/runner/index.js
+++ b/test/functional/runner/index.js
@@ -117,6 +117,7 @@ function shouldSkipTest(spec) {
 
 function generateTopologyTests(testSuites, testContext) {
   testSuites.forEach(testSuite => {
+    // TODO: remove this when SPEC-1255 is completed
     let runOn = testSuite.runOn;
     if (!testSuite.runOn) {
       runOn = [{ minServerVersion: testSuite.minServerVersion }];

--- a/test/functional/spec/crud/v2/aggregate-merge.json
+++ b/test/functional/spec/crud/v2/aggregate-merge.json
@@ -1,0 +1,411 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "minServerVersion": "4.2.0",
+  "collection_name": "test_aggregate_merge",
+  "tests": [
+    {
+      "description": "Aggregate with $merge",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_test_collection"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_merge",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_test_collection"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Aggregate with $merge and batch size of 0",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_test_collection"
+                }
+              }
+            ],
+            "batchSize": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_merge",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_test_collection"
+                  }
+                }
+              ],
+              "cursor": {}
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Aggregate with $merge and majority readConcern",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_test_collection"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_merge",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_test_collection"
+                  }
+                }
+              ],
+              "readConcern": {
+                "level": "majority"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Aggregate with $merge and local readConcern",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "local"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_test_collection"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_merge",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_test_collection"
+                  }
+                }
+              ],
+              "readConcern": {
+                "level": "local"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Aggregate with $merge and available readConcern",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "available"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_test_collection"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_merge",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_test_collection"
+                  }
+                }
+              ],
+              "readConcern": {
+                "level": "available"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/crud/v2/aggregate-merge.yml
+++ b/test/functional/spec/crud/v2/aggregate-merge.yml
@@ -1,0 +1,101 @@
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+    - { _id: 3, x: 33 }
+
+minServerVersion: '4.2.0'
+
+collection_name: &collection_name 'test_aggregate_merge'
+
+tests:
+  -
+    description: "Aggregate with $merge"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        arguments: &arguments
+          pipeline: &pipeline
+            - $sort: { x : 1 }
+            - $match: { _id: { $gt: 1 } }
+            - $merge: { into: &output_collection "other_test_collection" }
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *pipeline
+    outcome: &outcome
+      collection:
+        name: *output_collection
+        data:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+  -
+    description: "Aggregate with $merge and batch size of 0"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        arguments:
+          <<: *arguments
+          batchSize: 0
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *pipeline
+            cursor: {}
+    outcome: *outcome
+  -
+    description: "Aggregate with $merge and majority readConcern"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        collectionOptions:
+          readConcern: { level: "majority" }
+        arguments: *arguments
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *pipeline
+            readConcern: { level: "majority" }
+    outcome: *outcome
+  -
+    description: "Aggregate with $merge and local readConcern"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        collectionOptions:
+          readConcern: { level: "local" }
+        arguments: *arguments
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *pipeline
+            readConcern: { level: "local" }
+    outcome: *outcome
+  -
+    description: "Aggregate with $merge and available readConcern"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        collectionOptions:
+          readConcern: { level: "available" }
+        arguments: *arguments
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *pipeline
+            readConcern: { level: "available" }
+    outcome: *outcome

--- a/test/functional/spec/crud/v2/db-aggregate.json
+++ b/test/functional/spec/crud/v2/db-aggregate.json
@@ -1,9 +1,9 @@
 {
   "database_name": "admin",
-  "minServerVersion": "4.0",
+  "minServerVersion": "3.6",
   "tests": [
     {
-      "description": "Aggregate with $currentOp",
+      "description": "Aggregate with $listLocalSessions",
       "operations": [
         {
           "name": "aggregate",
@@ -11,71 +11,34 @@
           "arguments": {
             "pipeline": [
               {
-                "$currentOp": {
-                  "allUsers": false,
-                  "idleConnections": false,
-                  "localOps": true
-                }
+                "$listLocalSessions": {}
               },
               {
-                "$match": {
-                  "command.aggregate": {
-                    "$eq": 1
-                  }
-                }
+                "$limit": 1
               },
               {
-                "$project": {
-                  "command": 1
+                "$addFields": {
+                  "dummy": "dummy field"
                 }
               },
               {
                 "$project": {
-                  "command.lsid": 0
+                  "_id": 0,
+                  "dummy": 1
                 }
               }
             ]
           },
           "result": [
             {
-              "command": {
-                "aggregate": 1,
-                "pipeline": [
-                  {
-                    "$currentOp": {
-                      "allUsers": false,
-                      "idleConnections": false,
-                      "localOps": true
-                    }
-                  },
-                  {
-                    "$match": {
-                      "command.aggregate": {
-                        "$eq": 1
-                      }
-                    }
-                  },
-                  {
-                    "$project": {
-                      "command": 1
-                    }
-                  },
-                  {
-                    "$project": {
-                      "command.lsid": 0
-                    }
-                  }
-                ],
-                "cursor": {},
-                "$db": "admin"
-              }
+              "dummy": "dummy field"
             }
           ]
         }
       ]
     },
     {
-      "description": "Aggregate with $currentOp and allowDiskUse",
+      "description": "Aggregate with $listLocalSessions and allowDiskUse",
       "operations": [
         {
           "name": "aggregate",
@@ -83,27 +46,20 @@
           "arguments": {
             "pipeline": [
               {
-                "$currentOp": {
-                  "allUsers": true,
-                  "idleConnections": true,
-                  "localOps": true
-                }
+                "$listLocalSessions": {}
               },
               {
-                "$match": {
-                  "command.aggregate": {
-                    "$eq": 1
-                  }
-                }
+                "$limit": 1
               },
               {
-                "$project": {
-                  "command": 1
+                "$addFields": {
+                  "dummy": "dummy field"
                 }
               },
               {
                 "$project": {
-                  "command.lsid": 0
+                  "_id": 0,
+                  "dummy": 1
                 }
               }
             ],
@@ -111,38 +67,7 @@
           },
           "result": [
             {
-              "command": {
-                "aggregate": 1,
-                "pipeline": [
-                  {
-                    "$currentOp": {
-                      "allUsers": true,
-                      "idleConnections": true,
-                      "localOps": true
-                    }
-                  },
-                  {
-                    "$match": {
-                      "command.aggregate": {
-                        "$eq": 1
-                      }
-                    }
-                  },
-                  {
-                    "$project": {
-                      "command": 1
-                    }
-                  },
-                  {
-                    "$project": {
-                      "command.lsid": 0
-                    }
-                  }
-                ],
-                "allowDiskUse": true,
-                "cursor": {},
-                "$db": "admin"
-              }
+              "dummy": "dummy field"
             }
           ]
         }

--- a/test/functional/spec/crud/v2/db-aggregate.yml
+++ b/test/functional/spec/crud/v2/db-aggregate.yml
@@ -1,53 +1,36 @@
 database_name: &database_name "admin"
 
-minServerVersion: '4.0'
+minServerVersion: '3.6'
 
 tests:
   -
-    description: "Aggregate with $currentOp"
+    description: "Aggregate with $listLocalSessions"
     operations:
       -
         name: aggregate
         object: database
         arguments:
           pipeline:
-            - $currentOp: { allUsers: false, idleConnections: false, localOps: true }
-            - $match: { command.aggregate: { $eq: 1 } }
-            - $project: { command: 1 }
-            - $project: { command.lsid: 0 }
+            - $listLocalSessions: { }
+            - $limit: 1
+            - $addFields: { dummy: "dummy field"}
+            - $project: { _id: 0, dummy: 1}
         result:
           -
-            command:
-              aggregate: 1
-              pipeline:
-                - $currentOp: { allUsers: false, idleConnections: false, localOps: true }
-                - $match: { command.aggregate: { $eq: 1 } }
-                - $project: { command: 1 }
-                - $project: { command.lsid: 0 }
-              cursor: {}
-              $db: "admin"
+            dummy: "dummy field"
   -
-    description: "Aggregate with $currentOp and allowDiskUse"
+    description: "Aggregate with $listLocalSessions and allowDiskUse"
     operations:
       -
         name: aggregate
         object: database
         arguments:
           pipeline:
-            - $currentOp: { allUsers: true, idleConnections: true, localOps: true }
-            - $match: { command.aggregate: {$eq: 1} }
-            - $project: { command: 1 }
-            - $project: { command.lsid: 0 }
+            - $listLocalSessions: { }
+            - $limit: 1
+            - $addFields: { dummy: "dummy field"}
+            - $project: { _id: 0, dummy: 1 }
           allowDiskUse: true
         result:
           -
-            command:
-              aggregate: 1
-              pipeline:
-                - $currentOp: { allUsers: true, idleConnections: true, localOps: true }
-                - $match: { command.aggregate: { $eq: 1 } }
-                - $project: { command: 1 }
-                - $project: { command.lsid: 0 }
-              allowDiskUse: true
-              cursor: {}
-              $db: "admin"
+            dummy: "dummy field"

--- a/test/functional/spec/crud/v2/updateWithPipelines.json
+++ b/test/functional/spec/crud/v2/updateWithPipelines.json
@@ -144,7 +144,8 @@
                         "foo": 1
                       }
                     }
-                  ]
+                  ],
+                  "multi": true
                 }
               ]
             },
@@ -198,28 +199,21 @@
         {
           "command_started_event": {
             "command": {
-              "update": "test",
-              "updates": [
+              "findAndModify": "test",
+              "update": [
                 {
-                  "q": {
-                    "_id": 1
-                  },
-                  "u": [
-                    {
-                      "$project": {
-                        "x": 1
-                      }
-                    },
-                    {
-                      "$addFields": {
-                        "foo": 1
-                      }
-                    }
-                  ]
+                  "$project": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$addFields": {
+                    "foo": 1
+                  }
                 }
               ]
             },
-            "command_name": "update",
+            "command_name": "findAndModify",
             "database_name": "crud-tests"
           }
         }

--- a/test/functional/spec/crud/v2/updateWithPipelines.yml
+++ b/test/functional/spec/crud/v2/updateWithPipelines.yml
@@ -57,6 +57,7 @@ tests:
               -
                 q: { }
                 u: [ { $project: { x: 1 } }, { $addFields: { foo: 1 } } ]
+                multi: true
           command_name: update
           database_name: *database_name
     outcome:
@@ -76,12 +77,11 @@ tests:
       -
         command_started_event:
           command:
-            update: *collection_name
-            updates:
-              -
-                q: { _id: 1 }
-                u: [ { $project: { x: 1 } }, { $addFields: { foo: 1 } } ]
-          command_name: update
+            findAndModify: *collection_name
+            update:
+              - $project: { x: 1 }
+              - $addFields: { foo: 1 }
+          command_name: findAndModify
           database_name: *database_name
     outcome:
       collection:


### PR DESCRIPTION
# Description
The main work here was that `$merge` is accepted as a final aggregation pipeline stage similar to `$out`. We needed to ensure that when this is provided, that the operation is considered a write operation, and therefore things like write concern apply.

**What changed?**
The tests are expressed in YAML in the CRUDv2 format, so I've also included updates to support running those tests. The commits are unit, and should have detailed descriptions where appropriate.

**Are there any files to ignore?**
No.