### PR TITLE
NODE-1682: implement connection pool reset

### DIFF
--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -26,6 +26,8 @@ var CONNECTED = 'connected';
 var DESTROYING = 'destroying';
 var DESTROYED = 'destroyed';
 
+const CONNECTION_EVENTS = ['error', 'close', 'timeout', 'parseError', 'connect', 'message'];
+
 var _id = 0;
 
 /**
@@ -631,9 +633,6 @@ Pool.prototype.unref = function() {
   });
 };
 
-// Events
-var events = ['error', 'close', 'timeout', 'parseError', 'connect', 'message'];
-
 // Destroy the connections
 function destroy(self, connections, options, callback) {
   let connectionCount = connections.length;
@@ -669,10 +668,7 @@ function destroy(self, connections, options, callback) {
 
   // Destroy all connections
   connections.forEach(conn => {
-    for (var i = 0; i < events.length; i++) {
-      conn.removeAllListeners(events[i]);
-    }
-
+    CONNECTION_EVENTS.forEach(eventName => conn.removeAllListeners(eventName));
     conn.destroy(options, connectionDestroyed);
   });
 }
@@ -758,19 +754,44 @@ Pool.prototype.destroy = function(force, callback) {
  * @param {function} [callback]
  */
 Pool.prototype.reset = function(callback) {
-  // this.destroy(true, err => {
-  //   if (err && typeof callback === 'function') {
-  //     callback(err, null);
-  //     return;
-  //   }
+  const connections = this.availableConnections.concat(this.inUseConnections);
+  let connectionCount = connections.length;
+  const connectionDestroyed = () => {
+    connectionCount--;
+    if (connectionCount > 0) {
+      return;
+    }
 
-  //   stateTransition(this, DISCONNECTED);
-  //   this.connect();
+    // clear all pool state
+    this.inUseConnections = [];
+    this.availableConnections = [];
+    this.connectingConnections = 0;
+    this.executing = false;
+    this.reconnectConnection = null;
+    this.numberOfConsecutiveTimeouts = 0;
+    this.connectionIndex = 0;
+    this.retriesLeft = this.options.reconnectTries;
+    this.reconnectId = null;
 
-  //   if (typeof callback === 'function') callback(null, null);
-  // });
+    // create an initial connection, and kick off execution again
+    _createConnection(this);
 
-  if (typeof callback === 'function') callback();
+    if (typeof callback === 'function') {
+      callback(null, null);
+    }
+  };
+
+  // if we already have no connections, just reset state and callback
+  if (connectionCount === 0) {
+    connectionDestroyed();
+    return;
+  }
+
+  // destroy all connections
+  connections.forEach(conn => {
+    CONNECTION_EVENTS.forEach(eventName => conn.removeAllListeners(eventName));
+    conn.destroy({ force: true }, connectionDestroyed);
+  });
 };
 
 // Prepare the buffer that Pool.prototype.write() uses to send to the server

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -27,7 +27,14 @@ var CONNECTED = 'connected';
 var DESTROYING = 'destroying';
 var DESTROYED = 'destroyed';
 
-const CONNECTION_EVENTS = ['error', 'close', 'timeout', 'parseError', 'connect', 'message'];
+const CONNECTION_EVENTS = new Set([
+  'error',
+  'close',
+  'timeout',
+  'parseError',
+  'connect',
+  'message'
+]);
 
 var _id = 0;
 
