### PR TITLE
refactor(sessions): Performance Improvement

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -131,7 +131,7 @@ function MongoClient(url, options) {
     options: options || {},
     promiseLibrary: null,
     dbCache: {},
-    sessions: []
+    sessions: new Set()
   };
 
   // Get the promiseLibrary

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -194,7 +194,7 @@ class Mongos extends TopologyBase {
       // Server Session Pool
       sessionPool: null,
       // Active client sessions
-      sessions: [],
+      sessions: new Set(),
       // Promise library
       promiseLibrary: options.promiseLibrary || Promise
     };

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -210,7 +210,7 @@ class ReplSet extends TopologyBase {
       // Server Session Pool
       sessionPool: null,
       // Active client sessions
-      sessions: [],
+      sessions: new Set(),
       // Promise library
       promiseLibrary: options.promiseLibrary || Promise
     };

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -202,7 +202,7 @@ class Server extends TopologyBase {
       // Server Session Pool
       sessionPool: null,
       // Active client sessions
-      sessions: [],
+      sessions: new Set(),
       // Promise library
       promiseLibrary: promiseLibrary || Promise
     };

--- a/lib/topologies/topology_base.js
+++ b/lib/topologies/topology_base.js
@@ -291,11 +291,12 @@ class TopologyBase extends EventEmitter {
 
   startSession(options, clientOptions) {
     const session = new ClientSession(this, this.s.sessionPool, options, clientOptions);
+
     session.once('ended', () => {
-      this.s.sessions = this.s.sessions.filter(s => !s.equals(session));
+      this.s.sessions.delete(session);
     });
 
-    this.s.sessions.push(session);
+    this.s.sessions.add(session);
     return session;
   }
 
@@ -382,9 +383,7 @@ class TopologyBase extends EventEmitter {
   close(forceClosed, callback) {
     // If we have sessions, we want to individually move them to the session pool,
     // and then send a single endSessions call.
-    if (this.s.sessions.length) {
-      this.s.sessions.forEach(session => session.endSession());
-    }
+    this.s.sessions.forEach(session => session.endSession());
 
     if (this.s.sessionPool) {
       this.s.sessionPool.endAllPooledSessions();

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -4364,7 +4364,7 @@ describe('Cursor', function() {
             const cursor = collection.find({});
 
             cursor.next(function() {
-              test.equal(client.topology.s.sessions.length, 0);
+              test.equal(client.topology.s.sessions.size, 0);
               client.close();
               done();
             });
@@ -4405,13 +4405,13 @@ describe('Cursor', function() {
             test.equal(null, err);
             const cursor = collection.find({}, { batchSize: 3 });
             cursor.next(function() {
-              test.equal(client.topology.s.sessions.length, 1);
+              test.equal(client.topology.s.sessions.size, 1);
               cursor.next(function() {
-                test.equal(client.topology.s.sessions.length, 1);
+                test.equal(client.topology.s.sessions.size, 1);
                 cursor.next(function() {
-                  test.equal(client.topology.s.sessions.length, 1);
+                  test.equal(client.topology.s.sessions.size, 1);
                   cursor.next(function() {
-                    test.equal(client.topology.s.sessions.length, 0);
+                    test.equal(client.topology.s.sessions.size, 0);
                     client.close();
                     done();
                   });

--- a/test/functional/sessions_tests.js
+++ b/test/functional/sessions_tests.js
@@ -46,7 +46,7 @@ describe('Sessions', function() {
         expect(test.commands.started[0].commandName).to.equal('endSessions');
         expect(test.commands.started[0].command.endSessions).to.include.deep.members(sessions);
 
-        expect(client.s.sessions).to.have.length(0);
+        test.equal(client.s.sessions.size, 0);
         done();
       });
     }


### PR DESCRIPTION
Changed the sessions structure to an object instead of an array
so when we close a session we could remove it from the data structure more efficiently

## Description
On a medium system (2k clients) I've noticed that if all of the machines reports to the web server at the same time, like when the web server starts last. The server CPU goes to 100% and it's not responding. After running a profiler on node, it was apparent that we're wasting a lot of time closing sessions. This patch seems to solve the problem.  

**What changed?**
When closing a session we used to search for the closed session in the sessions array, filter it out, and override the sessions array. Instead, we can maintain the sessions as an object to save all the searching and memcopy. 

**Are there any files to ignore?**
