### PR TITLE
refactor(cursor): simplify `Cursor` constructor

### DIFF
--- a/lib/aggregation_cursor.js
+++ b/lib/aggregation_cursor.js
@@ -56,10 +56,12 @@ const MongoDBNamespace = require('./utils').MongoDBNamespace;
  * @fires AggregationCursor#readable
  * @return {AggregationCursor} an AggregationCursor instance.
  */
-var AggregationCursor = function(bson, ns, cmd, options, topology, topologyOptions) {
+var AggregationCursor = function(topology, ns, cmd, options) {
   CoreCursor.apply(this, Array.prototype.slice.call(arguments, 0));
   var state = AggregationCursor.INIT;
   var streamOptions = {};
+  const bson = topology.s.bson;
+  const topologyOptions = topology.s.options;
 
   // MaxTimeMS
   var maxTimeMS = null;

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -242,9 +242,9 @@ class ChangeStream extends EventEmitter {
 }
 
 class ChangeStreamCursor extends Cursor {
-  constructor(bson, ns, cmd, options, topology, topologyOptions) {
+  constructor(topology, ns, cmd, options) {
     // TODO: spread will help a lot here
-    super(bson, ns, cmd, options, topology, topologyOptions);
+    super(topology, ns, cmd, options);
 
     options = options || {};
     this._resumeToken = null;

--- a/lib/command_cursor.js
+++ b/lib/command_cursor.js
@@ -55,10 +55,12 @@ const MongoDBNamespace = require('./utils').MongoDBNamespace;
  * @fires CommandCursor#readable
  * @return {CommandCursor} an CommandCursor instance.
  */
-var CommandCursor = function(bson, ns, cmd, options, topology, topologyOptions) {
+var CommandCursor = function(topology, ns, cmd, options) {
   CoreCursor.apply(this, Array.prototype.slice.call(arguments, 0));
   var state = CommandCursor.INIT;
   var streamOptions = {};
+  const bson = topology.s.bson;
+  const topologyOptions = topology.s.options;
 
   // MaxTimeMS
   var maxTimeMS = null;

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -29,7 +29,7 @@ const Long = BSON.Long;
 /**
  * Creates a new Cursor, not to be used directly
  * @class
- * @param {object} bson An instance of the BSON parser
+ * @param {object} topology The server topology instance.
  * @param {string} ns The MongoDB fully qualified namespace (ex: db1.collection1)
  * @param {{object}|Long} cmd The selector (can be a command or a cursorId)
  * @param {object} [options=null] Optional settings.
@@ -38,14 +38,12 @@ const Long = BSON.Long;
  * @param {object} [options.transforms=null] Transform methods for the cursor results
  * @param {function} [options.transforms.query] Transform the value returned from the initial query
  * @param {function} [options.transforms.doc] Transform each document returned from Cursor.prototype.next
- * @param {object} topology The server topology instance.
- * @param {object} topologyOptions The server topology options.
  * @return {Cursor} A cursor instance
  * @property {number} cursorBatchSize The current cursorBatchSize for the cursor
  * @property {number} cursorLimit The current cursorLimit for the cursor
  * @property {number} cursorSkip The current cursorSkip for the cursor
  */
-var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
+var Cursor = function(topology, ns, cmd, options) {
   options = options || {};
 
   // Cursor pool
@@ -57,7 +55,7 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
   this.disconnectHandler = options.disconnectHandler;
 
   // Set local values
-  this.bson = bson;
+  this.bson = topology.s.bson;
   this.ns = ns;
   this.cmd = cmd;
   this.options = options;
@@ -87,6 +85,7 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
   }
 
   // Add promoteLong to cursor state
+  const topologyOptions = topology.s.options;
   if (typeof topologyOptions.promoteLongs === 'boolean') {
     this.cursorState.promoteLongs = topologyOptions.promoteLongs;
   } else if (typeof options.promoteLongs === 'boolean') {

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -633,7 +633,7 @@ class Topology extends EventEmitter {
     const CursorClass = options.cursorFactory || this.s.Cursor;
     translateReadPreference(options);
 
-    return new CursorClass(this.s.bson, ns, cmd, options, topology, this.s.options);
+    return new CursorClass(topology, ns, cmd, options);
   }
 
   get clientInfo() {

--- a/lib/core/topologies/mongos.js
+++ b/lib/core/topologies/mongos.js
@@ -1110,7 +1110,7 @@ Mongos.prototype.cursor = function(ns, cmd, options) {
   var FinalCursor = options.cursorFactory || this.s.Cursor;
 
   // Return the cursor
-  return new FinalCursor(this.s.bson, ns, cmd, options, topology, this.s.options);
+  return new FinalCursor(topology, ns, cmd, options);
 };
 
 /**

--- a/lib/core/topologies/replset.js
+++ b/lib/core/topologies/replset.js
@@ -1364,7 +1364,7 @@ ReplSet.prototype.cursor = function(ns, cmd, options) {
   var FinalCursor = options.cursorFactory || this.s.Cursor;
 
   // Return the cursor
-  return new FinalCursor(this.s.bson, ns, cmd, options, topology, this.s.options);
+  return new FinalCursor(topology, ns, cmd, options);
 };
 
 /**

--- a/lib/core/topologies/server.js
+++ b/lib/core/topologies/server.js
@@ -752,7 +752,7 @@ Server.prototype.cursor = function(ns, cmd, options) {
   var FinalCursor = options.cursorFactory || this.s.Cursor;
 
   // Return the cursor
-  return new FinalCursor(this.s.bson, ns, cmd, options, topology, this.s.options);
+  return new FinalCursor(topology, ns, cmd, options);
 };
 
 /**

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -106,10 +106,12 @@ const fields = ['numberOfRetries', 'tailableRetryInterval'];
  *
  * collection.find({}).maxTimeMS(1000).maxScan(100).skip(1).toArray(..)
  */
-function Cursor(bson, ns, cmd, options, topology, topologyOptions) {
+function Cursor(topology, ns, cmd, options) {
   CoreCursor.apply(this, Array.prototype.slice.call(arguments, 0));
   const state = Cursor.INIT;
   const streamOptions = {};
+  const bson = topology.s.bson;
+  const topologyOptions = topology.s.options;
 
   // Tailable cursor options
   const numberOfRetries = options.numberOfRetries || 5;


### PR DESCRIPTION
The current constructor is hard to reason about, in particular
during refactoring. This change reduces the duplication of the
passed in values.

NODE-2063