### PR TITLE
test(connections): fix connectionSurvivePrimaryStepdown tests

### DIFF
--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -162,9 +162,12 @@ const SDAM_UNRECOVERABLE_ERROR_CODES = new Set([
   13435, // NotMasterNoSlaveOk
   13436 // NotMasterOrSecondary
 ]);
+
 /**
- * Determines whether an error is a "node is recovering" error or a "not master" error for SDAM retryability.
- * See https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#not-master-and-node-is-recovering
+ * Determines whether an error is a "node is recovering" error or
+ * a "not master" error for SDAM retryability.
+ *
+ * @see https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#not-master-and-node-is-recovering
  * @param {MongoError|Error} error
  */
 function isSDAMUnrecoverableError(error) {
@@ -175,20 +178,6 @@ function isSDAMUnrecoverableError(error) {
   );
 }
 
-const SDAM_NODE_IS_SHUTTING_DOWN_ERRORS = new Set([
-  91, // ShutdownInProgress
-  11600 // InterruptedAtShutdown
-]);
-
-function isErrorWhereSDAMShouldClearPool(server, error) {
-  return (
-    error instanceof MongoParseError ||
-    maxWireVersion(server) < 8 ||
-    (isSDAMUnrecoverableError(error) && SDAM_NODE_IS_SHUTTING_DOWN_ERRORS.has(error.code))
-  );
-  Î;
-}
-
 module.exports = {
   MongoError,
   MongoNetworkError,
@@ -197,6 +186,5 @@ module.exports = {
   MongoWriteConcernError,
   mongoErrorContextSymbol,
   isRetryableError,
-  isSDAMUnrecoverableError,
-  isErrorWhereSDAMShouldClearPool
+  isSDAMUnrecoverableError
 };

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -205,11 +205,19 @@ function isNodeShuttingDownError(err) {
  * @param {Server} server
  */
 function isSDAMUnrecoverableError(error, server) {
-  return (
-    error instanceof MongoParseError ||
-    ((isRecoveringError(error) || isNotMasterError(error)) &&
-      (maxWireVersion(server) >= 8 && isNodeShuttingDownError(error)))
-  );
+  if (error instanceof MongoParseError) {
+    return true;
+  }
+
+  if (isRecoveringError(error) || isNotMasterError(error)) {
+    if (maxWireVersion(server) >= 8 && !isNodeShuttingDownError(error)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
 }
 
 module.exports = {

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -153,28 +153,62 @@ function isRetryableError(error) {
   );
 }
 
-const SDAM_UNRECOVERABLE_ERROR_CODES = new Set([
+const SDAM_RECOVERING_CODES = new Set([
   91, // ShutdownInProgress
   189, // PrimarySteppedDown
-  10107, // NotMaster
   11600, // InterruptedAtShutdown
   11602, // InterruptedDueToReplStateChange
-  13435, // NotMasterNoSlaveOk
   13436 // NotMasterOrSecondary
 ]);
 
+const SDAM_NOTMASTER_CODES = new Set([
+  10107, // NotMaster
+  13435 // NotMasterNoSlaveOk
+]);
+
+const SDAM_NODE_SHUTTING_DOWN_ERROR_CODES = new Set([
+  11600, // InterruptedAtShutdown
+  91 // ShutdownInProgress
+]);
+
+function isRecoveringError(err) {
+  if (err.code && SDAM_RECOVERING_CODES.has(err.code)) {
+    return true;
+  }
+
+  return err.message.match(/not master or secondary/) || err.message.match(/node is recovering/);
+}
+
+function isNotMasterError(err) {
+  if (err.code && SDAM_NOTMASTER_CODES.has(err.code)) {
+    return true;
+  }
+
+  if (isRecoveringError(err)) {
+    return false;
+  }
+
+  return err.message.match(/not master/);
+}
+
+function isNodeShuttingDownError(err) {
+  return SDAM_NODE_SHUTTING_DOWN_ERROR_CODES.has(err.code);
+}
+
 /**
- * Determines whether an error is a "node is recovering" error or
- * a "not master" error for SDAM retryability.
+ * Determines whether SDAM can recover from a given error. If it cannot
+ * then the pool will be cleared, and server state will completely reset
+ * locally.
  *
  * @see https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#not-master-and-node-is-recovering
  * @param {MongoError|Error} error
+ * @param {Server} server
  */
-function isSDAMUnrecoverableError(error) {
+function isSDAMUnrecoverableError(error, server) {
   return (
-    SDAM_UNRECOVERABLE_ERROR_CODES.has(error.code) ||
-    (error.message &&
-      (error.message.match(/not master/) || error.message.match(/node is recovering/)))
+    error instanceof MongoParseError ||
+    ((isRecoveringError(error) || isNotMasterError(error)) &&
+      (maxWireVersion(server) >= 8 && isNodeShuttingDownError(error)))
   );
 }
 

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const mongoErrorContextSymbol = Symbol('mongoErrorContextSymbol');
+const maxWireVersion = require('./utils').maxWireVersion;
 
 /**
  * Creates a new MongoError
@@ -174,6 +175,20 @@ function isSDAMUnrecoverableError(error) {
   );
 }
 
+const SDAM_NODE_IS_SHUTTING_DOWN_ERRORS = new Set([
+  91, // ShutdownInProgress
+  11600 // InterruptedAtShutdown
+]);
+
+function isErrorWhereSDAMShouldClearPool(server, error) {
+  return (
+    error instanceof MongoParseError ||
+    maxWireVersion(server) < 8 ||
+    (isSDAMUnrecoverableError(error) && SDAM_NODE_IS_SHUTTING_DOWN_ERRORS.has(error.code))
+  );
+  Î;
+}
+
 module.exports = {
   MongoError,
   MongoNetworkError,
@@ -182,5 +197,6 @@ module.exports = {
   MongoWriteConcernError,
   mongoErrorContextSymbol,
   isRetryableError,
-  isSDAMUnrecoverableError
+  isSDAMUnrecoverableError,
+  isErrorWhereSDAMShouldClearPool
 };

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -192,7 +192,7 @@ function isNotMasterError(err) {
 }
 
 function isNodeShuttingDownError(err) {
-  return SDAM_NODE_SHUTTING_DOWN_ERROR_CODES.has(err.code);
+  return err.code && SDAM_NODE_SHUTTING_DOWN_ERROR_CODES.has(err.code);
 }
 
 /**

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -245,7 +245,7 @@ class Server extends EventEmitter {
           options.session.serverSession.isDirty = true;
         }
 
-        if (isSDAMUnrecoverableError(err)) {
+        if (isSDAMUnrecoverableError(err, this)) {
           this.emit('error', err);
         }
       }
@@ -269,7 +269,7 @@ class Server extends EventEmitter {
           options.session.serverSession.isDirty = true;
         }
 
-        if (isSDAMUnrecoverableError(err)) {
+        if (isSDAMUnrecoverableError(err, this)) {
           this.emit('error', err);
         }
       }
@@ -293,7 +293,7 @@ class Server extends EventEmitter {
           options.session.serverSession.isDirty = true;
         }
 
-        if (isSDAMUnrecoverableError(err)) {
+        if (isSDAMUnrecoverableError(err, this)) {
           this.emit('error', err);
         }
       }
@@ -311,7 +311,7 @@ class Server extends EventEmitter {
    */
   killCursors(ns, cursorState, callback) {
     wireProtocol.killCursors(this, ns, cursorState, (err, result) => {
-      if (err && isSDAMUnrecoverableError(err)) {
+      if (err && isSDAMUnrecoverableError(err, this)) {
         this.emit('error', err);
       }
 
@@ -419,7 +419,7 @@ function executeWriteOperation(args, options, callback) {
   }
 
   if (collationNotSupported(server, options)) {
-    callback(new MongoError(`server ${this.name} does not support collation`));
+    callback(new MongoError(`server ${server.name} does not support collation`));
     return;
   }
 
@@ -429,7 +429,7 @@ function executeWriteOperation(args, options, callback) {
         options.session.serverSession.isDirty = true;
       }
 
-      if (isSDAMUnrecoverableError(err)) {
+      if (isSDAMUnrecoverableError(err, server)) {
         server.emit('error', err);
       }
     }

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -20,6 +20,7 @@ const createCompressionInfo = require('../topologies/shared').createCompressionI
 const isRetryableError = require('../error').isRetryableError;
 const MongoParseError = require('../error').MongoParseError;
 const isSDAMUnrecoverableError = require('../error').isSDAMUnrecoverableError;
+const isErrorWhereSDAMShouldClearPool = require('../error').isErrorWhereSDAMShouldClearPool;
 const ClientSession = require('../sessions').ClientSession;
 const createClientInfo = require('../topologies/shared').createClientInfo;
 const MongoError = require('../error').MongoError;
@@ -938,7 +939,7 @@ function serverErrorEventHandler(server, topology) {
       new monitoring.ServerClosedEvent(topology.s.id, server.description.address)
     );
 
-    if (err instanceof MongoParseError || isSDAMUnrecoverableError(err)) {
+    if (isErrorWhereSDAMShouldClearPool(server, err)) {
       resetServerState(server, err, { clearPool: true });
       return;
     }

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -18,7 +18,6 @@ const deprecate = require('util').deprecate;
 const BSON = require('../connection/utils').retrieveBSON();
 const createCompressionInfo = require('../topologies/shared').createCompressionInfo;
 const isRetryableError = require('../error').isRetryableError;
-const MongoParseError = require('../error').MongoParseError;
 const isSDAMUnrecoverableError = require('../error').isSDAMUnrecoverableError;
 const ClientSession = require('../sessions').ClientSession;
 const createClientInfo = require('../topologies/shared').createClientInfo;
@@ -938,7 +937,7 @@ function serverErrorEventHandler(server, topology) {
       new monitoring.ServerClosedEvent(topology.s.id, server.description.address)
     );
 
-    if (err instanceof MongoParseError || isSDAMUnrecoverableError(err)) {
+    if (isSDAMUnrecoverableError(err, server)) {
       resetServerState(server, err, { clearPool: true });
       return;
     }

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -20,7 +20,6 @@ const createCompressionInfo = require('../topologies/shared').createCompressionI
 const isRetryableError = require('../error').isRetryableError;
 const MongoParseError = require('../error').MongoParseError;
 const isSDAMUnrecoverableError = require('../error').isSDAMUnrecoverableError;
-const isErrorWhereSDAMShouldClearPool = require('../error').isErrorWhereSDAMShouldClearPool;
 const ClientSession = require('../sessions').ClientSession;
 const createClientInfo = require('../topologies/shared').createClientInfo;
 const MongoError = require('../error').MongoError;
@@ -939,7 +938,7 @@ function serverErrorEventHandler(server, topology) {
       new monitoring.ServerClosedEvent(topology.s.id, server.description.address)
     );
 
-    if (isErrorWhereSDAMShouldClearPool(server, err)) {
+    if (err instanceof MongoParseError || isSDAMUnrecoverableError(err)) {
       resetServerState(server, err, { clearPool: true });
       return;
     }

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -32,8 +32,8 @@ let globalTopologyCounter = 0;
 // Constants
 const TOPOLOGY_DEFAULTS = {
   localThresholdMS: 15,
-  serverSelectionTimeoutMS: 10000,
-  heartbeatFrequencyMS: 30000,
+  serverSelectionTimeoutMS: 30000,
+  heartbeatFrequencyMS: 10000,
   minHeartbeatFrequencyMS: 500
 };
 

--- a/test/functional/connections_stepdown_tests.js
+++ b/test/functional/connections_stepdown_tests.js
@@ -3,13 +3,13 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-describe.skip('Connections survive primary step down', function() {
+describe('Connections survive primary step down', function() {
   let client;
 
   beforeEach(function() {
     client = this.configuration.newClient(
       { w: 1 },
-      { poolSize: 1, retryWrites: false, useUnifiedTopology: true }
+      { poolSize: 1, retryWrites: false, useUnifiedTopology: true, serverSelectionTimeoutMS: 30000 }
     );
     return client.connect();
   });
@@ -61,6 +61,7 @@ describe.skip('Connections survive primary step down', function() {
                           .then(result =>
                             expect(result.connections.totalCreated).to.equal(numberOfConnections)
                           )
+                          .then(() => cursor.close())
                       )
                   );
               })

--- a/test/functional/connections_stepdown_tests.js
+++ b/test/functional/connections_stepdown_tests.js
@@ -130,7 +130,7 @@ describe('Connections survive primary step down', function() {
               db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
             );
 
-            collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(10107));
+            return collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(10107));
           })
           .then(() => connectionCount(db).then(expectPoolWasCleared(initialConnectionCount)));
       });
@@ -151,6 +151,7 @@ describe('Connections survive primary step down', function() {
             deferred.push(() =>
               db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
             );
+
             return collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(91));
           })
           .then(() => connectionCount(db).then(expectPoolWasCleared(initialConnectionCount)));
@@ -172,6 +173,7 @@ describe('Connections survive primary step down', function() {
             deferred.push(() =>
               db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
             );
+
             return collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(11600));
           })
           .then(() => connectionCount(db).then(expectPoolWasCleared(initialConnectionCount)));

--- a/test/functional/connections_stepdown_tests.js
+++ b/test/functional/connections_stepdown_tests.js
@@ -30,7 +30,7 @@ describe('Connections survive primary step down', function() {
   beforeEach(function() {
     client = this.configuration.newClient(
       { w: 1 },
-      { poolSize: 1, retryWrites: false, useUnifiedTopology: true, serverSelectionTimeoutMS: 30000 }
+      { poolSize: 1, retryWrites: false, useUnifiedTopology: true }
     );
 
     return client

--- a/test/functional/connections_stepdown_tests.js
+++ b/test/functional/connections_stepdown_tests.js
@@ -3,247 +3,179 @@
 const chai = require('chai');
 const expect = chai.expect;
 
+function ignoreNsNotFound(err) {
+  if (!err.message.match(/ns not found/)) throw err;
+}
+
+function connectionCount(db) {
+  return db
+    .admin()
+    .serverStatus()
+    .then(result => result.connections.totalCreated);
+}
+
+function expectPoolWasCleared(initialCount) {
+  return count => expect(count).to.equal(initialCount + 1);
+}
+
+function expectPoolWasNotCleared(initialCount) {
+  return count => expect(count).to.equal(initialCount);
+}
+
 describe('Connections survive primary step down', function() {
   let client;
+  let db;
+  let collection;
 
   beforeEach(function() {
     client = this.configuration.newClient(
       { w: 1 },
       { poolSize: 1, retryWrites: false, useUnifiedTopology: true, serverSelectionTimeoutMS: 30000 }
     );
-    return client.connect();
+
+    return client
+      .connect()
+      .then(() => {
+        db = client.db('step-down');
+        collection = db.collection('step-down');
+      })
+      .then(() => collection.drop({ w: 'majority' }))
+      .catch(ignoreNsNotFound)
+      .then(() => db.createCollection('step-down', { w: 'majority' }));
   });
 
+  let deferred = [];
   afterEach(function() {
-    return client.close();
+    return Promise.all(deferred.map(d => d())).then(() => {
+      deferred = [];
+      client.close();
+    });
   });
 
   it('getMore iteration', {
     metadata: { requires: { mongodb: '>=4.2.0', topology: 'replicaset' } },
-    test: function() {
-      const db = client.db('step-down');
-      let numberOfConnections;
 
-      return Promise.resolve()
-        .then(() =>
-          db
-            .admin()
-            .serverStatus()
-            .then(result => {
-              numberOfConnections = result.connections.totalCreated;
-            })
-        )
-        .then(() => db.createCollection('step-down').then(coll => coll.drop({ w: 'majority' })))
-        .then(() =>
-          db.createCollection('step-down', { w: 'majority' }).then(collection =>
-            collection
-              .insertMany([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 }], { w: 'majority' })
-              .then(result => expect(result.insertedCount).to.equal(5))
-              .then(() => {
-                const cursor = collection.find({}, { batchSize: 2 });
-                return cursor
-                  .next()
-                  .then(item => expect(item.a).to.equal(1))
+    test: function() {
+      return connectionCount(db).then(initialConnectionCount => {
+        return collection
+          .insertMany([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 }], {
+            w: 'majority'
+          })
+          .then(result => expect(result.insertedCount).to.equal(5))
+          .then(() => {
+            const cursor = collection.find({}, { batchSize: 2 });
+            deferred.push(() => cursor.close());
+
+            return cursor
+              .next()
+              .then(item => expect(item.a).to.equal(1))
+              .then(() => cursor.next())
+              .then(item => expect(item.a).to.equal(2))
+              .then(() =>
+                db
+                  .executeDbAdminCommand(
+                    { replSetStepDown: 5, force: true },
+                    { readPreference: 'primary' }
+                  )
                   .then(() => cursor.next())
-                  .then(item => expect(item.a).to.equal(2))
+                  .then(item => expect(item.a).to.equal(3))
                   .then(() =>
-                    db
-                      .executeDbAdminCommand(
-                        { replSetStepDown: 5, force: true },
-                        { readPreference: 'primary' }
-                      )
-                      .then(() => cursor.next())
-                      .then(item => expect(item.a).to.equal(3))
-                      .then(() =>
-                        db
-                          .admin()
-                          .serverStatus()
-                          .then(result =>
-                            expect(result.connections.totalCreated).to.equal(numberOfConnections)
-                          )
-                          .then(() => cursor.close())
-                      )
-                  );
-              })
-          )
-        );
+                    connectionCount(db).then(expectPoolWasNotCleared(initialConnectionCount))
+                  )
+              );
+          });
+      });
     }
   });
 
   it('Not Master - Keep Connection Pool', {
     metadata: { requires: { mongodb: '>=4.2.0', topology: 'replicaset' } },
     test: function() {
-      const db = client.db('step-down');
-      let numberOfConnections;
+      return connectionCount(db).then(initialConnectionCount => {
+        return db
+          .executeDbAdminCommand({
+            configureFailPoint: 'failCommand',
+            mode: { times: 1 },
+            data: { failCommands: ['insert'], errorCode: 10107 }
+          })
+          .then(() => {
+            deferred.push(() =>
+              db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
+            );
 
-      return Promise.resolve()
-        .then(() =>
-          db
-            .admin()
-            .serverStatus()
-            .then(result => {
-              numberOfConnections = result.connections.totalCreated;
+            return collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(10107));
+          })
+          .then(() =>
+            collection.insertOne({ test: 1 }).then(result => {
+              expect(result.insertedCount).to.equal(1);
             })
-        )
-        .then(() => db.createCollection('step-down').then(coll => coll.drop({ w: 'majority' })))
-        .then(() =>
-          db.createCollection('step-down', { w: 'majority' }).then(collection =>
-            db
-              .executeDbAdminCommand({
-                configureFailPoint: 'failCommand',
-                mode: { times: 1 },
-                data: { failCommands: ['insert'], errorCode: 10107 }
-              })
-              .then(() =>
-                collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(10107))
-              )
-              .then(() =>
-                collection.insertOne({ test: 1 }).then(result => {
-                  expect(result.insertedCount).to.equal(1);
-                })
-              )
-              .then(() =>
-                db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
-              )
-              .then(() =>
-                db
-                  .admin()
-                  .serverStatus()
-                  .then(result =>
-                    expect(result.connections.totalCreated).to.equal(numberOfConnections)
-                  )
-              )
           )
-        );
+          .then(() => connectionCount(db).then(expectPoolWasNotCleared(initialConnectionCount)));
+      });
     }
   });
 
   it('Not Master - Reset Connection Pool', {
     metadata: { requires: { mongodb: '4.0.x', topology: 'replicaset' } },
     test: function() {
-      const db = client.db('step-down');
-      let numberOfConnections;
+      return connectionCount(db).then(initialConnectionCount => {
+        return db
+          .executeDbAdminCommand({
+            configureFailPoint: 'failCommand',
+            mode: { times: 1 },
+            data: { failCommands: ['insert'], errorCode: 10107 }
+          })
+          .then(() => {
+            deferred.push(() =>
+              db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
+            );
 
-      return Promise.resolve()
-        .then(() =>
-          db
-            .admin()
-            .serverStatus()
-            .then(result => {
-              numberOfConnections = result.connections.totalCreated;
-            })
-        )
-        .then(() => db.createCollection('step-down').then(coll => coll.drop({ w: 'majority' })))
-        .then(() =>
-          db.createCollection('step-down', { w: 'majority' }).then(collection =>
-            db
-              .executeDbAdminCommand({
-                configureFailPoint: 'failCommand',
-                mode: { times: 1 },
-                data: { failCommands: ['insert'], errorCode: 10107 }
-              })
-              .then(() =>
-                collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(10107))
-              )
-              .then(() =>
-                db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
-              )
-              .then(() =>
-                db
-                  .admin()
-                  .serverStatus()
-                  .then(result =>
-                    expect(result.connections.totalCreated).to.equal(numberOfConnections + 1)
-                  )
-              )
-          )
-        );
+            collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(10107));
+          })
+          .then(() => connectionCount(db).then(expectPoolWasCleared(initialConnectionCount)));
+      });
     }
   });
 
   it('Shutdown in progress - Reset Connection Pool', {
     metadata: { requires: { mongodb: '>=4.0.0', topology: 'replicaset' } },
     test: function() {
-      const db = client.db('step-down');
-      let numberOfConnections;
-
-      return Promise.resolve()
-        .then(() =>
-          db
-            .admin()
-            .serverStatus()
-            .then(result => {
-              numberOfConnections = result.connections.totalCreated;
-            })
-        )
-        .then(() => db.createCollection('step-down').then(coll => coll.drop({ w: 'majority' })))
-        .then(() =>
-          db.createCollection('step-down', { w: 'majority' }).then(collection =>
-            db
-              .executeDbAdminCommand({
-                configureFailPoint: 'failCommand',
-                mode: { times: 1 },
-                data: { failCommands: ['insert'], errorCode: 91 }
-              })
-              .then(() =>
-                collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(91))
-              )
-              .then(() =>
-                db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
-              )
-              .then(() =>
-                db
-                  .admin()
-                  .serverStatus()
-                  .then(result =>
-                    expect(result.connections.totalCreated).to.equal(numberOfConnections + 1)
-                  )
-              )
-          )
-        );
+      return connectionCount(db).then(initialConnectionCount => {
+        return db
+          .executeDbAdminCommand({
+            configureFailPoint: 'failCommand',
+            mode: { times: 1 },
+            data: { failCommands: ['insert'], errorCode: 91 }
+          })
+          .then(() => {
+            deferred.push(() =>
+              db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
+            );
+            return collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(91));
+          })
+          .then(() => connectionCount(db).then(expectPoolWasCleared(initialConnectionCount)));
+      });
     }
   });
 
   it('Interrupted at shutdown - Reset Connection Pool', {
     metadata: { requires: { mongodb: '>=4.0.0', topology: 'replicaset' } },
     test: function() {
-      const db = client.db('step-down');
-      let numberOfConnections;
-
-      return Promise.resolve()
-        .then(() =>
-          db
-            .admin()
-            .serverStatus()
-            .then(result => {
-              numberOfConnections = result.connections.totalCreated;
-            })
-        )
-        .then(() => db.createCollection('step-down').then(coll => coll.drop({ w: 'majority' })))
-        .then(() =>
-          db.createCollection('step-down', { w: 'majority' }).then(collection =>
-            db
-              .executeDbAdminCommand({
-                configureFailPoint: 'failCommand',
-                mode: { times: 1 },
-                data: { failCommands: ['insert'], errorCode: 11600 }
-              })
-              .then(() =>
-                collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(11600))
-              )
-              .then(() =>
-                db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
-              )
-              .then(() =>
-                db
-                  .admin()
-                  .serverStatus()
-                  .then(result =>
-                    expect(result.connections.totalCreated).to.equal(numberOfConnections + 1)
-                  )
-              )
-          )
-        );
+      return connectionCount(db).then(initialConnectionCount => {
+        return db
+          .executeDbAdminCommand({
+            configureFailPoint: 'failCommand',
+            mode: { times: 1 },
+            data: { failCommands: ['insert'], errorCode: 11600 }
+          })
+          .then(() => {
+            deferred.push(() =>
+              db.executeDbAdminCommand({ configureFailPoint: 'failCommand', mode: 'off' })
+            );
+            return collection.insertOne({ test: 1 }).catch(err => expect(err.code).to.equal(11600));
+          })
+          .then(() => connectionCount(db).then(expectPoolWasCleared(initialConnectionCount)));
+      });
     }
   });
 });

--- a/test/functional/connections_stepdown_tests.js
+++ b/test/functional/connections_stepdown_tests.js
@@ -4,7 +4,9 @@ const chai = require('chai');
 const expect = chai.expect;
 
 function ignoreNsNotFound(err) {
-  if (!err.message.match(/ns not found/)) throw err;
+  if (!err.message.match(/ns not found/)) {
+    throw err;
+  }
 }
 
 function connectionCount(db) {


### PR DESCRIPTION

## Description
Does three things to fix connectionSurvivePrimaryStepdown tests

1. Increase the serverSelectionTimeout to 30s to align with SDAM
2. make sure we close the cursor from the first test
3. Alter SDAM to make sure we do not clear the pool for certain
errors.

Part of NODE-2112.

**There are still some periodic errors that occur in `Not Master - Keep Connection Pool` where, despite not creating a connection anywhere on our end, a connection is still created on the server. I am not sure where it is coming from, but my best guess is that it is the replSet members creating connections between each other. I am not sure how to go about fixing this.**

**What changed?**

- Fix to SDAM to implement this:
> If the client is connected to server version 4.2 or higher, and the client receives a "not master" or "node is recovering" error which is not a "node is shutting down" error, the client MUST keep any connections it has to the server open, and MUST NOT clear its connection pool for the server. If the client is connected to server version 4.2 or higher and receives a "node is shutting down" error, or if the client is connected to server version 4.0 or lower and receives a "not master" or "node is recovering" error, the client MUST clear its connection pool to the server.

See https://github.com/mongodb/specifications/blob/573b1f58a129056d651781ad99317b6c656e050e/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#not-master-and-node-is-recovering

- increased serverSelectionTimeout to 30s. This gives the tests enough time to wait for an election to occur.

- Closed the cursor in the first test.

**Are there any files to ignore?**
No