### PR TITLE
NODE-1744: retryable change streams

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -3,11 +3,10 @@
 const EventEmitter = require('events');
 const isResumableError = require('./error').isResumableError;
 const MongoError = require('./core').MongoError;
-const ReadConcern = require('./read_concern');
-const MongoDBNamespace = require('./utils').MongoDBNamespace;
 const Cursor = require('./cursor');
 const relayEvents = require('./core/utils').relayEvents;
 const maxWireVersion = require('./core/utils').maxWireVersion;
+const AggregateOperation = require('./operations/aggregate');
 
 const CHANGE_STREAM_OPTIONS = ['resumeAfter', 'startAfter', 'startAtOperationTime', 'fullDocument'];
 const CURSOR_OPTIONS = ['batchSize', 'maxAwaitTimeMS', 'collation', 'readPreference'].concat(
@@ -49,7 +48,7 @@ const CHANGE_DOMAIN_TYPES = {
  * Creates a new Change Stream instance. Normally created using {@link Collection#watch|Collection.watch()}.
  * @class ChangeStream
  * @since 3.0.0
- * @param {(MongoClient|Db|Collection)} changeDomain The domain against which to create the change stream
+ * @param {(MongoClient|Db|Collection)} parent The parent object that created this change stream
  * @param {Array} pipeline An array of {@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/|aggregation pipeline stages} through which to pass change stream documents
  * @param {ChangeStreamOptions} [options] Optional settings
  * @fires ChangeStream#close
@@ -60,7 +59,7 @@ const CHANGE_DOMAIN_TYPES = {
  * @return {ChangeStream} a ChangeStream instance.
  */
 class ChangeStream extends EventEmitter {
-  constructor(changeDomain, pipeline, options) {
+  constructor(parent, pipeline, options) {
     super();
     const Collection = require('./collection');
     const Db = require('./db');
@@ -69,29 +68,26 @@ class ChangeStream extends EventEmitter {
     this.pipeline = pipeline || [];
     this.options = options || {};
 
-    this.namespace =
-      changeDomain instanceof MongoClient
-        ? new MongoDBNamespace('admin')
-        : changeDomain.s.namespace;
-
-    if (changeDomain instanceof Collection) {
+    this.parent = parent;
+    this.namespace = parent.s.namespace;
+    if (parent instanceof Collection) {
       this.type = CHANGE_DOMAIN_TYPES.COLLECTION;
-      this.topology = changeDomain.s.db.serverConfig;
-    } else if (changeDomain instanceof Db) {
+      this.topology = parent.s.db.serverConfig;
+    } else if (parent instanceof Db) {
       this.type = CHANGE_DOMAIN_TYPES.DATABASE;
-      this.topology = changeDomain.serverConfig;
-    } else if (changeDomain instanceof MongoClient) {
+      this.topology = parent.serverConfig;
+    } else if (parent instanceof MongoClient) {
       this.type = CHANGE_DOMAIN_TYPES.CLUSTER;
-      this.topology = changeDomain.topology;
+      this.topology = parent.topology;
     } else {
       throw new TypeError(
-        'changeDomain provided to ChangeStream constructor is not an instance of Collection, Db, or MongoClient'
+        'parent provided to ChangeStream constructor is not an instance of Collection, Db, or MongoClient'
       );
     }
 
-    this.promiseLibrary = changeDomain.s.promiseLibrary;
-    if (!this.options.readPreference && changeDomain.s.readPreference) {
-      this.options.readPreference = changeDomain.s.readPreference;
+    this.promiseLibrary = parent.s.promiseLibrary;
+    if (!this.options.readPreference && parent.s.readPreference) {
+      this.options.readPreference = parent.s.readPreference;
     }
 
     // Create contained Change Stream cursor
@@ -259,9 +255,8 @@ class ChangeStream extends EventEmitter {
 }
 
 class ChangeStreamCursor extends Cursor {
-  constructor(topology, ns, cmd, options) {
-    // TODO: spread will help a lot here
-    super(topology, ns, cmd, options);
+  constructor(topology, operation, options) {
+    super(topology, operation, options);
 
     options = options || {};
     this._resumeToken = null;
@@ -363,8 +358,22 @@ class ChangeStreamCursor extends Cursor {
  */
 
 // Create a new change stream cursor based on self's configuration
-var createChangeStreamCursor = function(self, options) {
-  const changeStreamCursor = buildChangeStreamAggregationCommand(self, options);
+function createChangeStreamCursor(self, options) {
+  const changeStreamStageOptions = { fullDocument: options.fullDocument || 'default' };
+  applyKnownOptions(changeStreamStageOptions, options, CHANGE_STREAM_OPTIONS);
+  if (self.type === CHANGE_DOMAIN_TYPES.CLUSTER) {
+    changeStreamStageOptions.allChangesForCluster = true;
+  }
+
+  const pipeline = [{ $changeStream: changeStreamStageOptions }].concat(self.pipeline);
+  const cursorOptions = applyKnownOptions({}, options, CURSOR_OPTIONS);
+  const changeStreamOptions = Object.assign({ batchSize: 1 }, options);
+  const changeStreamCursor = new ChangeStreamCursor(
+    self.topology,
+    new AggregateOperation(self.parent, pipeline, changeStreamOptions),
+    cursorOptions
+  );
+
   relayEvents(changeStreamCursor, self, ['resumeTokenChanged', 'end', 'close']);
 
   /**
@@ -420,7 +429,7 @@ var createChangeStreamCursor = function(self, options) {
   }
 
   return changeStreamCursor;
-};
+}
 
 function applyKnownOptions(target, source, optionNames) {
   optionNames.forEach(name => {
@@ -428,42 +437,9 @@ function applyKnownOptions(target, source, optionNames) {
       target[name] = source[name];
     }
   });
+
+  return target;
 }
-
-var buildChangeStreamAggregationCommand = function(self, options) {
-  options = options || {};
-  const topology = self.topology;
-  const namespace = self.namespace;
-  const pipeline = self.pipeline;
-
-  const changeStreamStageOptions = { fullDocument: options.fullDocument || 'default' };
-  applyKnownOptions(changeStreamStageOptions, options, CHANGE_STREAM_OPTIONS);
-
-  // Map cursor options
-  const cursorOptions = { cursorFactory: ChangeStreamCursor };
-  applyKnownOptions(cursorOptions, options, CURSOR_OPTIONS);
-
-  if (self.type === CHANGE_DOMAIN_TYPES.CLUSTER) {
-    changeStreamStageOptions.allChangesForCluster = true;
-  }
-
-  var changeStreamPipeline = [{ $changeStream: changeStreamStageOptions }];
-
-  changeStreamPipeline = changeStreamPipeline.concat(pipeline);
-
-  var command = {
-    aggregate: self.type === CHANGE_DOMAIN_TYPES.COLLECTION ? namespace.collection : 1,
-    pipeline: changeStreamPipeline,
-    readConcern: new ReadConcern(ReadConcern.MAJORITY),
-    cursor: {
-      batchSize: options.batchSize || 1
-    }
-  };
-
-  // Create and return the cursor
-  // TODO: switch to passing namespace object later
-  return topology.cursor(namespace.toString(), command, cursorOptions);
-};
 
 // This method performs a basic server selection loop, satisfying the requirements of
 // ChangeStream resumability until the new SDAM layer can be used.

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -961,6 +961,7 @@ class Cursor extends CoreCursor {
     //       subclass `CommandOperationV2`. To be removed asap.
     if (this.operation && this.operation.cmd == null) {
       this.operation.options.explain = true;
+      this.operation.fullResponse = false;
       return executeOperation(this.topology, this.operation, callback);
     }
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -159,6 +159,10 @@ class Cursor extends CoreCursor {
   }
 
   get readPreference() {
+    if (this.operation) {
+      return this.operation.readPreference;
+    }
+
     return this.options.readPreference;
   }
 

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -8,6 +8,8 @@ const inherits = require('util').inherits;
 const MongoError = require('./core').MongoError;
 const deprecate = require('util').deprecate;
 const WriteConcern = require('./write_concern');
+const MongoDBNamespace = require('./utils').MongoDBNamespace;
+const ReadPreference = require('./core/topologies/read_preference');
 
 // Operations
 const ConnectOperation = require('./operations/connect');
@@ -150,7 +152,8 @@ function MongoClient(url, options) {
     promiseLibrary: null,
     dbCache: new Map(),
     sessions: [],
-    writeConcern: WriteConcern.fromOptions(options)
+    writeConcern: WriteConcern.fromOptions(options),
+    namespace: new MongoDBNamespace('admin')
   };
 
   // Get the promiseLibrary
@@ -169,6 +172,13 @@ Object.defineProperty(MongoClient.prototype, 'writeConcern', {
   enumerable: true,
   get: function() {
     return this.s.writeConcern;
+  }
+});
+
+Object.defineProperty(MongoClient.prototype, 'readPreference', {
+  enumerable: true,
+  get: function() {
+    return ReadPreference.primary;
   }
 });
 

--- a/lib/operations/aggregate.js
+++ b/lib/operations/aggregate.js
@@ -12,9 +12,7 @@ const MIN_WIRE_VERSION_$OUT_READ_CONCERN_SUPPORT = 8;
 
 class AggregateOperation extends CommandOperationV2 {
   constructor(parent, pipeline, options) {
-    // ensure we receive an unchanged raw response from the server (for cursor logic)
-    options.full = true;
-    super(parent, options);
+    super(parent, options, { fullResponse: true });
 
     this.target =
       parent.s.namespace && parent.s.namespace.collection

--- a/lib/operations/command_v2.js
+++ b/lib/operations/command_v2.js
@@ -12,7 +12,7 @@ const MongoError = require('../error').MongoError;
 const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
 
 class CommandOperationV2 extends OperationBase {
-  constructor(parent, options) {
+  constructor(parent, options, operationOptions) {
     super(options);
 
     this.ns = parent.s.namespace.withCollection('$cmd');
@@ -20,6 +20,10 @@ class CommandOperationV2 extends OperationBase {
     this.readConcern = resolveReadConcern(parent, this.options);
     this.writeConcern = resolveWriteConcern(parent, this.options);
     this.explain = false;
+
+    if (operationOptions && typeof operationOptions.fullResponse === 'boolean') {
+      this.fullResponse = true;
+    }
 
     // TODO: A lot of our code depends on having the read preference in the options. This should
     //       go away, but also requires massive test rewrites.
@@ -78,14 +82,13 @@ class CommandOperationV2 extends OperationBase {
       this.logger.debug(`executing command ${JSON.stringify(cmd)} against ${this.ns}`);
     }
 
-    let fullResponse = this.options.full;
     server.command(this.ns.toString(), cmd, this.options, (err, result) => {
       if (err) {
         callback(err, null);
         return;
       }
 
-      if (fullResponse) {
+      if (this.fullResponse) {
         callback(null, result);
         return;
       }

--- a/lib/operations/list_collections.js
+++ b/lib/operations/list_collections.js
@@ -26,8 +26,7 @@ function listCollectionsTransforms(databaseName) {
 
 class ListCollectionsOperation extends CommandOperationV2 {
   constructor(db, filter, options) {
-    super(db, options);
-    this.options.full = true;
+    super(db, options, { fullResponse: true });
 
     this.db = db;
     this.filter = filter;

--- a/lib/operations/list_indexes.js
+++ b/lib/operations/list_indexes.js
@@ -9,8 +9,7 @@ const LIST_INDEXES_WIRE_VERSION = 3;
 
 class ListIndexesOperation extends CommandOperationV2 {
   constructor(collection, options) {
-    super(collection, options);
-    this.options.full = true;
+    super(collection, options, { fullResponse: true });
 
     this.collectionNamespace = collection.s.namespace;
   }


### PR DESCRIPTION
## Description
Implements change streams through an `AggregateOperation` providing retryability for the `ChangeStreamCursor` through `executeOperation`. We cannot presently implement the retryable reads tests because we don't provide a `tryNext`, the tests depend on `next` returning in a reasonable about of time. 
