### PR TITLE
feat(transaction): allow applications to set maxTimeMS for commitTransaction

### DIFF
--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -287,6 +287,7 @@ class ClientSession extends EventEmitter {
 const MAX_WITH_TRANSACTION_TIMEOUT = 120000;
 const UNSATISFIABLE_WRITE_CONCERN_CODE = 100;
 const UNKNOWN_REPL_WRITE_CONCERN_CODE = 79;
+const MAX_TIME_MS_EXPIRED_CODE = 50;
 const NON_DETERMINISTIC_WRITE_CONCERN_ERRORS = new Set([
   'CannotSatisfyWriteConcern',
   'UnknownReplWriteConcern',
@@ -305,9 +306,20 @@ function isUnknownTransactionCommitResult(err) {
   );
 }
 
+function isMaxTimeMSExpiredError(err) {
+  return (
+    err.code === MAX_TIME_MS_EXPIRED_CODE ||
+    (err.writeConcernError && err.writeConcernError.code === MAX_TIME_MS_EXPIRED_CODE)
+  );
+}
+
 function attemptTransactionCommit(session, startTime, fn, options) {
   return session.commitTransaction().catch(err => {
-    if (err instanceof MongoError && hasNotTimedOut(startTime, MAX_WITH_TRANSACTION_TIMEOUT)) {
+    if (
+      err instanceof MongoError &&
+      hasNotTimedOut(startTime, MAX_WITH_TRANSACTION_TIMEOUT) &&
+      !isMaxTimeMSExpiredError(err)
+    ) {
       if (err.hasErrorLabel('UnknownTransactionCommitResult')) {
         return attemptTransactionCommit(session, startTime, fn, options);
       }
@@ -362,6 +374,13 @@ function attemptTransaction(session, startTime, fn, options) {
           hasNotTimedOut(startTime, MAX_WITH_TRANSACTION_TIMEOUT)
         ) {
           return attemptTransaction(session, startTime, fn, options);
+        }
+
+        if (isMaxTimeMSExpiredError(err)) {
+          if (err.errorLabels == null) {
+            err.errorLabels = [];
+          }
+          err.errorLabels.push('UnknownTransactionCommitResult');
         }
 
         throw err;
@@ -445,6 +464,10 @@ function endTransaction(session, commandName, callback) {
     Object.assign(command, { writeConcern });
   }
 
+  if (commandName === 'commitTransaction' && session.transaction.options.maxTimeMS) {
+    Object.assign(command, { maxTimeMS: session.transaction.options.maxTimeMS });
+  }
+
   function commandHandler(e, r) {
     if (commandName === 'commitTransaction') {
       session.transaction.transition(TxnState.TRANSACTION_COMMITTED);
@@ -453,7 +476,8 @@ function endTransaction(session, commandName, callback) {
         e &&
         (e instanceof MongoNetworkError ||
           e instanceof MongoWriteConcernError ||
-          isRetryableError(e))
+          isRetryableError(e) ||
+          isMaxTimeMSExpiredError(e))
       ) {
         if (e.errorLabels) {
           const idx = e.errorLabels.indexOf('TransientTransactionError');
@@ -464,7 +488,7 @@ function endTransaction(session, commandName, callback) {
           e.errorLabels = [];
         }
 
-        if (isUnknownTransactionCommitResult(e)) {
+        if (isUnknownTransactionCommitResult(e) || isMaxTimeMSExpiredError(e)) {
           e.errorLabels.push('UnknownTransactionCommitResult');
 
           // per txns spec, must unpin session in this case

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -300,9 +300,10 @@ function hasNotTimedOut(startTime, max) {
 
 function isUnknownTransactionCommitResult(err) {
   return (
-    !NON_DETERMINISTIC_WRITE_CONCERN_ERRORS.has(err.codeName) &&
-    err.code !== UNSATISFIABLE_WRITE_CONCERN_CODE &&
-    err.code !== UNKNOWN_REPL_WRITE_CONCERN_CODE
+    isMaxTimeMSExpiredError(err) ||
+    (!NON_DETERMINISTIC_WRITE_CONCERN_ERRORS.has(err.codeName) &&
+      err.code !== UNSATISFIABLE_WRITE_CONCERN_CODE &&
+      err.code !== UNKNOWN_REPL_WRITE_CONCERN_CODE)
   );
 }
 
@@ -488,7 +489,7 @@ function endTransaction(session, commandName, callback) {
           e.errorLabels = [];
         }
 
-        if (isUnknownTransactionCommitResult(e) || isMaxTimeMSExpiredError(e)) {
+        if (isUnknownTransactionCommitResult(e)) {
           e.errorLabels.push('UnknownTransactionCommitResult');
 
           // per txns spec, must unpin session in this case

--- a/lib/core/transactions.js
+++ b/lib/core/transactions.js
@@ -101,6 +101,7 @@ class Transaction {
 
     if (options.readConcern) this.options.readConcern = options.readConcern;
     if (options.readPreference) this.options.readPreference = options.readPreference;
+    if (options.maxCommitTimeMS) this.options.maxTimeMS = options.maxCommitTimeMS;
 
     // TODO: This isn't technically necessary
     this._pinnedServer = undefined;

--- a/test/functional/spec/transactions/convenient-api/commit-retry.json
+++ b/test/functional/spec/transactions/convenient-api/commit-retry.json
@@ -423,6 +423,106 @@
           ]
         }
       }
+    },
+    {
+      "description": "commit is not retried after MaxTimeMSExpired error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 50
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            },
+            "options": {
+              "maxCommitTimeMS": 60000
+            }
+          },
+          "result": {
+            "errorCodeName": "MaxTimeMSExpired",
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "maxTimeMS": 60000,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
     }
   ]
 }

--- a/test/functional/spec/transactions/convenient-api/commit-retry.yml
+++ b/test/functional/spec/transactions/convenient-api/commit-retry.yml
@@ -21,7 +21,7 @@ tests:
           failCommands: ["commitTransaction"]
           closeConnection: true
     operations:
-      -
+      - &withTransaction
         name: withTransaction
         object: session0
         arguments:
@@ -194,20 +194,7 @@ tests:
           errorCode: 10107 # NotMaster
           closeConnection: false
     operations:
-      -
-        name: withTransaction
-        object: session0
-        arguments:
-          callback:
-            operations:
-              -
-                name: insertOne
-                object: collection
-                arguments:
-                  session: session0
-                  document: { _id: 1 }
-                result:
-                  insertedId: 1
+      - *withTransaction
     expectations:
       -
         command_started_event:
@@ -270,3 +257,68 @@ tests:
       collection:
         data:
           - { _id: 1 }
+  -
+    description: commit is not retried after MaxTimeMSExpired error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 50 # MaxTimeMSExpired
+    operations:
+      - name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+          options:
+            maxCommitTimeMS: 60000
+        result:
+          errorCodeName: MaxTimeMSExpired
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            maxTimeMS: 60000
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        # In reality, the outcome of the commit is unknown but we fabricate
+        # the error with failCommand.errorCode which does not apply the commit
+        # operation.
+        data: []

--- a/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.json
+++ b/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.json
@@ -493,6 +493,110 @@
           ]
         }
       }
+    },
+    {
+      "description": "commitTransaction is not retried after MaxTimeMSExpired error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 50,
+            "codeName": "MaxTimeMSExpired",
+            "errmsg": "operation exceeded time limit"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorCodeName": "MaxTimeMSExpired",
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.yml
+++ b/test/functional/spec/transactions/convenient-api/commit-writeconcernerror.yml
@@ -193,3 +193,24 @@ tests:
     expectations: *expectations_without_retries
     # failCommand with writeConcernError still applies the write operation(s)
     outcome: *outcome
+
+  -
+    description: commitTransaction is not retried after MaxTimeMSExpired error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 50
+            codeName: MaxTimeMSExpired
+            errmsg: "operation exceeded time limit"
+    operations:
+      - <<: *operation
+        result:
+          errorCodeName: MaxTimeMSExpired
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+    expectations: *expectations_without_retries
+    # failCommand with writeConcernError still applies the write operation(s)
+    outcome: *outcome

--- a/test/functional/spec/transactions/error-labels.json
+++ b/test/functional/spec/transactions/error-labels.json
@@ -1564,6 +1564,400 @@
           ]
         }
       }
+    },
+    {
+      "description": "do not add unknown commit label to MaxTimeMSExpired inside transactions",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 50
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "maxTimeMS": 60000,
+            "session": "session0"
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult",
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$project": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "cursor": {},
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "maxTimeMS": 60000
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "add unknown commit label to MaxTimeMSExpired",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 50
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxCommitTimeMS": 60000
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "add unknown commit label to writeConcernError MaxTimeMSExpired",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 50,
+            "errmsg": "operation exceeded time limit"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxCommitTimeMS": 60000
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/functional/spec/transactions/error-labels.yml
+++ b/test/functional/spec/transactions/error-labels.yml
@@ -499,7 +499,7 @@ tests:
       mode: { times: 2 }
       data:
           failCommands: ["commitTransaction"]
-          errorCode: 11602  # InterruptedDueToStepDown 
+          errorCode: 11602  # InterruptedDueToReplStateChange 
 
     operations:
       - name: startTransaction
@@ -952,6 +952,250 @@ tests:
             autocommit: false
             writeConcern:
               w: majority
+          command_name: commitTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1
+
+  - description: do not add unknown commit label to MaxTimeMSExpired inside transactions
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+        failCommands: ["aggregate"]
+        errorCode: 50  # MaxTimeMSExpired
+
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: aggregate
+        object: collection
+        arguments:
+          pipeline:
+            - $project:
+                _id: 1
+          maxTimeMS: 60000
+          session: session0
+        result:
+          errorLabelsOmit: ["UnknownTransactionCommitResult", "TransientTransactionError"]
+      - name: abortTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline:
+              - $project:
+                  _id: 1
+            cursor: {}
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            autocommit: false
+            maxTimeMS: 60000
+          command_name: aggregate
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data: []
+
+  - description: add unknown commit label to MaxTimeMSExpired
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 50  # MaxTimeMSExpired
+
+    operations:
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            writeConcern:
+              w: majority
+            maxCommitTimeMS: 60000
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+        result:
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+      - name: commitTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+              w: majority
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            # commitTransaction applies w:majority on retries
+            writeConcern: { w: majority, wtimeout: 10000 }
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1
+
+  - description: add unknown commit label to writeConcernError MaxTimeMSExpired
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 50  # MaxTimeMSExpired
+            errmsg: operation exceeded time limit
+
+    operations:
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            writeConcern:
+              w: majority
+            maxCommitTimeMS: 60000
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+        result:
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+      - name: commitTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+              w: majority
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            # commitTransaction applies w:majority on retries
+            writeConcern: { w: majority, wtimeout: 10000 }
+            maxTimeMS: 60000
           command_name: commitTransaction
           database_name: admin
 

--- a/test/functional/spec/transactions/transaction-options.json
+++ b/test/functional/spec/transactions/transaction-options.json
@@ -81,7 +81,8 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": null,
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -98,7 +99,8 @@
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -123,7 +125,8 @@
               "readConcern": {
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -140,7 +143,8 @@
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -227,7 +231,8 @@
               "readConcern": {
                 "level": "local"
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -246,7 +251,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": 1
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -272,7 +278,8 @@
                 "level": "local",
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -291,7 +298,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": 1
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -318,7 +326,8 @@
             },
             "writeConcern": {
               "w": 1
-            }
+            },
+            "maxCommitTimeMS": 60000
           }
         }
       },
