### PR TITLE
fix(autoEncryption): use new url parser for autoEncryption client

### DIFF
--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -492,7 +492,10 @@ function createTopology(mongoClient, topologyType, options, callback) {
       connectionString = 'mongodb://%2Ftmp%2Fmongocryptd.sock/?serverSelectionTimeoutMS=1000';
     }
 
-    const mongocryptdClient = new MongoClient(connectionString, { useUnifiedTopology: true });
+    const mongocryptdClient = new MongoClient(connectionString, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true
+    });
     mongocryptdClient.connect(err => {
       if (err) return callback(err, null);
 


### PR DESCRIPTION
Fixes NODE-2054

# Description

Used the flag `useNewUrlParser` when creating the client for mongocryptd.
