### PR TITLE
fixing transaction tests

### DIFF
--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -18,7 +18,7 @@ const resolveClusterTime = require('./topologies/shared').resolveClusterTime;
 const isSharded = require('./wireprotocol/shared').isSharded;
 const maxWireVersion = require('./utils').maxWireVersion;
 
-const MAX_FOR_TRANSACTIONS = 7;
+const minWireVersionForShardedTransactions = 8;
 
 function assertAlive(session, callback) {
   if (session.serverSession == null) {
@@ -191,8 +191,9 @@ class ClientSession extends EventEmitter {
 
     const topologyMaxWireVersion = maxWireVersion(this.topology);
     if (
-      isSharded(this.topology) ||
-      (topologyMaxWireVersion != null && topologyMaxWireVersion < MAX_FOR_TRANSACTIONS)
+      isSharded(this.topology) &&
+      (topologyMaxWireVersion == null ||
+        topologyMaxWireVersion < minWireVersionForShardedTransactions)
     ) {
       throw new MongoError('Transactions are not supported on sharded clusters in MongoDB < 4.2.');
     }

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -192,8 +192,8 @@ class ClientSession extends EventEmitter {
     const topologyMaxWireVersion = maxWireVersion(this.topology);
     if (
       isSharded(this.topology) &&
-      (topologyMaxWireVersion == null ||
-        topologyMaxWireVersion < minWireVersionForShardedTransactions)
+      topologyMaxWireVersion != null &&
+      topologyMaxWireVersion < minWireVersionForShardedTransactions
     ) {
       throw new MongoError('Transactions are not supported on sharded clusters in MongoDB < 4.2.');
     }

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -87,6 +87,13 @@ function maxWireVersion(topologyOrServer) {
     return topologyOrServer.ismaster.maxWireVersion;
   }
 
+  if (typeof topologyOrServer.lastIsMaster === 'function') {
+    const lastIsMaster = topologyOrServer.lastIsMaster();
+    if (lastIsMaster) {
+      return lastIsMaster.maxWireVersion;
+    }
+  }
+
   if (topologyOrServer.description) {
     return topologyOrServer.description.maxWireVersion;
   }

--- a/lib/operations/execute_operation.js
+++ b/lib/operations/execute_operation.js
@@ -132,6 +132,11 @@ function executeWithServerSelection(topology, operation, callback) {
     return;
   }
 
+  const serverSelectionOptions = {
+    readPreference,
+    session: operation.session
+  };
+
   function callbackWithRetry(err, result) {
     if (err == null) {
       return callback(null, result);
@@ -142,7 +147,7 @@ function executeWithServerSelection(topology, operation, callback) {
     }
 
     // select a new server, and attempt to retry the operation
-    topology.selectServer(readPreference, (err, server) => {
+    topology.selectServer(serverSelectionOptions, (err, server) => {
       if (err || !supportsRetryableReads(server)) {
         callback(err, null);
         return;
@@ -153,7 +158,7 @@ function executeWithServerSelection(topology, operation, callback) {
   }
 
   // select a server, and execute the operation against it
-  topology.selectServer(readPreference, (err, server) => {
+  topology.selectServer(serverSelectionOptions, (err, server) => {
     if (err) {
       callback(err, null);
       return;

--- a/test/environments.js
+++ b/test/environments.js
@@ -137,10 +137,13 @@ class ShardedEnvironment extends EnvironmentBase {
     this.host = 'localhost';
     this.port = 51000;
 
-    // NOTE: only connect to a single shard because there can be consistency issues using
-    //       more, revolving around the inability for shards to keep up-to-date views of
-    //       changes to the world (such as dropping a database).
-    this.url = 'mongodb://%slocalhost:51000/integration_tests';
+    // TODO: we used to only connect to a single shard here b/c of consistency issues
+    // revolving around the inability for shards to keep up-to-date views of
+    // changes to the world (such as dropping a database). However, b/c the unified
+    // topology treats a single shard like a Single topology instead of a Sharded
+    // topology, we need to use multiple shards as much as possible to ensure that
+    // we get sharded test coverage (looking at you transactions tests!)
+    this.url = 'mongodb://%slocalhost:51000,localhost:51001/integration_tests';
 
     this.writeConcernMax = { w: 'majority', wtimeout: 30000 };
     this.topology = (host, port, options) => {

--- a/test/functional/runner/index.js
+++ b/test/functional/runner/index.js
@@ -221,7 +221,7 @@ function parseSessionOptions(options) {
   return result;
 }
 
-const IGNORED_COMMANDS = new Set(['ismaster']);
+const IGNORED_COMMANDS = new Set(['ismaster', 'configureFailPoint']);
 
 let displayCommands = false;
 function runTestSuiteTest(configuration, spec, context) {

--- a/test/functional/sessions_tests.js
+++ b/test/functional/sessions_tests.js
@@ -180,10 +180,19 @@ describe('Sessions', function() {
         this.skip();
         return;
       }
-
       return testContext.setup(this.configuration);
     });
 
-    generateTopologyTests(testSuites, testContext);
+    function testFilter(spec) {
+      const SKIP_TESTS = [
+        // These two tests need to run against multiple mongoses
+        'Dirty explicit session is discarded',
+        'Dirty implicit session is discarded (write)'
+      ];
+
+      return SKIP_TESTS.indexOf(spec.description) === -1;
+    }
+
+    generateTopologyTests(testSuites, testContext, testFilter);
   });
 });

--- a/test/functional/sharding_read_preference_tests.js
+++ b/test/functional/sharding_read_preference_tests.js
@@ -19,9 +19,12 @@ describe('Sharding (Read Preference)', function() {
     // The actual test we wish to run
     test: function(done) {
       const configuration = this.configuration;
+      const host = configuration.host;
+      const port = configuration.port;
 
+      const url = `mongodb://${host}:${port}/sharded_test_db?w=1`;
       // Connect using the mongos connections
-      var client = new MongoClient(configuration.url(), { w: 0, monitorCommands: true });
+      var client = new MongoClient(url, { w: 0, monitorCommands: true });
       client.connect(function(err) {
         expect(err).to.not.exist;
         const db = client.db(configuration.db);
@@ -77,9 +80,12 @@ describe('Sharding (Read Preference)', function() {
     // The actual test we wish to run
     test: function(done) {
       const configuration = this.configuration;
+      const host = configuration.host;
+      const port = configuration.port;
 
+      const url = `mongodb://${host}:${port}/sharded_test_db?w=1`;
       // Connect using the mongos connections
-      const client = new MongoClient(configuration.url(), { w: 0 });
+      const client = new MongoClient(url, { w: 0 });
       client.connect(function(err) {
         expect(err).to.not.exist;
         const db = client.db(configuration.db);

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -71,7 +71,7 @@ describe('Transactions', function() {
 
   describe('startTransaction', function() {
     it('should error if transactions are not supported', {
-      metadata: { requires: { topology: ['sharded'], mongodb: '>4.0.0' } },
+      metadata: { requires: { topology: ['sharded'], mongodb: '4.0.x' } },
       test: function(done) {
         const configuration = this.configuration;
         const client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });


### PR DESCRIPTION
## Description

A few things:
- Fixed a bug where session was not getting passed to serverSelection, which broke mongos-pinning for transactions
- Fixed the error that is thrown for invalid sharded transaction sessions. Now that we support
sharded transactions, it should not throw on sharded unless wire version is low enough
- Fixed a bunch of test runner issues that were causing test failures
- Temporarily disabled some tests that could not be worked around in the current state of the unified test runner.

**Are there any files to ignore?**
No