### PR TITLE
NODE-2068: perform server selection to determine session support, if needed

### DIFF
--- a/lib/command_cursor.js
+++ b/lib/command_cursor.js
@@ -159,8 +159,7 @@ var methodsToInherit = [
   'explain',
   'isNotified',
   'isKilled',
-  '_endSession',
-  '_initImplicitSession'
+  '_endSession'
 ];
 
 // Only inherit the types we need

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -586,7 +586,7 @@ Cursor.prototype._initializeCursor = function(callback) {
   const cursor = this;
 
   // NOTE: this goes away once cursors use `executeOperation`
-  if (cursor.topology.shouldCheckForSessionSupport()) {
+  if (cursor.topology.description != null && cursor.topology.shouldCheckForSessionSupport()) {
     cursor.topology.selectServer(ReadPreference.primaryPreferred, err => {
       if (err) {
         callback(err);

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -7,6 +7,7 @@ const MongoNetworkError = require('./error').MongoNetworkError;
 const mongoErrorContextSymbol = require('./error').mongoErrorContextSymbol;
 const f = require('util').format;
 const collationNotSupported = require('./utils').collationNotSupported;
+const ReadPreference = require('./topologies/read_preference');
 const BSON = retrieveBSON();
 const Long = BSON.Long;
 
@@ -583,6 +584,20 @@ var nextFunction = function(self, callback) {
 
 Cursor.prototype._initializeCursor = function(callback) {
   const cursor = this;
+
+  // NOTE: this goes away once cursors use `executeOperation`
+  if (cursor.topology.shouldCheckForSessionSupport()) {
+    cursor.topology.selectServer(ReadPreference.primaryPreferred, err => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      cursor.next(callback);
+    });
+
+    return;
+  }
 
   // Very explicitly choose what is passed to selectServer
   const serverSelectOptions = {};

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -8,6 +8,8 @@ const mongoErrorContextSymbol = require('./error').mongoErrorContextSymbol;
 const f = require('util').format;
 const collationNotSupported = require('./utils').collationNotSupported;
 const ReadPreference = require('./topologies/read_preference');
+const isUnifiedTopology = require('./utils').isUnifiedTopology;
+
 const BSON = retrieveBSON();
 const Long = BSON.Long;
 
@@ -586,7 +588,7 @@ Cursor.prototype._initializeCursor = function(callback) {
   const cursor = this;
 
   // NOTE: this goes away once cursors use `executeOperation`
-  if (cursor.topology.description != null && cursor.topology.shouldCheckForSessionSupport()) {
+  if (isUnifiedTopology(cursor.topology) && cursor.topology.shouldCheckForSessionSupport()) {
     cursor.topology.selectServer(ReadPreference.primaryPreferred, err => {
       if (err) {
         callback(err);

--- a/lib/core/sdam/server_description.js
+++ b/lib/core/sdam/server_description.js
@@ -19,6 +19,13 @@ const WRITABLE_SERVER_TYPES = new Set([
   ServerType.Mongos
 ]);
 
+const DATA_BEARING_SERVER_TYPES = new Set([
+  ServerType.RSPrimary,
+  ServerType.RSSecondary,
+  ServerType.Mongos,
+  ServerType.Standalone
+]);
+
 const ISMASTER_FIELDS = [
   'minWireVersion',
   'maxWireVersion',
@@ -97,6 +104,13 @@ class ServerDescription {
    */
   get isReadable() {
     return this.type === ServerType.RSSecondary || this.isWritable;
+  }
+
+  /**
+   * @return {Boolean} Is this server data bearing
+   */
+  get isDataBearing() {
+    return DATA_BEARING_SERVER_TYPES.has(this.type);
   }
 
   /**

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -391,6 +391,17 @@ class Topology extends EventEmitter {
   }
 
   // Sessions related methods
+
+  /**
+   * @return Whether the topology should initiate selection to determine session support
+   */
+  shouldCheckForSessionSupport() {
+    return (
+      (this.description.type === TopologyType.Single && !this.description.hasKnownServers) ||
+      !this.description.hasDataBearingServers
+    );
+  }
+
   /**
    * @return Whether sessions are supported on the current topology
    */

--- a/lib/core/sdam/topology_description.js
+++ b/lib/core/sdam/topology_description.js
@@ -1,7 +1,6 @@
 'use strict';
 const ServerType = require('./server_description').ServerType;
 const ServerDescription = require('./server_description').ServerDescription;
-const ReadPreference = require('../topologies/read_preference');
 const WIRE_CONSTANTS = require('../wireprotocol/constants');
 
 // contstants related to compatability checks
@@ -258,24 +257,17 @@ class TopologyDescription {
   }
 
   /**
-   * Determines if the topology has a readable server available. See the table in the
-   * following section for behaviour rules.
-   *
-   * @param {ReadPreference} [readPreference] An optional read preference for determining if a readable server is present
-   * @return {Boolean} Whether there is a readable server in this topology
+   * Determines if the topology description has any known servers
    */
-  hasReadableServer(/* readPreference */) {
-    // To be implemented when server selection is implemented
+  get hasKnownServers() {
+    return Array.from(this.servers.values()).some(sd => sd.type !== ServerDescription.Unknown);
   }
 
   /**
-   * Determines if the topology has a writable server available. See the table in the
-   * following section for behaviour rules.
-   *
-   * @return {Boolean} Whether there is a writable server in this topology
+   * Determines if this topology description has a data-bearing server available.
    */
-  hasWritableServer() {
-    return this.hasReadableServer(ReadPreference.primary);
+  get hasDataBearingServers() {
+    return Array.from(this.servers.values()).some(sd => sd.isDataBearing);
   }
 
   /**

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -147,6 +147,10 @@ function eachAsync(arr, eachFn, callback) {
   }
 }
 
+function isUnifiedTopology(topology) {
+  return topology.description != null;
+}
+
 module.exports = {
   uuidV4,
   calculateDurationInMs,
@@ -156,5 +160,6 @@ module.exports = {
   retrieveKerberos,
   maxWireVersion,
   isPromiseLike,
-  eachAsync
+  eachAsync,
+  isUnifiedTopology
 };

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -216,9 +216,6 @@ if (SUPPORTS.ASYNC_ITERATOR) {
 
 // Map core cursor _next method so we can apply mapping
 Cursor.prototype._next = function() {
-  if (this._initImplicitSession) {
-    this._initImplicitSession();
-  }
   return CoreCursor.prototype.next.apply(this, arguments);
 };
 
@@ -226,11 +223,14 @@ for (let name in CoreCursor.prototype) {
   Cursor.prototype[name] = CoreCursor.prototype[name];
 }
 
-Cursor.prototype._initImplicitSession = function() {
+Cursor.prototype._initializeCursor = function(callback) {
+  // implicitly create a session if one has not been provided
   if (!this.s.explicitlyIgnoreSession && !this.s.session && this.s.topology.hasSessionSupport()) {
     this.s.session = this.s.topology.startSession({ owner: this });
     this.cursorState.session = this.s.session;
   }
+
+  CoreCursor.prototype._initializeCursor.apply(this, [callback]);
 };
 
 Cursor.prototype._endSession = function() {

--- a/lib/operations/execute_operation.js
+++ b/lib/operations/execute_operation.js
@@ -6,6 +6,7 @@ const OperationBase = require('./operation').OperationBase;
 const ReadPreference = require('../core').ReadPreference;
 const isRetryableError = require('../core/error').isRetryableError;
 const maxWireVersion = require('../core/utils').maxWireVersion;
+const isUnifiedTopology = require('../core/utils').isUnifiedTopology;
 
 /**
  * Executes the given operation with provided arguments.
@@ -30,7 +31,7 @@ function executeOperation(topology, operation, callback) {
   }
 
   if (
-    topology.description != null &&
+    isUnifiedTopology(topology) &&
     !operation.hasAspect(Aspect.SKIP_SESSION) &&
     topology.shouldCheckForSessionSupport()
   ) {

--- a/lib/operations/execute_operation.js
+++ b/lib/operations/execute_operation.js
@@ -6,7 +6,6 @@ const OperationBase = require('./operation').OperationBase;
 const ReadPreference = require('../core').ReadPreference;
 const isRetryableError = require('../core/error').isRetryableError;
 const maxWireVersion = require('../core/utils').maxWireVersion;
-const TopologyType = require('../core/sdam/topology_description').TopologyType;
 
 /**
  * Executes the given operation with provided arguments.
@@ -33,7 +32,7 @@ function executeOperation(topology, operation, callback) {
   if (
     topology.description != null &&
     !operation.hasAspect(Aspect.SKIP_SESSION) &&
-    shouldCheckForSessionSupport(topology)
+    topology.shouldCheckForSessionSupport()
   ) {
     // TODO: this is only supported for unified topology, the first part of this check
     //       should go away when we drop legacy topology types.
@@ -160,13 +159,6 @@ function executeWithServerSelection(topology, operation, callback) {
 
     operation.execute(server, callback);
   });
-}
-
-function shouldCheckForSessionSupport(topology) {
-  return (
-    (topology.description.type === TopologyType.Single && !topology.description.hasKnownServers) ||
-    !topology.description.hasDataBearingServers
-  );
 }
 
 module.exports = executeOperation;

--- a/lib/operations/execute_operation.js
+++ b/lib/operations/execute_operation.js
@@ -6,6 +6,7 @@ const OperationBase = require('./operation').OperationBase;
 const ReadPreference = require('../core').ReadPreference;
 const isRetryableError = require('../core/error').isRetryableError;
 const maxWireVersion = require('../core/utils').maxWireVersion;
+const TopologyType = require('../core/sdam/topology_description').TopologyType;
 
 /**
  * Executes the given operation with provided arguments.
@@ -27,6 +28,25 @@ function executeOperation(topology, operation, callback) {
 
   if (!(operation instanceof OperationBase)) {
     throw new TypeError('This method requires a valid operation instance');
+  }
+
+  if (
+    topology.description != null &&
+    !operation.hasAspect(Aspect.SKIP_SESSION) &&
+    shouldCheckForSessionSupport(topology)
+  ) {
+    // TODO: this is only supported for unified topology, the first part of this check
+    //       should go away when we drop legacy topology types.
+    topology.selectServer(ReadPreference.primaryPreferred, err => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      executeOperation(topology, operation, callback);
+    });
+
+    return;
   }
 
   const Promise = topology.s.promiseLibrary;
@@ -140,6 +160,13 @@ function executeWithServerSelection(topology, operation, callback) {
 
     operation.execute(server, callback);
   });
+}
+
+function shouldCheckForSessionSupport(topology) {
+  return (
+    (topology.description.type === TopologyType.Single && !topology.description.hasKnownServers) ||
+    !topology.description.hasDataBearingServers
+  );
 }
 
 module.exports = executeOperation;

--- a/lib/operations/explain.js
+++ b/lib/operations/explain.js
@@ -14,10 +14,6 @@ class ExplainOperation extends OperationBase {
 
   execute() {
     const cursor = this.cursor;
-
-    if (cursor._initImplicitSession) {
-      cursor._initImplicitSession();
-    }
     return CoreCursor.prototype.next.apply(cursor, arguments);
   }
 }


### PR DESCRIPTION
## Description
In accordance with the [drivers-sessions](https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst#how-to-check-whether-a-deployment-supports-sessions) and [SDAM](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#data-bearing-server-type) specs, we must perform server selection under certain circumstances in order to ensure we have accurate information about sessions support.

**What changed?**
- ability to filter by "data-bearing" and "known" servers was added to `TopologyDescription` and `ServerDescription`.
- `executeOperation` gains the ability to execute server selection prior to operation execution if `shouldCheckForSessionSupport` is true

**Are there any files to ignore?**
No.