### PR TITLE
 feat(test-runner-poc): Removes dependencies on topologyManager

### DIFF
--- a/test-runner-poc/config.js
+++ b/test-runner-poc/config.js
@@ -1,0 +1,248 @@
+'use strict';
+const f = require('util').format;
+const url = require('url');
+const qs = require('querystring');
+const core = require('../lib/core');
+
+class ConfigurationBase {
+  constructor(options) {
+    this.options = options || {};
+    this.host = options.host || 'localhost';
+    this.port = options.port || 27017;
+    this.db = options.db || 'integration_tests';
+    this.manager = options.manager;
+    this.mongo = options.mongo;
+    this.skipStart = typeof options.skipStart === 'boolean' ? options.skipStart : false;
+    this.skipTermination =
+      typeof options.skipTermination === 'boolean' ? options.skipTermination : false;
+    this.setName = options.setName || 'rs';
+    this.require = this.mongo;
+    this.writeConcern = function() {
+      return { w: 1 };
+    };
+  }
+
+  stop(callback) {
+    if (this.skipTermination) return callback();
+    // Stop the servers
+    this.manager
+      .stop()
+      .then(function() {
+        callback(null);
+      })
+      .catch(function(err) {
+        callback(err, null);
+      });
+  }
+
+  restart(opts, callback) {
+    if (typeof opts === 'function') {
+      callback = opts;
+      opts = { purge: true, kill: true };
+    }
+    if (this.skipTermination) return callback();
+
+    // Stop the servers
+    this.manager
+      .restart()
+      .then(function() {
+        callback(null);
+      })
+      .catch(function(err) {
+        callback(err, null);
+      });
+  }
+
+  setup(callback) {
+    callback();
+  }
+
+  teardown(callback) {
+    callback();
+  }
+}
+
+class NativeConfiguration extends ConfigurationBase {
+  constructor(environment) {
+    super(environment);
+
+    this.type = 'native';
+    this.topology = environment.topology || this.defaultTopology;
+    this.environment = environment;
+
+    if (environment.setName) {
+      this.replicasetName = environment.setName || 'rs';
+    }
+  }
+
+  usingUnifiedTopology() {
+    return !!process.env.MONGODB_UNIFIED_TOPOLOGY;
+  }
+
+  defaultTopology(host, port, serverOptions) {
+    host = host || 'localhost';
+    port = port || 27017;
+
+    const options = Object.assign({}, { host, port }, serverOptions);
+    if (this.usingUnifiedTopology()) {
+      return new core.Topology(options);
+    }
+
+    return new core.Server(options);
+  }
+
+  start(callback) {
+    const self = this;
+    if (this.skipStart) return callback();
+
+    const client = this.newClient({}, { host: self.host, port: self.port });
+    this.manager
+      .purge()
+      .then(function() {
+        console.log('[purge the directories]');
+        return self.manager.start();
+      })
+      .then(() => {
+        if (this.environment.server37631WorkaroundNeeded) {
+          return this.server37631Workaround();
+        }
+      })
+      .then(function() {
+        console.log('[started the topology]');
+        return client.connect();
+      })
+      .then(function() {
+        console.log('[get connection to topology]');
+        return client.db(self.db).dropDatabase();
+      })
+      .then(function() {
+        console.log('[dropped database]');
+        return client.close();
+      })
+      .then(function() {
+        callback(null);
+      })
+      .catch(function(err) {
+        callback(err, null);
+      });
+  }
+
+  newClient(dbOptions, serverOptions) {
+    // support MongoClient contructor form (url, options) for `newClient`
+    if (typeof dbOptions === 'string') {
+      return new this.mongo.MongoClient(
+        dbOptions,
+        this.usingUnifiedTopology()
+          ? Object.assign({ useUnifiedTopology: true }, serverOptions)
+          : serverOptions
+      );
+    }
+
+    dbOptions = dbOptions || {};
+    serverOptions = Object.assign({}, { haInterval: 100 }, serverOptions);
+    if (this.usingUnifiedTopology()) serverOptions.useUnifiedTopology = true;
+
+    // Override implementation
+    if (this.options.newDbInstance) {
+      return this.options.newDbInstance(dbOptions, serverOptions);
+    }
+
+    // Set up the options
+    const keys = Object.keys(this.options);
+    if (keys.indexOf('sslOnNormalPorts') !== -1) serverOptions.ssl = true;
+
+    // Fall back
+    let dbHost = (serverOptions && serverOptions.host) || 'localhost';
+    const dbPort = (serverOptions && serverOptions.port) || this.options.port || 27017;
+
+    if (dbHost.indexOf('.sock') !== -1) {
+      dbHost = qs.escape(dbHost);
+    }
+
+    if (this.options.setName) {
+      Object.assign(dbOptions, { replicaSet: this.options.setName, auto_reconnect: false });
+    }
+
+    const connectionString = url.format({
+      protocol: 'mongodb',
+      slashes: true,
+      hostname: dbHost,
+      port: dbPort,
+      query: dbOptions,
+      pathname: '/'
+    });
+
+    return new this.mongo.MongoClient(connectionString, serverOptions);
+  }
+
+  newTopology(host, port, options) {
+    options = options || {};
+    return this.topology(host, port, options);
+  }
+
+  newConnection(host, port, options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    var server = this.topology(host, port, options);
+    var errorHandler = function(err) {
+      callback(err);
+    };
+
+    // Set up connect
+    server.once('connect', function() {
+      server.removeListener('error', errorHandler);
+      callback(null, server);
+    });
+
+    server.once('error', errorHandler);
+
+    // Connect
+    try {
+      server.connect();
+    } catch (err) {
+      server.removeListener('error', errorHandler);
+      callback(err);
+    }
+  }
+
+  url(username, password) {
+    const url = this.options.url || 'mongodb://%slocalhost:27017/' + this.db;
+
+    // Fall back
+    const auth = username && password ? f('%s:%s@', username, password) : '';
+    return f(url, auth);
+  }
+
+  writeConcern() {
+    return Object.assign({}, this.options.writeConcern || { w: 1 });
+  }
+
+  writeConcernMax() {
+    return Object.assign({}, this.options.writeConcernMax || { w: 1 });
+  }
+
+  server37631Workaround() {
+    console.log('[applying SERVER-37631 workaround]');
+    const configServers = this.manager.configurationServers.managers;
+    const proxies = this.manager.proxies;
+
+    const configServersPromise = configServers.reduce((result, server) => {
+      return result.then(() =>
+        server.executeCommand('admin.$cmd', { refreshLogicalSessionCacheNow: 1 })
+      );
+    }, Promise.resolve());
+
+    return configServersPromise.then(() => {
+      return proxies.reduce((promise, proxy) => {
+        return promise.then(() =>
+          proxy.executeCommand('admin.$cmd', { refreshLogicalSessionCacheNow: 1 })
+        );
+      }, Promise.resolve());
+    });
+  }
+}
+
+module.exports = NativeConfiguration;

