### PR TITLE
test(collection tests): Clean up collection_tests and make them DRY

### DIFF
--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -1158,7 +1158,6 @@ function updateDocuments(coll, selector, document, options, callback) {
   if ('function' === typeof options) (callback = options), (options = null);
   if (options == null) options = {};
   if (!('function' === typeof callback)) callback = null;
-
   // If we are not providing a selector or document throw
   if (selector == null || typeof selector !== 'object')
     return callback(toError('selector must be a valid JavaScript object'));

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -1158,6 +1158,7 @@ function updateDocuments(coll, selector, document, options, callback) {
   if ('function' === typeof options) (callback = options), (options = null);
   if (options == null) options = {};
   if (!('function' === typeof callback)) callback = null;
+
   // If we are not providing a selector or document throw
   if (selector == null || typeof selector !== 'object')
     return callback(toError('selector must be a valid JavaScript object'));

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -12,65 +12,162 @@ describe('Collection', function() {
     return setupDatabase(this.configuration);
   });
 
-  /**
-   * @ignore
-   */
-  it('should correctly execute basic collection methods', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
+  describe('', function() {
+    let client;
+    beforeEach(function() {
+      client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
       });
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
+    });
+    afterEach(function() {
+      return client.close();
+    });
 
-        db.createCollection('test_collection_methods', function(err, collection) {
-          // Verify that all the result are correct coming back (should contain the value ok)
-          test.equal('test_collection_methods', collection.collectionName);
-          // Let's check that the collection was created correctly
-          db.listCollections().toArray(function(err, documents) {
-            var found = false;
-            documents.forEach(function(document) {
-              if (document.name === 'integration_tests_.test_collection_methods') found = true;
-            });
-            test.ok(true, found);
+    /**
+     * @ignore
+     */
+    it('should correctly execute basic collection methods', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-            // Rename the collection and check that it's gone
-            db.renameCollection('test_collection_methods', 'test_collection_methods2', function(
-              err
-            ) {
-              test.equal(null, err);
-              // Drop the collection and check that it's gone
-              db.dropCollection('test_collection_methods2', function(err, result) {
-                test.equal(true, result);
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('test_collection_methods', (err, collection) => {
+            // Verify that all the result are correct coming back (should contain the value ok)
+            test.equal('test_collection_methods', collection.collectionName);
+            // Let's check that the collection was created correctly
+            db.listCollections().toArray((err, documents) => {
+              const found = false;
+              documents.forEach(document => {
+                if (document.name === 'integration_tests_.test_collection_methods') found = true;
+              });
+              test.ok(true, found);
+
+              // Rename the collection and check that it's gone
+              db.renameCollection('test_collection_methods', 'test_collection_methods2', err => {
+                test.equal(null, err);
+                // Drop the collection and check that it's gone
+                db.dropCollection('test_collection_methods2', (err, result) => {
+                  test.equal(true, result);
+                });
+              });
+
+              db.createCollection('test_collection_methods3', (err, collection) => {
+                // Verify that all the result are correct coming back (should contain the value ok)
+                test.equal('test_collection_methods3', collection.collectionName);
+
+                db.createCollection('test_collection_methods4', (err, collection) => {
+                  // Verify that all the result are correct coming back (should contain the value ok)
+                  test.equal('test_collection_methods4', collection.collectionName);
+
+                  // Rename the collection and with the dropTarget boolean, and check to make sure only onen exists.
+                  db.renameCollection(
+                    'test_collection_methods4',
+                    'test_collection_methods3',
+                    { dropTarget: true },
+                    err => {
+                      test.equal(null, err);
+
+                      db.dropCollection('test_collection_methods3', (err, result) => {
+                        test.equal(true, result);
+                        client.close();
+                        done();
+                      });
+                    }
+                  );
+                });
               });
             });
+          });
+        });
+      }
+    });
+    /**
+     * @ignore
+     */
+    it('should correctly list back collection names containing .', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-            db.createCollection('test_collection_methods3', function(err, collection) {
-              // Verify that all the result are correct coming back (should contain the value ok)
-              test.equal('test_collection_methods3', collection.collectionName);
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db1 = client.db('test');
+          db1.createCollection('test.game', (err, collection) => {
+            // Verify that all the result are correct coming back (should contain the value ok)
+            test.equal('test.game', collection.collectionName);
+            // Let's check that the collection was created correctly
+            db1.listCollections().toArray((err, documents) => {
+              test.equal(null, err);
+              let found = false;
+              documents.forEach(x => {
+                if (x.name === 'test.game') found = true;
+              });
 
-              db.createCollection('test_collection_methods4', function(err, collection) {
-                // Verify that all the result are correct coming back (should contain the value ok)
-                test.equal('test_collection_methods4', collection.collectionName);
+              test.ok(found);
+              client.close();
+              done();
+            });
+          });
+        });
+      }
+    });
 
-                // Rename the collection and with the dropTarget boolean, and check to make sure only onen exists.
-                db.renameCollection(
-                  'test_collection_methods4',
-                  'test_collection_methods3',
-                  { dropTarget: true },
-                  function(err) {
+    /**
+     * @ignore
+     */
+    it('should access to collections', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          // Create two collections
+          db.createCollection('test.spiderman', () => {
+            db.createCollection('test.mario', () => {
+              // Insert test documents (creates collections)
+              db.collection('test.spiderman', (err, spiderman_collection) => {
+                spiderman_collection.insert(
+                  { foo: 5 },
+                  this.configuration.writeConcernMax(),
+                  err => {
                     test.equal(null, err);
+                    db.collection('test.mario', (err, mario_collection) => {
+                      mario_collection.insert(
+                        { bar: 0 },
+                        this.configuration.writeConcernMax(),
+                        err => {
+                          test.equal(null, err);
+                          // Assert collections
+                          db.collections((err, collections) => {
+                            let found_spiderman = false;
+                            let found_mario = false;
+                            let found_does_not_exist = false;
 
-                    db.dropCollection('test_collection_methods3', function(err, result) {
-                      test.equal(true, result);
-                      client.close();
-                      done();
+                            collections.forEach(collection => {
+                              if (collection.collectionName === 'test.spiderman') found_spiderman = true;
+                              if (collection.collectionName === 'test.mario') found_mario = true;
+                              if (collection.collectionName === 'does_not_exist') found_does_not_exist = true;
+                            });
+
+                            test.ok(found_spiderman);
+                            test.ok(found_mario);
+                            test.ok(!found_does_not_exist);
+                            client.close();
+                            done();
+                          });
+                        }
+                      );
                     });
                   }
                 );
@@ -78,356 +175,240 @@ describe('Collection', function() {
             });
           });
         });
-      });
-    }
-  });
+      }
+    });
 
-  /**
-   * @ignore
-   */
-  it('should correctly list back collection names containing .', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+    /**
+     * @ignore
+     */
+    it('should correctly retrieve listCollections', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db1 = client.db('test');
-        db1.createCollection('test.game', function(err, collection) {
-          // Verify that all the result are correct coming back (should contain the value ok)
-          test.equal('test.game', collection.collectionName);
-          // Let's check that the collection was created correctly
-          db1.listCollections().toArray(function(err, documents) {
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('test_collection_names', err => {
             test.equal(null, err);
-            var found = false;
-            documents.forEach(function(x) {
-              if (x.name === 'test.game') found = true;
-            });
 
-            test.ok(found);
-            client.close();
-            done();
+            db.listCollections().toArray((err, documents) => {
+              let found = false;
+              let found2 = false;
+
+              documents.forEach(document => {
+                if (
+                  document.name === this.configuration.db + '.test_collection_names' ||
+                  document.name === 'test_collection_names'
+                )
+                  found = true;
+              });
+
+              test.ok(found);
+              // Insert a document in an non-existing collection should create the collection
+              const collection = db.collection('test_collection_names2');
+              collection.insert({ a: 1 }, this.configuration.writeConcernMax(), err => {
+                test.equal(null, err);
+
+                db.listCollections().toArray((err, documents) => {
+                  documents.forEach(document => {
+                    if (
+                      document.name === this.configuration.db + '.test_collection_names2' ||
+                      document.name === 'test_collection_names2'
+                    )
+                      found = true;
+                    if (
+                      document.name === this.configuration.db + '.test_collection_names' ||
+                      document.name === 'test_collection_names'
+                    )
+                      found2 = true;
+                  });
+
+                  test.ok(found);
+                  test.ok(found2);
+
+                  // Let's close the db
+                  client.close();
+                  done();
+                });
+              });
+            });
           });
         });
-      });
-    }
-  });
+      }
+    });
 
-  /**
-   * @ignore
-   */
-  it('should access to collections', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+    /**
+     * @ignore
+     */
+    it('should ensure strict access collection', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.collection('does-not-exist', { strict: true }, err => {
+            test.ok(err instanceof Error);
+            test.equal(
+              'Collection does-not-exist does not exist. Currently in strict mode.',
+              err.message
+            );
 
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-        // Create two collections
-        db.createCollection('test.spiderman', function() {
-          db.createCollection('test.mario', function() {
-            // Insert test documents (creates collections)
-            db.collection('test.spiderman', function(err, spiderman_collection) {
-              spiderman_collection.insert(
-                { foo: 5 },
-                self.configuration.writeConcernMax(),
-                function(err) {
+            db.createCollection('test_strict_access_collection', err => {
+              test.equal(null, err);
+              db.collection(
+                'test_strict_access_collection',
+                this.configuration.writeConcernMax(),
+                (err, collection) => {
                   test.equal(null, err);
-                  db.collection('test.mario', function(err, mario_collection) {
-                    mario_collection.insert(
-                      { bar: 0 },
-                      self.configuration.writeConcernMax(),
-                      function(err) {
-                        test.equal(null, err);
-                        // Assert collections
-                        db.collections(function(err, collections) {
-                          var found_spiderman = false;
-                          var found_mario = false;
-                          var found_does_not_exist = false;
-
-                          collections.forEach(function(collection) {
-                            if (collection.collectionName === 'test.spiderman')
-                              found_spiderman = true;
-                            if (collection.collectionName === 'test.mario') found_mario = true;
-                            if (collection.collectionName === 'does_not_exist')
-                              found_does_not_exist = true;
-                          });
-
-                          test.ok(found_spiderman);
-                          test.ok(found_mario);
-                          test.ok(!found_does_not_exist);
-                          client.close();
-                          done();
-                        });
-                      }
-                    );
-                  });
+                  test.ok(collection.collectionName);
+                  // Let's close the db
+                  client.close();
+                  done();
                 }
               );
             });
           });
         });
-      });
-    }
-  });
+      }
+    });
 
-  /**
-   * @ignore
-   */
-  it('should correctly retrieve listCollections', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+    /**
+     * @ignore
+     */
+    it('should perform strict create collection', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('test_collection_names', function(err) {
-          test.equal(null, err);
-
-          db.listCollections().toArray(function(err, documents) {
-            var found = false;
-            var found2 = false;
-
-            documents.forEach(function(document) {
-              if (
-                document.name === self.configuration.db + '.test_collection_names' ||
-                document.name === 'test_collection_names'
-              )
-                found = true;
-            });
-
-            test.ok(found);
-            // Insert a document in an non-existing collection should create the collection
-            var collection = db.collection('test_collection_names2');
-            collection.insert({ a: 1 }, self.configuration.writeConcernMax(), function(err) {
-              test.equal(null, err);
-
-              db.listCollections().toArray(function(err, documents) {
-                documents.forEach(function(document) {
-                  if (
-                    document.name === self.configuration.db + '.test_collection_names2' ||
-                    document.name === 'test_collection_names2'
-                  )
-                    found = true;
-                  if (
-                    document.name === self.configuration.db + '.test_collection_names' ||
-                    document.name === 'test_collection_names'
-                  )
-                    found2 = true;
-                });
-
-                test.ok(found);
-                test.ok(found2);
-
-                // Let's close the db
-                client.close();
-                done();
-              });
-            });
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should ensure strict access collection', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.collection('does-not-exist', { strict: true }, function(err) {
-          test.ok(err instanceof Error);
-          test.equal(
-            'Collection does-not-exist does not exist. Currently in strict mode.',
-            err.message
-          );
-
-          db.createCollection('test_strict_access_collection', function(err) {
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('test_strict_create_collection', (err, collection) => {
             test.equal(null, err);
-            db.collection(
-              'test_strict_access_collection',
-              self.configuration.writeConcernMax(),
-              function(err, collection) {
-                test.equal(null, err);
-                test.ok(collection.collectionName);
-                // Let's close the db
-                client.close();
-                done();
-              }
-            );
-          });
-        });
-      });
-    }
-  });
+            test.equal('test_strict_create_collection', collection.collectionName);
 
-  /**
-   * @ignore
-   */
-  it('should perform strict create collection', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+            // Creating an existing collection should fail
+            db.createCollection('test_strict_create_collection', { strict: true }, err => {
+              test.ok(err instanceof Error);
+              test.equal(
+                'Collection test_strict_create_collection already exists. Currently in strict mode.',
+                err.message
+              );
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
+              // Switch out of strict mode and try to re-create collection
+              db.createCollection(
+                'test_strict_create_collection',
+                { strict: false },
+                (err, collection) => {
+                  test.equal(null, err);
+                  test.ok(collection.collectionName);
 
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('test_strict_create_collection', function(err, collection) {
-          test.equal(null, err);
-          test.equal('test_strict_create_collection', collection.collectionName);
-
-          // Creating an existing collection should fail
-          db.createCollection('test_strict_create_collection', { strict: true }, function(err) {
-            test.ok(err instanceof Error);
-            test.equal(
-              'Collection test_strict_create_collection already exists. Currently in strict mode.',
-              err.message
-            );
-
-            // Switch out of strict mode and try to re-create collection
-            db.createCollection('test_strict_create_collection', { strict: false }, function(
-              err,
-              collection
-            ) {
-              test.equal(null, err);
-              test.ok(collection.collectionName);
-
-              // Let's close the db
-              client.close();
-              done();
+                  // Let's close the db
+                  client.close();
+                  done();
+                }
+              );
             });
           });
         });
-      });
-    }
-  });
+      }
+    });
 
