### PR TITLE
test(test-runner): add test files to demonstrate test runner poc

### DIFF
--- a/test-runner-poc/crud_tests.js
+++ b/test-runner-poc/crud_tests.js
@@ -1,0 +1,136 @@
+'use strict';
+/* include stuff */
+const expect = require('chai').expect;
+const MongoClient = require('mongodb').MongoClient;
+
+let client;
+let db;
+
+describe('CRUD', function() {
+  it('should correctly insert documents', function(done) {
+    const collection = db.collection('insertTest');
+
+    collection.insertOne({ a: 1 }, (err, result) => {
+      expect(err).to.not.exist;
+      expect(result).to.exist;
+      expect(result.insertedCount).to.equal(1);
+      expect(result.ops[0].a).to.equal(1);
+      done();
+    });
+  });
+
+  it('should correctly insertMany documents', function(done) {
+    const collection = db.collection('insertManyTest');
+
+    collection.insertMany([{ b: 2 }, { c: 3 }], (err, result) => {
+      expect(err).to.not.exist;
+      expect(result).to.exist;
+      expect(result.insertedCount).to.equal(2);
+      expect(result.ops[0].b).to.equal(2);
+      expect(result.ops[1].c).to.equal(3);
+      done();
+    });
+  });
+
+  it('should correctly update documents', function(done) {
+    const collection = db.collection('updateTest');
+
+    collection.insertOne({ a: 1 }, (err, result) => {
+      expect(err).to.not.exist;
+      expect(result).to.exist;
+      expect(result.insertedCount).to.equal(1);
+
+      collection.updateOne({ a: 1 }, { $set: { a: 2 } }, (err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+        expect(result.modifiedCount).to.equal(1);
+        expect(result.matchedCount).to.equal(1);
+        done();
+      });
+    });
+  });
+
+  it('should correctly updateMany documents', function(done) {
+    const collection = db.collection('updateManyTest');
+
+    collection.insertMany([{ a: 1 }, { a: 1 }], (err, result) => {
+      expect(err).to.not.exist;
+      expect(result).to.exist;
+      expect(result.insertedCount).to.equal(2);
+
+      collection.updateMany({ a: 1 }, { $set: { a: 2 } }, (err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+        expect(result.modifiedCount).to.equal(2);
+        expect(result.matchedCount).to.equal(2);
+        done();
+      });
+    });
+  });
+
+  it('should correctly delete documents', function(done) {
+    const collection = db.collection('deleteTest');
+
+    collection.insertOne({ a: 1 }, (err, result) => {
+      expect(err).to.not.exist;
+      expect(result).to.exist;
+      expect(result.insertedCount).to.equal(1);
+
+      collection.deleteOne({ a: 1 }, (err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+        expect(result.deletedCount).to.equal(1);
+        done();
+      });
+    });
+  });
+
+  it('should correctly deleteMany documents', function(done) {
+    const collection = db.collection('deleteManyTest');
+
+    collection.insertMany([{ a: 1 }, { a: 1 }, { a: 1 }], (err, result) => {
+      expect(err).to.not.exist;
+      expect(result).to.exist;
+      expect(result.insertedCount).to.equal(3);
+
+      collection.deleteMany({ a: 1 }, (err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+        expect(result.deletedCount).to.equal(3);
+        done();
+      });
+    });
+  });
+
+  it('should correctly find documents', function(done) {
+    const collection = db.collection('findTest');
+
+    collection.insertOne({ a: 1 }, (err, result) => {
+      expect(err).to.not.exist;
+      expect(result).to.exist;
+      expect(result.insertedCount).to.equal(1);
+
+      collection.findOne({ a: 1 }, (err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+        expect(result.a).to.equal(1);
+        done();
+      });
+    });
+  });
+  before(function(done) {
+    client = new MongoClient(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017', {
+      w: 1,
+      poolSize: 1
+    });
+    client.connect(err => {
+      expect(err).to.not.exist;
+      db = client.db('test');
+      done();
+    });
+  });
+
+  after(function(done) {
+    client.close(done);
+  });
+});

--- a/test-runner-poc/filter_tests.js
+++ b/test-runner-poc/filter_tests.js
@@ -1,0 +1,40 @@
+'use strict';
+const expect = require('chai').expect;
+describe('Filter', function() {
+  it('should skip because version is too high', {
+    metadata: { requires: { mongodb: '>=4.6.0' } },
+    test: function() {
+      expect(1).to.equal(1);
+    }
+  });
+  it('should run because version is low', {
+    metadata: { requires: { mongodb: '>=3.6.0' } },
+    test: function() {
+      expect(1).to.equal(1);
+    }
+  });
+  it('should only run when topology is single', {
+    metadata: { requires: { topology: 'single' } },
+    test: function() {
+      expect(1).to.equal(1);
+    }
+  });
+  it('should only run when topology is replicaset', {
+    metadata: { requires: { topology: 'replicaset' } },
+    test: function() {
+      expect(1).to.equal(1);
+    }
+  });
+  it('should only run when topology is sharded', {
+    metadata: { requires: { topology: 'sharded' } },
+    test: function() {
+      expect(1).to.equal(1);
+    }
+  });
+  it('should run when topology is single, replicaset OR sharded', {
+    metadata: { requires: { topology: ['single', 'replicaset', 'sharded'] } },
+    test: function() {
+      expect(1).to.equal(1);
+    }
+  });
+});


### PR DESCRIPTION
Fixes NODE-2059

## Description
Added tests that show `test-runner-poc` operating correctly when running tests on filtering different versions and topologies, and doing CRUD commands.
**What changed?**
Added `crud_tests.js` and `filter_tests.js` to the `test-runner-poc` folder