--- a/test-runner-poc/environments.js
+++ b/test-runner-poc/environments.js
@@ -1,0 +1,254 @@
+'use strict';
+
+const f = require('util').format;
+const semver = require('semver');
+const path = require('path');
+const core = require('../lib/core');
+
+/**
+ * Base class for environments in projects that use the test
+ * runner
+ */
+class EnvironmentBase {
+  /**
+   * The default implementation of the environment setup
+   *
+   * @param {*} callback
+   */
+  setup(callback) {
+    callback();
+  }
+}
+
+const genReplsetConfig = (port, options) => {
+  return Object.assign(
+    {
+      options: {
+        bind_ip: 'localhost',
+        port: port,
+        dbpath: `${__dirname}/../db/${port}`,
+        setParameter: ['enableTestCommands=1']
+      }
+    },
+    options
+  );
+};
+
+function usingUnifiedTopology() {
+  return !!process.env.MONGODB_UNIFIED_TOPOLOGY;
+}
+
+/**
+ *
+ * @param {*} discoverResult
+ */
+class ReplicaSetEnvironment extends EnvironmentBase {
+  constructor(version) {
+    super();
+
+    this.setName = 'replset';
+    this.writeConcernMax = { w: 'majority', wtimeout: 30000 };
+    this.replicasetName = 'rs';
+    this.topology = function(host, port, options) {
+      host = host || 'localhost';
+      port = port || 31000;
+      options = Object.assign({}, options);
+      options.replicaSet = 'rs';
+      options.poolSize = 1;
+      options.autoReconnect = false;
+
+      if (usingUnifiedTopology()) {
+        return new core.Topology([{ host, port }], options);
+      }
+
+      return new core.ReplSet([{ host, port }], options);
+    };
+
+    this.nodes = [
+      genReplsetConfig(31000, { tags: { loc: 'ny' } }),
+      genReplsetConfig(31001, { tags: { loc: 'sf' } }),
+      genReplsetConfig(31002, { tags: { loc: 'sf' } }),
+      genReplsetConfig(31003, { tags: { loc: 'sf' } }),
+      genReplsetConfig(31004, { arbiter: true })
+    ];
+
+    // Do we have 3.2+
+    if (semver.satisfies(version, '>=3.2.0')) {
+      this.nodes = this.nodes.map(function(x) {
+        x.options.enableMajorityReadConcern = null;
+        return x;
+      });
+    }
+
+  }
+}
+
+/**
+ *
+ */
+class SingleEnvironment extends EnvironmentBase {
+  constructor() {
+    super();
+  }
+}
+
+const genShardedConfig = (port, options, shardOptions) => {
+  return Object.assign(
+    {
+      options: {
+        bind_ip: 'localhost',
+        port: port,
+        dbpath: `${__dirname}/../db/${port}`,
+        shardsvr: null
+      }
+    },
+    options,
+    shardOptions
+  );
+};
+
+const genConfigNode = (port, options) => {
+  return Object.assign(
+    {
+      options: {
+        bind_ip: 'localhost',
+        port: port,
+        dbpath: `${__dirname}/../db/${port}`,
+        setParameter: ['enableTestCommands=1']
+      }
+    },
+    options
+  );
+};
+
+/**
+ *
+ */
+class ShardedEnvironment extends EnvironmentBase {
+  constructor(version) {
+    super();
+
+    this.writeConcernMax = { w: 'majority', wtimeout: 30000 };
+    this.topology = (host, port, options) => {
+      host = host || 'localhost';
+      port = port || 51000;
+      options = options || {};
+
+      if (usingUnifiedTopology()) {
+        return new core.Topology([{ host, port }], options);
+      }
+
+      return new core.Mongos([{ host, port }], options);
+    };
+
+    this.server37631WorkaroundNeeded = semver.satisfies(version, '3.6.x');
+
+  }
+
+  setup(callback) {
+    const shardOptions = this.options && this.options.shard ? this.options.shard : {};
+
+    // First set of nodes
+    const nodes1 = [
+      genShardedConfig(31010, { tags: { loc: 'ny' } }, shardOptions),
+      genShardedConfig(31011, { tags: { loc: 'sf' } }, shardOptions),
+      genShardedConfig(31012, { arbiter: true }, shardOptions)
+    ];
+
+    const configOptions = this.options && this.options.config ? this.options.config : {};
+    const configNodes = [genConfigNode(35000, configOptions)];
+
+    let proxyNodes = [
+      {
+        bind_ip: 'localhost',
+        port: 51000,
+        configdb: 'localhost:35000,localhost:35001,localhost:35002',
+        setParameter: ['enableTestCommands=1']
+      },
+      {
+        bind_ip: 'localhost',
+        port: 51001,
+        configdb: 'localhost:35000,localhost:35001,localhost:35002',
+        setParameter: ['enableTestCommands=1']
+      }
+    ];
+
+    // Additional mapping
+    const self = this;
+    proxyNodes = proxyNodes.map(function(x) {
+      if (self.options && self.options.proxy) {
+        for (let name in self.options.proxy) {
+          x[name] = self.options.proxy[name];
+        }
+      }
+
+      return x;
+    });
+
+    this.proxies = proxyNodes.map(proxy => {
+      return { host: proxy.bind_ip, port: proxy.port };
+    });
+
+  }
+}
+
+/**
+ *
+ */
+class SslEnvironment extends EnvironmentBase {
+  constructor() {
+    super();
+
+    this.sslOnNormalPorts = null;
+    this.fork = null;
+    this.sslPEMKeyFile = __dirname + '/functional/ssl/server.pem';
+    this.url = 'mongodb://%slocalhost:27017/integration_tests?ssl=true&sslValidate=false';
+    this.topology = function(host, port, serverOptions) {
+      host = host || 'localhost';
+      port = port || 27017;
+      serverOptions = Object.assign({}, serverOptions);
+      serverOptions.poolSize = 1;
+      serverOptions.ssl = true;
+      serverOptions.sslValidate = false;
+      return new core.Server(host, port, serverOptions);
+    };
+
+  }
+}
+
+/**
+ *
+ */
+class AuthEnvironment extends EnvironmentBase {
+  constructor() {
+    super();
+
+    this.url = 'mongodb://%slocalhost:27017/integration_tests';
+    this.topology = function(host, port, serverOptions) {
+      host = host || 'localhost';
+      port = port || 27017;
+      serverOptions = Object.assign({}, serverOptions);
+      serverOptions.poolSize = 1;
+      return new core.Server(host, port, serverOptions);
+    };
+
+  }
+}
+
+module.exports = {
+  single: SingleEnvironment,
+  replicaset: ReplicaSetEnvironment,
+  sharded: ShardedEnvironment,
+  ssl: SslEnvironment,
+  auth: AuthEnvironment,
+
+  // informational aliases
+  kerberos: SingleEnvironment,
+  ldap: SingleEnvironment,
+  sni: SingleEnvironment,
+
+  // for compatability with evergreen template
+  server: SingleEnvironment,
+  replica_set: ReplicaSetEnvironment,
+  sharded_cluster: ShardedEnvironment
+};

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -4,6 +4,12 @@ const path = require("path");
 const fs = require("fs");
 const utils = require("mocha").utils;
 
