### PR TITLE
Aggregation cursor doc fix

### DIFF
--- a/lib/aggregation_cursor.js
+++ b/lib/aggregation_cursor.js
@@ -349,6 +349,7 @@ AggregationCursor.prototype.get = AggregationCursor.prototype.toArray;
  * at any given time if batch size is specified. Otherwise, the caller is responsible
  * for making sure that the entire result can fit the memory.
  * @method AggregationCursor.prototype.each
+ * @deprecated
  * @param {AggregationCursor~resultCallback} callback The result callback.
  * @throws {MongoError}
  * @return {null}

--- a/lib/aggregation_cursor.js
+++ b/lib/aggregation_cursor.js
@@ -399,7 +399,7 @@ AggregationCursor.prototype.get = AggregationCursor.prototype.toArray;
  * @param {MongoError} error An error instance representing the error during the execution.
  */
 
-/*
+/**
  * Iterates over all the documents for this cursor using the iterator, callback pattern.
  * @method AggregationCursor.prototype.forEach
  * @param {AggregationCursor~iteratorCallback} iterator The iteration callback.


### PR DESCRIPTION
## Description

Update AggregationCursor documentation to show `.each` usage as deprecated and promote usage of proper `.forEach` method on the aggregation cursor

**What changed?**

Documentation definition in **lib/aggregation_cursor.js** changed

**Are there any files to ignore?**

No