### PR TITLE
docs(drop): document writeConcern usage for drop methods

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1059,6 +1059,10 @@ Collection.prototype.rename = function(newName, options, callback) {
  *
  * @method
  * @param {object} [options] Optional settings.
+ * @param {WriteConcern} [options.writeConcern] A full WriteConcern object
+ * @param {(number|string)} [options.w] The write concern
+ * @param {number} [options.wtimeout] The write concern timeout
+ * @param {boolean} [options.j] The journal write concern
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed

--- a/lib/db.js
+++ b/lib/db.js
@@ -687,6 +687,10 @@ Db.prototype.renameCollection = function(fromCollection, toCollection, options, 
  * @method
  * @param {string} name Name of collection to drop
  * @param {Object} [options] Optional settings
+ * @param {WriteConcern} [options.writeConcern] A full WriteConcern object
+ * @param {(number|string)} [options.w] The write concern
+ * @param {number} [options.wtimeout] The write concern timeout
+ * @param {boolean} [options.j] The journal write concern
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Db~resultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed


### PR DESCRIPTION
Fixes NODE-1631

# Description

Adds documentation for write concern options to `Collection.prototype.drop` and `Db.prototype.dropCollection`

**What changed?**
jsdoc comments on the methods mentioned above

**Are there any files to ignore?**
No