### PR TITLE
NODE-1977: discard session on network error

### DIFF
--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -736,7 +736,7 @@ Cursor.prototype._initializeCursor = function(callback) {
       return;
     }
 
-    const commandOptions = Object.assign({}, cursor.options, cursor.cursorState);
+    const commandOptions = Object.assign({ session: cursor.cursorState.session }, cursor.options);
     server.command(cursor.ns, cursor.cmd, commandOptions, queryCallback);
   });
 };

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -736,7 +736,8 @@ Cursor.prototype._initializeCursor = function(callback) {
       return;
     }
 
-    server.command(cursor.ns, cursor.cmd, cursor.options, queryCallback);
+    const commandOptions = Object.assign({}, cursor.options, cursor.cursorState);
+    server.command(cursor.ns, cursor.cmd, commandOptions, queryCallback);
   });
 };
 

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -240,6 +240,12 @@ class Server extends EventEmitter {
     }
 
     wireProtocol.command(this, ns, cmd, options, (err, result) => {
+      if (err && err instanceof MongoNetworkError) {
+        if (options.session) {
+          options.session.serverSession.isDirty = true;
+        }
+      }
+
       if (err && isSDAMUnrecoverableError(err)) {
         this.emit('error', err);
       }
@@ -258,6 +264,12 @@ class Server extends EventEmitter {
    */
   query(ns, cmd, cursorState, options, callback) {
     wireProtocol.query(this, ns, cmd, cursorState, options, (err, result) => {
+      if (err && err instanceof MongoNetworkError) {
+        if (options.session) {
+          options.session.serverSession.isDirty = true;
+        }
+      }
+
       if (err && isSDAMUnrecoverableError(err)) {
         this.emit('error', err);
       }
@@ -276,6 +288,12 @@ class Server extends EventEmitter {
    */
   getMore(ns, cursorState, batchSize, options, callback) {
     wireProtocol.getMore(this, ns, cursorState, batchSize, options, (err, result) => {
+      if (err && err instanceof MongoNetworkError) {
+        if (options.session) {
+          options.session.serverSession.isDirty = true;
+        }
+      }
+
       if (err && isSDAMUnrecoverableError(err)) {
         this.emit('error', err);
       }
@@ -406,6 +424,12 @@ function executeWriteOperation(args, options, callback) {
   }
 
   return wireProtocol[op](server, ns, ops, options, (err, result) => {
+    if (err && err instanceof MongoNetworkError) {
+      if (options.session) {
+        options.session.serverSession.isDirty = true;
+      }
+    }
+
     if (err && isSDAMUnrecoverableError(err)) {
       server.emit('error', err);
     }

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -240,14 +240,14 @@ class Server extends EventEmitter {
     }
 
     wireProtocol.command(this, ns, cmd, options, (err, result) => {
-      if (err && err instanceof MongoNetworkError) {
-        if (options.session) {
+      if (err) {
+        if (options.session && err instanceof MongoNetworkError) {
           options.session.serverSession.isDirty = true;
         }
-      }
 
-      if (err && isSDAMUnrecoverableError(err)) {
-        this.emit('error', err);
+        if (isSDAMUnrecoverableError(err)) {
+          this.emit('error', err);
+        }
       }
 
       callback(err, result);
@@ -264,14 +264,14 @@ class Server extends EventEmitter {
    */
   query(ns, cmd, cursorState, options, callback) {
     wireProtocol.query(this, ns, cmd, cursorState, options, (err, result) => {
-      if (err && err instanceof MongoNetworkError) {
-        if (options.session) {
+      if (err) {
+        if (options.session && err instanceof MongoNetworkError) {
           options.session.serverSession.isDirty = true;
         }
-      }
 
-      if (err && isSDAMUnrecoverableError(err)) {
-        this.emit('error', err);
+        if (isSDAMUnrecoverableError(err)) {
+          this.emit('error', err);
+        }
       }
 
       callback(err, result);
@@ -288,14 +288,14 @@ class Server extends EventEmitter {
    */
   getMore(ns, cursorState, batchSize, options, callback) {
     wireProtocol.getMore(this, ns, cursorState, batchSize, options, (err, result) => {
-      if (err && err instanceof MongoNetworkError) {
-        if (options.session) {
+      if (err) {
+        if (options.session && err instanceof MongoNetworkError) {
           options.session.serverSession.isDirty = true;
         }
-      }
 
-      if (err && isSDAMUnrecoverableError(err)) {
-        this.emit('error', err);
+        if (isSDAMUnrecoverableError(err)) {
+          this.emit('error', err);
+        }
       }
 
       callback(err, result);
@@ -424,14 +424,14 @@ function executeWriteOperation(args, options, callback) {
   }
 
   return wireProtocol[op](server, ns, ops, options, (err, result) => {
-    if (err && err instanceof MongoNetworkError) {
-      if (options.session) {
+    if (err) {
+      if (options.session && err instanceof MongoNetworkError) {
         options.session.serverSession.isDirty = true;
       }
-    }
 
-    if (err && isSDAMUnrecoverableError(err)) {
-      server.emit('error', err);
+      if (isSDAMUnrecoverableError(err)) {
+        server.emit('error', err);
+      }
     }
 
     callback(err, result);

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -617,6 +617,21 @@ class ServerSessionPool {
   }
 }
 
+// TODO: this should be codified in command construction
+// @see https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#read-concern
+function commandSupportsReadConcern(command) {
+  return (
+    command.aggregate ||
+    command.count ||
+    command.distinct ||
+    command.find ||
+    command.mapReduce ||
+    command.parallelCollectionScan ||
+    command.geoNear ||
+    command.geoSearch
+  );
+}
+
 /**
  * Optionally decorate a command with sessions specific keys
  *
@@ -640,6 +655,7 @@ function applySession(session, command, options) {
   // first apply non-transaction-specific sessions data
   const inTransaction = session.inTransaction() || isTransactionCommand(command);
   const isRetryableWrite = options.willRetryWrite;
+  const shouldApplyReadConcern = commandSupportsReadConcern(command);
 
   if (serverSession.txnNumber && (isRetryableWrite || inTransaction)) {
     command.txnNumber = BSON.Long.fromNumber(serverSession.txnNumber);
@@ -653,7 +669,7 @@ function applySession(session, command, options) {
 
     // TODO: the following should only be applied to read operation per spec.
     // for causal consistency
-    if (session.supports.causalConsistency && session.operationTime) {
+    if (session.supports.causalConsistency && session.operationTime && shouldApplyReadConcern) {
       command.readConcern = command.readConcern || {};
       Object.assign(command.readConcern, { afterClusterTime: session.operationTime });
     }

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -527,6 +527,7 @@ class ServerSession {
     this.id = { id: new Binary(uuidV4(), Binary.SUBTYPE_UUID) };
     this.lastUse = Date.now();
     this.txnNumber = 0;
+    this.isDirty = false;
   }
 
   /**
@@ -603,8 +604,8 @@ class ServerSessionPool {
   release(session) {
     const sessionTimeoutMinutes = this.topology.logicalSessionTimeoutMinutes;
     while (this.sessions.length) {
-      const session = this.sessions[this.sessions.length - 1];
-      if (session.hasTimedOut(sessionTimeoutMinutes)) {
+      const pooledSession = this.sessions[this.sessions.length - 1];
+      if (pooledSession.hasTimedOut(sessionTimeoutMinutes)) {
         this.sessions.pop();
       } else {
         break;
@@ -612,6 +613,11 @@ class ServerSessionPool {
     }
 
     if (!session.hasTimedOut(sessionTimeoutMinutes)) {
+      if (session.isDirty) {
+        return;
+      }
+
+      // otherwise, readd this session to the session pool
       this.sessions.unshift(session);
     }
   }

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -625,17 +625,24 @@ class ServerSessionPool {
 
 // TODO: this should be codified in command construction
 // @see https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#read-concern
-function commandSupportsReadConcern(command) {
-  return (
+function commandSupportsReadConcern(command, options) {
+  if (
     command.aggregate ||
     command.count ||
     command.distinct ||
     command.find ||
-    command.mapReduce ||
     command.parallelCollectionScan ||
     command.geoNear ||
     command.geoSearch
-  );
+  ) {
+    return true;
+  }
+
+  if (command.mapReduce && options.out && (options.out.inline === 1 || options.out === 'inline')) {
+    return true;
+  }
+
+  return false;
 }
 
 /**

--- a/lib/core/wireprotocol/get_more.js
+++ b/lib/core/wireprotocol/get_more.js
@@ -80,6 +80,10 @@ function getMore(server, ns, cursorState, batchSize, options, callback) {
     options
   );
 
+  if (cursorState.session) {
+    commandOptions.session = cursorState.session;
+  }
+
   command(server, ns, getMoreCmd, commandOptions, queryCallback);
 }
 

--- a/lib/core/wireprotocol/query.js
+++ b/lib/core/wireprotocol/query.js
@@ -46,7 +46,14 @@ function query(server, ns, cmd, cursorState, options, callback) {
     options
   );
 
-  if (cmd.readPreference) commandOptions.readPreference = readPreference;
+  if (cmd.readPreference) {
+    commandOptions.readPreference = readPreference;
+  }
+
+  if (cursorState.session) {
+    commandOptions.session = cursorState.session;
+  }
+
   command(server, ns, findCmd, commandOptions, callback);
 }
 

--- a/test/functional/runner/context.js
+++ b/test/functional/runner/context.js
@@ -8,6 +8,7 @@ class TestRunnerContext {
     this.sharedClient = null;
     this.failPointClients = [];
     this.appliedFailPoints = [];
+    this.commandEvents = [];
   }
 
   runForAllClients(fn) {

--- a/test/functional/runner/index.js
+++ b/test/functional/runner/index.js
@@ -225,7 +225,7 @@ const IGNORED_COMMANDS = new Set(['ismaster']);
 
 let displayCommands = false;
 function runTestSuiteTest(configuration, spec, context) {
-  const commandEvents = [];
+  context.commandEvents = [];
   const clientOptions = translateClientOptions(
     Object.assign({ monitorCommands: true }, spec.clientOptions)
   );
@@ -247,7 +247,7 @@ function runTestSuiteTest(configuration, spec, context) {
         return;
       }
 
-      commandEvents.push(event);
+      context.commandEvents.push(event);
 
       // very useful for debugging
       if (displayCommands) {
@@ -294,7 +294,7 @@ function runTestSuiteTest(configuration, spec, context) {
         session0.endSession();
         session1.endSession();
 
-        return validateExpectations(commandEvents, spec, savedSessionData);
+        return validateExpectations(context.commandEvents, spec, savedSessionData);
       });
   });
 }

--- a/test/functional/runner/index.js
+++ b/test/functional/runner/index.js
@@ -396,15 +396,13 @@ function isTestRunnerCommand(context, commandName) {
 
   let methods = new Set();
   let object = testRunnerContext;
-  do {
-    if (object === Object.prototype) {
-      break;
-    }
-
+  while (object !== Object.prototype) {
     Object.getOwnPropertyNames(object)
       .filter(prop => typeof object[prop] === 'function' && prop !== 'constructor')
       .map(prop => methods.add(prop));
-  } while ((object = Object.getPrototypeOf(object)));
+
+    object = Object.getPrototypeOf(object);
+  }
 
   return methods.has(commandName);
 }

--- a/test/functional/sessions_tests.js
+++ b/test/functional/sessions_tests.js
@@ -173,17 +173,16 @@ describe('Sessions', function() {
     const testContext = new SessionSpecTestContext();
     const testSuites = gatherTestSuites(path.join(__dirname, 'spec', 'sessions'));
 
-    let shouldRunTests = false;
     after(() => testContext.teardown());
     before(function() {
-      shouldRunTests = this.configuration.usingUnifiedTopology();
+      if (!this.configuration.usingUnifiedTopology()) {
+        this.test.parent.pending = true; // https://github.com/mochajs/mocha/issues/2683
+        this.skip();
+        return;
+      }
+
       return testContext.setup(this.configuration);
     });
-
-    if (!shouldRunTests) {
-      it.skip('sessions spec tests only run against a unified topology');
-      return;
-    }
 
     generateTopologyTests(testSuites, testContext);
   });

--- a/test/functional/spec/sessions/README.rst
+++ b/test/functional/spec/sessions/README.rst
@@ -1,0 +1,84 @@
+====================
+Driver Session Tests
+====================
+
+.. contents::
+
+----
+
+Introduction
+============
+
+The YAML and JSON files in this directory are platform-independent tests that
+drivers can use to prove their conformance to the Driver Sessions Spec. They are
+designed with the intention of sharing most test-runner code with the
+Transactions spec tests.
+
+Several prose tests, which are not easily expressed in YAML, are also presented
+in the Driver Sessions Spec. Those tests will need to be manually implemented
+by each driver.
+
+Test Format
+===========
+
+The same as the `Transactions Spec Test format
+<../../transactions/tests/README.rst#test-format>`_.
+
+Special Test Operations
+```````````````````````
+
+Certain operations that appear in the "operations" array do not correspond to
+API methods but instead represent special test operations. Such operations are
+defined on the "testRunner" object and are documented in the
+`Transactions Spec Test
+<../../transactions/tests/README.rst#special-test-operations>`_.
+Additional, session test specific operations are documented here:
+
+assertDifferentLsidOnLastTwoCommands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The "assertDifferentLsidOnLastTwoCommands" operation instructs the test runner
+to assert that the last two command started events from the test's MongoClient
+have different "lsid" fields. This assertion is used to ensure that dirty
+server sessions are discarded from the pool::
+
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+
+assertSameLsidOnLastTwoCommands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The "assertSameLsidOnLastTwoCommands" operation instructs the test runner
+to assert that the last two command started events from the test's MongoClient
+have the same "lsid" field. This assertion is used to ensure that non-dirty
+server sessions are not discarded from the pool::
+
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+
+assertSessionDirty
+~~~~~~~~~~~~~~~~~~
+
+The "assertSessionDirty" operation instructs the test runner to assert that
+the given session is marked dirty::
+
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: session0
+
+assertSessionNotDirty
+~~~~~~~~~~~~~~~~~~~~~
+
+The "assertSessionNotDirty" operation instructs the test runner to assert that
+the given session is *not* marked dirty::
+
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: session0
+
+Changelog
+=========
+
+:2019-05-15: Initial version.

--- a/test/functional/spec/sessions/dirty-session-errors.json
+++ b/test/functional/spec/sessions/dirty-session-errors.json
@@ -1,0 +1,523 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "session-tests",
+  "collection_name": "test",
+  "data": [
+    {
+      "_id": 1
+    }
+  ],
+  "tests": [
+    {
+      "description": "Clean explicit session is not discarded",
+      "operations": [
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0"
+            },
+            "command_name": "insert",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "filter": {
+                "_id": -1
+              },
+              "lsid": "session0"
+            },
+            "command_name": "find",
+            "database_name": "session-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Clean implicit session is not discarded",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "filter": {
+                "_id": -1
+              }
+            },
+            "command_name": "find",
+            "database_name": "session-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Dirty explicit session is discarded",
+      "clientOptions": {
+        "retryWrites": true
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              }
+            },
+            "command_name": "insert",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              }
+            },
+            "command_name": "insert",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              }
+            },
+            "command_name": "insert",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "filter": {
+                "_id": -1
+              }
+            },
+            "command_name": "find",
+            "database_name": "session-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Dirty implicit session is discarded (write)",
+      "clientOptions": {
+        "retryWrites": true
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "txnNumber": {
+                "$numberLong": "1"
+              }
+            },
+            "command_name": "insert",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "txnNumber": {
+                "$numberLong": "1"
+              }
+            },
+            "command_name": "insert",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "filter": {
+                "_id": -1
+              }
+            },
+            "command_name": "find",
+            "database_name": "session-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Dirty implicit session is discarded (read)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ]
+          },
+          "error": true
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/sessions/dirty-session-errors.yml
+++ b/test/functional/spec/sessions/dirty-session-errors.yml
@@ -1,0 +1,272 @@
+runOn:
+  - minServerVersion: "4.0"
+    topology: ["replicaset"]
+  - minServerVersion: "4.1.8"
+    topology: ["sharded"]
+
+database_name: &database_name "session-tests"
+collection_name: &collection_name "test"
+
+data:
+  - {_id: 1}
+
+tests:
+  - description: Clean explicit session is not discarded
+
+    operations:
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - &insert_with_explicit_session
+        name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document: {_id: 2}
+        result:
+          insertedId: 2
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - name: endSession
+        object: session0
+      - &find_with_implicit_session
+        name: find
+        object: collection
+        arguments:
+          filter: {_id: -1}
+        result: []
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 2}
+            ordered: true
+            lsid: session0
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: {_id: -1}
+            lsid: session0
+          command_name: find
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}
+
+  - description: Clean implicit session is not discarded
+
+    operations:
+      - &insert_with_implicit_session
+        name: insertOne
+        object: collection
+        arguments:
+          document: {_id: 2}
+        result:
+          insertedId: 2
+      - *find_with_implicit_session
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 2}
+            ordered: true
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: {_id: -1}
+          command_name: find
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}
+
+  - description: Dirty explicit session is discarded
+
+    clientOptions:
+      retryWrites: true
+
+    failPoint:
+        configureFailPoint: failCommand
+        mode: { times: 1 }
+        data:
+            failCommands: ["insert"]
+            closeConnection: true
+
+    operations:
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - *insert_with_explicit_session
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document: {_id: 3}
+        result:
+          insertedId: 3
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - name: endSession
+        object: session0
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 2}
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 2}
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 3}
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "2"
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: {_id: -1}
+          command_name: find
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}
+          - {_id: 3}
+
+  - description: Dirty implicit session is discarded (write)
+
+    clientOptions:
+      retryWrites: true
+
+    failPoint:
+        configureFailPoint: failCommand
+        mode: { times: 1 }
+        data:
+            failCommands: ["insert"]
+            closeConnection: true
+
+    operations:
+      - *insert_with_implicit_session
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 2}
+            ordered: true
+            txnNumber:
+              $numberLong: "1"
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 2}
+            ordered: true
+            txnNumber:
+              $numberLong: "1"
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: {_id: -1}
+          command_name: find
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}
+
+  - description: Dirty implicit session is discarded (read)
+
+    # Enable the failpoint with times:2 so that this test can pass with or
+    # without retryable reads.
+    failPoint:
+        configureFailPoint: failCommand
+        mode: { times: 2 }
+        data:
+            failCommands: ["aggregate"]
+            closeConnection: true
+
+    operations:
+      - name: aggregate
+        object: collection
+        arguments:
+          pipeline:
+            - $project:
+                _id: 1
+        error: true
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+
+    # Don't include expectations because a driver may or may not retry the
+    # aggregate depending on if they have implemented the retryable reads spec.
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}


### PR DESCRIPTION
## Description
**NOTE:** this depends on #2072, so there is duplicate code in here. Please review that PR first, and re-review once it has been merged.

On the surface this PR does what the ticket asks: marks sessions as dirty on a network error, and evicts them from the `ServerSessionPool` upon operation execution. More importantly, this introduces YAML tests around session behavior and reintroduces support for `lsid` on read operations. We stopped sending sessions data on read operations during the wire protocol refactor, and this corrects that.

**What changed?**
I made _very_ incremental commits on this one, so you should be able to clearly follow the changes through individual commits. Mostly what's happening here is:
- each of the command handlers for wire protocol methods has gained an ability to set `isDirty` on an optionally provided session
- the `acquire`/`release` logic of `ServerSessionPool` is slightly modified to pay attention to this flag
- a spec test runner was added which reuses the unified runner, adding a `TestRunnerContext` subclass which provides custom assertion methods required by the test runner

**Are there any files to ignore?**
The actual JSON and YAML tests, these are just synced from the specifications repo