### PR TITLE
refactor(list-databases): support retryable reads

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -6,6 +6,7 @@ const AddUserOperation = require('./operations/add_user');
 const ExecuteDbAdminCommandOperation = require('./operations/execute_db_admin_command');
 const RemoveUserOperation = require('./operations/remove_user');
 const ValidateCollectionOperation = require('./operations/validate_collection');
+const ListDatabasesOperation = require('./operations/list_databases');
 
 const executeOperation = require('./operations/execute_operation');
 
@@ -261,12 +262,11 @@ Admin.prototype.listDatabases = function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  const cmd = { listDatabases: 1 };
-  if (options.nameOnly) cmd.nameOnly = Number(cmd.nameOnly);
-
-  const listDatabasesOperation = new ExecuteDbAdminCommandOperation(this.s.db, cmd, options);
-
-  return executeOperation(this.s.db.s.topology, listDatabasesOperation, callback);
+  return executeOperation(
+    this.s.db.s.topology,
+    new ListDatabasesOperation(this.s.db, options),
+    callback
+  );
 };
 
 /**

--- a/lib/operations/list_databases.js
+++ b/lib/operations/list_databases.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const CommandOperationV2 = require('./command_v2');
+const Aspect = require('./operation').Aspect;
+const defineAspects = require('./operation').defineAspects;
+const MongoDBNamespace = require('../utils').MongoDBNamespace;
+
+class ListDatabasesOperation extends CommandOperationV2 {
+  constructor(db, options) {
+    super(db, options);
+    this.ns = new MongoDBNamespace('admin', '$cmd');
+  }
+
+  execute(server, callback) {
+    const cmd = { listDatabases: 1 };
+    if (this.options.nameOnly) {
+      cmd.nameOnly = Number(cmd.nameOnly);
+    }
+
+    if (this.options.filter) {
+      cmd.filter = this.options.filter;
+    }
+
+    if (typeof this.options.authorizedDatabases === 'boolean') {
+      cmd.authorizedDatabases = this.options.authorizedDatabases;
+    }
+
+    super.executeCommand(server, cmd, callback);
+  }
+}
+
+defineAspects(ListDatabasesOperation, [
+  Aspect.READ_OPERATION,
+  Aspect.RETRYABLE,
+  Aspect.EXECUTE_WITH_SELECTION
+]);
+
+module.exports = ListDatabasesOperation;

--- a/test/functional/retryable_reads_tests.js
+++ b/test/functional/retryable_reads_tests.js
@@ -19,7 +19,9 @@ describe('Retryable Reads', function() {
       spec.description.match(/distinct/i) ||
       spec.description.match(/aggregate/i) ||
       spec.description.match(/countDocuments/i) ||
-      spec.description.match(/listIndexes/i)
+      spec.description.match(/listIndexes/i) ||
+      spec.description.match(/listDatabases/i) ||
+      spec.description.match(/listDatabaseNames/i)
     );
   });
 });

--- a/test/functional/runner/index.js
+++ b/test/functional/runner/index.js
@@ -275,6 +275,7 @@ function runTestSuiteTest(configuration, spec, context) {
     // displayCommands = true;
 
     const operationContext = {
+      client,
       database,
       collectionName: context.collectionName,
       session0,
@@ -413,6 +414,7 @@ function extractBulkRequests(requests) {
 
 function translateOperationName(operationName) {
   if (operationName === 'runCommand') return 'command';
+  if (operationName === 'listDatabaseNames') return 'listDatabases';
   return operationName;
 }
 
@@ -463,6 +465,7 @@ function resolveOperationArgs(operationName, operationArgs, context) {
 }
 
 const CURSOR_COMMANDS = new Set(['find', 'aggregate', 'listIndexes']);
+const ADMIN_COMMANDS = new Set(['listDatabases']);
 
 /**
  *
@@ -548,6 +551,14 @@ function testOperation(operation, obj, context, options) {
     }
 
     args.push(opOptions);
+  }
+
+  if (ADMIN_COMMANDS.has(operationName)) {
+    obj = obj.db().admin();
+  }
+
+  if (operation.name === 'listDatabaseNames') {
+    opOptions.nameOnly = true;
   }
 
   let opPromise;


### PR DESCRIPTION
## Description
Add retryable read support for `listDatabases`

**What changed?**
Added a `ListDatabasesOperation`, used it in the `Amin.listDatabases` method. This operation should prove useful if we choose to move this method to the top level of the `MongoClient` (which would be consistent with other drivers)

