### PR TITLE
feat(AutoEncryption): improve error message for missing mongodb-client-encryption

### DIFF
--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -472,14 +472,19 @@ function createTopology(mongoClient, topologyType, options, callback) {
     // setup for client side encryption
     let AutoEncrypter;
     try {
-      AutoEncrypter = require('mongodb-client-encryption').AutoEncrypter;
+      require.resolve('mongodb-client-encryption');
     } catch (err) {
       callback(
         new MongoError(
           'Auto-encryption requested, but the module is not installed. Please add `mongodb-client-encryption` as a dependency of your project'
         )
       );
-
+      return;
+    }
+    try {
+      AutoEncrypter = require('mongodb-client-encryption').AutoEncrypter;
+    } catch (err) {
+      callback(err);
       return;
     }
 


### PR DESCRIPTION
Fixes NODE-2078

## Description
Our handling for missing `mongodb-client-encryption` was covering up other errors.

**What changed?**
We now explicitly check for `mongodb-client-encryption` existence with `require.resolve`, and emit the error if the package is not found. Any other errors stemming from pulling in the package are directly propagated to the user.

**Are there any files to ignore?**
No
