### PR TITLE
Node 2070/auto spawn mongocryptd

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const connect = require('./lib/mongo_client').connect;
 // Expose error class
 connect.MongoError = core.MongoError;
 connect.MongoNetworkError = core.MongoNetworkError;
+connect.MongoTimeoutError = core.MongoTimeoutError;
 
 // Actual driver classes exported
 connect.Admin = require('./lib/admin');

--- a/lib/operations/close.js
+++ b/lib/operations/close.js
@@ -25,7 +25,7 @@ class CloseOperation extends OperationBase {
     };
 
     if (client.topology == null) {
-      completeClose;
+      completeClose();
       return;
     }
 

--- a/lib/operations/close.js
+++ b/lib/operations/close.js
@@ -23,22 +23,21 @@ class CloseOperation extends OperationBase {
       client.removeAllListeners('close');
       callback(err, null);
     };
-    const mongocryptdClientClose = err => {
-      const mongocryptdClient = client.s.mongocryptdClient;
-      if (!mongocryptdClient) {
+
+    if (client.topology == null) {
+      completeClose;
+      return;
+    }
+
+    client.topology.close(force, err => {
+      const autoEncrypter = client.topology.s.options.autoEncrypter;
+      if (!autoEncrypter) {
         completeClose(err);
         return;
       }
 
-      mongocryptdClient.close(force, err2 => completeClose(err || err2));
-    };
-
-    if (client.topology == null) {
-      mongocryptdClientClose();
-      return;
-    }
-
-    client.topology.close(force, mongocryptdClientClose);
+      autoEncrypter.teardown(force, err2 => completeClose(err || err2));
+    });
   }
 }
 

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const os = require('os');
 const OperationBase = require('./operation').OperationBase;
 const defineAspects = require('./operation').defineAspects;
 const Aspect = require('./operation').Aspect;
@@ -482,37 +481,43 @@ function createTopology(mongoClient, topologyType, options, callback) {
       return;
     }
     try {
-      AutoEncrypter = require('mongodb-client-encryption').AutoEncrypter;
+      AutoEncrypter = require('mongodb-client-encryption')(require('../../index')).AutoEncrypter;
     } catch (err) {
       callback(err);
       return;
     }
 
-    const MongoClient = loadClient();
-    let connectionString;
-    if (options.autoEncryption.extraOptions && options.autoEncryption.extraOptions.mongocryptURI) {
-      connectionString = options.autoEncryption.extraOptions.mongocryptURI;
-    } else if (os.platform() === 'win32') {
-      connectionString = 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000';
-    } else {
-      connectionString = 'mongodb://%2Ftmp%2Fmongocryptd.sock/?serverSelectionTimeoutMS=1000';
-    }
-
-    const mongocryptdClient = new MongoClient(connectionString, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true
-    });
-    mongoClient.s.mongocryptdClient = mongocryptdClient;
-    mongocryptdClient.connect(err => {
+    const mongoCryptOptions = Object.assign({}, options.autoEncryption);
+    topology.s.options.autoEncrypter = new AutoEncrypter(mongoClient, mongoCryptOptions);
+    topology.s.options.autoEncrypter.init(err => {
       if (err) return callback(err, null);
-
-      const mongoCryptOptions = Object.assign({}, options.autoEncryption, {
-        mongocryptdClient
-      });
-
-      topology.s.options.autoEncrypter = new AutoEncrypter(mongoClient, mongoCryptOptions);
       callback(null, newTopology);
     });
+    // const MongoClient = loadClient();
+    // let connectionString;
+    // if (options.autoEncryption.extraOptions && options.autoEncryption.extraOptions.mongocryptURI) {
+    //   connectionString = options.autoEncryption.extraOptions.mongocryptURI;
+    // } else if (os.platform() === 'win32') {
+    //   connectionString = 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000';
+    // } else {
+    //   connectionString = 'mongodb://%2Ftmp%2Fmongocryptd.sock/?serverSelectionTimeoutMS=1000';
+    // }
+
+    // const mongocryptdClient = new MongoClient(connectionString, {
+    //   useNewUrlParser: true,
+    //   useUnifiedTopology: true
+    // });
+    // mongoClient.s.mongocryptdClient = mongocryptdClient;
+    // mongocryptdClient.connect(err => {
+    //   if (err) return callback(err, null);
+
+    //   const mongoCryptOptions = Object.assign({}, options.autoEncryption, {
+    //     mongocryptdClient
+    //   });
+
+    //   topology.s.options.autoEncrypter = new AutoEncrypter(mongoClient, mongoCryptOptions);
+    //   callback(null, newTopology);
+    // });
   });
 }
 

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -493,31 +493,6 @@ function createTopology(mongoClient, topologyType, options, callback) {
       if (err) return callback(err, null);
       callback(null, newTopology);
     });
-    // const MongoClient = loadClient();
-    // let connectionString;
-    // if (options.autoEncryption.extraOptions && options.autoEncryption.extraOptions.mongocryptURI) {
-    //   connectionString = options.autoEncryption.extraOptions.mongocryptURI;
-    // } else if (os.platform() === 'win32') {
-    //   connectionString = 'mongodb://localhost:27020/?serverSelectionTimeoutMS=1000';
-    // } else {
-    //   connectionString = 'mongodb://%2Ftmp%2Fmongocryptd.sock/?serverSelectionTimeoutMS=1000';
-    // }
-
-    // const mongocryptdClient = new MongoClient(connectionString, {
-    //   useNewUrlParser: true,
-    //   useUnifiedTopology: true
-    // });
-    // mongoClient.s.mongocryptdClient = mongocryptdClient;
-    // mongocryptdClient.connect(err => {
-    //   if (err) return callback(err, null);
-
-    //   const mongoCryptOptions = Object.assign({}, options.autoEncryption, {
-    //     mongocryptdClient
-    //   });
-
-    //   topology.s.options.autoEncrypter = new AutoEncrypter(mongoClient, mongoCryptOptions);
-    //   callback(null, newTopology);
-    // });
   });
 }
 


### PR DESCRIPTION
## Description

Delegates most autoEncryption resource management to autoEncryptor. autoEncryptor now spawns `mongocryptd` as well as a client to connect to it, and handles teardown.

The driver portion of https://github.com/mongodb/libmongocrypt/pull/33

**What changed?**

- setup and teardown logic in `lib/operations/connect` and `lib/operations/close`
- Exposes `MongoTimeoutError` for injection into `mongodb-client-encryption`

**Are there any files to ignore?**
