### PR TITLE
fix(change_stream): emit 'close' event if reconnecting failed

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -405,7 +405,11 @@ function processNewChange(args) {
       // attempt recreating the cursor
       if (eventEmitter) {
         waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-          if (err) return changeStream.emit('error', err);
+          if (err) {
+            changeStream.emit('error', err);
+            changeStream.emit('close');
+            return;
+          }
           changeStream.cursor = createChangeStreamCursor(changeStream);
         });
 


### PR DESCRIPTION
# Description

Re: https://github.com/Automattic/mongoose/issues/7930, if the underlying replica set dies and the driver gives up reconnecting, the change stream doesn't emit a 'close' event. Based on my reading of [the stream 'close' event](https://nodejs.org/api/stream.html#stream_event_close_1), closing the underlying topology should result in a 'close' event.

**What changed?**

Added `emit('close')` it `waitForTopologyConnected()` returned an error. It looks like the only way `waitForTopologyConnected()` can return an error is if it times out.

**Are there any files to ignore?**
