### PR TITLE
chore(transactions): enable recovery token by default

### DIFF
--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -209,6 +209,7 @@ function connect(mongoClient, url, options, callback) {
     if (_finalOptions.socketTimeoutMS == null) _finalOptions.socketTimeoutMS = 360000;
     if (_finalOptions.connectTimeoutMS == null) _finalOptions.connectTimeoutMS = 30000;
     if (_finalOptions.retryWrites == null) _finalOptions.retryWrites = true;
+    if (_finalOptions.useRecoveryToken == null) _finalOptions.useRecoveryToken = true;
 
     if (_finalOptions.db_options && _finalOptions.db_options.auth) {
       delete _finalOptions.db_options.auth;


### PR DESCRIPTION
Fixes NODE-2023

# Description

Enables the sharded recovery token by default.

An alternative option is to remove the option `useRecoveryToken`

**What changed?**
Enables the sharded recovery token by default

**Are there any files to ignore?**
No
