### PR TITLE
fix(change_stream): emit close event after cursor is closed during error

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -190,7 +190,8 @@ class ChangeStream extends EventEmitter {
       });
     }
 
-    return new Promise((resolve, reject) => {
+    const PromiseCtor = this.promiseLibrary || Promise;
+    return new PromiseCtor((resolve, reject) => {
       cursor.close(err => {
         ['data', 'close', 'end', 'error'].forEach(event => cursor.removeAllListeners(event));
         delete this.cursor;

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -179,10 +179,26 @@ class ChangeStream extends EventEmitter {
     }
 
     // Tidy up the existing cursor
-    var cursor = this.cursor;
-    ['data', 'close', 'end', 'error'].forEach(event => this.cursor.removeAllListeners(event));
-    delete this.cursor;
-    return cursor.close(callback);
+    const cursor = this.cursor;
+
+    if (callback) {
+      return cursor.close(err => {
+        ['data', 'close', 'end', 'error'].forEach(event => cursor.removeAllListeners(event));
+        delete this.cursor;
+
+        return callback(err);
+      });
+    }
+
+    return new Promise((resolve, reject) => {
+      cursor.close(err => {
+        ['data', 'close', 'end', 'error'].forEach(event => cursor.removeAllListeners(event));
+        delete this.cursor;
+
+        if (err) return reject(err);
+        resolve();
+      });
+    });
   }
 
   /**

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -1889,10 +1889,13 @@ describe('Change Streams', function() {
 
         const db = client.db('integration_tests');
         const coll = db.collection('event_test');
+
+        // This will cause an error because the _id will be projected out, which causes the following error:
+        // "A change stream document has been received that lacks a resume token (_id)."
         const changeStream = coll.watch([{ $project: { _id: false } }]);
 
-        changeStream.on('change', () => {
-          assert.ok(false);
+        changeStream.on('change', changeDoc => {
+          expect(changeDoc).to.be.null;
         });
 
         changeStream.on('error', err => {


### PR DESCRIPTION
Fixes NODE-2075

## Description
When `cursor.close()` was called, all event listeners were removed before the cursor actually closed. Because of this, a `close` event was not emitted.

**What changed?**
This PR removes event listeners after the cursor is closed, handling both callbacks and promises.

**Are there any files to ignore?**
No.