+const environments = require('../environments');
+const TestConfiguration = require('../config');
+
+const mock = require('mongodb-mock-server');
+
+let mongoClient;
 let filters = [];
 let files = [];
 
@@ -27,7 +33,47 @@ function addFilter(filter) {
 	}
 }
 
-before(function() {
+function environmentSetup(environmentCallback) {
+  const mongodb_uri = process.env.MONGODB_URI || 'mongodb://localhost:27017';
+  mongoClient = new MongoClient(mongodb_uri);
+
+  mongoClient.connect((err, client) => {
+    if (err) throw new Error(err);
+
+    createFilters(environmentParser);
+
+    function environmentParser(environmentName, version) {
+      console.log('environmentName ', environmentName);
+      const Environment = environments[environmentName];
+      const environment = new Environment(version);
+
+      parseConnectionString(mongodb_uri, (err, parsedURI) => {
+        if (err) throw new Error(err);
+        environment.port = parsedURI.hosts[0].port;
+        environment.host = parsedURI.hosts[0].host;
+        environment.url = mongodb_uri;
+      });
+      if (environmentName !== 'single') environment.url += '/integration_tests';
+
+      try {
+        const mongoPackage = {
+          path: path.resolve(process.cwd(), '..'),
+          package: 'mongodb'
+        };
+        environment.mongo = require(mongoPackage.path);
+      } catch (err) {
+        throw new Error('The test runner must be a dependency of mongodb or mongodb-core');
+      }
+      environmentCallback(environment, client);
+    }
+  });
+}
+
+function createFilters(callback) {
+  let filtersInitialized = 0;
+  const filterFiles = fs.readdirSync(path.join(__dirname, 'filters'));
+
+  let topology, version;
 
 	const environmentName = process.env['MONGODB_ENVIRONMENT'];
 

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -45,26 +45,26 @@ function environmentSetup(environmentCallback) {
     function environmentParser(environmentName, version) {
       console.log('environmentName ', environmentName);
       const Environment = environments[environmentName];
-      const environment = new Environment(version);
 
+      let host, port;
       parseConnectionString(mongodb_uri, (err, parsedURI) => {
         if (err) throw new Error(err);
-        environment.port = parsedURI.hosts[0].port;
-        environment.host = parsedURI.hosts[0].host;
-        environment.url = mongodb_uri;
-      });
-      if (environmentName !== 'single') environment.url += '/integration_tests';
+        port = parsedURI.hosts[0].port;
+        host = parsedURI.hosts[0].host;
 
-      try {
-        const mongoPackage = {
-          path: path.resolve(process.cwd(), '..'),
-          package: 'mongodb'
-        };
-        environment.mongo = require(mongoPackage.path);
-      } catch (err) {
-        throw new Error('The test runner must be a dependency of mongodb or mongodb-core');
-      }
-      environmentCallback(environment, client);
+        const environment = new Environment(host, port, version);
+
+        try {
+          const mongoPackage = {
+            path: path.resolve(process.cwd(), '..'),
+            package: 'mongodb'
+          };
+          environment.mongo = require(mongoPackage.path);
+        } catch (err) {
+          throw new Error('The test runner must be a dependency of mongodb or mongodb-core');
+        }
+        environmentCallback(environment, client);
+      });
     }
   });
 }


### PR DESCRIPTION
Fixes NODE-2046

## Description
Part of the overall goal to replace `mongodb-topology-manager` with `mongo-orchestration`.
**What changed?**
There are new `environments.js` and `config.js` files in the `test-runner-poc` folder, and the file paths are updated to route to the locations of these new files. Furthermore, `environments.js` and  no longer `requires` mongodb-topology-manager.

