### PR TITLE
fix(topology): add new error for retryWrites on MMAPv1

### DIFF
--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -26,6 +26,8 @@ const MongoError = require('../error').MongoError;
 const resolveClusterTime = require('../topologies/shared').resolveClusterTime;
 const SrvPoller = require('./srv_polling').SrvPoller;
 
+const MMAPv1_RETRY_WRITES_ERROR_CODE = 20;
+
 // Global state
 let globalTopologyCounter = 0;
 
@@ -972,6 +974,18 @@ function executeWriteOperation(args, options, callback) {
     const handler = (err, result) => {
       if (!err) return callback(null, result);
       if (!isRetryableError(err)) {
+        if (
+          err.code === MMAPv1_RETRY_WRITES_ERROR_CODE &&
+          err.errmsg.includes('Transaction numbers')
+        ) {
+          // According to the retryable writes spec, we must replace the error message in this case.
+          // We need to replace err.message so the thrown message is correct and we need to replace err.errmsg to meet the spec requirement.
+          err.message =
+            'This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string.';
+          err.errmsg = err.message;
+          throw err;
+        }
+
         return callback(err);
       }
 

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -25,8 +25,7 @@ const createClientInfo = require('../topologies/shared').createClientInfo;
 const MongoError = require('../error').MongoError;
 const resolveClusterTime = require('../topologies/shared').resolveClusterTime;
 const SrvPoller = require('./srv_polling').SrvPoller;
-
-const MMAPv1_RETRY_WRITES_ERROR_CODE = 20;
+const getMMAPError = require('../topologies/shared').getMMAPError;
 
 // Global state
 let globalTopologyCounter = 0;
@@ -974,18 +973,7 @@ function executeWriteOperation(args, options, callback) {
     const handler = (err, result) => {
       if (!err) return callback(null, result);
       if (!isRetryableError(err)) {
-        if (
-          err.code === MMAPv1_RETRY_WRITES_ERROR_CODE &&
-          err.errmsg.includes('Transaction numbers')
-        ) {
-          // According to the retryable writes spec, we must replace the error message in this case.
-          // We need to replace err.message so the thrown message is correct and we need to replace err.errmsg to meet the spec requirement.
-          err.message =
-            'This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string.';
-          err.errmsg = err.message;
-          throw err;
-        }
-
+        err = getMMAPError(err);
         return callback(err);
       }
 

--- a/lib/core/topologies/mongos.js
+++ b/lib/core/topologies/mongos.js
@@ -17,6 +17,7 @@ const isRetryableWritesSupported = require('./shared').isRetryableWritesSupporte
 const relayEvents = require('../utils').relayEvents;
 const isRetryableError = require('../error').isRetryableError;
 const BSON = retrieveBSON();
+const handleMMAPError = require('./shared').handleMMAPError;
 
 /**
  * @fileOverview The **Mongos** class is a class that represents a Mongos Proxy topology and is
@@ -880,6 +881,7 @@ function executeWriteOperation(args, options, callback) {
   const handler = (err, result) => {
     if (!err) return callback(null, result);
     if (!isRetryableError(err) || !willRetryWrite) {
+      handleMMAPError(err);
       return callback(err);
     }
 

--- a/lib/core/topologies/mongos.js
+++ b/lib/core/topologies/mongos.js
@@ -17,7 +17,7 @@ const isRetryableWritesSupported = require('./shared').isRetryableWritesSupporte
 const relayEvents = require('../utils').relayEvents;
 const isRetryableError = require('../error').isRetryableError;
 const BSON = retrieveBSON();
-const handleMMAPError = require('./shared').handleMMAPError;
+const getMMAPError = require('./shared').getMMAPError;
 
 /**
  * @fileOverview The **Mongos** class is a class that represents a Mongos Proxy topology and is
@@ -881,7 +881,7 @@ function executeWriteOperation(args, options, callback) {
   const handler = (err, result) => {
     if (!err) return callback(null, result);
     if (!isRetryableError(err) || !willRetryWrite) {
-      handleMMAPError(err);
+      err = getMMAPError(err);
       return callback(err);
     }
 

--- a/lib/core/topologies/replset.js
+++ b/lib/core/topologies/replset.js
@@ -20,7 +20,7 @@ const relayEvents = require('../utils').relayEvents;
 const isRetryableError = require('../error').isRetryableError;
 const BSON = retrieveBSON();
 const calculateDurationInMs = require('../utils').calculateDurationInMs;
-const handleMMAPError = require('./shared').handleMMAPError;
+const getMMAPError = require('./shared').getMMAPError;
 
 //
 // States
@@ -1191,7 +1191,7 @@ function executeWriteOperation(args, options, callback) {
   const handler = (err, result) => {
     if (!err) return callback(null, result);
     if (!isRetryableError(err)) {
-      handleMMAPError(err);
+      err = getMMAPError(err);
       return callback(err);
     }
 

--- a/lib/core/topologies/replset.js
+++ b/lib/core/topologies/replset.js
@@ -20,6 +20,7 @@ const relayEvents = require('../utils').relayEvents;
 const isRetryableError = require('../error').isRetryableError;
 const BSON = retrieveBSON();
 const calculateDurationInMs = require('../utils').calculateDurationInMs;
+const handleMMAPError = require('./shared').handleMMAPError;
 
 //
 // States
@@ -1190,6 +1191,7 @@ function executeWriteOperation(args, options, callback) {
   const handler = (err, result) => {
     if (!err) return callback(null, result);
     if (!isRetryableError(err)) {
+      handleMMAPError(err);
       return callback(err);
     }
 

--- a/lib/core/topologies/shared.js
+++ b/lib/core/topologies/shared.js
@@ -5,6 +5,7 @@ const f = require('util').format;
 const ReadPreference = require('./read_preference');
 const Buffer = require('safe-buffer').Buffer;
 const TopologyType = require('../sdam/topology_description').TopologyType;
+const MongoError = require('../error').MongoError;
 
 const MMAPv1_RETRY_WRITES_ERROR_CODE = 20;
 
@@ -439,15 +440,22 @@ const isRetryableWritesSupported = function(topology) {
   return true;
 };
 
-function handleMMAPError(err) {
-  if (err.code === MMAPv1_RETRY_WRITES_ERROR_CODE && err.errmsg.includes('Transaction numbers')) {
-    // According to the retryable writes spec, we must replace the error message in this case.
-    // We need to replace err.message so the thrown message is correct and we need to replace err.errmsg to meet the spec requirement.
-    err.message =
-      'This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string.';
-    err.errmsg = err.message;
-    throw err;
+const MMAPv1_RETRY_WRITES_ERROR_MESSAGE =
+  'This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string.';
+
+function getMMAPError(err) {
+  if (err.code !== MMAPv1_RETRY_WRITES_ERROR_CODE || !err.errmsg.includes('Transaction numbers')) {
+    return err;
   }
+
+  // According to the retryable writes spec, we must replace the error message in this case.
+  // We need to replace err.message so the thrown message is correct and we need to replace err.errmsg to meet the spec requirement.
+  const newErr = new MongoError({
+    message: MMAPv1_RETRY_WRITES_ERROR_MESSAGE,
+    errmsg: MMAPv1_RETRY_WRITES_ERROR_MESSAGE,
+    originalError: err
+  });
+  return newErr;
 }
 
 module.exports.SessionMixins = SessionMixins;
@@ -464,5 +472,4 @@ module.exports.diff = diff;
 module.exports.Interval = Interval;
 module.exports.Timeout = Timeout;
 module.exports.isRetryableWritesSupported = isRetryableWritesSupported;
-module.exports.MMAPv1_RETRY_WRITES_ERROR_CODE = MMAPv1_RETRY_WRITES_ERROR_CODE;
-module.exports.handleMMAPError = handleMMAPError;
+module.exports.getMMAPError = getMMAPError;

--- a/lib/core/topologies/shared.js
+++ b/lib/core/topologies/shared.js
@@ -6,6 +6,8 @@ const ReadPreference = require('./read_preference');
 const Buffer = require('safe-buffer').Buffer;
 const TopologyType = require('../sdam/topology_description').TopologyType;
 
+const MMAPv1_RETRY_WRITES_ERROR_CODE = 20;
+
 /**
  * Emit event if it exists
  * @method
@@ -437,6 +439,17 @@ const isRetryableWritesSupported = function(topology) {
   return true;
 };
 
+function handleMMAPError(err) {
+  if (err.code === MMAPv1_RETRY_WRITES_ERROR_CODE && err.errmsg.includes('Transaction numbers')) {
+    // According to the retryable writes spec, we must replace the error message in this case.
+    // We need to replace err.message so the thrown message is correct and we need to replace err.errmsg to meet the spec requirement.
+    err.message =
+      'This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string.';
+    err.errmsg = err.message;
+    throw err;
+  }
+}
+
 module.exports.SessionMixins = SessionMixins;
 module.exports.resolveClusterTime = resolveClusterTime;
 module.exports.inquireServerState = inquireServerState;
@@ -451,3 +464,5 @@ module.exports.diff = diff;
 module.exports.Interval = Interval;
 module.exports.Timeout = Timeout;
 module.exports.isRetryableWritesSupported = isRetryableWritesSupported;
+module.exports.MMAPv1_RETRY_WRITES_ERROR_CODE = MMAPv1_RETRY_WRITES_ERROR_CODE;
+module.exports.handleMMAPError = handleMMAPError;


### PR DESCRIPTION
Fixes NODE-2098

## Description

**What changed?**
This adds a new error message for `retryWrites` failures on MMAPv1.

**Are there any files to ignore?**
No.