### PR TITLE
fix(find): respect client-level provided read preference

### DIFF
--- a/lib/operations/find.js
+++ b/lib/operations/find.js
@@ -3,6 +3,7 @@
 const OperationBase = require('./operation').OperationBase;
 const Aspect = require('./operation').Aspect;
 const defineAspects = require('./operation').defineAspects;
+const resolveReadPreference = require('../utils').resolveReadPreference;
 
 class FindOperation extends OperationBase {
   constructor(collection, ns, command, options) {
@@ -10,6 +11,7 @@ class FindOperation extends OperationBase {
 
     this.ns = ns;
     this.cmd = command;
+    this.readPreference = resolveReadPreference(collection, this.options);
   }
 
   execute(server, callback) {


### PR DESCRIPTION
Fixes a regression introduced in v3.3.0 that ignores a user provided read preference at the client level.

NODE-2124