### PR TITLE
refactor(test-runner-poc): removes dependencies on topologyManager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
   - mongocryptd/bin/mongocryptd&
   - wget https://s3.amazonaws.com/mciuploads/libmongocrypt/ubuntu1604/master/1c6c72377582ebcd8402f6f15fff5c3143b46741/libmongocrypt.tar.gz
   - sudo tar -xzf libmongocrypt.tar.gz -C /usr/local
-  - sudo pip install mongo-orchestration && mongo-orchestration start
+  - sudo pip install mongo-orchestration
+  - mongo-orchestration start
 
 jobs:
   include:
@@ -54,6 +55,7 @@ jobs:
       node_js: 4
       env:
         - MONGODB_VERSION=4.0.x
+        - MONGODB_ENVIRONMENT=replicaset
     - stage: replicaset
       node_js: 4
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - mongocryptd/bin/mongocryptd&
   - wget https://s3.amazonaws.com/mciuploads/libmongocrypt/ubuntu1604/master/1c6c72377582ebcd8402f6f15fff5c3143b46741/libmongocrypt.tar.gz
   - sudo tar -xzf libmongocrypt.tar.gz -C /usr/local
+  - sudo pip install mongo-orchestration && mongo-orchestration start
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ branches:
     - next
     - test-runner
 
+before_script:
+  - cat /home/travis/tmp/orchestrations/db27017.log
+  - cat /home/travis/build/mongodb/node-mongodb-native/server.log
+
 before_install:
   - wget -O mongocryptd.tgz https://s3.amazonaws.com/mciuploads/mongodb-mongo-v4.2/enterprise-ubuntu1604-64/f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a/binaries/mongo-cryptd-mongodb_mongo_v4.2_enterprise_ubuntu1604_64_f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a_19_06_13_17_31_40.tgz
   - mkdir mongocryptd && tar xzf mongocryptd.tgz -C mongocryptd --strip-components 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,32 +24,50 @@ jobs:
   include:
     - stage: standalone
       node_js: 4
-      env: MONGODB_VERSION=2.6.x
+      env:
+        - MONGODB_VERSION=2.6.x
+        - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
       node_js: 4
-      env: MONGODB_VERSION=3.0.x
+      env:
+        - MONGODB_VERSION=3.0.x
+        - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
       node_js: 4
-      env: MONGODB_VERSION=3.2.x
+      env:
+        - MONGODB_VERSION=3.2.x
+        - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
       node_js: 4
-      env: MONGODB_VERSION=3.4.x
+      env:
+        - MONGODB_VERSION=3.4.x
+        - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
       node_js: 4
-      env: MONGODB_VERSION=3.6.x
+      env:
+        - MONGODB_VERSION=3.6.x
+        - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
       node_js: 4
-      env: MONGODB_VERSION=4.0.x
+      env:
+        - MONGODB_VERSION=4.0.x
+        - MONGODB_ENVIRONMENT=standalone
 
     - stage: standalone
       node_js: 6
-      env: MONGODB_VERSION=4.0.x
+      env:
+        - MONGODB_VERSION=4.0.x
+        - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
       node_js: 8
-      env: MONGODB_VERSION=4.0.x
+      env:
+        - MONGODB_VERSION=4.0.x
+        - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
       node_js: 10
-      env: MONGODB_VERSION=4.0.x
+      env:
+        - MONGODB_VERSION=4.0.x
+        - MONGODB_ENVIRONMENT=standalone
 
     - stage: replicaset
       node_js: 4
@@ -78,6 +96,7 @@ jobs:
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_UNIFIED_TOPOLOGY=1
+        - MONGODB_ENVIRONMENT=standalone
     - stage: unified
       node_js: 4
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,78 +23,51 @@ jobs:
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=2.6.x
-      before_script:
-        - mlaunch --single
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=3.0.x
-      before_script:
-        - mlaunch --single
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=3.2.x
-      before_script:
-        - mlaunch --single
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=3.4.x
-      before_script:
-        - mlaunch --single
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=3.6.x
-      before_script:
-        - mlaunch --single
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=4.0.x
-      before_script:
-        - mlaunch --single
 
     - stage: standalone
       node_js: 6
       env: MONGODB_VERSION=4.0.x
-      before_script:
-        - mlaunch --single
     - stage: standalone
       node_js: 8
       env: MONGODB_VERSION=4.0.x
-      before_script:
-        - mlaunch --single
     - stage: standalone
       node_js: 10
       env: MONGODB_VERSION=4.0.x
-      before_script:
-        - mlaunch --single
 
     - stage: replicaset
       node_js: 4
       env:
         - MONGODB_VERSION=4.0.x
-        - MONGODB_ENVIRONMENT=replicaset
-      before_script:
-        - mlaunch --init --replicaset --setParameter enableTestCommands=1
     - stage: replicaset
       node_js: 4
       env:
         - MONGODB_VERSION=4.2.x
         - MONGODB_ENVIRONMENT=replicaset
-      before_script:
-        - mlaunch --init --replicaset --setParameter enableTestCommands=1
     - stage: sharded
       node_js: 4
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_ENVIRONMENT=sharded
-      before_script:
-        - mlaunch —replicaset --sharded 3
     - stage: sharded
       node_js: 4
       env:
         - MONGODB_VERSION=4.2.x
         - MONGODB_ENVIRONMENT=sharded
-      before_script:
-        - mlaunch —replicaset --sharded 3
 
     # basic smoke test of the unified topology
     - stage: unified

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ branches:
     - next
     - test-runner
 
-before_script:
-  - cat /home/travis/tmp/orchestrations/db27017.log
-  - cat /home/travis/build/mongodb/node-mongodb-native/server.log
-
 before_install:
   - wget -O mongocryptd.tgz https://s3.amazonaws.com/mciuploads/mongodb-mongo-v4.2/enterprise-ubuntu1604-64/f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a/binaries/mongo-cryptd-mongodb_mongo_v4.2_enterprise_ubuntu1604_64_f92115cad9d2a4c2ddcf3c2c65092dda2fd7147a_19_06_13_17_31_40.tgz
   - mkdir mongocryptd && tar xzf mongocryptd.tgz -C mongocryptd --strip-components 1
@@ -145,3 +141,7 @@ jobs:
         - MONGODB_UNIFIED_TOPOLOGY=1
         - MONGODB_ENVIRONMENT=sharded
     - stage: client-encryption
+
+after_failure:
+  - cat /home/travis/tmp/orchestrations/db27017.log
+  - cat /home/travis/build/mongodb/node-mongodb-native/server.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,32 +23,32 @@ before_install:
 jobs:
   include:
     - stage: standalone
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=2.6.x
         - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=3.0.x
         - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=3.2.x
         - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=3.4.x
         - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=3.6.x
         - MONGODB_ENVIRONMENT=standalone
     - stage: standalone
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_ENVIRONMENT=standalone
@@ -70,60 +70,60 @@ jobs:
         - MONGODB_ENVIRONMENT=standalone
 
     - stage: replicaset
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_ENVIRONMENT=replicaset
     - stage: replicaset
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=4.2.x
         - MONGODB_ENVIRONMENT=replicaset
     - stage: sharded
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_ENVIRONMENT=sharded
     - stage: sharded
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=4.2.x
         - MONGODB_ENVIRONMENT=sharded
 
     # basic smoke test of the unified topology
     - stage: unified
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_UNIFIED_TOPOLOGY=1
         - MONGODB_ENVIRONMENT=standalone
     - stage: unified
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_UNIFIED_TOPOLOGY=1
         - MONGODB_ENVIRONMENT=replicaset
     - stage: unified
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_UNIFIED_TOPOLOGY=1
         - MONGODB_ENVIRONMENT=sharded
     - stage: unified
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=4.2.x
         - MONGODB_UNIFIED_TOPOLOGY=1
         - MONGODB_ENVIRONMENT=replicaset
     - stage: unified
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=4.2.x
         - MONGODB_UNIFIED_TOPOLOGY=1
         - MONGODB_ENVIRONMENT=sharded
 
     - stage: client-encryption
