### PR TITLE
chore(ci): update evergreen config to test Ubuntu 18.04 on mongodb >= 4.2

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -709,41 +709,25 @@ buildvariants:
     run_on: ubuntu1604-arm64-small
     expansions:
       NODE_LTS_NAME: dubnium
-    tasks: &ref_5
-      - test-latest-single
-      - test-latest-replicaset
-      - test-latest-sharded
-      - test-4.2-single
-      - test-4.2-replicaset
-      - test-4.2-sharded
-      - test-4.0-single
-      - test-4.0-replicaset
-      - test-4.0-sharded
-      - test-3.6-single
-      - test-3.6-replicaset
-      - test-3.6-sharded
-      - test-3.4-single
-      - test-3.4-replicaset
-      - test-3.4-sharded
-      - test-atlas-connectivity
+    tasks: *ref_2
   - name: ubuntu1604-arm64-small-carbon
     display_name: Ubuntu 16.04 (ARM64) Node Carbon
     run_on: ubuntu1604-arm64-small
     expansions:
       NODE_LTS_NAME: carbon
-    tasks: *ref_5
+    tasks: *ref_2
   - name: ubuntu1604-arm64-small-boron
     display_name: Ubuntu 16.04 (ARM64) Node Boron
     run_on: ubuntu1604-arm64-small
     expansions:
       NODE_LTS_NAME: boron
-    tasks: *ref_5
+    tasks: *ref_2
   - name: ubuntu1604-arm64-small-argon
     display_name: Ubuntu 16.04 (ARM64) Node Argon
     run_on: ubuntu1604-arm64-small
     expansions:
       NODE_LTS_NAME: argon
-    tasks: *ref_5
+    tasks: *ref_2
   - name: ubuntu1604-power8-test-dubnium
     display_name: Ubuntu 16.04 (POWER8) Node Dubnium
     run_on: ubuntu1604-power8-test
@@ -768,3 +752,34 @@ buildvariants:
     expansions:
       NODE_LTS_NAME: argon
     tasks: *ref_2
+  - name: ubuntu1804-arm64-test-dubnium
+    display_name: Ubuntu 18.04 (ARM64) Node Dubnium
+    run_on: ubuntu1804-arm64-test
+    expansions:
+      NODE_LTS_NAME: dubnium
+    tasks: &ref_5
+      - test-latest-single
+      - test-latest-replicaset
+      - test-latest-sharded
+      - test-4.2-single
+      - test-4.2-replicaset
+      - test-4.2-sharded
+      - test-atlas-connectivity
+  - name: ubuntu1804-arm64-test-carbon
+    display_name: Ubuntu 18.04 (ARM64) Node Carbon
+    run_on: ubuntu1804-arm64-test
+    expansions:
+      NODE_LTS_NAME: carbon
+    tasks: *ref_5
+  - name: ubuntu1804-arm64-test-boron
+    display_name: Ubuntu 18.04 (ARM64) Node Boron
+    run_on: ubuntu1804-arm64-test
+    expansions:
+      NODE_LTS_NAME: boron
+    tasks: *ref_5
+  - name: ubuntu1804-arm64-test-argon
+    display_name: Ubuntu 18.04 (ARM64) Node Argon
+    run_on: ubuntu1804-arm64-test
+    expansions:
+      NODE_LTS_NAME: argon
+    tasks: *ref_5

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -87,13 +87,19 @@ const OPERATING_SYSTEMS = [
     name: 'ubuntu1604-arm64-small',
     display_name: 'Ubuntu 16.04 (ARM64)',
     run_on: 'ubuntu1604-arm64-small',
-    mongoVersion: '>=3.4'
+    mongoVersion: '>=3.4 <4.2'
   },
   {
     name: 'ubuntu1604-power8-test',
     display_name: 'Ubuntu 16.04 (POWER8)',
     run_on: 'ubuntu1604-power8-test',
     mongoVersion: '>=3.4 <4.2'
+  },
+  {
+    name: 'ubuntu1804-arm64-test',
+    display_name: 'Ubuntu 18.04 (ARM64)',
+    run_on: 'ubuntu1804-arm64-test',
+    mongoVersion: '>=4.2'
   }
 
   // reenable when these are actually running 7.2, or we release a 7.4 rpm


### PR DESCRIPTION
Fixes NODE-2095

## Description
This updates Evergreen to test MongoDB >= 4.2 on Ubuntu 18.04 and to only test MongoDB < 4.2 on Ubuntu 16.04 ARM.

**What changed?**
I made changes to `generate_evergreen_tasks.js` and ran the script to generate `config.yml`. This is my first time updating the Evergreen config so I'd appreciate a double-check that the `config.yml` is correct.

**Are there any files to ignore?**
No.