### PR TITLE
NODE-1744: retryable listIndexes

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -22,6 +22,7 @@ const WriteConcern = require('./write_concern');
 const ReadConcern = require('./read_concern');
 const MongoDBNamespace = require('./utils').MongoDBNamespace;
 const AggregationCursor = require('./aggregation_cursor');
+const CommandCursor = require('./command_cursor');
 
 // Operations
 const checkForAtomicOperators = require('./operations/collection_ops').checkForAtomicOperators;
@@ -1255,9 +1256,13 @@ Collection.prototype.reIndex = function(options, callback) {
  * @return {CommandCursor}
  */
 Collection.prototype.listIndexes = function(options) {
-  const listIndexesOperation = new ListIndexesOperation(this, options);
+  const cursor = new CommandCursor(
+    this.s.topology,
+    new ListIndexesOperation(this, options),
+    options
+  );
 
-  return listIndexesOperation.execute();
+  return cursor;
 };
 
 /**

--- a/lib/command_cursor.js
+++ b/lib/command_cursor.js
@@ -62,6 +62,13 @@ var CommandCursor = function(topology, ns, cmd, options) {
   const bson = topology.s.bson;
   const topologyOptions = topology.s.options;
 
+  if (typeof ns !== 'string') {
+    this.operation = ns;
+    ns = this.operation.ns.toString();
+    options = this.operation.options;
+    cmd = {};
+  }
+
   // MaxTimeMS
   var maxTimeMS = null;
 

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -345,8 +345,14 @@ class Topology extends EventEmitter {
       if (typeof selector !== 'function') {
         options = selector;
 
-        translateReadPreference(options);
-        const readPreference = options.readPreference || ReadPreference.primary;
+        let readPreference;
+        if (selector instanceof ReadPreference) {
+          readPreference = selector;
+        } else {
+          translateReadPreference(options);
+          readPreference = options.readPreference || ReadPreference.primary;
+        }
+
         selector = readPreferenceServerSelector(readPreference);
       } else {
         options = {};

--- a/lib/core/topologies/mongos.js
+++ b/lib/core/topologies/mongos.js
@@ -1130,6 +1130,11 @@ Mongos.prototype.selectServer = function(selector, options, callback) {
   options = options || {};
 
   const server = pickProxy(this, options.session);
+  if (server == null) {
+    callback(new MongoError('server selection failed'));
+    return;
+  }
+
   if (this.s.debug) this.emit('pickedServer', null, server);
   callback(null, server);
 };

--- a/lib/core/topologies/replset.js
+++ b/lib/core/topologies/replset.js
@@ -1111,6 +1111,16 @@ ReplSet.prototype.selectServer = function(selector, options, callback) {
   }
 
   const server = this.s.replicaSetState.pickServer(readPreference);
+  if (server == null) {
+    callback(new MongoError('server selection failed'));
+    return;
+  }
+
+  if (!(server instanceof Server)) {
+    callback(server, null);
+    return;
+  }
+
   if (this.s.debug) this.emit('pickedServer', options.readPreference, server);
   callback(null, server);
 };

--- a/lib/core/topologies/replset.js
+++ b/lib/core/topologies/replset.js
@@ -19,6 +19,7 @@ const isRetryableWritesSupported = require('./shared').isRetryableWritesSupporte
 const relayEvents = require('../utils').relayEvents;
 const isRetryableError = require('../error').isRetryableError;
 const BSON = retrieveBSON();
+const calculateDurationInMs = require('../utils').calculateDurationInMs;
 
 //
 // States
@@ -1110,19 +1111,36 @@ ReplSet.prototype.selectServer = function(selector, options, callback) {
     readPreference = options.readPreference || ReadPreference.primary;
   }
 
-  const server = this.s.replicaSetState.pickServer(readPreference);
-  if (server == null) {
-    callback(new MongoError('server selection failed'));
-    return;
-  }
+  let lastError;
+  const start = process.hrtime();
+  const _selectServer = () => {
+    if (calculateDurationInMs(start) >= 10000) {
+      if (lastError != null) {
+        callback(lastError, null);
+      } else {
+        callback(new MongoError('Server selection timed out'));
+      }
 
-  if (!(server instanceof Server)) {
-    callback(server, null);
-    return;
-  }
+      return;
+    }
 
-  if (this.s.debug) this.emit('pickedServer', options.readPreference, server);
-  callback(null, server);
+    const server = this.s.replicaSetState.pickServer(readPreference);
+    if (server == null) {
+      setTimeout(_selectServer, 1000);
+      return;
+    }
+
+    if (!(server instanceof Server)) {
+      lastError = server;
+      setTimeout(_selectServer, 1000);
+      return;
+    }
+
+    if (this.s.debug) this.emit('pickedServer', options.readPreference, server);
+    callback(null, server);
+  };
+
+  _selectServer();
 };
 
 /**

--- a/lib/core/topologies/replset.js
+++ b/lib/core/topologies/replset.js
@@ -1089,9 +1089,8 @@ ReplSet.prototype.isDestroyed = function() {
   return this.state === DESTROYED;
 };
 
-// hard coded `serverSelectionTimeoutMS` for legacy topology
-const SERVER_SELECTION_TIMEOUT_MS = 10000;
-
+const SERVER_SELECTION_TIMEOUT_MS = 10000; // hardcoded `serverSelectionTimeoutMS` for legacy topology
+const SERVER_SELECTION_INTERVAL_MS = 1000; // time to wait between selection attempts
 /**
  * Selects a server
  *
@@ -1129,13 +1128,13 @@ ReplSet.prototype.selectServer = function(selector, options, callback) {
 
     const server = this.s.replicaSetState.pickServer(readPreference);
     if (server == null) {
-      setTimeout(_selectServer, 1000);
+      setTimeout(_selectServer, SERVER_SELECTION_INTERVAL_MS);
       return;
     }
 
     if (!(server instanceof Server)) {
       lastError = server;
-      setTimeout(_selectServer, 1000);
+      setTimeout(_selectServer, SERVER_SELECTION_INTERVAL_MS);
       return;
     }
 

--- a/lib/core/topologies/replset.js
+++ b/lib/core/topologies/replset.js
@@ -1089,6 +1089,9 @@ ReplSet.prototype.isDestroyed = function() {
   return this.state === DESTROYED;
 };
 
+// hard coded `serverSelectionTimeoutMS` for legacy topology
+const SERVER_SELECTION_TIMEOUT_MS = 10000;
+
 /**
  * Selects a server
  *
@@ -1114,7 +1117,7 @@ ReplSet.prototype.selectServer = function(selector, options, callback) {
   let lastError;
   const start = process.hrtime();
   const _selectServer = () => {
-    if (calculateDurationInMs(start) >= 10000) {
+    if (calculateDurationInMs(start) >= SERVER_SELECTION_TIMEOUT_MS) {
       if (lastError != null) {
         callback(lastError, null);
       } else {

--- a/lib/core/topologies/replset.js
+++ b/lib/core/topologies/replset.js
@@ -1100,11 +1100,17 @@ ReplSet.prototype.isDestroyed = function() {
 ReplSet.prototype.selectServer = function(selector, options, callback) {
   if (typeof selector === 'function' && typeof callback === 'undefined')
     (callback = selector), (selector = undefined), (options = {});
-  if (typeof options === 'function')
-    (callback = options), (options = selector), (selector = undefined);
+  if (typeof options === 'function') (callback = options), (options = selector);
   options = options || {};
 
-  const server = this.s.replicaSetState.pickServer(options.readPreference);
+  let readPreference;
+  if (selector instanceof ReadPreference) {
+    readPreference = selector;
+  } else {
+    readPreference = options.readPreference || ReadPreference.primary;
+  }
+
+  const server = this.s.replicaSetState.pickServer(readPreference);
   if (this.s.debug) this.emit('pickedServer', options.readPreference, server);
   callback(null, server);
 };

--- a/lib/operations/command_v2.js
+++ b/lib/operations/command_v2.js
@@ -15,6 +15,10 @@ class CommandOperationV2 extends OperationBase {
     this.writeConcern = resolveWriteConcern(parent, this.options);
     this.explain = false;
 
+    // TODO: A lot of our code depends on having the read preference in the options. This should
+    //       go away, but also requires massive test rewrites.
+    this.options.readPreference = this.readPreference;
+
     // TODO(NODE-2056): make logger another "inheritable" property
     if (parent.s.logger) {
       this.logger = parent.s.logger;

--- a/lib/operations/list_indexes.js
+++ b/lib/operations/list_indexes.js
@@ -6,7 +6,6 @@ const defineAspects = require('./operation').defineAspects;
 const maxWireVersion = require('../core/utils').maxWireVersion;
 
 const LIST_INDEXES_WIRE_VERSION = 3;
-const SUPPORTS_FIND_COMMAND = 4;
 
 class ListIndexesOperation extends CommandOperationV2 {
   constructor(collection, options) {
@@ -18,31 +17,20 @@ class ListIndexesOperation extends CommandOperationV2 {
 
   execute(server, callback) {
     const serverWireVersion = maxWireVersion(server);
-    if (serverWireVersion >= LIST_INDEXES_WIRE_VERSION) {
-      const cursor = this.options.batchSize ? { batchSize: this.options.batchSize } : {};
-      super.executeCommand(
-        server,
-        { listIndexes: this.collectionNamespace.collection, cursor },
-        callback
-      );
+    if (serverWireVersion < LIST_INDEXES_WIRE_VERSION) {
+      const systemIndexesNS = this.collectionNamespace.withCollection('system.indexes').toString();
+      const collectionNS = this.collectionNamespace.toString();
 
+      server.query(systemIndexesNS, { query: { ns: collectionNS } }, {}, this.options, callback);
       return;
     }
 
-    const systemIndexesNS = this.collectionNamespace.withCollection('system.indexes').toString();
-    const collectionNS = this.collectionNamespace.toString();
-
-    if (serverWireVersion >= SUPPORTS_FIND_COMMAND) {
-      super.executeCommand(
-        server,
-        { find: systemIndexesNS, query: { ns: collectionNS } },
-        callback
-      );
-      return;
-    }
-
-    // fall back to running a query
-    server.query(systemIndexesNS, { query: { ns: collectionNS } }, {}, this.options, callback);
+    const cursor = this.options.batchSize ? { batchSize: this.options.batchSize } : {};
+    super.executeCommand(
+      server,
+      { listIndexes: this.collectionNamespace.collection, cursor },
+      callback
+    );
   }
 }
 

--- a/lib/operations/list_indexes.js
+++ b/lib/operations/list_indexes.js
@@ -6,6 +6,7 @@ const defineAspects = require('./operation').defineAspects;
 const maxWireVersion = require('../core/utils').maxWireVersion;
 
 const LIST_INDEXES_WIRE_VERSION = 3;
+const SUPPORTS_FIND_COMMAND = 4;
 
 class ListIndexesOperation extends CommandOperationV2 {
   constructor(collection, options) {
@@ -16,7 +17,8 @@ class ListIndexesOperation extends CommandOperationV2 {
   }
 
   execute(server, callback) {
-    if (maxWireVersion(server) >= LIST_INDEXES_WIRE_VERSION) {
+    const serverWireVersion = maxWireVersion(server);
+    if (serverWireVersion >= LIST_INDEXES_WIRE_VERSION) {
       const cursor = this.options.batchSize ? { batchSize: this.options.batchSize } : {};
       super.executeCommand(
         server,
@@ -29,7 +31,18 @@ class ListIndexesOperation extends CommandOperationV2 {
 
     const systemIndexesNS = this.collectionNamespace.withCollection('system.indexes').toString();
     const collectionNS = this.collectionNamespace.toString();
-    super.executeCommand(server, { find: systemIndexesNS, query: { ns: collectionNS } }, callback);
+
+    if (serverWireVersion >= SUPPORTS_FIND_COMMAND) {
+      super.executeCommand(
+        server,
+        { find: systemIndexesNS, query: { ns: collectionNS } },
+        callback
+      );
+      return;
+    }
+
+    // fall back to running a query
+    server.query(systemIndexesNS, { query: { ns: collectionNS } }, {}, this.options, callback);
   }
 }
 

--- a/lib/operations/list_indexes.js
+++ b/lib/operations/list_indexes.js
@@ -1,66 +1,42 @@
 'use strict';
 
-const OperationBase = require('./operation').OperationBase;
-const CommandCursor = require('../command_cursor');
-const MongoError = require('../core').MongoError;
-const resolveReadPreference = require('../utils').resolveReadPreference;
+const CommandOperationV2 = require('./command_v2');
+const Aspect = require('./operation').Aspect;
+const defineAspects = require('./operation').defineAspects;
+const maxWireVersion = require('../core/utils').maxWireVersion;
 
-class ListIndexesOperation extends OperationBase {
+const LIST_INDEXES_WIRE_VERSION = 3;
+
+class ListIndexesOperation extends CommandOperationV2 {
   constructor(collection, options) {
-    super(options);
+    super(collection, options);
+    this.options.full = true;
 
-    this.collection = collection;
+    this.collectionNamespace = collection.s.namespace;
   }
 
-  execute() {
-    const coll = this.collection;
-    let options = this.options;
-
-    options = options || {};
-    // Clone the options
-    options = Object.assign({}, options);
-    // Determine the read preference in the options.
-    options.readPreference = resolveReadPreference(coll, options);
-    // Set the CommandCursor constructor
-    options.cursorFactory = CommandCursor;
-    // Set the promiseLibrary
-    options.promiseLibrary = coll.s.promiseLibrary;
-
-    if (!coll.s.topology.capabilities()) {
-      throw new MongoError('cannot connect to server');
-    }
-
-    // Cursor options
-    let cursor = options.batchSize ? { batchSize: options.batchSize } : {};
-
-    // We have a list collections command
-    if (coll.s.topology.capabilities().hasListIndexesCommand) {
-      // Build the command
-      const command = { listIndexes: coll.collectionName, cursor: cursor };
-      // Execute the cursor
-      cursor = coll.s.topology.cursor(
-        coll.s.namespace.withCollection('$cmd').toString(),
-        command,
-        options
+  execute(server, callback) {
+    if (maxWireVersion(server) >= LIST_INDEXES_WIRE_VERSION) {
+      const cursor = this.options.batchSize ? { batchSize: this.options.batchSize } : {};
+      super.executeCommand(
+        server,
+        { listIndexes: this.collectionNamespace.collection, cursor },
+        callback
       );
-      // Do we have a readPreference, apply it
-      if (options.readPreference) cursor.setReadPreference(options.readPreference);
-      // Return the cursor
-      return cursor;
+
+      return;
     }
 
-    // Get the namespace
-    const namespace = coll.s.namespace.withCollection('system.indexes');
-    const ns = namespace.toString();
-    // Get the query
-    cursor = coll.s.topology.cursor(ns, { find: ns, query: { ns: coll.namespace } }, options);
-    // Do we have a readPreference, apply it
-    if (options.readPreference) cursor.setReadPreference(options.readPreference);
-    // Set the passed in batch size if one was provided
-    if (options.batchSize) cursor = cursor.batchSize(options.batchSize);
-    // Return the cursor
-    return cursor;
+    const systemIndexesNS = this.collectionNamespace.withCollection('system.indexes').toString();
+    const collectionNS = this.collectionNamespace.toString();
+    super.executeCommand(server, { find: systemIndexesNS, query: { ns: collectionNS } }, callback);
   }
 }
+
+defineAspects(ListIndexesOperation, [
+  Aspect.READ_OPERATION,
+  Aspect.RETRYABLE,
+  Aspect.EXECUTE_WITH_SELECTION
+]);
 
 module.exports = ListIndexesOperation;

--- a/test/functional/apm_tests.js
+++ b/test/functional/apm_tests.js
@@ -252,7 +252,7 @@ describe('APM', function() {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.0.0' } },
 
     // The actual test we wish to run
-    test: function(done) {
+    test: function() {
       const self = this;
       const ReadPreference = self.configuration.require.ReadPreference;
       const started = [];
@@ -266,10 +266,10 @@ describe('APM', function() {
       client.on('commandStarted', filterForCommands(desiredEvents, started));
       client.on('commandSucceeded', filterForCommands(desiredEvents, succeeded));
 
-      client.connect().then(() => {
+      return client.connect().then(() => {
         const db = client.db(self.configuration.db);
 
-        db
+        return db
           .collection('apm_test_list_collections')
           .insertOne({ a: 1 }, self.configuration.writeConcernMax())
           .then(r => {
@@ -291,8 +291,7 @@ describe('APM', function() {
 
             // Ensure command was not sent to the primary
             expect(started[0].connectionId).to.not.equal(started[1].connectionId);
-            client.close();
-            done();
+            return client.close();
           });
       });
     }

--- a/test/functional/retryable_reads_tests.js
+++ b/test/functional/retryable_reads_tests.js
@@ -18,7 +18,8 @@ describe('Retryable Reads', function() {
     return (
       spec.description.match(/distinct/i) ||
       spec.description.match(/aggregate/i) ||
-      spec.description.match(/countDocuments/i)
+      spec.description.match(/countDocuments/i) ||
+      spec.description.match(/listIndexes/i)
     );
   });
 });

--- a/test/functional/runner/index.js
+++ b/test/functional/runner/index.js
@@ -462,6 +462,8 @@ function resolveOperationArgs(operationName, operationArgs, context) {
   return result;
 }
 
+const CURSOR_COMMANDS = new Set(['find', 'aggregate', 'listIndexes']);
+
 /**
  *
  * @param {Object} operation the operation definition from the spec test
@@ -549,7 +551,8 @@ function testOperation(operation, obj, context, options) {
   }
 
   let opPromise;
-  if (operationName === 'find' || operationName === 'aggregate') {
+
+  if (CURSOR_COMMANDS.has(operationName)) {
     // `find` creates a cursor, so we need to call `toArray` on it
     const cursor = obj[operationName].apply(obj, args);
     opPromise = cursor.toArray();


### PR DESCRIPTION
## Description
Enables retryability for the `listIndexes` operation

**What changed?**
- `ListIndexesOperation` was refactored to exclude notions of cursors
- The `Collection.listIndexes` now return a cursor constructed with an operation
- The unified `Topology` and legacy `ReplSet` topology classes gained an ability to respect a passed in read preference to `selectServer`

**Are there any files to ignore?**
No