-      node_js: 4
+      node_js: 6
       env:
         - MONGODB_VERSION=latest
         - MONGODB_UNIFIED_TOPOLOGY=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,52 +23,78 @@ jobs:
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=2.6.x
+      before_script:
+        - mlaunch --single
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=3.0.x
+      before_script:
+        - mlaunch --single
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=3.2.x
+      before_script:
+        - mlaunch --single
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=3.4.x
+      before_script:
+        - mlaunch --single
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=3.6.x
+      before_script:
+        - mlaunch --single
     - stage: standalone
       node_js: 4
       env: MONGODB_VERSION=4.0.x
+      before_script:
+        - mlaunch --single
 
     - stage: standalone
       node_js: 6
       env: MONGODB_VERSION=4.0.x
+      before_script:
+        - mlaunch --single
     - stage: standalone
       node_js: 8
       env: MONGODB_VERSION=4.0.x
+      before_script:
+        - mlaunch --single
     - stage: standalone
       node_js: 10
       env: MONGODB_VERSION=4.0.x
+      before_script:
+        - mlaunch --single
 
     - stage: replicaset
       node_js: 4
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_ENVIRONMENT=replicaset
+        before_script:
+          - mlaunch --init --replicaset --setParameter enableTestCommands=1
     - stage: replicaset
       node_js: 4
       env:
         - MONGODB_VERSION=4.2.x
         - MONGODB_ENVIRONMENT=replicaset
+      before_script:
+        - mlaunch --init --replicaset --setParameter enableTestCommands=1
     - stage: sharded
       node_js: 4
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_ENVIRONMENT=sharded
+      before_script:
+        - mlaunch —replicaset --sharded 3
     - stage: sharded
       node_js: 4
       env:
         - MONGODB_VERSION=4.2.x
         - MONGODB_ENVIRONMENT=sharded
+      before_script:
+        - mlaunch —replicaset --sharded 3
 
     # basic smoke test of the unified topology
     - stage: unified

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ jobs:
       env:
         - MONGODB_VERSION=4.0.x
         - MONGODB_ENVIRONMENT=replicaset
