### PR TITLE
refactor(readconcern_tests): refactor readconcern tests to be more DRY

### DIFF
--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -468,4 +468,28 @@ describe('ReadConcern', function() {
       });
     }
   });
+  it('Should set local readConcern on db level when using createCollection method', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2' } },
+
+    test: function(done) {
+      // Get a new instance
+      const configuration = this.configuration;
+      const client = configuration.newClient(
+        { w: 1 },
+        { poolSize: 1, readConcern: { level: 'local' } }
+      );
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+        const db = client.db(configuration.db);
+        expect(db.s.readConcern).to.deep.equal({ level: 'local' });
+
+        // Get a collection using createCollection
+        db.createCollection('readConcernCollection', (err, collection) => {
+          // Validate readConcern
+          expect(collection.s.readConcern).to.deep.equal({ level: 'local' });
+          client.close(done);
+        });
+      });
+    }
+  });
 });

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -151,7 +151,6 @@ describe('ReadConcern', function() {
       {
         description: 'Should set majority readConcern using MongoClient with options',
         level: 'majority',
-        urlOptions: 'majority',
         readConcern: { level: 'majority' }
       }
     ];
@@ -164,35 +163,24 @@ describe('ReadConcern', function() {
           const succeeded = [];
           // Get a new instance
           const configuration = this.configuration;
-          let options;
-          let url;
 
-          if (test.urlReadConcernLevel || test.urlOptions) {
-            url = configuration.url();
-            if (test.urlOptions == null) {
-              url =
-                url.indexOf('?') !== -1
-                  ? `${url}&${test.urlReadConcernLevel}`
-                  : `${url}?${test.urlReadConcernLevel}`;
-            } else {
-              options = {
-                readConcern: {
-                  level: test.level
-                }
-              };
-            }
+          let url = configuration.url();
+          if (test.urlReadConcernLevel != null) {
+            url =
+              url.indexOf('?') !== -1
+                ? `${url}&${test.urlReadConcernLevel}`
+                : `${url}?${test.urlReadConcernLevel}`;
           }
 
           client =
-            test.urlOptions != null
-              ? configuration.newClient(url, options)
-              : configuration.newClient(url);
+            test.urlReadConcernLevel != null
+              ? configuration.newClient(url)
+              : configuration.newClient(url, { readConcern: test.readConcern });
 
           client.connect((err, client) => {
             expect(err).to.not.exist;
 
             const db = client.db(configuration.db);
-            // console.log();
             expect(db.readConcern).to.deep.equal(test.readConcern);
 
             // Get a collection

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -300,7 +300,7 @@ describe('ReadConcern', function() {
                   }
                 );
               } else if (test.commandName === 'parallelCollectionScan') {
-                collection.parallelCollectionScan({ numCursors: 1 }, function(err) {
+                collection.parallelCollectionScan({ numCursors: 1 }, err => {
                   expect(err).to.not.exist;
                   run_tests(0, test.commandName, test.level);
                   done();
@@ -324,7 +324,7 @@ describe('ReadConcern', function() {
         { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
-      client.connect(function(err, client) {
+      client.connect((err, client) => {
         expect(err).to.not.exist;
 
         const db = client.db(configuration.db);
@@ -336,24 +336,24 @@ describe('ReadConcern', function() {
         expect({ level: 'majority' }).to.deep.equal(collection.s.readConcern);
 
         // Listen to apm events
-        info.listener.on('started', function(event) {
+        info.listener.on('started', event => {
           if (event.commandName === 'aggregate') info.commands.started.push(event);
         });
-        info.listener.on('succeeded', function(event) {
+        info.listener.on('succeeded', event => {
           if (event.commandName === 'aggregate') info.commands.succeeded.push(event);
         });
 
         // Execute find
         collection
           .aggregate([{ $match: {} }, { $out: 'readConcernCollectionAggregate1Output' }])
-          .toArray(function(err) {
+          .toArray(err => {
             expect(err).to.not.exist;
             run_tests(0, 'aggregate', undefined);
 
             // Execute find
             collection
               .aggregate([{ $match: {} }], { out: 'readConcernCollectionAggregate2Output' })
-              .toArray(function(err) {
+              .toArray(err => {
                 expect(err).to.not.exist;
                 run_tests(1, 'aggregate', undefined);
                 done();
@@ -421,7 +421,7 @@ describe('ReadConcern', function() {
         { poolSize: 1, readConcern: { level: 'majority' } }
       );
 
-      client.connect(function(err, client) {
+      client.connect((err, client) => {
         expect(err).to.not.exist;
 
         const db = client.db(configuration.db);
@@ -432,24 +432,22 @@ describe('ReadConcern', function() {
         collection.insertMany(
           [{ user_id: 1 }, { user_id: 2 }],
           configuration.writeConcernMax(),
-          function(err) {
+          err => {
             expect(err).to.not.exist;
             // String functions
             const map = 'function() { emit(this.user_id, 1); }';
             const reduce = 'function(k,vals) { return 1; }';
 
             // Listen to apm events
-            info.listener.on('started', function(event) {
+            info.listener.on('started', event => {
               if (event.commandName === 'mapreduce') info.commands.started.push(event);
             });
-            info.listener.on('succeeded', function(event) {
+            info.listener.on('succeeded', event => {
               if (event.commandName === 'mapreduce') info.commands.succeeded.push(event);
             });
 
             // Execute mapReduce
-            collection.mapReduce(map, reduce, { out: { replace: 'tempCollection' } }, function(
-              err
-            ) {
+            collection.mapReduce(map, reduce, { out: { replace: 'tempCollection' } }, err => {
               expect(err).to.not.exist;
               run_tests(0, 'mapreduce', undefined);
               done();

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -198,28 +198,32 @@ describe('ReadConcern', function() {
     {
       description: 'Should set majority readConcern distinct command',
       level: 'majority',
-      commandName: 'distinct'
+      commandName: 'distinct',
+      mongodbVersion: '>= 3.2'
     },
     {
       description: 'Should set majority readConcern count command',
       level: 'majority',
-      commandName: 'count'
+      commandName: 'count',
+      mongodbVersion: '>= 3.2'
     },
     {
       description: 'Should set majority readConcern group command',
       level: 'majority',
-      commandName: 'group'
+      commandName: 'group',
+      mongodbVersion: '>= 3.2 <=4.1.0'
     },
     {
       description: 'Should set majority readConcern parallelCollectionScan command',
       level: 'majority',
-      commandName: 'parallelCollectionScan'
+      commandName: 'parallelCollectionScan',
+      mongodbVersion: '>= 3.2 <=4.1.0'
     }
   ];
 
   insertTests.forEach(test => {
     it(test.description, {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2' } },
+      metadata: { requires: { topology: 'replicaset', mongodb: test.mongodbVersion } },
 
       test: function(done) {
         // Get a new instance
@@ -282,7 +286,7 @@ describe('ReadConcern', function() {
                   done();
                 });
               } else if (test.commandName === 'count') {
-                collection.count({ a: 1 }, err => {
+                collection.estimatedDocumentCount({ a: 1 }, err => {
                   expect(err).to.not.exist;
                   run_tests(0, test.commandName, test.level);
                   done();

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -170,12 +170,10 @@ describe('ReadConcern', function() {
               url.indexOf('?') !== -1
                 ? `${url}&${test.urlReadConcernLevel}`
                 : `${url}?${test.urlReadConcernLevel}`;
+            client = configuration.newClient(url);
+          } else {
+            client = configuration.newClient(url, { readConcern: test.readConcern });
           }
-
-          client =
-            test.urlReadConcernLevel != null
-              ? configuration.newClient(url)
-              : configuration.newClient(url, { readConcern: test.readConcern });
 
           client.connect((err, client) => {
             expect(err).to.not.exist;

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -14,7 +14,7 @@ describe('ReadConcern', function() {
 
   function validateTestResults(started, succeeded, commandName, level) {
     expect(started.length).to.equal(succeeded.length);
-    for (var i = 0; i < started.length; i++) {
+    for (let i = 0; i < started.length; i++) {
       expect(started[i]).to.have.property('commandName', commandName);
       expect(succeeded[i]).to.have.property('commandName', commandName);
       if (level != null) {
@@ -457,10 +457,7 @@ describe('ReadConcern', function() {
     test: function(done) {
       // Get a new instance
       const configuration = this.configuration;
-      const client = configuration.newClient(
-        { w: 1 },
-        { poolSize: 1, readConcern: { level: 'local' } }
-      );
+      client = configuration.newClient({ w: 1 }, { poolSize: 1, readConcern: { level: 'local' } });
       client.connect((err, client) => {
         expect(err).to.not.exist;
         const db = client.db(configuration.db);

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -3,6 +3,13 @@
 const MongoClient = require('../../').MongoClient;
 const expect = require('chai').expect;
 
+function filterForCommands(commands, bag) {
+  commands = Array.isArray(commands) ? commands : [commands];
+  return function(event) {
+    if (commands.indexOf(event.commandName) !== -1) bag.push(event);
+  };
+}
+
 function connectToDb(url, db, options, callback) {
   if (typeof options === 'function') {
     callback = options;
@@ -106,5 +113,6 @@ module.exports = {
   setupDatabase,
   assert,
   delay,
-  withClient
+  withClient,
+  filterForCommands
 };


### PR DESCRIPTION
Fixes NODE-1811

# Description
`readconcern_tests.js` previously included a lot of repeated tests and logic, which is now extracted out into a more templated form.

**What changed?**
The tests have become more streamlined, and similar aspects have been extracted out and put into an array that can be passed into a templated test format. This includes command monitoring.

**Are there any files to ignore?**
None.