### PR TITLE
fix(command): only add TransientTransactionError label when in a transaction

### DIFF
--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -60,9 +60,6 @@ class MongoNetworkError extends MongoError {
   constructor(message) {
     super(message);
     this.name = 'MongoNetworkError';
-
-    // This is added as part of the transactions specification
-    this.errorLabels = ['TransientTransactionError'];
   }
 }
 

--- a/lib/core/wireprotocol/command.js
+++ b/lib/core/wireprotocol/command.js
@@ -8,6 +8,7 @@ const isSharded = require('./shared').isSharded;
 const databaseNamespace = require('./shared').databaseNamespace;
 const isTransactionCommand = require('../transactions').isTransactionCommand;
 const applySession = require('../sessions').applySession;
+const MongoNetworkError = require('../error').MongoNetworkError;
 
 function isClientEncryptionEnabled(server) {
   return server.autoEncrypter;
@@ -90,6 +91,18 @@ function _command(server, ns, cmd, options, callback) {
   const inTransaction = session && (session.inTransaction() || isTransactionCommand(finalCmd));
   const commandResponseHandler = inTransaction
     ? function(err) {
+        // We need to add a TransientTransactionError errorLabel, as stated in the transaction spec.
+        if (
+          err &&
+          err instanceof MongoNetworkError &&
+          !err.hasErrorLabel('TransientTransactionError')
+        ) {
+          if (err.errorLabels == null) {
+            err.errorLabels = [];
+          }
+          err.errorLabels.push('TransientTransactionError');
+        }
+
         if (
           !cmd.commitTransaction &&
           err &&

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -135,36 +135,63 @@ describe('Transactions', function() {
           const session = client.startSession();
           const db = client.db(configuration.db);
           const coll = db.collection('transaction_error_test');
-          expect(err).to.not.exist;
+
           session.startTransaction();
+          coll.insertOne({ a: 1 }, { session }, err => {
+            expect(err).to.not.exist;
+            expect(session.inTransaction()).to.be.true;
 
-          coll.insertOne({ a: 1 }, err => {
-            expect(err).to.be.null;
-            coll.insertOne({ a: 2 }, { session }, err => {
-              expect(err).to.not.exist;
-              expect(session.inTransaction()).to.be.true;
-
-              db.executeDbAdminCommand(
-                {
-                  configureFailPoint: 'failCommand',
-                  mode: { times: 1 },
-                  data: { failCommands: ['abortTransaction'], closeConnection: true }
-                },
-                () => {
-                  expect(session.inTransaction()).to.be.true;
-                  session.abortTransaction(err => {
-                    expect(err).to.exist;
-                    db.executeDbAdminCommand(
-                      { configureFailPoint: 'failCommand', mode: 'off' },
-                      () => {
-                        client.close(done);
-                      }
-                    );
-                  });
-                }
-              );
-            });
+            db.executeDbAdminCommand(
+              {
+                configureFailPoint: 'failCommand',
+                mode: { times: 2 },
+                data: { failCommands: ['commitTransaction'], closeConnection: true }
+              },
+              () => {
+                expect(session.inTransaction()).to.be.true;
+                session.commitTransaction(err => {
+                  expect(err).to.exist;
+                  expect(err.errorLabels).to.deep.equal(['UnknownTransactionCommitResult']);
+                  db.executeDbAdminCommand(
+                    { configureFailPoint: 'failCommand', mode: 'off' },
+                    () => {
+                      client.close(done);
+                    }
+                  );
+                });
+              }
+            );
           });
+        });
+      }
+    });
+
+    it('should not have a TransientTransactionError label outside of a transaction', {
+      metadata: { requires: { topology: 'replicaset', mongodb: '>=4.0.0' } },
+      test: function(done) {
+        const configuration = this.configuration;
+        const client = configuration.newClient({ w: 1 }, { useUnifiedTopology: true });
+
+        client.connect((err, client) => {
+          const db = client.db(configuration.db);
+          const coll = db.collection('transaction_error_test1');
+
+          db.executeDbAdminCommand(
+            {
+              configureFailPoint: 'failCommand',
+              mode: 'alwaysOn',
+              data: { failCommands: ['insert'], closeConnection: true }
+            },
+            () => {
+              coll.insertOne({ a: 1 }, err => {
+                expect(err).to.exist;
+                expect(err.errorLabels).to.not.exist;
+                db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' }, () => {
+                  client.close(done);
+                });
+              });
+            }
+          );
         });
       }
     });

--- a/test/functional/transactions_tests.js
+++ b/test/functional/transactions_tests.js
@@ -155,7 +155,9 @@ describe('Transactions', function() {
                     db.executeDbAdminCommand(
                       { configureFailPoint: 'failCommand', mode: 'off' },
                       () => {
-                        client.close(done);
+                        session.endSession(() => {
+                          client.close(done);
+                        });
                       }
                     );
                   });


### PR DESCRIPTION
Fixes NODE-2089

## Description
The transaction specification states that we must add the `TransientTransactionError` label to any `MongoNetworkError` that occurs within a transaction. Previously, we were adding the label for any `MongoNetworkError`, regardless of whether we were in a transaction or not. This led to a confusing `MongoNetworkError` with a `TransientTransactionError` label, which implied that we were adding transactions automatically (which we were not).

**What changed?**
Now, we only apply a `TransientTransactionError` label when a `MongoNetworkError` occurs within a transaction.

**Are there any files to ignore?**
