### PR TITLE
fix(MongoClient): allow Object.prototype items as db names

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -148,7 +148,7 @@ function MongoClient(url, options) {
     url: url,
     options: options || {},
     promiseLibrary: null,
-    dbCache: {},
+    dbCache: new Map(),
     sessions: [],
     writeConcern: WriteConcern.fromOptions(options)
   };
@@ -243,8 +243,8 @@ MongoClient.prototype.db = function(dbName, options) {
   const finalOptions = Object.assign({}, this.s.options, options);
 
   // Do we have the db in the cache already
-  if (this.s.dbCache[dbName] && finalOptions.returnNonCachedInstance !== true) {
-    return this.s.dbCache[dbName];
+  if (this.s.dbCache.has(dbName) && finalOptions.returnNonCachedInstance !== true) {
+    return this.s.dbCache.get(dbName);
   }
 
   // Add promiseLibrary
@@ -259,7 +259,7 @@ MongoClient.prototype.db = function(dbName, options) {
   const db = new Db(dbName, this.topology, finalOptions);
 
   // Add the db to the cache
-  this.s.dbCache[dbName] = db;
+  this.s.dbCache.set(dbName, db);
   // Return the database
   return db;
 };

--- a/lib/operations/close.js
+++ b/lib/operations/close.js
@@ -16,8 +16,8 @@ class CloseOperation extends OperationBase {
     const force = this.force;
     const completeClose = err => {
       client.emit('close', client);
-      for (const name in client.s.dbCache) {
-        client.s.dbCache[name].emit('close', client);
+      for (const item of client.s.dbCache) {
+        item[1].emit('close', client);
       }
 
       client.removeAllListeners('close');

--- a/test/functional/mongo_client_tests.js
+++ b/test/functional/mongo_client_tests.js
@@ -3,6 +3,7 @@
 var f = require('util').format;
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
+const Db = require('../../lib/db');
 const expect = require('chai').expect;
 
 describe('MongoClient', function() {
@@ -825,5 +826,25 @@ describe('MongoClient', function() {
         });
       });
     }
+  });
+
+  it('should be able to access a database named "constructor"', function() {
+    const client = this.configuration.newClient();
+    let err;
+    return client
+      .connect()
+      .then(() => {
+        const db = client.db('constructor');
+        expect(db).to.not.be.a('function');
+        expect(db).to.be.an.instanceOf(Db);
+      })
+      .catch(_err => (err = _err))
+      .then(() => client.close())
+      .catch(() => {})
+      .then(() => {
+        if (err) {
+          throw err;
+        }
+      });
   });
 });


### PR DESCRIPTION
Switched the internal dbCache from a plain object to
a Map.

Fixes NODE-2060

## Description

**What changed?**

Replaced `MongoClient.s.dbCache` with a Map, allowing for cached db's with names like `constructor`