### PR TITLE
feat(cryptdConnectionString): makes mongocryptd uri configurable

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -67,7 +67,7 @@ const closeOperation = require('./operations/mongo_client_ops').closeOperation;
  * @property {string} [kmsProviders.local.key] The master key used to encrypt/decrypt data keys
  * @property {object} [schemaMap] A map of namespaces to a local JSON schema for encryption
  * @property {boolean} [bypassAutoEncryption] Allows the user to bypass auto encryption, maintaining implicit decryption
- * @param {string} [cryptdConnectionString] A local process the driver communicates with to determine how to encrypt values in a command. Defaults to "mongodb://%2Fvar%2Fmongocryptd.sock" if domain sockets are available or "mongodb://localhost:27020" otherwise.
+ * @param {string} [extraOptions.mongocryptURI] A local process the driver communicates with to determine how to encrypt values in a command. Defaults to "mongodb://%2Fvar%2Fmongocryptd.sock" if domain sockets are available or "mongodb://localhost:27020" otherwise.
  */
 
 /**

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -67,6 +67,7 @@ const closeOperation = require('./operations/mongo_client_ops').closeOperation;
  * @property {string} [kmsProviders.local.key] The master key used to encrypt/decrypt data keys
  * @property {object} [schemaMap] A map of namespaces to a local JSON schema for encryption
  * @property {boolean} [bypassAutoEncryption] Allows the user to bypass auto encryption, maintaining implicit decryption
+ * @param {string} [cryptdConnectionString] A local process the driver communicates with to determine how to encrypt values in a command. Defaults to "mongodb://%2Fvar%2Fmongocryptd.sock" if domain sockets are available or "mongodb://localhost:27020" otherwise.
  */
 
 /**
@@ -134,7 +135,6 @@ const closeOperation = require('./operations/mongo_client_ops').closeOperation;
  * @param {number} [options.minSize] If present, the connection pool will be initialized with minSize connections, and will never dip below minSize connections
  * @param {boolean} [options.useNewUrlParser=false] Determines whether or not to use the new url parser. Enables the new, spec-compliant, url parser shipped in the core driver. This url parser fixes a number of problems with the original parser, and aims to outright replace that parser in the near future.
  * @param {boolean} [options.useUnifiedTopology] Enables the new unified topology layer
- * @param {string} [options.cryptdConnectionString] The connection string for mongocryptd
  * @param {AutoEncryptionOptions} [options.autoEncryption] Optionally enable client side auto encryption
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {MongoClient} a MongoClient instance

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -134,6 +134,7 @@ const closeOperation = require('./operations/mongo_client_ops').closeOperation;
  * @param {number} [options.minSize] If present, the connection pool will be initialized with minSize connections, and will never dip below minSize connections
  * @param {boolean} [options.useNewUrlParser=false] Determines whether or not to use the new url parser. Enables the new, spec-compliant, url parser shipped in the core driver. This url parser fixes a number of problems with the original parser, and aims to outright replace that parser in the near future.
  * @param {boolean} [options.useUnifiedTopology] Enables the new unified topology layer
+ * @param {string} [options.cryptdConnectionString] The connection string for mongocryptd
  * @param {AutoEncryptionOptions} [options.autoEncryption] Optionally enable client side auto encryption
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {MongoClient} a MongoClient instance

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -439,10 +439,12 @@ function createTopology(mongoClient, topologyType, options, callback) {
     }
 
     const MongoClient = loadClient();
-    const connectionString =
-      os.platform() === 'win32'
-        ? 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000'
-        : 'mongodb://%2Ftmp%2Fmongocryptd.sock/?serverSelectionTimeoutMS=1000';
+    let connectionString =
+      mongoClient.s.options.cryptdConnectionString != null
+        ? mongoClient.s.options.cryptdConnectionString
+        : os.platform() === 'win32'
+          ? 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000'
+          : 'mongodb://%2Ftmp%2Fmongocryptd.sock/?serverSelectionTimeoutMS=1000';
 
     const mongocryptdClient = new MongoClient(connectionString, { useUnifiedTopology: true });
     mongocryptdClient.connect(err => {

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -440,8 +440,8 @@ function createTopology(mongoClient, topologyType, options, callback) {
 
     const MongoClient = loadClient();
     let connectionString;
-    if (mongoClient.s.options.autoEncryption.cryptdConnectionString != null) {
-      connectionString = mongoClient.s.options.autoEncryption.cryptdConnectionString;
+    if (options.autoEncryption.cryptdConnectionString != null) {
+      connectionString = options.autoEncryption.cryptdConnectionString;
     } else if (os.platform() === 'win32') {
       connectionString = 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000';
     } else {

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -440,8 +440,8 @@ function createTopology(mongoClient, topologyType, options, callback) {
 
     const MongoClient = loadClient();
     let connectionString;
-    if (options.autoEncryption.cryptdConnectionString != null) {
-      connectionString = options.autoEncryption.cryptdConnectionString;
+    if (options.autoEncryption.extraOptions && options.autoEncryption.extraOptions.mongocryptURI) {
+      connectionString = options.autoEncryption.extraOptions.mongocryptURI;
     } else if (os.platform() === 'win32') {
       connectionString = 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000';
     } else {

--- a/lib/operations/mongo_client_ops.js
+++ b/lib/operations/mongo_client_ops.js
@@ -439,12 +439,14 @@ function createTopology(mongoClient, topologyType, options, callback) {
     }
 
     const MongoClient = loadClient();
-    let connectionString =
-      mongoClient.s.options.cryptdConnectionString != null
-        ? mongoClient.s.options.cryptdConnectionString
-        : os.platform() === 'win32'
-          ? 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000'
-          : 'mongodb://%2Ftmp%2Fmongocryptd.sock/?serverSelectionTimeoutMS=1000';
+    let connectionString;
+    if (mongoClient.s.options.autoEncryption.cryptdConnectionString != null) {
+      connectionString = mongoClient.s.options.autoEncryption.cryptdConnectionString;
+    } else if (os.platform() === 'win32') {
+      connectionString = 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000';
+    } else {
+      connectionString = 'mongodb://%2Ftmp%2Fmongocryptd.sock/?serverSelectionTimeoutMS=1000';
+    }
 
     const mongocryptdClient = new MongoClient(connectionString, { useUnifiedTopology: true });
     mongocryptdClient.connect(err => {


### PR DESCRIPTION
Fixes NODE-2012

# Description
Previously, cryptd's connectionString was not configurable. Now, the user has the option of setting connectionString by passing it in as an option for MongoClient.

**What changed?**
cryptdConnectionString is now a valid option for MongoClient
