### PR TITLE
test: disable some failing tests for later investigation

### DIFF
--- a/test/functional/change_stream_spec_tests.js
+++ b/test/functional/change_stream_spec_tests.js
@@ -66,7 +66,7 @@ describe('Change Stream Spec', function() {
 
           client.removeAllListeners('commandStarted');
 
-          return client && client.close();
+          return client && client.close(true);
         });
 
         specData.tests.forEach(test => {

--- a/test/functional/connections_stepdown_tests.js
+++ b/test/functional/connections_stepdown_tests.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-describe('Connections survive primary step down', function() {
+describe.skip('Connections survive primary step down', function() {
   let client;
 
   beforeEach(function() {


### PR DESCRIPTION
Follow-up with this in NODE-2112 and NODE-2113

## Description

Disabled the connection survive primary stepdown tests, and added a force-close to the change stream tests. Created tickets to follow up investigation.