-  /**
-   * @ignore
-   */
-  it.skip('should fail to insert due to illegal keys', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+    /**
+     * @ignore
+     */
+    it.skip('should fail to insert due to illegal keys', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('test_invalid_key_names', (err, collection) => {
+            // Legal inserts
+            collection.insert(
+              [{ hello: 'world' }, { hello: { hello: 'world' } }],
+              this.configuration.writeConcernMax(),
+              err => {
+                test.equal(null, err);
 
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('test_invalid_key_names', function(err, collection) {
-          // Legal inserts
-          collection.insert(
-            [{ hello: 'world' }, { hello: { hello: 'world' } }],
-            self.configuration.writeConcernMax(),
-            function(err) {
-              test.equal(null, err);
-
-              // Illegal insert for key
-              collection.insert({ $hello: 'world' }, self.configuration.writeConcernMax(), function(
-                err
-              ) {
-                test.ok(err instanceof Error);
-                test.equal("key $hello must not start with '$'", err.message);
-
+                // Illegal insert for key
                 collection.insert(
-                  { hello: { $hello: 'world' } },
-                  self.configuration.writeConcernMax(),
-                  function(err) {
+                  { $hello: 'world' },
+                  this.configuration.writeConcernMax(),
+                  err => {
                     test.ok(err instanceof Error);
                     test.equal("key $hello must not start with '$'", err.message);
 
                     collection.insert(
-                      { he$llo: 'world' },
-                      self.configuration.writeConcernMax(),
-                      function(err) {
-                        test.equal(null, err);
+                      { hello: { $hello: 'world' } },
+                      this.configuration.writeConcernMax(),
+                      err => {
+                        test.ok(err instanceof Error);
+                        test.equal("key $hello must not start with '$'", err.message);
 
                         collection.insert(
-                          { hello: { hell$o: 'world' } },
-                          self.configuration.writeConcernMax(),
-                          function(err) {
-                            test.ok(err == null);
+                          { he$llo: 'world' },
+                          this.configuration.writeConcernMax(),
+                          err => {
+                            test.equal(null, err);
 
                             collection.insert(
-                              { '.hello': 'world' },
-                              self.configuration.writeConcernMax(),
-                              function(err) {
-                                test.ok(err instanceof Error);
-                                test.equal("key .hello must not contain '.'", err.message);
+                              { hello: { hell$o: 'world' } },
+                              this.configuration.writeConcernMax(),
+                              err => {
+                                test.ok(err == null);
 
                                 collection.insert(
-                                  { hello: { '.hello': 'world' } },
-                                  self.configuration.writeConcernMax(),
-                                  function(err) {
+                                  { '.hello': 'world' },
+                                  this.configuration.writeConcernMax(),
+                                  err => {
                                     test.ok(err instanceof Error);
                                     test.equal("key .hello must not contain '.'", err.message);
 
                                     collection.insert(
-                                      { 'hello.': 'world' },
-                                      self.configuration.writeConcernMax(),
-                                      function(err) {
+                                      { hello: { '.hello': 'world' } },
+                                      this.configuration.writeConcernMax(),
+                                      err => {
                                         test.ok(err instanceof Error);
-                                        test.equal("key hello. must not contain '.'", err.message);
+                                        test.equal("key .hello must not contain '.'", err.message);
 
                                         collection.insert(
-                                          { hello: { 'hello.': 'world' } },
-                                          self.configuration.writeConcernMax(),
-                                          function(err) {
+                                          { 'hello.': 'world' },
+                                          this.configuration.writeConcernMax(),
+                                          err => {
                                             test.ok(err instanceof Error);
                                             test.equal(
                                               "key hello. must not contain '.'",
                                               err.message
                                             );
-                                            // Let's close the db
-                                            client.close();
-                                            done();
+
+                                            collection.insert(
+                                              { hello: { 'hello.': 'world' } },
+                                              this.configuration.writeConcernMax(),
+                                              err => {
+                                                test.ok(err instanceof Error);
+                                                test.equal(
+                                                  "key hello. must not contain '.'",
+                                                  err.message
+                                                );
+                                                // Let's close the db
+                                                client.close();
+                                                done();
+                                              }
+                                            );
                                           }
                                         );
                                       }
@@ -442,177 +423,159 @@ describe('Collection', function() {
                     );
                   }
                 );
-              });
-            }
-          );
+              }
+            );
+          });
         });
-      });
-    }
-  });
+      }
+    });
 
-  /**
-   * @ignore
-   */
-  it('should fail due to illegal listCollections', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+    /**
+     * @ignore
+     */
+    it('should fail due to illegal listCollections', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.collection(5, function(err) {
-          test.equal('collection name must be a String', err.message);
-        });
-
-        db.collection('', function(err) {
-          test.equal('collection names cannot be empty', err.message);
-        });
-
-        db.collection('te$t', function(err) {
-          test.equal("collection names must not contain '$'", err.message);
-        });
-
-        db.collection('.test', function(err) {
-          test.equal("collection names must not start or end with '.'", err.message);
-        });
-
-        db.collection('test.', function(err) {
-          test.equal("collection names must not start or end with '.'", err.message);
-        });
-
-        db.collection('test..t', function(err) {
-          test.equal('collection names cannot be empty', err.message);
-          client.close();
-          done();
-        });
-      });
-    }
-  });
-
-  it('should return invalid collection name error by callback for createCollection', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    test: function(done) {
-      const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-
-        const db = client.db('test_crate_collection');
-
-        db.dropDatabase(err => {
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
           expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.collection(5, err => {
+            test.equal('collection name must be a String', err.message);
+          });
 
-          db.createCollection('test/../', err => {
-            expect(err).to.exist;
+          db.collection('', err => {
+            test.equal('collection names cannot be empty', err.message);
+          });
+
+          db.collection('te$t', err => {
+            test.equal("collection names must not contain '$'", err.message);
+          });
+
+          db.collection('.test', err => {
+            test.equal("collection names must not start or end with '.'", err.message);
+          });
+
+          db.collection('test.', err => {
+            test.equal("collection names must not start or end with '.'", err.message);
+          });
+
+          db.collection('test..t', err => {
+            test.equal('collection names cannot be empty', err.message);
             client.close();
             done();
           });
         });
-      });
-    }
-  });
+      }
+    });
 
-  /**
-   * @ignore
-   */
-  it('should crrectly count on non-existent collection', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+    it('should return invalid collection name error by callback for createCollection', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
+      test: function(done) {
+        const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
+          poolSize: 1
+        });
 
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db('test_crate_collection');
+          db.dropDatabase(err => {
+            expect(err).to.not.exist;
 
-        db.collection('test_multiple_insert_2', function(err, collection) {
-          collection.count(function(err, count) {
-            test.equal(0, count);
-            // Let's close the db
-            client.close();
-            done();
+            db.createCollection('test/../', err => {
+              expect(err).to.exist;
+              client.close();
+              done();
+            });
           });
         });
-      });
-    }
-  });
+      }
+    });
+    /**
+     * @ignore
+     */
+    it('should crrectly count on non-existent collection', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-  /**
-   * @ignore
-   */
-  it('should correctly execute save', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.collection('test_multiple_insert_2', (err, collection) => {
+            collection.count((err, count) => {
+              test.equal(0, count);
+              // Let's close the db
+              client.close();
+              done();
+            });
+          });
+        });
+      }
+    });
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
+    /**
+     * @ignore
+     */
+    it('should correctly execute save', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('test_save', (err, collection) => {
+            const doc = { hello: 'world' };
+            collection.save(doc, this.configuration.writeConcernMax(), (err, r) => {
+              test.ok(r.ops[0]._id != null);
 
-        db.createCollection('test_save', function(err, collection) {
-          var doc = { hello: 'world' };
-          collection.save(doc, self.configuration.writeConcernMax(), function(err, r) {
-            test.ok(r.ops[0]._id != null);
+              collection.count((err, count) => {
+                test.equal(1, count);
 
-            collection.count(function(err, count) {
-              test.equal(1, count);
+                collection.save(r.ops[0], this.configuration.writeConcernMax(), err => {
+                  test.equal(null, err);
+                  collection.count((err, count) => {
+                    test.equal(1, count);
 
-              collection.save(r.ops[0], self.configuration.writeConcernMax(), function(err) {
-                test.equal(null, err);
-                collection.count(function(err, count) {
-                  test.equal(1, count);
+                    collection.findOne((err, doc3) => {
+                      test.equal('world', doc3.hello);
 
-                  collection.findOne(function(err, doc3) {
-                    test.equal('world', doc3.hello);
+                      doc3.hello = 'mike';
 
-                    doc3.hello = 'mike';
+                      collection.save(doc3, this.configuration.writeConcernMax(), err => {
+                        test.equal(null, err);
+                        collection.count((err, count) => {
+                          test.equal(1, count);
 
-                    collection.save(doc3, self.configuration.writeConcernMax(), function(err) {
-                      test.equal(null, err);
-                      collection.count(function(err, count) {
-                        test.equal(1, count);
+                          collection.findOne((err, doc5) => {
+                            test.equal('mike', doc5.hello);
 
-                        collection.findOne(function(err, doc5) {
-                          test.equal('mike', doc5.hello);
-
-                          // Save another document
-                          collection.save(
-                            { hello: 'world' },
-                            self.configuration.writeConcernMax(),
-                            function(err) {
-                              test.equal(null, err);
-                              collection.count(function(err, count) {
-                                test.equal(2, count);
-                                // Let's close the db
-                                client.close();
-                                done();
-                              });
-                            }
-                          );
+                            // Save another document
+                            collection.save(
+                              { hello: 'world' },
+                              this.configuration.writeConcernMax(),
+                              err => {
+                                test.equal(null, err);
+                                collection.count((err, count) => {
+                                  test.equal(2, count);
+                                  // Let's close the db
+                                  client.close();
+                                  done();
+                                });
+                              }
+                            );
+                          });
                         });
                       });
                     });
@@ -622,1086 +585,998 @@ describe('Collection', function() {
             });
           });
         });
-      });
-    }
-  });
+      }
+    });
 
-  /**
-   * @ignore
-   */
-  it('should correctly save document with Long value', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+    /**
+     * @ignore
+     */
+    it('should correctly save document with Long value', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var Long = self.configuration.require.Long;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('test_save_long', function(err, collection) {
-          collection.insert(
-            { x: Long.fromNumber(9223372036854775807) },
-            self.configuration.writeConcernMax(),
-            function(err) {
-              test.equal(null, err);
-              collection.findOne(function(err, doc) {
+      // The actual test we wish to run
+      test: function(done) {
+        const Long = this.configuration.require.Long;
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('test_save_long', (err, collection) => {
+            collection.insert(
+              { x: Long.fromNumber(9223372036854775807) },
+              this.configuration.writeConcernMax(),
+              err => {
                 test.equal(null, err);
-                test.ok(Long.fromNumber(9223372036854775807).equals(doc.x));
-                // Let's close the db
+                collection.findOne((err, doc) => {
+                  test.equal(null, err);
+                  test.ok(Long.fromNumber(9223372036854775807).equals(doc.x));
+                  // Let's close the db
+                  client.close();
+                  done();
+                });
+              }
+            );
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should save object that has id but does not exist in collection', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection(
+            'test_save_with_object_that_has_id_but_does_not_actually_exist_in_collection',
+            (err, collection) => {
+              const a = { _id: '1', hello: 'world' };
+              collection.save(a, this.configuration.writeConcernMax(), err => {
+                test.equal(null, err);
+                collection.count((err, count) => {
+                  test.equal(1, count);
+
+                  collection.findOne((err, doc) => {
+                    test.equal('world', doc.hello);
+
+                    doc.hello = 'mike';
+                    collection.save(doc, this.configuration.writeConcernMax(), err => {
+                      test.equal(null, err);
+                      collection.findOne((err, doc) => {
+                        collection.count((err, count) => {
+                          test.equal(1, count);
+
+                          test.equal('mike', doc.hello);
+                          // Let's close the db
+                          client.close();
+                          done();
+                        });
+                      });
+                    });
+                  });
+                });
+              });
+            }
+          );
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly update with no docs', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        const ObjectID = this.configuration.require.ObjectID;
+
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('test_should_correctly_do_update_with_no_docs', (err, collection) => {
+            const id = new ObjectID(null);
+            const doc = { _id: id, a: 1 };
+
+            collection.update({ _id: id }, doc, this.configuration.writeConcernMax(), (err, r) => {
+              test.equal(null, err);
+              test.equal(0, r.result.n);
+
+              client.close();
+              done();
+            });
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly execute insert update delete safe mode', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection(
+            'test_should_execute_insert_update_delete_safe_mode',
+            (err, collection) => {
+              test.equal(
+                'test_should_execute_insert_update_delete_safe_mode',
+                collection.collectionName
+              );
+
+              collection.insert({ i: 1 }, this.configuration.writeConcernMax(), (err, r) => {
+                test.equal(1, r.ops.length);
+                test.ok(r.ops[0]._id.toHexString().length === 24);
+
+                // Update the record
+                collection.update(
+                  { i: 1 },
+                  { $set: { i: 2 } },
+                  this.configuration.writeConcernMax(),
+                  err => {
+                    test.equal(null, err);
+                    test.equal(1, r.result.n);
+
+                    // Remove safely
+                    collection.remove({}, this.configuration.writeConcernMax(), err => {
+                      test.equal(null, err);
+
+                      client.close();
+                      done();
+                    });
+                  }
+                );
+              });
+            }
+          );
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should perform multiple saves', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('multiple_save_test', (err, collection) => {
+            const doc = {
+              name: 'amit',
+              text: 'some text'
+            };
+
+            //insert new user
+            collection.save(doc, this.configuration.writeConcernMax(), err => {
+              test.equal(null, err);
+
+              collection
+                .find({}, { name: 1 })
+                .limit(1)
+                .toArray((err, users) => {
+                  const user = users[0];
+
+                  if (err) {
+                    throw new Error(err);
+                  } else if (user) {
+                    user.pants = 'worn';
+
+                    collection.save(user, this.configuration.writeConcernMax(), (err, result) => {
+                      test.equal(null, err);
+                      test.equal(1, result.result.n);
+                      client.close();
+                      done();
+                    });
+                  }
+                });
+            });
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly save document with nested array', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        const ObjectID = this.configuration.require.ObjectID;
+
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('save_error_on_save_test', (err, collection) => {
+            // Create unique index for username
+            collection.createIndex([['username', 1]], this.configuration.writeConcernMax(), err => {
+              test.equal(null, err);
+              const doc = {
+                email: 'email@email.com',
+                encrypted_password: 'password',
+                friends: [
+                  '4db96b973d01205364000006',
+                  '4db94a1948a683a176000001',
+                  '4dc77b24c5ba38be14000002'
+                ],
+                location: [72.4930088, 23.0431957],
+                name: 'Amit Kumar',
+                password_salt: 'salty',
+                profile_fields: [],
+                username: 'amit'
+              };
+              //insert new user
+              collection.save(doc, this.configuration.writeConcernMax(), err => {
+                test.equal(null, err);
+
+                collection
+                  .find({})
+                  .limit(1)
+                  .toArray((err, users) => {
+                    test.equal(null, err);
+                    const user = users[0];
+                    user.friends.splice(1, 1);
+
+                    collection.save(user, err => {
+                      test.equal(null, err);
+
+                      // Update again
+                      collection.update(
+                        { _id: new ObjectID(user._id.toString()) },
+                        { friends: user.friends },
+                        { upsert: true, w: 1 },
+                        (err, result) => {
+                          test.equal(null, err);
+                          test.equal(1, result.result.n);
+
+                          client.close();
+                          done();
+                        }
+                      );
+                    });
+                  });
+              });
+            });
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should perform collection remove with no callback', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.collection('remove_with_no_callback_bug_test', (err, collection) => {
+            test.equal(null, err);
+            collection.save({ a: 1 }, this.configuration.writeConcernMax(), err => {
+              test.equal(null, err);
+              collection.save({ b: 1 }, this.configuration.writeConcernMax(), err => {
+                test.equal(null, err);
+                collection.save({ c: 1 }, this.configuration.writeConcernMax(), err => {
+                  test.equal(null, err);
+                  collection.remove({ a: 1 }, this.configuration.writeConcernMax(), err => {
+                    test.equal(null, err);
+                    // Let's perform a count
+                    collection.count((err, count) => {
+                      test.equal(null, err);
+                      test.equal(2, count);
+                      client.close();
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly create TTL collection with index using ensureIndex', {
+      metadata: {
+        requires: {
+          mongodb: '>2.1.0',
+          topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
+        }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection(
+            'shouldCorrectlyCreateTTLCollectionWithIndexUsingEnsureIndex',
+            (err, collection) => {
+              collection.ensureIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
+                test.equal(null, err);
+
+                // Insert a document with a date
+                collection.insert(
+                  { a: 1, createdAt: new Date() },
+                  this.configuration.writeConcernMax(),
+                  err => {
+                    test.equal(null, err);
+
+                    collection.indexInformation({ full: true }, (err, indexes) => {
+                      test.equal(null, err);
+
+                      for (let i = 0; i < indexes.length; i++) {
+                        if (indexes[i].name === 'createdAt_1') {
+                          test.equal(1, indexes[i].expireAfterSeconds);
+                          break;
+                        }
+                      }
+
+                      client.close();
+                      done();
+                    });
+                  }
+                );
+              });
+            }
+          );
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly create TTL collection with index using createIndex', {
+      metadata: {
+        requires: {
+          mongodb: '>2.1.0',
+          topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
+        }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection(
+            'shouldCorrectlyCreateTTLCollectionWithIndexCreateIndex',
+            {},
+            (err, collection) => {
+              collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
+                test.equal(null, err);
+
+                // Insert a document with a date
+                collection.insert(
+                  { a: 1, createdAt: new Date() },
+                  this.configuration.writeConcernMax(),
+                  err => {
+                    test.equal(null, err);
+
+                    collection.indexInformation({ full: true }, (err, indexes) => {
+                      test.equal(null, err);
+
+                      for (let i = 0; i < indexes.length; i++) {
+                        if (indexes[i].name === 'createdAt_1') {
+                          test.equal(1, indexes[i].expireAfterSeconds);
+                          break;
+                        }
+                      }
+
+                      client.close();
+                      done();
+                    });
+                  }
+                );
+              });
+            }
+          );
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should support createIndex with no options', {
+      metadata: {
+        requires: {
+          mongodb: '>2.1.0',
+          topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
+        }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('create_index_without_options', {}, (err, collection) => {
+            collection.createIndex({ createdAt: 1 }, err => {
+              test.equal(null, err);
+
+              collection.indexInformation({ full: true }, (err, indexes) => {
+                test.equal(null, err);
+                const indexNames = indexes.map(i => i.name);
+                expect(indexNames).to.include('createdAt_1');
+
+                client.close();
+                done();
+              });
+            });
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly read back document with null', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('shouldCorrectlyReadBackDocumentWithNull', {}, (err, collection) => {
+            // Insert a document with a date
+            collection.insert({ test: null }, this.configuration.writeConcernMax(), err => {
+              test.equal(null, err);
+
+              collection.findOne(err => {
+                test.equal(null, err);
+
+                client.close();
+                done();
+              });
+            });
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should throw error due to illegal update', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection('shouldThrowErrorDueToIllegalUpdate', {}, (err, coll) => {
+            try {
+              coll.update({}, null, () => {});
+            } catch (err) {
+              test.equal('document must be a valid JavaScript object', err.message);
+            }
+
+            try {
+              coll.update(null, null, () => {});
+            } catch (err) {
+              test.equal('selector must be a valid JavaScript object', err.message);
+            }
+
+            client.close();
+            done();
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly handle 0 as id for save', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
+            test.equal(null, err);
+
+            db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
+              test.equal(null, err);
+              client.close();
+              done();
+            });
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly execute update with . field in selector', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db
+            .collection('executeUpdateWithElemMatch')
+            .update({ 'item.i': 1 }, { $set: { a: 1 } }, err => {
+              test.equal(null, err);
+
+              client.close();
+              done();
+            });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly execute update with elemMatch field in selector', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db
+            .collection('executeUpdateWithElemMatch')
+            .update({ item: { $elemMatch: { name: 'my_name' } } }, { $set: { a: 1 } }, err => {
+              test.equal(null, err);
+
+              client.close();
+              done();
+            });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should fail due to exiting collection', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          db.createCollection(
+            'shouldFailDueToExistingCollection',
+            { strict: true },
+            (err, coll) => {
+              test.equal(null, err);
+              test.ok(coll != null);
+
+              db.createCollection('shouldFailDueToExistingCollection', { strict: true }, err => {
+                test.ok(err != null);
+
                 client.close();
                 done();
               });
             }
           );
         });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should save object that has id but does not exist in collection', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection(
-          'test_save_with_object_that_has_id_but_does_not_actually_exist_in_collection',
-          function(err, collection) {
-            var a = { _id: '1', hello: 'world' };
-            collection.save(a, self.configuration.writeConcernMax(), function(err) {
-              test.equal(null, err);
-              collection.count(function(err, count) {
-                test.equal(1, count);
-
-                collection.findOne(function(err, doc) {
-                  test.equal('world', doc.hello);
-
-                  doc.hello = 'mike';
-                  collection.save(doc, self.configuration.writeConcernMax(), function(err) {
-                    test.equal(null, err);
-                    collection.findOne(function(err, doc) {
-                      collection.count(function(err, count) {
-                        test.equal(1, count);
-
-                        test.equal('mike', doc.hello);
-                        // Let's close the db
-                        client.close();
-                        done();
-                      });
-                    });
-                  });
-                });
-              });
-            });
-          }
-        );
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly update with no docs', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var ObjectID = self.configuration.require.ObjectID;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('test_should_correctly_do_update_with_no_docs', function(
-          err,
-          collection
-        ) {
-          var id = new ObjectID(null);
-          var doc = { _id: id, a: 1 };
-
-          collection.update({ _id: id }, doc, self.configuration.writeConcernMax(), function(
-            err,
-            r
-          ) {
-            test.equal(null, err);
-            test.equal(0, r.result.n);
-
-            client.close();
-            done();
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly execute insert update delete safe mode', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('test_should_execute_insert_update_delete_safe_mode', function(
-          err,
-          collection
-        ) {
-          test.equal(
-            'test_should_execute_insert_update_delete_safe_mode',
-            collection.collectionName
-          );
-
-          collection.insert({ i: 1 }, self.configuration.writeConcernMax(), function(err, r) {
-            test.equal(1, r.ops.length);
-            test.ok(r.ops[0]._id.toHexString().length === 24);
-
-            // Update the record
-            collection.update(
-              { i: 1 },
-              { $set: { i: 2 } },
-              self.configuration.writeConcernMax(),
-              function(err) {
-                test.equal(null, err);
-                test.equal(1, r.result.n);
-
-                // Remove safely
-                collection.remove({}, self.configuration.writeConcernMax(), function(err) {
-                  test.equal(null, err);
-
-                  client.close();
-                  done();
-                });
-              }
-            );
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should perform multiple saves', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('multiple_save_test', function(err, collection) {
-          var doc = {
-            name: 'amit',
-            text: 'some text'
-          };
-
-          //insert new user
-          collection.save(doc, self.configuration.writeConcernMax(), function(err) {
-            test.equal(null, err);
-
-            collection
-              .find({}, { name: 1 })
-              .limit(1)
-              .toArray(function(err, users) {
-                var user = users[0];
-
-                if (err) {
-                  throw new Error(err);
-                } else if (user) {
-                  user.pants = 'worn';
-
-                  collection.save(user, self.configuration.writeConcernMax(), function(
-                    err,
-                    result
-                  ) {
-                    test.equal(null, err);
-                    test.equal(1, result.result.n);
-                    client.close();
-                    done();
-                  });
-                }
-              });
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly save document with nested array', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var ObjectID = self.configuration.require.ObjectID;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('save_error_on_save_test', function(err, collection) {
-          // Create unique index for username
-          collection.createIndex([['username', 1]], self.configuration.writeConcernMax(), function(
-            err
-          ) {
-            test.equal(null, err);
-            var doc = {
-              email: 'email@email.com',
-              encrypted_password: 'password',
-              friends: [
-                '4db96b973d01205364000006',
-                '4db94a1948a683a176000001',
-                '4dc77b24c5ba38be14000002'
-              ],
-              location: [72.4930088, 23.0431957],
-              name: 'Amit Kumar',
-              password_salt: 'salty',
-              profile_fields: [],
-              username: 'amit'
-            };
-            //insert new user
-            collection.save(doc, self.configuration.writeConcernMax(), function(err) {
-              test.equal(null, err);
-
-              collection
-                .find({})
-                .limit(1)
-                .toArray(function(err, users) {
-                  test.equal(null, err);
-                  var user = users[0];
-                  user.friends.splice(1, 1);
-
-                  collection.save(user, function(err) {
-                    test.equal(null, err);
-
-                    // Update again
-                    collection.update(
-                      { _id: new ObjectID(user._id.toString()) },
-                      { friends: user.friends },
-                      { upsert: true, w: 1 },
-                      function(err, result) {
-                        test.equal(null, err);
-                        test.equal(1, result.result.n);
-
-                        client.close();
-                        done();
-                      }
-                    );
-                  });
-                });
-            });
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should perform collection remove with no callback', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.collection('remove_with_no_callback_bug_test', function(err, collection) {
-          test.equal(null, err);
-          collection.save({ a: 1 }, self.configuration.writeConcernMax(), function(err) {
-            test.equal(null, err);
-            collection.save({ b: 1 }, self.configuration.writeConcernMax(), function(err) {
-              test.equal(null, err);
-              collection.save({ c: 1 }, self.configuration.writeConcernMax(), function(err) {
-                test.equal(null, err);
-                collection.remove({ a: 1 }, self.configuration.writeConcernMax(), function(err) {
-                  test.equal(null, err);
-                  // Let's perform a count
-                  collection.count(function(err, count) {
-                    test.equal(null, err);
-                    test.equal(2, count);
-                    client.close();
-                    done();
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly create TTL collection with index using ensureIndex', {
-    metadata: {
-      requires: {
-        mongodb: '>2.1.0',
-        topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
       }
-    },
+    });
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
+    /**
+     * @ignore
+     */
+    it('should filter correctly during list', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
+      // The actual test we wish to run
+      test: function(done) {
+        const testCollection = 'integration_tests_collection_123'; // The collection happens to contain the database name
 
-        db.createCollection('shouldCorrectlyCreateTTLCollectionWithIndexUsingEnsureIndex', function(
-          err,
-          collection
-        ) {
-          collection.ensureIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, function(err) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(this.configuration.db);
+          // Create a collection
+          db.createCollection(testCollection, err => {
             test.equal(null, err);
 
-            // Insert a document with a date
-            collection.insert(
-              { a: 1, createdAt: new Date() },
-              self.configuration.writeConcernMax(),
-              function(err) {
-                test.equal(null, err);
-
-                collection.indexInformation({ full: true }, function(err, indexes) {
-                  test.equal(null, err);
-
-                  for (var i = 0; i < indexes.length; i++) {
-                    if (indexes[i].name === 'createdAt_1') {
-                      test.equal(1, indexes[i].expireAfterSeconds);
-                      break;
-                    }
-                  }
-
-                  client.close();
-                  done();
-                });
-              }
-            );
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly create TTL collection with index using createIndex', {
-    metadata: {
-      requires: {
-        mongodb: '>2.1.0',
-        topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
-      }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('shouldCorrectlyCreateTTLCollectionWithIndexCreateIndex', {}, function(
-          err,
-          collection
-        ) {
-          collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, function(err) {
-            test.equal(null, err);
-
-            // Insert a document with a date
-            collection.insert(
-              { a: 1, createdAt: new Date() },
-              self.configuration.writeConcernMax(),
-              function(err) {
-                test.equal(null, err);
-
-                collection.indexInformation({ full: true }, function(err, indexes) {
-                  test.equal(null, err);
-
-                  for (var i = 0; i < indexes.length; i++) {
-                    if (indexes[i].name === 'createdAt_1') {
-                      test.equal(1, indexes[i].expireAfterSeconds);
-                      break;
-                    }
-                  }
-
-                  client.close();
-                  done();
-                });
-              }
-            );
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should support createIndex with no options', {
-    metadata: {
-      requires: {
-        mongodb: '>2.1.0',
-        topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
-      }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('create_index_without_options', {}, function(err, collection) {
-          collection.createIndex({ createdAt: 1 }, function(err) {
-            test.equal(null, err);
-
-            collection.indexInformation({ full: true }, function(err, indexes) {
+            db.listCollections({ name: testCollection }).toArray((err, documents) => {
               test.equal(null, err);
-              const indexNames = indexes.map(i => i.name);
-              expect(indexNames).to.include('createdAt_1');
-
-              client.close();
-              done();
-            });
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly read back document with null', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('shouldCorrectlyReadBackDocumentWithNull', {}, function(
-          err,
-          collection
-        ) {
-          // Insert a document with a date
-          collection.insert({ test: null }, self.configuration.writeConcernMax(), function(err) {
-            test.equal(null, err);
-
-            collection.findOne(function(err) {
-              test.equal(null, err);
-
-              client.close();
-              done();
-            });
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should throw error due to illegal update', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('shouldThrowErrorDueToIllegalUpdate', {}, function(err, coll) {
-          try {
-            coll.update({}, null, function() {});
-          } catch (err) {
-            test.equal('document must be a valid JavaScript object', err.message);
-          }
-
-          try {
-            coll.update(null, null, function() {});
-          } catch (err) {
-            test.equal('selector must be a valid JavaScript object', err.message);
-          }
-
-          client.close();
-          done();
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly handle 0 as id for save', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, function(err) {
-          test.equal(null, err);
-
-          db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, function(err) {
-            test.equal(null, err);
-            client.close();
-            done();
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly execute update with . field in selector', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db
-          .collection('executeUpdateWithElemMatch')
-          .update({ 'item.i': 1 }, { $set: { a: 1 } }, function(err) {
-            test.equal(null, err);
-
-            client.close();
-            done();
-          });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly execute update with elemMatch field in selector', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db
-          .collection('executeUpdateWithElemMatch')
-          .update({ item: { $elemMatch: { name: 'my_name' } } }, { $set: { a: 1 } }, function(err) {
-            test.equal(null, err);
-
-            client.close();
-            done();
-          });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should fail due to exiting collection', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        db.createCollection('shouldFailDueToExistingCollection', { strict: true }, function(
-          err,
-          coll
-        ) {
-          test.equal(null, err);
-          test.ok(coll != null);
-
-          db.createCollection('shouldFailDueToExistingCollection', { strict: true }, function(err) {
-            test.ok(err != null);
-
-            client.close();
-            done();
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should filter correctly during list', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var testCollection = 'integration_tests_collection_123'; // The collection happens to contain the database name
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        // Create a collection
-        db.createCollection(testCollection, function(err) {
-          test.equal(null, err);
-
-          db.listCollections({ name: testCollection }).toArray(function(err, documents) {
-            test.equal(null, err);
-            test.equal(documents.length, 1);
-            var found = false;
-            documents.forEach(function(document) {
-              if (document.name === testCollection) found = true;
-            });
-            test.ok(found);
-            client.close();
-            done();
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should filter correctly with index during list', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var testCollection = 'collection_124';
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-
-        // Create a collection
-        db.createCollection(testCollection, function(err) {
-          test.equal(null, err);
-
-          // Index name happens to be the same as collection name
-          db.createIndex(testCollection, 'collection_124', { w: 1 }, function(err, indexName) {
-            test.equal(null, err);
-            test.equal('collection_124_1', indexName);
-
-            db.listCollections().toArray(function(err, documents) {
-              test.equal(null, err);
-              test.ok(documents.length > 1);
-              var found = false;
-
-              documents.forEach(function(document) {
+              test.equal(documents.length, 1);
+              let found = false;
+              documents.forEach(document => {
                 if (document.name === testCollection) found = true;
               });
-
               test.ok(found);
               client.close();
               done();
             });
           });
         });
-      });
-    }
-  });
+      }
+    });
 
-  /**
-   * @ignore
-   */
-  it('should correctly list multipleCollections', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+    /**
+     * @ignore
+     */
+    it('should filter correctly with index during list', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
+      // The actual test we wish to run
+      test: function(done) {
+        const testCollection = 'collection_124';
 
-      client.connect(function(err, client) {
-        test.equal(null, err);
-
-        var emptyDb = client.db('listCollectionsDb');
-        emptyDb.createCollection('test1', function(err) {
-          test.equal(null, err);
-
-          emptyDb.createCollection('test2', function(err) {
+        client.connect((err, client) => {
+          const db = client.db(this.configuration.db);
+          // Create a collection
+          db.createCollection(testCollection, err => {
             test.equal(null, err);
 
-            emptyDb.createCollection('test3', function(err) {
+            // Index name happens to be the same as collection name
+            db.createIndex(testCollection, 'collection_124', { w: 1 }, (err, indexName) => {
               test.equal(null, err);
+              test.equal('collection_124_1', indexName);
 
-              emptyDb.listCollections().toArray(function(err, collections) {
+              db.listCollections().toArray((err, documents) => {
                 test.equal(null, err);
-                // By name
-                var names = {};
+                test.ok(documents.length > 1);
+                let found = false;
 
-                for (var i = 0; i < collections.length; i++) {
-                  names[collections[i].name] = collections[i];
-                }
-
-                test.ok(names['test1'] != null);
-                test.ok(names['test2'] != null);
-                test.ok(names['test3'] != null);
-
-                client.close();
-                done();
-              });
-            });
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly list multipleCollections', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        test.equal(null, err);
-
-        var emptyDb = client.db('listCollectionsDb');
-        emptyDb.createCollection('test1', function(err) {
-          test.equal(null, err);
-
-          emptyDb.createCollection('test2', function(err) {
-            test.equal(null, err);
-
-            emptyDb.createCollection('test3', function(err) {
-              test.equal(null, err);
-
-              emptyDb.listCollections().toArray(function(err, collections) {
-                test.equal(null, err);
-                // By name
-                var names = {};
-
-                for (var i = 0; i < collections.length; i++) {
-                  names[collections[i].name] = collections[i];
-                }
-
-                test.ok(names['test1'] != null);
-                test.ok(names['test2'] != null);
-                test.ok(names['test3'] != null);
-
-                client.close();
-                done();
-              });
-            });
-          });
-        });
-      });
-    }
-  });
-
-  /**
-   * @ignore
-   */
-  it('should correctly handle namespace when using collections method', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        test.equal(null, err);
-
-        var emptyDb = client.db('listCollectionsDb2');
-        emptyDb.createCollection('test1', function(err) {
-          test.equal(null, err);
-
-          emptyDb.createCollection('test.test', function(err) {
-            test.equal(null, err);
-
-            emptyDb.createCollection('test3', function(err) {
-              test.equal(null, err);
-
-              emptyDb.collections(function(err, collections) {
-                collections = collections.map(function(collection) {
-                  return {
-                    collectionName: collection.collectionName,
-                    namespace: collection.namespace
-                  };
+                documents.forEach(document => {
+                  if (document.name === testCollection) found = true;
                 });
 
-                var foundCollection = false;
-                collections.forEach(function(x) {
-                  if (
-                    x.namespace === 'listCollectionsDb2.test.test' &&
-                    x.collectionName === 'test.test'
-                  ) {
-                    foundCollection = true;
+                test.ok(found);
+                client.close();
+                done();
+              });
+            });
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly list multipleCollections', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          test.equal(null, err);
+          const emptyDb = client.db('listCollectionsDb');
+          emptyDb.createCollection('test1', err => {
+            test.equal(null, err);
+
+            emptyDb.createCollection('test2', err => {
+              test.equal(null, err);
+
+              emptyDb.createCollection('test3', err => {
+                test.equal(null, err);
+
+                emptyDb.listCollections().toArray((err, collections) => {
+                  test.equal(null, err);
+                  // By name
+                  let names = {};
+
+                  for (let i = 0; i < collections.length; i++) {
+                    names[collections[i].name] = collections[i];
                   }
-                });
 
-                test.ok(foundCollection);
-                client.close();
-                done();
+                  test.ok(names['test1'] != null);
+                  test.ok(names['test2'] != null);
+                  test.ok(names['test3'] != null);
+
+                  client.close();
+                  done();
+                });
               });
             });
           });
         });
-      });
-    }
-  });
+      }
+    });
 
-  /**
-   * @ignore
-   */
-  it('should provide access to the database name', {
-    metadata: {
-      requires: { topology: ['single'] }
-    },
+    /**
+     * @ignore
+     */
+    it('should correctly list multipleCollections', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-    test: function() {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          test.equal(null, err);
+          const emptyDb = client.db('listCollectionsDb');
+          emptyDb.createCollection('test1', err => {
+            test.equal(null, err);
 
-      return client
-        .connect()
-        .then(client => client.db('test_db').createCollection('test1'))
-        .then(coll => {
-          expect(coll.dbName).to.equal('test_db');
-          return client.close();
+            emptyDb.createCollection('test2', err => {
+              test.equal(null, err);
+
+              emptyDb.createCollection('test3', err => {
+                test.equal(null, err);
+
+                emptyDb.listCollections().toArray((err, collections) => {
+                  test.equal(null, err);
+                  // By name
+                  let names = {};
+
+                  for (let i = 0; i < collections.length; i++) {
+                    names[collections[i].name] = collections[i];
+                  }
+
+                  test.ok(names['test1'] != null);
+                  test.ok(names['test2'] != null);
+                  test.ok(names['test3'] != null);
+
+                  client.close();
+                  done();
+                });
+              });
+            });
+          });
         });
-    }
-  });
+      }
+    });
 
-  it('should correctly perform estimatedDocumentCount on non-matching query', function(done) {
-    const configuration = this.configuration;
-    const client = configuration.newClient({}, { w: 1 });
+    /**
+     * @ignore
+     */
+    it('should correctly handle namespace when using collections method', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
 
-    client.connect(function(err, client) {
-      const db = client.db(configuration.db);
-      const collection = db.collection('nonexistent_coll_1');
-      const close = e => client.close(() => done(e));
+      // The actual test we wish to run
+      test: function(done) {
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          test.equal(null, err);
+          const emptyDb = client.db('listCollectionsDb2');
+          emptyDb.createCollection('test1', err => {
+            test.equal(null, err);
 
-      Promise.resolve()
-        .then(() => collection.estimatedDocumentCount({ a: 'b' }))
-        .then(count => expect(count).to.equal(0))
-        .then(() => close())
-        .catch(e => close(e));
+            emptyDb.createCollection('test.test', err => {
+              test.equal(null, err);
+
+              emptyDb.createCollection('test3', err => {
+                test.equal(null, err);
+
+                emptyDb.collections((err, collections) => {
+                  collections = collections.map(collection => {
+                    return {
+                      collectionName: collection.collectionName,
+                      namespace: collection.namespace
+                    };
+                  });
+
+                  let foundCollection = false;
+                  collections.forEach(x => {
+                    if (
+                      x.namespace === 'listCollectionsDb2.test.test' &&
+                      x.collectionName === 'test.test'
+                    ) {
+                      foundCollection = true;
+                    }
+                  });
+
+                  test.ok(foundCollection);
+                  client.close();
+                  done();
+                });
+              });
+            });
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should provide access to the database name', {
+      metadata: {
+        requires: { topology: ['single'] }
+      },
+
+      test: () => {
+        return client
+          .connect()
+          .then(client => client.db('test_db').createCollection('test1'))
+          .then(coll => {
+            expect(coll.dbName).to.equal('test_db');
+            return client.close();
+          });
+      }
+    });
+
+    it('should correctly update with pipeline', {
+      metadata: {
+        requires: { mongodb: '>=4.2.0' }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+
+        client.connect((err, client) => {
+          expect(err).to.not.exist;
+          const db = client.db(configuration.db);
+
+          db.createCollection('test_should_correctly_do_update_with_pipeline', (err, collection) => {
+            collection.updateOne(
+              {},
+              [{ $set: { a: 1 } }, { $set: { b: 1 } }, { $set: { d: 1 } }],
+              configuration.writeConcernMax(),
+              (err, r) => {
+                expect(err).to.not.exist;
+                expect(r.result.n).to.equal(0);
+
+                client.close(done);
+              }
+            );
+          });
+        });
+      }
     });
   });
 
-  it('should correctly perform countDocuments on non-matching query', function(done) {
-    const configuration = this.configuration;
-    const client = configuration.newClient({}, { w: 1 });
-
-    client.connect(function(err, client) {
-      const db = client.db(configuration.db);
-      const collection = db.collection('nonexistent_coll_2');
-      const close = e => client.close(() => done(e));
-
-      Promise.resolve()
-        .then(() => collection.countDocuments({ a: 'b' }))
-        .then(count => expect(count).to.equal(0))
-        .then(() => close())
-        .catch(e => close(e));
+  describe('', function() {
+    let configuration;
+    let client;
+    beforeEach(function() {
+      configuration = this.configuration;
+      client = configuration.newClient({}, { w: 1 });
     });
-  });
-
-  it('countDocuments should return Promise that resolves when no callback passed', function(done) {
-    const configuration = this.configuration;
-    const client = configuration.newClient({}, { w: 1 });
-
-    client.connect(function(err, client) {
-      const db = client.db(configuration.db);
-      const collection = db.collection('countDoc_return_promise');
-      const docsPromise = collection.countDocuments();
-      const close = e => client.close(() => done(e));
-
-      expect(docsPromise).to.exist.and.to.be.an.instanceof(collection.s.promiseLibrary);
-
-      docsPromise
-        .then(result => expect(result).to.equal(0))
-        .then(() => close())
-        .catch(e => close(e));
+    afterEach(function() {
+      return client.close();
     });
-  });
 
-  it('countDocuments should not return a promise if callback given', function(done) {
-    const configuration = this.configuration;
-    const client = configuration.newClient({}, { w: 1 });
+    it('should correctly perform estimatedDocumentCount on non-matching query', function(done) {
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+        const db = client.db(configuration.db);
+        const collection = db.collection('nonexistent_coll_1');
+        const close = e => client.close(() => done(e));
 
-    client.connect(function(err, client) {
-      const db = client.db(configuration.db);
-      const collection = db.collection('countDoc_no_promise');
-      const close = e => client.close(() => done(e));
+        Promise.resolve()
+          .then(() => collection.estimatedDocumentCount({ a: 'b' }))
+          .then(count => expect(count).to.equal(0))
+          .then(() => close())
+          .catch(e => close(e));
+      });
+    });
 
-      const notPromise = collection.countDocuments({ a: 1 }, function() {
-        expect(notPromise).to.be.undefined;
-        close();
+    it('should correctly perform countDocuments on non-matching query', function(done) {
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+        const db = client.db(configuration.db);
+        const collection = db.collection('nonexistent_coll_2');
+        const close = e => client.close(() => done(e));
+
+        Promise.resolve()
+          .then(() => collection.countDocuments({ a: 'b' }))
+          .then(count => expect(count).to.equal(0))
+          .then(() => close())
+          .catch(e => close(e));
+      });
+    });
+
+    it('countDocuments should return Promise that resolves when no callback passed', function(done) {
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+        const db = client.db(configuration.db);
+        const collection = db.collection('countDoc_return_promise');
+        const docsPromise = collection.countDocuments();
+        const close = e => client.close(() => done(e));
+
+        expect(docsPromise).to.exist.and.to.be.an.instanceof(collection.s.promiseLibrary);
+
+        docsPromise
+          .then(result => expect(result).to.equal(0))
+          .then(() => close())
+          .catch(e => close(e));
+      });
+    });
+
+    it('countDocuments should not return a promise if callback given', function(done) {
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+        const db = client.db(configuration.db);
+        const collection = db.collection('countDoc_no_promise');
+        const close = e => client.close(() => done(e));
+
+        const notPromise = collection.countDocuments({ a: 1 }, () => {
+          expect(notPromise).to.be.undefined;
+          close();
+        });
+      });
+    });
+
+    it('countDocuments should correctly call the given callback', function(done) {
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+        const db = client.db(configuration.db);
+        const collection = db.collection('countDoc_callback');
+        const docs = [{ a: 1 }, { a: 2 }];
+        const close = e => client.close(() => done(e));
+
+        collection.insertMany(docs).then(() =>
+          collection.countDocuments({ a: 1 }, (err, data) => {
+            expect(data).to.equal(1);
+            close(err);
+          })
+        );
       });
     });
   });
 
-  it('countDocuments should correctly call the given callback', function(done) {
-    const configuration = this.configuration;
-    const client = configuration.newClient({}, { w: 1 });
-
-    client.connect(function(err, client) {
-      const db = client.db(configuration.db);
-      const collection = db.collection('countDoc_callback');
-      const docs = [{ a: 1 }, { a: 2 }];
-      const close = e => client.close(() => done(e));
-
-      collection.insertMany(docs).then(() =>
-        collection.countDocuments({ a: 1 }, (err, data) => {
-          expect(data).to.equal(1);
-          close(err);
-        })
-      );
-    });
-  });
-
-  describe('countDocuments with mock server', function() {
+  describe('countDocuments with mock server', () => {
     let server;
 
     beforeEach(() => {
@@ -1734,7 +1609,7 @@ describe('Collection', function() {
         }
       });
 
-      client.connect(function(err, client) {
+      client.connect((err, client) => {
         const db = client.db('test');
         const collection = db.collection('countDoc_mock');
 
@@ -1814,7 +1689,7 @@ describe('Collection', function() {
     const configuration = config.config;
     const client = testConfiguration.newClient({}, { w: 1 });
 
-    client.connect(function(err, client) {
+    client.connect((err, client) => {
       const db = client.db(configuration.db);
       const close = e => client.close(() => done(e));
 
@@ -1843,14 +1718,14 @@ describe('Collection', function() {
     );
   });
 
-  describe('Retryable Writes on bulk ops', function() {
+  describe('Retryable Writes on bulk ops', () => {
     let client;
     let db;
     let collection;
 
     const metadata = { requires: { topology: ['replicaset'], mongodb: '>=3.6.0' } };
 
-    beforeEach(function() {
+    beforeEach(() => {
       client = this.configuration.newClient({}, { retryWrites: true });
       return client.connect().then(() => {
         db = client.db('test_retry_writes');
@@ -1862,20 +1737,20 @@ describe('Collection', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(() => {
       return client.close();
     });
 
     it('should succeed with retryWrite=true when using updateMany', {
       metadata,
-      test: function() {
+      test: () => {
         return collection.updateMany({ name: 'foobar' }, { $set: { name: 'fizzbuzz' } });
       }
     });
 
     it('should succeed with retryWrite=true when using update with multi=true', {
       metadata,
-      test: function() {
+      test: () => {
         return collection.update(
           { name: 'foobar' },
           { $set: { name: 'fizzbuzz' } },
@@ -1886,48 +1761,16 @@ describe('Collection', function() {
 
     it('should succeed with retryWrite=true when using remove without option single', {
       metadata,
-      test: function() {
+      test: () => {
         return collection.remove({ name: 'foobar' });
       }
     });
 
     it('should succeed with retryWrite=true when using deleteMany', {
       metadata,
-      test: function() {
+      test: () => {
         return collection.deleteMany({ name: 'foobar' });
       }
     });
-  });
-
-  it('should correctly update with pipeline', {
-    metadata: {
-      requires: { mongodb: '>=4.2.0' }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient(configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect((err, client) => {
-        const db = client.db(configuration.db);
-
-        db.createCollection('test_should_correctly_do_update_with_pipeline', (err, collection) => {
-          collection.updateOne(
-            {},
-            [{ $set: { a: 1 } }, { $set: { b: 1 } }, { $set: { d: 1 } }],
-            configuration.writeConcernMax(),
-            (err, r) => {
-              expect(err).to.not.exist;
-              expect(r.result.n).to.equal(0);
-
-              client.close(done);
-            }
-          );
-        });
-      });
-    }
   });
 });

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -58,24 +58,20 @@ describe('Collection', function() {
             db.createCollection('test_collection_methods4', (err, collection) => {
               // Verify that all the result are correct coming back (should contain the value ok)
               expect(collection.collectionName).to.equal('test_collection_methods4');
-              // Let's check that the collection was created correctly
-              db.listCollections().toArray(err => {
-                expect(err).to.not.exist;
-                // Rename the collection and with the dropTarget boolean, and check to make sure only onen exists.
-                db.renameCollection(
-                  'test_collection_methods4',
-                  'test_collection_methods3',
-                  { dropTarget: true },
-                  err => {
-                    expect(err).to.not.exist;
+              // Rename the collection and with the dropTarget boolean, and check to make sure only onen exists.
+              db.renameCollection(
+                'test_collection_methods4',
+                'test_collection_methods3',
+                { dropTarget: true },
+                err => {
+                  expect(err).to.not.exist;
 
-                    db.dropCollection('test_collection_methods3', (err, result) => {
-                      expect(result).to.be.true;
-                      done();
-                    });
-                  }
-                );
-              });
+                  db.dropCollection('test_collection_methods3', (err, result) => {
+                    expect(result).to.be.true;
+                    done();
+                  });
+                }
+              );
             });
           });
         });
@@ -870,16 +866,14 @@ describe('Collection', function() {
 
             emptyDb.listCollections().toArray((err, collections) => {
               expect(err).to.not.exist;
-              // By name
-              let names = {};
-
+              let names = [];
               for (let i = 0; i < collections.length; i++) {
-                names[collections[i].name] = collections[i];
+                names.push(collections[i].name);
               }
-              for (let i = 0; i < collections.length; i++) {
-                expect(names[collections[i].name]).to.equal(collections[i]);
-              }
-
+              expect(names.length).to.equal(3);
+              expect(names).to.include('test1');
+              expect(names).to.include('test2');
+              expect(names).to.include('test3');
               done();
             });
           });

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -871,7 +871,6 @@ describe('Collection', function() {
                 names.push(collections[i].name);
                 console.log('Name of the collection: ', collections[i].name);
               }
-              expect(names.length).to.equal(3);
               expect(names).to.include('test1');
               expect(names).to.include('test2');
               expect(names).to.include('test3');

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -11,7 +11,7 @@ describe('Collection', function() {
     return setupDatabase(this.configuration);
   });
 
-  describe('(non >2.1.0)', function() {
+  describe('tests with standard configuration', function() {
     let client;
     let db;
     beforeEach(function() {
@@ -928,126 +928,97 @@ describe('Collection', function() {
         );
       });
     });
-  });
-
-  describe('(requires >2.1.0)', function() {
-    let client;
-    let db;
-    const metadata = { requires: { mongodb: '>2.1.0' } };
-    beforeEach(function() {
-      client = this.configuration.newClient(this.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-      return client.connect().then(client => {
-        db = client.db(this.configuration.db);
-      });
-    });
-    afterEach(function() {
-      client.close();
-    })
 
     /**
      * @ignore
      */
-    it('should correctly create TTL collection with index using createIndex', {
-      metadata,
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection(
-          'shouldCorrectlyCreateTTLCollectionWithIndexCreateIndex',
-          {},
-          (err, collection) => {
-            collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
-              expect(err).to.not.exist;
-
-              // Insert a document with a date
-              collection.insertOne(
-                { a: 1, createdAt: new Date() },
-                this.configuration.writeConcernMax(),
-                err => {
-                  expect(err).to.not.exist;
-
-                  collection.indexInformation({ full: true }, (err, indexes) => {
-                    expect(err).to.not.exist;
-
-                    for (let i = 0; i < indexes.length; i++) {
-                      if (indexes[i].name === 'createdAt_1') {
-                        expect(1).to.equal(indexes[i].expireAfterSeconds);
-                        break;
-                      }
-                    }
-
-                    done();
-                  });
-                }
-              );
-            });
-          }
-        );
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly create TTL collection with index using ensureIndex', {
-      metadata,
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection(
-          'shouldCorrectlyCreateTTLCollectionWithIndexUsingEnsureIndex',
-          (err, collection) => {
-            collection.ensureIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
-              expect(err).to.not.exist;
-
-              // Insert a document with a date
-              collection.insertOne(
-                { a: 1, createdAt: new Date() },
-                this.configuration.writeConcernMax(),
-                err => {
-                  expect(err).to.not.exist;
-
-                  collection.indexInformation({ full: true }, (err, indexes) => {
-                    expect(err).to.not.exist;
-
-                    for (let i = 0; i < indexes.length; i++) {
-                      if (indexes[i].name === 'createdAt_1') {
-                        expect(1).to.equal(indexes[i].expireAfterSeconds);
-                        break;
-                      }
-                    }
-
-                    done();
-                  });
-                }
-              );
-            });
-          }
-        );
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should support createIndex with no options', {
-      metadata,
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection('create_index_without_options', {}, (err, collection) => {
-          collection.createIndex({ createdAt: 1 }, err => {
+    it('should correctly create TTL collection with index using createIndex', function(done) {
+      db.createCollection(
+        'shouldCorrectlyCreateTTLCollectionWithIndexCreateIndex',
+        {},
+        (err, collection) => {
+          collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
             expect(err).to.not.exist;
 
-            collection.indexInformation({ full: true }, (err, indexes) => {
-              expect(err).to.not.exist;
-              const indexNames = indexes.map(i => i.name);
-              expect(indexNames).to.include('createdAt_1');
+            // Insert a document with a date
+            collection.insertOne(
+              { a: 1, createdAt: new Date() },
+              this.configuration.writeConcernMax(),
+              err => {
+                expect(err).to.not.exist;
 
-              done();
-            });
+                collection.indexInformation({ full: true }, (err, indexes) => {
+                  expect(err).to.not.exist;
+
+                  for (let i = 0; i < indexes.length; i++) {
+                    if (indexes[i].name === 'createdAt_1') {
+                      expect(1).to.equal(indexes[i].expireAfterSeconds);
+                      break;
+                    }
+                  }
+
+                  done();
+                });
+              }
+            );
+          });
+        }
+      );
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly create TTL collection with index using ensureIndex', function(done) {
+      db.createCollection(
+        'shouldCorrectlyCreateTTLCollectionWithIndexUsingEnsureIndex',
+        (err, collection) => {
+          collection.ensureIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
+            expect(err).to.not.exist;
+
+            // Insert a document with a date
+            collection.insertOne(
+              { a: 1, createdAt: new Date() },
+              this.configuration.writeConcernMax(),
+              err => {
+                expect(err).to.not.exist;
+
+                collection.indexInformation({ full: true }, (err, indexes) => {
+                  expect(err).to.not.exist;
+
+                  for (let i = 0; i < indexes.length; i++) {
+                    if (indexes[i].name === 'createdAt_1') {
+                      expect(1).to.equal(indexes[i].expireAfterSeconds);
+                      break;
+                    }
+                  }
+
+                  done();
+                });
+              }
+            );
+          });
+        }
+      );
+    });
+
+    /**
+     * @ignore
+     */
+    it('should support createIndex with no options', function(done) {
+      db.createCollection('create_index_without_options', {}, (err, collection) => {
+        collection.createIndex({ createdAt: 1 }, err => {
+          expect(err).to.not.exist;
+
+          collection.indexInformation({ full: true }, (err, indexes) => {
+            expect(err).to.not.exist;
+            const indexNames = indexes.map(i => i.name);
+            expect(indexNames).to.include('createdAt_1');
+
+            done();
           });
         });
-      }
+      });
     });
   });
 

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -31,8 +31,14 @@ describe('Collection', function() {
         // Verify that all the result are correct coming back (should contain the value ok)
         expect('test_collection_methods').to.equal(collection.collectionName);
         // Let's check that the collection was created correctly
-        db.listCollections().toArray(err => {
+        db.listCollections().toArray((err, documents) => {
           expect(err).to.not.exist;
+          let found = false;
+          documents.forEach(doc => {
+            console.log("doc.name: ",doc.name);
+            if (doc.name === 'test_collection_methods') found = true;
+          });
+          expect(found).to.be.true;
           // Rename the collection and check that it's gone
           db.renameCollection('test_collection_methods', 'test_collection_methods2', err => {
             expect(err).to.not.exist;
@@ -50,10 +56,7 @@ describe('Collection', function() {
               // Verify that all the result are correct coming back (should contain the value ok)
               expect(collection.collectionName).to.equal('test_collection_methods4');
               // Let's check that the collection was created correctly
-              db.listCollections().toArray(function(err, documents) {
-                let found = false;
-                if (documents.name === 'integration_tests_.test_collection_methods') found = true;
-                expect(found).to.be.true;
+              db.listCollections().toArray((err, documents) => {
                 // Rename the collection and with the dropTarget boolean, and check to make sure only onen exists.
                 db.renameCollection(
                   'test_collection_methods4',

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -663,13 +663,13 @@ describe('Collection', function() {
     it('should throw error due to illegal update', function(done) {
       db.createCollection('shouldThrowErrorDueToIllegalUpdate', {}, (err, coll) => {
         try {
-          coll.updateOne({}, null, () => {});
+          coll.update({}, null, () => {});
         } catch (err) {
           expect(err.message).to.equal('document must be a valid JavaScript object');
         }
 
         try {
-          coll.updateOne(null, null, () => {});
+          coll.update(null, null, () => {});
         } catch (err) {
           expect(err.message).to.equal('selector must be a valid JavaScript object');
         }

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -663,13 +663,13 @@ describe('Collection', function() {
     it('should throw error due to illegal update', function(done) {
       db.createCollection('shouldThrowErrorDueToIllegalUpdate', {}, (err, coll) => {
         try {
-          coll.update({}, null, () => {});
+          coll.updateOne({}, null, () => {});
         } catch (err) {
           expect(err.message).to.equal('document must be a valid JavaScript object');
         }
 
         try {
-          coll.update(null, null, () => {});
+          coll.updateOne(null, null, () => {});
         } catch (err) {
           expect(err.message).to.equal('selector must be a valid JavaScript object');
         }
@@ -702,18 +702,6 @@ describe('Collection', function() {
       {
         title: 'should correctly execute update with elemMatch field in selector',
         collectionName: 'executeUpdateWithElemMatch',
-        filterObject: { item: { $elemMatch: { name: 'my_name' } } },
-        updateObject: { $set: { a: 1 } }
-      },
-      {
-        title: 'should correctly update with no docs',
-        collectionName: 'test_should_correctly_do_update_with_no_docs',
-        filterObject: { item: { $elemMatch: { name: 'my_name' } } },
-        updateObject: { $set: { a: 1 } }
-      },
-      {
-        title: 'should correctly update with pipeline',
-        collectionName: 'test_should_correctly_do_update_with_pipeline',
         filterObject: { item: { $elemMatch: { name: 'my_name' } } },
         updateObject: { $set: { a: 1 } }
       }
@@ -802,10 +790,8 @@ describe('Collection', function() {
     listCollectionsTests.forEach(test => {
       it(test.title, function(done) {
         db.createCollection(test.collectionName, (err, collection) => {
-          if (test.title === 'should correctly list back collection names containing .') {
-            expect(collection.collectionName).to.equal(test.collectionName);
-          }
           expect(err).to.not.exist;
+          expect(collection.collectionName).to.equal(test.collectionName);
           db.listCollections().toArray((err, documents) => {
             expect(err).to.not.exist;
             let found = false;
@@ -1092,7 +1078,7 @@ describe('Collection', function() {
     });
   });
 
-  describe('countDocuments with mock server', () => {
+  describe('countDocuments with mock server', function() {
     let server;
 
     beforeEach(() => {

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -1,5 +1,4 @@
 'use strict';
-const test = require('./shared').assert;
 const setupDatabase = require('./shared').setupDatabase;
 const chai = require('chai');
 const expect = chai.expect;
@@ -14,9 +13,13 @@ describe('Collection', function() {
 
   describe('', function() {
     let client;
+    let db;
     beforeEach(function() {
       client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
+      });
+      return client.connect().then(client => {
+        db = client.db(this.configuration.db);
       });
     });
     afterEach(function() {
@@ -33,52 +36,44 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('test_collection_methods', (err, collection) => {
-            // Verify that all the result are correct coming back (should contain the value ok)
-            expect('test_collection_methods').to.equal(collection.collectionName);
-            // Let's check that the collection was created correctly
-            db.listCollections().toArray((err, documents) => {
-              let found = false;
-              documents.forEach(document => {
-                if (document.name === 'integration_tests_.test_collection_methods') found = true;
+        db.createCollection('test_collection_methods', (err, collection) => {
+          // Verify that all the result are correct coming back (should contain the value ok)
+          expect('test_collection_methods').to.equal(collection.collectionName);
+          // Let's check that the collection was created correctly
+          db.listCollections().toArray(err => {
+            expect(err).to.not.exist;
+            // Rename the collection and check that it's gone
+            db.renameCollection('test_collection_methods', 'test_collection_methods2', err => {
+              expect(err).to.not.exist;
+              // Drop the collection and check that it's gone
+              db.dropCollection('test_collection_methods2', (err, result) => {
+                expect(true).to.equal(result);
               });
+            });
 
-              // Rename the collection and check that it's gone
-              db.renameCollection('test_collection_methods', 'test_collection_methods2', err => {
-                expect(err).to.not.exist;
-                // Drop the collection and check that it's gone
-                db.dropCollection('test_collection_methods2', (err, result) => {
-                  expect(true).to.equal(result);
-                });
-              });
+            db.createCollection('test_collection_methods3', (err, collection) => {
+              // Verify that all the result are correct coming back (should contain the value ok)
+              expect('test_collection_methods3').to.equal(collection.collectionName);
 
-              db.createCollection('test_collection_methods3', (err, collection) => {
+              db.createCollection('test_collection_methods4', (err, collection) => {
                 // Verify that all the result are correct coming back (should contain the value ok)
-                expect('test_collection_methods3').to.equal(collection.collectionName);
+                expect('test_collection_methods4').to.equal(collection.collectionName);
 
-                db.createCollection('test_collection_methods4', (err, collection) => {
-                  // Verify that all the result are correct coming back (should contain the value ok)
-                  expect('test_collection_methods4').to.equal(collection.collectionName);
+                // Rename the collection and with the dropTarget boolean, and check to make sure only onen exists.
+                db.renameCollection(
+                  'test_collection_methods4',
+                  'test_collection_methods3',
+                  { dropTarget: true },
+                  err => {
+                    expect(err).to.not.exist;
 
-                  // Rename the collection and with the dropTarget boolean, and check to make sure only onen exists.
-                  db.renameCollection(
-                    'test_collection_methods4',
-                    'test_collection_methods3',
-                    { dropTarget: true },
-                    err => {
-                      expect(err).to.not.exist;
-
-                      db.dropCollection('test_collection_methods3', (err, result) => {
-                        expect(true).to.equal(result);
-                        client.close();
-                        done();
-                      });
-                    }
-                  );
-                });
+                    db.dropCollection('test_collection_methods3', (err, result) => {
+                      expect(true).to.equal(result);
+                      client.close();
+                      done();
+                    });
+                  }
+                );
               });
             });
           });
@@ -95,24 +90,21 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db1 = client.db('test');
-          db1.createCollection('test.game', (err, collection) => {
-            // Verify that all the result are correct coming back (should contain the value ok)
-            expect('test.game').to.equal(collection.collectionName);
-            // Let's check that the collection was created correctly
-            db1.listCollections().toArray((err, documents) => {
-              expect(err).to.not.exist;
-              let found = false;
-              documents.forEach(x => {
-                if (x.name === 'test.game') found = true;
-              });
-
-              expect(found).to.be.true;
-              client.close();
-              done();
+        const db1 = client.db('test');
+        db1.createCollection('test.game', (err, collection) => {
+          // Verify that all the result are correct coming back (should contain the value ok)
+          expect('test.game').to.equal(collection.collectionName);
+          // Let's check that the collection was created correctly
+          db1.listCollections().toArray((err, documents) => {
+            expect(err).to.not.exist;
+            let found = false;
+            documents.forEach(x => {
+              if (x.name === 'test.game') found = true;
             });
+
+            expect(found).to.be.true;
+            client.close();
+            done();
           });
         });
       }
@@ -128,50 +120,37 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          // Create two collections
-          db.createCollection('test.spiderman', () => {
-            db.createCollection('test.mario', () => {
-              // Insert test documents (creates collections)
-              db.collection('test.spiderman', (err, spiderman_collection) => {
-                spiderman_collection.insert(
-                  { foo: 5 },
-                  this.configuration.writeConcernMax(),
-                  err => {
+        // Create two collections
+        db.createCollection('test.spiderman', () => {
+          db.createCollection('test.mario', () => {
+            // Insert test documents (creates collections)
+            db.collection('test.spiderman', (err, spiderman_collection) => {
+              spiderman_collection.insert({ foo: 5 }, this.configuration.writeConcernMax(), err => {
+                expect(err).to.not.exist;
+                db.collection('test.mario', (err, mario_collection) => {
+                  mario_collection.insert({ bar: 0 }, this.configuration.writeConcernMax(), err => {
                     expect(err).to.not.exist;
-                    db.collection('test.mario', (err, mario_collection) => {
-                      mario_collection.insert(
-                        { bar: 0 },
-                        this.configuration.writeConcernMax(),
-                        err => {
-                          expect(err).to.not.exist;
-                          // Assert collections
-                          db.collections((err, collections) => {
-                            let found_spiderman = false;
-                            let found_mario = false;
-                            let found_does_not_exist = false;
+                    // Assert collections
+                    db.collections((err, collections) => {
+                      let found_spiderman = false;
+                      let found_mario = false;
+                      let found_does_not_exist = false;
 
-                            collections.forEach(collection => {
-                              if (collection.collectionName === 'test.spiderman')
-                                found_spiderman = true;
-                              if (collection.collectionName === 'test.mario') found_mario = true;
-                              if (collection.collectionName === 'does_not_exist')
-                                found_does_not_exist = true;
-                            });
+                      collections.forEach(collection => {
+                        if (collection.collectionName === 'test.spiderman') found_spiderman = true;
+                        if (collection.collectionName === 'test.mario') found_mario = true;
+                        if (collection.collectionName === 'does_not_exist')
+                          found_does_not_exist = true;
+                      });
 
-                            expect(found_spiderman).to.be.true;
-                            expect(found_mario).to.be.true;
-                            expect(found_does_not_exist).to.be.false;
-                            client.close();
-                            done();
-                          });
-                        }
-                      );
+                      expect(found_spiderman).to.be.true;
+                      expect(found_mario).to.be.true;
+                      expect(found_does_not_exist).to.be.false;
+                      client.close();
+                      done();
                     });
-                  }
-                );
+                  });
+                });
               });
             });
           });
@@ -189,51 +168,47 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
+        db.createCollection('test_collection_names', err => {
           expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('test_collection_names', err => {
-            expect(err).to.not.exist;
 
-            db.listCollections().toArray((err, documents) => {
-              let found = false;
-              let found2 = false;
+          db.listCollections().toArray((err, documents) => {
+            let found = false;
+            let found2 = false;
 
-              documents.forEach(document => {
-                if (
-                  document.name === this.configuration.db + '.test_collection_names' ||
-                  document.name === 'test_collection_names'
-                )
-                  found = true;
-              });
+            documents.forEach(document => {
+              if (
+                document.name === this.configuration.db + '.test_collection_names' ||
+                document.name === 'test_collection_names'
+              )
+                found = true;
+            });
 
-              expect(found).to.be.true;
-              // Insert a document in an non-existing collection should create the collection
-              const collection = db.collection('test_collection_names2');
-              collection.insert({ a: 1 }, this.configuration.writeConcernMax(), err => {
-                expect(err).to.not.exist;
+            expect(found).to.be.true;
+            // Insert a document in an non-existing collection should create the collection
+            const collection = db.collection('test_collection_names2');
+            collection.insert({ a: 1 }, this.configuration.writeConcernMax(), err => {
+              expect(err).to.not.exist;
 
-                db.listCollections().toArray((err, documents) => {
-                  documents.forEach(document => {
-                    if (
-                      document.name === this.configuration.db + '.test_collection_names2' ||
-                      document.name === 'test_collection_names2'
-                    )
-                      found = true;
-                    if (
-                      document.name === this.configuration.db + '.test_collection_names' ||
-                      document.name === 'test_collection_names'
-                    )
-                      found2 = true;
-                  });
-
-                  expect(found).to.be.true;
-                  expect(found2).to.be.true
-
-                  // Let's close the db
-                  client.close();
-                  done();
+              db.listCollections().toArray((err, documents) => {
+                documents.forEach(document => {
+                  if (
+                    document.name === this.configuration.db + '.test_collection_names2' ||
+                    document.name === 'test_collection_names2'
+                  )
+                    found = true;
+                  if (
+                    document.name === this.configuration.db + '.test_collection_names' ||
+                    document.name === 'test_collection_names'
+                  )
+                    found2 = true;
                 });
+
+                expect(found).to.be.true;
+                expect(found2).to.be.true;
+
+                // Let's close the db
+                client.close();
+                done();
               });
             });
           });
@@ -251,25 +226,23 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.collection('does-not-exist', { strict: true }, err => {
-            expect(err instanceof Error).to.be.true;
-            expect('Collection does-not-exist does not exist. Currently in strict mode.').to.equal(err.message);
-            db.createCollection('test_strict_access_collection', err => {
-              expect(err).to.not.exist;
-              db.collection(
-                'test_strict_access_collection',
-                this.configuration.writeConcernMax(),
-                (err, collection) => {
-                  expect(err).to.not.exist;
-                  // Let's close the db
-                  client.close();
-                  done();
-                }
-              );
-            });
+        db.collection('does-not-exist', { strict: true }, err => {
+          expect(err instanceof Error).to.be.true;
+          expect('Collection does-not-exist does not exist. Currently in strict mode.').to.equal(
+            err.message
+          );
+          db.createCollection('test_strict_access_collection', err => {
+            expect(err).to.not.exist;
+            db.collection(
+              'test_strict_access_collection',
+              this.configuration.writeConcernMax(),
+              err => {
+                expect(err).to.not.exist;
+                // Let's close the db
+                client.close();
+                done();
+              }
+            );
           });
         });
       }
@@ -285,30 +258,23 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
+        db.createCollection('test_strict_create_collection', (err, collection) => {
           expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('test_strict_create_collection', (err, collection) => {
-            expect(err).to.not.exist;
-            expect('test_strict_create_collection').to.equal(collection.collectionName);
+          expect('test_strict_create_collection').to.equal(collection.collectionName);
 
-            // Creating an existing collection should fail
-            db.createCollection('test_strict_create_collection', { strict: true }, err => {
-              expect(err instanceof Error).to.be.true;
-              expect('Collection test_strict_create_collection already exists. Currently in strict mode.').to.equal(err.message);
+          // Creating an existing collection should fail
+          db.createCollection('test_strict_create_collection', { strict: true }, err => {
+            expect(err instanceof Error).to.be.true;
+            expect(
+              'Collection test_strict_create_collection already exists. Currently in strict mode.'
+            ).to.equal(err.message);
 
-              // Switch out of strict mode and try to re-create collection
-              db.createCollection(
-                'test_strict_create_collection',
-                { strict: false },
-                (err, collection) => {
-                  expect(err).to.not.exist;
-
-                  // Let's close the db
-                  client.close();
-                  done();
-                }
-              );
+            // Switch out of strict mode and try to re-create collection
+            db.createCollection('test_strict_create_collection', { strict: false }, err => {
+              expect(err).to.not.exist;
+              // Let's close the db
+              client.close();
+              done();
             });
           });
         });
@@ -325,76 +291,72 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('test_invalid_key_names', (err, collection) => {
-            // Legal inserts
-            collection.insert(
-              [{ hello: 'world' }, { hello: { hello: 'world' } }],
-              this.configuration.writeConcernMax(),
-              err => {
-                expect(err).to.not.exist;
+        db.createCollection('test_invalid_key_names', (err, collection) => {
+          // Legal inserts
+          collection.insert(
+            [{ hello: 'world' }, { hello: { hello: 'world' } }],
+            this.configuration.writeConcernMax(),
+            err => {
+              expect(err).to.not.exist;
 
-                // Illegal insert for key
+              // Illegal insert for key
+              collection.insert({ $hello: 'world' }, this.configuration.writeConcernMax(), err => {
+                expect(err instanceof Error).to.be.true;
+                expect("key $hello must not start with '$'").to.equal(err.message);
+
                 collection.insert(
-                  { $hello: 'world' },
+                  { hello: { $hello: 'world' } },
                   this.configuration.writeConcernMax(),
                   err => {
                     expect(err instanceof Error).to.be.true;
                     expect("key $hello must not start with '$'").to.equal(err.message);
 
                     collection.insert(
-                      { hello: { $hello: 'world' } },
+                      { he$llo: 'world' },
                       this.configuration.writeConcernMax(),
                       err => {
-                        expect(err instanceof Error).to.be.true;
-                        expect("key $hello must not start with '$'").to.equal(err.message);
+                        expect(err).to.not.exist;
 
                         collection.insert(
-                          { he$llo: 'world' },
+                          { hello: { hell$o: 'world' } },
                           this.configuration.writeConcernMax(),
                           err => {
                             expect(err).to.not.exist;
 
                             collection.insert(
-                              { hello: { hell$o: 'world' } },
+                              { '.hello': 'world' },
                               this.configuration.writeConcernMax(),
                               err => {
-                                expect(err).to.not.exist;
+                                expect(err instanceof Error).to.be.true;
+                                expect("key .hello must not contain '.'").to.equal(err.message);
 
                                 collection.insert(
-                                  { '.hello': 'world' },
+                                  { hello: { '.hello': 'world' } },
                                   this.configuration.writeConcernMax(),
                                   err => {
                                     expect(err instanceof Error).to.be.true;
                                     expect("key .hello must not contain '.'").to.equal(err.message);
 
                                     collection.insert(
-                                      { hello: { '.hello': 'world' } },
+                                      { 'hello.': 'world' },
                                       this.configuration.writeConcernMax(),
                                       err => {
                                         expect(err instanceof Error).to.be.true;
-                                        expect("key .hello must not contain '.'").to.equal(err.message);
+                                        expect("key hello. must not contain '.'").to.equal(
+                                          err.message
+                                        );
 
                                         collection.insert(
-                                          { 'hello.': 'world' },
+                                          { hello: { 'hello.': 'world' } },
                                           this.configuration.writeConcernMax(),
                                           err => {
                                             expect(err instanceof Error).to.be.true;
-                                            expect("key hello. must not contain '.'").to.equal(err.message);
-
-                                            collection.insert(
-                                              { hello: { 'hello.': 'world' } },
-                                              this.configuration.writeConcernMax(),
-                                              err => {
-                                                expect(err instanceof Error).to.be.true;
-                                                expect("key hello. must not contain '.'").to.equal(err.message);
-                                                // Let's close the db
-                                                client.close();
-                                                done();
-                                              }
+                                            expect("key hello. must not contain '.'").to.equal(
+                                              err.message
                                             );
+                                            // Let's close the db
+                                            client.close();
+                                            done();
                                           }
                                         );
                                       }
@@ -409,9 +371,9 @@ describe('Collection', function() {
                     );
                   }
                 );
-              }
-            );
-          });
+              });
+            }
+          );
         });
       }
     });
@@ -426,34 +388,30 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.collection(5, err => {
-            expect('collection name must be a String').to.equal(err.message);
-          });
+        db.collection(5, err => {
+          expect('collection name must be a String').to.equal(err.message);
+        });
 
-          db.collection('', err => {
-            expect('collection names cannot be empty').to.equal(err.message);
-          });
+        db.collection('', err => {
+          expect('collection names cannot be empty').to.equal(err.message);
+        });
 
-          db.collection('te$t', err => {
-            expect("collection names must not contain '$'").to.equal(err.message);
-          });
+        db.collection('te$t', err => {
+          expect("collection names must not contain '$'").to.equal(err.message);
+        });
 
-          db.collection('.test', err => {
-            expect("collection names must not start or end with '.'").to.equal(err.message);
-          });
+        db.collection('.test', err => {
+          expect("collection names must not start or end with '.'").to.equal(err.message);
+        });
 
-          db.collection('test.', err => {
-            expect("collection names must not start or end with '.'").to.equal(err.message);
-          });
+        db.collection('test.', err => {
+          expect("collection names must not start or end with '.'").to.equal(err.message);
+        });
 
-          db.collection('test..t', err => {
-            expect('collection names cannot be empty').to.equal(err.message);
-            client.close();
-            done();
-          });
+        db.collection('test..t', err => {
+          expect('collection names cannot be empty').to.equal(err.message);
+          client.close();
+          done();
         });
       }
     });
@@ -467,18 +425,13 @@ describe('Collection', function() {
         const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
           poolSize: 1
         });
-
-        client.connect((err, client) => {
+        db.dropDatabase(err => {
           expect(err).to.not.exist;
-          const db = client.db('test_crate_collection');
-          db.dropDatabase(err => {
-            expect(err).to.not.exist;
 
-            db.createCollection('test/../', err => {
-              expect(err).to.exist;
-              client.close();
-              done();
-            });
+          db.createCollection('test/../', err => {
+            expect(err).to.exist;
+            client.close();
+            done();
           });
         });
       }
@@ -493,16 +446,12 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.collection('test_multiple_insert_2', (err, collection) => {
-            collection.count((err, count) => {
-              expect(count).to.equal(0)
-              // Let's close the db
-              client.close();
-              done();
-            });
+        db.collection('test_multiple_insert_2', (err, collection) => {
+          collection.count((err, count) => {
+            expect(count).to.equal(0);
+            // Let's close the db
+            client.close();
+            done();
           });
         });
       }
@@ -518,50 +467,46 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('test_save', (err, collection) => {
-            const doc = { hello: 'world' };
-            collection.save(doc, this.configuration.writeConcernMax(), (err, r) => {
-              expect(r.ops[0]._id != null).to.be.true;
+        db.createCollection('test_save', (err, collection) => {
+          const doc = { hello: 'world' };
+          collection.save(doc, this.configuration.writeConcernMax(), (err, r) => {
+            expect(r.ops[0]._id != null).to.be.true;
 
-              collection.count((err, count) => {
-                expect(count).to.equal(1)
+            collection.count((err, count) => {
+              expect(count).to.equal(1);
 
-                collection.save(r.ops[0], this.configuration.writeConcernMax(), err => {
-                  expect(err).to.not.exist;
-                  collection.count((err, count) => {
-                    expect(count).to.equal(1)
+              collection.save(r.ops[0], this.configuration.writeConcernMax(), err => {
+                expect(err).to.not.exist;
+                collection.count((err, count) => {
+                  expect(count).to.equal(1);
 
-                    collection.findOne((err, doc3) => {
-                      expect('world').to.equal(doc3.hello);
+                  collection.findOne((err, doc3) => {
+                    expect('world').to.equal(doc3.hello);
 
-                      doc3.hello = 'mike';
+                    doc3.hello = 'mike';
 
-                      collection.save(doc3, this.configuration.writeConcernMax(), err => {
-                        expect(err).to.not.exist;
-                        collection.count((err, count) => {
-                          expect(count).to.equal(1)
+                    collection.save(doc3, this.configuration.writeConcernMax(), err => {
+                      expect(err).to.not.exist;
+                      collection.count((err, count) => {
+                        expect(count).to.equal(1);
 
-                          collection.findOne((err, doc5) => {
-                            expect('mike').to.equal(doc5.hello);
+                        collection.findOne((err, doc5) => {
+                          expect('mike').to.equal(doc5.hello);
 
-                            // Save another document
-                            collection.save(
-                              { hello: 'world' },
-                              this.configuration.writeConcernMax(),
-                              err => {
-                                expect(err).to.not.exist;
-                                collection.count((err, count) => {
-                                  expect(count).to.equal(2);
-                                  // Let's close the db
-                                  client.close();
-                                  done();
-                                });
-                              }
-                            );
-                          });
+                          // Save another document
+                          collection.save(
+                            { hello: 'world' },
+                            this.configuration.writeConcernMax(),
+                            err => {
+                              expect(err).to.not.exist;
+                              collection.count((err, count) => {
+                                expect(count).to.equal(2);
+                                // Let's close the db
+                                client.close();
+                                done();
+                              });
+                            }
+                          );
                         });
                       });
                     });
@@ -585,25 +530,21 @@ describe('Collection', function() {
       // The actual test we wish to run
       test: function(done) {
         const Long = this.configuration.require.Long;
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('test_save_long', (err, collection) => {
-            collection.insert(
-              { x: Long.fromNumber(9223372036854775807) },
-              this.configuration.writeConcernMax(),
-              err => {
+        db.createCollection('test_save_long', (err, collection) => {
+          collection.insert(
+            { x: Long.fromNumber(9223372036854775807) },
+            this.configuration.writeConcernMax(),
+            err => {
+              expect(err).to.not.exist;
+              collection.findOne((err, doc) => {
                 expect(err).to.not.exist;
-                collection.findOne((err, doc) => {
-                  expect(err).to.not.exist;
-                  expect(Long.fromNumber(9223372036854775807)).to.deep.equal(doc.x);
-                  // Let's close the db
-                  client.close();
-                  done();
-                });
-              }
-            );
-          });
+                expect(Long.fromNumber(9223372036854775807)).to.deep.equal(doc.x);
+                // Let's close the db
+                client.close();
+                done();
+              });
+            }
+          );
         });
       }
     });
@@ -618,41 +559,37 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection(
-            'test_save_with_object_that_has_id_but_does_not_actually_exist_in_collection',
-            (err, collection) => {
-              const a = { _id: '1', hello: 'world' };
-              collection.save(a, this.configuration.writeConcernMax(), err => {
-                expect(err).to.not.exist;
-                collection.count((err, count) => {
-                  expect(count).to.equal(1)
+        db.createCollection(
+          'test_save_with_object_that_has_id_but_does_not_actually_exist_in_collection',
+          (err, collection) => {
+            const a = { _id: '1', hello: 'world' };
+            collection.save(a, this.configuration.writeConcernMax(), err => {
+              expect(err).to.not.exist;
+              collection.count((err, count) => {
+                expect(count).to.equal(1);
 
-                  collection.findOne((err, doc) => {
-                    expect('world').to.equal(doc.hello);
+                collection.findOne((err, doc) => {
+                  expect('world').to.equal(doc.hello);
 
-                    doc.hello = 'mike';
-                    collection.save(doc, this.configuration.writeConcernMax(), err => {
-                      expect(err).to.not.exist;
-                      collection.findOne((err, doc) => {
-                        collection.count((err, count) => {
-                          expect(count).to.equal(1)
+                  doc.hello = 'mike';
+                  collection.save(doc, this.configuration.writeConcernMax(), err => {
+                    expect(err).to.not.exist;
+                    collection.findOne((err, doc) => {
+                      collection.count((err, count) => {
+                        expect(count).to.equal(1);
 
-                          expect('mike').to.equal(doc.hello);
-                          // Let's close the db
-                          client.close();
-                          done();
-                        });
+                        expect('mike').to.equal(doc.hello);
+                        // Let's close the db
+                        client.close();
+                        done();
                       });
                     });
                   });
                 });
               });
-            }
-          );
-        });
+            });
+          }
+        );
       }
     });
 
@@ -667,21 +604,16 @@ describe('Collection', function() {
       // The actual test we wish to run
       test: function(done) {
         const ObjectID = this.configuration.require.ObjectID;
+        db.createCollection('test_should_correctly_do_update_with_no_docs', (err, collection) => {
+          const id = new ObjectID(null);
+          const doc = { _id: id, a: 1 };
 
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('test_should_correctly_do_update_with_no_docs', (err, collection) => {
-            const id = new ObjectID(null);
-            const doc = { _id: id, a: 1 };
+          collection.update({ _id: id }, doc, this.configuration.writeConcernMax(), (err, r) => {
+            expect(err).to.not.exist;
+            expect(0).to.equal(r.result.n);
 
-            collection.update({ _id: id }, doc, this.configuration.writeConcernMax(), (err, r) => {
-              expect(err).to.not.exist;
-              expect(0).to.equal(r.result.n);
-
-              client.close();
-              done();
-            });
+            client.close();
+            done();
           });
         });
       }
@@ -697,40 +629,38 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection(
-            'test_should_execute_insert_update_delete_safe_mode',
-            (err, collection) => {
-              expect('test_should_execute_insert_update_delete_safe_mode').to.equal(collection.collectionName);
+        db.createCollection(
+          'test_should_execute_insert_update_delete_safe_mode',
+          (err, collection) => {
+            expect('test_should_execute_insert_update_delete_safe_mode').to.equal(
+              collection.collectionName
+            );
 
-              collection.insert({ i: 1 }, this.configuration.writeConcernMax(), (err, r) => {
-                expect(1).to.equal(r.ops.length);
-                expect(r.ops[0]._id.toHexString().length === 24).to.be.true;
+            collection.insert({ i: 1 }, this.configuration.writeConcernMax(), (err, r) => {
+              expect(1).to.equal(r.ops.length);
+              expect(r.ops[0]._id.toHexString().length === 24).to.be.true;
 
-                // Update the record
-                collection.update(
-                  { i: 1 },
-                  { $set: { i: 2 } },
-                  this.configuration.writeConcernMax(),
-                  err => {
+              // Update the record
+              collection.update(
+                { i: 1 },
+                { $set: { i: 2 } },
+                this.configuration.writeConcernMax(),
+                err => {
+                  expect(err).to.not.exist;
+                  expect(1).to.equal(r.result.n);
+
+                  // Remove safely
+                  collection.remove({}, this.configuration.writeConcernMax(), err => {
                     expect(err).to.not.exist;
-                    expect(1).to.equal(r.result.n);
 
-                    // Remove safely
-                    collection.remove({}, this.configuration.writeConcernMax(), err => {
-                      expect(err).to.not.exist;
-
-                      client.close();
-                      done();
-                    });
-                  }
-                );
-              });
-            }
-          );
-        });
+                    client.close();
+                    done();
+                  });
+                }
+              );
+            });
+          }
+        );
       }
     });
 
@@ -744,39 +674,35 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('multiple_save_test', (err, collection) => {
-            const doc = {
-              name: 'amit',
-              text: 'some text'
-            };
+        db.createCollection('multiple_save_test', (err, collection) => {
+          const doc = {
+            name: 'amit',
+            text: 'some text'
+          };
 
-            //insert new user
-            collection.save(doc, this.configuration.writeConcernMax(), err => {
-              expect(err).to.not.exist;
+          //insert new user
+          collection.save(doc, this.configuration.writeConcernMax(), err => {
+            expect(err).to.not.exist;
 
-              collection
-                .find({}, { name: 1 })
-                .limit(1)
-                .toArray((err, users) => {
-                  const user = users[0];
+            collection
+              .find({}, { name: 1 })
+              .limit(1)
+              .toArray((err, users) => {
+                const user = users[0];
 
-                  if (err) {
-                    throw new Error(err);
-                  } else if (user) {
-                    user.pants = 'worn';
+                if (err) {
+                  throw new Error(err);
+                } else if (user) {
+                  user.pants = 'worn';
 
-                    collection.save(user, this.configuration.writeConcernMax(), (err, result) => {
-                      expect(err).to.not.exist;
-                      expect(1).to.equal(result.result.n);
-                      client.close();
-                      done();
-                    });
-                  }
-                });
-            });
+                  collection.save(user, this.configuration.writeConcernMax(), (err, result) => {
+                    expect(err).to.not.exist;
+                    expect(1).to.equal(result.result.n);
+                    client.close();
+                    done();
+                  });
+                }
+              });
           });
         });
       }
@@ -793,59 +719,54 @@ describe('Collection', function() {
       // The actual test we wish to run
       test: function(done) {
         const ObjectID = this.configuration.require.ObjectID;
-
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('save_error_on_save_test', (err, collection) => {
-            // Create unique index for username
-            collection.createIndex([['username', 1]], this.configuration.writeConcernMax(), err => {
+        db.createCollection('save_error_on_save_test', (err, collection) => {
+          // Create unique index for username
+          collection.createIndex([['username', 1]], this.configuration.writeConcernMax(), err => {
+            expect(err).to.not.exist;
+            const doc = {
+              email: 'email@email.com',
+              encrypted_password: 'password',
+              friends: [
+                '4db96b973d01205364000006',
+                '4db94a1948a683a176000001',
+                '4dc77b24c5ba38be14000002'
+              ],
+              location: [72.4930088, 23.0431957],
+              name: 'Amit Kumar',
+              password_salt: 'salty',
+              profile_fields: [],
+              username: 'amit'
+            };
+            //insert new user
+            collection.save(doc, this.configuration.writeConcernMax(), err => {
               expect(err).to.not.exist;
-              const doc = {
-                email: 'email@email.com',
-                encrypted_password: 'password',
-                friends: [
-                  '4db96b973d01205364000006',
-                  '4db94a1948a683a176000001',
-                  '4dc77b24c5ba38be14000002'
-                ],
-                location: [72.4930088, 23.0431957],
-                name: 'Amit Kumar',
-                password_salt: 'salty',
-                profile_fields: [],
-                username: 'amit'
-              };
-              //insert new user
-              collection.save(doc, this.configuration.writeConcernMax(), err => {
-                expect(err).to.not.exist;
 
-                collection
-                  .find({})
-                  .limit(1)
-                  .toArray((err, users) => {
+              collection
+                .find({})
+                .limit(1)
+                .toArray((err, users) => {
+                  expect(err).to.not.exist;
+                  const user = users[0];
+                  user.friends.splice(1, 1);
+
+                  collection.save(user, err => {
                     expect(err).to.not.exist;
-                    const user = users[0];
-                    user.friends.splice(1, 1);
 
-                    collection.save(user, err => {
-                      expect(err).to.not.exist;
+                    // Update again
+                    collection.update(
+                      { _id: new ObjectID(user._id.toString()) },
+                      { friends: user.friends },
+                      { upsert: true, w: 1 },
+                      (err, result) => {
+                        expect(err).to.not.exist;
+                        expect(1).to.equal(result.result.n);
 
-                      // Update again
-                      collection.update(
-                        { _id: new ObjectID(user._id.toString()) },
-                        { friends: user.friends },
-                        { upsert: true, w: 1 },
-                        (err, result) => {
-                          expect(err).to.not.exist;
-                          expect(1).to.equal(result.result.n);
-
-                          client.close();
-                          done();
-                        }
-                      );
-                    });
+                        client.close();
+                        done();
+                      }
+                    );
                   });
-              });
+                });
             });
           });
         });
@@ -862,26 +783,22 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
+        db.collection('remove_with_no_callback_bug_test', (err, collection) => {
           expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.collection('remove_with_no_callback_bug_test', (err, collection) => {
+          collection.save({ a: 1 }, this.configuration.writeConcernMax(), err => {
             expect(err).to.not.exist;
-            collection.save({ a: 1 }, this.configuration.writeConcernMax(), err => {
+            collection.save({ b: 1 }, this.configuration.writeConcernMax(), err => {
               expect(err).to.not.exist;
-              collection.save({ b: 1 }, this.configuration.writeConcernMax(), err => {
+              collection.save({ c: 1 }, this.configuration.writeConcernMax(), err => {
                 expect(err).to.not.exist;
-                collection.save({ c: 1 }, this.configuration.writeConcernMax(), err => {
+                collection.remove({ a: 1 }, this.configuration.writeConcernMax(), err => {
                   expect(err).to.not.exist;
-                  collection.remove({ a: 1 }, this.configuration.writeConcernMax(), err => {
+                  // Let's perform a count
+                  collection.count((err, count) => {
                     expect(err).to.not.exist;
-                    // Let's perform a count
-                    collection.count((err, count) => {
-                      expect(err).to.not.exist;
-                      expect(count).to.equal(2);
-                      client.close();
-                      done();
-                    });
+                    expect(count).to.equal(2);
+                    client.close();
+                    done();
                   });
                 });
               });
@@ -904,41 +821,37 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection(
-            'shouldCorrectlyCreateTTLCollectionWithIndexUsingEnsureIndex',
-            (err, collection) => {
-              collection.ensureIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
-                expect(err).to.not.exist;
+        db.createCollection(
+          'shouldCorrectlyCreateTTLCollectionWithIndexUsingEnsureIndex',
+          (err, collection) => {
+            collection.ensureIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
+              expect(err).to.not.exist;
 
-                // Insert a document with a date
-                collection.insert(
-                  { a: 1, createdAt: new Date() },
-                  this.configuration.writeConcernMax(),
-                  err => {
+              // Insert a document with a date
+              collection.insert(
+                { a: 1, createdAt: new Date() },
+                this.configuration.writeConcernMax(),
+                err => {
+                  expect(err).to.not.exist;
+
+                  collection.indexInformation({ full: true }, (err, indexes) => {
                     expect(err).to.not.exist;
 
-                    collection.indexInformation({ full: true }, (err, indexes) => {
-                      expect(err).to.not.exist;
-
-                      for (let i = 0; i < indexes.length; i++) {
-                        if (indexes[i].name === 'createdAt_1') {
-                          expect(1).to.equal(indexes[i].expireAfterSeconds);
-                          break;
-                        }
+                    for (let i = 0; i < indexes.length; i++) {
+                      if (indexes[i].name === 'createdAt_1') {
+                        expect(1).to.equal(indexes[i].expireAfterSeconds);
+                        break;
                       }
+                    }
 
-                      client.close();
-                      done();
-                    });
-                  }
-                );
-              });
-            }
-          );
-        });
+                    client.close();
+                    done();
+                  });
+                }
+              );
+            });
+          }
+        );
       }
     });
 
@@ -955,42 +868,38 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection(
-            'shouldCorrectlyCreateTTLCollectionWithIndexCreateIndex',
-            {},
-            (err, collection) => {
-              collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
-                expect(err).to.not.exist;
+        db.createCollection(
+          'shouldCorrectlyCreateTTLCollectionWithIndexCreateIndex',
+          {},
+          (err, collection) => {
+            collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
+              expect(err).to.not.exist;
 
-                // Insert a document with a date
-                collection.insert(
-                  { a: 1, createdAt: new Date() },
-                  this.configuration.writeConcernMax(),
-                  err => {
+              // Insert a document with a date
+              collection.insert(
+                { a: 1, createdAt: new Date() },
+                this.configuration.writeConcernMax(),
+                err => {
+                  expect(err).to.not.exist;
+
+                  collection.indexInformation({ full: true }, (err, indexes) => {
                     expect(err).to.not.exist;
 
-                    collection.indexInformation({ full: true }, (err, indexes) => {
-                      expect(err).to.not.exist;
-
-                      for (let i = 0; i < indexes.length; i++) {
-                        if (indexes[i].name === 'createdAt_1') {
-                          expect(1).to.equal(indexes[i].expireAfterSeconds);
-                          break;
-                        }
+                    for (let i = 0; i < indexes.length; i++) {
+                      if (indexes[i].name === 'createdAt_1') {
+                        expect(1).to.equal(indexes[i].expireAfterSeconds);
+                        break;
                       }
+                    }
 
-                      client.close();
-                      done();
-                    });
-                  }
-                );
-              });
-            }
-          );
-        });
+                    client.close();
+                    done();
+                  });
+                }
+              );
+            });
+          }
+        );
       }
     });
 
@@ -1007,21 +916,17 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('create_index_without_options', {}, (err, collection) => {
-            collection.createIndex({ createdAt: 1 }, err => {
+        db.createCollection('create_index_without_options', {}, (err, collection) => {
+          collection.createIndex({ createdAt: 1 }, err => {
+            expect(err).to.not.exist;
+
+            collection.indexInformation({ full: true }, (err, indexes) => {
               expect(err).to.not.exist;
+              const indexNames = indexes.map(i => i.name);
+              expect(indexNames).to.include('createdAt_1');
 
-              collection.indexInformation({ full: true }, (err, indexes) => {
-                expect(err).to.not.exist;
-                const indexNames = indexes.map(i => i.name);
-                expect(indexNames).to.include('createdAt_1');
-
-                client.close();
-                done();
-              });
+              client.close();
+              done();
             });
           });
         });
@@ -1038,20 +943,16 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('shouldCorrectlyReadBackDocumentWithNull', {}, (err, collection) => {
-            // Insert a document with a date
-            collection.insert({ test: null }, this.configuration.writeConcernMax(), err => {
+        db.createCollection('shouldCorrectlyReadBackDocumentWithNull', {}, (err, collection) => {
+          // Insert a document with a date
+          collection.insert({ test: null }, this.configuration.writeConcernMax(), err => {
+            expect(err).to.not.exist;
+
+            collection.findOne(err => {
               expect(err).to.not.exist;
 
-              collection.findOne(err => {
-                expect(err).to.not.exist;
-
-                client.close();
-                done();
-              });
+              client.close();
+              done();
             });
           });
         });
@@ -1068,25 +969,21 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection('shouldThrowErrorDueToIllegalUpdate', {}, (err, coll) => {
-            try {
-              coll.update({}, null, () => {});
-            } catch (err) {
-              expect('document must be a valid JavaScript object').to.equal(err.message);
-            }
+        db.createCollection('shouldThrowErrorDueToIllegalUpdate', {}, (err, coll) => {
+          try {
+            coll.update({}, null, () => {});
+          } catch (err) {
+            expect('document must be a valid JavaScript object').to.equal(err.message);
+          }
 
-            try {
-              coll.update(null, null, () => {});
-            } catch (err) {
-              expect('selector must be a valid JavaScript object').to.equal(err.message);
-            }
+          try {
+            coll.update(null, null, () => {});
+          } catch (err) {
+            expect('selector must be a valid JavaScript object').to.equal(err.message);
+          }
 
-            client.close();
-            done();
-          });
+          client.close();
+          done();
         });
       }
     });
@@ -1101,17 +998,13 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
+        db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
           expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
+
           db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
             expect(err).to.not.exist;
-
-            db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
-              expect(err).to.not.exist;
-              client.close();
-              done();
-            });
+            client.close();
+            done();
           });
         });
       }
@@ -1127,18 +1020,14 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db
-            .collection('executeUpdateWithElemMatch')
-            .update({ 'item.i': 1 }, { $set: { a: 1 } }, err => {
-              expect(err).to.not.exist;
+        db
+          .collection('executeUpdateWithElemMatch')
+          .update({ 'item.i': 1 }, { $set: { a: 1 } }, err => {
+            expect(err).to.not.exist;
 
-              client.close();
-              done();
-            });
-        });
+            client.close();
+            done();
+          });
       }
     });
 
@@ -1152,18 +1041,14 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db
-            .collection('executeUpdateWithElemMatch')
-            .update({ item: { $elemMatch: { name: 'my_name' } } }, { $set: { a: 1 } }, err => {
-              expect(err).to.not.exist;
+        db
+          .collection('executeUpdateWithElemMatch')
+          .update({ item: { $elemMatch: { name: 'my_name' } } }, { $set: { a: 1 } }, err => {
+            expect(err).to.not.exist;
 
-              client.close();
-              done();
-            });
-        });
+            client.close();
+            done();
+          });
       }
     });
 
@@ -1177,24 +1062,16 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
+        db.createCollection('shouldFailDueToExistingCollection', { strict: true }, (err, coll) => {
           expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          db.createCollection(
-            'shouldFailDueToExistingCollection',
-            { strict: true },
-            (err, coll) => {
-              expect(err).to.not.exist;
-              expect(coll != null).to.be.true;
+          expect(coll != null).to.be.true;
 
-              db.createCollection('shouldFailDueToExistingCollection', { strict: true }, err => {
-                expect(err != null).to.be.true;
+          db.createCollection('shouldFailDueToExistingCollection', { strict: true }, err => {
+            expect(err != null).to.be.true;
 
-                client.close();
-                done();
-              });
-            }
-          );
+            client.close();
+            done();
+          });
         });
       }
     });
@@ -1210,25 +1087,20 @@ describe('Collection', function() {
       // The actual test we wish to run
       test: function(done) {
         const testCollection = 'integration_tests_collection_123'; // The collection happens to contain the database name
-
-        client.connect((err, client) => {
+        // Create a collection
+        db.createCollection(testCollection, err => {
           expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
-          // Create a collection
-          db.createCollection(testCollection, err => {
-            expect(err).to.not.exist;
 
-            db.listCollections({ name: testCollection }).toArray((err, documents) => {
-              expect(err).to.not.exist;
-              expect(documents.length).to.equal(1);
-              let found = false;
-              documents.forEach(document => {
-                if (document.name === testCollection) found = true;
-              });
-              expect(found).to.be.true;
-              client.close();
-              done();
+          db.listCollections({ name: testCollection }).toArray((err, documents) => {
+            expect(err).to.not.exist;
+            expect(documents.length).to.equal(1);
+            let found = false;
+            documents.forEach(document => {
+              if (document.name === testCollection) found = true;
             });
+            expect(found).to.be.true;
+            client.close();
+            done();
           });
         });
       }
@@ -1245,28 +1117,66 @@ describe('Collection', function() {
       // The actual test we wish to run
       test: function(done) {
         const testCollection = 'collection_124';
+        // Create a collection
+        db.createCollection(testCollection, err => {
+          expect(err).to.not.exist;
 
-        client.connect((err, client) => {
-          const db = client.db(this.configuration.db);
-          // Create a collection
-          db.createCollection(testCollection, err => {
+          // Index name happens to be the same as collection name
+          db.createIndex(testCollection, 'collection_124', { w: 1 }, (err, indexName) => {
+            expect(err).to.not.exist;
+            expect('collection_124_1').to.equal(indexName);
+
+            db.listCollections().toArray((err, documents) => {
+              expect(err).to.not.exist;
+              expect(documents.length > 1).to.be.true;
+              let found = false;
+
+              documents.forEach(document => {
+                if (document.name === testCollection) found = true;
+              });
+
+              expect(found).to.be.true;
+              client.close();
+              done();
+            });
+          });
+        });
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly list multipleCollections', {
+      metadata: {
+        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+      },
+
+      // The actual test we wish to run
+      test: function(done) {
+        const emptyDb = client.db('listCollectionsDb');
+        emptyDb.createCollection('test1', err => {
+          expect(err).to.not.exist;
+
+          emptyDb.createCollection('test2', err => {
             expect(err).to.not.exist;
 
-            // Index name happens to be the same as collection name
-            db.createIndex(testCollection, 'collection_124', { w: 1 }, (err, indexName) => {
+            emptyDb.createCollection('test3', err => {
               expect(err).to.not.exist;
-              expect('collection_124_1').to.equal(indexName);
 
-              db.listCollections().toArray((err, documents) => {
+              emptyDb.listCollections().toArray((err, collections) => {
                 expect(err).to.not.exist;
-                expect(documents.length > 1).to.be.true;
-                let found = false;
+                // By name
+                let names = {};
 
-                documents.forEach(document => {
-                  if (document.name === testCollection) found = true;
-                });
+                for (let i = 0; i < collections.length; i++) {
+                  names[collections[i].name] = collections[i];
+                }
 
-                expect(found).to.be.true;
+                expect(names['test1'] != null).to.be.true;
+                expect(names['test2'] != null).to.be.true;
+                expect(names['test3'] != null).to.be.true;
+
                 client.close();
                 done();
               });
@@ -1286,81 +1196,31 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
+        const emptyDb = client.db('listCollectionsDb');
+        emptyDb.createCollection('test1', err => {
           expect(err).to.not.exist;
-          expect(err).to.not.exist;
-          const emptyDb = client.db('listCollectionsDb');
-          emptyDb.createCollection('test1', err => {
+
+          emptyDb.createCollection('test2', err => {
             expect(err).to.not.exist;
 
-            emptyDb.createCollection('test2', err => {
+            emptyDb.createCollection('test3', err => {
               expect(err).to.not.exist;
 
-              emptyDb.createCollection('test3', err => {
+              emptyDb.listCollections().toArray((err, collections) => {
                 expect(err).to.not.exist;
+                // By name
+                let names = {};
 
-                emptyDb.listCollections().toArray((err, collections) => {
-                  expect(err).to.not.exist;
-                  // By name
-                  let names = {};
+                for (let i = 0; i < collections.length; i++) {
+                  names[collections[i].name] = collections[i];
+                }
 
-                  for (let i = 0; i < collections.length; i++) {
-                    names[collections[i].name] = collections[i];
-                  }
+                expect(names['test1'] != null).to.be.true;
+                expect(names['test2'] != null).to.be.true;
+                expect(names['test3'] != null).to.be.true;
 
-                  expect(names['test1'] != null).to.be.true;
-                  expect(names['test2'] != null).to.be.true;
-                  expect(names['test3'] != null).to.be.true;
-
-                  client.close();
-                  done();
-                });
-              });
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly list multipleCollections', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          expect(err).to.not.exist;
-          const emptyDb = client.db('listCollectionsDb');
-          emptyDb.createCollection('test1', err => {
-            expect(err).to.not.exist;
-
-            emptyDb.createCollection('test2', err => {
-              expect(err).to.not.exist;
-
-              emptyDb.createCollection('test3', err => {
-                expect(err).to.not.exist;
-
-                emptyDb.listCollections().toArray((err, collections) => {
-                  expect(err).to.not.exist;
-                  // By name
-                  let names = {};
-
-                  for (let i = 0; i < collections.length; i++) {
-                    names[collections[i].name] = collections[i];
-                  }
-
-                  expect(names['test1'] != null).to.be.true;
-                  expect(names['test2'] != null).to.be.true;
-                  expect(names['test3'] != null).to.be.true;
-
-                  client.close();
-                  done();
-                });
+                client.close();
+                done();
               });
             });
           });
@@ -1378,41 +1238,37 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
+        const emptyDb = client.db('listCollectionsDb2');
+        emptyDb.createCollection('test1', err => {
           expect(err).to.not.exist;
-          expect(err).to.not.exist;
-          const emptyDb = client.db('listCollectionsDb2');
-          emptyDb.createCollection('test1', err => {
+
+          emptyDb.createCollection('test.test', err => {
             expect(err).to.not.exist;
 
-            emptyDb.createCollection('test.test', err => {
+            emptyDb.createCollection('test3', err => {
               expect(err).to.not.exist;
 
-              emptyDb.createCollection('test3', err => {
-                expect(err).to.not.exist;
-
-                emptyDb.collections((err, collections) => {
-                  collections = collections.map(collection => {
-                    return {
-                      collectionName: collection.collectionName,
-                      namespace: collection.namespace
-                    };
-                  });
-
-                  let foundCollection = false;
-                  collections.forEach(x => {
-                    if (
-                      x.namespace === 'listCollectionsDb2.test.test' &&
-                      x.collectionName === 'test.test'
-                    ) {
-                      foundCollection = true;
-                    }
-                  });
-
-                  expect(foundCollection).to.be.true;
-                  client.close();
-                  done();
+              emptyDb.collections((err, collections) => {
+                collections = collections.map(collection => {
+                  return {
+                    collectionName: collection.collectionName,
+                    namespace: collection.namespace
+                  };
                 });
+
+                let foundCollection = false;
+                collections.forEach(x => {
+                  if (
+                    x.namespace === 'listCollectionsDb2.test.test' &&
+                    x.collectionName === 'test.test'
+                  ) {
+                    foundCollection = true;
+                  }
+                });
+
+                expect(foundCollection).to.be.true;
+                client.close();
+                done();
               });
             });
           });
@@ -1446,24 +1302,18 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-        client.connect((err, client) => {
-          expect(err).to.not.exist;
-          const db = client.db(this.configuration.db);
+        const db = client.db(this.configuration.db);
 
-          db.createCollection(
-            'test_should_correctly_do_update_with_pipeline',
-            (err, collection) => {
-              collection.updateOne(
-                {},
-                [{ $set: { a: 1 } }, { $set: { b: 1 } }, { $set: { d: 1 } }],
-                this.configuration.writeConcernMax(),
-                (err, r) => {
-                  expect(err).to.not.exist;
-                  expect(r.result.n).to.equal(0);
+        db.createCollection('test_should_correctly_do_update_with_pipeline', (err, collection) => {
+          collection.updateOne(
+            {},
+            [{ $set: { a: 1 } }, { $set: { b: 1 } }, { $set: { d: 1 } }],
+            this.configuration.writeConcernMax(),
+            (err, r) => {
+              expect(err).to.not.exist;
+              expect(r.result.n).to.equal(0);
 
-                  client.close(done);
-                }
-              );
+              client.close(done);
             }
           );
         });
@@ -1474,90 +1324,71 @@ describe('Collection', function() {
   describe('', function() {
     let configuration;
     let client;
+    let db;
+    let collection;
+    let close;
     beforeEach(function() {
       configuration = this.configuration;
       client = configuration.newClient({}, { w: 1 });
+
+      return client.connect().then(client => {
+        db = client.db(configuration.db);
+        collection = db.collection('test_coll');
+      });
     });
     afterEach(function() {
       return client.close();
     });
 
     it('should correctly perform estimatedDocumentCount on non-matching query', function(done) {
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        const db = client.db(configuration.db);
-        const collection = db.collection('nonexistent_coll_1');
-        const close = e => client.close(() => done(e));
-
-        Promise.resolve()
-          .then(() => collection.estimatedDocumentCount({ a: 'b' }))
-          .then(count => expect(count).to.equal(0))
-          .then(() => close())
-          .catch(e => close(e));
-      });
+      close = e => client.close(() => done(e));
+      Promise.resolve()
+        .then(() => collection.estimatedDocumentCount({ a: 'b' }))
+        .then(count => expect(count).to.equal(0))
+        .then(() => close())
+        .catch(e => close(e));
     });
 
     it('should correctly perform countDocuments on non-matching query', function(done) {
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        const db = client.db(configuration.db);
-        const collection = db.collection('nonexistent_coll_2');
-        const close = e => client.close(() => done(e));
-
-        Promise.resolve()
-          .then(() => collection.countDocuments({ a: 'b' }))
-          .then(count => expect(count).to.equal(0))
-          .then(() => close())
-          .catch(e => close(e));
-      });
+      close = e => client.close(() => done(e));
+      Promise.resolve()
+        .then(() => collection.countDocuments({ a: 'b' }))
+        .then(count => expect(count).to.equal(0))
+        .then(() => close())
+        .catch(e => close(e));
     });
 
     it('countDocuments should return Promise that resolves when no callback passed', function(done) {
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        const db = client.db(configuration.db);
-        const collection = db.collection('countDoc_return_promise');
-        const docsPromise = collection.countDocuments();
-        const close = e => client.close(() => done(e));
+      const docsPromise = collection.countDocuments();
+      const close = e => client.close(() => done(e));
 
-        expect(docsPromise).to.exist.and.to.be.an.instanceof(collection.s.promiseLibrary);
+      expect(docsPromise).to.exist.and.to.be.an.instanceof(collection.s.promiseLibrary);
 
-        docsPromise
-          .then(result => expect(result).to.equal(0))
-          .then(() => close())
-          .catch(e => close(e));
-      });
+      docsPromise
+        .then(result => expect(result).to.equal(0))
+        .then(() => close())
+        .catch(e => close(e));
     });
 
     it('countDocuments should not return a promise if callback given', function(done) {
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        const db = client.db(configuration.db);
-        const collection = db.collection('countDoc_no_promise');
-        const close = e => client.close(() => done(e));
+      const close = e => client.close(() => done(e));
 
-        const notPromise = collection.countDocuments({ a: 1 }, () => {
-          expect(notPromise).to.be.undefined;
-          close();
-        });
+      const notPromise = collection.countDocuments({ a: 1 }, () => {
+        expect(notPromise).to.be.undefined;
+        close();
       });
     });
 
     it('countDocuments should correctly call the given callback', function(done) {
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        const db = client.db(configuration.db);
-        const collection = db.collection('countDoc_callback');
-        const docs = [{ a: 1 }, { a: 2 }];
-        const close = e => client.close(() => done(e));
+      const docs = [{ a: 1 }, { a: 2 }];
+      const close = e => client.close(() => done(e));
 
-        collection.insertMany(docs).then(() =>
-          collection.countDocuments({ a: 1 }, (err, data) => {
-            expect(data).to.equal(1);
-            close(err);
-          })
-        );
-      });
+      collection.insertMany(docs).then(() =>
+        collection.countDocuments({ a: 1 }, (err, data) => {
+          expect(data).to.equal(1);
+          close(err);
+        })
+      );
     });
   });
 

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -376,7 +376,7 @@ describe('Collection', function() {
     it('should correctly execute save', function(done) {
       db.createCollection('test_save', (err, collection) => {
         const doc = { hello: 'world' };
-        collection.insertOne(doc, this.configuration.writeConcernMax(), (err, r) => {
+        collection.save(doc, this.configuration.writeConcernMax(), (err, r) => {
           expect(r.ops[0]._id).to.exist;
 
           collection.countDocuments((err, count) => {
@@ -454,7 +454,7 @@ describe('Collection', function() {
         'test_save_with_object_that_has_id_but_does_not_actually_exist_in_collection',
         (err, collection) => {
           const a = { _id: '1', hello: 'world' };
-          collection.insertOne(a, this.configuration.writeConcernMax(), err => {
+          collection.save(a, this.configuration.writeConcernMax(), err => {
             expect(err).to.not.exist;
             collection.countDocuments((err, count) => {
               expect(count).to.equal(1);
@@ -530,7 +530,7 @@ describe('Collection', function() {
         };
 
         //insert new user
-        collection.insertOne(doc, this.configuration.writeConcernMax(), err => {
+        collection.save(doc, this.configuration.writeConcernMax(), err => {
           expect(err).to.not.exist;
 
           collection
@@ -579,7 +579,7 @@ describe('Collection', function() {
             username: 'amit'
           };
           //insert new user
-          collection.insertOne(doc, this.configuration.writeConcernMax(), err => {
+          collection.save(doc, this.configuration.writeConcernMax(), err => {
             expect(err).to.not.exist;
 
             collection
@@ -624,7 +624,7 @@ describe('Collection', function() {
             expect(err).to.not.exist;
             collection.insertOne({ c: 1 }, this.configuration.writeConcernMax(), err => {
               expect(err).to.not.exist;
-              collection.deleteOne({ a: 1 }, this.configuration.writeConcernMax(), err => {
+              collection.remove({ a: 1 }, this.configuration.writeConcernMax(), err => {
                 expect(err).to.not.exist;
                 // Let's perform a count
                 collection.countDocuments((err, count) => {
@@ -869,7 +869,6 @@ describe('Collection', function() {
               let names = [];
               for (let i = 0; i < collections.length; i++) {
                 names.push(collections[i].name);
-                console.log('Name of the collection: ', collections[i].name);
               }
               expect(names).to.include('test1');
               expect(names).to.include('test2');

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -41,7 +41,7 @@ describe('Collection', function() {
             test.equal('test_collection_methods', collection.collectionName);
             // Let's check that the collection was created correctly
             db.listCollections().toArray((err, documents) => {
-              const found = false;
+              let found = false;
               documents.forEach(document => {
                 if (document.name === 'integration_tests_.test_collection_methods') found = true;
               });
@@ -155,9 +155,11 @@ describe('Collection', function() {
                             let found_does_not_exist = false;
 
                             collections.forEach(collection => {
-                              if (collection.collectionName === 'test.spiderman') found_spiderman = true;
+                              if (collection.collectionName === 'test.spiderman')
+                                found_spiderman = true;
                               if (collection.collectionName === 'test.mario') found_mario = true;
-                              if (collection.collectionName === 'does_not_exist') found_does_not_exist = true;
+                              if (collection.collectionName === 'does_not_exist')
+                                found_does_not_exist = true;
                             });
 
                             test.ok(found_spiderman);
@@ -1463,24 +1465,26 @@ describe('Collection', function() {
 
       // The actual test we wish to run
       test: function(done) {
-
         client.connect((err, client) => {
           expect(err).to.not.exist;
-          const db = client.db(configuration.db);
+          const db = client.db(this.configuration.db);
 
-          db.createCollection('test_should_correctly_do_update_with_pipeline', (err, collection) => {
-            collection.updateOne(
-              {},
-              [{ $set: { a: 1 } }, { $set: { b: 1 } }, { $set: { d: 1 } }],
-              configuration.writeConcernMax(),
-              (err, r) => {
-                expect(err).to.not.exist;
-                expect(r.result.n).to.equal(0);
+          db.createCollection(
+            'test_should_correctly_do_update_with_pipeline',
+            (err, collection) => {
+              collection.updateOne(
+                {},
+                [{ $set: { a: 1 } }, { $set: { b: 1 } }, { $set: { d: 1 } }],
+                this.configuration.writeConcernMax(),
+                (err, r) => {
+                  expect(err).to.not.exist;
+                  expect(r.result.n).to.equal(0);
 
-                client.close(done);
-              }
-            );
-          });
+                  client.close(done);
+                }
+              );
+            }
+          );
         });
       }
     });

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -14,6 +14,9 @@ describe('Collection', function() {
   describe('', function() {
     let client;
     let db;
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    };
     beforeEach(function() {
       client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
@@ -29,13 +32,7 @@ describe('Collection', function() {
     /**
      * @ignore
      */
-    it('should correctly execute basic collection methods', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
+    it('should correctly execute basic collection methods', function(done) {
         db.createCollection('test_collection_methods', (err, collection) => {
           // Verify that all the result are correct coming back (should contain the value ok)
           expect('test_collection_methods').to.equal(collection.collectionName);
@@ -58,7 +55,13 @@ describe('Collection', function() {
               db.createCollection('test_collection_methods4', (err, collection) => {
                 // Verify that all the result are correct coming back (should contain the value ok)
                 expect('test_collection_methods4').to.equal(collection.collectionName);
-
+                // Let's check that the collection was created correctly
+                db.listCollections().toArray(function(err, documents) {
+                  let found = false;
+                  documents.forEach(doc => {
+                    if (doc.name === 'integration_tests_.test_collection_methods') found = true;
+                  });
+                  expect(found).to.be.true;
                 // Rename the collection and with the dropTarget boolean, and check to make sure only onen exists.
                 db.renameCollection(
                   'test_collection_methods4',
@@ -79,7 +82,7 @@ describe('Collection', function() {
           });
         });
       }
-    });
+    );
     /**
      * @ignore
      */

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -38,31 +38,30 @@ describe('Collection', function() {
           const db = client.db(this.configuration.db);
           db.createCollection('test_collection_methods', (err, collection) => {
             // Verify that all the result are correct coming back (should contain the value ok)
-            test.equal('test_collection_methods', collection.collectionName);
+            expect('test_collection_methods').to.equal(collection.collectionName);
             // Let's check that the collection was created correctly
             db.listCollections().toArray((err, documents) => {
               let found = false;
               documents.forEach(document => {
                 if (document.name === 'integration_tests_.test_collection_methods') found = true;
               });
-              test.ok(true, found);
 
               // Rename the collection and check that it's gone
               db.renameCollection('test_collection_methods', 'test_collection_methods2', err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 // Drop the collection and check that it's gone
                 db.dropCollection('test_collection_methods2', (err, result) => {
-                  test.equal(true, result);
+                  expect(true).to.equal(result);
                 });
               });
 
               db.createCollection('test_collection_methods3', (err, collection) => {
                 // Verify that all the result are correct coming back (should contain the value ok)
-                test.equal('test_collection_methods3', collection.collectionName);
+                expect('test_collection_methods3').to.equal(collection.collectionName);
 
                 db.createCollection('test_collection_methods4', (err, collection) => {
                   // Verify that all the result are correct coming back (should contain the value ok)
-                  test.equal('test_collection_methods4', collection.collectionName);
+                  expect('test_collection_methods4').to.equal(collection.collectionName);
 
                   // Rename the collection and with the dropTarget boolean, and check to make sure only onen exists.
                   db.renameCollection(
@@ -70,10 +69,10 @@ describe('Collection', function() {
                     'test_collection_methods3',
                     { dropTarget: true },
                     err => {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
 
                       db.dropCollection('test_collection_methods3', (err, result) => {
-                        test.equal(true, result);
+                        expect(true).to.equal(result);
                         client.close();
                         done();
                       });
@@ -101,16 +100,16 @@ describe('Collection', function() {
           const db1 = client.db('test');
           db1.createCollection('test.game', (err, collection) => {
             // Verify that all the result are correct coming back (should contain the value ok)
-            test.equal('test.game', collection.collectionName);
+            expect('test.game').to.equal(collection.collectionName);
             // Let's check that the collection was created correctly
             db1.listCollections().toArray((err, documents) => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
               let found = false;
               documents.forEach(x => {
                 if (x.name === 'test.game') found = true;
               });
 
-              test.ok(found);
+              expect(found).to.be.true;
               client.close();
               done();
             });
@@ -141,13 +140,13 @@ describe('Collection', function() {
                   { foo: 5 },
                   this.configuration.writeConcernMax(),
                   err => {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
                     db.collection('test.mario', (err, mario_collection) => {
                       mario_collection.insert(
                         { bar: 0 },
                         this.configuration.writeConcernMax(),
                         err => {
-                          test.equal(null, err);
+                          expect(err).to.not.exist;
                           // Assert collections
                           db.collections((err, collections) => {
                             let found_spiderman = false;
@@ -162,9 +161,9 @@ describe('Collection', function() {
                                 found_does_not_exist = true;
                             });
 
-                            test.ok(found_spiderman);
-                            test.ok(found_mario);
-                            test.ok(!found_does_not_exist);
+                            expect(found_spiderman).to.be.true;
+                            expect(found_mario).to.be.true;
+                            expect(found_does_not_exist).to.be.false;
                             client.close();
                             done();
                           });
@@ -194,7 +193,7 @@ describe('Collection', function() {
           expect(err).to.not.exist;
           const db = client.db(this.configuration.db);
           db.createCollection('test_collection_names', err => {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             db.listCollections().toArray((err, documents) => {
               let found = false;
@@ -208,11 +207,11 @@ describe('Collection', function() {
                   found = true;
               });
 
-              test.ok(found);
+              expect(found).to.be.true;
               // Insert a document in an non-existing collection should create the collection
               const collection = db.collection('test_collection_names2');
               collection.insert({ a: 1 }, this.configuration.writeConcernMax(), err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 db.listCollections().toArray((err, documents) => {
                   documents.forEach(document => {
@@ -228,8 +227,8 @@ describe('Collection', function() {
                       found2 = true;
                   });
 
-                  test.ok(found);
-                  test.ok(found2);
+                  expect(found).to.be.true;
+                  expect(found2).to.be.true
 
                   // Let's close the db
                   client.close();
@@ -256,20 +255,15 @@ describe('Collection', function() {
           expect(err).to.not.exist;
           const db = client.db(this.configuration.db);
           db.collection('does-not-exist', { strict: true }, err => {
-            test.ok(err instanceof Error);
-            test.equal(
-              'Collection does-not-exist does not exist. Currently in strict mode.',
-              err.message
-            );
-
+            expect(err instanceof Error).to.be.true;
+            expect('Collection does-not-exist does not exist. Currently in strict mode.').to.equal(err.message);
             db.createCollection('test_strict_access_collection', err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
               db.collection(
                 'test_strict_access_collection',
                 this.configuration.writeConcernMax(),
                 (err, collection) => {
-                  test.equal(null, err);
-                  test.ok(collection.collectionName);
+                  expect(err).to.not.exist;
                   // Let's close the db
                   client.close();
                   done();
@@ -295,24 +289,20 @@ describe('Collection', function() {
           expect(err).to.not.exist;
           const db = client.db(this.configuration.db);
           db.createCollection('test_strict_create_collection', (err, collection) => {
-            test.equal(null, err);
-            test.equal('test_strict_create_collection', collection.collectionName);
+            expect(err).to.not.exist;
+            expect('test_strict_create_collection').to.equal(collection.collectionName);
 
             // Creating an existing collection should fail
             db.createCollection('test_strict_create_collection', { strict: true }, err => {
-              test.ok(err instanceof Error);
-              test.equal(
-                'Collection test_strict_create_collection already exists. Currently in strict mode.',
-                err.message
-              );
+              expect(err instanceof Error).to.be.true;
+              expect('Collection test_strict_create_collection already exists. Currently in strict mode.').to.equal(err.message);
 
               // Switch out of strict mode and try to re-create collection
               db.createCollection(
                 'test_strict_create_collection',
                 { strict: false },
                 (err, collection) => {
-                  test.equal(null, err);
-                  test.ok(collection.collectionName);
+                  expect(err).to.not.exist;
 
                   // Let's close the db
                   client.close();
@@ -328,7 +318,7 @@ describe('Collection', function() {
     /**
      * @ignore
      */
-    it.skip('should fail to insert due to illegal keys', {
+    it('should fail to insert due to illegal keys', {
       metadata: {
         requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
       },
@@ -344,68 +334,62 @@ describe('Collection', function() {
               [{ hello: 'world' }, { hello: { hello: 'world' } }],
               this.configuration.writeConcernMax(),
               err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 // Illegal insert for key
                 collection.insert(
                   { $hello: 'world' },
                   this.configuration.writeConcernMax(),
                   err => {
-                    test.ok(err instanceof Error);
-                    test.equal("key $hello must not start with '$'", err.message);
+                    expect(err instanceof Error).to.be.true;
+                    expect("key $hello must not start with '$'").to.equal(err.message);
 
                     collection.insert(
                       { hello: { $hello: 'world' } },
                       this.configuration.writeConcernMax(),
                       err => {
-                        test.ok(err instanceof Error);
-                        test.equal("key $hello must not start with '$'", err.message);
+                        expect(err instanceof Error).to.be.true;
+                        expect("key $hello must not start with '$'").to.equal(err.message);
 
                         collection.insert(
                           { he$llo: 'world' },
                           this.configuration.writeConcernMax(),
                           err => {
-                            test.equal(null, err);
+                            expect(err).to.not.exist;
 
                             collection.insert(
                               { hello: { hell$o: 'world' } },
                               this.configuration.writeConcernMax(),
                               err => {
-                                test.ok(err == null);
+                                expect(err).to.not.exist;
 
                                 collection.insert(
                                   { '.hello': 'world' },
                                   this.configuration.writeConcernMax(),
                                   err => {
-                                    test.ok(err instanceof Error);
-                                    test.equal("key .hello must not contain '.'", err.message);
+                                    expect(err instanceof Error).to.be.true;
+                                    expect("key .hello must not contain '.'").to.equal(err.message);
 
                                     collection.insert(
                                       { hello: { '.hello': 'world' } },
                                       this.configuration.writeConcernMax(),
                                       err => {
-                                        test.ok(err instanceof Error);
-                                        test.equal("key .hello must not contain '.'", err.message);
+                                        expect(err instanceof Error).to.be.true;
+                                        expect("key .hello must not contain '.'").to.equal(err.message);
 
                                         collection.insert(
                                           { 'hello.': 'world' },
                                           this.configuration.writeConcernMax(),
                                           err => {
-                                            test.ok(err instanceof Error);
-                                            test.equal(
-                                              "key hello. must not contain '.'",
-                                              err.message
-                                            );
+                                            expect(err instanceof Error).to.be.true;
+                                            expect("key hello. must not contain '.'").to.equal(err.message);
 
                                             collection.insert(
                                               { hello: { 'hello.': 'world' } },
                                               this.configuration.writeConcernMax(),
                                               err => {
-                                                test.ok(err instanceof Error);
-                                                test.equal(
-                                                  "key hello. must not contain '.'",
-                                                  err.message
-                                                );
+                                                expect(err instanceof Error).to.be.true;
+                                                expect("key hello. must not contain '.'").to.equal(err.message);
                                                 // Let's close the db
                                                 client.close();
                                                 done();
@@ -446,27 +430,27 @@ describe('Collection', function() {
           expect(err).to.not.exist;
           const db = client.db(this.configuration.db);
           db.collection(5, err => {
-            test.equal('collection name must be a String', err.message);
+            expect('collection name must be a String').to.equal(err.message);
           });
 
           db.collection('', err => {
-            test.equal('collection names cannot be empty', err.message);
+            expect('collection names cannot be empty').to.equal(err.message);
           });
 
           db.collection('te$t', err => {
-            test.equal("collection names must not contain '$'", err.message);
+            expect("collection names must not contain '$'").to.equal(err.message);
           });
 
           db.collection('.test', err => {
-            test.equal("collection names must not start or end with '.'", err.message);
+            expect("collection names must not start or end with '.'").to.equal(err.message);
           });
 
           db.collection('test.', err => {
-            test.equal("collection names must not start or end with '.'", err.message);
+            expect("collection names must not start or end with '.'").to.equal(err.message);
           });
 
           db.collection('test..t', err => {
-            test.equal('collection names cannot be empty', err.message);
+            expect('collection names cannot be empty').to.equal(err.message);
             client.close();
             done();
           });
@@ -514,7 +498,7 @@ describe('Collection', function() {
           const db = client.db(this.configuration.db);
           db.collection('test_multiple_insert_2', (err, collection) => {
             collection.count((err, count) => {
-              test.equal(0, count);
+              expect(count).to.equal(0)
               // Let's close the db
               client.close();
               done();
@@ -540,37 +524,37 @@ describe('Collection', function() {
           db.createCollection('test_save', (err, collection) => {
             const doc = { hello: 'world' };
             collection.save(doc, this.configuration.writeConcernMax(), (err, r) => {
-              test.ok(r.ops[0]._id != null);
+              expect(r.ops[0]._id != null).to.be.true;
 
               collection.count((err, count) => {
-                test.equal(1, count);
+                expect(count).to.equal(1)
 
                 collection.save(r.ops[0], this.configuration.writeConcernMax(), err => {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
                   collection.count((err, count) => {
-                    test.equal(1, count);
+                    expect(count).to.equal(1)
 
                     collection.findOne((err, doc3) => {
-                      test.equal('world', doc3.hello);
+                      expect('world').to.equal(doc3.hello);
 
                       doc3.hello = 'mike';
 
                       collection.save(doc3, this.configuration.writeConcernMax(), err => {
-                        test.equal(null, err);
+                        expect(err).to.not.exist;
                         collection.count((err, count) => {
-                          test.equal(1, count);
+                          expect(count).to.equal(1)
 
                           collection.findOne((err, doc5) => {
-                            test.equal('mike', doc5.hello);
+                            expect('mike').to.equal(doc5.hello);
 
                             // Save another document
                             collection.save(
                               { hello: 'world' },
                               this.configuration.writeConcernMax(),
                               err => {
-                                test.equal(null, err);
+                                expect(err).to.not.exist;
                                 collection.count((err, count) => {
-                                  test.equal(2, count);
+                                  expect(count).to.equal(2);
                                   // Let's close the db
                                   client.close();
                                   done();
@@ -609,10 +593,10 @@ describe('Collection', function() {
               { x: Long.fromNumber(9223372036854775807) },
               this.configuration.writeConcernMax(),
               err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 collection.findOne((err, doc) => {
-                  test.equal(null, err);
-                  test.ok(Long.fromNumber(9223372036854775807).equals(doc.x));
+                  expect(err).to.not.exist;
+                  expect(Long.fromNumber(9223372036854775807)).to.deep.equal(doc.x);
                   // Let's close the db
                   client.close();
                   done();
@@ -642,21 +626,21 @@ describe('Collection', function() {
             (err, collection) => {
               const a = { _id: '1', hello: 'world' };
               collection.save(a, this.configuration.writeConcernMax(), err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 collection.count((err, count) => {
-                  test.equal(1, count);
+                  expect(count).to.equal(1)
 
                   collection.findOne((err, doc) => {
-                    test.equal('world', doc.hello);
+                    expect('world').to.equal(doc.hello);
 
                     doc.hello = 'mike';
                     collection.save(doc, this.configuration.writeConcernMax(), err => {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
                       collection.findOne((err, doc) => {
                         collection.count((err, count) => {
-                          test.equal(1, count);
+                          expect(count).to.equal(1)
 
-                          test.equal('mike', doc.hello);
+                          expect('mike').to.equal(doc.hello);
                           // Let's close the db
                           client.close();
                           done();
@@ -692,8 +676,8 @@ describe('Collection', function() {
             const doc = { _id: id, a: 1 };
 
             collection.update({ _id: id }, doc, this.configuration.writeConcernMax(), (err, r) => {
-              test.equal(null, err);
-              test.equal(0, r.result.n);
+              expect(err).to.not.exist;
+              expect(0).to.equal(r.result.n);
 
               client.close();
               done();
@@ -719,14 +703,11 @@ describe('Collection', function() {
           db.createCollection(
             'test_should_execute_insert_update_delete_safe_mode',
             (err, collection) => {
-              test.equal(
-                'test_should_execute_insert_update_delete_safe_mode',
-                collection.collectionName
-              );
+              expect('test_should_execute_insert_update_delete_safe_mode').to.equal(collection.collectionName);
 
               collection.insert({ i: 1 }, this.configuration.writeConcernMax(), (err, r) => {
-                test.equal(1, r.ops.length);
-                test.ok(r.ops[0]._id.toHexString().length === 24);
+                expect(1).to.equal(r.ops.length);
+                expect(r.ops[0]._id.toHexString().length === 24).to.be.true;
 
                 // Update the record
                 collection.update(
@@ -734,12 +715,12 @@ describe('Collection', function() {
                   { $set: { i: 2 } },
                   this.configuration.writeConcernMax(),
                   err => {
-                    test.equal(null, err);
-                    test.equal(1, r.result.n);
+                    expect(err).to.not.exist;
+                    expect(1).to.equal(r.result.n);
 
                     // Remove safely
                     collection.remove({}, this.configuration.writeConcernMax(), err => {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
 
                       client.close();
                       done();
@@ -774,7 +755,7 @@ describe('Collection', function() {
 
             //insert new user
             collection.save(doc, this.configuration.writeConcernMax(), err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               collection
                 .find({}, { name: 1 })
@@ -788,8 +769,8 @@ describe('Collection', function() {
                     user.pants = 'worn';
 
                     collection.save(user, this.configuration.writeConcernMax(), (err, result) => {
-                      test.equal(null, err);
-                      test.equal(1, result.result.n);
+                      expect(err).to.not.exist;
+                      expect(1).to.equal(result.result.n);
                       client.close();
                       done();
                     });
@@ -819,7 +800,7 @@ describe('Collection', function() {
           db.createCollection('save_error_on_save_test', (err, collection) => {
             // Create unique index for username
             collection.createIndex([['username', 1]], this.configuration.writeConcernMax(), err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
               const doc = {
                 email: 'email@email.com',
                 encrypted_password: 'password',
@@ -836,18 +817,18 @@ describe('Collection', function() {
               };
               //insert new user
               collection.save(doc, this.configuration.writeConcernMax(), err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 collection
                   .find({})
                   .limit(1)
                   .toArray((err, users) => {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
                     const user = users[0];
                     user.friends.splice(1, 1);
 
                     collection.save(user, err => {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
 
                       // Update again
                       collection.update(
@@ -855,8 +836,8 @@ describe('Collection', function() {
                         { friends: user.friends },
                         { upsert: true, w: 1 },
                         (err, result) => {
-                          test.equal(null, err);
-                          test.equal(1, result.result.n);
+                          expect(err).to.not.exist;
+                          expect(1).to.equal(result.result.n);
 
                           client.close();
                           done();
@@ -885,19 +866,19 @@ describe('Collection', function() {
           expect(err).to.not.exist;
           const db = client.db(this.configuration.db);
           db.collection('remove_with_no_callback_bug_test', (err, collection) => {
-            test.equal(null, err);
+            expect(err).to.not.exist;
             collection.save({ a: 1 }, this.configuration.writeConcernMax(), err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
               collection.save({ b: 1 }, this.configuration.writeConcernMax(), err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 collection.save({ c: 1 }, this.configuration.writeConcernMax(), err => {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
                   collection.remove({ a: 1 }, this.configuration.writeConcernMax(), err => {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
                     // Let's perform a count
                     collection.count((err, count) => {
-                      test.equal(null, err);
-                      test.equal(2, count);
+                      expect(err).to.not.exist;
+                      expect(count).to.equal(2);
                       client.close();
                       done();
                     });
@@ -930,21 +911,21 @@ describe('Collection', function() {
             'shouldCorrectlyCreateTTLCollectionWithIndexUsingEnsureIndex',
             (err, collection) => {
               collection.ensureIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 // Insert a document with a date
                 collection.insert(
                   { a: 1, createdAt: new Date() },
                   this.configuration.writeConcernMax(),
                   err => {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     collection.indexInformation({ full: true }, (err, indexes) => {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
 
                       for (let i = 0; i < indexes.length; i++) {
                         if (indexes[i].name === 'createdAt_1') {
-                          test.equal(1, indexes[i].expireAfterSeconds);
+                          expect(1).to.equal(indexes[i].expireAfterSeconds);
                           break;
                         }
                       }
@@ -982,21 +963,21 @@ describe('Collection', function() {
             {},
             (err, collection) => {
               collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 // Insert a document with a date
                 collection.insert(
                   { a: 1, createdAt: new Date() },
                   this.configuration.writeConcernMax(),
                   err => {
-                    test.equal(null, err);
+                    expect(err).to.not.exist;
 
                     collection.indexInformation({ full: true }, (err, indexes) => {
-                      test.equal(null, err);
+                      expect(err).to.not.exist;
 
                       for (let i = 0; i < indexes.length; i++) {
                         if (indexes[i].name === 'createdAt_1') {
-                          test.equal(1, indexes[i].expireAfterSeconds);
+                          expect(1).to.equal(indexes[i].expireAfterSeconds);
                           break;
                         }
                       }
@@ -1031,10 +1012,10 @@ describe('Collection', function() {
           const db = client.db(this.configuration.db);
           db.createCollection('create_index_without_options', {}, (err, collection) => {
             collection.createIndex({ createdAt: 1 }, err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               collection.indexInformation({ full: true }, (err, indexes) => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
                 const indexNames = indexes.map(i => i.name);
                 expect(indexNames).to.include('createdAt_1');
 
@@ -1063,10 +1044,10 @@ describe('Collection', function() {
           db.createCollection('shouldCorrectlyReadBackDocumentWithNull', {}, (err, collection) => {
             // Insert a document with a date
             collection.insert({ test: null }, this.configuration.writeConcernMax(), err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               collection.findOne(err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 client.close();
                 done();
@@ -1094,13 +1075,13 @@ describe('Collection', function() {
             try {
               coll.update({}, null, () => {});
             } catch (err) {
-              test.equal('document must be a valid JavaScript object', err.message);
+              expect('document must be a valid JavaScript object').to.equal(err.message);
             }
 
             try {
               coll.update(null, null, () => {});
             } catch (err) {
-              test.equal('selector must be a valid JavaScript object', err.message);
+              expect('selector must be a valid JavaScript object').to.equal(err.message);
             }
 
             client.close();
@@ -1124,10 +1105,10 @@ describe('Collection', function() {
           expect(err).to.not.exist;
           const db = client.db(this.configuration.db);
           db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
               client.close();
               done();
             });
@@ -1152,7 +1133,7 @@ describe('Collection', function() {
           db
             .collection('executeUpdateWithElemMatch')
             .update({ 'item.i': 1 }, { $set: { a: 1 } }, err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               client.close();
               done();
@@ -1177,7 +1158,7 @@ describe('Collection', function() {
           db
             .collection('executeUpdateWithElemMatch')
             .update({ item: { $elemMatch: { name: 'my_name' } } }, { $set: { a: 1 } }, err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               client.close();
               done();
@@ -1203,11 +1184,11 @@ describe('Collection', function() {
             'shouldFailDueToExistingCollection',
             { strict: true },
             (err, coll) => {
-              test.equal(null, err);
-              test.ok(coll != null);
+              expect(err).to.not.exist;
+              expect(coll != null).to.be.true;
 
               db.createCollection('shouldFailDueToExistingCollection', { strict: true }, err => {
-                test.ok(err != null);
+                expect(err != null).to.be.true;
 
                 client.close();
                 done();
@@ -1235,16 +1216,16 @@ describe('Collection', function() {
           const db = client.db(this.configuration.db);
           // Create a collection
           db.createCollection(testCollection, err => {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             db.listCollections({ name: testCollection }).toArray((err, documents) => {
-              test.equal(null, err);
-              test.equal(documents.length, 1);
+              expect(err).to.not.exist;
+              expect(documents.length).to.equal(1);
               let found = false;
               documents.forEach(document => {
                 if (document.name === testCollection) found = true;
               });
-              test.ok(found);
+              expect(found).to.be.true;
               client.close();
               done();
             });
@@ -1269,23 +1250,23 @@ describe('Collection', function() {
           const db = client.db(this.configuration.db);
           // Create a collection
           db.createCollection(testCollection, err => {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             // Index name happens to be the same as collection name
             db.createIndex(testCollection, 'collection_124', { w: 1 }, (err, indexName) => {
-              test.equal(null, err);
-              test.equal('collection_124_1', indexName);
+              expect(err).to.not.exist;
+              expect('collection_124_1').to.equal(indexName);
 
               db.listCollections().toArray((err, documents) => {
-                test.equal(null, err);
-                test.ok(documents.length > 1);
+                expect(err).to.not.exist;
+                expect(documents.length > 1).to.be.true;
                 let found = false;
 
                 documents.forEach(document => {
                   if (document.name === testCollection) found = true;
                 });
 
-                test.ok(found);
+                expect(found).to.be.true;
                 client.close();
                 done();
               });
@@ -1307,19 +1288,19 @@ describe('Collection', function() {
       test: function(done) {
         client.connect((err, client) => {
           expect(err).to.not.exist;
-          test.equal(null, err);
+          expect(err).to.not.exist;
           const emptyDb = client.db('listCollectionsDb');
           emptyDb.createCollection('test1', err => {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             emptyDb.createCollection('test2', err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               emptyDb.createCollection('test3', err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 emptyDb.listCollections().toArray((err, collections) => {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
                   // By name
                   let names = {};
 
@@ -1327,9 +1308,9 @@ describe('Collection', function() {
                     names[collections[i].name] = collections[i];
                   }
 
-                  test.ok(names['test1'] != null);
-                  test.ok(names['test2'] != null);
-                  test.ok(names['test3'] != null);
+                  expect(names['test1'] != null).to.be.true;
+                  expect(names['test2'] != null).to.be.true;
+                  expect(names['test3'] != null).to.be.true;
 
                   client.close();
                   done();
@@ -1353,19 +1334,19 @@ describe('Collection', function() {
       test: function(done) {
         client.connect((err, client) => {
           expect(err).to.not.exist;
-          test.equal(null, err);
+          expect(err).to.not.exist;
           const emptyDb = client.db('listCollectionsDb');
           emptyDb.createCollection('test1', err => {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             emptyDb.createCollection('test2', err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               emptyDb.createCollection('test3', err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 emptyDb.listCollections().toArray((err, collections) => {
-                  test.equal(null, err);
+                  expect(err).to.not.exist;
                   // By name
                   let names = {};
 
@@ -1373,9 +1354,9 @@ describe('Collection', function() {
                     names[collections[i].name] = collections[i];
                   }
 
-                  test.ok(names['test1'] != null);
-                  test.ok(names['test2'] != null);
-                  test.ok(names['test3'] != null);
+                  expect(names['test1'] != null).to.be.true;
+                  expect(names['test2'] != null).to.be.true;
+                  expect(names['test3'] != null).to.be.true;
 
                   client.close();
                   done();
@@ -1399,16 +1380,16 @@ describe('Collection', function() {
       test: function(done) {
         client.connect((err, client) => {
           expect(err).to.not.exist;
-          test.equal(null, err);
+          expect(err).to.not.exist;
           const emptyDb = client.db('listCollectionsDb2');
           emptyDb.createCollection('test1', err => {
-            test.equal(null, err);
+            expect(err).to.not.exist;
 
             emptyDb.createCollection('test.test', err => {
-              test.equal(null, err);
+              expect(err).to.not.exist;
 
               emptyDb.createCollection('test3', err => {
-                test.equal(null, err);
+                expect(err).to.not.exist;
 
                 emptyDb.collections((err, collections) => {
                   collections = collections.map(collection => {
@@ -1428,7 +1409,7 @@ describe('Collection', function() {
                     }
                   });
 
-                  test.ok(foundCollection);
+                  expect(foundCollection).to.be.true;
                   client.close();
                   done();
                 });

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -1729,7 +1729,7 @@ describe('Collection', function() {
 
     const metadata = { requires: { topology: ['replicaset'], mongodb: '>=3.6.0' } };
 
-    beforeEach(() => {
+    beforeEach(function() {
       client = this.configuration.newClient({}, { retryWrites: true });
       return client.connect().then(() => {
         db = client.db('test_retry_writes');
@@ -1741,7 +1741,7 @@ describe('Collection', function() {
       });
     });
 
-    afterEach(() => {
+    afterEach(function() {
       return client.close();
     });
 

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -11,12 +11,9 @@ describe('Collection', function() {
     return setupDatabase(this.configuration);
   });
 
-  describe('', function() {
+  describe('(non >2.1.0)', function() {
     let client;
     let db;
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    };
     beforeEach(function() {
       client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
@@ -25,43 +22,38 @@ describe('Collection', function() {
         db = client.db(this.configuration.db);
       });
     });
-    afterEach(function() {
-      return client.close();
-    });
 
     /**
      * @ignore
      */
     it('should correctly execute basic collection methods', function(done) {
-        db.createCollection('test_collection_methods', (err, collection) => {
-          // Verify that all the result are correct coming back (should contain the value ok)
-          expect('test_collection_methods').to.equal(collection.collectionName);
-          // Let's check that the collection was created correctly
-          db.listCollections().toArray(err => {
+      db.createCollection('test_collection_methods', (err, collection) => {
+        // Verify that all the result are correct coming back (should contain the value ok)
+        expect('test_collection_methods').to.equal(collection.collectionName);
+        // Let's check that the collection was created correctly
+        db.listCollections().toArray(err => {
+          expect(err).to.not.exist;
+          // Rename the collection and check that it's gone
+          db.renameCollection('test_collection_methods', 'test_collection_methods2', err => {
             expect(err).to.not.exist;
-            // Rename the collection and check that it's gone
-            db.renameCollection('test_collection_methods', 'test_collection_methods2', err => {
-              expect(err).to.not.exist;
-              // Drop the collection and check that it's gone
-              db.dropCollection('test_collection_methods2', (err, result) => {
-                expect(true).to.equal(result);
-              });
+            // Drop the collection and check that it's gone
+            db.dropCollection('test_collection_methods2', (err, result) => {
+              expect(result).to.be.true;
             });
+          });
 
-            db.createCollection('test_collection_methods3', (err, collection) => {
+          db.createCollection('test_collection_methods3', (err, collection) => {
+            // Verify that all the result are correct coming back (should contain the value ok)
+            expect(collection.collectionName).to.equal('test_collection_methods3');
+
+            db.createCollection('test_collection_methods4', (err, collection) => {
               // Verify that all the result are correct coming back (should contain the value ok)
-              expect('test_collection_methods3').to.equal(collection.collectionName);
-
-              db.createCollection('test_collection_methods4', (err, collection) => {
-                // Verify that all the result are correct coming back (should contain the value ok)
-                expect('test_collection_methods4').to.equal(collection.collectionName);
-                // Let's check that the collection was created correctly
-                db.listCollections().toArray(function(err, documents) {
-                  let found = false;
-                  documents.forEach(doc => {
-                    if (doc.name === 'integration_tests_.test_collection_methods') found = true;
-                  });
-                  expect(found).to.be.true;
+              expect(collection.collectionName).to.equal('test_collection_methods4');
+              // Let's check that the collection was created correctly
+              db.listCollections().toArray(function(err, documents) {
+                let found = false;
+                if (documents.name === 'integration_tests_.test_collection_methods') found = true;
+                expect(found).to.be.true;
                 // Rename the collection and with the dropTarget boolean, and check to make sure only onen exists.
                 db.renameCollection(
                   'test_collection_methods4',
@@ -71,9 +63,8 @@ describe('Collection', function() {
                     expect(err).to.not.exist;
 
                     db.dropCollection('test_collection_methods3', (err, result) => {
-                      expect(true).to.equal(result);
-                      client.close();
-                      done();
+                      expect(result).to.be.true;
+                      client.close(done);
                     });
                   }
                 );
@@ -81,54 +72,43 @@ describe('Collection', function() {
             });
           });
         });
-      }
-    );
-    /**
-     * @ignore
-     */
-    it('should correctly list back collection names containing .', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        const db1 = client.db('test');
-        db1.createCollection('test.game', (err, collection) => {
-          // Verify that all the result are correct coming back (should contain the value ok)
-          expect('test.game').to.equal(collection.collectionName);
-          // Let's check that the collection was created correctly
-          db1.listCollections().toArray((err, documents) => {
-            expect(err).to.not.exist;
-            let found = false;
-            documents.forEach(x => {
-              if (x.name === 'test.game') found = true;
-            });
-
-            expect(found).to.be.true;
-            client.close();
-            done();
-          });
-        });
-      }
+      });
     });
 
     /**
      * @ignore
      */
-    it('should access to collections', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
+    it('should correctly list back collection names containing .', function(done) {
+      db.createCollection('test.game', (err, collection) => {
+        // Verify that all the result are correct coming back (should contain the value ok)
+        expect('test.game').to.equal(collection.collectionName);
+        // Let's check that the collection was created correctly
+        db.listCollections().toArray((err, documents) => {
+          expect(err).to.not.exist;
+          let found = false;
+          documents.forEach(x => {
+            if (x.name === 'test.game') found = true;
+          });
 
-      // The actual test we wish to run
-      test: function(done) {
-        // Create two collections
-        db.createCollection('test.spiderman', () => {
-          db.createCollection('test.mario', () => {
-            // Insert test documents (creates collections)
-            db.collection('test.spiderman', (err, spiderman_collection) => {
-              spiderman_collection.insert({ foo: 5 }, this.configuration.writeConcernMax(), err => {
+          expect(found).to.be.true;
+          client.close(done);
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should access to collections', function(done) {
+      // Create two collections
+      db.createCollection('test.spiderman', () => {
+        db.createCollection('test.mario', () => {
+          // Insert test documents (creates collections)
+          db.collection('test.spiderman', (err, spiderman_collection) => {
+            spiderman_collection.insertOne(
+              { foo: 5 },
+              this.configuration.writeConcernMax(),
+              err => {
                 expect(err).to.not.exist;
                 db.collection('test.mario', (err, mario_collection) => {
                   mario_collection.insert({ bar: 0 }, this.configuration.writeConcernMax(), err => {
@@ -149,726 +129,818 @@ describe('Collection', function() {
                       expect(found_spiderman).to.be.true;
                       expect(found_mario).to.be.true;
                       expect(found_does_not_exist).to.be.false;
-                      client.close();
-                      done();
+                      client.close(done);
                     });
                   });
                 });
-              });
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly retrieve listCollections', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection('test_collection_names', err => {
-          expect(err).to.not.exist;
-
-          db.listCollections().toArray((err, documents) => {
-            let found = false;
-            let found2 = false;
-
-            documents.forEach(document => {
-              if (
-                document.name === this.configuration.db + '.test_collection_names' ||
-                document.name === 'test_collection_names'
-              )
-                found = true;
-            });
-
-            expect(found).to.be.true;
-            // Insert a document in an non-existing collection should create the collection
-            const collection = db.collection('test_collection_names2');
-            collection.insert({ a: 1 }, this.configuration.writeConcernMax(), err => {
-              expect(err).to.not.exist;
-
-              db.listCollections().toArray((err, documents) => {
-                documents.forEach(document => {
-                  if (
-                    document.name === this.configuration.db + '.test_collection_names2' ||
-                    document.name === 'test_collection_names2'
-                  )
-                    found = true;
-                  if (
-                    document.name === this.configuration.db + '.test_collection_names' ||
-                    document.name === 'test_collection_names'
-                  )
-                    found2 = true;
-                });
-
-                expect(found).to.be.true;
-                expect(found2).to.be.true;
-
-                // Let's close the db
-                client.close();
-                done();
-              });
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should ensure strict access collection', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.collection('does-not-exist', { strict: true }, err => {
-          expect(err instanceof Error).to.be.true;
-          expect('Collection does-not-exist does not exist. Currently in strict mode.').to.equal(
-            err.message
-          );
-          db.createCollection('test_strict_access_collection', err => {
-            expect(err).to.not.exist;
-            db.collection(
-              'test_strict_access_collection',
-              this.configuration.writeConcernMax(),
-              err => {
-                expect(err).to.not.exist;
-                // Let's close the db
-                client.close();
-                done();
               }
             );
           });
         });
-      }
+      });
     });
 
     /**
      * @ignore
      */
-    it('should perform strict create collection', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
+    it('should correctly retrieve listCollections', function(done) {
+      db.createCollection('test_collection_names', err => {
+        expect(err).to.not.exist;
 
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection('test_strict_create_collection', (err, collection) => {
+        db.listCollections().toArray((err, documents) => {
+          let found = false;
+          let found2 = false;
+
+          documents.forEach(document => {
+            if (
+              document.name === this.configuration.db + '.test_collection_names' ||
+              document.name === 'test_collection_names'
+            )
+              found = true;
+          });
+
+          expect(found).to.be.true;
+          // Insert a document in an non-existing collection should create the collection
+          const collection = db.collection('test_collection_names2');
+          collection.insert({ a: 1 }, this.configuration.writeConcernMax(), err => {
+            expect(err).to.not.exist;
+
+            db.listCollections().toArray((err, documents) => {
+              documents.forEach(document => {
+                if (
+                  document.name === this.configuration.db + '.test_collection_names2' ||
+                  document.name === 'test_collection_names2'
+                )
+                  found = true;
+                if (
+                  document.name === this.configuration.db + '.test_collection_names' ||
+                  document.name === 'test_collection_names'
+                )
+                  found2 = true;
+              });
+
+              expect(found).to.be.true;
+              expect(found2).to.be.true;
+
+              // Let's close the db
+              client.close(done);
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should ensure strict access collection', function(done) {
+      db.collection('does-not-exist', { strict: true }, err => {
+        expect(err).to.be.an.instanceof(Error);
+        expect(err.message).to.equal(
+          'Collection does-not-exist does not exist. Currently in strict mode.'
+        );
+        db.createCollection('test_strict_access_collection', err => {
           expect(err).to.not.exist;
-          expect('test_strict_create_collection').to.equal(collection.collectionName);
-
-          // Creating an existing collection should fail
-          db.createCollection('test_strict_create_collection', { strict: true }, err => {
-            expect(err instanceof Error).to.be.true;
-            expect(
-              'Collection test_strict_create_collection already exists. Currently in strict mode.'
-            ).to.equal(err.message);
-
-            // Switch out of strict mode and try to re-create collection
-            db.createCollection('test_strict_create_collection', { strict: false }, err => {
+          db.collection(
+            'test_strict_access_collection',
+            this.configuration.writeConcernMax(),
+            err => {
               expect(err).to.not.exist;
               // Let's close the db
-              client.close();
-              done();
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should fail to insert due to illegal keys', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection('test_invalid_key_names', (err, collection) => {
-          // Legal inserts
-          collection.insert(
-            [{ hello: 'world' }, { hello: { hello: 'world' } }],
-            this.configuration.writeConcernMax(),
-            err => {
-              expect(err).to.not.exist;
-
-              // Illegal insert for key
-              collection.insert({ $hello: 'world' }, this.configuration.writeConcernMax(), err => {
-                expect(err instanceof Error).to.be.true;
-                expect("key $hello must not start with '$'").to.equal(err.message);
-
-                collection.insert(
-                  { hello: { $hello: 'world' } },
-                  this.configuration.writeConcernMax(),
-                  err => {
-                    expect(err instanceof Error).to.be.true;
-                    expect("key $hello must not start with '$'").to.equal(err.message);
-
-                    collection.insert(
-                      { he$llo: 'world' },
-                      this.configuration.writeConcernMax(),
-                      err => {
-                        expect(err).to.not.exist;
-
-                        collection.insert(
-                          { hello: { hell$o: 'world' } },
-                          this.configuration.writeConcernMax(),
-                          err => {
-                            expect(err).to.not.exist;
-
-                            collection.insert(
-                              { '.hello': 'world' },
-                              this.configuration.writeConcernMax(),
-                              err => {
-                                expect(err instanceof Error).to.be.true;
-                                expect("key .hello must not contain '.'").to.equal(err.message);
-
-                                collection.insert(
-                                  { hello: { '.hello': 'world' } },
-                                  this.configuration.writeConcernMax(),
-                                  err => {
-                                    expect(err instanceof Error).to.be.true;
-                                    expect("key .hello must not contain '.'").to.equal(err.message);
-
-                                    collection.insert(
-                                      { 'hello.': 'world' },
-                                      this.configuration.writeConcernMax(),
-                                      err => {
-                                        expect(err instanceof Error).to.be.true;
-                                        expect("key hello. must not contain '.'").to.equal(
-                                          err.message
-                                        );
-
-                                        collection.insert(
-                                          { hello: { 'hello.': 'world' } },
-                                          this.configuration.writeConcernMax(),
-                                          err => {
-                                            expect(err instanceof Error).to.be.true;
-                                            expect("key hello. must not contain '.'").to.equal(
-                                              err.message
-                                            );
-                                            // Let's close the db
-                                            client.close();
-                                            done();
-                                          }
-                                        );
-                                      }
-                                    );
-                                  }
-                                );
-                              }
-                            );
-                          }
-                        );
-                      }
-                    );
-                  }
-                );
-              });
+              client.close(done);
             }
           );
         });
-      }
+      });
     });
 
     /**
      * @ignore
      */
-    it('should fail due to illegal listCollections', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
+    it('should perform strict create collection', function(done) {
+      db.createCollection('test_strict_create_collection', (err, collection) => {
+        expect(err).to.not.exist;
+        expect(collection.collectionName).to.equal('test_strict_create_collection');
 
-      // The actual test we wish to run
-      test: function(done) {
-        db.collection(5, err => {
-          expect('collection name must be a String').to.equal(err.message);
-        });
-
-        db.collection('', err => {
-          expect('collection names cannot be empty').to.equal(err.message);
-        });
-
-        db.collection('te$t', err => {
-          expect("collection names must not contain '$'").to.equal(err.message);
-        });
-
-        db.collection('.test', err => {
-          expect("collection names must not start or end with '.'").to.equal(err.message);
-        });
-
-        db.collection('test.', err => {
-          expect("collection names must not start or end with '.'").to.equal(err.message);
-        });
-
-        db.collection('test..t', err => {
-          expect('collection names cannot be empty').to.equal(err.message);
-          client.close();
-          done();
-        });
-      }
-    });
-
-    it('should return invalid collection name error by callback for createCollection', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      test: function(done) {
-        const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
-          poolSize: 1
-        });
-        db.dropDatabase(err => {
-          expect(err).to.not.exist;
-
-          db.createCollection('test/../', err => {
-            expect(err).to.exist;
-            client.close();
-            done();
-          });
-        });
-      }
-    });
-    /**
-     * @ignore
-     */
-    it('should crrectly count on non-existent collection', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.collection('test_multiple_insert_2', (err, collection) => {
-          collection.count((err, count) => {
-            expect(count).to.equal(0);
-            // Let's close the db
-            client.close();
-            done();
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly execute save', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection('test_save', (err, collection) => {
-          const doc = { hello: 'world' };
-          collection.save(doc, this.configuration.writeConcernMax(), (err, r) => {
-            expect(r.ops[0]._id != null).to.be.true;
-
-            collection.count((err, count) => {
-              expect(count).to.equal(1);
-
-              collection.save(r.ops[0], this.configuration.writeConcernMax(), err => {
-                expect(err).to.not.exist;
-                collection.count((err, count) => {
-                  expect(count).to.equal(1);
-
-                  collection.findOne((err, doc3) => {
-                    expect('world').to.equal(doc3.hello);
-
-                    doc3.hello = 'mike';
-
-                    collection.save(doc3, this.configuration.writeConcernMax(), err => {
-                      expect(err).to.not.exist;
-                      collection.count((err, count) => {
-                        expect(count).to.equal(1);
-
-                        collection.findOne((err, doc5) => {
-                          expect('mike').to.equal(doc5.hello);
-
-                          // Save another document
-                          collection.save(
-                            { hello: 'world' },
-                            this.configuration.writeConcernMax(),
-                            err => {
-                              expect(err).to.not.exist;
-                              collection.count((err, count) => {
-                                expect(count).to.equal(2);
-                                // Let's close the db
-                                client.close();
-                                done();
-                              });
-                            }
-                          );
-                        });
-                      });
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly save document with Long value', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        const Long = this.configuration.require.Long;
-        db.createCollection('test_save_long', (err, collection) => {
-          collection.insert(
-            { x: Long.fromNumber(9223372036854775807) },
-            this.configuration.writeConcernMax(),
-            err => {
-              expect(err).to.not.exist;
-              collection.findOne((err, doc) => {
-                expect(err).to.not.exist;
-                expect(Long.fromNumber(9223372036854775807)).to.deep.equal(doc.x);
-                // Let's close the db
-                client.close();
-                done();
-              });
-            }
+        // Creating an existing collection should fail
+        db.createCollection('test_strict_create_collection', { strict: true }, err => {
+          expect(err).to.be.an.instanceof(Error);
+          expect(err.message).to.equal(
+            'Collection test_strict_create_collection already exists. Currently in strict mode.'
           );
-        });
-      }
-    });
 
-    /**
-     * @ignore
-     */
-    it('should save object that has id but does not exist in collection', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection(
-          'test_save_with_object_that_has_id_but_does_not_actually_exist_in_collection',
-          (err, collection) => {
-            const a = { _id: '1', hello: 'world' };
-            collection.save(a, this.configuration.writeConcernMax(), err => {
-              expect(err).to.not.exist;
-              collection.count((err, count) => {
-                expect(count).to.equal(1);
-
-                collection.findOne((err, doc) => {
-                  expect('world').to.equal(doc.hello);
-
-                  doc.hello = 'mike';
-                  collection.save(doc, this.configuration.writeConcernMax(), err => {
-                    expect(err).to.not.exist;
-                    collection.findOne((err, doc) => {
-                      collection.count((err, count) => {
-                        expect(count).to.equal(1);
-
-                        expect('mike').to.equal(doc.hello);
-                        // Let's close the db
-                        client.close();
-                        done();
-                      });
-                    });
-                  });
-                });
-              });
-            });
-          }
-        );
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly update with no docs', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        const ObjectID = this.configuration.require.ObjectID;
-        db.createCollection('test_should_correctly_do_update_with_no_docs', (err, collection) => {
-          const id = new ObjectID(null);
-          const doc = { _id: id, a: 1 };
-
-          collection.update({ _id: id }, doc, this.configuration.writeConcernMax(), (err, r) => {
+          // Switch out of strict mode and try to re-create collection
+          db.createCollection('test_strict_create_collection', { strict: false }, err => {
             expect(err).to.not.exist;
-            expect(0).to.equal(r.result.n);
-
-            client.close();
-            done();
+            // Let's close the db
+            client.close(done);
           });
         });
-      }
+      });
     });
 
     /**
      * @ignore
      */
-    it('should correctly execute insert update delete safe mode', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
+    it('should fail to insert due to illegal keys', function(done) {
+      db.createCollection('test_invalid_key_names', (err, collection) => {
+        // Legal inserts
+        collection.insert(
+          [{ hello: 'world' }, { hello: { hello: 'world' } }],
+          this.configuration.writeConcernMax(),
+          err => {
+            expect(err).to.not.exist;
 
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection(
-          'test_should_execute_insert_update_delete_safe_mode',
-          (err, collection) => {
-            expect('test_should_execute_insert_update_delete_safe_mode').to.equal(
-              collection.collectionName
-            );
+            // Illegal insert for key
+            collection.insert({ $hello: 'world' }, this.configuration.writeConcernMax(), err => {
+              expect(err).to.be.an.instanceof(Error);
+              expect(err.message).to.equal("key $hello must not start with '$'");
 
-            collection.insert({ i: 1 }, this.configuration.writeConcernMax(), (err, r) => {
-              expect(1).to.equal(r.ops.length);
-              expect(r.ops[0]._id.toHexString().length === 24).to.be.true;
-
-              // Update the record
-              collection.update(
-                { i: 1 },
-                { $set: { i: 2 } },
+              collection.insert(
+                { hello: { $hello: 'world' } },
                 this.configuration.writeConcernMax(),
                 err => {
-                  expect(err).to.not.exist;
-                  expect(1).to.equal(r.result.n);
+                  expect(err).to.be.an.instanceof(Error);
+                  expect(err.message).to.equal("key $hello must not start with '$'");
 
-                  // Remove safely
-                  collection.remove({}, this.configuration.writeConcernMax(), err => {
-                    expect(err).to.not.exist;
+                  collection.insert(
+                    { he$llo: 'world' },
+                    this.configuration.writeConcernMax(),
+                    err => {
+                      expect(err).to.not.exist;
 
-                    client.close();
-                    done();
-                  });
+                      collection.insert(
+                        { hello: { hell$o: 'world' } },
+                        this.configuration.writeConcernMax(),
+                        err => {
+                          expect(err).to.not.exist;
+
+                          collection.insert(
+                            { '.hello': 'world' },
+                            this.configuration.writeConcernMax(),
+                            err => {
+                              expect(err).to.be.an.instanceof(Error);
+                              expect(err.message).to.equal("key .hello must not contain '.'");
+
+                              collection.insert(
+                                { hello: { '.hello': 'world' } },
+                                this.configuration.writeConcernMax(),
+                                err => {
+                                  expect(err).to.be.an.instanceof(Error);
+                                  expect(err.message).to.equal("key .hello must not contain '.'");
+
+                                  collection.insert(
+                                    { 'hello.': 'world' },
+                                    this.configuration.writeConcernMax(),
+                                    err => {
+                                      expect(err).to.be.an.instanceof(Error);
+                                      expect(err.message).to.equal(
+                                        "key hello. must not contain '.'"
+                                      );
+
+                                      collection.insert(
+                                        { hello: { 'hello.': 'world' } },
+                                        this.configuration.writeConcernMax(),
+                                        err => {
+                                          expect(err).to.be.an.instanceof(Error);
+                                          expect(err.message).to.equal(
+                                            "key hello. must not contain '.'"
+                                          );
+                                          // Let's close the db
+                                          client.close(done);
+                                        }
+                                      );
+                                    }
+                                  );
+                                }
+                              );
+                            }
+                          );
+                        }
+                      );
+                    }
+                  );
                 }
               );
             });
           }
         );
-      }
+      });
     });
 
     /**
      * @ignore
      */
-    it('should perform multiple saves', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
+    it('should fail due to illegal listCollections', function(done) {
+      db.collection(5, err => {
+        expect(err.message).to.equal('collection name must be a String');
+      });
 
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection('multiple_save_test', (err, collection) => {
+      db.collection('', err => {
+        expect(err.message).to.equal('collection names cannot be empty');
+      });
+
+      db.collection('te$t', err => {
+        expect(err.message).to.equal("collection names must not contain '$'");
+      });
+
+      db.collection('.test', err => {
+        expect(err.message).to.equal("collection names must not start or end with '.'");
+      });
+
+      db.collection('test.', err => {
+        expect(err.message).to.equal("collection names must not start or end with '.'");
+      });
+
+      db.collection('test..t', err => {
+        expect(err.message).to.equal('collection names cannot be empty');
+        client.close(done);
+      });
+    });
+
+    it('should return invalid collection name error by callback for createCollection', function(done) {
+      db.dropDatabase(err => {
+        expect(err).to.not.exist;
+
+        db.createCollection('test/../', err => {
+          expect(err).to.exist;
+          client.close(done);
+        });
+      });
+    });
+    /**
+     * @ignore
+     */
+    it('should correctly count on non-existent collection', function(done) {
+      db.collection('test_multiple_insert_2', (err, collection) => {
+        collection.countDocuments((err, count) => {
+          expect(count).to.equal(0);
+          // Let's close the db
+          client.close(done);
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly execute save', function(done) {
+      db.createCollection('test_save', (err, collection) => {
+        const doc = { hello: 'world' };
+        collection.save(doc, this.configuration.writeConcernMax(), (err, r) => {
+          expect(r.ops[0]._id).to.exist;
+
+          collection.count((err, count) => {
+            expect(count).to.equal(1);
+
+            collection.save(r.ops[0], this.configuration.writeConcernMax(), err => {
+              expect(err).to.not.exist;
+              collection.count((err, count) => {
+                expect(count).to.equal(1);
+
+                collection.findOne((err, doc3) => {
+                  expect(doc3.hello).to.equal('world');
+
+                  doc3.hello = 'mike';
+
+                  collection.save(doc3, this.configuration.writeConcernMax(), err => {
+                    expect(err).to.not.exist;
+                    collection.count((err, count) => {
+                      expect(count).to.equal(1);
+
+                      collection.findOne((err, doc5) => {
+                        expect(doc5.hello).to.equal('mike');
+
+                        // Save another document
+                        collection.save(
+                          { hello: 'world' },
+                          this.configuration.writeConcernMax(),
+                          err => {
+                            expect(err).to.not.exist;
+                            collection.count((err, count) => {
+                              expect(count).to.equal(2);
+                              // Let's close the db
+                              client.close(done);
+                            });
+                          }
+                        );
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly save document with Long value', function(done) {
+      const Long = this.configuration.require.Long;
+      db.createCollection('test_save_long', (err, collection) => {
+        collection.insert(
+          { x: Long.fromNumber(9223372036854775807) },
+          this.configuration.writeConcernMax(),
+          err => {
+            expect(err).to.not.exist;
+            collection.findOne((err, doc) => {
+              expect(err).to.not.exist;
+              expect(doc.x).to.deep.equal(Long.fromNumber(9223372036854775807));
+              // Let's close the db
+              client.close(done);
+            });
+          }
+        );
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should save object that has id but does not exist in collection', function(done) {
+      db.createCollection(
+        'test_save_with_object_that_has_id_but_does_not_actually_exist_in_collection',
+        (err, collection) => {
+          const a = { _id: '1', hello: 'world' };
+          collection.save(a, this.configuration.writeConcernMax(), err => {
+            expect(err).to.not.exist;
+            collection.count((err, count) => {
+              expect(count).to.equal(1);
+
+              collection.findOne((err, doc) => {
+                expect(doc.hello).to.equal('world');
+
+                doc.hello = 'mike';
+                collection.save(doc, this.configuration.writeConcernMax(), err => {
+                  expect(err).to.not.exist;
+                  collection.findOne((err, doc) => {
+                    collection.count((err, count) => {
+                      expect(count).to.equal(1);
+
+                      expect(doc.hello).to.equal('mike');
+                      // Let's close the db
+                      client.close(done);
+                    });
+                  });
+                });
+              });
+            });
+          });
+        }
+      );
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly update with no docs', function(done) {
+      const ObjectID = this.configuration.require.ObjectID;
+      db.createCollection('test_should_correctly_do_update_with_no_docs', (err, collection) => {
+        const id = new ObjectID(null);
+        const doc = { _id: id, a: 1 };
+
+        collection.update({ _id: id }, doc, this.configuration.writeConcernMax(), (err, r) => {
+          expect(err).to.not.exist;
+          expect(r.result.n).to.equal(0);
+
+          client.close(done);
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly execute insert update delete safe mode', function(done) {
+      db.createCollection(
+        'test_should_execute_insert_update_delete_safe_mode',
+        (err, collection) => {
+          expect(collection.collectionName).to.equal(
+            'test_should_execute_insert_update_delete_safe_mode'
+          );
+
+          collection.insert({ i: 1 }, this.configuration.writeConcernMax(), (err, r) => {
+            expect(r.ops.length).to.equal(1);
+            expect(r.ops[0]._id.toHexString().length).to.equal(24);
+
+            // Update the record
+            collection.update(
+              { i: 1 },
+              { $set: { i: 2 } },
+              this.configuration.writeConcernMax(),
+              err => {
+                expect(err).to.not.exist;
+                expect(r.result.n).to.equal(1);
+
+                // Remove safely
+                collection.remove({}, this.configuration.writeConcernMax(), err => {
+                  expect(err).to.not.exist;
+
+                  client.close(done);
+                });
+              }
+            );
+          });
+        }
+      );
+    });
+
+    /**
+     * @ignore
+     */
+    it('should perform multiple saves', function(done) {
+      db.createCollection('multiple_save_test', (err, collection) => {
+        const doc = {
+          name: 'amit',
+          text: 'some text'
+        };
+
+        //insert new user
+        collection.save(doc, this.configuration.writeConcernMax(), err => {
+          expect(err).to.not.exist;
+
+          collection
+            .find({}, { name: 1 })
+            .limit(1)
+            .toArray((err, users) => {
+              const user = users[0];
+
+              if (err) {
+                throw new Error(err);
+              } else if (user) {
+                user.pants = 'worn';
+
+                collection.save(user, this.configuration.writeConcernMax(), (err, result) => {
+                  expect(err).to.not.exist;
+                  expect(result.result.n).to.equal(1);
+                  client.close(done);
+                });
+              }
+            });
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly save document with nested array', function(done) {
+      const ObjectID = this.configuration.require.ObjectID;
+      db.createCollection('save_error_on_save_test', (err, collection) => {
+        // Create unique index for username
+        collection.createIndex([['username', 1]], this.configuration.writeConcernMax(), err => {
+          expect(err).to.not.exist;
           const doc = {
-            name: 'amit',
-            text: 'some text'
+            email: 'email@email.com',
+            encrypted_password: 'password',
+            friends: [
+              '4db96b973d01205364000006',
+              '4db94a1948a683a176000001',
+              '4dc77b24c5ba38be14000002'
+            ],
+            location: [72.4930088, 23.0431957],
+            name: 'Amit Kumar',
+            password_salt: 'salty',
+            profile_fields: [],
+            username: 'amit'
           };
-
           //insert new user
           collection.save(doc, this.configuration.writeConcernMax(), err => {
             expect(err).to.not.exist;
 
             collection
-              .find({}, { name: 1 })
+              .find({})
               .limit(1)
               .toArray((err, users) => {
-                const user = users[0];
-
-                if (err) {
-                  throw new Error(err);
-                } else if (user) {
-                  user.pants = 'worn';
-
-                  collection.save(user, this.configuration.writeConcernMax(), (err, result) => {
-                    expect(err).to.not.exist;
-                    expect(1).to.equal(result.result.n);
-                    client.close();
-                    done();
-                  });
-                }
-              });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly save document with nested array', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        const ObjectID = this.configuration.require.ObjectID;
-        db.createCollection('save_error_on_save_test', (err, collection) => {
-          // Create unique index for username
-          collection.createIndex([['username', 1]], this.configuration.writeConcernMax(), err => {
-            expect(err).to.not.exist;
-            const doc = {
-              email: 'email@email.com',
-              encrypted_password: 'password',
-              friends: [
-                '4db96b973d01205364000006',
-                '4db94a1948a683a176000001',
-                '4dc77b24c5ba38be14000002'
-              ],
-              location: [72.4930088, 23.0431957],
-              name: 'Amit Kumar',
-              password_salt: 'salty',
-              profile_fields: [],
-              username: 'amit'
-            };
-            //insert new user
-            collection.save(doc, this.configuration.writeConcernMax(), err => {
-              expect(err).to.not.exist;
-
-              collection
-                .find({})
-                .limit(1)
-                .toArray((err, users) => {
-                  expect(err).to.not.exist;
-                  const user = users[0];
-                  user.friends.splice(1, 1);
-
-                  collection.save(user, err => {
-                    expect(err).to.not.exist;
-
-                    // Update again
-                    collection.update(
-                      { _id: new ObjectID(user._id.toString()) },
-                      { friends: user.friends },
-                      { upsert: true, w: 1 },
-                      (err, result) => {
-                        expect(err).to.not.exist;
-                        expect(1).to.equal(result.result.n);
-
-                        client.close();
-                        done();
-                      }
-                    );
-                  });
-                });
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should perform collection remove with no callback', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.collection('remove_with_no_callback_bug_test', (err, collection) => {
-          expect(err).to.not.exist;
-          collection.save({ a: 1 }, this.configuration.writeConcernMax(), err => {
-            expect(err).to.not.exist;
-            collection.save({ b: 1 }, this.configuration.writeConcernMax(), err => {
-              expect(err).to.not.exist;
-              collection.save({ c: 1 }, this.configuration.writeConcernMax(), err => {
                 expect(err).to.not.exist;
-                collection.remove({ a: 1 }, this.configuration.writeConcernMax(), err => {
+                const user = users[0];
+                user.friends.splice(1, 1);
+
+                collection.save(user, err => {
                   expect(err).to.not.exist;
-                  // Let's perform a count
-                  collection.count((err, count) => {
-                    expect(err).to.not.exist;
-                    expect(count).to.equal(2);
-                    client.close();
-                    done();
-                  });
+
+                  // Update again
+                  collection.update(
+                    { _id: new ObjectID(user._id.toString()) },
+                    { friends: user.friends },
+                    { upsert: true, w: 1 },
+                    (err, result) => {
+                      expect(err).to.not.exist;
+                      expect(result.result.n).to.equal(1);
+
+                      client.close(done);
+                    }
+                  );
                 });
               });
-            });
           });
         });
-      }
+      });
     });
 
     /**
      * @ignore
      */
-    it('should correctly create TTL collection with index using ensureIndex', {
-      metadata: {
-        requires: {
-          mongodb: '>2.1.0',
-          topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
-        }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection(
-          'shouldCorrectlyCreateTTLCollectionWithIndexUsingEnsureIndex',
-          (err, collection) => {
-            collection.ensureIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
+    it('should perform collection remove with no callback', function(done) {
+      db.collection('remove_with_no_callback_bug_test', (err, collection) => {
+        expect(err).to.not.exist;
+        collection.save({ a: 1 }, this.configuration.writeConcernMax(), err => {
+          expect(err).to.not.exist;
+          collection.save({ b: 1 }, this.configuration.writeConcernMax(), err => {
+            expect(err).to.not.exist;
+            collection.save({ c: 1 }, this.configuration.writeConcernMax(), err => {
               expect(err).to.not.exist;
-
-              // Insert a document with a date
-              collection.insert(
-                { a: 1, createdAt: new Date() },
-                this.configuration.writeConcernMax(),
-                err => {
+              collection.remove({ a: 1 }, this.configuration.writeConcernMax(), err => {
+                expect(err).to.not.exist;
+                // Let's perform a count
+                collection.count((err, count) => {
                   expect(err).to.not.exist;
-
-                  collection.indexInformation({ full: true }, (err, indexes) => {
-                    expect(err).to.not.exist;
-
-                    for (let i = 0; i < indexes.length; i++) {
-                      if (indexes[i].name === 'createdAt_1') {
-                        expect(1).to.equal(indexes[i].expireAfterSeconds);
-                        break;
-                      }
-                    }
-
-                    client.close();
-                    done();
-                  });
-                }
-              );
+                  expect(count).to.equal(2);
+                  client.close(done);
+                });
+              });
             });
+          });
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly read back document with null', function(done) {
+      db.createCollection('shouldCorrectlyReadBackDocumentWithNull', {}, (err, collection) => {
+        // Insert a document with a date
+        collection.insert({ test: null }, this.configuration.writeConcernMax(), err => {
+          expect(err).to.not.exist;
+
+          collection.findOne((err, result) => {
+            expect(err).to.not.exist;
+            expect(result.test).to.not.exist;
+            client.close(done);
+          });
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should throw error due to illegal update', function(done) {
+      db.createCollection('shouldThrowErrorDueToIllegalUpdate', {}, (err, coll) => {
+        try {
+          coll.update({}, null, () => {});
+        } catch (err) {
+          expect(err.message).to.equal('document must be a valid JavaScript object');
+        }
+
+        try {
+          coll.update(null, null, () => {});
+        } catch (err) {
+          expect(err.message).to.equal('selector must be a valid JavaScript object');
+        }
+
+        client.close(done);
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly handle 0 as id for save', function(done) {
+      db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
+        expect(err).to.not.exist;
+
+        db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
+          expect(err).to.not.exist;
+          client.close(done);
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly execute update with . field in selector', function(done) {
+      db
+        .collection('executeUpdateWithElemMatch')
+        .update({ 'item.i': 1 }, { $set: { a: 1 } }, (err, r) => {
+          expect(err).to.not.exist;
+          expect(r.result.n).to.equal(0);
+          client.close(done);
+        });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly execute update with elemMatch field in selector', function(done) {
+      db
+        .collection('executeUpdateWithElemMatch')
+        .update({ item: { $elemMatch: { name: 'my_name' } } }, { $set: { a: 1 } }, (err, r) => {
+          expect(err).to.not.exist;
+          expect(r.result.n).to.equal(0);
+          client.close(done);
+        });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should fail due to existing collection', function(done) {
+      db.createCollection('shouldFailDueToExistingCollection', { strict: true }, (err, coll) => {
+        expect(err).to.not.exist;
+        expect(coll).to.exist;
+
+        db.createCollection('shouldFailDueToExistingCollection', { strict: true }, err => {
+          expect(err).to.be.an.instanceof(Error);
+          expect(err.message).to.equal(
+            'Collection shouldFailDueToExistingCollection already exists. Currently in strict mode.'
+          );
+          client.close(done);
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should filter correctly during list', function(done) {
+      const testCollection = 'integration_tests_collection_123'; // The collection happens to contain the database name
+      // Create a collection
+      db.createCollection(testCollection, err => {
+        expect(err).to.not.exist;
+
+        db.listCollections({ name: testCollection }).toArray((err, documents) => {
+          expect(err).to.not.exist;
+          expect(documents.length).to.equal(1);
+          let found = false;
+          documents.forEach(document => {
+            if (document.name === testCollection) found = true;
+          });
+          expect(found).to.be.true;
+          client.close(done);
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should filter correctly with index during list', function(done) {
+      const testCollection = 'collection_124';
+      // Create a collection
+      db.createCollection(testCollection, err => {
+        expect(err).to.not.exist;
+
+        // Index name happens to be the same as collection name
+        db.createIndex(testCollection, 'collection_124', { w: 1 }, (err, indexName) => {
+          expect(err).to.not.exist;
+          expect(indexName).to.equal('collection_124_1');
+
+          db.listCollections().toArray((err, documents) => {
+            expect(err).to.not.exist;
+            expect(documents.length > 1).to.be.true;
+            let found = false;
+
+            documents.forEach(document => {
+              if (document.name === testCollection) found = true;
+            });
+
+            expect(found).to.be.true;
+            client.close(done);
+          });
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly list multipleCollections', function(done) {
+      const emptyDb = client.db('listCollectionsDb');
+      emptyDb.createCollection('test1', err => {
+        expect(err).to.not.exist;
+
+        emptyDb.createCollection('test2', err => {
+          expect(err).to.not.exist;
+
+          emptyDb.createCollection('test3', err => {
+            expect(err).to.not.exist;
+
+            emptyDb.listCollections().toArray((err, collections) => {
+              expect(err).to.not.exist;
+              // By name
+              let names = {};
+
+              for (let i = 0; i < collections.length; i++) {
+                names[collections[i].name] = collections[i];
+              }
+
+              expect(names['test1']).to.equal(collections[2]);
+              expect(names['test2']).to.equal(collections[1]);
+              expect(names['test3']).to.equal(collections[0]);
+
+              client.close(done);
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly handle namespace when using collections method', function(done) {
+      const emptyDb = client.db('listCollectionsDb2');
+      emptyDb.createCollection('test1', err => {
+        expect(err).to.not.exist;
+
+        emptyDb.createCollection('test.test', err => {
+          expect(err).to.not.exist;
+
+          emptyDb.createCollection('test3', err => {
+            expect(err).to.not.exist;
+
+            emptyDb.collections((err, collections) => {
+              collections = collections.map(collection => {
+                return {
+                  collectionName: collection.collectionName,
+                  namespace: collection.namespace
+                };
+              });
+
+              let foundCollection = false;
+              collections.forEach(x => {
+                if (
+                  x.namespace === 'listCollectionsDb2.test.test' &&
+                  x.collectionName === 'test.test'
+                ) {
+                  foundCollection = true;
+                }
+              });
+
+              expect(foundCollection).to.be.true;
+              client.close(done);
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * @ignore
+     */
+    it('should provide access to the database name', function() {
+      return client
+        .connect()
+        .then(client => client.db('test_db').createCollection('test1'))
+        .then(coll => {
+          expect(coll.dbName).to.equal('test_db');
+          return client.close();
+        });
+    });
+
+    it('should correctly update with pipeline', function(done) {
+      const db = client.db(this.configuration.db);
+
+      db.createCollection('test_should_correctly_do_update_with_pipeline', (err, collection) => {
+        collection.updateOne(
+          {},
+          { $set: { a: 1, b: 1, d: 1 } },
+          this.configuration.writeConcernMax(),
+          (err, r) => {
+            expect(err).to.not.exist;
+            expect(r.result.n).to.equal(0);
+
+            client.close(done);
           }
         );
-      }
+      });
+    });
+  });
+
+  describe('(requires >2.1.0)', function() {
+    let client;
+    let db;
+    const metadata = { requires: { mongodb: '>2.1.0' } };
+    beforeEach(function() {
+      client = this.configuration.newClient(this.configuration.writeConcernMax(), {
+        poolSize: 1
+      });
+      return client.connect().then(client => {
+        db = client.db(this.configuration.db);
+      });
     });
 
     /**
      * @ignore
      */
     it('should correctly create TTL collection with index using createIndex', {
-      metadata: {
-        requires: {
-          mongodb: '>2.1.0',
-          topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
-        }
-      },
-
+      metadata,
       // The actual test we wish to run
       test: function(done) {
         db.createCollection(
@@ -895,8 +967,47 @@ describe('Collection', function() {
                       }
                     }
 
-                    client.close();
-                    done();
+                    client.close(done);
+                  });
+                }
+              );
+            });
+          }
+        );
+      }
+    });
+
+    /**
+     * @ignore
+     */
+    it('should correctly create TTL collection with index using ensureIndex', {
+      metadata,
+      // The actual test we wish to run
+      test: function(done) {
+        db.createCollection(
+          'shouldCorrectlyCreateTTLCollectionWithIndexUsingEnsureIndex',
+          (err, collection) => {
+            collection.ensureIndex({ createdAt: 1 }, { expireAfterSeconds: 1, w: 1 }, err => {
+              expect(err).to.not.exist;
+
+              // Insert a document with a date
+              collection.insert(
+                { a: 1, createdAt: new Date() },
+                this.configuration.writeConcernMax(),
+                err => {
+                  expect(err).to.not.exist;
+
+                  collection.indexInformation({ full: true }, (err, indexes) => {
+                    expect(err).to.not.exist;
+
+                    for (let i = 0; i < indexes.length; i++) {
+                      if (indexes[i].name === 'createdAt_1') {
+                        expect(1).to.equal(indexes[i].expireAfterSeconds);
+                        break;
+                      }
+                    }
+
+                    client.close(done);
                   });
                 }
               );
@@ -910,13 +1021,7 @@ describe('Collection', function() {
      * @ignore
      */
     it('should support createIndex with no options', {
-      metadata: {
-        requires: {
-          mongodb: '>2.1.0',
-          topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
-        }
-      },
-
+      metadata,
       // The actual test we wish to run
       test: function(done) {
         db.createCollection('create_index_without_options', {}, (err, collection) => {
@@ -928,410 +1033,20 @@ describe('Collection', function() {
               const indexNames = indexes.map(i => i.name);
               expect(indexNames).to.include('createdAt_1');
 
-              client.close();
-              done();
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly read back document with null', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection('shouldCorrectlyReadBackDocumentWithNull', {}, (err, collection) => {
-          // Insert a document with a date
-          collection.insert({ test: null }, this.configuration.writeConcernMax(), err => {
-            expect(err).to.not.exist;
-
-            collection.findOne(err => {
-              expect(err).to.not.exist;
-
-              client.close();
-              done();
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should throw error due to illegal update', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection('shouldThrowErrorDueToIllegalUpdate', {}, (err, coll) => {
-          try {
-            coll.update({}, null, () => {});
-          } catch (err) {
-            expect('document must be a valid JavaScript object').to.equal(err.message);
-          }
-
-          try {
-            coll.update(null, null, () => {});
-          } catch (err) {
-            expect('selector must be a valid JavaScript object').to.equal(err.message);
-          }
-
-          client.close();
-          done();
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly handle 0 as id for save', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
-          expect(err).to.not.exist;
-
-          db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
-            expect(err).to.not.exist;
-            client.close();
-            done();
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly execute update with . field in selector', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db
-          .collection('executeUpdateWithElemMatch')
-          .update({ 'item.i': 1 }, { $set: { a: 1 } }, err => {
-            expect(err).to.not.exist;
-
-            client.close();
-            done();
-          });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly execute update with elemMatch field in selector', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db
-          .collection('executeUpdateWithElemMatch')
-          .update({ item: { $elemMatch: { name: 'my_name' } } }, { $set: { a: 1 } }, err => {
-            expect(err).to.not.exist;
-
-            client.close();
-            done();
-          });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should fail due to exiting collection', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        db.createCollection('shouldFailDueToExistingCollection', { strict: true }, (err, coll) => {
-          expect(err).to.not.exist;
-          expect(coll != null).to.be.true;
-
-          db.createCollection('shouldFailDueToExistingCollection', { strict: true }, err => {
-            expect(err != null).to.be.true;
-
-            client.close();
-            done();
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should filter correctly during list', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        const testCollection = 'integration_tests_collection_123'; // The collection happens to contain the database name
-        // Create a collection
-        db.createCollection(testCollection, err => {
-          expect(err).to.not.exist;
-
-          db.listCollections({ name: testCollection }).toArray((err, documents) => {
-            expect(err).to.not.exist;
-            expect(documents.length).to.equal(1);
-            let found = false;
-            documents.forEach(document => {
-              if (document.name === testCollection) found = true;
-            });
-            expect(found).to.be.true;
-            client.close();
-            done();
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should filter correctly with index during list', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        const testCollection = 'collection_124';
-        // Create a collection
-        db.createCollection(testCollection, err => {
-          expect(err).to.not.exist;
-
-          // Index name happens to be the same as collection name
-          db.createIndex(testCollection, 'collection_124', { w: 1 }, (err, indexName) => {
-            expect(err).to.not.exist;
-            expect('collection_124_1').to.equal(indexName);
-
-            db.listCollections().toArray((err, documents) => {
-              expect(err).to.not.exist;
-              expect(documents.length > 1).to.be.true;
-              let found = false;
-
-              documents.forEach(document => {
-                if (document.name === testCollection) found = true;
-              });
-
-              expect(found).to.be.true;
-              client.close();
-              done();
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly list multipleCollections', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        const emptyDb = client.db('listCollectionsDb');
-        emptyDb.createCollection('test1', err => {
-          expect(err).to.not.exist;
-
-          emptyDb.createCollection('test2', err => {
-            expect(err).to.not.exist;
-
-            emptyDb.createCollection('test3', err => {
-              expect(err).to.not.exist;
-
-              emptyDb.listCollections().toArray((err, collections) => {
-                expect(err).to.not.exist;
-                // By name
-                let names = {};
-
-                for (let i = 0; i < collections.length; i++) {
-                  names[collections[i].name] = collections[i];
-                }
-
-                expect(names['test1'] != null).to.be.true;
-                expect(names['test2'] != null).to.be.true;
-                expect(names['test3'] != null).to.be.true;
-
-                client.close();
-                done();
-              });
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly list multipleCollections', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        const emptyDb = client.db('listCollectionsDb');
-        emptyDb.createCollection('test1', err => {
-          expect(err).to.not.exist;
-
-          emptyDb.createCollection('test2', err => {
-            expect(err).to.not.exist;
-
-            emptyDb.createCollection('test3', err => {
-              expect(err).to.not.exist;
-
-              emptyDb.listCollections().toArray((err, collections) => {
-                expect(err).to.not.exist;
-                // By name
-                let names = {};
-
-                for (let i = 0; i < collections.length; i++) {
-                  names[collections[i].name] = collections[i];
-                }
-
-                expect(names['test1'] != null).to.be.true;
-                expect(names['test2'] != null).to.be.true;
-                expect(names['test3'] != null).to.be.true;
-
-                client.close();
-                done();
-              });
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should correctly handle namespace when using collections method', {
-      metadata: {
-        requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        const emptyDb = client.db('listCollectionsDb2');
-        emptyDb.createCollection('test1', err => {
-          expect(err).to.not.exist;
-
-          emptyDb.createCollection('test.test', err => {
-            expect(err).to.not.exist;
-
-            emptyDb.createCollection('test3', err => {
-              expect(err).to.not.exist;
-
-              emptyDb.collections((err, collections) => {
-                collections = collections.map(collection => {
-                  return {
-                    collectionName: collection.collectionName,
-                    namespace: collection.namespace
-                  };
-                });
-
-                let foundCollection = false;
-                collections.forEach(x => {
-                  if (
-                    x.namespace === 'listCollectionsDb2.test.test' &&
-                    x.collectionName === 'test.test'
-                  ) {
-                    foundCollection = true;
-                  }
-                });
-
-                expect(foundCollection).to.be.true;
-                client.close();
-                done();
-              });
-            });
-          });
-        });
-      }
-    });
-
-    /**
-     * @ignore
-     */
-    it('should provide access to the database name', {
-      metadata: {
-        requires: { topology: ['single'] }
-      },
-
-      test: () => {
-        return client
-          .connect()
-          .then(client => client.db('test_db').createCollection('test1'))
-          .then(coll => {
-            expect(coll.dbName).to.equal('test_db');
-            return client.close();
-          });
-      }
-    });
-
-    it('should correctly update with pipeline', {
-      metadata: {
-        requires: { mongodb: '>=4.2.0' }
-      },
-
-      // The actual test we wish to run
-      test: function(done) {
-        const db = client.db(this.configuration.db);
-
-        db.createCollection('test_should_correctly_do_update_with_pipeline', (err, collection) => {
-          collection.updateOne(
-            {},
-            [{ $set: { a: 1 } }, { $set: { b: 1 } }, { $set: { d: 1 } }],
-            this.configuration.writeConcernMax(),
-            (err, r) => {
-              expect(err).to.not.exist;
-              expect(r.result.n).to.equal(0);
-
               client.close(done);
-            }
-          );
+            });
+          });
         });
       }
     });
   });
 
-  describe('', function() {
-    let configuration;
+  describe('(countDocuments)', function() {
     let client;
     let db;
     let collection;
-    let close;
     beforeEach(function() {
-      configuration = this.configuration;
+      const configuration = this.configuration;
       client = configuration.newClient({}, { w: 1 });
 
       return client.connect().then(client => {
@@ -1344,7 +1059,7 @@ describe('Collection', function() {
     });
 
     it('should correctly perform estimatedDocumentCount on non-matching query', function(done) {
-      close = e => client.close(() => done(e));
+      const close = e => client.close(() => done(e));
       Promise.resolve()
         .then(() => collection.estimatedDocumentCount({ a: 'b' }))
         .then(count => expect(count).to.equal(0))
@@ -1353,7 +1068,7 @@ describe('Collection', function() {
     });
 
     it('should correctly perform countDocuments on non-matching query', function(done) {
-      close = e => client.close(() => done(e));
+      const close = e => client.close(() => done(e));
       Promise.resolve()
         .then(() => collection.countDocuments({ a: 'b' }))
         .then(count => expect(count).to.equal(0))
@@ -1537,7 +1252,7 @@ describe('Collection', function() {
     );
   });
 
-  describe('Retryable Writes on bulk ops', () => {
+  describe('Retryable Writes on bulk ops', function() {
     let client;
     let db;
     let collection;
@@ -1562,14 +1277,14 @@ describe('Collection', function() {
 
     it('should succeed with retryWrite=true when using updateMany', {
       metadata,
-      test: () => {
+      test: function() {
         return collection.updateMany({ name: 'foobar' }, { $set: { name: 'fizzbuzz' } });
       }
     });
 
     it('should succeed with retryWrite=true when using update with multi=true', {
       metadata,
-      test: () => {
+      test: function() {
         return collection.update(
           { name: 'foobar' },
           { $set: { name: 'fizzbuzz' } },
@@ -1580,14 +1295,14 @@ describe('Collection', function() {
 
     it('should succeed with retryWrite=true when using remove without option single', {
       metadata,
-      test: () => {
+      test: function() {
         return collection.remove({ name: 'foobar' });
       }
     });
 
     it('should succeed with retryWrite=true when using deleteMany', {
       metadata,
-      test: () => {
+      test: function() {
         return collection.deleteMany({ name: 'foobar' });
       }
     });

--- a/test/functional/collection_tests.js
+++ b/test/functional/collection_tests.js
@@ -376,15 +376,15 @@ describe('Collection', function() {
     it('should correctly execute save', function(done) {
       db.createCollection('test_save', (err, collection) => {
         const doc = { hello: 'world' };
-        collection.save(doc, this.configuration.writeConcernMax(), (err, r) => {
+        collection.insertOne(doc, this.configuration.writeConcernMax(), (err, r) => {
           expect(r.ops[0]._id).to.exist;
 
-          collection.count((err, count) => {
+          collection.countDocuments((err, count) => {
             expect(count).to.equal(1);
 
             collection.save(r.ops[0], this.configuration.writeConcernMax(), err => {
               expect(err).to.not.exist;
-              collection.count((err, count) => {
+              collection.countDocuments((err, count) => {
                 expect(count).to.equal(1);
 
                 collection.findOne((err, doc3) => {
@@ -394,7 +394,7 @@ describe('Collection', function() {
 
                   collection.save(doc3, this.configuration.writeConcernMax(), err => {
                     expect(err).to.not.exist;
-                    collection.count((err, count) => {
+                    collection.countDocuments((err, count) => {
                       expect(count).to.equal(1);
 
                       collection.findOne((err, doc5) => {
@@ -406,7 +406,7 @@ describe('Collection', function() {
                           this.configuration.writeConcernMax(),
                           err => {
                             expect(err).to.not.exist;
-                            collection.count((err, count) => {
+                            collection.countDocuments((err, count) => {
                               expect(count).to.equal(2);
                               // Let's close the db
                               done();
@@ -454,9 +454,9 @@ describe('Collection', function() {
         'test_save_with_object_that_has_id_but_does_not_actually_exist_in_collection',
         (err, collection) => {
           const a = { _id: '1', hello: 'world' };
-          collection.save(a, this.configuration.writeConcernMax(), err => {
+          collection.insertOne(a, this.configuration.writeConcernMax(), err => {
             expect(err).to.not.exist;
-            collection.count((err, count) => {
+            collection.countDocuments((err, count) => {
               expect(count).to.equal(1);
 
               collection.findOne((err, doc) => {
@@ -466,7 +466,7 @@ describe('Collection', function() {
                 collection.save(doc, this.configuration.writeConcernMax(), err => {
                   expect(err).to.not.exist;
                   collection.findOne((err, doc) => {
-                    collection.count((err, count) => {
+                    collection.countDocuments((err, count) => {
                       expect(count).to.equal(1);
 
                       expect(doc.hello).to.equal('mike');
@@ -507,7 +507,7 @@ describe('Collection', function() {
                 expect(r.result.n).to.equal(1);
 
                 // Remove safely
-                collection.remove({}, this.configuration.writeConcernMax(), err => {
+                collection.deleteOne({}, this.configuration.writeConcernMax(), err => {
                   expect(err).to.not.exist;
 
                   done();
@@ -530,7 +530,7 @@ describe('Collection', function() {
         };
 
         //insert new user
-        collection.save(doc, this.configuration.writeConcernMax(), err => {
+        collection.insertOne(doc, this.configuration.writeConcernMax(), err => {
           expect(err).to.not.exist;
 
           collection
@@ -579,7 +579,7 @@ describe('Collection', function() {
             username: 'amit'
           };
           //insert new user
-          collection.save(doc, this.configuration.writeConcernMax(), err => {
+          collection.insertOne(doc, this.configuration.writeConcernMax(), err => {
             expect(err).to.not.exist;
 
             collection
@@ -618,16 +618,16 @@ describe('Collection', function() {
     it('should perform collection remove with no callback', function(done) {
       db.collection('remove_with_no_callback_bug_test', (err, collection) => {
         expect(err).to.not.exist;
-        collection.save({ a: 1 }, this.configuration.writeConcernMax(), err => {
+        collection.insertOne({ a: 1 }, this.configuration.writeConcernMax(), err => {
           expect(err).to.not.exist;
-          collection.save({ b: 1 }, this.configuration.writeConcernMax(), err => {
+          collection.insertOne({ b: 1 }, this.configuration.writeConcernMax(), err => {
             expect(err).to.not.exist;
-            collection.save({ c: 1 }, this.configuration.writeConcernMax(), err => {
+            collection.insertOne({ c: 1 }, this.configuration.writeConcernMax(), err => {
               expect(err).to.not.exist;
-              collection.remove({ a: 1 }, this.configuration.writeConcernMax(), err => {
+              collection.deleteOne({ a: 1 }, this.configuration.writeConcernMax(), err => {
                 expect(err).to.not.exist;
                 // Let's perform a count
-                collection.count((err, count) => {
+                collection.countDocuments((err, count) => {
                   expect(err).to.not.exist;
                   expect(count).to.equal(2);
                   done();
@@ -869,6 +869,7 @@ describe('Collection', function() {
               let names = [];
               for (let i = 0; i < collections.length; i++) {
                 names.push(collections[i].name);
+                console.log('Name of the collection: ', collections[i].name);
               }
               expect(names.length).to.equal(3);
               expect(names).to.include('test1');
@@ -1279,7 +1280,7 @@ describe('Collection', function() {
     it('should succeed with retryWrite=true when using remove without option single', {
       metadata,
       test: function() {
-        return collection.remove({ name: 'foobar' });
+        return collection.deleteOne({ name: 'foobar' });
       }
     });
 


### PR DESCRIPTION
Fixes NODE-1986

# Description
Removed duplication in collection_tests.js and modernized the code, using `const` and `let` instead of `var` as well as arrow functions when possible.

**What changed?**

The tests in collection_tests.js have been refactored and certain configuration and client statements have been moved to beforeEach() hooks to reduce redundancy.