@@ -653,7 +660,10 @@ function destroy(self, connections, options, callback) {
   eachAsync(
     connections,
     (conn, cb) => {
-      CONNECTION_EVENTS.forEach(eventName => conn.removeAllListeners(eventName));
+      for (const eventName of CONNECTION_EVENTS) {
+        conn.removeAllListeners(eventName);
+      }
+
       conn.destroy(options, cb);
     },
     err => {
@@ -754,7 +764,10 @@ Pool.prototype.reset = function(callback) {
   eachAsync(
     connections,
     (conn, cb) => {
-      CONNECTION_EVENTS.forEach(eventName => conn.removeAllListeners(eventName));
+      for (const eventName of CONNECTION_EVENTS) {
+        conn.removeAllListeners(eventName);
+      }
+
       conn.destroy({ force: true }, cb);
     },
     err => {

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -201,6 +201,20 @@ Object.defineProperty(Pool.prototype, 'socketTimeout', {
   }
 });
 
+// clears all pool state
+function resetPoolState(pool) {
+  pool.inUseConnections = [];
+  pool.availableConnections = [];
+  pool.connectingConnections = 0;
+  pool.executing = false;
+  pool.queue = [];
+  pool.reconnectConnection = null;
+  pool.numberOfConsecutiveTimeouts = 0;
+  pool.connectionIndex = 0;
+  pool.retriesLeft = pool.options.reconnectTries;
+  pool.reconnectId = null;
+}
+
 function stateTransition(self, newState) {
   var legalTransitions = {
     disconnected: [CONNECTING, DESTROYING, DISCONNECTED],
@@ -648,19 +662,7 @@ function destroy(self, connections, options, callback) {
         return;
       }
 
-      // clear all pool state
-      self.inUseConnections = [];
-      self.availableConnections = [];
-      self.connectingConnections = 0;
-      self.executing = false;
-      self.queue = [];
-      self.reconnectConnection = null;
-      self.numberOfConsecutiveTimeouts = 0;
-      self.connectionIndex = 0;
-      self.retriesLeft = self.options.reconnectTries;
-      self.reconnectId = null;
-
-      // Set state to destroyed
+      resetPoolState(self);
       stateTransition(self, DESTROYED);
       if (typeof callback === 'function') callback(null, null);
     }
@@ -763,16 +765,7 @@ Pool.prototype.reset = function(callback) {
         }
       }
 
-      // clear all pool state
-      this.inUseConnections = [];
-      this.availableConnections = [];
-      this.connectingConnections = 0;
-      this.executing = false;
-      this.reconnectConnection = null;
-      this.numberOfConsecutiveTimeouts = 0;
-      this.connectionIndex = 0;
-      this.retriesLeft = this.options.reconnectTries;
-      this.reconnectId = null;
+      resetPoolState(this);
 
       // create an initial connection, and kick off execution again
       _createConnection(this);

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -19,6 +19,7 @@ const apm = require('./apm');
 const Buffer = require('safe-buffer').Buffer;
 const connect = require('./connect');
 const updateSessionFromResponse = require('../sessions').updateSessionFromResponse;
+const eachAsync = require('../utils').eachAsync;
 
 var DISCONNECTED = 'disconnected';
 var CONNECTING = 'connecting';
@@ -635,42 +636,35 @@ Pool.prototype.unref = function() {
 
 // Destroy the connections
 function destroy(self, connections, options, callback) {
-  let connectionCount = connections.length;
-  function connectionDestroyed() {
-    connectionCount--;
-    if (connectionCount > 0) {
-      return;
+  eachAsync(
+    connections,
+    (conn, cb) => {
+      CONNECTION_EVENTS.forEach(eventName => conn.removeAllListeners(eventName));
+      conn.destroy(options, cb);
+    },
+    err => {
+      if (err) {
+        if (typeof callback === 'function') callback(err, null);
+        return;
+      }
+
+      // clear all pool state
+      self.inUseConnections = [];
+      self.availableConnections = [];
+      self.connectingConnections = 0;
+      self.executing = false;
+      self.queue = [];
+      self.reconnectConnection = null;
+      self.numberOfConsecutiveTimeouts = 0;
+      self.connectionIndex = 0;
+      self.retriesLeft = self.options.reconnectTries;
+      self.reconnectId = null;
+
+      // Set state to destroyed
+      stateTransition(self, DESTROYED);
+      if (typeof callback === 'function') callback(null, null);
     }
-
-    // clear all pool state
-    self.inUseConnections = [];
-    self.availableConnections = [];
-    self.connectingConnections = 0;
-    self.executing = false;
-    self.queue = [];
-    self.reconnectConnection = null;
-    self.numberOfConsecutiveTimeouts = 0;
-    self.connectionIndex = 0;
-    self.retriesLeft = self.options.reconnectTries;
-    self.reconnectId = null;
-
-    // Set state to destroyed
-    stateTransition(self, DESTROYED);
-    if (typeof callback === 'function') {
-      callback(null, null);
-    }
-  }
-
-  if (connectionCount === 0) {
-    connectionDestroyed();
-    return;
-  }
-
-  // Destroy all connections
-  connections.forEach(conn => {
-    CONNECTION_EVENTS.forEach(eventName => conn.removeAllListeners(eventName));
-    conn.destroy(options, connectionDestroyed);
-  });
+  );
 }
 
 /**
@@ -755,43 +749,39 @@ Pool.prototype.destroy = function(force, callback) {
  */
 Pool.prototype.reset = function(callback) {
   const connections = this.availableConnections.concat(this.inUseConnections);
-  let connectionCount = connections.length;
-  const connectionDestroyed = () => {
-    connectionCount--;
-    if (connectionCount > 0) {
-      return;
+  eachAsync(
+    connections,
+    (conn, cb) => {
+      CONNECTION_EVENTS.forEach(eventName => conn.removeAllListeners(eventName));
+      conn.destroy({ force: true }, cb);
+    },
+    err => {
+      if (err) {
+        if (typeof callback === 'function') {
+          callback(err, null);
+          return;
+        }
+      }
+
+      // clear all pool state
+      this.inUseConnections = [];
+      this.availableConnections = [];
+      this.connectingConnections = 0;
+      this.executing = false;
+      this.reconnectConnection = null;
+      this.numberOfConsecutiveTimeouts = 0;
+      this.connectionIndex = 0;
+      this.retriesLeft = this.options.reconnectTries;
+      this.reconnectId = null;
+
+      // create an initial connection, and kick off execution again
+      _createConnection(this);
+
+      if (typeof callback === 'function') {
+        callback(null, null);
+      }
     }
-
-    // clear all pool state
-    this.inUseConnections = [];
-    this.availableConnections = [];
-    this.connectingConnections = 0;
-    this.executing = false;
-    this.reconnectConnection = null;
-    this.numberOfConsecutiveTimeouts = 0;
-    this.connectionIndex = 0;
-    this.retriesLeft = this.options.reconnectTries;
-    this.reconnectId = null;
-
-    // create an initial connection, and kick off execution again
-    _createConnection(this);
-
-    if (typeof callback === 'function') {
-      callback(null, null);
-    }
-  };
-
-  // if we already have no connections, just reset state and callback
-  if (connectionCount === 0) {
-    connectionDestroyed();
-    return;
-  }
-
-  // destroy all connections
-  connections.forEach(conn => {
-    CONNECTION_EVENTS.forEach(eventName => conn.removeAllListeners(eventName));
-    conn.destroy({ force: true }, connectionDestroyed);
-  });
+  );
 };
 
 // Prepare the buffer that Pool.prototype.write() uses to send to the server

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -643,10 +643,17 @@ function destroy(self, connections, options, callback) {
       return;
     }
 
-    // Zero out all connections
+    // clear all pool state
     self.inUseConnections = [];
     self.availableConnections = [];
     self.connectingConnections = 0;
+    self.executing = false;
+    self.queue = [];
+    self.reconnectConnection = null;
+    self.numberOfConsecutiveTimeouts = 0;
+    self.connectionIndex = 0;
+    self.retriesLeft = self.options.reconnectTries;
+    self.reconnectId = null;
 
     // Set state to destroyed
     stateTransition(self, DESTROYED);

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -214,7 +214,6 @@ function resetPoolState(pool) {
   pool.availableConnections = [];
   pool.connectingConnections = 0;
   pool.executing = false;
-  pool.queue = [];
   pool.reconnectConnection = null;
   pool.numberOfConsecutiveTimeouts = 0;
   pool.connectionIndex = 0;
@@ -673,6 +672,8 @@ function destroy(self, connections, options, callback) {
       }
 
       resetPoolState(self);
+      self.queue = [];
+
       stateTransition(self, DESTROYED);
       if (typeof callback === 'function') callback(null, null);
     }

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -161,13 +161,16 @@ class Server extends EventEmitter {
     if (typeof options === 'function') (callback = options), (options = {});
     options = Object.assign({}, { force: false }, options);
 
-    if (!this.s.pool) {
+    const done = err => {
+      this.emit('closed');
       this.s.state = STATE_DISCONNECTED;
       if (typeof callback === 'function') {
-        callback(null, null);
+        callback(err, null);
       }
+    };
 
-      return;
+    if (!this.s.pool) {
+      return done();
     }
 
     ['close', 'error', 'timeout', 'parseError', 'connect'].forEach(event => {
@@ -178,10 +181,7 @@ class Server extends EventEmitter {
       clearTimeout(this.s.monitorId);
     }
 
-    this.s.pool.destroy(options.force, err => {
-      this.s.state = STATE_DISCONNECTED;
-      callback(err);
-    });
+    this.s.pool.destroy(options.force, done);
   }
 
   /**

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -116,6 +116,37 @@ function isPromiseLike(maybePromise) {
   return maybePromise && typeof maybePromise.then === 'function';
 }
 
+/**
+ * Applies the function `eachFn` to each item in `arr`, in parallel.
+ *
+ * @param {array} arr an array of items to asynchronusly iterate over
+ * @param {function} eachFn A function to call on each item of the array. The callback signature is `(item, callback)`, where the callback indicates iteration is complete.
+ * @param {function} callback The callback called after every item has been iterated
+ */
+function eachAsync(arr, eachFn, callback) {
+  if (arr.length === 0) {
+    callback(null);
+    return;
+  }
+
+  const length = arr.length;
+  let completed = 0;
+  function eachCallback(err) {
+    if (err) {
+      callback(err, null);
+      return;
+    }
+
+    if (++completed === length) {
+      callback(null);
+    }
+  }
+
+  for (let idx = 0; idx < length; ++idx) {
+    eachFn(arr[idx], eachCallback);
+  }
+}
+
 module.exports = {
   uuidV4,
   calculateDurationInMs,
@@ -124,5 +155,6 @@ module.exports = {
   retrieveEJSON,
   retrieveKerberos,
   maxWireVersion,
-  isPromiseLike
+  isPromiseLike,
+  eachAsync
 };


### PR DESCRIPTION
# Description
This change implements reset functionality for the connection pool, which is required for the "connections survive primary stepdown" as well as prose tests for SDAM. 

**What changed?**
The `Pool.prototype.reset` was implemented, which essentially destroys the pool, transitions it to a `DISCONNECTED` state, and then reconnects it. The only questionable change is in the pool's `_execute` method, where we now attempt to create more connections if none are available rather than flushing monitoring operations. As noted in the code, it's unclear why this was implemented this way, but there aren't broken tests, and the fallback behavior is to use the old code path.

**Are there any files to ignore?**
No.