### PR TITLE
style(autoEncrypter): make autoEncrypter more easily accessible

### DIFF
--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -95,6 +95,13 @@ class Server extends EventEmitter {
     return this.s.description.address;
   }
 
+  get autoEncrypter() {
+    if (this.s.options && this.s.options.autoEncrypter) {
+      return this.s.options.autoEncrypter;
+    }
+    return null;
+  }
+
   /**
    * Initiate server connect
    */

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -95,6 +95,13 @@ class Server extends EventEmitter {
     return this.s.description.address;
   }
 
+  get autoEncrypter() {
+    if (this.s.options && this.s.options.autoEncrypter) {
+      return this.s.options.autoEncrypter;
+    }
+    return null;
+  }
+
   /**
    * Initiate server connect
    */
@@ -289,16 +296,6 @@ Object.defineProperty(Server.prototype, 'clusterTime', {
   },
   set: function(clusterTime) {
     this.s.topology.clusterTime = clusterTime;
-  }
-});
-
-Object.defineProperty(Server.prototype, 'autoEncrypter', {
-  enumerable: true,
-  get: function() {
-    if (this.s.options && this.s.options.autoEncrypter) {
-      return this.s.options.autoEncrypter;
-    }
-    return null;
   }
 });
 

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -95,13 +95,6 @@ class Server extends EventEmitter {
     return this.s.description.address;
   }
 
-  get autoEncrypter() {
-    if (this.s.options && this.s.options.autoEncrypter) {
-      return this.s.options.autoEncrypter;
-    }
-    return null;
-  }
-
   /**
    * Initiate server connect
    */
@@ -296,6 +289,16 @@ Object.defineProperty(Server.prototype, 'clusterTime', {
   },
   set: function(clusterTime) {
     this.s.topology.clusterTime = clusterTime;
+  }
+});
+
+Object.defineProperty(Server.prototype, 'autoEncrypter', {
+  enumerable: true,
+  get: function() {
+    if (this.s.options && this.s.options.autoEncrypter) {
+      return this.s.options.autoEncrypter;
+    }
+    return null;
   }
 });
 

--- a/lib/core/wireprotocol/command.js
+++ b/lib/core/wireprotocol/command.js
@@ -10,7 +10,7 @@ const isTransactionCommand = require('../transactions').isTransactionCommand;
 const applySession = require('../sessions').applySession;
 
 function isClientEncryptionEnabled(server) {
-  return server && server.s && server.s.options && server.s.options.autoEncrypter;
+  return server.autoEncrypter;
 }
 
 function command(server, ns, cmd, options, callback) {
@@ -133,7 +133,7 @@ function supportsOpMsg(topologyOrServer) {
 
 function _cryptCommand(server, ns, cmd, options, callback) {
   const shouldBypassAutoEncryption = !!server.s.options.bypassAutoEncryption;
-  const autoEncrypter = server.s.options.autoEncrypter;
+  const autoEncrypter = server.autoEncrypter;
   function commandResponseHandler(err, response) {
     if (err || response == null) {
       callback(err, response);

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -392,7 +392,7 @@ Object.defineProperty(Server.prototype, 'port', {
 Object.defineProperty(Server.prototype, 'autoEncrypter', {
   enumerable: true,
   get: function() {
-    if (server.s && server.s.options && server.s.options.autoEncrypter) {
+    if (this.s && this.s.options && this.s.options.autoEncrypter) {
       return this.s.options.autoEncrypter;
     }
     return null;

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -389,16 +389,6 @@ Object.defineProperty(Server.prototype, 'port', {
   }
 });
 
-Object.defineProperty(Server.prototype, 'autoEncrypter', {
-  enumerable: true,
-  get: function() {
-    if (this.s && this.s.options && this.s.options.autoEncrypter) {
-      return this.s.options.autoEncrypter;
-    }
-    return null;
-  }
-});
-
 /**
  * Server connect event
  *

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -392,7 +392,10 @@ Object.defineProperty(Server.prototype, 'port', {
 Object.defineProperty(Server.prototype, 'autoEncrypter', {
   enumerable: true,
   get: function() {
-    return this.s.options.autoEncrypter;
+    if (server.s && server.s.options && server.s.options.autoEncrypter) {
+      return this.s.options.autoEncrypter;
+    }
+    return null;
   }
 });
 

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -389,6 +389,13 @@ Object.defineProperty(Server.prototype, 'port', {
   }
 });
 
+Object.defineProperty(Server.prototype, 'autoEncrypter', {
+  enumerable: true,
+  get: function() {
+    return this.s.options.autoEncrypter;
+  }
+});
+
 /**
  * Server connect event
  *


### PR DESCRIPTION
Fixes NODE-2013

# Description

`AutoEncrypter` is now accessible as a server property. Improves readability.

**What changed?**

Make access of autoEncrypter easier, by defining a server property. Changed variables assigned as autoEncrypter accordingly, thus making commands more readable.
