### PR TITLE
fix(AutoEncryption): tear down mongocryptd client when main client closes

### DIFF
--- a/lib/operations/close.js
+++ b/lib/operations/close.js
@@ -23,13 +23,22 @@ class CloseOperation extends OperationBase {
       client.removeAllListeners('close');
       callback(err, null);
     };
+    const mongocryptdClientClose = err => {
+      const mongocryptdClient = client.s.mongocryptdClient;
+      if (!mongocryptdClient) {
+        completeClose(err);
+        return;
+      }
+
+      mongocryptdClient.close(force, err2 => completeClose(err || err2));
+    };
 
     if (client.topology == null) {
-      completeClose();
+      mongocryptdClientClose();
       return;
     }
 
-    client.topology.close(force, completeClose);
+    client.topology.close(force, mongocryptdClientClose);
   }
 }
 

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -497,6 +497,7 @@ function createTopology(mongoClient, topologyType, options, callback) {
       useNewUrlParser: true,
       useUnifiedTopology: true
     });
+    mongoClient.s.mongocryptdClient = mongocryptdClient;
     mongocryptdClient.connect(err => {
       if (err) return callback(err, null);
 


### PR DESCRIPTION
Fixes NODE-2051

# Description

**What changed?**
Made sure to store off mongocryptd client as `client.s.mongocryptdClient`. In close operation, added logic to ensure that `client.s.mongocryptdClient` is clused as well.

This has the tricky issue of multiple optionally async callbacks nested within each other.
