### PR TITLE
Don't set startAtOperationTime if resumeToken is available

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -453,6 +453,10 @@ function processNewChange(args) {
 
   changeStream.resumeToken = change._id;
 
+  // wipe the startAtOperationTime if there was one so that there won't be a conflict
+  // between resumeToken and startAtOperationTime if we need to reconnect the cursor
+  changeStream.options.startAtOperationTime = undefined;
+
   // Return the change
   if (eventEmitter) return changeStream.emit('change', change);
   if (typeof callback === 'function') return callback(error, change);


### PR DESCRIPTION
# Avoid sending startAtOperationTime on cursor reconnects if resumeToken is available

**What changed?**

This is basically a duplicate of [JAVA-2987](https://jira.mongodb.org/browse/JAVA-2987) but in the node driver.  When the cursor tries to reconnect, it has an internal resumeToken value that it has acquired while iterating over earlier changes.  If a startAtOperationTime was set when the cursor was originally created, it will also be sent and the server will respond with "Only one type of resume option is allowed, but multiple were found"

**Are there any files to ignore?**

No