@@ -405,7 +414,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": 1
-              }
+              },
+              "maxTimeMS": 60000
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -481,7 +491,8 @@
             },
             "writeConcern": {
               "w": 1
-            }
+            },
+            "maxCommitTimeMS": 30000
           }
         }
       },
@@ -496,7 +507,8 @@
               },
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxCommitTimeMS": 60000
             }
           }
         },
@@ -569,7 +581,8 @@
               "readConcern": {
                 "level": "snapshot"
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -588,7 +601,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": 60000
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -614,7 +628,8 @@
                 "level": "snapshot",
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -633,7 +648,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -664,7 +680,8 @@
             },
             "writeConcern": {
               "w": "majority"
-            }
+            },
+            "maxCommitTimeMS": 60000
           }
         }
       },
@@ -732,7 +749,8 @@
               "readConcern": {
                 "level": "snapshot"
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -751,7 +769,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": 60000
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -777,7 +796,8 @@
                 "level": "snapshot",
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -796,7 +816,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/test/functional/spec/transactions/transaction-options.yml
+++ b/test/functional/spec/transactions/transaction-options.yml
@@ -55,6 +55,7 @@ tests:
             autocommit: false
             readConcern:
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -67,6 +68,7 @@ tests:
             autocommit: false
             readConcern:
             writeConcern:
+            maxTimeMS:
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -83,6 +85,7 @@ tests:
             readConcern:
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -95,6 +98,7 @@ tests:
             autocommit: false
             readConcern:
             writeConcern:
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 
@@ -126,6 +130,7 @@ tests:
             readConcern:
               level: local
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -139,6 +144,7 @@ tests:
             readConcern:
             writeConcern:
               w: 1
+            maxTimeMS:
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -156,6 +162,7 @@ tests:
               level: local
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -169,6 +176,7 @@ tests:
             readConcern:
             writeConcern:
               w: 1
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 
@@ -183,6 +191,7 @@ tests:
             level: snapshot
           writeConcern:
             w: 1
+          maxCommitTimeMS: 60000
 
     operations: *commitAbortOperations
 
@@ -214,6 +223,7 @@ tests:
             readConcern:
             writeConcern:
               w: 1
+            maxTimeMS: 60000
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -262,6 +272,7 @@ tests:
             level: majority
           writeConcern:
             w: 1
+          maxCommitTimeMS: 30000
 
     operations:
       - name: startTransaction
@@ -272,6 +283,7 @@ tests:
               level: snapshot
             writeConcern:
               w: majority
+            maxCommitTimeMS: 60000
       - name: insertOne
         object: collection
         arguments:
@@ -316,6 +328,7 @@ tests:
             readConcern:
               level: snapshot
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -329,6 +342,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS: 60000
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -346,6 +360,7 @@ tests:
               level: snapshot
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -359,6 +374,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 
@@ -377,6 +393,7 @@ tests:
             level: snapshot
           writeConcern:
             w: majority
+          maxCommitTimeMS: 60000
 
     operations: *commitAbortOperations
 
@@ -395,6 +412,7 @@ tests:
             readConcern:
               level: snapshot
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -408,6 +426,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS: 60000
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -425,6 +444,7 @@ tests:
               level: snapshot
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -438,6 +458,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 


### PR DESCRIPTION
## Description

**What changed?**
This PR adds the spec tests for NODE-1978 and the code needed to pass those tests. This includes adding `maxTimeMS` to the transaction options, as well as checking for `maxTimeMSExpired` errors before retrying.

**Are there any files to ignore?**
Any test files are just syncing spec tests.
