### PR TITLE
NODE-1744: modernize and dedupe cursor classes

### DIFF
--- a/lib/aggregation_cursor.js
+++ b/lib/aggregation_cursor.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const inherits = require('util').inherits;
 const MongoError = require('./core').MongoError;
-const Readable = require('stream').Readable;
-const CoreCursor = require('./cursor');
+const Cursor = require('./cursor');
+const CursorState = require('./core/cursor').CursorState;
 const deprecate = require('util').deprecate;
-const SUPPORTS = require('./utils').SUPPORTS;
 
 /**
  * @fileOverview The **AggregationCursor** class is an internal class that embodies an aggregation cursor on MongoDB
@@ -55,46 +53,183 @@ const SUPPORTS = require('./utils').SUPPORTS;
  * @fires AggregationCursor#readable
  * @return {AggregationCursor} an AggregationCursor instance.
  */
-var AggregationCursor = function(topology, operation, options) {
-  CoreCursor.apply(this, Array.prototype.slice.call(arguments, 0));
-  var state = AggregationCursor.INIT;
-  var streamOptions = {};
-  const bson = topology.s.bson;
-  const topologyOptions = topology.s.options;
+class AggregationCursor extends Cursor {
+  constructor(topology, operation, options) {
+    super(topology, operation, options);
+  }
 
-  // MaxTimeMS
-  var maxTimeMS = null;
+  /**
+   * Set the batch size for the cursor.
+   * @method
+   * @param {number} value The batchSize for the cursor.
+   * @throws {MongoError}
+   * @return {AggregationCursor}
+   */
+  batchSize(value) {
+    if (this.s.state === CursorState.CLOSED || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
 
-  // Get the promiseLibrary
-  var promiseLibrary = options.promiseLibrary || Promise;
+    if (typeof value !== 'number') {
+      throw MongoError.create({ message: 'batchSize requires an integer', driver: true });
+    }
 
-  // Set up
-  Readable.call(this, { objectMode: true });
+    this.operation.options.batchSize = value;
+    this.setCursorBatchSize(value);
+    return this;
+  }
 
-  // Internal state
-  this.s = {
-    // MaxTimeMS
-    maxTimeMS: maxTimeMS,
-    // State
-    state: state,
-    // Stream options
-    streamOptions: streamOptions,
-    // BSON
-    bson: bson,
-    // Namespace
-    namespace: operation.ns,
-    // Options
-    options: options,
-    // Topology
-    topology: topology,
-    // Topology Options
-    topologyOptions: topologyOptions,
-    // Promise library
-    promiseLibrary: promiseLibrary,
-    // Optional ClientSession
-    session: options.session
-  };
-};
+  /**
+   * Add a geoNear stage to the aggregation pipeline
+   * @method
+   * @param {object} document The geoNear stage document.
+   * @return {AggregationCursor}
+   */
+  geoNear(document) {
+    this.operation.addToPipeline({ $geoNear: document });
+    return this;
+  }
+
+  /**
+   * Add a group stage to the aggregation pipeline
+   * @method
+   * @param {object} document The group stage document.
+   * @return {AggregationCursor}
+   */
+  group(document) {
+    this.operation.addToPipeline({ $group: document });
+    return this;
+  }
+
+  /**
+   * Add a limit stage to the aggregation pipeline
+   * @method
+   * @param {number} value The state limit value.
+   * @return {AggregationCursor}
+   */
+  limit(value) {
+    this.operation.addToPipeline({ $limit: value });
+    return this;
+  }
+
+  /**
+   * Add a match stage to the aggregation pipeline
+   * @method
+   * @param {object} document The match stage document.
+   * @return {AggregationCursor}
+   */
+  match(document) {
+    this.operation.addToPipeline({ $match: document });
+    return this;
+  }
+
+  /**
+   * Add a maxTimeMS stage to the aggregation pipeline
+   * @method
+   * @param {number} value The state maxTimeMS value.
+   * @return {AggregationCursor}
+   */
+  maxTimeMS(value) {
+    this.operation.options.maxTimeMS = value;
+    return this;
+  }
+
+  /**
+   * Add a out stage to the aggregation pipeline
+   * @method
+   * @param {number} destination The destination name.
+   * @return {AggregationCursor}
+   */
+  out(destination) {
+    this.operation.addToPipeline({ $out: destination });
+    return this;
+  }
+
+  /**
+   * Add a project stage to the aggregation pipeline
+   * @method
+   * @param {object} document The project stage document.
+   * @return {AggregationCursor}
+   */
+  project(document) {
+    this.operation.addToPipeline({ $project: document });
+    return this;
+  }
+
+  /**
+   * Add a lookup stage to the aggregation pipeline
+   * @method
+   * @param {object} document The lookup stage document.
+   * @return {AggregationCursor}
+   */
+  lookup(document) {
+    this.operation.addToPipeline({ $lookup: document });
+    return this;
+  }
+
+  /**
+   * Add a redact stage to the aggregation pipeline
+   * @method
+   * @param {object} document The redact stage document.
+   * @return {AggregationCursor}
+   */
+  redact(document) {
+    this.operation.addToPipeline({ $redact: document });
+    return this;
+  }
+
+  /**
+   * Add a skip stage to the aggregation pipeline
+   * @method
+   * @param {number} value The state skip value.
+   * @return {AggregationCursor}
+   */
+  skip(value) {
+    this.operation.addToPipeline({ $skip: value });
+    return this;
+  }
+
+  /**
+   * Add a sort stage to the aggregation pipeline
+   * @method
+   * @param {object} document The sort stage document.
+   * @return {AggregationCursor}
+   */
+  sort(document) {
+    this.operation.addToPipeline({ $sort: document });
+    return this;
+  }
+
+  /**
+   * Add a unwind stage to the aggregation pipeline
+   * @method
+   * @param {number} field The unwind field name.
+   * @return {AggregationCursor}
+   */
+  unwind(field) {
+    this.operation.addToPipeline({ $unwind: field });
+    return this;
+  }
+
+  /**
+   * Return the cursor logger
+   * @method
+   * @return {Logger} return the cursor logger
+   * @ignore
+   */
+  getLogger() {
+    return this.logger;
+  }
+}
+
+// aliases
+AggregationCursor.prototype.get = AggregationCursor.prototype.toArray;
+
+// deprecated methods
+deprecate(
+  AggregationCursor.prototype.geoNear,
+  'The `$geoNear` stage is deprecated in MongoDB 4.0, and removed in version 4.2.'
+);
 
 /**
  * AggregationCursor stream data event, fired for each document in the cursor.
@@ -123,184 +258,6 @@ var AggregationCursor = function(topology, operation, options) {
  * @event AggregationCursor#readable
  * @type {null}
  */
-
-// Inherit from Readable
-inherits(AggregationCursor, Readable);
-
-// Extend the Cursor
-for (var name in CoreCursor.prototype) {
-  AggregationCursor.prototype[name] = CoreCursor.prototype[name];
-}
-if (SUPPORTS.ASYNC_ITERATOR) {
-  AggregationCursor.prototype[
-    Symbol.asyncIterator
-  ] = require('./async/async_iterator').asyncIterator;
-}
-
-/**
- * Set the batch size for the cursor.
- * @method
- * @param {number} value The batchSize for the cursor.
- * @throws {MongoError}
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.batchSize = function(value) {
-  if (this.s.state === AggregationCursor.CLOSED || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  if (typeof value !== 'number') {
-    throw MongoError.create({ message: 'batchSize requires an integer', driver: true });
-  }
-
-  this.operation.options.batchSize = value;
-  this.setCursorBatchSize(value);
-  return this;
-};
-
-/**
- * Add a geoNear stage to the aggregation pipeline
- * @method
- * @param {object} document The geoNear stage document.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.geoNear = deprecate(function(document) {
-  this.operation.addToPipeline({ $geoNear: document });
-  return this;
-}, 'The `$geoNear` stage is deprecated in MongoDB 4.0, and removed in version 4.2.');
-
-/**
- * Add a group stage to the aggregation pipeline
- * @method
- * @param {object} document The group stage document.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.group = function(document) {
-  this.operation.addToPipeline({ $group: document });
-  return this;
-};
-
-/**
- * Add a limit stage to the aggregation pipeline
- * @method
- * @param {number} value The state limit value.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.limit = function(value) {
-  this.operation.addToPipeline({ $limit: value });
-  return this;
-};
-
-/**
- * Add a match stage to the aggregation pipeline
- * @method
- * @param {object} document The match stage document.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.match = function(document) {
-  this.operation.addToPipeline({ $match: document });
-  return this;
-};
-
-/**
- * Add a maxTimeMS stage to the aggregation pipeline
- * @method
- * @param {number} value The state maxTimeMS value.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.maxTimeMS = function(value) {
-  this.operation.options.maxTimeMS = value;
-  return this;
-};
-
-/**
- * Add a out stage to the aggregation pipeline
- * @method
- * @param {number} destination The destination name.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.out = function(destination) {
-  this.operation.addToPipeline({ $out: destination });
-  return this;
-};
-
-/**
- * Add a project stage to the aggregation pipeline
- * @method
- * @param {object} document The project stage document.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.project = function(document) {
-  this.operation.addToPipeline({ $project: document });
-  return this;
-};
-
-/**
- * Add a lookup stage to the aggregation pipeline
- * @method
- * @param {object} document The lookup stage document.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.lookup = function(document) {
-  this.operation.addToPipeline({ $lookup: document });
-  return this;
-};
-
-/**
- * Add a redact stage to the aggregation pipeline
- * @method
- * @param {object} document The redact stage document.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.redact = function(document) {
-  this.operation.addToPipeline({ $redact: document });
-  return this;
-};
-
-/**
- * Add a skip stage to the aggregation pipeline
- * @method
- * @param {number} value The state skip value.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.skip = function(value) {
-  this.operation.addToPipeline({ $skip: value });
-  return this;
-};
-
-/**
- * Add a sort stage to the aggregation pipeline
- * @method
- * @param {object} document The sort stage document.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.sort = function(document) {
-  this.operation.addToPipeline({ $sort: document });
-  return this;
-};
-
-/**
- * Add a unwind stage to the aggregation pipeline
- * @method
- * @param {number} field The unwind field name.
- * @return {AggregationCursor}
- */
-AggregationCursor.prototype.unwind = function(field) {
-  this.operation.addToPipeline({ $unwind: field });
-  return this;
-};
-
-/**
- * Return the cursor logger
- * @method
- * @return {Logger} return the cursor logger
- * @ignore
- */
-AggregationCursor.prototype.getLogger = function() {
-  return this.logger;
-};
-
-AggregationCursor.prototype.get = AggregationCursor.prototype.toArray;
 
 /**
  * Get the next available document from the cursor, returns null if no more documents are available.
@@ -408,9 +365,5 @@ AggregationCursor.prototype.get = AggregationCursor.prototype.toArray;
  * @throws {MongoError}
  * @return {null}
  */
-
-AggregationCursor.INIT = 0;
-AggregationCursor.OPEN = 1;
-AggregationCursor.CLOSED = 2;
 
 module.exports = AggregationCursor;

--- a/lib/command_cursor.js
+++ b/lib/command_cursor.js
@@ -216,11 +216,18 @@ CommandCursor.prototype.setReadPreference = function(readPreference) {
  * @return {CommandCursor}
  */
 CommandCursor.prototype.batchSize = function(value) {
-  if (this.s.state === CommandCursor.CLOSED || this.isDead())
+  if (this.s.state === CommandCursor.CLOSED || this.isDead()) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  if (typeof value !== 'number')
+  }
+
+  if (typeof value !== 'number') {
     throw MongoError.create({ message: 'batchSize requires an integer', driver: true });
-  if (this.s.cmd.cursor) this.s.cmd.cursor.batchSize = value;
+  }
+
+  if (this.cmd.cursor) {
+    this.cmd.cursor.batchSize = value;
+  }
+
   this.setCursorBatchSize(value);
   return this;
 };
@@ -233,8 +240,9 @@ CommandCursor.prototype.batchSize = function(value) {
  */
 CommandCursor.prototype.maxTimeMS = function(value) {
   if (this.s.topology.lastIsMaster().minWireVersion > 2) {
-    this.s.cmd.maxTimeMS = value;
+    this.cmd.maxTimeMS = value;
   }
+
   return this;
 };
 

--- a/lib/command_cursor.js
+++ b/lib/command_cursor.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const inherits = require('util').inherits;
 const ReadPreference = require('./core').ReadPreference;
 const MongoError = require('./core').MongoError;
-const Readable = require('stream').Readable;
-const CoreCursor = require('./cursor');
-const SUPPORTS = require('./utils').SUPPORTS;
-const MongoDBNamespace = require('./utils').MongoDBNamespace;
+const Cursor = require('./cursor');
+const CursorState = require('./core/cursor').CursorState;
 
 /**
  * @fileOverview The **CommandCursor** class is an internal class that embodies a
@@ -55,62 +52,92 @@ const MongoDBNamespace = require('./utils').MongoDBNamespace;
  * @fires CommandCursor#readable
  * @return {CommandCursor} an CommandCursor instance.
  */
-var CommandCursor = function(topology, ns, cmd, options) {
-  CoreCursor.apply(this, Array.prototype.slice.call(arguments, 0));
-  var state = CommandCursor.INIT;
-  var streamOptions = {};
-  const bson = topology.s.bson;
-  const topologyOptions = topology.s.options;
-
-  if (typeof ns !== 'string') {
-    this.operation = ns;
-    ns = this.operation.ns.toString();
-    options = this.operation.options;
-    cmd = {};
+class CommandCursor extends Cursor {
+  constructor(topology, ns, cmd, options) {
+    super(topology, ns, cmd, options);
   }
 
-  // MaxTimeMS
-  var maxTimeMS = null;
+  /**
+   * Set the ReadPreference for the cursor.
+   * @method
+   * @param {(string|ReadPreference)} readPreference The new read preference for the cursor.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  setReadPreference(readPreference) {
+    if (this.s.state === CursorState.CLOSED || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
 
-  // Get the promiseLibrary
-  var promiseLibrary = options.promiseLibrary || Promise;
+    if (this.s.state !== CursorState.INIT) {
+      throw MongoError.create({
+        message: 'cannot change cursor readPreference after cursor has been accessed',
+        driver: true
+      });
+    }
 
-  // Set up
-  Readable.call(this, { objectMode: true });
+    if (readPreference instanceof ReadPreference) {
+      this.options.readPreference = readPreference;
+    } else if (typeof readPreference === 'string') {
+      this.options.readPreference = new ReadPreference(readPreference);
+    } else {
+      throw new TypeError('Invalid read preference: ' + readPreference);
+    }
 
-  // Internal state
-  this.s = {
-    // MaxTimeMS
-    maxTimeMS: maxTimeMS,
-    // State
-    state: state,
-    // Stream options
-    streamOptions: streamOptions,
-    // BSON
-    bson: bson,
-    // Namespace
-    namespace: MongoDBNamespace.fromString(ns),
-    // Command
-    cmd: cmd,
-    // Options
-    options: options,
-    // Topology
-    topology: topology,
-    // Topology Options
-    topologyOptions: topologyOptions,
-    // Promise library
-    promiseLibrary: promiseLibrary,
-    // Optional ClientSession
-    session: options.session
-  };
-};
-
-Object.defineProperty(CommandCursor.prototype, 'namespace', {
-  enumerable: true,
-  get: function() {
-    return this.s.namespace.toString();
+    return this;
   }
-});
+
+  /**
+   * Set the batch size for the cursor.
+   * @method
+   * @param {number} value The batchSize for the cursor.
+   * @throws {MongoError}
+   * @return {CommandCursor}
+   */
+  batchSize(value) {
+    if (this.s.state === CursorState.CLOSED || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    if (typeof value !== 'number') {
+      throw MongoError.create({ message: 'batchSize requires an integer', driver: true });
+    }
+
+    if (this.cmd.cursor) {
+      this.cmd.cursor.batchSize = value;
+    }
+
+    this.setCursorBatchSize(value);
+    return this;
+  }
+
+  /**
+   * Add a maxTimeMS stage to the aggregation pipeline
+   * @method
+   * @param {number} value The state maxTimeMS value.
+   * @return {CommandCursor}
+   */
+  maxTimeMS(value) {
+    if (this.topology.lastIsMaster().minWireVersion > 2) {
+      this.cmd.maxTimeMS = value;
+    }
+
+    return this;
+  }
+
+  /**
+   * Return the cursor logger
+   * @method
+   * @return {Logger} return the cursor logger
+   * @ignore
+   */
+  getLogger() {
+    return this.logger;
+  }
+}
+
+// aliases
+CommandCursor.prototype.get = CommandCursor.prototype.toArray;
 
 /**
  * CommandCursor stream data event, fired for each document in the cursor.
@@ -139,124 +166,6 @@ Object.defineProperty(CommandCursor.prototype, 'namespace', {
  * @event CommandCursor#readable
  * @type {null}
  */
-
-// Inherit from Readable
-inherits(CommandCursor, Readable);
-
-// Set the methods to inherit from prototype
-var methodsToInherit = [
-  '_next',
-  'next',
-  'hasNext',
-  'each',
-  'forEach',
-  'toArray',
-  'rewind',
-  'bufferedCount',
-  'readBufferedDocuments',
-  'close',
-  'isClosed',
-  'kill',
-  'setCursorBatchSize',
-  '_find',
-  '_initializeCursor',
-  '_getMore',
-  '_killcursor',
-  'isDead',
-  'explain',
-  'isNotified',
-  'isKilled',
-  '_endSession'
-];
-
-// Only inherit the types we need
-for (var i = 0; i < methodsToInherit.length; i++) {
-  CommandCursor.prototype[methodsToInherit[i]] = CoreCursor.prototype[methodsToInherit[i]];
-}
-
-if (SUPPORTS.ASYNC_ITERATOR) {
-  CommandCursor.prototype[Symbol.asyncIterator] = require('./async/async_iterator').asyncIterator;
-}
-
-/**
- * Set the ReadPreference for the cursor.
- * @method
- * @param {(string|ReadPreference)} readPreference The new read preference for the cursor.
- * @throws {MongoError}
- * @return {Cursor}
- */
-CommandCursor.prototype.setReadPreference = function(readPreference) {
-  if (this.s.state === CommandCursor.CLOSED || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  if (this.s.state !== CommandCursor.INIT) {
-    throw MongoError.create({
-      message: 'cannot change cursor readPreference after cursor has been accessed',
-      driver: true
-    });
-  }
-
-  if (readPreference instanceof ReadPreference) {
-    this.s.options.readPreference = readPreference;
-  } else if (typeof readPreference === 'string') {
-    this.s.options.readPreference = new ReadPreference(readPreference);
-  } else {
-    throw new TypeError('Invalid read preference: ' + readPreference);
-  }
-
-  return this;
-};
-
-/**
- * Set the batch size for the cursor.
- * @method
- * @param {number} value The batchSize for the cursor.
- * @throws {MongoError}
- * @return {CommandCursor}
- */
-CommandCursor.prototype.batchSize = function(value) {
-  if (this.s.state === CommandCursor.CLOSED || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  if (typeof value !== 'number') {
-    throw MongoError.create({ message: 'batchSize requires an integer', driver: true });
-  }
-
-  if (this.cmd.cursor) {
-    this.cmd.cursor.batchSize = value;
-  }
-
-  this.setCursorBatchSize(value);
-  return this;
-};
-
-/**
- * Add a maxTimeMS stage to the aggregation pipeline
- * @method
- * @param {number} value The state maxTimeMS value.
- * @return {CommandCursor}
- */
-CommandCursor.prototype.maxTimeMS = function(value) {
-  if (this.s.topology.lastIsMaster().minWireVersion > 2) {
-    this.cmd.maxTimeMS = value;
-  }
-
-  return this;
-};
-
-/**
- * Return the cursor logger
- * @method
- * @return {Logger} return the cursor logger
- * @ignore
- */
-CommandCursor.prototype.getLogger = function() {
-  return this.logger;
-};
-
-CommandCursor.prototype.get = CommandCursor.prototype.toArray;
 
 /**
  * Get the next available document from the cursor, returns null if no more documents are available.
@@ -356,9 +265,5 @@ CommandCursor.prototype.get = CommandCursor.prototype.toArray;
  * @throws {MongoError}
  * @return {null}
  */
-
-CommandCursor.INIT = 0;
-CommandCursor.OPEN = 1;
-CommandCursor.CLOSED = 2;
 
 module.exports = CommandCursor;

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -5,14 +5,36 @@ const retrieveBSON = require('./connection/utils').retrieveBSON;
 const MongoError = require('./error').MongoError;
 const MongoNetworkError = require('./error').MongoNetworkError;
 const mongoErrorContextSymbol = require('./error').mongoErrorContextSymbol;
-const f = require('util').format;
 const collationNotSupported = require('./utils').collationNotSupported;
 const ReadPreference = require('./topologies/read_preference');
 const isUnifiedTopology = require('./utils').isUnifiedTopology;
 const executeOperation = require('../operations/execute_operation');
+const Readable = require('stream').Readable;
+const SUPPORTS = require('../utils').SUPPORTS;
+const MongoDBNamespace = require('../utils').MongoDBNamespace;
 
 const BSON = retrieveBSON();
 const Long = BSON.Long;
+
+// Possible states for a cursor
+const CursorState = {
+  INIT: 0,
+  OPEN: 1,
+  CLOSED: 2,
+  GET_MORE: 3
+};
+
+//
+// Handle callback (including any exceptions thrown)
+function handleCallback(callback, err, result) {
+  try {
+    callback(err, result);
+  } catch (err) {
+    process.nextTick(function() {
+      throw err;
+    });
+  }
+}
 
 /**
  * This is a cursor results callback
@@ -30,335 +52,580 @@ const Long = BSON.Long;
  */
 
 /**
- * Creates a new Cursor, not to be used directly
- * @class
- * @param {object} topology The server topology instance.
- * @param {string} ns The MongoDB fully qualified namespace (ex: db1.collection1)
- * @param {{object}|Long} cmd The selector (can be a command or a cursorId)
- * @param {object} [options=null] Optional settings.
- * @param {object} [options.batchSize=1000] Batchsize for the operation
- * @param {array} [options.documents=[]] Initial documents list for cursor
- * @param {object} [options.transforms=null] Transform methods for the cursor results
- * @param {function} [options.transforms.query] Transform the value returned from the initial query
- * @param {function} [options.transforms.doc] Transform each document returned from Cursor.prototype.next
- * @return {Cursor} A cursor instance
+ * The core cursor class. All cursors in the driver build off of this one.
+ *
  * @property {number} cursorBatchSize The current cursorBatchSize for the cursor
  * @property {number} cursorLimit The current cursorLimit for the cursor
  * @property {number} cursorSkip The current cursorSkip for the cursor
  */
-var Cursor = function(topology, ns, cmd, options) {
-  options = options || {};
+class CoreCursor extends Readable {
+  /**
+   * Create a new core `Cursor` instance.
+   * **NOTE** Not to be instantiated directly
+   *
+   * @param {object} topology The server topology instance.
+   * @param {string} ns The MongoDB fully qualified namespace (ex: db1.collection1)
+   * @param {{object}|Long} cmd The selector (can be a command or a cursorId)
+   * @param {object} [options=null] Optional settings.
+   * @param {object} [options.batchSize=1000] Batchsize for the operation
+   * @param {array} [options.documents=[]] Initial documents list for cursor
+   * @param {object} [options.transforms=null] Transform methods for the cursor results
+   * @param {function} [options.transforms.query] Transform the value returned from the initial query
+   * @param {function} [options.transforms.doc] Transform each document returned from Cursor.prototype._next
+   */
+  constructor(topology, ns, cmd, options) {
+    super({ objectMode: true });
+    options = options || {};
 
-  if (typeof ns !== 'string') {
-    this.operation = ns;
-    ns = this.operation.ns.toString();
-    options = this.operation.options;
-    cmd = {};
-  }
+    if (typeof ns !== 'string') {
+      this.operation = ns;
+      ns = this.operation.ns.toString();
+      options = this.operation.options;
+      cmd = {};
+    }
 
-  // Cursor pool
-  this.pool = null;
-  // Cursor server
-  this.server = null;
+    // Cursor pool
+    this.pool = null;
+    // Cursor server
+    this.server = null;
 
-  // Do we have a not connected handler
-  this.disconnectHandler = options.disconnectHandler;
+    // Do we have a not connected handler
+    this.disconnectHandler = options.disconnectHandler;
 
-  // Set local values
-  this.bson = topology.s.bson;
-  this.ns = ns;
-  this.cmd = cmd;
-  this.options = options;
-  this.topology = topology;
+    // Set local values
+    this.bson = topology.s.bson;
+    this.ns = ns;
+    this.namespace = MongoDBNamespace.fromString(ns);
+    this.cmd = cmd;
+    this.options = options;
+    this.topology = topology;
 
-  // All internal state
-  this.cursorState = {
-    cursorId: null,
-    cmd: cmd,
-    documents: options.documents || [],
-    cursorIndex: 0,
-    dead: false,
-    killed: false,
-    init: false,
-    notified: false,
-    limit: options.limit || cmd.limit || 0,
-    skip: options.skip || cmd.skip || 0,
-    batchSize: options.batchSize || cmd.batchSize || 1000,
-    currentLimit: 0,
-    // Result field name if not a cursor (contains the array of results)
-    transforms: options.transforms,
-    raw: options.raw || (cmd && cmd.raw)
-  };
+    // All internal state
+    this.cursorState = {
+      cursorId: null,
+      cmd,
+      documents: options.documents || [],
+      cursorIndex: 0,
+      dead: false,
+      killed: false,
+      init: false,
+      notified: false,
+      limit: options.limit || cmd.limit || 0,
+      skip: options.skip || cmd.skip || 0,
+      batchSize: options.batchSize || cmd.batchSize || 1000,
+      currentLimit: 0,
+      // Result field name if not a cursor (contains the array of results)
+      transforms: options.transforms,
+      raw: options.raw || (cmd && cmd.raw)
+    };
 
-  if (typeof options.session === 'object') {
-    this.cursorState.session = options.session;
-  }
+    if (typeof options.session === 'object') {
+      this.cursorState.session = options.session;
+    }
 
-  // Add promoteLong to cursor state
-  const topologyOptions = topology.s.options;
-  if (typeof topologyOptions.promoteLongs === 'boolean') {
-    this.cursorState.promoteLongs = topologyOptions.promoteLongs;
-  } else if (typeof options.promoteLongs === 'boolean') {
-    this.cursorState.promoteLongs = options.promoteLongs;
-  }
+    // Add promoteLong to cursor state
+    const topologyOptions = topology.s.options;
+    if (typeof topologyOptions.promoteLongs === 'boolean') {
+      this.cursorState.promoteLongs = topologyOptions.promoteLongs;
+    } else if (typeof options.promoteLongs === 'boolean') {
+      this.cursorState.promoteLongs = options.promoteLongs;
+    }
 
-  // Add promoteValues to cursor state
-  if (typeof topologyOptions.promoteValues === 'boolean') {
-    this.cursorState.promoteValues = topologyOptions.promoteValues;
-  } else if (typeof options.promoteValues === 'boolean') {
-    this.cursorState.promoteValues = options.promoteValues;
-  }
+    // Add promoteValues to cursor state
+    if (typeof topologyOptions.promoteValues === 'boolean') {
+      this.cursorState.promoteValues = topologyOptions.promoteValues;
+    } else if (typeof options.promoteValues === 'boolean') {
+      this.cursorState.promoteValues = options.promoteValues;
+    }
 
-  // Add promoteBuffers to cursor state
-  if (typeof topologyOptions.promoteBuffers === 'boolean') {
-    this.cursorState.promoteBuffers = topologyOptions.promoteBuffers;
-  } else if (typeof options.promoteBuffers === 'boolean') {
-    this.cursorState.promoteBuffers = options.promoteBuffers;
-  }
+    // Add promoteBuffers to cursor state
+    if (typeof topologyOptions.promoteBuffers === 'boolean') {
+      this.cursorState.promoteBuffers = topologyOptions.promoteBuffers;
+    } else if (typeof options.promoteBuffers === 'boolean') {
+      this.cursorState.promoteBuffers = options.promoteBuffers;
+    }
 
-  if (topologyOptions.reconnect) {
-    this.cursorState.reconnect = topologyOptions.reconnect;
-  }
+    if (topologyOptions.reconnect) {
+      this.cursorState.reconnect = topologyOptions.reconnect;
+    }
 
-  // Logger
-  this.logger = Logger('Cursor', topologyOptions);
+    // Logger
+    this.logger = Logger('Cursor', topologyOptions);
 
-  //
-  // Did we pass in a cursor id
-  if (typeof cmd === 'number') {
-    this.cursorState.cursorId = Long.fromNumber(cmd);
-    this.cursorState.lastCursorId = this.cursorState.cursorId;
-  } else if (cmd instanceof Long) {
-    this.cursorState.cursorId = cmd;
-    this.cursorState.lastCursorId = cmd;
-  }
-};
-
-Cursor.prototype.setCursorBatchSize = function(value) {
-  this.cursorState.batchSize = value;
-};
-
-Cursor.prototype.cursorBatchSize = function() {
-  return this.cursorState.batchSize;
-};
-
-Cursor.prototype.setCursorLimit = function(value) {
-  this.cursorState.limit = value;
-};
-
-Cursor.prototype.cursorLimit = function() {
-  return this.cursorState.limit;
-};
-
-Cursor.prototype.setCursorSkip = function(value) {
-  this.cursorState.skip = value;
-};
-
-Cursor.prototype.cursorSkip = function() {
-  return this.cursorState.skip;
-};
-
-Cursor.prototype._endSession = function(options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-  options = options || {};
-
-  const session = this.cursorState.session;
-
-  if (session && (options.force || session.owner === this)) {
-    this.cursorState.session = undefined;
-    session.endSession(callback);
-    return true;
-  }
-
-  if (callback) {
-    callback();
-  }
-  return false;
-};
-
-//
-// Handle callback (including any exceptions thrown)
-var handleCallback = function(callback, err, result) {
-  try {
-    callback(err, result);
-  } catch (err) {
-    process.nextTick(function() {
-      throw err;
-    });
-  }
-};
-
-// Internal methods
-Cursor.prototype._getMore = function(callback) {
-  if (this.logger.isDebug())
-    this.logger.debug(f('schedule getMore call for query [%s]', JSON.stringify(this.query)));
-
-  // Set the current batchSize
-  var batchSize = this.cursorState.batchSize;
-  if (
-    this.cursorState.limit > 0 &&
-    this.cursorState.currentLimit + batchSize > this.cursorState.limit
-  ) {
-    batchSize = this.cursorState.limit - this.cursorState.currentLimit;
-  }
-
-  this.server.getMore(this.ns, this.cursorState, batchSize, this.options, callback);
-};
-
-/**
- * Clone the cursor
- * @method
- * @return {Cursor}
- */
-Cursor.prototype.clone = function() {
-  return this.topology.cursor(this.ns, this.cmd, this.options);
-};
-
-/**
- * Checks if the cursor is dead
- * @method
- * @return {boolean} A boolean signifying if the cursor is dead or not
- */
-Cursor.prototype.isDead = function() {
-  return this.cursorState.dead === true;
-};
-
-/**
- * Checks if the cursor was killed by the application
- * @method
- * @return {boolean} A boolean signifying if the cursor was killed by the application
- */
-Cursor.prototype.isKilled = function() {
-  return this.cursorState.killed === true;
-};
-
-/**
- * Checks if the cursor notified it's caller about it's death
- * @method
- * @return {boolean} A boolean signifying if the cursor notified the callback
- */
-Cursor.prototype.isNotified = function() {
-  return this.cursorState.notified === true;
-};
-
-/**
- * Returns current buffered documents length
- * @method
- * @return {number} The number of items in the buffered documents
- */
-Cursor.prototype.bufferedCount = function() {
-  return this.cursorState.documents.length - this.cursorState.cursorIndex;
-};
-
-/**
- * Returns current buffered documents
- * @method
- * @return {Array} An array of buffered documents
- */
-Cursor.prototype.readBufferedDocuments = function(number) {
-  var unreadDocumentsLength = this.cursorState.documents.length - this.cursorState.cursorIndex;
-  var length = number < unreadDocumentsLength ? number : unreadDocumentsLength;
-  var elements = this.cursorState.documents.slice(
-    this.cursorState.cursorIndex,
-    this.cursorState.cursorIndex + length
-  );
-
-  // Transform the doc with passed in transformation method if provided
-  if (this.cursorState.transforms && typeof this.cursorState.transforms.doc === 'function') {
-    // Transform all the elements
-    for (var i = 0; i < elements.length; i++) {
-      elements[i] = this.cursorState.transforms.doc(elements[i]);
+    //
+    // Did we pass in a cursor id
+    if (typeof cmd === 'number') {
+      this.cursorState.cursorId = Long.fromNumber(cmd);
+      this.cursorState.lastCursorId = this.cursorState.cursorId;
+    } else if (cmd instanceof Long) {
+      this.cursorState.cursorId = cmd;
+      this.cursorState.lastCursorId = cmd;
     }
   }
 
-  // Ensure we do not return any more documents than the limit imposed
-  // Just return the number of elements up to the limit
-  if (
-    this.cursorState.limit > 0 &&
-    this.cursorState.currentLimit + elements.length > this.cursorState.limit
-  ) {
-    elements = elements.slice(0, this.cursorState.limit - this.cursorState.currentLimit);
-    this.kill();
+  setCursorBatchSize(value) {
+    this.cursorState.batchSize = value;
   }
 
-  // Adjust current limit
-  this.cursorState.currentLimit = this.cursorState.currentLimit + elements.length;
-  this.cursorState.cursorIndex = this.cursorState.cursorIndex + elements.length;
-
-  // Return elements
-  return elements;
-};
-
-/**
- * Kill the cursor
- * @method
- * @param {resultCallback} callback A callback function
- */
-Cursor.prototype.kill = function(callback) {
-  // Set cursor to dead
-  this.cursorState.dead = true;
-  this.cursorState.killed = true;
-  // Remove documents
-  this.cursorState.documents = [];
-
-  // If no cursor id just return
-  if (
-    this.cursorState.cursorId == null ||
-    this.cursorState.cursorId.isZero() ||
-    this.cursorState.init === false
-  ) {
-    if (callback) callback(null, null);
-    return;
+  cursorBatchSize() {
+    return this.cursorState.batchSize;
   }
 
-  this.server.killCursors(this.ns, this.cursorState, callback);
-};
+  setCursorLimit(value) {
+    this.cursorState.limit = value;
+  }
 
-/**
- * Resets the cursor
- * @method
- * @return {null}
- */
-Cursor.prototype.rewind = function() {
-  if (this.cursorState.init) {
-    if (!this.cursorState.dead) {
+  cursorLimit() {
+    return this.cursorState.limit;
+  }
+
+  setCursorSkip(value) {
+    this.cursorState.skip = value;
+  }
+
+  cursorSkip() {
+    return this.cursorState.skip;
+  }
+
+  /**
+   * Retrieve the next document from the cursor
+   * @method
+   * @param {resultCallback} callback A callback function
+   */
+  _next(callback) {
+    nextFunction(this, callback);
+  }
+
+  /**
+   * Clone the cursor
+   * @method
+   * @return {Cursor}
+   */
+  clone() {
+    return this.topology.cursor(this.ns, this.cmd, this.options);
+  }
+
+  /**
+   * Checks if the cursor is dead
+   * @method
+   * @return {boolean} A boolean signifying if the cursor is dead or not
+   */
+  isDead() {
+    return this.cursorState.dead === true;
+  }
+
+  /**
+   * Checks if the cursor was killed by the application
+   * @method
+   * @return {boolean} A boolean signifying if the cursor was killed by the application
+   */
+  isKilled() {
+    return this.cursorState.killed === true;
+  }
+
+  /**
+   * Checks if the cursor notified it's caller about it's death
+   * @method
+   * @return {boolean} A boolean signifying if the cursor notified the callback
+   */
+  isNotified() {
+    return this.cursorState.notified === true;
+  }
+
+  /**
+   * Returns current buffered documents length
+   * @method
+   * @return {number} The number of items in the buffered documents
+   */
+  bufferedCount() {
+    return this.cursorState.documents.length - this.cursorState.cursorIndex;
+  }
+
+  /**
+   * Returns current buffered documents
+   * @method
+   * @return {Array} An array of buffered documents
+   */
+  readBufferedDocuments(number) {
+    const unreadDocumentsLength = this.cursorState.documents.length - this.cursorState.cursorIndex;
+    const length = number < unreadDocumentsLength ? number : unreadDocumentsLength;
+    let elements = this.cursorState.documents.slice(
+      this.cursorState.cursorIndex,
+      this.cursorState.cursorIndex + length
+    );
+
+    // Transform the doc with passed in transformation method if provided
+    if (this.cursorState.transforms && typeof this.cursorState.transforms.doc === 'function') {
+      // Transform all the elements
+      for (let i = 0; i < elements.length; i++) {
+        elements[i] = this.cursorState.transforms.doc(elements[i]);
+      }
+    }
+
+    // Ensure we do not return any more documents than the limit imposed
+    // Just return the number of elements up to the limit
+    if (
+      this.cursorState.limit > 0 &&
+      this.cursorState.currentLimit + elements.length > this.cursorState.limit
+    ) {
+      elements = elements.slice(0, this.cursorState.limit - this.cursorState.currentLimit);
       this.kill();
     }
 
-    this.cursorState.currentLimit = 0;
-    this.cursorState.init = false;
-    this.cursorState.dead = false;
-    this.cursorState.killed = false;
-    this.cursorState.notified = false;
-    this.cursorState.documents = [];
-    this.cursorState.cursorId = null;
-    this.cursorState.cursorIndex = 0;
+    // Adjust current limit
+    this.cursorState.currentLimit = this.cursorState.currentLimit + elements.length;
+    this.cursorState.cursorIndex = this.cursorState.cursorIndex + elements.length;
+
+    // Return elements
+    return elements;
   }
-};
+
+  /**
+   * Resets local state for this cursor instance, and issues a `killCursors` command to the server
+   *
+   * @param {resultCallback} callback A callback function
+   */
+  kill(callback) {
+    // Set cursor to dead
+    this.cursorState.dead = true;
+    this.cursorState.killed = true;
+    // Remove documents
+    this.cursorState.documents = [];
+
+    // If no cursor id just return
+    if (
+      this.cursorState.cursorId == null ||
+      this.cursorState.cursorId.isZero() ||
+      this.cursorState.init === false
+    ) {
+      if (callback) callback(null, null);
+      return;
+    }
+
+    this.server.killCursors(this.ns, this.cursorState, callback);
+  }
+
+  /**
+   * Resets the cursor
+   */
+  rewind() {
+    if (this.cursorState.init) {
+      if (!this.cursorState.dead) {
+        this.kill();
+      }
+
+      this.cursorState.currentLimit = 0;
+      this.cursorState.init = false;
+      this.cursorState.dead = false;
+      this.cursorState.killed = false;
+      this.cursorState.notified = false;
+      this.cursorState.documents = [];
+      this.cursorState.cursorId = null;
+      this.cursorState.cursorIndex = 0;
+    }
+  }
+
+  // Internal methods
+  _read() {
+    if ((this.s && this.s.state === CursorState.CLOSED) || this.isDead()) {
+      return this.push(null);
+    }
+
+    // Get the next item
+    this._next((err, result) => {
+      if (err) {
+        if (this.listeners('error') && this.listeners('error').length > 0) {
+          this.emit('error', err);
+        }
+        if (!this.isDead()) this.close();
+
+        // Emit end event
+        this.emit('end');
+        return this.emit('finish');
+      }
+
+      // If we provided a transformation method
+      if (
+        this.cursorState.streamOptions &&
+        typeof this.cursorState.streamOptions.transform === 'function' &&
+        result != null
+      ) {
+        return this.push(this.cursorState.streamOptions.transform(result));
+      }
+
+      // If we provided a map function
+      if (
+        this.cursorState.transforms &&
+        typeof this.cursorState.transforms.doc === 'function' &&
+        result != null
+      ) {
+        return this.push(this.cursorState.transforms.doc(result));
+      }
+
+      // Return the result
+      this.push(result);
+
+      if (result === null && this.isDead()) {
+        this.once('end', () => {
+          this.close();
+          this.emit('finish');
+        });
+      }
+    });
+  }
+
+  _endSession(options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    const session = this.cursorState.session;
+
+    if (session && (options.force || session.owner === this)) {
+      this.cursorState.session = undefined;
+      session.endSession(callback);
+      return true;
+    }
+
+    if (callback) {
+      callback();
+    }
+
+    return false;
+  }
+
+  _getMore(callback) {
+    if (this.logger.isDebug()) {
+      this.logger.debug(`schedule getMore call for query [${JSON.stringify(this.query)}]`);
+    }
+
+    // Set the current batchSize
+    let batchSize = this.cursorState.batchSize;
+    if (
+      this.cursorState.limit > 0 &&
+      this.cursorState.currentLimit + batchSize > this.cursorState.limit
+    ) {
+      batchSize = this.cursorState.limit - this.cursorState.currentLimit;
+    }
+
+    this.server.getMore(this.ns, this.cursorState, batchSize, this.options, callback);
+  }
+
+  _initializeCursor(callback) {
+    const cursor = this;
+
+    // NOTE: this goes away once cursors use `executeOperation`
+    if (isUnifiedTopology(cursor.topology) && cursor.topology.shouldCheckForSessionSupport()) {
+      cursor.topology.selectServer(ReadPreference.primaryPreferred, err => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        cursor._next(callback);
+      });
+
+      return;
+    }
+
+    function done(err, result) {
+      if (
+        cursor.cursorState.cursorId &&
+        cursor.cursorState.cursorId.isZero() &&
+        cursor._endSession
+      ) {
+        cursor._endSession();
+      }
+
+      if (
+        cursor.cursorState.documents.length === 0 &&
+        cursor.cursorState.cursorId &&
+        cursor.cursorState.cursorId.isZero() &&
+        !cursor.cmd.tailable &&
+        !cursor.cmd.awaitData
+      ) {
+        return setCursorNotified(cursor, callback);
+      }
+
+      callback(err, result);
+    }
+
+    const queryCallback = (err, r) => {
+      if (err) {
+        return done(err);
+      }
+
+      const result = r.message;
+      if (result.queryFailure) {
+        return done(new MongoError(result.documents[0]), null);
+      }
+
+      // Check if we have a command cursor
+      if (
+        Array.isArray(result.documents) &&
+        result.documents.length === 1 &&
+        (!cursor.cmd.find || (cursor.cmd.find && cursor.cmd.virtual === false)) &&
+        (typeof result.documents[0].cursor !== 'string' ||
+          result.documents[0]['$err'] ||
+          result.documents[0]['errmsg'] ||
+          Array.isArray(result.documents[0].result))
+      ) {
+        // We have an error document, return the error
+        if (result.documents[0]['$err'] || result.documents[0]['errmsg']) {
+          return done(new MongoError(result.documents[0]), null);
+        }
+
+        // We have a cursor document
+        if (result.documents[0].cursor != null && typeof result.documents[0].cursor !== 'string') {
+          const id = result.documents[0].cursor.id;
+          // If we have a namespace change set the new namespace for getmores
+          if (result.documents[0].cursor.ns) {
+            cursor.ns = result.documents[0].cursor.ns;
+          }
+          // Promote id to long if needed
+          cursor.cursorState.cursorId = typeof id === 'number' ? Long.fromNumber(id) : id;
+          cursor.cursorState.lastCursorId = cursor.cursorState.cursorId;
+          cursor.cursorState.operationTime = result.documents[0].operationTime;
+
+          // If we have a firstBatch set it
+          if (Array.isArray(result.documents[0].cursor.firstBatch)) {
+            cursor.cursorState.documents = result.documents[0].cursor.firstBatch; //.reverse();
+          }
+
+          // Return after processing command cursor
+          return done(null, result);
+        }
+
+        if (Array.isArray(result.documents[0].result)) {
+          cursor.cursorState.documents = result.documents[0].result;
+          cursor.cursorState.cursorId = Long.ZERO;
+          return done(null, result);
+        }
+      }
+
+      // Otherwise fall back to regular find path
+      const cursorId = result.cursorId || 0;
+      cursor.cursorState.cursorId = cursorId instanceof Long ? cursorId : Long.fromNumber(cursorId);
+      cursor.cursorState.documents = result.documents;
+      cursor.cursorState.lastCursorId = result.cursorId;
+
+      // Transform the results with passed in transformation method if provided
+      if (
+        cursor.cursorState.transforms &&
+        typeof cursor.cursorState.transforms.query === 'function'
+      ) {
+        cursor.cursorState.documents = cursor.cursorState.transforms.query(result);
+      }
+
+      done(null, result);
+    };
+
+    if (cursor.operation) {
+      executeOperation(cursor.topology, cursor.operation, (err, result) => {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        cursor.server = cursor.operation.server;
+        cursor.cursorState.init = true;
+
+        // NOTE: this is a special internal method for cloning a cursor, consider removing
+        if (cursor.cursorState.cursorId != null) {
+          return done();
+        }
+
+        queryCallback(err, result);
+      });
+
+      return;
+    }
+
+    // Very explicitly choose what is passed to selectServer
+    const serverSelectOptions = {};
+    if (cursor.cursorState.session) {
+      serverSelectOptions.session = cursor.cursorState.session;
+    }
+
+    if (cursor.operation) {
+      serverSelectOptions.readPreference = cursor.operation.readPreference;
+    } else if (cursor.options.readPreference) {
+      serverSelectOptions.readPreference = cursor.options.readPreference;
+    }
+
+    return cursor.topology.selectServer(serverSelectOptions, (err, server) => {
+      if (err) {
+        const disconnectHandler = cursor.disconnectHandler;
+        if (disconnectHandler != null) {
+          return disconnectHandler.addObjectAndMethod(
+            'cursor',
+            cursor,
+            'next',
+            [callback],
+            callback
+          );
+        }
+
+        return callback(err);
+      }
+
+      cursor.server = server;
+      cursor.cursorState.init = true;
+      if (collationNotSupported(cursor.server, cursor.cmd)) {
+        return callback(new MongoError(`server ${cursor.server.name} does not support collation`));
+      }
+
+      // NOTE: this is a special internal method for cloning a cursor, consider removing
+      if (cursor.cursorState.cursorId != null) {
+        return done();
+      }
+
+      if (cursor.logger.isDebug()) {
+        cursor.logger.debug(
+          `issue initial query [${JSON.stringify(cursor.cmd)}] with flags [${JSON.stringify(
+            cursor.query
+          )}]`
+        );
+      }
+
+      if (cursor.cmd.find != null) {
+        server.query(cursor.ns, cursor.cmd, cursor.cursorState, cursor.options, queryCallback);
+        return;
+      }
+
+      const commandOptions = Object.assign({ session: cursor.cursorState.session }, cursor.options);
+      server.command(cursor.ns, cursor.cmd, commandOptions, queryCallback);
+    });
+  }
+}
+
+if (SUPPORTS.ASYNC_ITERATOR) {
+  CoreCursor.prototype[Symbol.asyncIterator] = require('../async/async_iterator').asyncIterator;
+}
 
 /**
  * Validate if the pool is dead and return error
  */
-var isConnectionDead = function(self, callback) {
+function isConnectionDead(self, callback) {
   if (self.pool && self.pool.isDestroyed()) {
     self.cursorState.killed = true;
     const err = new MongoNetworkError(
-      f('connection to host %s:%s was destroyed', self.pool.host, self.pool.port)
+      `connection to host ${self.pool.host}:${self.pool.port} was destroyed`
     );
+
     _setCursorNotifiedImpl(self, () => callback(err));
     return true;
   }
 
   return false;
-};
+}
 
 /**
  * Validate if the cursor is dead but was not explicitly killed by user
  */
-var isCursorDeadButNotkilled = function(self, callback) {
+function isCursorDeadButNotkilled(self, callback) {
   // Cursor is dead but not marked killed, return null
   if (self.cursorState.dead && !self.cursorState.killed) {
     self.cursorState.killed = true;
@@ -367,59 +634,61 @@ var isCursorDeadButNotkilled = function(self, callback) {
   }
 
   return false;
-};
+}
 
 /**
  * Validate if the cursor is dead and was killed by user
  */
-var isCursorDeadAndKilled = function(self, callback) {
+function isCursorDeadAndKilled(self, callback) {
   if (self.cursorState.dead && self.cursorState.killed) {
     handleCallback(callback, new MongoError('cursor is dead'));
     return true;
   }
 
   return false;
-};
+}
 
 /**
  * Validate if the cursor was killed by the user
  */
-var isCursorKilled = function(self, callback) {
+function isCursorKilled(self, callback) {
   if (self.cursorState.killed) {
     setCursorNotified(self, callback);
     return true;
   }
 
   return false;
-};
+}
 
 /**
  * Mark cursor as being dead and notified
  */
-var setCursorDeadAndNotified = function(self, callback) {
+function setCursorDeadAndNotified(self, callback) {
   self.cursorState.dead = true;
   setCursorNotified(self, callback);
-};
+}
 
 /**
  * Mark cursor as being notified
  */
-var setCursorNotified = function(self, callback) {
+function setCursorNotified(self, callback) {
   _setCursorNotifiedImpl(self, () => handleCallback(callback, null, null));
-};
+}
 
-var _setCursorNotifiedImpl = function(self, callback) {
+function _setCursorNotifiedImpl(self, callback) {
   self.cursorState.notified = true;
   self.cursorState.documents = [];
   self.cursorState.cursorIndex = 0;
+
   if (self._endSession) {
-    return self._endSession(undefined, () => callback());
+    self._endSession(undefined, () => callback());
+    return;
   }
 
   return callback();
-};
+}
 
-var nextFunction = function(self, callback) {
+function nextFunction(self, callback) {
   // We have notified about it
   if (self.cursorState.notified) {
     return callback(new Error('cursor is exhausted'));
@@ -570,7 +839,7 @@ var nextFunction = function(self, callback) {
     self.cursorState.currentLimit += 1;
 
     // Get the document
-    var doc = self.cursorState.documents[self.cursorState.cursorIndex++];
+    let doc = self.cursorState.documents[self.cursorState.cursorIndex++];
 
     // Doc overflow
     if (!doc || doc.$err) {
@@ -590,192 +859,9 @@ var nextFunction = function(self, callback) {
     // Return the document
     handleCallback(callback, null, doc);
   }
+}
+
+module.exports = {
+  CursorState,
+  CoreCursor
 };
-
-Cursor.prototype._initializeCursor = function(callback) {
-  const cursor = this;
-
-  // NOTE: this goes away once cursors use `executeOperation`
-  if (isUnifiedTopology(cursor.topology) && cursor.topology.shouldCheckForSessionSupport()) {
-    cursor.topology.selectServer(ReadPreference.primaryPreferred, err => {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      cursor.next(callback);
-    });
-
-    return;
-  }
-
-  function done(err, result) {
-    if (cursor.cursorState.cursorId && cursor.cursorState.cursorId.isZero() && cursor._endSession) {
-      cursor._endSession();
-    }
-
-    if (
-      cursor.cursorState.documents.length === 0 &&
-      cursor.cursorState.cursorId &&
-      cursor.cursorState.cursorId.isZero() &&
-      !cursor.cmd.tailable &&
-      !cursor.cmd.awaitData
-    ) {
-      return setCursorNotified(cursor, callback);
-    }
-
-    callback(err, result);
-  }
-
-  const queryCallback = (err, r) => {
-    if (err) {
-      return done(err);
-    }
-
-    const result = r.message;
-    if (result.queryFailure) {
-      return done(new MongoError(result.documents[0]), null);
-    }
-
-    // Check if we have a command cursor
-    if (
-      Array.isArray(result.documents) &&
-      result.documents.length === 1 &&
-      (!cursor.cmd.find || (cursor.cmd.find && cursor.cmd.virtual === false)) &&
-      (typeof result.documents[0].cursor !== 'string' ||
-        result.documents[0]['$err'] ||
-        result.documents[0]['errmsg'] ||
-        Array.isArray(result.documents[0].result))
-    ) {
-      // We have an error document, return the error
-      if (result.documents[0]['$err'] || result.documents[0]['errmsg']) {
-        return done(new MongoError(result.documents[0]), null);
-      }
-
-      // We have a cursor document
-      if (result.documents[0].cursor != null && typeof result.documents[0].cursor !== 'string') {
-        var id = result.documents[0].cursor.id;
-        // If we have a namespace change set the new namespace for getmores
-        if (result.documents[0].cursor.ns) {
-          cursor.ns = result.documents[0].cursor.ns;
-        }
-        // Promote id to long if needed
-        cursor.cursorState.cursorId = typeof id === 'number' ? Long.fromNumber(id) : id;
-        cursor.cursorState.lastCursorId = cursor.cursorState.cursorId;
-        cursor.cursorState.operationTime = result.documents[0].operationTime;
-
-        // If we have a firstBatch set it
-        if (Array.isArray(result.documents[0].cursor.firstBatch)) {
-          cursor.cursorState.documents = result.documents[0].cursor.firstBatch; //.reverse();
-        }
-
-        // Return after processing command cursor
-        return done(null, result);
-      }
-
-      if (Array.isArray(result.documents[0].result)) {
-        cursor.cursorState.documents = result.documents[0].result;
-        cursor.cursorState.cursorId = Long.ZERO;
-        return done(null, result);
-      }
-    }
-
-    // Otherwise fall back to regular find path
-    const cursorId = result.cursorId || 0;
-    cursor.cursorState.cursorId = cursorId instanceof Long ? cursorId : Long.fromNumber(cursorId);
-    cursor.cursorState.documents = result.documents;
-    cursor.cursorState.lastCursorId = result.cursorId;
-
-    // Transform the results with passed in transformation method if provided
-    if (
-      cursor.cursorState.transforms &&
-      typeof cursor.cursorState.transforms.query === 'function'
-    ) {
-      cursor.cursorState.documents = cursor.cursorState.transforms.query(result);
-    }
-
-    done(null, result);
-  };
-
-  if (cursor.operation) {
-    executeOperation(cursor.topology, cursor.operation, (err, result) => {
-      if (err) {
-        done(err);
-        return;
-      }
-
-      cursor.server = cursor.operation.server;
-      cursor.cursorState.init = true;
-
-      // NOTE: this is a special internal method for cloning a cursor, consider removing
-      if (cursor.cursorState.cursorId != null) {
-        return done();
-      }
-
-      queryCallback(err, result);
-    });
-
-    return;
-  }
-
-  // Very explicitly choose what is passed to selectServer
-  const serverSelectOptions = {};
-  if (cursor.cursorState.session) {
-    serverSelectOptions.session = cursor.cursorState.session;
-  }
-
-  if (cursor.operation) {
-    serverSelectOptions.readPreference = cursor.operation.readPreference;
-  } else if (cursor.options.readPreference) {
-    serverSelectOptions.readPreference = cursor.options.readPreference;
-  }
-
-  return cursor.topology.selectServer(serverSelectOptions, (err, server) => {
-    if (err) {
-      const disconnectHandler = cursor.disconnectHandler;
-      if (disconnectHandler != null) {
-        return disconnectHandler.addObjectAndMethod('cursor', cursor, 'next', [callback], callback);
-      }
-
-      return callback(err);
-    }
-
-    cursor.server = server;
-    cursor.cursorState.init = true;
-    if (collationNotSupported(cursor.server, cursor.cmd)) {
-      return callback(new MongoError(`server ${cursor.server.name} does not support collation`));
-    }
-
-    // NOTE: this is a special internal method for cloning a cursor, consider removing
-    if (cursor.cursorState.cursorId != null) {
-      return done();
-    }
-
-    if (cursor.logger.isDebug()) {
-      cursor.logger.debug(
-        `issue initial query [${JSON.stringify(cursor.cmd)}] with flags [${JSON.stringify(
-          cursor.query
-        )}]`
-      );
-    }
-
-    if (cursor.cmd.find != null) {
-      server.query(cursor.ns, cursor.cmd, cursor.cursorState, cursor.options, queryCallback);
-      return;
-    }
-
-    const commandOptions = Object.assign({ session: cursor.cursorState.session }, cursor.options);
-    server.command(cursor.ns, cursor.cmd, commandOptions, queryCallback);
-  });
-};
-
-/**
- * Retrieve the next document from the cursor
- * @method
- * @param {resultCallback} callback A callback function
- */
-Cursor.prototype.next = function(callback) {
-  nextFunction(this, callback);
-};
-
-module.exports = Cursor;

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -28,7 +28,7 @@ module.exports = {
   ReplSet: require('./topologies/replset'),
   Mongos: require('./topologies/mongos'),
   Logger: require('./connection/logger'),
-  Cursor: require('./cursor'),
+  Cursor: require('./cursor').CoreCursor,
   ReadPreference: require('./topologies/read_preference'),
   Sessions: require('./sessions'),
   BSON: BSON,

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -13,7 +13,7 @@ const ReadPreference = require('../topologies/read_preference');
 const readPreferenceServerSelector = require('./server_selectors').readPreferenceServerSelector;
 const writableServerSelector = require('./server_selectors').writableServerSelector;
 const isRetryableWritesSupported = require('../topologies/shared').isRetryableWritesSupported;
-const Cursor = require('../cursor');
+const CoreCursor = require('../cursor').CoreCursor;
 const deprecate = require('util').deprecate;
 const BSON = require('../connection/utils').retrieveBSON();
 const createCompressionInfo = require('../topologies/shared').createCompressionInfo;
@@ -131,7 +131,7 @@ class Topology extends EventEmitter {
       heartbeatFrequencyMS: options.heartbeatFrequencyMS,
       minHeartbeatIntervalMS: options.minHeartbeatIntervalMS,
       // allow users to override the cursor factory
-      Cursor: options.cursorFactory || Cursor,
+      Cursor: options.cursorFactory || CoreCursor,
       // the bson parser
       bson: options.bson || new BSON(),
       // a map of server instances to normalized addresses

--- a/lib/core/topologies/mongos.js
+++ b/lib/core/topologies/mongos.js
@@ -3,7 +3,7 @@
 const inherits = require('util').inherits;
 const f = require('util').format;
 const EventEmitter = require('events').EventEmitter;
-const BasicCursor = require('../cursor');
+const CoreCursor = require('../cursor').CoreCursor;
 const Logger = require('../connection/logger');
 const retrieveBSON = require('../connection/utils').retrieveBSON;
 const MongoError = require('../error').MongoError;
@@ -135,7 +135,7 @@ var Mongos = function(seedlist, options) {
         BSON.Timestamp
       ]),
     // Factory overrides
-    Cursor: options.cursorFactory || BasicCursor,
+    Cursor: options.cursorFactory || CoreCursor,
     // Logger instance
     logger: Logger('Mongos', options),
     // Seedlist

--- a/lib/core/topologies/replset.js
+++ b/lib/core/topologies/replset.js
@@ -4,7 +4,7 @@ const inherits = require('util').inherits;
 const f = require('util').format;
 const EventEmitter = require('events').EventEmitter;
 const ReadPreference = require('./read_preference');
-const BasicCursor = require('../cursor');
+const CoreCursor = require('../cursor').CoreCursor;
 const retrieveBSON = require('../connection/utils').retrieveBSON;
 const Logger = require('../connection/logger');
 const MongoError = require('../error').MongoError;
@@ -160,7 +160,7 @@ var ReplSet = function(seedlist, options) {
         BSON.Timestamp
       ]),
     // Factory overrides
-    Cursor: options.cursorFactory || BasicCursor,
+    Cursor: options.cursorFactory || CoreCursor,
     // Logger instance
     logger: logger,
     // Seedlist

--- a/lib/core/topologies/server.js
+++ b/lib/core/topologies/server.js
@@ -11,7 +11,7 @@ var inherits = require('util').inherits,
   MongoError = require('../error').MongoError,
   MongoNetworkError = require('../error').MongoNetworkError,
   wireProtocol = require('../wireprotocol'),
-  BasicCursor = require('../cursor'),
+  CoreCursor = require('../cursor').CoreCursor,
   sdam = require('./shared'),
   createClientInfo = require('./shared').createClientInfo,
   createCompressionInfo = require('./shared').createCompressionInfo,
@@ -120,7 +120,7 @@ var Server = function(options) {
     // Logger
     logger: Logger('Server', options),
     // Factory overrides
-    Cursor: options.cursorFactory || BasicCursor,
+    Cursor: options.cursorFactory || CoreCursor,
     // BSON instance
     bson:
       options.bson ||

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -108,10 +108,7 @@ const fields = ['numberOfRetries', 'tailableRetryInterval'];
  */
 function Cursor(topology, ns, cmd, options) {
   CoreCursor.apply(this, Array.prototype.slice.call(arguments, 0));
-  const state = Cursor.INIT;
   const streamOptions = {};
-  const bson = topology.s.bson;
-  const topologyOptions = topology.s.options;
 
   if (typeof ns !== 'string') {
     this.operation = ns;
@@ -138,21 +135,11 @@ function Cursor(topology, ns, cmd, options) {
     tailableRetryInterval: tailableRetryInterval,
     currentNumberOfRetries: currentNumberOfRetries,
     // State
-    state: state,
+    state: Cursor.INIT,
     // Stream options
-    streamOptions: streamOptions,
-    // BSON
-    bson: bson,
+    streamOptions,
     // Namespace
     namespace: MongoDBNamespace.fromString(ns),
-    // Command
-    cmd: cmd,
-    // Options
-    options: options,
-    // Topology
-    topology: topology,
-    // Topology options
-    topologyOptions: topologyOptions,
     // Promise library
     promiseLibrary: promiseLibrary,
     // Current doc
@@ -167,12 +154,12 @@ function Cursor(topology, ns, cmd, options) {
   }
 
   // Translate correctly
-  if (this.s.options.noCursorTimeout === true) {
+  if (this.options.noCursorTimeout === true) {
     this.addCursorFlag('noCursorTimeout', true);
   }
 
   // Set the sort value
-  this.sortValue = this.s.cmd.sort;
+  this.sortValue = this.cmd.sort;
 
   // Get the batchSize
   let batchSize = 1000;
@@ -238,8 +225,8 @@ Cursor.prototype._initializeCursor = function(callback) {
     this.cursorState.session = this.operation.session;
   } else {
     // implicitly create a session if one has not been provided
-    if (!this.s.explicitlyIgnoreSession && !this.s.session && this.s.topology.hasSessionSupport()) {
-      this.s.session = this.s.topology.startSession({ owner: this });
+    if (!this.s.explicitlyIgnoreSession && !this.s.session && this.topology.hasSessionSupport()) {
+      this.s.session = this.topology.startSession({ owner: this });
       this.cursorState.session = this.s.session;
 
       if (this.operation) {
@@ -268,7 +255,7 @@ Cursor.prototype._endSession = function() {
 Cursor.prototype.hasNext = function(callback) {
   const hasNextOperation = new HasNextOperation(this);
 
-  return executeOperation(this.s.topology, hasNextOperation, callback);
+  return executeOperation(this.topology, hasNextOperation, callback);
 };
 
 /**
@@ -281,7 +268,7 @@ Cursor.prototype.hasNext = function(callback) {
 Cursor.prototype.next = function(callback) {
   const nextOperation = new NextOperation(this);
 
-  return executeOperation(this.s.topology, nextOperation, callback);
+  return executeOperation(this.topology, nextOperation, callback);
 };
 
 /**
@@ -295,7 +282,7 @@ Cursor.prototype.filter = function(filter) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.query = filter;
+  this.cmd.query = filter;
   return this;
 };
 
@@ -311,7 +298,7 @@ Cursor.prototype.maxScan = deprecate(function(maxScan) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.maxScan = maxScan;
+  this.cmd.maxScan = maxScan;
   return this;
 }, 'Cursor.maxScan is deprecated, and will be removed in a later version');
 
@@ -326,7 +313,7 @@ Cursor.prototype.hint = function(hint) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.hint = hint;
+  this.cmd.hint = hint;
   return this;
 };
 
@@ -339,7 +326,7 @@ Cursor.prototype.hint = function(hint) {
 Cursor.prototype.min = function(min) {
   if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  this.s.cmd.min = min;
+  this.cmd.min = min;
   return this;
 };
 
@@ -354,7 +341,7 @@ Cursor.prototype.max = function(max) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.max = max;
+  this.cmd.max = max;
   return this;
 };
 
@@ -369,7 +356,7 @@ Cursor.prototype.returnKey = function(value) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.returnKey = value;
+  this.cmd.returnKey = value;
   return this;
 };
 
@@ -384,7 +371,7 @@ Cursor.prototype.showRecordId = function(value) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.showDiskLoc = value;
+  this.cmd.showDiskLoc = value;
   return this;
 };
 
@@ -400,7 +387,7 @@ Cursor.prototype.snapshot = deprecate(function(value) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.snapshot = value;
+  this.cmd.snapshot = value;
   return this;
 }, 'Cursor Snapshot is deprecated, and will be removed in a later version');
 
@@ -453,7 +440,7 @@ Cursor.prototype.addCursorFlag = function(flag, value) {
     throw MongoError.create({ message: `flag ${flag} must be a boolean value`, driver: true });
   }
 
-  this.s.cmd[flag] = value;
+  this.cmd[flag] = value;
   return this;
 };
 
@@ -477,9 +464,9 @@ Cursor.prototype.addQueryModifier = function(name, value) {
   // Strip of the $
   const field = name.substr(1);
   // Set on the command
-  this.s.cmd[field] = value;
+  this.cmd[field] = value;
   // Deal with the special case for sort
-  if (field === 'orderby') this.s.cmd.sort = this.s.cmd[field];
+  if (field === 'orderby') this.cmd.sort = this.cmd[field];
   return this;
 };
 
@@ -495,7 +482,7 @@ Cursor.prototype.comment = function(value) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.comment = value;
+  this.cmd.comment = value;
   return this;
 };
 
@@ -515,7 +502,7 @@ Cursor.prototype.maxAwaitTimeMS = function(value) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.maxAwaitTimeMS = value;
+  this.cmd.maxAwaitTimeMS = value;
   return this;
 };
 
@@ -535,7 +522,7 @@ Cursor.prototype.maxTimeMS = function(value) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.maxTimeMS = value;
+  this.cmd.maxTimeMS = value;
   return this;
 };
 
@@ -553,7 +540,7 @@ Cursor.prototype.project = function(value) {
     throw MongoError.create({ message: 'Cursor is closed', driver: true });
   }
 
-  this.s.cmd.fields = value;
+  this.cmd.fields = value;
   return this;
 };
 
@@ -566,7 +553,7 @@ Cursor.prototype.project = function(value) {
  * @return {Cursor}
  */
 Cursor.prototype.sort = function(keyOrList, direction) {
-  if (this.s.options.tailable) {
+  if (this.options.tailable) {
     throw MongoError.create({ message: "Tailable cursor doesn't support sorting", driver: true });
   }
 
@@ -603,7 +590,7 @@ Cursor.prototype.sort = function(keyOrList, direction) {
     order = [[keyOrList, direction]];
   }
 
-  this.s.cmd.sort = order;
+  this.cmd.sort = order;
   this.sortValue = order;
   return this;
 };
@@ -616,7 +603,7 @@ Cursor.prototype.sort = function(keyOrList, direction) {
  * @return {Cursor}
  */
 Cursor.prototype.batchSize = function(value) {
-  if (this.s.options.tailable) {
+  if (this.options.tailable) {
     throw MongoError.create({ message: "Tailable cursor doesn't support batchSize", driver: true });
   }
 
@@ -628,7 +615,7 @@ Cursor.prototype.batchSize = function(value) {
     throw MongoError.create({ message: 'batchSize requires an integer', driver: true });
   }
 
-  this.s.cmd.batchSize = value;
+  this.cmd.batchSize = value;
   this.setCursorBatchSize(value);
   return this;
 };
@@ -641,7 +628,7 @@ Cursor.prototype.batchSize = function(value) {
  * @return {Cursor}
  */
 Cursor.prototype.collation = function(value) {
-  this.s.cmd.collation = value;
+  this.cmd.collation = value;
   return this;
 };
 
@@ -653,7 +640,7 @@ Cursor.prototype.collation = function(value) {
  * @return {Cursor}
  */
 Cursor.prototype.limit = function(value) {
-  if (this.s.options.tailable) {
+  if (this.options.tailable) {
     throw MongoError.create({ message: "Tailable cursor doesn't support limit", driver: true });
   }
 
@@ -665,7 +652,7 @@ Cursor.prototype.limit = function(value) {
     throw MongoError.create({ message: 'limit requires an integer', driver: true });
   }
 
-  this.s.cmd.limit = value;
+  this.cmd.limit = value;
   // this.cursorLimit = value;
   this.setCursorLimit(value);
   return this;
@@ -679,7 +666,7 @@ Cursor.prototype.limit = function(value) {
  * @return {Cursor}
  */
 Cursor.prototype.skip = function(value) {
-  if (this.s.options.tailable) {
+  if (this.options.tailable) {
     throw MongoError.create({ message: "Tailable cursor doesn't support skip", driver: true });
   }
 
@@ -691,7 +678,7 @@ Cursor.prototype.skip = function(value) {
     throw MongoError.create({ message: 'skip requires an integer', driver: true });
   }
 
-  this.s.cmd.skip = value;
+  this.cmd.skip = value;
   this.setCursorSkip(value);
   return this;
 };
@@ -815,9 +802,9 @@ Cursor.prototype.setReadPreference = function(readPreference) {
   }
 
   if (readPreference instanceof ReadPreference) {
-    this.s.options.readPreference = readPreference;
+    this.options.readPreference = readPreference;
   } else if (typeof readPreference === 'string') {
-    this.s.options.readPreference = new ReadPreference(readPreference);
+    this.options.readPreference = new ReadPreference(readPreference);
   } else {
     throw new TypeError('Invalid read preference: ' + readPreference);
   }
@@ -843,7 +830,7 @@ Cursor.prototype.setReadPreference = function(readPreference) {
  * @return {Promise} returns Promise if no callback passed
  */
 Cursor.prototype.toArray = function(callback) {
-  if (this.s.options.tailable) {
+  if (this.options.tailable) {
     throw MongoError.create({
       message: 'Tailable cursor cannot be converted to array',
       driver: true
@@ -852,7 +839,7 @@ Cursor.prototype.toArray = function(callback) {
 
   const toArrayOperation = new ToArrayOperation(this);
 
-  return executeOperation(this.s.topology, toArrayOperation, callback);
+  return executeOperation(this.topology, toArrayOperation, callback);
 };
 
 /**
@@ -876,7 +863,7 @@ Cursor.prototype.toArray = function(callback) {
  * @return {Promise} returns Promise if no callback passed
  */
 Cursor.prototype.count = function(applySkipLimit, opts, callback) {
-  if (this.s.cmd.query == null)
+  if (this.cmd.query == null)
     throw MongoError.create({ message: 'count can only be used with find command', driver: true });
   if (typeof opts === 'function') (callback = opts), (opts = {});
   opts = opts || {};
@@ -892,7 +879,7 @@ Cursor.prototype.count = function(applySkipLimit, opts, callback) {
 
   const countOperation = new CountOperation(this, applySkipLimit, opts);
 
-  return executeOperation(this.s.topology, countOperation, callback);
+  return executeOperation(this.topology, countOperation, callback);
 };
 
 /**
@@ -1020,19 +1007,19 @@ Cursor.prototype.transformStream = function(options) {
 Cursor.prototype.explain = function(callback) {
   if (this.operation) {
     this.operation.options.explain = true;
-    return executeOperation(this.s.topology, this.operation, callback);
+    return executeOperation(this.topology, this.operation, callback);
   }
 
-  this.s.cmd.explain = true;
+  this.cmd.explain = true;
 
   // Do we have a readConcern
-  if (this.s.cmd.readConcern) {
-    delete this.s.cmd['readConcern'];
+  if (this.cmd.readConcern) {
+    delete this.cmd['readConcern'];
   }
 
   const explainOperation = new ExplainOperation(this);
 
-  return executeOperation(this.s.topology, explainOperation, callback);
+  return executeOperation(this.topology, explainOperation, callback);
 };
 
 Cursor.prototype._read = function() {
@@ -1096,7 +1083,7 @@ Object.defineProperty(Cursor.prototype, 'readPreference', {
       return null;
     }
 
-    return this.s.options.readPreference;
+    return this.options.readPreference;
   }
 });
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -2,15 +2,12 @@
 
 const Transform = require('stream').Transform;
 const PassThrough = require('stream').PassThrough;
-const inherits = require('util').inherits;
 const deprecate = require('util').deprecate;
 const handleCallback = require('./utils').handleCallback;
-const SUPPORTS = require('./utils').SUPPORTS;
-const MongoDBNamespace = require('./utils').MongoDBNamespace;
 const ReadPreference = require('./core').ReadPreference;
 const MongoError = require('./core').MongoError;
-const Readable = require('stream').Readable;
-const CoreCursor = require('./core').Cursor;
+const CoreCursor = require('./core/cursor').CoreCursor;
+const CursorState = require('./core/cursor').CursorState;
 const Map = require('./core').BSON.Map;
 
 const each = require('./operations/cursor_ops').each;
@@ -106,73 +103,889 @@ const fields = ['numberOfRetries', 'tailableRetryInterval'];
  *
  * collection.find({}).maxTimeMS(1000).maxScan(100).skip(1).toArray(..)
  */
-function Cursor(topology, ns, cmd, options) {
-  CoreCursor.apply(this, Array.prototype.slice.call(arguments, 0));
-  const streamOptions = {};
+class Cursor extends CoreCursor {
+  constructor(topology, ns, cmd, options) {
+    super(topology, ns, cmd, options);
+    const streamOptions = {};
 
-  if (typeof ns !== 'string') {
-    this.operation = ns;
-    ns = this.operation.ns.toString();
-    options = this.operation.options;
-    cmd = {};
-  }
+    if (typeof ns !== 'string') {
+      this.operation = ns;
+      ns = this.operation.ns.toString();
+      options = this.operation.options;
+      cmd = {};
+    }
 
-  // Tailable cursor options
-  const numberOfRetries = options.numberOfRetries || 5;
-  const tailableRetryInterval = options.tailableRetryInterval || 500;
-  const currentNumberOfRetries = numberOfRetries;
-
-  // Get the promiseLibrary
-  const promiseLibrary = options.promiseLibrary || Promise;
-
-  // Set up
-  Readable.call(this, { objectMode: true });
-
-  // Internal cursor state
-  this.s = {
     // Tailable cursor options
-    numberOfRetries: numberOfRetries,
-    tailableRetryInterval: tailableRetryInterval,
-    currentNumberOfRetries: currentNumberOfRetries,
-    // State
-    state: Cursor.INIT,
-    // Stream options
-    streamOptions,
-    // Namespace
-    namespace: MongoDBNamespace.fromString(ns),
-    // Promise library
-    promiseLibrary: promiseLibrary,
-    // Current doc
-    currentDoc: null,
-    // explicitlyIgnoreSession
-    explicitlyIgnoreSession: options.explicitlyIgnoreSession
-  };
+    const numberOfRetries = options.numberOfRetries || 5;
+    const tailableRetryInterval = options.tailableRetryInterval || 500;
+    const currentNumberOfRetries = numberOfRetries;
 
-  // Optional ClientSession
-  if (!options.explicitlyIgnoreSession && options.session) {
-    this.s.session = options.session;
+    // Get the promiseLibrary
+    const promiseLibrary = options.promiseLibrary || Promise;
+
+    // Internal cursor state
+    this.s = {
+      // Tailable cursor options
+      numberOfRetries: numberOfRetries,
+      tailableRetryInterval: tailableRetryInterval,
+      currentNumberOfRetries: currentNumberOfRetries,
+      // State
+      state: CursorState.INIT,
+      // Stream options
+      streamOptions,
+      // Promise library
+      promiseLibrary,
+      // Current doc
+      currentDoc: null,
+      // explicitlyIgnoreSession
+      explicitlyIgnoreSession: !!options.explicitlyIgnoreSession
+    };
+
+    // Optional ClientSession
+    if (!options.explicitlyIgnoreSession && options.session) {
+      this.cursorState.session = options.session;
+    }
+
+    // Translate correctly
+    if (this.options.noCursorTimeout === true) {
+      this.addCursorFlag('noCursorTimeout', true);
+    }
+
+    // Get the batchSize
+    let batchSize = 1000;
+    if (cmd.cursor && cmd.cursor.batchSize) {
+      batchSize = cmd.cursor && cmd.cursor.batchSize;
+    } else if (options.cursor && options.cursor.batchSize) {
+      batchSize = options.cursor.batchSize;
+    } else if (typeof options.batchSize === 'number') {
+      batchSize = options.batchSize;
+    }
+
+    // Set the batchSize
+    this.setCursorBatchSize(batchSize);
   }
 
-  // Translate correctly
-  if (this.options.noCursorTimeout === true) {
-    this.addCursorFlag('noCursorTimeout', true);
+  get readPreference() {
+    return this.options.readPreference;
   }
 
-  // Set the sort value
-  this.sortValue = this.cmd.sort;
-
-  // Get the batchSize
-  let batchSize = 1000;
-  if (cmd.cursor && cmd.cursor.batchSize) {
-    batchSize = cmd.cursor && cmd.cursor.batchSize;
-  } else if (options.cursor && options.cursor.batchSize) {
-    batchSize = options.cursor.batchSize;
-  } else if (typeof options.batchSize === 'number') {
-    batchSize = options.batchSize;
+  get sortValue() {
+    return this.cmd.sort;
   }
 
-  // Set the batchSize
-  this.setCursorBatchSize(batchSize);
+  _initializeCursor(callback) {
+    if (this.operation && this.operation.session != null) {
+      this.cursorState.session = this.operation.session;
+    } else {
+      // implicitly create a session if one has not been provided
+      if (
+        !this.s.explicitlyIgnoreSession &&
+        !this.cursorState.session &&
+        this.topology.hasSessionSupport()
+      ) {
+        this.cursorState.session = this.topology.startSession({ owner: this });
+
+        if (this.operation) {
+          this.operation.session = this.cursorState.session;
+        }
+      }
+    }
+
+    super._initializeCursor(callback);
+  }
+
+  /**
+   * Check if there is any document still available in the cursor
+   * @method
+   * @param {Cursor~resultCallback} [callback] The result callback.
+   * @throws {MongoError}
+   * @return {Promise} returns Promise if no callback passed
+   */
+  hasNext(callback) {
+    const hasNextOperation = new HasNextOperation(this);
+
+    return executeOperation(this.topology, hasNextOperation, callback);
+  }
+
+  /**
+   * Get the next available document from the cursor, returns null if no more documents are available.
+   * @method
+   * @param {Cursor~resultCallback} [callback] The result callback.
+   * @throws {MongoError}
+   * @return {Promise} returns Promise if no callback passed
+   */
+  next(callback) {
+    const nextOperation = new NextOperation(this);
+
+    return executeOperation(this.topology, nextOperation, callback);
+  }
+
+  /**
+   * Set the cursor query
+   * @method
+   * @param {object} filter The filter object used for the cursor.
+   * @return {Cursor}
+   */
+  filter(filter) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.query = filter;
+    return this;
+  }
+
+  /**
+   * Set the cursor maxScan
+   * @method
+   * @param {object} maxScan Constrains the query to only scan the specified number of documents when fulfilling the query
+   * @deprecated as of MongoDB 4.0
+   * @return {Cursor}
+   */
+  maxScan(maxScan) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.maxScan = maxScan;
+    return this;
+  }
+
+  /**
+   * Set the cursor hint
+   * @method
+   * @param {object} hint If specified, then the query system will only consider plans using the hinted index.
+   * @return {Cursor}
+   */
+  hint(hint) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.hint = hint;
+    return this;
+  }
+
+  /**
+   * Set the cursor min
+   * @method
+   * @param {object} min Specify a $min value to specify the inclusive lower bound for a specific index in order to constrain the results of find(). The $min specifies the lower bound for all keys of a specific index in order.
+   * @return {Cursor}
+   */
+  min(min) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.min = min;
+    return this;
+  }
+
+  /**
+   * Set the cursor max
+   * @method
+   * @param {object} max Specify a $max value to specify the exclusive upper bound for a specific index in order to constrain the results of find(). The $max specifies the upper bound for all keys of a specific index in order.
+   * @return {Cursor}
+   */
+  max(max) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.max = max;
+    return this;
+  }
+
+  /**
+   * Set the cursor returnKey. If set to true, modifies the cursor to only return the index field or fields for the results of the query, rather than documents. If set to true and the query does not use an index to perform the read operation, the returned documents will not contain any fields.
+   * @method
+   * @param {bool} returnKey the returnKey value.
+   * @return {Cursor}
+   */
+  returnKey(value) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.returnKey = value;
+    return this;
+  }
+
+  /**
+   * Set the cursor showRecordId
+   * @method
+   * @param {object} showRecordId The $showDiskLoc option has now been deprecated and replaced with the showRecordId field. $showDiskLoc will still be accepted for OP_QUERY stye find.
+   * @return {Cursor}
+   */
+  showRecordId(value) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.showDiskLoc = value;
+    return this;
+  }
+
+  /**
+   * Set the cursor snapshot
+   * @method
+   * @param {object} snapshot The $snapshot operator prevents the cursor from returning a document more than once because an intervening write operation results in a move of the document.
+   * @deprecated as of MongoDB 4.0
+   * @return {Cursor}
+   */
+  snapshot(value) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.snapshot = value;
+    return this;
+  }
+
+  /**
+   * Set a node.js specific cursor option
+   * @method
+   * @param {string} field The cursor option to set ['numberOfRetries', 'tailableRetryInterval'].
+   * @param {object} value The field value.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  setCursorOption(field, value) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    if (fields.indexOf(field) === -1) {
+      throw MongoError.create({
+        message: `option ${field} is not a supported option ${fields}`,
+        driver: true
+      });
+    }
+
+    this.s[field] = value;
+    if (field === 'numberOfRetries') this.s.currentNumberOfRetries = value;
+    return this;
+  }
+
+  /**
+   * Add a cursor flag to the cursor
+   * @method
+   * @param {string} flag The flag to set, must be one of following ['tailable', 'oplogReplay', 'noCursorTimeout', 'awaitData', 'partial'].
+   * @param {boolean} value The flag boolean value.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  addCursorFlag(flag, value) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    if (flags.indexOf(flag) === -1) {
+      throw MongoError.create({
+        message: `flag ${flag} is not a supported flag ${flags}`,
+        driver: true
+      });
+    }
+
+    if (typeof value !== 'boolean') {
+      throw MongoError.create({ message: `flag ${flag} must be a boolean value`, driver: true });
+    }
+
+    this.cmd[flag] = value;
+    return this;
+  }
+
+  /**
+   * Add a query modifier to the cursor query
+   * @method
+   * @param {string} name The query modifier (must start with $, such as $orderby etc)
+   * @param {string|boolean|number} value The modifier value.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  addQueryModifier(name, value) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    if (name[0] !== '$') {
+      throw MongoError.create({ message: `${name} is not a valid query modifier`, driver: true });
+    }
+
+    // Strip of the $
+    const field = name.substr(1);
+    // Set on the command
+    this.cmd[field] = value;
+    // Deal with the special case for sort
+    if (field === 'orderby') this.cmd.sort = this.cmd[field];
+    return this;
+  }
+
+  /**
+   * Add a comment to the cursor query allowing for tracking the comment in the log.
+   * @method
+   * @param {string} value The comment attached to this query.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  comment(value) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.comment = value;
+    return this;
+  }
+
+  /**
+   * Set a maxAwaitTimeMS on a tailing cursor query to allow to customize the timeout value for the option awaitData (Only supported on MongoDB 3.2 or higher, ignored otherwise)
+   * @method
+   * @param {number} value Number of milliseconds to wait before aborting the tailed query.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  maxAwaitTimeMS(value) {
+    if (typeof value !== 'number') {
+      throw MongoError.create({ message: 'maxAwaitTimeMS must be a number', driver: true });
+    }
+
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.maxAwaitTimeMS = value;
+    return this;
+  }
+
+  /**
+   * Set a maxTimeMS on the cursor query, allowing for hard timeout limits on queries (Only supported on MongoDB 2.6 or higher)
+   * @method
+   * @param {number} value Number of milliseconds to wait before aborting the query.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  maxTimeMS(value) {
+    if (typeof value !== 'number') {
+      throw MongoError.create({ message: 'maxTimeMS must be a number', driver: true });
+    }
+
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.maxTimeMS = value;
+    return this;
+  }
+
+  /**
+   * Sets a field projection for the query.
+   * @method
+   * @param {object} value The field projection object.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  project(value) {
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    this.cmd.fields = value;
+    return this;
+  }
+
+  /**
+   * Sets the sort order of the cursor query.
+   * @method
+   * @param {(string|array|object)} keyOrList The key or keys set for the sort.
+   * @param {number} [direction] The direction of the sorting (1 or -1).
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  sort(keyOrList, direction) {
+    if (this.options.tailable) {
+      throw MongoError.create({ message: "Tailable cursor doesn't support sorting", driver: true });
+    }
+
+    if (this.s.state === CursorState.CLOSED || this.s.state === CursorState.OPEN || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    let order = keyOrList;
+
+    // We have an array of arrays, we need to preserve the order of the sort
+    // so we will us a Map
+    if (Array.isArray(order) && Array.isArray(order[0])) {
+      order = new Map(
+        order.map(x => {
+          const value = [x[0], null];
+          if (x[1] === 'asc') {
+            value[1] = 1;
+          } else if (x[1] === 'desc') {
+            value[1] = -1;
+          } else if (x[1] === 1 || x[1] === -1 || x[1].$meta) {
+            value[1] = x[1];
+          } else {
+            throw new MongoError(
+              "Illegal sort clause, must be of the form [['field1', '(ascending|descending)'], ['field2', '(ascending|descending)']]"
+            );
+          }
+
+          return value;
+        })
+      );
+    }
+
+    if (direction != null) {
+      order = [[keyOrList, direction]];
+    }
+
+    this.cmd.sort = order;
+    return this;
+  }
+
+  /**
+   * Set the batch size for the cursor.
+   * @method
+   * @param {number} value The batchSize for the cursor.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  batchSize(value) {
+    if (this.options.tailable) {
+      throw MongoError.create({
+        message: "Tailable cursor doesn't support batchSize",
+        driver: true
+      });
+    }
+
+    if (this.s.state === CursorState.CLOSED || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    if (typeof value !== 'number') {
+      throw MongoError.create({ message: 'batchSize requires an integer', driver: true });
+    }
+
+    this.cmd.batchSize = value;
+    this.setCursorBatchSize(value);
+    return this;
+  }
+
+  /**
+   * Set the collation options for the cursor.
+   * @method
+   * @param {object} value The cursor collation options (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  collation(value) {
+    this.cmd.collation = value;
+    return this;
+  }
+
+  /**
+   * Set the limit for the cursor.
+   * @method
+   * @param {number} value The limit for the cursor query.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  limit(value) {
+    if (this.options.tailable) {
+      throw MongoError.create({ message: "Tailable cursor doesn't support limit", driver: true });
+    }
+
+    if (this.s.state === CursorState.OPEN || this.s.state === CursorState.CLOSED || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    if (typeof value !== 'number') {
+      throw MongoError.create({ message: 'limit requires an integer', driver: true });
+    }
+
+    this.cmd.limit = value;
+    this.setCursorLimit(value);
+    return this;
+  }
+
+  /**
+   * Set the skip for the cursor.
+   * @method
+   * @param {number} value The skip for the cursor query.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  skip(value) {
+    if (this.options.tailable) {
+      throw MongoError.create({ message: "Tailable cursor doesn't support skip", driver: true });
+    }
+
+    if (this.s.state === CursorState.OPEN || this.s.state === CursorState.CLOSED || this.isDead()) {
+      throw MongoError.create({ message: 'Cursor is closed', driver: true });
+    }
+
+    if (typeof value !== 'number') {
+      throw MongoError.create({ message: 'skip requires an integer', driver: true });
+    }
+
+    this.cmd.skip = value;
+    this.setCursorSkip(value);
+    return this;
+  }
+
+  /**
+   * The callback format for results
+   * @callback Cursor~resultCallback
+   * @param {MongoError} error An error instance representing the error during the execution.
+   * @param {(object|null|boolean)} result The result object if the command was executed successfully.
+   */
+
+  /**
+   * Clone the cursor
+   * @function external:CoreCursor#clone
+   * @return {Cursor}
+   */
+
+  /**
+   * Resets the cursor
+   * @function external:CoreCursor#rewind
+   * @return {null}
+   */
+
+  /**
+   * Iterates over all the documents for this cursor. As with **{cursor.toArray}**,
+   * not all of the elements will be iterated if this cursor had been previously accessed.
+   * In that case, **{cursor.rewind}** can be used to reset the cursor. However, unlike
+   * **{cursor.toArray}**, the cursor will only hold a maximum of batch size elements
+   * at any given time if batch size is specified. Otherwise, the caller is responsible
+   * for making sure that the entire result can fit the memory.
+   * @method
+   * @deprecated
+   * @param {Cursor~resultCallback} callback The result callback.
+   * @throws {MongoError}
+   * @return {null}
+   */
+  each(callback) {
+    // Rewind cursor state
+    this.rewind();
+    // Set current cursor to INIT
+    this.s.state = CursorState.INIT;
+    // Run the query
+    each(this, callback);
+  }
+
+  /**
+   * The callback format for the forEach iterator method
+   * @callback Cursor~iteratorCallback
+   * @param {Object} doc An emitted document for the iterator
+   */
+
+  /**
+   * The callback error format for the forEach iterator method
+   * @callback Cursor~endCallback
+   * @param {MongoError} error An error instance representing the error during the execution.
+   */
+
+  /**
+   * Iterates over all the documents for this cursor using the iterator, callback pattern.
+   * @method
+   * @param {Cursor~iteratorCallback} iterator The iteration callback.
+   * @param {Cursor~endCallback} callback The end callback.
+   * @throws {MongoError}
+   * @return {Promise} if no callback supplied
+   */
+  forEach(iterator, callback) {
+    // Rewind cursor state
+    this.rewind();
+
+    // Set current cursor to INIT
+    this.s.state = CursorState.INIT;
+
+    if (typeof callback === 'function') {
+      each(this, (err, doc) => {
+        if (err) {
+          callback(err);
+          return false;
+        }
+        if (doc != null) {
+          iterator(doc);
+          return true;
+        }
+        if (doc == null && callback) {
+          const internalCallback = callback;
+          callback = null;
+          internalCallback(null);
+          return false;
+        }
+      });
+    } else {
+      return new this.s.promiseLibrary((fulfill, reject) => {
+        each(this, (err, doc) => {
+          if (err) {
+            reject(err);
+            return false;
+          } else if (doc == null) {
+            fulfill(null);
+            return false;
+          } else {
+            iterator(doc);
+            return true;
+          }
+        });
+      });
+    }
+  }
+
+  /**
+   * Set the ReadPreference for the cursor.
+   * @method
+   * @param {(string|ReadPreference)} readPreference The new read preference for the cursor.
+   * @throws {MongoError}
+   * @return {Cursor}
+   */
+  setReadPreference(readPreference) {
+    if (this.s.state !== CursorState.INIT) {
+      throw MongoError.create({
+        message: 'cannot change cursor readPreference after cursor has been accessed',
+        driver: true
+      });
+    }
+
+    if (readPreference instanceof ReadPreference) {
+      this.options.readPreference = readPreference;
+    } else if (typeof readPreference === 'string') {
+      this.options.readPreference = new ReadPreference(readPreference);
+    } else {
+      throw new TypeError('Invalid read preference: ' + readPreference);
+    }
+
+    return this;
+  }
+
+  /**
+   * The callback format for results
+   * @callback Cursor~toArrayResultCallback
+   * @param {MongoError} error An error instance representing the error during the execution.
+   * @param {object[]} documents All the documents the satisfy the cursor.
+   */
+
+  /**
+   * Returns an array of documents. The caller is responsible for making sure that there
+   * is enough memory to store the results. Note that the array only contains partial
+   * results when this cursor had been previously accessed. In that case,
+   * cursor.rewind() can be used to reset the cursor.
+   * @method
+   * @param {Cursor~toArrayResultCallback} [callback] The result callback.
+   * @throws {MongoError}
+   * @return {Promise} returns Promise if no callback passed
+   */
+  toArray(callback) {
+    if (this.options.tailable) {
+      throw MongoError.create({
+        message: 'Tailable cursor cannot be converted to array',
+        driver: true
+      });
+    }
+
+    const toArrayOperation = new ToArrayOperation(this);
+
+    return executeOperation(this.topology, toArrayOperation, callback);
+  }
+
+  /**
+   * The callback format for results
+   * @callback Cursor~countResultCallback
+   * @param {MongoError} error An error instance representing the error during the execution.
+   * @param {number} count The count of documents.
+   */
+
+  /**
+   * Get the count of documents for this cursor
+   * @method
+   * @param {boolean} [applySkipLimit=true] Should the count command apply limit and skip settings on the cursor or in the passed in options.
+   * @param {object} [options] Optional settings.
+   * @param {number} [options.skip] The number of documents to skip.
+   * @param {number} [options.limit] The maximum amounts to count before aborting.
+   * @param {number} [options.maxTimeMS] Number of milliseconds to wait before aborting the query.
+   * @param {string} [options.hint] An index name hint for the query.
+   * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
+   * @param {Cursor~countResultCallback} [callback] The result callback.
+   * @return {Promise} returns Promise if no callback passed
+   */
+  count(applySkipLimit, opts, callback) {
+    if (this.cmd.query == null)
+      throw MongoError.create({
+        message: 'count can only be used with find command',
+        driver: true
+      });
+    if (typeof opts === 'function') (callback = opts), (opts = {});
+    opts = opts || {};
+
+    if (typeof applySkipLimit === 'function') {
+      callback = applySkipLimit;
+      applySkipLimit = true;
+    }
+
+    if (this.cursorState.session) {
+      opts = Object.assign({}, opts, { session: this.cursorState.session });
+    }
+
+    const countOperation = new CountOperation(this, applySkipLimit, opts);
+
+    return executeOperation(this.topology, countOperation, callback);
+  }
+
+  /**
+   * Close the cursor, sending a KillCursor command and emitting close.
+   * @method
+   * @param {object} [options] Optional settings.
+   * @param {boolean} [options.skipKillCursors] Bypass calling killCursors when closing the cursor.
+   * @param {Cursor~resultCallback} [callback] The result callback.
+   * @return {Promise} returns Promise if no callback passed
+   */
+  close(options, callback) {
+    if (typeof options === 'function') (callback = options), (options = {});
+    options = Object.assign({}, { skipKillCursors: false }, options);
+
+    this.s.state = CursorState.CLOSED;
+    if (!options.skipKillCursors) {
+      // Kill the cursor
+      this.kill();
+    }
+
+    const completeClose = () => {
+      // Emit the close event for the cursor
+      this.emit('close');
+
+      // Callback if provided
+      if (typeof callback === 'function') {
+        return handleCallback(callback, null, this);
+      }
+
+      // Return a Promise
+      return new this.s.promiseLibrary(resolve => {
+        resolve();
+      });
+    };
+
+    if (this.cursorState.session) {
+      if (typeof callback === 'function') {
+        return this._endSession(() => completeClose());
+      }
+
+      return new this.s.promiseLibrary(resolve => {
+        this._endSession(() => completeClose().then(resolve));
+      });
+    }
+
+    return completeClose();
+  }
+
+  /**
+   * Map all documents using the provided function
+   * @method
+   * @param {function} [transform] The mapping transformation method.
+   * @return {Cursor}
+   */
+  map(transform) {
+    if (this.cursorState.transforms && this.cursorState.transforms.doc) {
+      const oldTransform = this.cursorState.transforms.doc;
+      this.cursorState.transforms.doc = doc => {
+        return transform(oldTransform(doc));
+      };
+    } else {
+      this.cursorState.transforms = { doc: transform };
+    }
+
+    return this;
+  }
+
+  /**
+   * Is the cursor closed
+   * @method
+   * @return {boolean}
+   */
+  isClosed() {
+    return this.isDead();
+  }
+
+  destroy(err) {
+    if (err) this.emit('error', err);
+    this.pause();
+    this.close();
+  }
+
+  /**
+   * Return a modified Readable stream including a possible transform method.
+   * @method
+   * @param {object} [options] Optional settings.
+   * @param {function} [options.transform] A transformation method applied to each document emitted by the stream.
+   * @return {Cursor}
+   * TODO: replace this method with transformStream in next major release
+   */
+  stream(options) {
+    this.cursorState.streamOptions = options || {};
+    return this;
+  }
+
+  /**
+   * Return a modified Readable stream that applies a given transform function, if supplied. If none supplied,
+   * returns a stream of unmodified docs.
+   * @method
+   * @param {object} [options] Optional settings.
+   * @param {function} [options.transform] A transformation method applied to each document emitted by the stream.
+   * @return {stream}
+   */
+  transformStream(options) {
+    const streamOptions = options || {};
+    if (typeof streamOptions.transform === 'function') {
+      const stream = new Transform({
+        objectMode: true,
+        transform: function(chunk, encoding, callback) {
+          this.push(streamOptions.transform(chunk));
+          callback();
+        }
+      });
+
+      return this.pipe(stream);
+    }
+
+    return this.pipe(new PassThrough({ objectMode: true }));
+  }
+
+  /**
+   * Execute the explain for the cursor
+   * @method
+   * @param {Cursor~resultCallback} [callback] The result callback.
+   * @return {Promise} returns Promise if no callback passed
+   */
+  explain(callback) {
+    if (this.operation) {
+      this.operation.options.explain = true;
+      return executeOperation(this.topology, this.operation, callback);
+    }
+
+    this.cmd.explain = true;
+
+    // Do we have a readConcern
+    if (this.cmd.readConcern) {
+      delete this.cmd['readConcern'];
+    }
+
+    const explainOperation = new ExplainOperation(this);
+
+    return executeOperation(this.topology, explainOperation, callback);
+  }
+
+  /**
+   * Return the cursor logger
+   * @method
+   * @return {Logger} return the cursor logger
+   * @ignore
+   */
+  getLogger() {
+    return this.logger;
+  }
 }
 
 /**
@@ -203,900 +1016,20 @@ function Cursor(topology, ns, cmd, options) {
  * @type {null}
  */
 
-// Inherit from Readable
-inherits(Cursor, Readable);
-
-if (SUPPORTS.ASYNC_ITERATOR) {
-  Cursor.prototype[Symbol.asyncIterator] = require('./async/async_iterator').asyncIterator;
-}
-
-// Map core cursor _next method so we can apply mapping
-Cursor.prototype._next = function() {
-  return CoreCursor.prototype.next.apply(this, arguments);
-};
-
-for (let name in CoreCursor.prototype) {
-  Cursor.prototype[name] = CoreCursor.prototype[name];
-}
-
-Cursor.prototype._initializeCursor = function(callback) {
-  if (this.operation && this.operation.session != null) {
-    this.s.session = this.operation.session;
-    this.cursorState.session = this.operation.session;
-  } else {
-    // implicitly create a session if one has not been provided
-    if (!this.s.explicitlyIgnoreSession && !this.s.session && this.topology.hasSessionSupport()) {
-      this.s.session = this.topology.startSession({ owner: this });
-      this.cursorState.session = this.s.session;
-
-      if (this.operation) {
-        this.operation.session = this.s.session;
-      }
-    }
-  }
-
-  CoreCursor.prototype._initializeCursor.apply(this, [callback]);
-};
-
-Cursor.prototype._endSession = function() {
-  const didCloseCursor = CoreCursor.prototype._endSession.apply(this, arguments);
-  if (didCloseCursor) {
-    this.s.session = undefined;
-  }
-};
-
-/**
- * Check if there is any document still available in the cursor
- * @method
- * @param {Cursor~resultCallback} [callback] The result callback.
- * @throws {MongoError}
- * @return {Promise} returns Promise if no callback passed
- */
-Cursor.prototype.hasNext = function(callback) {
-  const hasNextOperation = new HasNextOperation(this);
-
-  return executeOperation(this.topology, hasNextOperation, callback);
-};
-
-/**
- * Get the next available document from the cursor, returns null if no more documents are available.
- * @method
- * @param {Cursor~resultCallback} [callback] The result callback.
- * @throws {MongoError}
- * @return {Promise} returns Promise if no callback passed
- */
-Cursor.prototype.next = function(callback) {
-  const nextOperation = new NextOperation(this);
-
-  return executeOperation(this.topology, nextOperation, callback);
-};
-
-/**
- * Set the cursor query
- * @method
- * @param {object} filter The filter object used for the cursor.
- * @return {Cursor}
- */
-Cursor.prototype.filter = function(filter) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.query = filter;
-  return this;
-};
-
-/**
- * Set the cursor maxScan
- * @method
- * @param {object} maxScan Constrains the query to only scan the specified number of documents when fulfilling the query
- * @deprecated as of MongoDB 4.0
- * @return {Cursor}
- */
-Cursor.prototype.maxScan = deprecate(function(maxScan) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.maxScan = maxScan;
-  return this;
-}, 'Cursor.maxScan is deprecated, and will be removed in a later version');
-
-/**
- * Set the cursor hint
- * @method
- * @param {object} hint If specified, then the query system will only consider plans using the hinted index.
- * @return {Cursor}
- */
-Cursor.prototype.hint = function(hint) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.hint = hint;
-  return this;
-};
-
-/**
- * Set the cursor min
- * @method
- * @param {object} min Specify a $min value to specify the inclusive lower bound for a specific index in order to constrain the results of find(). The $min specifies the lower bound for all keys of a specific index in order.
- * @return {Cursor}
- */
-Cursor.prototype.min = function(min) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead())
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  this.cmd.min = min;
-  return this;
-};
-
-/**
- * Set the cursor max
- * @method
- * @param {object} max Specify a $max value to specify the exclusive upper bound for a specific index in order to constrain the results of find(). The $max specifies the upper bound for all keys of a specific index in order.
- * @return {Cursor}
- */
-Cursor.prototype.max = function(max) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.max = max;
-  return this;
-};
-
-/**
- * Set the cursor returnKey. If set to true, modifies the cursor to only return the index field or fields for the results of the query, rather than documents. If set to true and the query does not use an index to perform the read operation, the returned documents will not contain any fields.
- * @method
- * @param {bool} returnKey the returnKey value.
- * @return {Cursor}
- */
-Cursor.prototype.returnKey = function(value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.returnKey = value;
-  return this;
-};
-
-/**
- * Set the cursor showRecordId
- * @method
- * @param {object} showRecordId The $showDiskLoc option has now been deprecated and replaced with the showRecordId field. $showDiskLoc will still be accepted for OP_QUERY stye find.
- * @return {Cursor}
- */
-Cursor.prototype.showRecordId = function(value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.showDiskLoc = value;
-  return this;
-};
-
-/**
- * Set the cursor snapshot
- * @method
- * @param {object} snapshot The $snapshot operator prevents the cursor from returning a document more than once because an intervening write operation results in a move of the document.
- * @deprecated as of MongoDB 4.0
- * @return {Cursor}
- */
-Cursor.prototype.snapshot = deprecate(function(value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.snapshot = value;
-  return this;
-}, 'Cursor Snapshot is deprecated, and will be removed in a later version');
-
-/**
- * Set a node.js specific cursor option
- * @method
- * @param {string} field The cursor option to set ['numberOfRetries', 'tailableRetryInterval'].
- * @param {object} value The field value.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.setCursorOption = function(field, value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  if (fields.indexOf(field) === -1) {
-    throw MongoError.create({
-      message: `option ${field} is not a supported option ${fields}`,
-      driver: true
-    });
-  }
-
-  this.s[field] = value;
-  if (field === 'numberOfRetries') this.s.currentNumberOfRetries = value;
-  return this;
-};
-
-/**
- * Add a cursor flag to the cursor
- * @method
- * @param {string} flag The flag to set, must be one of following ['tailable', 'oplogReplay', 'noCursorTimeout', 'awaitData', 'partial'].
- * @param {boolean} value The flag boolean value.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.addCursorFlag = function(flag, value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  if (flags.indexOf(flag) === -1) {
-    throw MongoError.create({
-      message: `flag ${flag} is not a supported flag ${flags}`,
-      driver: true
-    });
-  }
-
-  if (typeof value !== 'boolean') {
-    throw MongoError.create({ message: `flag ${flag} must be a boolean value`, driver: true });
-  }
-
-  this.cmd[flag] = value;
-  return this;
-};
-
-/**
- * Add a query modifier to the cursor query
- * @method
- * @param {string} name The query modifier (must start with $, such as $orderby etc)
- * @param {string|boolean|number} value The modifier value.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.addQueryModifier = function(name, value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  if (name[0] !== '$') {
-    throw MongoError.create({ message: `${name} is not a valid query modifier`, driver: true });
-  }
-
-  // Strip of the $
-  const field = name.substr(1);
-  // Set on the command
-  this.cmd[field] = value;
-  // Deal with the special case for sort
-  if (field === 'orderby') this.cmd.sort = this.cmd[field];
-  return this;
-};
-
-/**
- * Add a comment to the cursor query allowing for tracking the comment in the log.
- * @method
- * @param {string} value The comment attached to this query.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.comment = function(value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.comment = value;
-  return this;
-};
-
-/**
- * Set a maxAwaitTimeMS on a tailing cursor query to allow to customize the timeout value for the option awaitData (Only supported on MongoDB 3.2 or higher, ignored otherwise)
- * @method
- * @param {number} value Number of milliseconds to wait before aborting the tailed query.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.maxAwaitTimeMS = function(value) {
-  if (typeof value !== 'number') {
-    throw MongoError.create({ message: 'maxAwaitTimeMS must be a number', driver: true });
-  }
-
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.maxAwaitTimeMS = value;
-  return this;
-};
-
-/**
- * Set a maxTimeMS on the cursor query, allowing for hard timeout limits on queries (Only supported on MongoDB 2.6 or higher)
- * @method
- * @param {number} value Number of milliseconds to wait before aborting the query.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.maxTimeMS = function(value) {
-  if (typeof value !== 'number') {
-    throw MongoError.create({ message: 'maxTimeMS must be a number', driver: true });
-  }
-
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.maxTimeMS = value;
-  return this;
-};
-
+// aliases
 Cursor.prototype.maxTimeMs = Cursor.prototype.maxTimeMS;
 
-/**
- * Sets a field projection for the query.
- * @method
- * @param {object} value The field projection object.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.project = function(value) {
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  this.cmd.fields = value;
-  return this;
-};
-
-/**
- * Sets the sort order of the cursor query.
- * @method
- * @param {(string|array|object)} keyOrList The key or keys set for the sort.
- * @param {number} [direction] The direction of the sorting (1 or -1).
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.sort = function(keyOrList, direction) {
-  if (this.options.tailable) {
-    throw MongoError.create({ message: "Tailable cursor doesn't support sorting", driver: true });
-  }
-
-  if (this.s.state === Cursor.CLOSED || this.s.state === Cursor.OPEN || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  let order = keyOrList;
-
-  // We have an array of arrays, we need to preserve the order of the sort
-  // so we will us a Map
-  if (Array.isArray(order) && Array.isArray(order[0])) {
-    order = new Map(
-      order.map(x => {
-        const value = [x[0], null];
-        if (x[1] === 'asc') {
-          value[1] = 1;
-        } else if (x[1] === 'desc') {
-          value[1] = -1;
-        } else if (x[1] === 1 || x[1] === -1 || x[1].$meta) {
-          value[1] = x[1];
-        } else {
-          throw new MongoError(
-            "Illegal sort clause, must be of the form [['field1', '(ascending|descending)'], ['field2', '(ascending|descending)']]"
-          );
-        }
-
-        return value;
-      })
-    );
-  }
-
-  if (direction != null) {
-    order = [[keyOrList, direction]];
-  }
-
-  this.cmd.sort = order;
-  this.sortValue = order;
-  return this;
-};
-
-/**
- * Set the batch size for the cursor.
- * @method
- * @param {number} value The batchSize for the cursor.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.batchSize = function(value) {
-  if (this.options.tailable) {
-    throw MongoError.create({ message: "Tailable cursor doesn't support batchSize", driver: true });
-  }
-
-  if (this.s.state === Cursor.CLOSED || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  if (typeof value !== 'number') {
-    throw MongoError.create({ message: 'batchSize requires an integer', driver: true });
-  }
-
-  this.cmd.batchSize = value;
-  this.setCursorBatchSize(value);
-  return this;
-};
-
-/**
- * Set the collation options for the cursor.
- * @method
- * @param {object} value The cursor collation options (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.collation = function(value) {
-  this.cmd.collation = value;
-  return this;
-};
-
-/**
- * Set the limit for the cursor.
- * @method
- * @param {number} value The limit for the cursor query.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.limit = function(value) {
-  if (this.options.tailable) {
-    throw MongoError.create({ message: "Tailable cursor doesn't support limit", driver: true });
-  }
-
-  if (this.s.state === Cursor.OPEN || this.s.state === Cursor.CLOSED || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  if (typeof value !== 'number') {
-    throw MongoError.create({ message: 'limit requires an integer', driver: true });
-  }
-
-  this.cmd.limit = value;
-  // this.cursorLimit = value;
-  this.setCursorLimit(value);
-  return this;
-};
-
-/**
- * Set the skip for the cursor.
- * @method
- * @param {number} value The skip for the cursor query.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.skip = function(value) {
-  if (this.options.tailable) {
-    throw MongoError.create({ message: "Tailable cursor doesn't support skip", driver: true });
-  }
-
-  if (this.s.state === Cursor.OPEN || this.s.state === Cursor.CLOSED || this.isDead()) {
-    throw MongoError.create({ message: 'Cursor is closed', driver: true });
-  }
-
-  if (typeof value !== 'number') {
-    throw MongoError.create({ message: 'skip requires an integer', driver: true });
-  }
-
-  this.cmd.skip = value;
-  this.setCursorSkip(value);
-  return this;
-};
-
-/**
- * The callback format for results
- * @callback Cursor~resultCallback
- * @param {MongoError} error An error instance representing the error during the execution.
- * @param {(object|null|boolean)} result The result object if the command was executed successfully.
- */
-
-/**
- * Clone the cursor
- * @function external:CoreCursor#clone
- * @return {Cursor}
- */
-
-/**
- * Resets the cursor
- * @function external:CoreCursor#rewind
- * @return {null}
- */
-
-/**
- * Iterates over all the documents for this cursor. As with **{cursor.toArray}**,
- * not all of the elements will be iterated if this cursor had been previously accessed.
- * In that case, **{cursor.rewind}** can be used to reset the cursor. However, unlike
- * **{cursor.toArray}**, the cursor will only hold a maximum of batch size elements
- * at any given time if batch size is specified. Otherwise, the caller is responsible
- * for making sure that the entire result can fit the memory.
- * @method
- * @deprecated
- * @param {Cursor~resultCallback} callback The result callback.
- * @throws {MongoError}
- * @return {null}
- */
-Cursor.prototype.each = deprecate(function(callback) {
-  // Rewind cursor state
-  this.rewind();
-  // Set current cursor to INIT
-  this.s.state = Cursor.INIT;
-  // Run the query
-  each(this, callback);
-}, 'Cursor.each is deprecated. Use Cursor.forEach instead.');
-
-/**
- * The callback format for the forEach iterator method
- * @callback Cursor~iteratorCallback
- * @param {Object} doc An emitted document for the iterator
- */
-
-/**
- * The callback error format for the forEach iterator method
- * @callback Cursor~endCallback
- * @param {MongoError} error An error instance representing the error during the execution.
- */
-
-/**
- * Iterates over all the documents for this cursor using the iterator, callback pattern.
- * @method
- * @param {Cursor~iteratorCallback} iterator The iteration callback.
- * @param {Cursor~endCallback} callback The end callback.
- * @throws {MongoError}
- * @return {Promise} if no callback supplied
- */
-Cursor.prototype.forEach = function(iterator, callback) {
-  // Rewind cursor state
-  this.rewind();
-
-  // Set current cursor to INIT
-  this.s.state = Cursor.INIT;
-
-  if (typeof callback === 'function') {
-    each(this, (err, doc) => {
-      if (err) {
-        callback(err);
-        return false;
-      }
-      if (doc != null) {
-        iterator(doc);
-        return true;
-      }
-      if (doc == null && callback) {
-        const internalCallback = callback;
-        callback = null;
-        internalCallback(null);
-        return false;
-      }
-    });
-  } else {
-    return new this.s.promiseLibrary((fulfill, reject) => {
-      each(this, (err, doc) => {
-        if (err) {
-          reject(err);
-          return false;
-        } else if (doc == null) {
-          fulfill(null);
-          return false;
-        } else {
-          iterator(doc);
-          return true;
-        }
-      });
-    });
-  }
-};
-
-/**
- * Set the ReadPreference for the cursor.
- * @method
- * @param {(string|ReadPreference)} readPreference The new read preference for the cursor.
- * @throws {MongoError}
- * @return {Cursor}
- */
-Cursor.prototype.setReadPreference = function(readPreference) {
-  if (this.s.state !== Cursor.INIT) {
-    throw MongoError.create({
-      message: 'cannot change cursor readPreference after cursor has been accessed',
-      driver: true
-    });
-  }
-
-  if (readPreference instanceof ReadPreference) {
-    this.options.readPreference = readPreference;
-  } else if (typeof readPreference === 'string') {
-    this.options.readPreference = new ReadPreference(readPreference);
-  } else {
-    throw new TypeError('Invalid read preference: ' + readPreference);
-  }
-
-  return this;
-};
-
-/**
- * The callback format for results
- * @callback Cursor~toArrayResultCallback
- * @param {MongoError} error An error instance representing the error during the execution.
- * @param {object[]} documents All the documents the satisfy the cursor.
- */
-
-/**
- * Returns an array of documents. The caller is responsible for making sure that there
- * is enough memory to store the results. Note that the array only contains partial
- * results when this cursor had been previously accessed. In that case,
- * cursor.rewind() can be used to reset the cursor.
- * @method
- * @param {Cursor~toArrayResultCallback} [callback] The result callback.
- * @throws {MongoError}
- * @return {Promise} returns Promise if no callback passed
- */
-Cursor.prototype.toArray = function(callback) {
-  if (this.options.tailable) {
-    throw MongoError.create({
-      message: 'Tailable cursor cannot be converted to array',
-      driver: true
-    });
-  }
-
-  const toArrayOperation = new ToArrayOperation(this);
-
-  return executeOperation(this.topology, toArrayOperation, callback);
-};
-
-/**
- * The callback format for results
- * @callback Cursor~countResultCallback
- * @param {MongoError} error An error instance representing the error during the execution.
- * @param {number} count The count of documents.
- */
-
-/**
- * Get the count of documents for this cursor
- * @method
- * @param {boolean} [applySkipLimit=true] Should the count command apply limit and skip settings on the cursor or in the passed in options.
- * @param {object} [options] Optional settings.
- * @param {number} [options.skip] The number of documents to skip.
- * @param {number} [options.limit] The maximum amounts to count before aborting.
- * @param {number} [options.maxTimeMS] Number of milliseconds to wait before aborting the query.
- * @param {string} [options.hint] An index name hint for the query.
- * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
- * @param {Cursor~countResultCallback} [callback] The result callback.
- * @return {Promise} returns Promise if no callback passed
- */
-Cursor.prototype.count = function(applySkipLimit, opts, callback) {
-  if (this.cmd.query == null)
-    throw MongoError.create({ message: 'count can only be used with find command', driver: true });
-  if (typeof opts === 'function') (callback = opts), (opts = {});
-  opts = opts || {};
-
-  if (typeof applySkipLimit === 'function') {
-    callback = applySkipLimit;
-    applySkipLimit = true;
-  }
-
-  if (this.s.session) {
-    opts = Object.assign({}, opts, { session: this.s.session });
-  }
-
-  const countOperation = new CountOperation(this, applySkipLimit, opts);
-
-  return executeOperation(this.topology, countOperation, callback);
-};
-
-/**
- * Close the cursor, sending a KillCursor command and emitting close.
- * @method
- * @param {object} [options] Optional settings.
- * @param {boolean} [options.skipKillCursors] Bypass calling killCursors when closing the cursor.
- * @param {Cursor~resultCallback} [callback] The result callback.
- * @return {Promise} returns Promise if no callback passed
- */
-Cursor.prototype.close = function(options, callback) {
-  if (typeof options === 'function') (callback = options), (options = {});
-  options = Object.assign({}, { skipKillCursors: false }, options);
-
-  this.s.state = Cursor.CLOSED;
-  if (!options.skipKillCursors) {
-    // Kill the cursor
-    this.kill();
-  }
-
-  const completeClose = () => {
-    // Emit the close event for the cursor
-    this.emit('close');
-
-    // Callback if provided
-    if (typeof callback === 'function') {
-      return handleCallback(callback, null, this);
-    }
-
-    // Return a Promise
-    return new this.s.promiseLibrary(resolve => {
-      resolve();
-    });
-  };
-
-  if (this.s.session) {
-    if (typeof callback === 'function') {
-      return this._endSession(() => completeClose());
-    }
-
-    return new this.s.promiseLibrary(resolve => {
-      this._endSession(() => completeClose().then(resolve));
-    });
-  }
-
-  return completeClose();
-};
-
-/**
- * Map all documents using the provided function
- * @method
- * @param {function} [transform] The mapping transformation method.
- * @return {Cursor}
- */
-Cursor.prototype.map = function(transform) {
-  if (this.cursorState.transforms && this.cursorState.transforms.doc) {
-    const oldTransform = this.cursorState.transforms.doc;
-    this.cursorState.transforms.doc = doc => {
-      return transform(oldTransform(doc));
-    };
-  } else {
-    this.cursorState.transforms = { doc: transform };
-  }
-  return this;
-};
-
-/**
- * Is the cursor closed
- * @method
- * @return {boolean}
- */
-Cursor.prototype.isClosed = function() {
-  return this.isDead();
-};
-
-Cursor.prototype.destroy = function(err) {
-  if (err) this.emit('error', err);
-  this.pause();
-  this.close();
-};
-
-/**
- * Return a modified Readable stream including a possible transform method.
- * @method
- * @param {object} [options] Optional settings.
- * @param {function} [options.transform] A transformation method applied to each document emitted by the stream.
- * @return {Cursor}
- * TODO: replace this method with transformStream in next major release
- */
-Cursor.prototype.stream = function(options) {
-  this.s.streamOptions = options || {};
-  return this;
-};
-
-/**
- * Return a modified Readable stream that applies a given transform function, if supplied. If none supplied,
- * returns a stream of unmodified docs.
- * @method
- * @param {object} [options] Optional settings.
- * @param {function} [options.transform] A transformation method applied to each document emitted by the stream.
- * @return {stream}
- */
-Cursor.prototype.transformStream = function(options) {
-  const streamOptions = options || {};
-  if (typeof streamOptions.transform === 'function') {
-    const stream = new Transform({
-      objectMode: true,
-      transform: function(chunk, encoding, callback) {
-        this.push(streamOptions.transform(chunk));
-        callback();
-      }
-    });
-
-    return this.pipe(stream);
-  }
-  return this.pipe(new PassThrough({ objectMode: true }));
-};
-
-/**
- * Execute the explain for the cursor
- * @method
- * @param {Cursor~resultCallback} [callback] The result callback.
- * @return {Promise} returns Promise if no callback passed
- */
-Cursor.prototype.explain = function(callback) {
-  if (this.operation) {
-    this.operation.options.explain = true;
-    return executeOperation(this.topology, this.operation, callback);
-  }
-
-  this.cmd.explain = true;
-
-  // Do we have a readConcern
-  if (this.cmd.readConcern) {
-    delete this.cmd['readConcern'];
-  }
-
-  const explainOperation = new ExplainOperation(this);
-
-  return executeOperation(this.topology, explainOperation, callback);
-};
-
-Cursor.prototype._read = function() {
-  if (this.s.state === Cursor.CLOSED || this.isDead()) {
-    return this.push(null);
-  }
-
-  // Get the next item
-  this.next((err, result) => {
-    if (err) {
-      if (this.listeners('error') && this.listeners('error').length > 0) {
-        this.emit('error', err);
-      }
-      if (!this.isDead()) this.close();
-
-      // Emit end event
-      this.emit('end');
-      return this.emit('finish');
-    }
-
-    // If we provided a transformation method
-    if (typeof this.s.streamOptions.transform === 'function' && result != null) {
-      return this.push(this.s.streamOptions.transform(result));
-    }
-
-    // If we provided a map function
-    if (
-      this.cursorState.transforms &&
-      typeof this.cursorState.transforms.doc === 'function' &&
-      result != null
-    ) {
-      return this.push(this.cursorState.transforms.doc(result));
-    }
-
-    // Return the result
-    this.push(result);
-
-    if (result === null && this.isDead()) {
-      this.once('end', () => {
-        this.close();
-        this.emit('finish');
-      });
-    }
-  });
-};
-
-/**
- * Return the cursor logger
- * @method
- * @return {Logger} return the cursor logger
- * @ignore
- */
-Cursor.prototype.getLogger = function() {
-  return this.logger;
-};
-
-Object.defineProperty(Cursor.prototype, 'readPreference', {
-  enumerable: true,
-  get: function() {
-    if (!this || !this.s) {
-      return null;
-    }
-
-    return this.options.readPreference;
-  }
-});
-
-Object.defineProperty(Cursor.prototype, 'namespace', {
-  enumerable: true,
-  get: function() {
-    if (!(this && this.s)) {
-      return;
-    }
-
-    return this.s.namespace.toString();
-  }
-});
+// deprecated methods
+deprecate(Cursor.prototype.each, 'Cursor.each is deprecated. Use Cursor.forEach instead.');
+deprecate(
+  Cursor.prototype.maxScan,
+  'Cursor.maxScan is deprecated, and will be removed in a later version'
+);
+
+deprecate(
+  Cursor.prototype.snapshot,
+  'Cursor Snapshot is deprecated, and will be removed in a later version'
+);
 
 /**
  * The read() method pulls some data out of the internal buffer and returns it. If there is no data available, then it will return null.
@@ -1152,10 +1085,5 @@ Object.defineProperty(Cursor.prototype, 'namespace', {
  * @param {Stream} stream An "old style" readable stream.
  * @return {null}
  */
-
-Cursor.INIT = 0;
-Cursor.OPEN = 1;
-Cursor.CLOSED = 2;
-Cursor.GET_MORE = 3;
 
 module.exports = Cursor;

--- a/lib/operations/common_functions.js
+++ b/lib/operations/common_functions.js
@@ -33,14 +33,14 @@ function buildCountCommand(collectionOrCursor, query, options) {
     query: query
   };
 
-  // check if collectionOrCursor is a cursor by using cursor.s.numberOfRetries
   if (collectionOrCursor.s.numberOfRetries) {
-    if (collectionOrCursor.s.options.hint) {
-      hint = collectionOrCursor.s.options.hint;
-    } else if (collectionOrCursor.s.cmd.hint) {
-      hint = collectionOrCursor.s.cmd.hint;
+    // collectionOrCursor is a cursor
+    if (collectionOrCursor.options.hint) {
+      hint = collectionOrCursor.options.hint;
+    } else if (collectionOrCursor.cmd.hint) {
+      hint = collectionOrCursor.cmd.hint;
     }
-    decorateWithCollation(cmd, collectionOrCursor, collectionOrCursor.s.cmd);
+    decorateWithCollation(cmd, collectionOrCursor, collectionOrCursor.cmd);
   } else {
     decorateWithCollation(cmd, collectionOrCursor, options);
   }
@@ -225,9 +225,9 @@ function nextObject(cursor, callback) {
     );
   }
 
-  if (cursor.s.state === Cursor.INIT && cursor.s.cmd && cursor.s.cmd.sort) {
+  if (cursor.s.state === Cursor.INIT && cursor.cmd && cursor.cmd.sort) {
     try {
-      cursor.s.cmd.sort = formattedOrderClause(cursor.s.cmd.sort);
+      cursor.cmd.sort = formattedOrderClause(cursor.cmd.sort);
     } catch (err) {
       return handleCallback(callback, err);
     }

--- a/lib/operations/common_functions.js
+++ b/lib/operations/common_functions.js
@@ -7,10 +7,10 @@ const decorateWithReadConcern = require('../utils').decorateWithReadConcern;
 const executeCommand = require('./db_ops').executeCommand;
 const formattedOrderClause = require('../utils').formattedOrderClause;
 const handleCallback = require('../utils').handleCallback;
-const loadCursor = require('../dynamic_loaders').loadCursor;
 const MongoError = require('../core').MongoError;
 const ReadPreference = require('../core').ReadPreference;
 const toError = require('../utils').toError;
+const CursorState = require('../core/cursor').CursorState;
 
 /**
  * Build the count command.
@@ -216,16 +216,14 @@ function prepareDocs(coll, docs, options) {
 
 // Get the next available document from the cursor, returns null if no more documents are available.
 function nextObject(cursor, callback) {
-  let Cursor = loadCursor();
-
-  if (cursor.s.state === Cursor.CLOSED || (cursor.isDead && cursor.isDead())) {
+  if (cursor.s.state === CursorState.CLOSED || (cursor.isDead && cursor.isDead())) {
     return handleCallback(
       callback,
       MongoError.create({ message: 'Cursor is closed', driver: true })
     );
   }
 
-  if (cursor.s.state === Cursor.INIT && cursor.cmd && cursor.cmd.sort) {
+  if (cursor.s.state === CursorState.INIT && cursor.cmd && cursor.cmd.sort) {
     try {
       cursor.cmd.sort = formattedOrderClause(cursor.cmd.sort);
     } catch (err) {
@@ -235,7 +233,7 @@ function nextObject(cursor, callback) {
 
   // Get the next object
   cursor._next((err, doc) => {
-    cursor.s.state = Cursor.OPEN;
+    cursor.s.state = CursorState.OPEN;
     if (err) return handleCallback(callback, err);
     handleCallback(callback, null, doc);
   });
@@ -282,8 +280,10 @@ function removeDocuments(coll, selector, options, callback) {
     if (err) return handleCallback(callback, err, null);
     if (result == null) return handleCallback(callback, null, null);
     if (result.result.code) return handleCallback(callback, toError(result.result));
-    if (result.result.writeErrors)
+    if (result.result.writeErrors) {
       return handleCallback(callback, toError(result.result.writeErrors[0]));
+    }
+
     // Return the results
     handleCallback(callback, null, result);
   });

--- a/lib/operations/count.js
+++ b/lib/operations/count.js
@@ -30,10 +30,10 @@ class CountOperation extends OperationBase {
 
     if (
       typeof options.maxTimeMS !== 'number' &&
-      cursor.s.cmd &&
-      typeof cursor.s.cmd.maxTimeMS === 'number'
+      cursor.cmd &&
+      typeof cursor.cmd.maxTimeMS === 'number'
     ) {
-      options.maxTimeMS = cursor.s.cmd.maxTimeMS;
+      options.maxTimeMS = cursor.cmd.maxTimeMS;
     }
 
     let finalOptions = {};
@@ -47,7 +47,7 @@ class CountOperation extends OperationBase {
 
     let command;
     try {
-      command = buildCountCommand(cursor, cursor.s.cmd.query, finalOptions);
+      command = buildCountCommand(cursor, cursor.cmd.query, finalOptions);
     } catch (err) {
       return callback(err);
     }
@@ -56,10 +56,10 @@ class CountOperation extends OperationBase {
     cursor.server = cursor.topology.s.coreTopology;
 
     // Execute the command
-    cursor.s.topology.command(
+    cursor.topology.command(
       cursor.s.namespace.withCollection('$cmd'),
       command,
-      cursor.s.options,
+      cursor.options,
       (err, result) => {
         callback(err, result ? result.result.n : null);
       }

--- a/lib/operations/count.js
+++ b/lib/operations/count.js
@@ -43,7 +43,7 @@ class CountOperation extends OperationBase {
     finalOptions.maxTimeMS = options.maxTimeMS;
 
     // Command
-    finalOptions.collectionName = cursor.s.namespace.collection;
+    finalOptions.collectionName = cursor.namespace.collection;
 
     let command;
     try {
@@ -57,7 +57,7 @@ class CountOperation extends OperationBase {
 
     // Execute the command
     cursor.topology.command(
-      cursor.s.namespace.withCollection('$cmd'),
+      cursor.namespace.withCollection('$cmd'),
       command,
       cursor.options,
       (err, result) => {

--- a/lib/operations/cursor_ops.js
+++ b/lib/operations/cursor_ops.js
@@ -5,14 +5,7 @@ const formattedOrderClause = require('../utils').formattedOrderClause;
 const handleCallback = require('../utils').handleCallback;
 const MongoError = require('../core').MongoError;
 const push = Array.prototype.push;
-
-let cursor;
-function loadCursor() {
-  if (!cursor) {
-    cursor = require('../cursor');
-  }
-  return cursor;
-}
+const CursorState = require('../core/cursor').CursorState;
 
 /**
  * Get the count of documents for this cursor.
@@ -49,7 +42,7 @@ function count(cursor, applySkipLimit, opts, callback) {
   options.maxTimeMS = opts.maxTimeMS;
 
   // Command
-  options.collectionName = cursor.s.namespace.collection;
+  options.collectionName = cursor.namespace.collection;
 
   let command;
   try {
@@ -62,10 +55,10 @@ function count(cursor, applySkipLimit, opts, callback) {
   cursor.server = cursor.topology.s.coreTopology;
 
   // Execute the command
-  cursor.s.topology.command(
-    cursor.s.namespace.withCollection('$cmd'),
+  cursor.topology.command(
+    cursor.namespace.withCollection('$cmd'),
     command,
-    cursor.s.options,
+    cursor.options,
     (err, result) => {
       callback(err, result ? result.result.n : null);
     }
@@ -81,18 +74,18 @@ function count(cursor, applySkipLimit, opts, callback) {
  * @param {Cursor~resultCallback} callback The result callback.
  */
 function each(cursor, callback) {
-  let Cursor = loadCursor();
-
   if (!callback) throw MongoError.create({ message: 'callback is mandatory', driver: true });
   if (cursor.isNotified()) return;
-  if (cursor.s.state === Cursor.CLOSED || cursor.isDead()) {
+  if (cursor.s.state === CursorState.CLOSED || cursor.isDead()) {
     return handleCallback(
       callback,
       MongoError.create({ message: 'Cursor is closed', driver: true })
     );
   }
 
-  if (cursor.s.state === Cursor.INIT) cursor.s.state = Cursor.OPEN;
+  if (cursor.s.state === CursorState.INIT) {
+    cursor.s.state = CursorState.OPEN;
+  }
 
   // Define function to avoid global scope escape
   let fn = null;
@@ -121,8 +114,6 @@ function each(cursor, callback) {
  * @param {Cursor~resultCallback} [callback] The result callback.
  */
 function hasNext(cursor, callback) {
-  let Cursor = loadCursor();
-
   if (cursor.s.currentDoc) {
     return callback(null, true);
   }
@@ -133,7 +124,10 @@ function hasNext(cursor, callback) {
 
   nextObject(cursor, (err, doc) => {
     if (err) return callback(err, null);
-    if (cursor.s.state === Cursor.CLOSED || cursor.isDead()) return callback(null, false);
+    if (cursor.s.state === CursorState.CLOSED || cursor.isDead()) {
+      return callback(null, false);
+    }
+
     if (!doc) return callback(null, false);
     cursor.s.currentDoc = doc;
     callback(null, true);
@@ -172,14 +166,12 @@ function next(cursor, callback) {
 
 // Get the next available document from the cursor, returns null if no more documents are available.
 function nextObject(cursor, callback) {
-  let Cursor = loadCursor();
-
-  if (cursor.s.state === Cursor.CLOSED || (cursor.isDead && cursor.isDead()))
+  if (cursor.s.state === CursorState.CLOSED || (cursor.isDead && cursor.isDead()))
     return handleCallback(
       callback,
       MongoError.create({ message: 'Cursor is closed', driver: true })
     );
-  if (cursor.s.state === Cursor.INIT && cursor.cmd.sort) {
+  if (cursor.s.state === CursorState.INIT && cursor.cmd.sort) {
     try {
       cursor.cmd.sort = formattedOrderClause(cursor.cmd.sort);
     } catch (err) {
@@ -189,7 +181,7 @@ function nextObject(cursor, callback) {
 
   // Get the next object
   cursor._next((err, doc) => {
-    cursor.s.state = Cursor.OPEN;
+    cursor.s.state = CursorState.OPEN;
     if (err) return handleCallback(callback, err);
     handleCallback(callback, null, doc);
   });
@@ -203,13 +195,11 @@ function nextObject(cursor, callback) {
  * @param {Cursor~toArrayResultCallback} [callback] The result callback.
  */
 function toArray(cursor, callback) {
-  let Cursor = loadCursor();
-
   const items = [];
 
   // Reset cursor
   cursor.rewind();
-  cursor.s.state = Cursor.INIT;
+  cursor.s.state = CursorState.INIT;
 
   // Fetch all the documents
   const fetchDocs = () => {

--- a/lib/operations/cursor_ops.js
+++ b/lib/operations/cursor_ops.js
@@ -36,10 +36,10 @@ function count(cursor, applySkipLimit, opts, callback) {
 
   if (
     typeof opts.maxTimeMS !== 'number' &&
-    cursor.s.cmd &&
-    typeof cursor.s.cmd.maxTimeMS === 'number'
+    cursor.cmd &&
+    typeof cursor.cmd.maxTimeMS === 'number'
   ) {
-    opts.maxTimeMS = cursor.s.cmd.maxTimeMS;
+    opts.maxTimeMS = cursor.cmd.maxTimeMS;
   }
 
   let options = {};
@@ -53,7 +53,7 @@ function count(cursor, applySkipLimit, opts, callback) {
 
   let command;
   try {
-    command = buildCountCommand(cursor, cursor.s.cmd.query, options);
+    command = buildCountCommand(cursor, cursor.cmd.query, options);
   } catch (err) {
     return callback(err);
   }
@@ -179,9 +179,9 @@ function nextObject(cursor, callback) {
       callback,
       MongoError.create({ message: 'Cursor is closed', driver: true })
     );
-  if (cursor.s.state === Cursor.INIT && cursor.s.cmd.sort) {
+  if (cursor.s.state === Cursor.INIT && cursor.cmd.sort) {
     try {
-      cursor.s.cmd.sort = formattedOrderClause(cursor.s.cmd.sort);
+      cursor.cmd.sort = formattedOrderClause(cursor.cmd.sort);
     } catch (err) {
       return handleCallback(callback, err);
     }

--- a/lib/operations/explain.js
+++ b/lib/operations/explain.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Aspect = require('./operation').Aspect;
-const CoreCursor = require('../core').Cursor;
+const CoreCursor = require('../core/cursor').CoreCursor;
 const defineAspects = require('./operation').defineAspects;
 const OperationBase = require('./operation').OperationBase;
 
@@ -14,7 +14,7 @@ class ExplainOperation extends OperationBase {
 
   execute() {
     const cursor = this.cursor;
-    return CoreCursor.prototype.next.apply(cursor, arguments);
+    return CoreCursor.prototype._next.apply(cursor, arguments);
   }
 }
 

--- a/lib/operations/to_array.js
+++ b/lib/operations/to_array.js
@@ -3,7 +3,7 @@
 const Aspect = require('./operation').Aspect;
 const defineAspects = require('./operation').defineAspects;
 const handleCallback = require('../utils').handleCallback;
-const loadCursor = require('../dynamic_loaders').loadCursor;
+const CursorState = require('../core/cursor').CursorState;
 const OperationBase = require('./operation').OperationBase;
 const push = Array.prototype.push;
 
@@ -16,14 +16,11 @@ class ToArrayOperation extends OperationBase {
 
   execute(callback) {
     const cursor = this.cursor;
-
-    let Cursor = loadCursor();
-
     const items = [];
 
     // Reset cursor
     cursor.rewind();
-    cursor.s.state = Cursor.INIT;
+    cursor.s.state = CursorState.INIT;
 
     // Fetch all the documents
     const fetchDocs = () => {
@@ -33,6 +30,7 @@ class ToArrayOperation extends OperationBase {
             ? cursor._endSession(() => handleCallback(callback, err))
             : handleCallback(callback, err);
         }
+
         if (doc == null) {
           return cursor.close({ skipKillCursors: true }, () =>
             handleCallback(callback, null, items)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -540,7 +540,7 @@ function isPromiseLike(maybePromise) {
  * @param {object} [options] options containing collation settings
  */
 function decorateWithCollation(command, target, options) {
-  const topology = target.s && target.s.topology;
+  const topology = (target.s && target.s.topology) || target.topology;
 
   if (!topology) {
     throw new TypeError('parameter "target" is missing a topology');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const MongoError = require('./core').MongoError;
-const ReadPreference = require('./core').ReadPreference;
+const MongoError = require('./core/error').MongoError;
+const ReadPreference = require('./core/topologies/read_preference');
 const WriteConcern = require('./write_concern');
 
 var shallowClone = function(obj) {

--- a/test/core/functional/cursor_tests.js
+++ b/test/core/functional/cursor_tests.js
@@ -38,13 +38,13 @@ describe('Cursor tests', function() {
             });
 
             // Execute next
-            cursor.next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function(nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
               expect(cursor.bufferedCount()).to.equal(1);
 
               // Kill the cursor
-              cursor.next(function(killCursorErr, killCursorD) {
+              cursor._next(function(killCursorErr, killCursorD) {
                 expect(killCursorErr).to.be.null;
                 expect(killCursorD.a).to.equal(2);
                 expect(cursor.bufferedCount()).to.equal(0);
@@ -93,7 +93,7 @@ describe('Cursor tests', function() {
             });
 
             // Execute next
-            cursor.next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function(nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
               expect(cursor.bufferedCount()).to.equal(4);
@@ -102,7 +102,7 @@ describe('Cursor tests', function() {
               cursor.readBufferedDocuments(cursor.bufferedCount());
 
               // Get the next item
-              cursor.next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function(secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD).to.be.null;
 
@@ -147,16 +147,16 @@ describe('Cursor tests', function() {
             var cursor = _server.cursor(ns, { find: ns, query: {}, batchSize: 5 });
 
             // Execute next
-            cursor.next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function(nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
 
               // Get the next item
-              cursor.next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function(secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD).to.be.null;
 
-                cursor.next(function(thirdCursorErr, thirdCursorD) {
+                cursor._next(function(thirdCursorErr, thirdCursorD) {
                   expect(thirdCursorErr).to.be.ok;
                   expect(thirdCursorD).to.be.undefined;
                   // Destroy the server connection
@@ -201,16 +201,16 @@ describe('Cursor tests', function() {
             var cursor = _server.cursor(ns, { find: ns, query: {}, batchSize: 2 });
 
             // Execute next
-            cursor.next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function(nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
 
               // Get the next item
-              cursor.next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function(secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD.a).to.equal(2);
 
-                cursor.next(function(thirdCursorErr, thirdCursorD) {
+                cursor._next(function(thirdCursorErr, thirdCursorD) {
                   expect(thirdCursorErr).to.be.null;
                   expect(thirdCursorD.a).to.equal(3);
                   // Destroy the server connection
@@ -255,19 +255,19 @@ describe('Cursor tests', function() {
             var cursor = _server.cursor(ns, { find: ns, query: {}, batchSize: 2 });
 
             // Execute next
-            cursor.next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function(nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
 
               // Get the next item
-              cursor.next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function(secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD.a).to.equal(2);
 
                 // Kill cursor
                 cursor.kill(function() {
                   // Should error out
-                  cursor.next(function(thirdCursorErr, thirdCursorD) {
+                  cursor._next(function(thirdCursorErr, thirdCursorD) {
                     expect(thirdCursorErr).to.not.exist;
                     expect(thirdCursorD).to.not.exist;
 
@@ -316,18 +316,18 @@ describe('Cursor tests', function() {
             var cursor = _server.cursor(ns, { find: ns, query: {}, batchSize: 2 });
 
             // Execute next
-            cursor.next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function(nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
 
               // Get the next item
-              cursor.next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function(secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD.a).to.equal(2);
 
                 self.configuration.manager.restart(false).then(function() {
                   // Should error out
-                  cursor.next(function(thirdCursorErr, thirdCursorD) {
+                  cursor._next(function(thirdCursorErr, thirdCursorD) {
                     expect(thirdCursorErr).to.be.ok;
                     expect(thirdCursorD).to.be.undefined;
 
@@ -377,18 +377,18 @@ describe('Cursor tests', function() {
             var cursor = _server.cursor(ns, { find: ns, query: {}, batchSize: 2 });
 
             // Execute next
-            cursor.next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function(nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
 
               // Get the next item
-              cursor.next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function(secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD.a).to.equal(2);
 
                 // Should be able to continue cursor after reconnect
                 _server.once('reconnect', function() {
-                  cursor.next(function(thirdCursorErr, thirdCursorD) {
+                  cursor._next(function(thirdCursorErr, thirdCursorD) {
                     expect(thirdCursorErr).to.be.null;
                     expect(thirdCursorD.a).to.equal(3);
 
@@ -448,7 +448,7 @@ describe('Cursor tests', function() {
             var cursor = _server.cursor(ns, { find: ns, query: {}, batchSize: 2 });
 
             // Execute next
-            cursor.next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function(nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
 
@@ -520,7 +520,7 @@ describe('Cursor tests', function() {
   //           });
 
   //           // Execute next
-  //           cursor.next(function(err) {
+  //           cursor._next(function(err) {
   //             expect(err).to.exist;
 
   //             cursor = server.cursor(ns, {
@@ -529,7 +529,7 @@ describe('Cursor tests', function() {
   //               batchSize: 1
   //             });
 
-  //             cursor.next(function(err) {
+  //             cursor._next(function(err) {
   //               expect(err).to.exist;
   //               done();
   //             });

--- a/test/core/functional/mongos_mocks/proxy_read_preference_tests.js
+++ b/test/core/functional/mongos_mocks/proxy_read_preference_tests.js
@@ -74,7 +74,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
           );
 
           // Execute next
-          cursor.next(function(err, d) {
+          cursor._next(function(err, d) {
             expect(err).to.not.exist;
             expect(d).to.be.null;
             expect(command).to.have.keys(['$query', '$readPreference']);
@@ -153,7 +153,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
           );
 
           // Execute next
-          cursor.next(function(err, d) {
+          cursor._next(function(err, d) {
             expect(err).to.be.null;
             expect(d).to.be.null;
             expect(command).to.have.keys(['$query', '$readPreference']);
@@ -225,7 +225,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
           );
 
           // Execute next
-          cursor.next(function(err, d) {
+          cursor._next(function(err, d) {
             expect(err).to.be.null;
             expect(d).to.be.null;
             expect(command).to.have.keys(['$query', '$readPreference']);

--- a/test/core/functional/mongos_mocks/single_proxy_connection_tests.js
+++ b/test/core/functional/mongos_mocks/single_proxy_connection_tests.js
@@ -166,11 +166,11 @@ describe('Mongos Single Proxy Connection (mocks)', function() {
           });
 
           // Execute next
-          cursor.next(function(err, d) {
+          cursor._next(function(err, d) {
             expect(err).to.not.exist;
             expect(d).to.exist;
 
-            cursor.next(function(_err, _d) {
+            cursor._next(function(_err, _d) {
               expect(_err).to.not.exist;
               expect(_d).to.exist;
 

--- a/test/core/functional/operation_example_tests.js
+++ b/test/core/functional/operation_example_tests.js
@@ -260,7 +260,7 @@ describe('Server operation example tests', function() {
             });
 
             // Get the first document
-            cursor.next(function(cursorErr, doc) {
+            cursor._next(function(cursorErr, doc) {
               expect(cursorErr).to.be.null;
               expect(doc.a).to.equal(1);
 
@@ -603,7 +603,7 @@ describe('Replset operation example tests', function() {
             });
 
             // Get the first document
-            cursor.next(function(cursorErr, doc) {
+            cursor._next(function(cursorErr, doc) {
               expect(cursorErr).to.be.null;
               expect(doc.a).to.equal(1);
 
@@ -905,7 +905,7 @@ describe.skip('Mongos operation example tests', function() {
             });
 
             // Get the first document
-            cursor.next(function(cursorErr, doc) {
+            cursor._next(function(cursorErr, doc) {
               expect(cursorErr).to.be.null;
               expect(doc.a).to.equal(1);
 

--- a/test/core/functional/operations_tests.js
+++ b/test/core/functional/operations_tests.js
@@ -148,12 +148,12 @@ describe('Operation tests', function() {
               );
 
               // Execute next
-              cursor.next(function(cursorErr, cursorD) {
+              cursor._next(function(cursorErr, cursorD) {
                 expect(cursorErr).to.be.null;
                 expect(cursorD.a).to.equal(1);
 
                 // Execute next
-                cursor.next(function(secondCursorErr, secondCursorD) {
+                cursor._next(function(secondCursorErr, secondCursorD) {
                   expect(secondCursorErr).to.be.null;
                   expect(secondCursorD).to.be.null;
                   // Destroy the server connection
@@ -213,12 +213,12 @@ describe('Operation tests', function() {
               );
 
               // Execute next
-              cursor.next(function(cursorErr, cursorD) {
+              cursor._next(function(cursorErr, cursorD) {
                 expect(cursorErr).to.be.null;
                 expect(cursorD.a).to.equal(2);
 
                 // Execute next
-                cursor.next(function(secondCursorErr, secondCursorD) {
+                cursor._next(function(secondCursorErr, secondCursorD) {
                   expect(secondCursorErr).to.be.null;
                   expect(secondCursorD).to.be.null;
                   // Destroy the server connection
@@ -276,7 +276,7 @@ describe('Operation tests', function() {
               );
 
               // Execute next
-              cursor.next(function(cursorErr, cursorD) {
+              cursor._next(function(cursorErr, cursorD) {
                 expect(cursorErr).to.be.null;
                 expect(cursorD.a).to.equal(1);
                 expect(cursorD.result[0].c).to.equal(1);
@@ -332,16 +332,16 @@ describe('Operation tests', function() {
             });
 
             // Execute next
-            cursor.next(function(cursorErr, cursorD) {
+            cursor._next(function(cursorErr, cursorD) {
               expect(cursorErr).to.be.null;
               expect(cursorD.a).to.equal(1);
 
               // Execute next
-              cursor.next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function(secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD.a).to.equal(2);
 
-                cursor.next(function(thirdCursorErr, thirdCursorD) {
+                cursor._next(function(thirdCursorErr, thirdCursorD) {
                   expect(thirdCursorErr).to.be.null;
                   expect(thirdCursorD.a).to.equal(3);
 
@@ -404,16 +404,16 @@ describe('Operation tests', function() {
                 );
 
                 // Execute next
-                cursor.next(function(cursorErr, cursorD) {
+                cursor._next(function(cursorErr, cursorD) {
                   expect(cursorErr).to.be.null;
                   expect(cursorD.a).to.equal(1);
 
                   // Execute next
-                  cursor.next(function(secondCursorErr, secondCursorD) {
+                  cursor._next(function(secondCursorErr, secondCursorD) {
                     expect(secondCursorErr).to.be.null;
                     expect(secondCursorD.a).to.equal(2);
 
-                    cursor.next(function(thirdCursorErr, thirdCursorD) {
+                    cursor._next(function(thirdCursorErr, thirdCursorD) {
                       expect(thirdCursorErr).to.be.null;
                       expect(thirdCursorD.a).to.equal(3);
 
@@ -470,13 +470,13 @@ describe('Operation tests', function() {
             });
 
             // Execute next
-            cursor.next(function(cursorErr, cursorD) {
+            cursor._next(function(cursorErr, cursorD) {
               expect(cursorErr).to.be.null;
               expect(cursorD.a).to.equal(1);
 
               // Kill the cursor
               cursor.kill(function() {
-                cursor.next(function(secondCursorErr, secondCursorD) {
+                cursor._next(function(secondCursorErr, secondCursorD) {
                   expect(secondCursorErr).to.not.exist;
                   expect(secondCursorD).to.not.exist;
                   // Destroy the server connection
@@ -529,13 +529,13 @@ describe('Operation tests', function() {
             });
 
             // Execute next
-            cursor.next(function(cursorErr, cursorD) {
+            cursor._next(function(cursorErr, cursorD) {
               expect(cursorErr).to.be.null;
               expect(cursorD.a).to.equal(1);
 
               // Kill the cursor
               cursor.kill(function() {
-                cursor.next(function(secondCursorErr, secondCursorD) {
+                cursor._next(function(secondCursorErr, secondCursorD) {
                   expect(secondCursorErr).to.not.exist;
                   expect(secondCursorD).to.not.exist;
                   // Destroy the server connection

--- a/test/core/functional/replset_tests.js
+++ b/test/core/functional/replset_tests.js
@@ -568,7 +568,7 @@ describe.skip('A replica set', function() {
             );
             cursor.setCursorLimit(1);
             // Execute next
-            cursor.next(queryCountDecrement);
+            cursor._next(queryCountDecrement);
           }
         });
 

--- a/test/core/functional/rs_mocks/step_down_tests.js
+++ b/test/core/functional/rs_mocks/step_down_tests.js
@@ -206,7 +206,7 @@
 //       });
 
 //       var nextObject = function() {
-//         cursor.next(function(err, doc) {
+//         cursor._next(function(err, doc) {
 //           if(err) {
 //             console.dir(err)
 //             process.exit(0)
@@ -222,7 +222,7 @@
 //       // var intervalId = setInterval(function() {
 //       //   console.log("------------------------------------------ next start");
 
-//       //   cursor.next(function(err, doc) {
+//       //   cursor._next(function(err, doc) {
 //       //     console.log("------------------------------------------ next end");
 //       //     console.dir(doc);
 //       //   });
@@ -237,13 +237,13 @@
 //       }, 1000);
 
 //       // // Execute next
-//       // cursor.next(function(err, d) {
+//       // cursor._next(function(err, d) {
 //       //   test.equal(null, err);
 //       //   test.equal(1, d.a);
 //       //   test.equal(1, cursor.bufferedCount());
 
 //       //   // Kill the cursor
-//       //   cursor.next(function(err, d) {
+//       //   cursor._next(function(err, d) {
 //       //     test.equal(null, err);
 //       //     test.equal(2, d.a);
 //       //     test.equal(0, cursor.bufferedCount());

--- a/test/core/functional/server_tests.js
+++ b/test/core/functional/server_tests.js
@@ -349,7 +349,7 @@ describe('Server tests', function() {
               });
 
               // Execute next
-              cursor.next(function() {
+              cursor._next(function() {
                 setTimeout(execute, 500);
               });
             });
@@ -366,7 +366,7 @@ describe('Server tests', function() {
               });
 
               // Execute next
-              cursor.next(function(cursorErr, d) {
+              cursor._next(function(cursorErr, d) {
                 expect(err).to.be.null;
                 expect(d).to.exist;
                 server.destroy();
@@ -752,7 +752,7 @@ describe('Server tests', function() {
           );
 
           function callNext(_cursor) {
-            _cursor.next(function(cursorErr, doc) {
+            _cursor._next(function(cursorErr, doc) {
               expect(cursorErr).to.not.exist;
               if (!doc) {
                 return done();

--- a/test/core/functional/tailable_cursor_tests.js
+++ b/test/core/functional/tailable_cursor_tests.js
@@ -47,13 +47,13 @@ describe('Tailable cursor tests', function() {
                 });
 
                 // Execute next
-                cursor.next(function(cursorErr, cursorD) {
+                cursor._next(function(cursorErr, cursorD) {
                   expect(cursorErr).to.be.null;
                   expect(cursorD).to.exist;
 
                   var s = new Date();
 
-                  cursor.next(function() {
+                  cursor._next(function() {
                     var e = new Date();
                     expect(e.getTime() - s.getTime()).to.be.at.least(300);
 

--- a/test/core/functional/undefined_tests.js
+++ b/test/core/functional/undefined_tests.js
@@ -42,7 +42,7 @@ describe('A server', function() {
               });
 
               // Execute next
-              cursor.next(function(nextErr, d) {
+              cursor._next(function(nextErr, d) {
                 expect(nextErr).to.be.null;
                 expect(d.b).to.be.undefined;
 
@@ -102,7 +102,7 @@ describe('A server', function() {
               });
 
               // Execute next
-              cursor.next(function(nextErr, d) {
+              cursor._next(function(nextErr, d) {
                 expect(nextErr).to.be.null;
                 expect(d.b).to.be.undefined;
 

--- a/test/core/unit/mongos/sessions_tests.js
+++ b/test/core/unit/mongos/sessions_tests.js
@@ -223,7 +223,7 @@ describe('Sessions (Mongos)', function() {
             readPreference
           });
 
-          cursor.next(() => {});
+          cursor._next(() => {});
         });
 
         mongos.connect();

--- a/test/core/unit/response_test.js
+++ b/test/core/unit/response_test.js
@@ -51,7 +51,7 @@ describe('Response', function() {
         const cursor = client.cursor('test.test', { find: 'test' });
 
         // Execute next
-        cursor.next(function(err) {
+        cursor._next(function(err) {
           expect(err).to.exist;
           expect(err).to.be.instanceof(MongoError);
           expect(err.message).to.equal(errdoc.errmsg);

--- a/test/core/unit/single/sessions_tests.js
+++ b/test/core/unit/single/sessions_tests.js
@@ -406,11 +406,11 @@ describe('Sessions (Single)', function() {
         );
 
         // Execute next
-        cursor.next(function(err) {
+        cursor._next(function(err) {
           expect(err).to.not.exist;
           expect(commands[0].lsid).to.eql(session.id);
 
-          cursor.next(function(err) {
+          cursor._next(function(err) {
             expect(err).to.not.exist;
             expect(commands[1].lsid).to.eql(session.id);
 
@@ -482,7 +482,7 @@ describe('Sessions (Single)', function() {
         );
 
         // Execute next
-        cursor.next(function(err) {
+        cursor._next(function(err) {
           expect(err).to.not.exist;
 
           cursor.kill(err => {

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4565,7 +4565,7 @@ describe('Cursor', function() {
         .then(() => (collection = db.collection('test_count_readPreference')))
         .then(() => collection.find())
         .then(_cursor => (cursor = _cursor))
-        .then(() => (spy = sinon.spy(cursor.s.topology, 'command')))
+        .then(() => (spy = sinon.spy(cursor.topology, 'command')))
         .then(() => cursor.count())
         .then(() =>
           expect(spy.firstCall.args[2])

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -3399,8 +3399,8 @@ describe('Cursor', function() {
 
         db.collection('myCollection').find({}, function(error, cursor) {
           test.equal(null, err);
-          test.equal('myCollection', cursor.s.namespace.collection);
-          test.equal('integration_tests', cursor.s.namespace.db);
+          test.equal('myCollection', cursor.namespace.collection);
+          test.equal('integration_tests', cursor.namespace.db);
 
           client.close();
           done();

--- a/test/functional/find_tests.js
+++ b/test/functional/find_tests.js
@@ -546,6 +546,7 @@ describe('Find', function() {
 
                 // Let's test usage of the $where statement
                 collection.find({ $where: new Code('this.a > 2') }).count(function(err, count) {
+                  if (err) console.dir({ err });
                   test.equal(null, err);
                   test.equal(1, count);
 
@@ -1211,13 +1212,13 @@ describe('Find', function() {
         var db = client.db(configuration.db);
         db.createCollection('timeoutFalse', function(err, collection) {
           collection.find({}, { timeout: false }, function(err, cursor) {
-            test.equal(false, cursor.s.cmd.noCursorTimeout);
+            test.equal(false, cursor.cmd.noCursorTimeout);
 
             collection.find({}, { timeout: true }, function(err, cursor) {
-              test.equal(true, cursor.s.cmd.noCursorTimeout);
+              test.equal(true, cursor.cmd.noCursorTimeout);
 
               collection.find({}, {}, function(err, cursor) {
-                test.ok(!cursor.s.cmd.noCursorTimeout);
+                test.ok(!cursor.cmd.noCursorTimeout);
 
                 client.close();
                 done();
@@ -3105,7 +3106,7 @@ describe('Find', function() {
           test.equal(null, err);
           // Ensure correct insertion testing via the cursor and the count function
           var cursor = collection.find({ c: undefined });
-          test.equal(true, cursor.s.options.ignoreUndefined);
+          test.equal(true, cursor.options.ignoreUndefined);
 
           cursor.toArray(function(err, documents) {
             test.equal(2, documents.length);

--- a/test/functional/find_tests.js
+++ b/test/functional/find_tests.js
@@ -546,7 +546,6 @@ describe('Find', function() {
 
                 // Let's test usage of the $where statement
                 collection.find({ $where: new Code('this.a > 2') }).count(function(err, count) {
-                  if (err) console.dir({ err });
                   test.equal(null, err);
                   test.equal(1, count);
 

--- a/test/functional/readpreference_tests.js
+++ b/test/functional/readpreference_tests.js
@@ -541,7 +541,7 @@ describe('ReadPreference', function() {
         var db = client.db(configuration.db);
         test.equal(null, err);
         var cursor = db.collection('test', { readPreference: SecondaryPreferred }).listIndexes();
-        test.equal(cursor.s.options.readPreference.mode, 'secondaryPreferred');
+        test.equal(cursor.options.readPreference.mode, 'secondaryPreferred');
         client.close();
         done();
       });


### PR DESCRIPTION
## Description
Since we merged core into native, there is no longer great need to maintain a fully functional "core" cursor type, it has become a private implementation detail. This changeset renames that class to `CoreCursor`, converts it to an ES6 class, and then builds the three public cursors on top of it. 

This is a huge change, but it will greatly reduce the complexity of implementing retryability for the find operation. The cursors are very intertwined, and switching them all to use an operation, in particular for the find operation, has proven exceedingly difficult.

**What changed?**
 - All cursor classes are now ES6 classes
 - The `Cursor` from "core" has been renamed `CoreCursor`
 - a `CursorState` has been exported from the `CoreCursor` module
   so that all cursors may share a common state definition
 - `CoreCursor` extends `Readable` stream. Each of its subclasses
   inherited this, so this is where it naturally fits in the
   hierarchy. This wasn't possible before because the cursor
   exported by `mongodb-core` did not want to concern itself with
   higher concepts like streams. We are no longer shackled by this
   idea.
 - `CoreCursor` only exposes a public `_next` method because of
   the way the other cursors have traditionally subclassed it.
 - We still have `cursorState` and `s`, but they are only in _two_
   locations now (`CoreCursor` has a `cursorState`, and `Cursor`
   has a `s). Eventually I think even these should be merged, but
   it did not seem important to distinguish this now.
 - All cursors had a _lot_ of duplicated properties. As much as
   possible these have been deduplicated, and include the following
   stored properties: bson, options, topology, topologyOptions,
   streamOptions, namespace, ns, cmd, promiseLibrary
 - generally sessions are stored and referred to by the core
   cursor's `cursorState`. We could move all functionality there
   eventually.

**Are there any files to ignore?**
Unfortunately, no. 