### PR TITLE
fix(uri_parser): keep original hostname when parsing srv uris

### DIFF
--- a/lib/core/uri_parser.js
+++ b/lib/core/uri_parser.js
@@ -69,7 +69,6 @@ function parseSrvConnectionString(uri, options, callback) {
 
     // Convert the original URL to a non-SRV URL.
     result.protocol = 'mongodb';
-    result.host = addresses.map(address => `${address.name}:${address.port}`).join(',');
 
     // Default to SSL true if it's not specified.
     if (

--- a/test/unit/uri_parser_tests.js
+++ b/test/unit/uri_parser_tests.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const parseConnectionString = require('../../lib/core/uri_parser');
+const expect = require('chai').expect;
+
+describe('New URL Parser', function() {
+  /**
+   * @ignore
+   */
+  it('should return the correct hostname when given a URL with srv', function(done) {
+    parseConnectionString(
+      'mongodb+srv://admin:password@compass-data-sets-e06dc.mongodb.net/admin',
+      (err, result) => {
+        expect(err).to.not.exist;
+        expect(result.hosts.length).to.equal(1);
+        expect(result.hosts[0]).to.deep.equal({
+          host: 'compass-data-sets-e06dc.mongodb.net',
+          port: 27017
+        });
+        done();
+      }
+    );
+  });
+});

--- a/test/unit/uri_parser_tests.js
+++ b/test/unit/uri_parser_tests.js
@@ -8,17 +8,14 @@ describe('New URL Parser', function() {
    * @ignore
    */
   it('should return the correct hostname when given a URL with srv', function(done) {
-    parseConnectionString(
-      'mongodb+srv://admin:password@compass-data-sets-e06dc.mongodb.net/admin',
-      (err, result) => {
-        expect(err).to.not.exist;
-        expect(result.hosts.length).to.equal(1);
-        expect(result.hosts[0]).to.deep.equal({
-          host: 'compass-data-sets-e06dc.mongodb.net',
-          port: 27017
-        });
-        done();
-      }
-    );
+    parseConnectionString('mongodb+srv://auser:apass@test1.test.build.10gen.cc', (err, result) => {
+      expect(err).to.not.exist;
+      expect(result.hosts.length).to.equal(1);
+      expect(result.hosts[0]).to.deep.equal({
+        host: 'test1.test.build.10gen.cc',
+        port: 27017
+      });
+      done();
+    });
   });
 });


### PR DESCRIPTION
Fixes NODE-2048

# Description
This PR fixes the issue raised in NODE-2048. I couldn't find exact wording in the connection-string specification to confirm that this is the behavior we should be following.

**What changed?**
This PR keeps the original `result.host` when parsing an SRV connection string. Before this change, `result.host` will be an array of multiple objects that look like `{ host: 'modifiedhostname', port: 27017 }`. After this change, `result.host` is an array of only one object with `{ host: 'originalhostname', port: 27017 }`.

**Are there any files to ignore?**
No.