### PR TITLE
fix(OpMsg): cap requestIds at 0x7fffffff

### DIFF
--- a/lib/core/connection/msg.js
+++ b/lib/core/connection/msg.js
@@ -130,7 +130,8 @@ class Msg {
 }
 
 Msg.getRequestId = function() {
-  return ++_requestId;
+  _requestId = (_requestId + 1) & 0x7fffffff;
+  return _requestId;
 };
 
 class BinMsg {


### PR DESCRIPTION
Since OpMsg uses buffer write methods, these methods can throw if the buffer
attempts to write a number to large for the space. We now cap the requestId
at 0x7fffffff and loop back around to 0

Fixes NODE-2067

## Description

**What changed?**

We now mask the OP_MSG `_requestId` with `0x7fffffff` to prevent it from exceeding signed int32 size.