-        before_script:
-          - mlaunch --init --replicaset --setParameter enableTestCommands=1
+      before_script:
+        - mlaunch --init --replicaset --setParameter enableTestCommands=1
     - stage: replicaset
       node_js: 4
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2743,6 +2743,12 @@
         }
       }
     },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -4541,6 +4547,15 @@
         }
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -4768,6 +4783,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "scripts": {
     "atlas": "node ./test/atlas_connectivity_tests.js",
-    "test": "npm run lint && mongodb-test-runner -t 60000 test/core test/unit test/functional",
+    "test": "npm run lint && cd test-runner-poc && npm run func",
     "coverage": "istanbul cover mongodb-test-runner -- -t 60000 test/core test/unit test/functional",
     "lint": "eslint lib test",
     "format": "prettier --print-width 100 --tab-width 2 --single-quote --write 'test/**/*.js' 'lib/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "version": "3.3.0",
+  "version": "3.3.0-beta1",
   "description": "The official MongoDB driver for Node.js",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
   },
   "scripts": {
     "atlas": "node ./test/atlas_connectivity_tests.js",
-    "test": "cd test-runner-poc && npm install && npm run func",
-    "test-old": "npm run lint && mongodb-test-runner -t 60000 test/core test/unit test/functional",
+    "test": "npm run lint && mongodb-test-runner -t 60000 test/core test/unit test/functional",
     "coverage": "istanbul cover mongodb-test-runner -- -t 60000 test/core test/unit test/functional",
     "lint": "eslint lib test",
     "format": "prettier --print-width 100 --tab-width 2 --single-quote --write 'test/**/*.js' 'lib/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "version": "3.3.0-beta1",
+  "version": "3.3.0",
   "description": "The official MongoDB driver for Node.js",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "bson": "^1.1.1",
     "require_optional": "^1.0.1",
+    "mocha": "*",
     "safe-buffer": "^5.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "scripts": {
     "atlas": "node ./test/atlas_connectivity_tests.js",
     "orchestration": "node test/check_mongo_orchestration_tests.js",
-    "test": "npm run orchestration && npm run lint && cd test-runner-poc && npm run func",
+    "test": "npm run orchestration && cd test-runner-poc && npm run func && cd .. && npm run lint",
     "coverage": "istanbul cover mongodb-test-runner -- -t 60000 test/core test/unit test/functional",
     "lint": "eslint lib test",
     "format": "prettier --print-width 100 --tab-width 2 --single-quote --write 'test/**/*.js' 'lib/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
   },
   "scripts": {
     "atlas": "node ./test/atlas_connectivity_tests.js",
-    "test": "npm run lint && mongodb-test-runner -t 60000 test/core test/unit test/functional",
+    "test": "cd test-runner-poc && npm install && npm run func",
+    "test-old": "npm run lint && mongodb-test-runner -t 60000 test/core test/unit test/functional",
     "coverage": "istanbul cover mongodb-test-runner -- -t 60000 test/core test/unit test/functional",
     "lint": "eslint lib test",
     "format": "prettier --print-width 100 --tab-width 2 --single-quote --write 'test/**/*.js' 'lib/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "mongodb-test-runner": "^1.1.18",
     "prettier": "~1.12.0",
     "semver": "^5.5.0",
+    "shelljs": "^0.8.3",
     "sinon": "^4.3.0",
     "sinon-chai": "^3.2.0",
     "snappy": "^6.1.2",
@@ -61,7 +62,8 @@
   },
   "scripts": {
     "atlas": "node ./test/atlas_connectivity_tests.js",
-    "test": "npm run lint && cd test-runner-poc && npm run func",
+    "orchestration": "node test/check_mongo_orchestration_tests.js",
+    "test": "npm run orchestration && npm run lint && cd test-runner-poc && npm run func",
     "coverage": "istanbul cover mongodb-test-runner -- -t 60000 test/core test/unit test/functional",
     "lint": "eslint lib test",
     "format": "prettier --print-width 100 --tab-width 2 --single-quote --write 'test/**/*.js' 'lib/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "bson": "^1.1.1",
     "require_optional": "^1.0.1",
-    "mocha": "*",
     "safe-buffer": "^5.1.2"
   },
   "devDependencies": {

--- a/test-runner-poc/LICENSE.md
+++ b/test-runner-poc/LICENSE.md
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test-runner-poc/config.js
+++ b/test-runner-poc/config.js
@@ -1,42 +1,28 @@
 'use strict';
-const f = require('util').format;
 const url = require('url');
 const qs = require('querystring');
 const core = require('../lib/core');
-
-class ConfigurationBase {
-  constructor(options) {
-    this.options = options || {};
-    this.host = options.host || 'localhost';
-    this.port = options.port || 27017;
-    this.db = options.db || 'integration_tests';
-    this.mongo = options.mongo;
-    this.setName = options.setName || 'rs';
+class NativeConfiguration {
+  constructor(environment) {
+    this.options = environment || {};
+    this.host = environment.host || 'localhost';
+    this.port = environment.port || 27017;
+    this.db = environment.db || 'integration_tests';
+    this.mongo = environment.mongo;
+    this.setName = environment.setName || 'rs';
     this.require = this.mongo;
     this.writeConcern = function() {
       return { w: 1 };
     };
-  }
-
-}
-
-class NativeConfiguration extends ConfigurationBase {
-  constructor(environment) {
-    super(environment);
-
-    this.type = 'native';
     this.topology = environment.topology || this.defaultTopology;
     this.environment = environment;
-
     if (environment.setName) {
       this.replicasetName = environment.setName || 'rs';
     }
   }
-
   usingUnifiedTopology() {
     return !!process.env.MONGODB_UNIFIED_TOPOLOGY;
   }
-
   newClient(dbOptions, serverOptions) {
     // support MongoClient contructor form (url, options) for `newClient`
     if (typeof dbOptions === 'string') {
@@ -47,32 +33,25 @@ class NativeConfiguration extends ConfigurationBase {
           : serverOptions
       );
     }
-
     dbOptions = dbOptions || {};
     serverOptions = Object.assign({}, { haInterval: 100 }, serverOptions);
-    if (this.usingUnifiedTopology()) serverOptions.useUnifiedTopology = true;
-
-    // Override implementation
-    if (this.options.newDbInstance) {
-      return this.options.newDbInstance(dbOptions, serverOptions);
+    if (this.usingUnifiedTopology()) {
+      serverOptions.useUnifiedTopology = true;
     }
-
     // Set up the options
     const keys = Object.keys(this.options);
-    if (keys.indexOf('sslOnNormalPorts') !== -1) serverOptions.ssl = true;
-
+    if (keys.indexOf('sslOnNormalPorts') !== -1) {
+      serverOptions.ssl = true;
+    }
     // Fall back
     let dbHost = (serverOptions && serverOptions.host) || 'localhost';
     const dbPort = (serverOptions && serverOptions.port) || this.options.port || 27017;
-
     if (dbHost.indexOf('.sock') !== -1) {
       dbHost = qs.escape(dbHost);
     }
-
     if (this.options.setName) {
       Object.assign(dbOptions, { replicaSet: this.options.setName, auto_reconnect: false });
     }
-
     const connectionString = url.format({
       protocol: 'mongodb',
       slashes: true,
@@ -81,66 +60,30 @@ class NativeConfiguration extends ConfigurationBase {
       query: dbOptions,
       pathname: '/'
     });
-
     return new this.mongo.MongoClient(connectionString, serverOptions);
   }
-
   newTopology(host, port, options) {
     options = options || {};
     return this.topology(host, port, options);
   }
-
-  newConnection(host, port, options, callback) {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
-    var server = this.topology(host, port, options);
-    var errorHandler = function(err) {
-      callback(err);
-    };
-
-    // Set up connect
-    server.once('connect', function() {
-      server.removeListener('error', errorHandler);
-      callback(null, server);
-    });
-
-    server.once('error', errorHandler);
-
-    // Connect
-    try {
-      server.connect();
-    } catch (err) {
-      server.removeListener('error', errorHandler);
-      callback(err);
-    }
-  }
-
   url(username, password) {
     const url = this.options.url || 'mongodb://%slocalhost:27017/' + this.db;
-
     // Fall back
-    const auth = username && password ? f('%s:%s@', username, password) : '';
-    return f(url, auth);
+    const auth = username && password ? String(username) + ':' + String(password) + '@' : '';
+    return String(url) + String(auth);
   }
-
   writeConcernMax() {
     return Object.assign({}, this.options.writeConcernMax || { w: 1 });
   }
-
   server37631Workaround() {
     console.log('[applying SERVER-37631 workaround]');
     const configServers = this.manager.configurationServers.managers;
     const proxies = this.manager.proxies;
-
     const configServersPromise = configServers.reduce((result, server) => {
       return result.then(() =>
         server.executeCommand('admin.$cmd', { refreshLogicalSessionCacheNow: 1 })
       );
     }, Promise.resolve());
-
     return configServersPromise.then(() => {
       return proxies.reduce((promise, proxy) => {
         return promise.then(() =>
@@ -150,5 +93,4 @@ class NativeConfiguration extends ConfigurationBase {
     });
   }
 }
-
 module.exports = NativeConfiguration;

--- a/test-runner-poc/config.js
+++ b/test-runner-poc/config.js
@@ -1,0 +1,248 @@
+'use strict';
+const f = require('util').format;
+const url = require('url');
+const qs = require('querystring');
+const core = require('../lib/core');
+
+class ConfigurationBase {
+  constructor(options) {
+    this.options = options || {};
+    this.host = options.host || 'localhost';
+    this.port = options.port || 27017;
+    this.db = options.db || 'integration_tests';
+    this.manager = options.manager;
+    this.mongo = options.mongo;
+    this.skipStart = typeof options.skipStart === 'boolean' ? options.skipStart : false;
+    this.skipTermination =
+      typeof options.skipTermination === 'boolean' ? options.skipTermination : false;
+    this.setName = options.setName || 'rs';
+    this.require = this.mongo;
+    this.writeConcern = function() {
+      return { w: 1 };
+    };
+  }
+
+  stop(callback) {
+    if (this.skipTermination) return callback();
+    // Stop the servers
+    this.manager
+      .stop()
+      .then(function() {
+        callback(null);
+      })
+      .catch(function(err) {
+        callback(err, null);
+      });
+  }
+
+  restart(opts, callback) {
+    if (typeof opts === 'function') {
+      callback = opts;
+      opts = { purge: true, kill: true };
+    }
+    if (this.skipTermination) return callback();
+
+    // Stop the servers
+    this.manager
+      .restart()
+      .then(function() {
+        callback(null);
+      })
+      .catch(function(err) {
+        callback(err, null);
+      });
+  }
+
+  setup(callback) {
+    callback();
+  }
+
+  teardown(callback) {
+    callback();
+  }
+}
+
+class NativeConfiguration extends ConfigurationBase {
+  constructor(environment) {
+    super(environment);
+
+    this.type = 'native';
+    this.topology = environment.topology || this.defaultTopology;
+    this.environment = environment;
+
+    if (environment.setName) {
+      this.replicasetName = environment.setName || 'rs';
+    }
+  }
+
+  usingUnifiedTopology() {
+    return !!process.env.MONGODB_UNIFIED_TOPOLOGY;
+  }
+
+  defaultTopology(host, port, serverOptions) {
+    host = host || 'localhost';
+    port = port || 27017;
+
+    const options = Object.assign({}, { host, port }, serverOptions);
+    if (this.usingUnifiedTopology()) {
+      return new core.Topology(options);
+    }
+
+    return new core.Server(options);
+  }
+
+  start(callback) {
+    const self = this;
+    if (this.skipStart) return callback();
+
+    const client = this.newClient({}, { host: self.host, port: self.port });
+    this.manager
+      .purge()
+      .then(function() {
+        console.log('[purge the directories]');
+        return self.manager.start();
+      })
+      .then(() => {
+        if (this.environment.server37631WorkaroundNeeded) {
+          return this.server37631Workaround();
+        }
+      })
+      .then(function() {
+        console.log('[started the topology]');
+        return client.connect();
+      })
+      .then(function() {
+        console.log('[get connection to topology]');
+        return client.db(self.db).dropDatabase();
+      })
+      .then(function() {
+        console.log('[dropped database]');
+        return client.close();
+      })
+      .then(function() {
+        callback(null);
+      })
+      .catch(function(err) {
+        callback(err, null);
+      });
+  }
+
+  newClient(dbOptions, serverOptions) {
+    // support MongoClient contructor form (url, options) for `newClient`
+    if (typeof dbOptions === 'string') {
+      return new this.mongo.MongoClient(
+        dbOptions,
+        this.usingUnifiedTopology()
+          ? Object.assign({ useUnifiedTopology: true }, serverOptions)
+          : serverOptions
+      );
+    }
+
+    dbOptions = dbOptions || {};
+    serverOptions = Object.assign({}, { haInterval: 100 }, serverOptions);
+    if (this.usingUnifiedTopology()) serverOptions.useUnifiedTopology = true;
+
+    // Override implementation
+    if (this.options.newDbInstance) {
+      return this.options.newDbInstance(dbOptions, serverOptions);
+    }
+
+    // Set up the options
+    const keys = Object.keys(this.options);
+    if (keys.indexOf('sslOnNormalPorts') !== -1) serverOptions.ssl = true;
+
+    // Fall back
+    let dbHost = (serverOptions && serverOptions.host) || 'localhost';
+    const dbPort = (serverOptions && serverOptions.port) || this.options.port || 27017;
+
+    if (dbHost.indexOf('.sock') !== -1) {
+      dbHost = qs.escape(dbHost);
+    }
+
+    if (this.options.setName) {
+      Object.assign(dbOptions, { replicaSet: this.options.setName, auto_reconnect: false });
+    }
+
+    const connectionString = url.format({
+      protocol: 'mongodb',
+      slashes: true,
+      hostname: dbHost,
+      port: dbPort,
+      query: dbOptions,
+      pathname: '/'
+    });
+
+    return new this.mongo.MongoClient(connectionString, serverOptions);
+  }
+
+  newTopology(host, port, options) {
+    options = options || {};
+    return this.topology(host, port, options);
+  }
+
+  newConnection(host, port, options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    var server = this.topology(host, port, options);
+    var errorHandler = function(err) {
+      callback(err);
+    };
+
+    // Set up connect
+    server.once('connect', function() {
+      server.removeListener('error', errorHandler);
+      callback(null, server);
+    });
+
+    server.once('error', errorHandler);
+
+    // Connect
+    try {
+      server.connect();
+    } catch (err) {
+      server.removeListener('error', errorHandler);
+      callback(err);
+    }
+  }
+
+  url(username, password) {
+    const url = this.options.url || 'mongodb://%slocalhost:27017/' + this.db;
+
+    // Fall back
+    const auth = username && password ? f('%s:%s@', username, password) : '';
+    return f(url, auth);
+  }
+
+  writeConcern() {
+    return Object.assign({}, this.options.writeConcern || { w: 1 });
+  }
+
+  writeConcernMax() {
+    return Object.assign({}, this.options.writeConcernMax || { w: 1 });
+  }
+
+  server37631Workaround() {
+    console.log('[applying SERVER-37631 workaround]');
+    const configServers = this.manager.configurationServers.managers;
+    const proxies = this.manager.proxies;
+
+    const configServersPromise = configServers.reduce((result, server) => {
+      return result.then(() =>
+        server.executeCommand('admin.$cmd', { refreshLogicalSessionCacheNow: 1 })
+      );
+    }, Promise.resolve());
+
+    return configServersPromise.then(() => {
+      return proxies.reduce((promise, proxy) => {
+        return promise.then(() =>
+          proxy.executeCommand('admin.$cmd', { refreshLogicalSessionCacheNow: 1 })
+        );
+      }, Promise.resolve());
+    });
+  }
+}
+
+module.exports = NativeConfiguration;

--- a/test-runner-poc/config.js
+++ b/test-runner-poc/config.js
@@ -69,8 +69,8 @@ class NativeConfiguration {
   url(username, password) {
     const url = this.options.url || 'mongodb://%slocalhost:27017/' + this.db;
     // Fall back
-    const auth = username && password ? String(username) + ':' + String(password) + '@' : '';
-    return String(url) + String(auth);
+    const auth = username && password ? `${username}:${password}@` : '';
+    return `${url} ${auth}`;
   }
   writeConcernMax() {
     return Object.assign({}, this.options.writeConcernMax || { w: 1 });

--- a/test-runner-poc/config.js
+++ b/test-runner-poc/config.js
@@ -1,4 +1,5 @@
 'use strict';
+const f = require('util').format;
 const url = require('url');
 const qs = require('querystring');
 const core = require('../lib/core');
@@ -20,9 +21,11 @@ class NativeConfiguration {
       this.replicasetName = environment.setName || 'rs';
     }
   }
+
   usingUnifiedTopology() {
     return !!process.env.MONGODB_UNIFIED_TOPOLOGY;
   }
+
   newClient(dbOptions, serverOptions) {
     // support MongoClient contructor form (url, options) for `newClient`
     if (typeof dbOptions === 'string') {
@@ -62,19 +65,24 @@ class NativeConfiguration {
     });
     return new this.mongo.MongoClient(connectionString, serverOptions);
   }
+
   newTopology(host, port, options) {
     options = options || {};
     return this.topology(host, port, options);
   }
+
   url(username, password) {
     const url = this.options.url || 'mongodb://%slocalhost:27017/' + this.db;
+
     // Fall back
-    const auth = username && password ? `${username}:${password}@` : '';
-    return `${url} ${auth}`;
+    const auth = username && password ? f('%s:%s@', username, password) : '';
+    return f(url, auth);
   }
+
   writeConcernMax() {
     return Object.assign({}, this.options.writeConcernMax || { w: 1 });
   }
+
   server37631Workaround() {
     console.log('[applying SERVER-37631 workaround]');
     const configServers = this.manager.configurationServers.managers;

--- a/test-runner-poc/environments.js
+++ b/test-runner-poc/environments.js
@@ -1,0 +1,254 @@
+'use strict';
+
+const f = require('util').format;
+const semver = require('semver');
+const path = require('path');
+const core = require('../lib/core');
+
+/**
+ * Base class for environments in projects that use the test
+ * runner
+ */
+class EnvironmentBase {
+  /**
+   * The default implementation of the environment setup
+   *
+   * @param {*} callback
+   */
+  setup(callback) {
+    callback();
+  }
+}
+
+const genReplsetConfig = (port, options) => {
+  return Object.assign(
+    {
+      options: {
+        bind_ip: 'localhost',
+        port: port,
+        dbpath: `${__dirname}/../db/${port}`,
+        setParameter: ['enableTestCommands=1']
+      }
+    },
+    options
+  );
+};
+
+function usingUnifiedTopology() {
+  return !!process.env.MONGODB_UNIFIED_TOPOLOGY;
+}
+
+/**
+ *
+ * @param {*} discoverResult
+ */
+class ReplicaSetEnvironment extends EnvironmentBase {
+  constructor(version) {
+    super();
+
+    this.setName = 'replset';
+    this.writeConcernMax = { w: 'majority', wtimeout: 30000 };
+    this.replicasetName = 'rs';
+    this.topology = function(host, port, options) {
+      host = host || 'localhost';
+      port = port || 31000;
+      options = Object.assign({}, options);
+      options.replicaSet = 'rs';
+      options.poolSize = 1;
+      options.autoReconnect = false;
+
+      if (usingUnifiedTopology()) {
+        return new core.Topology([{ host, port }], options);
+      }
+
+      return new core.ReplSet([{ host, port }], options);
+    };
+
+    this.nodes = [
+      genReplsetConfig(31000, { tags: { loc: 'ny' } }),
+      genReplsetConfig(31001, { tags: { loc: 'sf' } }),
+      genReplsetConfig(31002, { tags: { loc: 'sf' } }),
+      genReplsetConfig(31003, { tags: { loc: 'sf' } }),
+      genReplsetConfig(31004, { arbiter: true })
+    ];
+
+    // Do we have 3.2+
+    if (semver.satisfies(version, '>=3.2.0')) {
+      this.nodes = this.nodes.map(function(x) {
+        x.options.enableMajorityReadConcern = null;
+        return x;
+      });
+    }
+
+  }
+}
+
+/**
+ *
+ */
+class SingleEnvironment extends EnvironmentBase {
+  constructor() {
+    super();
+  }
+}
+
+const genShardedConfig = (port, options, shardOptions) => {
+  return Object.assign(
+    {
+      options: {
+        bind_ip: 'localhost',
+        port: port,
+        dbpath: `${__dirname}/../db/${port}`,
+        shardsvr: null
+      }
+    },
+    options,
+    shardOptions
+  );
+};
+
+const genConfigNode = (port, options) => {
+  return Object.assign(
+    {
+      options: {
+        bind_ip: 'localhost',
+        port: port,
+        dbpath: `${__dirname}/../db/${port}`,
+        setParameter: ['enableTestCommands=1']
+      }
+    },
+    options
+  );
+};
+
+/**
+ *
+ */
+class ShardedEnvironment extends EnvironmentBase {
+  constructor(version) {
+    super();
+
+    this.writeConcernMax = { w: 'majority', wtimeout: 30000 };
+    this.topology = (host, port, options) => {
+      host = host || 'localhost';
+      port = port || 51000;
+      options = options || {};
+
+      if (usingUnifiedTopology()) {
+        return new core.Topology([{ host, port }], options);
+      }
+
+      return new core.Mongos([{ host, port }], options);
+    };
+
+    this.server37631WorkaroundNeeded = semver.satisfies(version, '3.6.x');
+
+  }
+
+  setup(callback) {
+    const shardOptions = this.options && this.options.shard ? this.options.shard : {};
+
+    // First set of nodes
+    const nodes1 = [
+      genShardedConfig(31010, { tags: { loc: 'ny' } }, shardOptions),
+      genShardedConfig(31011, { tags: { loc: 'sf' } }, shardOptions),
+      genShardedConfig(31012, { arbiter: true }, shardOptions)
+    ];
+
+    const configOptions = this.options && this.options.config ? this.options.config : {};
+    const configNodes = [genConfigNode(35000, configOptions)];
+
+    let proxyNodes = [
+      {
+        bind_ip: 'localhost',
+        port: 51000,
+        configdb: 'localhost:35000,localhost:35001,localhost:35002',
+        setParameter: ['enableTestCommands=1']
+      },
+      {
+        bind_ip: 'localhost',
+        port: 51001,
+        configdb: 'localhost:35000,localhost:35001,localhost:35002',
+        setParameter: ['enableTestCommands=1']
+      }
+    ];
+
+    // Additional mapping
+    const self = this;
+    proxyNodes = proxyNodes.map(function(x) {
+      if (self.options && self.options.proxy) {
+        for (let name in self.options.proxy) {
+          x[name] = self.options.proxy[name];
+        }
+      }
+
+      return x;
+    });
+
+    this.proxies = proxyNodes.map(proxy => {
+      return { host: proxy.bind_ip, port: proxy.port };
+    });
+
+  }
+}
+
+/**
+ *
+ */
+class SslEnvironment extends EnvironmentBase {
+  constructor() {
+    super();
+
+    this.sslOnNormalPorts = null;
+    this.fork = null;
+    this.sslPEMKeyFile = __dirname + '/functional/ssl/server.pem';
+    this.url = 'mongodb://%slocalhost:27017/integration_tests?ssl=true&sslValidate=false';
+    this.topology = function(host, port, serverOptions) {
+      host = host || 'localhost';
+      port = port || 27017;
+      serverOptions = Object.assign({}, serverOptions);
+      serverOptions.poolSize = 1;
+      serverOptions.ssl = true;
+      serverOptions.sslValidate = false;
+      return new core.Server(host, port, serverOptions);
+    };
+
+  }
+}
+
+/**
+ *
+ */
+class AuthEnvironment extends EnvironmentBase {
+  constructor() {
+    super();
+
+    this.url = 'mongodb://%slocalhost:27017/integration_tests';
+    this.topology = function(host, port, serverOptions) {
+      host = host || 'localhost';
+      port = port || 27017;
+      serverOptions = Object.assign({}, serverOptions);
+      serverOptions.poolSize = 1;
+      return new core.Server(host, port, serverOptions);
+    };
+
+  }
+}
+
+module.exports = {
+  single: SingleEnvironment,
+  replicaset: ReplicaSetEnvironment,
+  sharded: ShardedEnvironment,
+  ssl: SslEnvironment,
+  auth: AuthEnvironment,
+
+  // informational aliases
+  kerberos: SingleEnvironment,
+  ldap: SingleEnvironment,
+  sni: SingleEnvironment,
+
+  // for compatability with evergreen template
+  server: SingleEnvironment,
+  replica_set: ReplicaSetEnvironment,
+  sharded_cluster: ShardedEnvironment
+};

--- a/test-runner-poc/environments.js
+++ b/test-runner-poc/environments.js
@@ -1,6 +1,9 @@
 'use strict';
+<<<<<<< HEAD
 
 const f = require('util').format;
+=======
+>>>>>>> incorporate feedback about requires
 const semver = require('semver');
 const path = require('path');
 const core = require('../lib/core');

--- a/test-runner-poc/environments.js
+++ b/test-runner-poc/environments.js
@@ -41,6 +41,7 @@ function usingUnifiedTopology() {
   return !!process.env.MONGODB_UNIFIED_TOPOLOGY;
 }
 
+<<<<<<< HEAD
 /**
  *
  * @param {*} discoverResult
@@ -53,6 +54,13 @@ class ReplicaSetEnvironment extends EnvironmentBase {
     this.port = port;
     this.setName = 'replset';
     this.url = `mongodb://%s${host}:${port}/integration_tests?rs_name=rs`;
+=======
+class ReplicaSetEnvironment extends EnvironmentBase {
+  constructor(parsedURI, version) {
+    super(parsedURI);
+    this.setName = 'rs';
+    this.url = `mongodb://%s${this.host}:${this.port}/integration_tests?rs_name=rs`;
+>>>>>>> address feedback
     this.writeConcernMax = { w: 'majority', wtimeout: 30000 };
     this.replicasetName = 'rs';
     this.topology = function(topologyHost, topologyPort, options) {
@@ -163,6 +171,7 @@ class ShardedEnvironment extends EnvironmentBase {
 
   setup(callback) {
     const shardOptions = this.options && this.options.shard ? this.options.shard : {};
+<<<<<<< HEAD
 
     // First set of nodes
     const nodes1 = [
@@ -171,6 +180,8 @@ class ShardedEnvironment extends EnvironmentBase {
       genShardedConfig(31012, { arbiter: true }, shardOptions)
     ];
 
+=======
+>>>>>>> address feedback
     const configOptions = this.options && this.options.config ? this.options.config : {};
     const configNodes = [genConfigNode(35000, configOptions)];
 

--- a/test-runner-poc/lib/filters/mongodb_topology_filter.js
+++ b/test-runner-poc/lib/filters/mongodb_topology_filter.js
@@ -16,10 +16,9 @@ class MongoDBTopologyFilter {
     const mongoClient = new MongoClient(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017');
     mongoClient.connect((err, client) => {
       if (err) {
-        callback(err);
-        return;
+        return callback(err);
       }
-      let topologyType = mongoClient.topology.type;
+      const topologyType = mongoClient.topology.type;
       switch (topologyType) {
         case 'server':
           if (client.topology.s.coreTopology.ismaster.hosts) this.runtimeTopology = 'replicaset';

--- a/test-runner-poc/lib/filters/mongodb_topology_filter.js
+++ b/test-runner-poc/lib/filters/mongodb_topology_filter.js
@@ -1,5 +1,5 @@
 'use strict';
-const MongoClient = require('mongodb').MongoClient;
+const MongoClient = require('../../../index').MongoClient;
 /**
  * Filter for the MongoDB toopology required for the test
  *
@@ -19,7 +19,6 @@ class MongoDBTopologyFilter {
         callback(err);
         return;
       }
-      console.log("client.topology.s.coreTopology.ismaster.hosts ",client.topology.s.coreTopology.ismaster)
       let topologyType = mongoClient.topology.type;
       switch (topologyType) {
         case 'server':

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -40,26 +40,26 @@ function environmentSetup(environmentCallback) {
     function environmentParser(environmentName, version) {
       console.log('environmentName ', environmentName);
       const Environment = environments[environmentName];
-      const environment = new Environment(version);
 
+      let host, port;
       parseConnectionString(mongodb_uri, (err, parsedURI) => {
         if (err) throw new Error(err);
-        environment.port = parsedURI.hosts[0].port;
-        environment.host = parsedURI.hosts[0].host;
-        environment.url = mongodb_uri;
-      });
-      if (environmentName !== 'single') environment.url += '/integration_tests';
+        port = parsedURI.hosts[0].port;
+        host = parsedURI.hosts[0].host;
 
-      try {
-        const mongoPackage = {
-          path: path.resolve(process.cwd(), '..'),
-          package: 'mongodb'
-        };
-        environment.mongo = require(mongoPackage.path);
-      } catch (err) {
-        throw new Error('The test runner must be a dependency of mongodb or mongodb-core');
-      }
-      environmentCallback(environment, client);
+        const environment = new Environment(host, port, version);
+
+        try {
+          const mongoPackage = {
+            path: path.resolve(process.cwd(), '..'),
+            package: 'mongodb'
+          };
+          environment.mongo = require(mongoPackage.path);
+        } catch (err) {
+          throw new Error('The test runner must be a dependency of mongodb or mongodb-core');
+        }
+        environmentCallback(environment, client);
+      });
     }
   });
 }

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -28,8 +28,7 @@ function environmentSetup(environmentCallback) {
 
   mongoClient.connect((err, client) => {
     if (err) {
-      environmentCallback(err);
-      return;
+      return environmentCallback(err);
     }
     createFilters(environmentParser);
 
@@ -40,8 +39,7 @@ function environmentSetup(environmentCallback) {
       let host, port;
       parseConnectionString(mongodb_uri, (err, parsedURI) => {
         if (err) {
-          environmentCallback(err);
-          return;
+          return environmentCallback(err);
         }
         const environment = new Environment(parsedURI, version);
         environment.mongo = require('../../index');

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -102,8 +102,8 @@ beforeEach(function(done) {
     filtersExecuted += 1;
 
     if (!filter.filter(self.currentTest)) {
+      //If we filter out a test, we'd like to ensure that any before hooks are skipped, as long as that hook is not the root hook.
       if (!self.currentTest.parent.parent.root) {
-        // self.currentTest.parent.pending = true; <-- this makes apm_tests skip when they should not
         self.currentTest.parent._beforeEach = [];
       }
       self.skip();

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -4,6 +4,12 @@ const path = require("path");
 const fs = require("fs");
 const utils = require("mocha").utils;
 
+const environments = require('../environments');
+const TestConfiguration = require('../config');
+
+const mock = require('mongodb-mock-server');
+
+let mongoClient;
 let filters = [];
 let files = [];
 
@@ -27,7 +33,47 @@ function addFilter(filter) {
 	}
 }
 
-before(function() {
+function environmentSetup(environmentCallback) {
+  const mongodb_uri = process.env.MONGODB_URI || 'mongodb://localhost:27017';
+  mongoClient = new MongoClient(mongodb_uri);
+
+  mongoClient.connect((err, client) => {
+    if (err) throw new Error(err);
+
+    createFilters(environmentParser);
+
+    function environmentParser(environmentName, version) {
+      console.log('environmentName ', environmentName);
+      const Environment = environments[environmentName];
+      const environment = new Environment(version);
+
+      parseConnectionString(mongodb_uri, (err, parsedURI) => {
+        if (err) throw new Error(err);
+        environment.port = parsedURI.hosts[0].port;
+        environment.host = parsedURI.hosts[0].host;
+        environment.url = mongodb_uri;
+      });
+      if (environmentName !== 'single') environment.url += '/integration_tests';
+
+      try {
+        const mongoPackage = {
+          path: path.resolve(process.cwd(), '..'),
+          package: 'mongodb'
+        };
+        environment.mongo = require(mongoPackage.path);
+      } catch (err) {
+        throw new Error('The test runner must be a dependency of mongodb or mongodb-core');
+      }
+      environmentCallback(environment, client);
+    }
+  });
+}
+
+function createFilters(callback) {
+  let filtersInitialized = 0;
+  const filterFiles = fs.readdirSync(path.join(__dirname, 'filters'));
+
+  let topology, version;
 
 	const environmentName = process.env['MONGODB_ENVIRONMENT'];
 

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -13,19 +13,14 @@ let filters = [];
 let files = [];
 
 function addFilter(filter) {
-  switch (typeof filter) {
-    case 'function':
-      filters.push({ filter: filter });
-      break;
-    case 'object':
-      if (!filter.filter || typeof filter.filter !== 'function') {
-        throw new Error('Object filters must have a function named filter');
-      }
-      filters.push(filter);
-      break;
-    default:
-      throw new Error('Type of filter must either be a function or an object');
+  if (typeof filter !== 'object') {
+    throw new Error('Type of filter must be an object');
   }
+  if (!filter.filter || typeof filter.filter !== 'function') {
+    throw new Error('Object filters must have a function named filter');
+  }
+  filters.push(filter);
+
 }
 
 function environmentSetup(environmentCallback) {

--- a/test-runner-poc/lib/runner.js
+++ b/test-runner-poc/lib/runner.js
@@ -35,8 +35,6 @@ function environmentSetup(environmentCallback) {
     function environmentParser(environmentName, version) {
       console.log('environmentName ', environmentName);
       const Environment = environments[environmentName];
-
-      let host, port;
       parseConnectionString(mongodb_uri, (err, parsedURI) => {
         if (err) {
           return environmentCallback(err);

--- a/test-runner-poc/package-lock.json
+++ b/test-runner-poc/package-lock.json
@@ -7,7 +7,7 @@
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
+      "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM="
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -17,7 +17,7 @@
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -25,7 +25,7 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -33,7 +33,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -43,7 +43,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -52,22 +52,22 @@
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
     },
     "bson": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
-      "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+      "integrity": "sha1-QzD16ZEExOdR5zUYWeLUCCefLxM="
     },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
     },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -80,7 +80,7 @@
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -90,7 +90,7 @@
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -105,7 +105,7 @@
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
       "requires": {
         "string-width": "^2.1.1",
         "strip-ansi": "^4.0.0",
@@ -120,7 +120,7 @@
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "requires": {
         "color-name": "1.1.3"
       }
@@ -138,7 +138,7 @@
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -150,7 +150,7 @@
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -163,7 +163,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -171,7 +171,7 @@
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -179,17 +179,17 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
     },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
     },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "requires": {
         "once": "^1.4.0"
       }
@@ -197,7 +197,7 @@
     "es-abstract": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -210,7 +210,7 @@
     "es-to-primitive": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -225,12 +225,12 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
     },
     "execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "requires": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -244,7 +244,7 @@
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "requires": {
         "locate-path": "^3.0.0"
       }
@@ -252,7 +252,7 @@
     "flat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
       "requires": {
         "is-buffer": "~2.0.3"
       }
@@ -265,12 +265,12 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -280,7 +280,7 @@
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "requires": {
         "pump": "^3.0.0"
       }
@@ -288,7 +288,7 @@
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -301,12 +301,12 @@
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+      "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4="
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -324,7 +324,7 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
     },
     "inflight": {
       "version": "1.0.6",
@@ -338,22 +338,27 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+      "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI="
     },
     "is-buffer": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+      "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
     },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU="
     },
     "is-date-object": {
       "version": "1.0.1",
@@ -381,7 +386,7 @@
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -394,7 +399,7 @@
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -403,7 +408,7 @@
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
       "requires": {
         "invert-kv": "^2.0.0"
       }
@@ -411,7 +416,7 @@
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -425,7 +430,7 @@
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
       "requires": {
         "chalk": "^2.0.1"
       }
@@ -433,7 +438,7 @@
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
       "requires": {
         "p-defer": "^1.0.0"
       }
@@ -441,7 +446,7 @@
     "mem": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
       "requires": {
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^2.0.0",
@@ -457,12 +462,12 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -533,17 +538,17 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
     },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y="
     },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "integrity": "sha1-+pMCdfW/Xa4YjWGSsktMi7rD12o=",
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
@@ -565,12 +570,12 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
     },
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -598,7 +603,7 @@
     "os-locale": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
       "requires": {
         "execa": "^1.0.0",
         "lcid": "^2.0.0",
@@ -618,7 +623,7 @@
     "p-is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
+      "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4="
     },
     "p-limit": {
       "version": "2.2.0",
@@ -631,7 +636,7 @@
     "p-locate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "requires": {
         "p-limit": "^2.0.0"
       }
@@ -639,7 +644,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -656,6 +661,11 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
@@ -664,10 +674,18 @@
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
       }
     },
     "require-directory": {
@@ -678,15 +696,23 @@
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
     },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
+      }
+    },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "requires": {
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -697,7 +723,7 @@
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "integrity": "sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk="
     },
     "saslprep": {
       "version": "1.0.3",
@@ -731,6 +757,16 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -753,7 +789,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -780,7 +816,7 @@
     "supports-color": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -788,12 +824,12 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
     },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -806,7 +842,7 @@
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
@@ -861,12 +897,12 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
     },
     "yargs": {
       "version": "13.2.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "integrity": "sha1-DBAfWArpXOp/Odkn53cOP9yX+ZM=",
       "requires": {
         "cliui": "^4.0.0",
         "find-up": "^3.0.0",
@@ -884,12 +920,12 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -899,7 +935,7 @@
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -909,7 +945,7 @@
     "yargs-parser": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "integrity": "sha1-P8RPPnaovbHMNgLoYBCGAuXM3os=",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -918,7 +954,7 @@
     "yargs-unparser": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
-      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "integrity": "sha1-8rsqfoPLyHu5XI5XKCigbJrdbg0=",
       "requires": {
         "flat": "^4.1.0",
         "lodash": "^4.17.11",
@@ -928,7 +964,7 @@
         "get-caller-file": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+          "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o="
         },
         "require-main-filename": {
           "version": "1.0.1",
@@ -938,7 +974,7 @@
         "yargs": {
           "version": "12.0.5",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.2.0",
@@ -957,7 +993,7 @@
         "yargs-parser": {
           "version": "11.1.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"

--- a/test-runner-poc/package.json
+++ b/test-runner-poc/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "runner.js",
   "scripts": {
-    "test": "mocha --file lib/runner.js test/crud_tests.js",
-    "func": "mocha --timeout 60000 --file lib/runner.js ../test/functional/*.js"
+    "test": "npm install && mocha --file lib/runner.js test/crud_tests.js",
+    "func": "npm install && mocha --timeout 60000 --file lib/runner.js ../test/functional/*.js"
   },
   "author": "",
   "license": "ISC",

--- a/test-runner-poc/package.json
+++ b/test-runner-poc/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "runner.js",
   "scripts": {
-    "test": "mocha --file lib/runner.js test/crud_tests.js",
-    "func": "mocha --timeout 60000 --file lib/runner.js ../test/functional/*.js"
+    "test": "npx mocha --file lib/runner.js test/crud_tests.js",
+    "func": "npx mocha --timeout 60000 --file lib/runner.js ../test/functional/*.js"
   },
   "author": "",
   "license": "ISC",

--- a/test-runner-poc/package.json
+++ b/test-runner-poc/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "runner.js",
   "scripts": {
-    "test": "npx mocha --file lib/runner.js test/crud_tests.js",
-    "func": "npx mocha --timeout 60000 --file lib/runner.js ../test/functional/*.js"
+    "test": "mocha --file lib/runner.js test/crud_tests.js",
+    "func": "mocha --timeout 60000 --file lib/runner.js ../test/functional/*.js"
   },
   "author": "",
   "license": "ISC",

--- a/test-runner-poc/package.json
+++ b/test-runner-poc/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "mocha": "*",
     "chai": "*",
+    "shelljs": "^0.8.3",
     "mongodb": "*"
   }
 }

--- a/test-runner-poc/package.json
+++ b/test-runner-poc/package.json
@@ -4,8 +4,7 @@
   "description": "",
   "main": "runner.js",
   "scripts": {
-    "test": "mocha --file lib/runner.js test/crud_tests.js",
-    "func": "mocha --timeout 60000 --file lib/runner.js ../test/functional/*.js"
+    "test": "mocha --file lib/runner.js test/crud_tests.js"
   },
   "author": "",
   "license": "ISC",

--- a/test-runner-poc/package.json
+++ b/test-runner-poc/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "runner.js",
   "scripts": {
-    "test": "mocha --file lib/runner.js test/crud_tests.js"
+    "test": "mocha --file lib/runner.js test/crud_tests.js",
+    "func": "mocha --timeout 60000 --file lib/runner.js ../test/functional/*.js"
   },
   "author": "",
   "license": "ISC",

--- a/test-runner-poc/test/tools/deprecate_warning_test_program.js
+++ b/test-runner-poc/test/tools/deprecate_warning_test_program.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// prevent this file from being imported; it is only for use in functional/deprecate_warning_tests.js
+if (require.main !== module) {
+  return;
+}
+
+const deprecateOptions = require('../../../lib/utils.js').deprecateOptions;
+
+const testDeprecationFlags = deprecateOptions(
+  {
+    name: 'testDeprecationFlags',
+    deprecatedOptions: ['maxScan', 'snapshot', 'fields'],
+    optionsIndex: 0
+  },
+  options => {
+    if (options) options = null;
+  }
+);
+
+testDeprecationFlags({ maxScan: 0 });
+
+// for tests that throw error on calling deprecated fn - this should never happen; stdout should be empty
+if (process.argv[2]) {
+  console.log(process.argv[2]);
+}
+
+process.nextTick(() => process.exit());

--- a/test-runner-poc/test/tools/utils.js
+++ b/test-runner-poc/test/tools/utils.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const Logger = require('../../lib/core').Logger;
+const deprecateOptions = require('../../lib/utils').deprecateOptions;
+const chai = require('chai');
+const expect = chai.expect;
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+
+function makeTestFunction(config) {
+  const fn = options => {
+    if (options) options = null;
+  };
+  return deprecateOptions(config, fn);
+}
+
+function ensureCalledWith(stub, args) {
+  args.forEach(m => expect(stub).to.have.been.calledWith(m));
+}
+
+// creation of class with a logger
+function ClassWithLogger() {
+  this.logger = new Logger('ClassWithLogger');
+}
+
+ClassWithLogger.prototype.f = makeTestFunction({
+  name: 'f',
+  deprecatedOptions: ['maxScan', 'snapshot', 'fields'],
+  optionsIndex: 0
+});
+
+ClassWithLogger.prototype.getLogger = function() {
+  return this.logger;
+};
+
+// creation of class without a logger
+function ClassWithoutLogger() {}
+
+ClassWithoutLogger.prototype.f = makeTestFunction({
+  name: 'f',
+  deprecatedOptions: ['maxScan', 'snapshot', 'fields'],
+  optionsIndex: 0
+});
+
+// creation of class where getLogger returns undefined
+function ClassWithUndefinedLogger() {}
+
+ClassWithUndefinedLogger.prototype.f = makeTestFunction({
+  name: 'f',
+  deprecatedOptions: ['maxScan', 'snapshot', 'fields'],
+  optionsIndex: 0
+});
+
+ClassWithUndefinedLogger.prototype.getLogger = function() {
+  return undefined;
+};
+
+module.exports = {
+  makeTestFunction,
+  ensureCalledWith,
+  ClassWithLogger,
+  ClassWithoutLogger,
+  ClassWithUndefinedLogger
+};

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -1,0 +1,14 @@
+'use strict';
+const shell = require('shelljs');
+if (!shell.which('mongo-orchestration')) {
+  //shell.echo('Warning: please install mongo-orchestration.');
+  // shell.echo('Mongo-orchestration not found. Installing mongo-orchestration.');
+  // shell.exec('pip install mongo-orchestration');
+  shell.exec('git clone https://github.com/10gen/mongo-orchestration.git');
+  shell.cd('mongo-orchestration');
+  shell.exec('pip install . --user')
+  //shell.exec('pip install git+https://github.com/10gen/mongo-orchestration.git --user')
+}
+shell.echo('Path to Mongo-Orchestration:');
+shell.echo(shell.which('mongo-orchestration'));
+shell.cd(shell.which('mongo-orchestration'));

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -10,4 +10,5 @@ if (!shell.test('-e', 'mongo-orchestration')) {
 }
 shell.cd('mongo_orchestration');
 shell.cd('configurations');
+shell.exec('mkdir /home/travis/tmp/');
 shell.exec('../../scripts/mo servers/clean.json start');

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -8,10 +8,9 @@ if (!shell.test('-e', 'mongo-orchestration')) {
 } else {
   shell.cd('mongo-orchestration');
 }
-shell.exec('nohup mongo-orchestration start > ./out.log 2> ./err.log < /dev/null &');
+shell.exec('nohup mongo-orchestration start &');
 shell.echo('finished starting mongo-orchestration');
 shell.cd('mongo_orchestration');
-shell.exec('mkdir /home/travis/tmp/');
 
 shell.exec('../scripts/mo configurations/servers/clean.json start');
 shell.echo('trying to run mongo --port 27017:')

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -8,7 +8,10 @@ if (!shell.test('-e', 'mongo-orchestration')) {
 } else {
   shell.cd('mongo-orchestration');
 }
+shell.exec('mongo-orchestration start')
 shell.cd('mongo_orchestration');
-shell.cd('configurations');
+//shell.cd('configurations');
 shell.exec('mkdir /home/travis/tmp/');
-shell.exec('../../scripts/mo servers/clean.json start');
+//shell.exec('mkdir /Users/rosemary.yin/tmp')
+
+shell.exec('../scripts/mo configuration/servers/clean.json start');

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -8,7 +8,7 @@ if (!shell.test('-e', 'mongo-orchestration')) {
 } else {
   shell.cd('mongo-orchestration');
 }
-shell.exec('nohup mongo-orchestration start --no-daemon &');
+shell.exec('nohup mongo-orchestration start &');
 shell.echo('finished starting mongo-orchestration');
 shell.cd('mongo_orchestration');
 

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -8,10 +8,14 @@ if (!shell.test('-e', 'mongo-orchestration')) {
 } else {
   shell.cd('mongo-orchestration');
 }
-shell.exec('mongo-orchestration start')
+shell.exec('mongo-orchestration start');
+shell.echo('finished starting mongo-orchestration');
 shell.cd('mongo_orchestration');
 //shell.cd('configurations');
 shell.exec('mkdir /home/travis/tmp/');
 //shell.exec('mkdir /Users/rosemary.yin/tmp')
 
 shell.exec('../scripts/mo configuration/servers/clean.json start');
+shell.echo('trying to run mongo --port 27017:')
+shell.exec('mongo --port 27017')
+shell.echo('finished check mongo orchestration script');

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -1,5 +1,7 @@
 'use strict';
 const shell = require('shelljs');
+shell.echo('mongodb environment variable is: ')
+shell.exec('echo $MONGODB_ENVIRONMENT');
 if (!shell.test('-e', 'mongo-orchestration')) {
   shell.echo('Mongo-orchestration not found. Installing mongo-orchestration.');
   shell.exec('git clone https://github.com/10gen/mongo-orchestration.git');
@@ -13,7 +15,4 @@ shell.echo('finished starting mongo-orchestration');
 shell.cd('mongo_orchestration');
 
 shell.exec('../scripts/mo configurations/servers/clean.json start');
-//shell.echo('trying to run mongo --port 27017:')
-//shell.exec('mongo --port 27017')
-//shell.exec('../scripts/mo configurations/servers/clean.json status');
 shell.echo('finished check mongo orchestration script');

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -6,7 +6,10 @@ if (!shell.which('mongo-orchestration')) {
   // shell.exec('pip install mongo-orchestration');
   shell.exec('git clone https://github.com/10gen/mongo-orchestration.git');
   shell.cd('mongo-orchestration');
-  shell.exec('pip install . --user')
+  shell.exec('pip install . --user');
+  shell.exec('ls');
+  shell.cd('scripts');
+  shell.exec('mo configurations/servers/clean.json start');
   //shell.exec('pip install git+https://github.com/10gen/mongo-orchestration.git --user')
 }
 shell.echo('Path to Mongo-Orchestration:');

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -11,11 +11,9 @@ if (!shell.test('-e', 'mongo-orchestration')) {
 shell.exec('nohup mongo-orchestration start > ./out.log 2> ./err.log < /dev/null &');
 shell.echo('finished starting mongo-orchestration');
 shell.cd('mongo_orchestration');
-//shell.cd('configurations');
 shell.exec('mkdir /home/travis/tmp/');
-//shell.exec('mkdir /Users/rosemary.yin/tmp')
 
-shell.exec('../scripts/mo configuration/servers/clean.json start');
+shell.exec('../scripts/mo configurations/servers/clean.json start');
 shell.echo('trying to run mongo --port 27017:')
 shell.exec('mongo --port 27017')
 shell.echo('finished check mongo orchestration script');

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -8,11 +8,12 @@ if (!shell.test('-e', 'mongo-orchestration')) {
 } else {
   shell.cd('mongo-orchestration');
 }
-shell.exec('nohup mongo-orchestration start &');
+shell.exec('nohup mongo-orchestration start --no-daemon &');
 shell.echo('finished starting mongo-orchestration');
 shell.cd('mongo_orchestration');
 
 shell.exec('../scripts/mo configurations/servers/clean.json start');
-shell.echo('trying to run mongo --port 27017:')
-shell.exec('mongo --port 27017')
+//shell.echo('trying to run mongo --port 27017:')
+//shell.exec('mongo --port 27017')
+//shell.exec('../scripts/mo configurations/servers/clean.json status');
 shell.echo('finished check mongo orchestration script');

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -1,7 +1,5 @@
 'use strict';
 const shell = require('shelljs');
-shell.echo('mongodb environment variable is: ')
-shell.exec('echo $MONGODB_ENVIRONMENT');
 if (!shell.test('-e', 'mongo-orchestration')) {
   shell.echo('Mongo-orchestration not found. Installing mongo-orchestration.');
   shell.exec('git clone https://github.com/10gen/mongo-orchestration.git');
@@ -13,6 +11,18 @@ if (!shell.test('-e', 'mongo-orchestration')) {
 shell.exec('nohup mongo-orchestration start &');
 shell.echo('finished starting mongo-orchestration');
 shell.cd('mongo_orchestration');
-
-shell.exec('../scripts/mo configurations/servers/clean.json start');
+shell.echo('mongodb environment variable is: ')
+shell.exec('echo $MONGODB_ENVIRONMENT');
+if (process.env.MONGODB_ENVIRONMENT === 'standalone') {
+  shell.exec('../scripts/mo configurations/servers/clean.json start');
+}
+else if (process.env.MONGODB_ENVIRONMENT === 'replicaset') {
+  shell.exec('../scripts/mo configurations/replica_sets/clean.json start');
+}
+else if (process.env.MONGODB_ENVIRONMENT === 'sharded') {
+  shell.exec('../scripts/mo configurations/sharded_clusters/clean.json start');
+}
+else {
+  shell.echo('mongodb environment error. Do not recognize $MONGODB_ENVIRONMENT');
+}
 shell.echo('finished check mongo orchestration script');

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -8,8 +8,10 @@ if (!shell.which('mongo-orchestration')) {
   shell.cd('mongo-orchestration');
   shell.exec('pip install . --user');
   shell.exec('ls');
-  shell.cd('scripts');
-  shell.exec('mo configurations/servers/clean.json start');
+  shell.cd('mongo_orchestration');
+  shell.exec('ls')
+  shell.cd('configurations')
+  shell.exec('mo servers/clean.json start');
   //shell.exec('pip install git+https://github.com/10gen/mongo-orchestration.git --user')
 }
 shell.echo('Path to Mongo-Orchestration:');

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -8,7 +8,7 @@ if (!shell.test('-e', 'mongo-orchestration')) {
 } else {
   shell.cd('mongo-orchestration');
 }
-shell.exec('mongo-orchestration start');
+shell.exec('nohup mongo-orchestration start > ./out.log 2> ./err.log < /dev/null &');
 shell.echo('finished starting mongo-orchestration');
 shell.cd('mongo_orchestration');
 //shell.cd('configurations');

--- a/test/check_mongo_orchestration_tests.js
+++ b/test/check_mongo_orchestration_tests.js
@@ -1,19 +1,13 @@
 'use strict';
 const shell = require('shelljs');
-if (!shell.which('mongo-orchestration')) {
-  //shell.echo('Warning: please install mongo-orchestration.');
-  // shell.echo('Mongo-orchestration not found. Installing mongo-orchestration.');
-  // shell.exec('pip install mongo-orchestration');
+if (!shell.test('-e', 'mongo-orchestration')) {
+  shell.echo('Mongo-orchestration not found. Installing mongo-orchestration.');
   shell.exec('git clone https://github.com/10gen/mongo-orchestration.git');
   shell.cd('mongo-orchestration');
   shell.exec('pip install . --user');
-  shell.exec('ls');
-  shell.cd('mongo_orchestration');
-  shell.exec('ls')
-  shell.cd('configurations')
-  shell.exec('mo servers/clean.json start');
-  //shell.exec('pip install git+https://github.com/10gen/mongo-orchestration.git --user')
+} else {
+  shell.cd('mongo-orchestration');
 }
-shell.echo('Path to Mongo-Orchestration:');
-shell.echo(shell.which('mongo-orchestration'));
-shell.cd(shell.which('mongo-orchestration'));
+shell.cd('mongo_orchestration');
+shell.cd('configurations');
+shell.exec('../../scripts/mo servers/clean.json start');


### PR DESCRIPTION
Fixes NODE-2046

## Description
Part of the overall goal to replace mongodb-topology-manager with mongo-orchestration.

**What changed?**
There are new environments.js and config.js files in the test-runner-poc folder, and the file paths are updated to route to the locations of these new files. Furthermore, environments.js and no longer requires mongodb-topology-manager.

Note: Another PR for this issue was previously opened. https://github.com/mongodb/node-mongodb-native/pull/2096