### PR TITLE
NODE-1744: retryable count commands

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -26,7 +26,6 @@ const CommandCursor = require('./command_cursor');
 
 // Operations
 const checkForAtomicOperators = require('./operations/collection_ops').checkForAtomicOperators;
-const count = require('./operations/collection_ops').count;
 const ensureIndex = require('./operations/collection_ops').ensureIndex;
 const findAndModify = require('./operations/collection_ops').findAndModify;
 const findAndRemove = require('./operations/collection_ops').findAndRemove;
@@ -1369,9 +1368,16 @@ Collection.prototype.count = deprecate(function(query, options, callback) {
   query = args.length ? args.shift() || {} : {};
   options = args.length ? args.shift() || {} : {};
 
-  return executeLegacyOperation(this.s.topology, count, [this, query, options, callback]);
+  if (typeof options === 'function') (callback = options), (options = {});
+  options = options || {};
+
+  return executeOperation(
+    this.s.topology,
+    new EstimatedDocumentCountOperation(this, query, options),
+    callback
+  );
 }, 'collection.count is deprecated, and will be removed in a future version.' +
-  ' Use collection.countDocuments or collection.estimatedDocumentCount instead');
+  ' Use Collection.countDocuments or Collection.estimatedDocumentCount instead');
 
 /**
  * Gets an estimate of the count of documents in a collection using collection metadata.

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -736,5 +736,6 @@ module.exports = {
   ServerSessionPool,
   TxnState,
   applySession,
-  updateSessionFromResponse
+  updateSessionFromResponse,
+  commandSupportsReadConcern
 };

--- a/lib/operations/aggregate.js
+++ b/lib/operations/aggregate.js
@@ -61,25 +61,15 @@ class AggregateOperation extends CommandOperationV2 {
   execute(server, callback) {
     const options = this.options;
     const serverWireVersion = maxWireVersion(server);
-    const inTransaction = this.session && this.session.inTransaction();
-
     const command = { aggregate: this.target, pipeline: this.pipeline };
 
-    if (
-      this.readConcern &&
-      (!this.hasWriteStage || serverWireVersion >= MIN_WIRE_VERSION_$OUT_READ_CONCERN_SUPPORT) &&
-      !inTransaction
-    ) {
-      Object.assign(command, { readConcern: this.readConcern });
+    if (this.hasWriteStage && serverWireVersion < MIN_WIRE_VERSION_$OUT_READ_CONCERN_SUPPORT) {
+      this.readConcern = null;
     }
 
     if (serverWireVersion >= 5) {
       if (this.hasWriteStage && this.writeConcern) {
         Object.assign(command, { writeConcern: this.writeConcern });
-      }
-
-      if (options.collation && typeof options.collation === 'object') {
-        Object.assign(command, { collation: options.collation });
       }
     }
 
@@ -91,10 +81,6 @@ class AggregateOperation extends CommandOperationV2 {
       command.allowDiskUse = options.allowDiskUse;
     }
 
-    if (typeof options.maxTimeMS === 'number') {
-      command.maxTimeMS = options.maxTimeMS;
-    }
-
     if (options.hint) {
       command.hint = options.hint;
     }
@@ -102,10 +88,6 @@ class AggregateOperation extends CommandOperationV2 {
     if (options.explain) {
       options.full = false;
       command.explain = options.explain;
-    }
-
-    if (typeof options.comment === 'string') {
-      command.comment = options.comment;
     }
 
     command.cursor = options.cursor || {};

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -173,80 +173,6 @@ function checkForAtomicOperators(update) {
 }
 
 /**
- * Count the number of documents in the collection that match the query.
- *
- * @method
- * @param {Collection} a Collection instance.
- * @param {object} query The query for the count.
- * @param {object} [options] Optional settings. See Collection.prototype.count for a list of options.
- * @param {Collection~countCallback} [callback] The command result callback
- */
-function count(coll, query, options, callback) {
-  if (typeof options === 'function') (callback = options), (options = {});
-  options = Object.assign({}, options);
-  options.collectionName = coll.collectionName;
-
-  options.readPreference = resolveReadPreference(coll, options);
-
-  let cmd;
-  try {
-    cmd = buildCountCommand(coll, query, options);
-  } catch (err) {
-    return callback(err);
-  }
-
-  executeCommand(coll.s.db, cmd, options, (err, result) => {
-    if (err) return handleCallback(callback, err);
-    handleCallback(callback, null, result.n);
-  });
-}
-
-/**
- * Build the count command.
- *
- * @method
- * @param {collectionOrCursor} an instance of a collection or cursor
- * @param {object} query The query for the count.
- * @param {object} [options] Optional settings. See Collection.prototype.count and Cursor.prototype.count for a list of options.
- */
-function buildCountCommand(collectionOrCursor, query, options) {
-  const skip = options.skip;
-  const limit = options.limit;
-  let hint = options.hint;
-  const maxTimeMS = options.maxTimeMS;
-  query = query || {};
-
-  // Final query
-  const cmd = {
-    count: options.collectionName,
-    query: query
-  };
-
-  // check if collectionOrCursor is a cursor by using cursor.s.numberOfRetries
-  if (collectionOrCursor.s.numberOfRetries) {
-    if (collectionOrCursor.s.options.hint) {
-      hint = collectionOrCursor.s.options.hint;
-    } else if (collectionOrCursor.s.cmd.hint) {
-      hint = collectionOrCursor.s.cmd.hint;
-    }
-    decorateWithCollation(cmd, collectionOrCursor, collectionOrCursor.s.cmd);
-  } else {
-    decorateWithCollation(cmd, collectionOrCursor, options);
-  }
-
-  // Add limit, skip and maxTimeMS if defined
-  if (typeof skip === 'number') cmd.skip = skip;
-  if (typeof limit === 'number') cmd.limit = limit;
-  if (typeof maxTimeMS === 'number') cmd.maxTimeMS = maxTimeMS;
-  if (hint) cmd.hint = hint;
-
-  // Do we have a readConcern specified
-  decorateWithReadConcern(cmd, collectionOrCursor);
-
-  return cmd;
-}
-
-/**
  * Create an index on the db and collection.
  *
  * @method
@@ -1223,8 +1149,6 @@ function updateOne(coll, filter, update, options, callback) {
 module.exports = {
   bulkWrite,
   checkForAtomicOperators,
-  count,
-  buildCountCommand,
   createIndex,
   createIndexes,
   deleteMany,

--- a/lib/operations/command_v2.js
+++ b/lib/operations/command_v2.js
@@ -7,6 +7,7 @@ const ReadConcern = require('../read_concern');
 const WriteConcern = require('../write_concern');
 const maxWireVersion = require('../core/utils').maxWireVersion;
 const commandSupportsReadConcern = require('../core/sessions').commandSupportsReadConcern;
+const MongoError = require('../error').MongoError;
 
 const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
 
@@ -42,6 +43,17 @@ class CommandOperationV2 extends OperationBase {
 
     if (this.readConcern && commandSupportsReadConcern(cmd) && !inTransaction) {
       Object.assign(cmd, { readConcern: this.readConcern });
+    }
+
+    if (options.collation && serverWireVersion < SUPPORTS_WRITE_CONCERN_AND_COLLATION) {
+      callback(
+        new MongoError(
+          `Server ${
+            server.name
+          }, which reports wire version ${serverWireVersion}, does not support collation`
+        )
+      );
+      return;
     }
 
     if (serverWireVersion >= SUPPORTS_WRITE_CONCERN_AND_COLLATION) {

--- a/lib/operations/command_v2.js
+++ b/lib/operations/command_v2.js
@@ -6,6 +6,7 @@ const resolveReadPreference = require('../utils').resolveReadPreference;
 const ReadConcern = require('../read_concern');
 const WriteConcern = require('../write_concern');
 const maxWireVersion = require('../core/utils').maxWireVersion;
+const commandSupportsReadConcern = require('../core/sessions').commandSupportsReadConcern;
 
 class CommandOperationV2 extends OperationBase {
   constructor(parent, options) {
@@ -37,7 +38,7 @@ class CommandOperationV2 extends OperationBase {
     const serverWireVersion = maxWireVersion(server);
     const inTransaction = this.session && this.session.inTransaction();
 
-    if (this.readConcern && this.hasAspect(Aspect.READ_OPERATION) && !inTransaction) {
+    if (this.readConcern && commandSupportsReadConcern(cmd) && !inTransaction) {
       Object.assign(cmd, { readConcern: this.readConcern });
     }
 

--- a/lib/operations/command_v2.js
+++ b/lib/operations/command_v2.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const Aspect = require('./operation').Aspect;
 const OperationBase = require('./operation').OperationBase;
 const resolveReadPreference = require('../utils').resolveReadPreference;
 const ReadConcern = require('../read_concern');
 const WriteConcern = require('../write_concern');
+const maxWireVersion = require('../core/utils').maxWireVersion;
 
 class CommandOperationV2 extends OperationBase {
   constructor(parent, options) {
@@ -30,6 +32,32 @@ class CommandOperationV2 extends OperationBase {
   executeCommand(server, cmd, callback) {
     // TODO: consider making this a non-enumerable property
     this.server = server;
+
+    const options = this.options;
+    const serverWireVersion = maxWireVersion(server);
+    const inTransaction = this.session && this.session.inTransaction();
+
+    if (this.readConcern && this.hasAspect(Aspect.READ_OPERATION) && !inTransaction) {
+      Object.assign(cmd, { readConcern: this.readConcern });
+    }
+
+    if (serverWireVersion >= 5) {
+      if (this.writeConcern && this.hasAspect(Aspect.WRITE_OPERATION)) {
+        Object.assign(cmd, { writeConcern: this.writeConcern });
+      }
+
+      if (options.collation && typeof options.collation === 'object') {
+        Object.assign(cmd, { collation: options.collation });
+      }
+    }
+
+    if (typeof options.maxTimeMS === 'number') {
+      cmd.maxTimeMS = options.maxTimeMS;
+    }
+
+    if (typeof options.comment === 'string') {
+      cmd.comment = options.comment;
+    }
 
     if (this.logger && this.logger.isDebug()) {
       this.logger.debug(`executing command ${JSON.stringify(cmd)} against ${this.ns}`);

--- a/lib/operations/command_v2.js
+++ b/lib/operations/command_v2.js
@@ -8,6 +8,8 @@ const WriteConcern = require('../write_concern');
 const maxWireVersion = require('../core/utils').maxWireVersion;
 const commandSupportsReadConcern = require('../core/sessions').commandSupportsReadConcern;
 
+const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
+
 class CommandOperationV2 extends OperationBase {
   constructor(parent, options) {
     super(options);
@@ -42,7 +44,7 @@ class CommandOperationV2 extends OperationBase {
       Object.assign(cmd, { readConcern: this.readConcern });
     }
 
-    if (serverWireVersion >= 5) {
+    if (serverWireVersion >= SUPPORTS_WRITE_CONCERN_AND_COLLATION) {
       if (this.writeConcern && this.hasAspect(Aspect.WRITE_OPERATION)) {
         Object.assign(cmd, { writeConcern: this.writeConcern });
       }

--- a/lib/operations/estimated_document_count.js
+++ b/lib/operations/estimated_document_count.js
@@ -5,14 +5,27 @@ const defineAspects = require('./operation').defineAspects;
 const CommandOperationV2 = require('./command_v2');
 
 class EstimatedDocumentCountOperation extends CommandOperationV2 {
-  constructor(collection, options) {
+  constructor(collection, query, options) {
+    if (typeof options === 'undefined') {
+      options = query;
+      query = undefined;
+    }
+
     super(collection, options);
     this.collectionName = collection.s.namespace.collection;
+    if (query) {
+      this.query = query;
+    }
   }
 
   execute(server, callback) {
     const options = this.options;
     const cmd = { count: this.collectionName };
+
+    if (this.query) {
+      cmd.query = this.query;
+    }
+
     if (typeof options.skip === 'number') {
       cmd.skip = options.skip;
     }

--- a/lib/operations/estimated_document_count.js
+++ b/lib/operations/estimated_document_count.js
@@ -2,32 +2,44 @@
 
 const Aspect = require('./operation').Aspect;
 const defineAspects = require('./operation').defineAspects;
-const CommandOperation = require('./command');
-const buildCountCommand = require('./common_functions').buildCountCommand;
-const handleCallback = require('../utils').handleCallback;
+const CommandOperationV2 = require('./command_v2');
 
-class EstimatedDocumentCountOperation extends CommandOperation {
+class EstimatedDocumentCountOperation extends CommandOperationV2 {
   constructor(collection, options) {
-    super(collection.s.db, options, collection);
+    super(collection, options);
+    this.collectionName = collection.s.namespace.collection;
   }
 
-  _buildCommand() {
-    const coll = this.collection;
-    let options = this.options;
+  execute(server, callback) {
+    const options = this.options;
+    const cmd = { count: this.collectionName };
+    if (typeof options.skip === 'number') {
+      cmd.skip = options.skip;
+    }
 
-    options.collectionName = coll.collectionName;
+    if (typeof options.limit === 'number') {
+      cmd.limit = options.limit;
+    }
 
-    return buildCountCommand(coll, null, options);
-  }
+    if (options.hint) {
+      cmd.hint = options.hint;
+    }
 
-  execute(callback) {
-    super.execute((err, result) => {
-      if (err) return handleCallback(callback, err);
-      handleCallback(callback, null, result.n);
+    super.executeCommand(server, cmd, (err, response) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      callback(null, response.n);
     });
   }
 }
 
-defineAspects(EstimatedDocumentCountOperation, Aspect.READ_OPERATION);
+defineAspects(EstimatedDocumentCountOperation, [
+  Aspect.READ_OPERATION,
+  Aspect.RETRYABLE,
+  Aspect.EXECUTE_WITH_SELECTION
+]);
 
 module.exports = EstimatedDocumentCountOperation;

--- a/lib/operations/rename.js
+++ b/lib/operations/rename.js
@@ -45,7 +45,7 @@ class RenameOperation extends OperationBase {
           new Collection(
             coll.s.db,
             coll.s.topology,
-            coll.databaseName,
+            coll.s.namespace.db,
             newName,
             coll.s.pkFactory,
             coll.s.options

--- a/test/functional/retryable_reads_tests.js
+++ b/test/functional/retryable_reads_tests.js
@@ -23,7 +23,8 @@ describe('Retryable Reads', function() {
       spec.description.match(/listDatabases/i) ||
       spec.description.match(/listDatabaseNames/i) ||
       spec.description.match(/listCollections/i) ||
-      spec.description.match(/listCollectionNames/i)
+      spec.description.match(/listCollectionNames/i) ||
+      spec.description.match(/estimatedDocumentCount/i)
     );
   });
 });

--- a/test/functional/retryable_reads_tests.js
+++ b/test/functional/retryable_reads_tests.js
@@ -24,7 +24,8 @@ describe('Retryable Reads', function() {
       spec.description.match(/listDatabaseNames/i) ||
       spec.description.match(/listCollections/i) ||
       spec.description.match(/listCollectionNames/i) ||
-      spec.description.match(/estimatedDocumentCount/i)
+      spec.description.match(/estimatedDocumentCount/i) ||
+      spec.description.match(/count/i)
     );
   });
 });


### PR DESCRIPTION
## Description
Add support for retryable reads to all of our count commands

**What changed?**
- `EstimatedDocumentCount` is now an operation subclassing `CommandOperationV2`, supporting execution by selection and retryability
- `Collection.count` now reuses the `EstimatedDocumentCountOperation`
- `commandSupportsReadConcern` has been reused from the command wire protocol temporarily
- The test runner now checks command names against a list of known cursor operations, and calls `toArray` on them (used to only be `aggregate` and `find`)
