### PR TITLE
feat(test-runner): move environment.js and config.js to test-runner

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -1,9 +1,66 @@
 'use strict';
-const ConfigurationBase = require('mongodb-test-runner').ConfigurationBase;
 const f = require('util').format;
 const url = require('url');
 const qs = require('querystring');
 const core = require('../lib/core');
+
+class ConfigurationBase {
+  constructor(options) {
+    this.options = options || {};
+    this.host = options.host || 'localhost';
+    this.port = options.port || 27017;
+    this.db = options.db || 'integration_tests';
+    this.manager = options.manager;
+    this.mongo = options.mongo;
+    this.skipStart = typeof options.skipStart === 'boolean' ? options.skipStart : false;
+    this.skipTermination =
+      typeof options.skipTermination === 'boolean' ? options.skipTermination : false;
+    this.setName = options.setName || 'rs';
+    this.require = this.mongo;
+    this.writeConcern = function() {
+      return { w: 1 };
+    };
+  }
+
+  stop(callback) {
+    if (this.skipTermination) return callback();
+    // Stop the servers
+    this.manager
+      .stop()
+      .then(function() {
+        callback(null);
+      })
+      .catch(function(err) {
+        callback(err, null);
+      });
+  }
+
+  restart(opts, callback) {
+    if (typeof opts === 'function') {
+      callback = opts;
+      opts = { purge: true, kill: true };
+    }
+    if (this.skipTermination) return callback();
+
+    // Stop the servers
+    this.manager
+      .restart()
+      .then(function() {
+        callback(null);
+      })
+      .catch(function(err) {
+        callback(err, null);
+      });
+  }
+
+  setup(callback) {
+    callback();
+  }
+
+  teardown(callback) {
+    callback();
+  }
+}
 
 class NativeConfiguration extends ConfigurationBase {
   constructor(environment) {

--- a/test/environments.js
+++ b/test/environments.js
@@ -3,7 +3,6 @@
 const f = require('util').format;
 const semver = require('semver');
 const path = require('path');
-const EnvironmentBase = require('mongodb-test-runner').EnvironmentBase;
 const core = require('../lib/core');
 
 // topology managers
@@ -11,6 +10,21 @@ const topologyManagers = require('mongodb-test-runner').topologyManagers;
 const ServerManager = topologyManagers.Server;
 const ReplSetManager = topologyManagers.ReplSet;
 const ShardingManager = topologyManagers.Sharded;
+
+/**
+ * Base class for environments in projects that use the test
+ * runner
+ */
+class EnvironmentBase {
+  /**
+   * The default implementation of the environment setup
+   *
+   * @param {*} callback
+   */
+  setup(callback) {
+    callback();
+  }
+}
 
 const genReplsetConfig = (port, options) => {
   return Object.assign(


### PR DESCRIPTION
NODE-2041

# Description
In order to move all use of `mongodb-test-runner` to the `test-runner` directory in node-mongodb-native` the `environments.js` and `config.js` files must be modified to include content from `mongodb-test-runner`.

**What changed?**
Content from `mongodb-test-runner/lib/environment_base.js` and `mongodb-test-runner/lib/configuration_base.js` was moved to `environments.js` and `config.js` respectively to spearhead the integration of the test-runner directly into `node-mongodb-native`.

**Are there any files to ignore?**
None.