### PR TITLE
 test(read-write-concern): sync spec tests and add test runner

### DIFF
--- a/lib/core/uri_parser.js
+++ b/lib/core/uri_parser.js
@@ -213,7 +213,6 @@ const CASE_TRANSLATION = {
   tlscafile: 'tlsCAFile',
   tlscertificatekeyfile: 'tlsCertificateKeyFile',
   tlscertificatekeyfilepassword: 'tlsCertificateKeyFilePassword',
-  wtimeout: 'wTimeoutMS',
   j: 'journal'
 };
 
@@ -414,6 +413,24 @@ function parseQueryString(query, options) {
   if (result.wtimeout && result.wtimeoutms) {
     delete result.wtimeout;
     console.warn('Unsupported option `wtimeout` specified');
+  }
+
+  if (
+    result.w != null &&
+    result.w === 0 &&
+    ((result.j != null && result.j === true) || (result.journal != null && result.journal === true))
+  ) {
+    throw new MongoParseError(
+      'An inconsistent WriteConcern of { w: 0, journal: true } was specified.'
+    );
+  }
+
+  if (result.w != null && result.w < 0) {
+    throw new MongoParseError('w must be greater than or equal to 0');
+  }
+
+  if (result.wtimeout != null && result.wtimeout < 0) {
+    throw new MongoParseError('wtimeout must be greater than or equal to 0');
   }
 
   return Object.keys(result).length ? result : null;

--- a/lib/core/uri_parser.js
+++ b/lib/core/uri_parser.js
@@ -415,21 +415,17 @@ function parseQueryString(query, options) {
     console.warn('Unsupported option `wtimeout` specified');
   }
 
-  if (
-    result.w != null &&
-    result.w === 0 &&
-    ((result.j != null && result.j === true) || (result.journal != null && result.journal === true))
-  ) {
+  if (result.w === 0 && (result.j === true || result.journal === true)) {
     throw new MongoParseError(
       'An inconsistent WriteConcern of { w: 0, journal: true } was specified.'
     );
   }
 
-  if (result.w != null && result.w < 0) {
+  if (result.w < 0) {
     throw new MongoParseError('w must be greater than or equal to 0');
   }
 
-  if (result.wtimeout != null && result.wtimeout < 0) {
+  if (result.wtimeout < 0) {
     throw new MongoParseError('wtimeout must be greater than or equal to 0');
   }
 

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -151,6 +151,15 @@ function MongoClient(url, options) {
   // Set up event emitter
   EventEmitter.call(this);
 
+  let writeConcern;
+  if (options == null) {
+    WriteConcern.fromUrl(url, wc => {
+      writeConcern = wc;
+    });
+  } else {
+    writeConcern = WriteConcern.fromOptions(options);
+  }
+
   // The internal state
   this.s = {
     url: url,
@@ -158,7 +167,7 @@ function MongoClient(url, options) {
     promiseLibrary: null,
     dbCache: new Map(),
     sessions: new Set(),
-    writeConcern: WriteConcern.fromOptions(options),
+    writeConcern,
     namespace: new MongoDBNamespace('admin')
   };
 

--- a/lib/write_concern.js
+++ b/lib/write_concern.js
@@ -2,7 +2,7 @@
 
 const parseConnectionString = require('./core/uri_parser');
 
-const writeConcernKeys = new Set(['w', 'wtimeout', 'j', 'fsync', 'wtimeoutMS', 'journal']);
+const WRITE_CONCERN_KEYS = new Set(['w', 'wtimeout', 'j', 'fsync', 'wtimeoutMS', 'journal']);
 
 /**
  * The **WriteConcern** class is a class that represents a MongoDB WriteConcern.
@@ -46,7 +46,7 @@ class WriteConcern {
       if (parsedUrl != null) {
         let writeConcernObject = {};
         Object.keys(parsedUrl.options).forEach(optionName => {
-          if (writeConcernKeys.has(optionName)) {
+          if (WRITE_CONCERN_KEYS.has(optionName)) {
             if (optionName === 'journal') {
               writeConcernObject['j'] = parsedUrl.options[optionName];
             } else {

--- a/lib/write_concern.js
+++ b/lib/write_concern.js
@@ -36,8 +36,7 @@ class WriteConcern {
     }
   }
 
-  static fromUrl(url) {
-    let wc;
+  static fromUrl(url, callback) {
     parseConnectionString(url, (err, parsedUrl) => {
       if (err) {
         throw err;
@@ -55,15 +54,16 @@ class WriteConcern {
           }
         });
 
-        wc = new WriteConcern(
-          writeConcernObject.w,
-          writeConcernObject.wtimeout,
-          writeConcernObject.j,
-          writeConcernObject.fsync
+        callback(
+          new WriteConcern(
+            writeConcernObject.w,
+            writeConcernObject.wtimeout,
+            writeConcernObject.j,
+            writeConcernObject.fsync
+          )
         );
       }
     });
-    return wc;
   }
 
   /**

--- a/lib/write_concern.js
+++ b/lib/write_concern.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const parseConnectionString = require('./core/uri_parser');
+
+const writeConcernKeys = new Set(['w', 'wtimeout', 'j', 'fsync', 'wtimeoutMS', 'journal']);
+
 /**
  * The **WriteConcern** class is a class that represents a MongoDB WriteConcern.
  * @class
@@ -30,6 +34,36 @@ class WriteConcern {
     if (fsync != null) {
       this.fsync = fsync;
     }
+  }
+
+  static fromUrl(url) {
+    let wc;
+    parseConnectionString(url, (err, parsedUrl) => {
+      if (err) {
+        throw err;
+      }
+
+      if (parsedUrl != null) {
+        let writeConcernObject = {};
+        Object.keys(parsedUrl.options).forEach(optionName => {
+          if (writeConcernKeys.has(optionName)) {
+            if (optionName === 'journal') {
+              writeConcernObject['j'] = parsedUrl.options[optionName];
+            } else {
+              writeConcernObject[optionName] = parsedUrl.options[optionName];
+            }
+          }
+        });
+
+        wc = new WriteConcern(
+          writeConcernObject.w,
+          writeConcernObject.wtimeout,
+          writeConcernObject.j,
+          writeConcernObject.fsync
+        );
+      }
+    });
+    return wc;
   }
 
   /**

--- a/test/functional/read_write_concern_spec_tests.js
+++ b/test/functional/read_write_concern_spec_tests.js
@@ -1,112 +1,104 @@
 'use strict';
 
-const fs = require('fs');
+const path = require('path');
 const chai = require('chai');
 const expect = chai.expect;
-
+const gatherTestSuites = require('./runner/index.js').gatherTestSuites;
 const core = require('../../lib/core');
 const parse = core.parseConnectionString;
 
 describe('Read Write Concern (spec)', function() {
   describe('Connection String', function() {
-    fs
-      .readdirSync(`${__dirname}/spec/read-write-concern/connection-string`)
-      .filter(filename => filename.match(/\.json$/))
-      .forEach(filename => {
-        const specString = fs.readFileSync(
-          `${__dirname}/spec/read-write-concern/connection-string/${filename}`,
-          'utf8'
-        );
-        const specData = JSON.parse(specString);
+    const testSuites = gatherTestSuites(
+      path.join(__dirname, 'spec', 'read-write-concern/connection-string')
+    );
 
-        describe(filename, () => {
-          specData.tests.forEach(test => {
-            const itFn = test.warning ? it.skip : it;
+    testSuites.forEach(testSuite => {
+      describe(testSuite.name, () => {
+        testSuite.tests.forEach(test => {
+          const itFn = test.warning ? it.skip : it;
 
-            itFn(test.description, function(done) {
-              parse(test.uri, {}, (err, result) => {
-                if (test.valid === false) {
-                  expect(err).to.exist;
-                  done();
-                }
-
-                expect(err).to.not.exist;
-                if (test.writeConcern != null && Object.keys(test.writeConcern).length !== 0) {
-                  if (test.valid === true) {
-                    expect(result.options).to.deep.include(test.writeConcern);
-                  } else {
-                    expect(result.options).to.not.deep.include(test.writeConcern);
-                  }
-                }
-                if (test.readConcern != null && Object.keys(test.readConcern).length !== 0) {
-                  if (test.valid === true) {
-                    expect(result.options.readConcern).to.deep.equal(test.readConcern);
-                  } else {
-                    expect(result.options).to.not.have.property('readConcern');
-                  }
-                }
+          itFn(test.description, function(done) {
+            parse(test.uri, {}, (err, result) => {
+              if (test.valid === false) {
+                expect(err).to.exist;
                 done();
-              });
+              }
+
+              expect(err).to.not.exist;
+              if (test.writeConcern != null && Object.keys(test.writeConcern).length !== 0) {
+                if (test.valid === true) {
+                  expect(result.options).to.deep.include(test.writeConcern);
+                } else {
+                  expect(result.options).to.not.deep.include(test.writeConcern);
+                }
+              }
+              if (test.readConcern != null && Object.keys(test.readConcern).length !== 0) {
+                if (test.valid === true) {
+                  expect(result.options.readConcern).to.deep.equal(test.readConcern);
+                } else {
+                  expect(result.options).to.not.have.property('readConcern');
+                }
+              }
+              done();
             });
           });
         });
       });
+    });
   });
 
   describe('Document', function() {
-    fs
-      .readdirSync(`${__dirname}/spec/read-write-concern/document`)
-      .filter(filename => filename.match(/\.json$/))
-      .forEach(filename => {
-        const specString = fs.readFileSync(
-          `${__dirname}/spec/read-write-concern/document/${filename}`,
-          'utf8'
-        );
-        const specData = JSON.parse(specString);
+    const testSuites = gatherTestSuites(
+      path.join(__dirname, 'spec', 'read-write-concern/document')
+    );
 
-        describe(filename, () => {
-          specData.tests.forEach(test => {
-            const itFn = test.warning ? it.skip : it;
+    testSuites.forEach(testSuite => {
+      describe(testSuite.name, () => {
+        testSuite.tests.forEach(test => {
+          const itFn = test.warning ? it.skip : it;
 
-            itFn(test.description, function(done) {
-              let client;
+          itFn(test.description, function(done) {
+            let client;
 
-              if (test.writeConcern != null) {
-                const url = constructUrl(this.configuration.url(), test.writeConcern);
-                try {
-                  client = this.configuration.newClient(url);
-                } catch (err) {
-                  if (test.valid === false) {
-                    expect(err).to.exist;
-                    done();
-                  }
-                }
-
-                client.connect((err, client) => {
-                  expect(err).to.not.exist;
-                  expect(client.s.writeConcern).to.deep.include(test.writeConcernDocument);
-                  client.close(done);
-                });
-              } else if (test.readConcern != null) {
-                client = this.configuration.newClient(this.configuration.url(), test.readConcern);
-
-                client.connect((err, client) => {
-                  if (test.valid === false) {
-                    expect(err).to.exist;
-                    client.close(done);
-                  } else {
-                    expect(err).to.not.exist;
-                    expect(client.s.options).to.deep.include(test.readConcernDocument);
-                    client.close(done);
-                  }
-                });
+            if (test.writeConcern != null) {
+              const url = constructUrl(this.configuration.url(), test.writeConcern);
+              try {
+                client = this.configuration.newClient(url);
+                expect(test.valid).to.be.true;
+              } catch (err) {
+                expect(test.valid).to.be.false;
+                done();
               }
-            });
+
+              connectAndValidate(client, test, done);
+            } else if (test.readConcern != null) {
+              client = this.configuration.newClient(this.configuration.url(), test.readConcern);
+              connectAndValidate(client, test, done);
+            }
           });
         });
       });
+    });
   });
 });
+
+function connectAndValidate(client, test, callback) {
+  client.connect((err, client) => {
+    if (test.valid === false) {
+      expect(err).to.exist;
+      client.close(callback);
+    } else {
+      expect(err).to.not.exist;
+      if (test.readConcern != null) {
+        expect(client.s.options).to.deep.include(test.readConcernDocument);
+      } else if (test.writeConcern != null) {
+        expect(client.writeConcern).to.deep.include(test.writeConcernDocument);
+      }
+      client.close(callback);
+    }
+  });
+}
 
 function constructUrl(url, writeConcernOptions) {
   Object.keys(writeConcernOptions).forEach(writeConcernKey => {

--- a/test/functional/read_write_concern_spec_tests.js
+++ b/test/functional/read_write_concern_spec_tests.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const fs = require('fs');
+const chai = require('chai');
+const expect = chai.expect;
+
+const core = require('../../lib/core');
+const parse = core.parseConnectionString;
+
+describe('Read Write Concern (spec)', function() {
+  describe('Connection String', function() {
+    fs
+      .readdirSync(`${__dirname}/spec/read-write-concern/connection-string`)
+      .filter(filename => filename.match(/\.json$/))
+      .forEach(filename => {
+        const specString = fs.readFileSync(
+          `${__dirname}/spec/read-write-concern/connection-string/${filename}`,
+          'utf8'
+        );
+        const specData = JSON.parse(specString);
+
+        describe(filename, () => {
+          specData.tests.forEach(test => {
+            const itFn = test.warning ? it.skip : it;
+
+            itFn(test.description, function(done) {
+              parse(test.uri, {}, (err, result) => {
+                if (test.valid === false) {
+                  expect(err).to.exist;
+                  done();
+                }
+
+                expect(err).to.not.exist;
+                if (test.writeConcern != null && Object.keys(test.writeConcern).length !== 0) {
+                  if (test.valid === true) {
+                    expect(result.options).to.deep.include(test.writeConcern);
+                  } else {
+                    expect(result.options).to.not.deep.include(test.writeConcern);
+                  }
+                }
+                if (test.readConcern != null && Object.keys(test.readConcern).length !== 0) {
+                  if (test.valid === true) {
+                    expect(result.options.readConcern).to.deep.equal(test.readConcern);
+                  } else {
+                    expect(result.options).to.not.have.property('readConcern');
+                  }
+                }
+                done();
+              });
+            });
+          });
+        });
+      });
+  });
+
+  describe('Document', function() {
+    fs
+      .readdirSync(`${__dirname}/spec/read-write-concern/document`)
+      .filter(filename => filename.match(/\.json$/))
+      .forEach(filename => {
+        const specString = fs.readFileSync(
+          `${__dirname}/spec/read-write-concern/document/${filename}`,
+          'utf8'
+        );
+        const specData = JSON.parse(specString);
+
+        describe(filename, () => {
+          specData.tests.forEach(test => {
+            const itFn = test.warning ? it.skip : it;
+
+            itFn(test.description, function(done) {
+              let client;
+
+              if (test.writeConcern != null) {
+                const url = constructUrl(this.configuration.url(), test.writeConcern);
+                try {
+                  client = this.configuration.newClient(url);
+                } catch (err) {
+                  if (test.valid === false) {
+                    expect(err).to.exist;
+                    done();
+                  }
+                }
+
+                client.connect((err, client) => {
+                  expect(err).to.not.exist;
+                  expect(client.s.writeConcern).to.deep.include(test.writeConcernDocument);
+                  client.close(done);
+                });
+              } else if (test.readConcern != null) {
+                client = this.configuration.newClient(this.configuration.url(), test.readConcern);
+
+                client.connect((err, client) => {
+                  if (test.valid === false) {
+                    expect(err).to.exist;
+                    client.close(done);
+                  } else {
+                    expect(err).to.not.exist;
+                    expect(client.s.options).to.deep.include(test.readConcernDocument);
+                    client.close(done);
+                  }
+                });
+              }
+            });
+          });
+        });
+      });
+  });
+});
+
+function constructUrl(url, writeConcernOptions) {
+  Object.keys(writeConcernOptions).forEach(writeConcernKey => {
+    url = url + `&${writeConcernKey}=${writeConcernOptions[writeConcernKey]}`;
+  });
+
+  return url;
+}

--- a/test/functional/spec/read-write-concern/README.rst
+++ b/test/functional/spec/read-write-concern/README.rst
@@ -1,0 +1,61 @@
+=======================
+Connection String Tests
+=======================
+
+The YAML and JSON files in this directory tree are platform-independent tests
+that drivers can use to prove their conformance to the Read and Write Concern 
+specification.
+
+Version
+-------
+
+Files in the "specifications" repository have no version scheme. They are not
+tied to a MongoDB server version.
+
+Format
+------
+
+Connection String
+~~~~~~~~~~~~~~~~~
+
+These tests are designed to exercise the connection string parsing related
+to read concern and write concern.
+
+Each YAML file contains an object with a single ``tests`` key. This key is an
+array of test case objects, each of which have the following keys:
+
+- ``description``: A string describing the test.
+- ``uri``: A string containing the URI to be parsed.
+- ``valid:``: a boolean indicating if parsing the uri should result in an error.
+- ``writeConcern:`` A document indicating the expected write concern.
+- ``readConcern:`` A document indicating the expected read concern.
+
+If a test case includes a null value for one of these keys, or if the key is missing,
+no assertion is necessary. This both simplifies parsing of the test files and allows flexibility
+for drivers that might substitute default values *during* parsing.
+
+Document
+~~~~~~~~
+
+These tests are designed to ensure compliance with the spec in relation to what should be 
+sent to the server.
+
+Each YAML file contains an object with a single ``tests`` key. This key is an
+array of test case objects, each of which have the following keys:
+
+- ``description``: A string describing the test.
+- ``valid:``: a boolean indicating if the write concern created from the document is valid.
+- ``writeConcern:`` A document indicating the write concern to use.
+- ``writeConcernDocument:`` A document indicating the write concern to be sent to the server.
+- ``readConcern:`` A document indicating the read concern to use.
+- ``readConcernDocument:`` A document indicating the read concern to be sent to the server.
+- ``isServerDefault:`` Indicates whether the read or write concern is considered the server's default.
+- ``isAcknowledged:`` Indicates if the write concern should be considered acknowledged.
+
+Use as unit tests
+=================
+
+Testing whether a URI is valid or not should simply be a matter of checking
+whether URI parsing raises an error or exception.
+Testing for emitted warnings may require more legwork (e.g. configuring a log
+handler and watching for output).

--- a/test/functional/spec/read-write-concern/connection-string/read-concern.json
+++ b/test/functional/spec/read-write-concern/connection-string/read-concern.json
@@ -1,0 +1,47 @@
+{
+  "tests": [
+    {
+      "description": "Default",
+      "uri": "mongodb://localhost/",
+      "valid": true,
+      "warning": false,
+      "readConcern": {}
+    },
+    {
+      "description": "local specified",
+      "uri": "mongodb://localhost/?readConcernLevel=local",
+      "valid": true,
+      "warning": false,
+      "readConcern": {
+        "level": "local"
+      }
+    },
+    {
+      "description": "majority specified",
+      "uri": "mongodb://localhost/?readConcernLevel=majority",
+      "valid": true,
+      "warning": false,
+      "readConcern": {
+        "level": "majority"
+      }
+    },
+    {
+      "description": "linearizable specified",
+      "uri": "mongodb://localhost/?readConcernLevel=linearizable",
+      "valid": true,
+      "warning": false,
+      "readConcern": {
+        "level": "linearizable"
+      }
+    },
+    {
+      "description": "available specified",
+      "uri": "mongodb://localhost/?readConcernLevel=available",
+      "valid": true,
+      "warning": false,
+      "readConcern": {
+        "level": "available"
+      }
+    }
+  ]
+}

--- a/test/functional/spec/read-write-concern/connection-string/read-concern.yml
+++ b/test/functional/spec/read-write-concern/connection-string/read-concern.yml
@@ -1,0 +1,32 @@
+tests:
+    -
+        description: "Default"
+        uri: "mongodb://localhost/"
+        valid: true
+        warning: false
+        readConcern: { }
+    -
+        description: "local specified"
+        uri: "mongodb://localhost/?readConcernLevel=local"
+        valid: true
+        warning: false
+        readConcern: { level: "local" }
+    -
+        description: "majority specified"
+        uri: "mongodb://localhost/?readConcernLevel=majority"
+        valid: true
+        warning: false
+        readConcern: { level: "majority" }
+    -
+        description: "linearizable specified"
+        uri: "mongodb://localhost/?readConcernLevel=linearizable"
+        valid: true
+        warning: false
+        readConcern: { level: "linearizable" }
+    -
+        description: "available specified"
+        uri: "mongodb://localhost/?readConcernLevel=available"
+        valid: true
+        warning: false
+        readConcern: { level: "available" }
+        

--- a/test/functional/spec/read-write-concern/connection-string/write-concern.json
+++ b/test/functional/spec/read-write-concern/connection-string/write-concern.json
@@ -1,0 +1,118 @@
+{
+  "tests": [
+    {
+      "description": "Default",
+      "uri": "mongodb://localhost/",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {}
+    },
+    {
+      "description": "w as a valid number",
+      "uri": "mongodb://localhost/?w=1",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": 1
+      }
+    },
+    {
+      "description": "w as an invalid number",
+      "uri": "mongodb://localhost/?w=-2",
+      "valid": false,
+      "warning": null
+    },
+    {
+      "description": "w as a string",
+      "uri": "mongodb://localhost/?w=majority",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": "majority"
+      }
+    },
+    {
+      "description": "wtimeoutMS as a valid number",
+      "uri": "mongodb://localhost/?wtimeoutMS=500",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "wtimeoutMS": 500
+      }
+    },
+    {
+      "description": "wtimeoutMS as an invalid number",
+      "uri": "mongodb://localhost/?wtimeoutMS=-500",
+      "valid": false,
+      "warning": null
+    },
+    {
+      "description": "journal as false",
+      "uri": "mongodb://localhost/?journal=false",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "journal": false
+      }
+    },
+    {
+      "description": "journal as true",
+      "uri": "mongodb://localhost/?journal=true",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "journal": true
+      }
+    },
+    {
+      "description": "All options combined",
+      "uri": "mongodb://localhost/?w=3&wtimeoutMS=500&journal=true",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": 3,
+        "wtimeoutMS": 500,
+        "journal": true
+      }
+    },
+    {
+      "description": "Unacknowledged with w",
+      "uri": "mongodb://localhost/?w=0",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": 0
+      }
+    },
+    {
+      "description": "Unacknowledged with w and journal",
+      "uri": "mongodb://localhost/?w=0&journal=false",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": 0,
+        "journal": false
+      }
+    },
+    {
+      "description": "Unacknowledged with w and wtimeoutMS",
+      "uri": "mongodb://localhost/?w=0&wtimeoutMS=500",
+      "valid": true,
+      "warning": false,
+      "writeConcern": {
+        "w": 0,
+        "wtimeoutMS": 500
+      }
+    },
+    {
+      "description": "Acknowledged with w as 0 and journal true",
+      "uri": "mongodb://localhost/?w=0&journal=true",
+      "valid": false,
+      "warning": false,
+      "writeConcern": {
+        "w": 0,
+        "journal": true
+      }
+    }
+  ]
+}

--- a/test/functional/spec/read-write-concern/connection-string/write-concern.yml
+++ b/test/functional/spec/read-write-concern/connection-string/write-concern.yml
@@ -1,0 +1,77 @@
+tests:
+    -
+        description: "Default"
+        uri: "mongodb://localhost/"
+        valid: true
+        warning: false
+        writeConcern: { }
+    -
+        description: "w as a valid number"
+        uri: "mongodb://localhost/?w=1"
+        valid: true
+        warning: false
+        writeConcern: { w: 1 }
+    -
+        description: "w as an invalid number"
+        uri: "mongodb://localhost/?w=-2"
+        valid: false
+        warning: ~
+    -
+        description: "w as a string"
+        uri: "mongodb://localhost/?w=majority"
+        valid: true
+        warning: false
+        writeConcern: { w: "majority" }
+    -
+        description: "wtimeoutMS as a valid number"
+        uri: "mongodb://localhost/?wtimeoutMS=500"
+        valid: true
+        warning: false
+        writeConcern: { wtimeoutMS: 500 }
+    -
+        description: "wtimeoutMS as an invalid number"
+        uri: "mongodb://localhost/?wtimeoutMS=-500"
+        valid: false
+        warning: ~
+    -
+        description: "journal as false"
+        uri: "mongodb://localhost/?journal=false"
+        valid: true
+        warning: false
+        writeConcern: { journal: false }
+    -
+        description: "journal as true"
+        uri: "mongodb://localhost/?journal=true"
+        valid: true
+        warning: false
+        writeConcern: { journal: true }
+    -
+        description: "All options combined"
+        uri: "mongodb://localhost/?w=3&wtimeoutMS=500&journal=true"
+        valid: true
+        warning: false
+        writeConcern: { w: 3, wtimeoutMS: 500, journal: true }
+    -
+        description: "Unacknowledged with w"
+        uri: "mongodb://localhost/?w=0"
+        valid: true
+        warning: false
+        writeConcern: { w: 0 }
+    -
+        description: "Unacknowledged with w and journal"
+        uri: "mongodb://localhost/?w=0&journal=false"
+        valid: true
+        warning: false
+        writeConcern: { w: 0, journal: false }
+    -
+        description: "Unacknowledged with w and wtimeoutMS"
+        uri: "mongodb://localhost/?w=0&wtimeoutMS=500"
+        valid: true
+        warning: false
+        writeConcern: { w: 0, wtimeoutMS: 500 }
+    -
+        description: "Acknowledged with w as 0 and journal true"
+        uri: "mongodb://localhost/?w=0&journal=true"
+        valid: false
+        warning: false
+        writeConcern: { w: 0, journal: true }

--- a/test/functional/spec/read-write-concern/document/read-concern.json
+++ b/test/functional/spec/read-write-concern/document/read-concern.json
@@ -1,0 +1,66 @@
+{
+  "tests": [
+    {
+      "description": "Default",
+      "valid": true,
+      "readConcern": {},
+      "readConcernDocument": {},
+      "isServerDefault": true
+    },
+    {
+      "description": "Majority",
+      "valid": true,
+      "readConcern": {
+        "level": "majority"
+      },
+      "readConcernDocument": {
+        "level": "majority"
+      },
+      "isServerDefault": false
+    },
+    {
+      "description": "Local",
+      "valid": true,
+      "readConcern": {
+        "level": "local"
+      },
+      "readConcernDocument": {
+        "level": "local"
+      },
+      "isServerDefault": false
+    },
+    {
+      "description": "Linearizable",
+      "valid": true,
+      "readConcern": {
+        "level": "linearizable"
+      },
+      "readConcernDocument": {
+        "level": "linearizable"
+      },
+      "isServerDefault": false
+    },
+    {
+      "description": "Snapshot",
+      "valid": true,
+      "readConcern": {
+        "level": "snapshot"
+      },
+      "readConcernDocument": {
+        "level": "snapshot"
+      },
+      "isServerDefault": false
+    },
+    {
+      "description": "Available",
+      "valid": true,
+      "readConcern": {
+        "level": "available"
+      },
+      "readConcernDocument": {
+        "level": "available"
+      },
+      "isServerDefault": false
+    }
+  ]
+}

--- a/test/functional/spec/read-write-concern/document/read-concern.yml
+++ b/test/functional/spec/read-write-concern/document/read-concern.yml
@@ -1,0 +1,37 @@
+tests:
+    -
+        description: "Default"
+        valid: true
+        readConcern: {}
+        readConcernDocument: {}
+        isServerDefault: true
+    - 
+        description: "Majority"
+        valid: true
+        readConcern: { level: "majority" }
+        readConcernDocument: { level: "majority" }
+        isServerDefault: false
+    -
+        description: "Local"
+        valid: true
+        readConcern: { level: "local" }
+        readConcernDocument: { level: "local" }
+        isServerDefault: false
+    -
+        description: "Linearizable"
+        valid: true
+        readConcern: { level: "linearizable" }
+        readConcernDocument: { level: "linearizable" }
+        isServerDefault: false
+    -
+        description: "Snapshot"
+        valid: true
+        readConcern: { level: "snapshot" }
+        readConcernDocument: {level: "snapshot" }
+        isServerDefault: false
+    -
+        description: "Available"
+        valid: true
+        readConcern: { level: "available" }
+        readConcernDocument: { level: "available" }
+        isServerDefault: false

--- a/test/functional/spec/read-write-concern/document/write-concern.json
+++ b/test/functional/spec/read-write-concern/document/write-concern.json
@@ -1,0 +1,174 @@
+{
+  "tests": [
+    {
+      "description": "Default",
+      "valid": true,
+      "writeConcern": {},
+      "writeConcernDocument": {},
+      "isServerDefault": true,
+      "isAcknowledged": true
+    },
+    {
+      "description": "W as a number",
+      "valid": true,
+      "writeConcern": {
+        "w": 3
+      },
+      "writeConcernDocument": {
+        "w": 3
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "W as an invalid number",
+      "valid": false,
+      "writeConcern": {
+        "w": -3
+      },
+      "writeConcernDocument": null,
+      "isServerDefault": null,
+      "isAcknowledged": null
+    },
+    {
+      "description": "W as majority",
+      "valid": true,
+      "writeConcern": {
+        "w": "majority"
+      },
+      "writeConcernDocument": {
+        "w": "majority"
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "W as a custom string",
+      "valid": true,
+      "writeConcern": {
+        "w": "my_mode"
+      },
+      "writeConcernDocument": {
+        "w": "my_mode"
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "WTimeoutMS",
+      "valid": true,
+      "writeConcern": {
+        "wtimeoutMS": 1000
+      },
+      "writeConcernDocument": {
+        "wtimeout": 1000
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "WTimeoutMS as an invalid number",
+      "valid": false,
+      "writeConcern": {
+        "wtimeoutMS": -1000
+      },
+      "writeConcernDocument": null,
+      "isServerDefault": null,
+      "isAcknowledged": null
+    },
+    {
+      "description": "Journal as true",
+      "valid": true,
+      "writeConcern": {
+        "journal": true
+      },
+      "writeConcernDocument": {
+        "j": true
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "Journal as false",
+      "valid": true,
+      "writeConcern": {
+        "journal": false
+      },
+      "writeConcernDocument": {
+        "j": false
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "Unacknowledged with only w",
+      "valid": true,
+      "writeConcern": {
+        "w": 0
+      },
+      "writeConcernDocument": {
+        "w": 0
+      },
+      "isServerDefault": false,
+      "isAcknowledged": false
+    },
+    {
+      "description": "Unacknowledged with wtimeoutMS",
+      "valid": true,
+      "writeConcern": {
+        "w": 0,
+        "wtimeoutMS": 500
+      },
+      "writeConcernDocument": {
+        "w": 0,
+        "wtimeout": 500
+      },
+      "isServerDefault": false,
+      "isAcknowledged": false
+    },
+    {
+      "description": "Unacknowledged with journal",
+      "valid": true,
+      "writeConcern": {
+        "w": 0,
+        "journal": false
+      },
+      "writeConcernDocument": {
+        "w": 0,
+        "j": false
+      },
+      "isServerDefault": false,
+      "isAcknowledged": false
+    },
+    {
+      "description": "W is 0 with journal true",
+      "valid": false,
+      "writeConcern": {
+        "w": 0,
+        "journal": true
+      },
+      "writeConcernDocument": {
+        "w": 0,
+        "j": true
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    },
+    {
+      "description": "Everything",
+      "valid": true,
+      "writeConcern": {
+        "w": 3,
+        "wtimeoutMS": 1000,
+        "journal": true
+      },
+      "writeConcernDocument": {
+        "w": 3,
+        "wtimeout": 1000,
+        "j": true
+      },
+      "isServerDefault": false,
+      "isAcknowledged": true
+    }
+  ]
+}

--- a/test/functional/spec/read-write-concern/document/write-concern.yml
+++ b/test/functional/spec/read-write-concern/document/write-concern.yml
@@ -1,0 +1,99 @@
+tests:
+    -
+        description: "Default"
+        valid: true
+        writeConcern: {}
+        writeConcernDocument: {}
+        isServerDefault: true
+        isAcknowledged: true
+    -
+        description: "W as a number"
+        valid: true
+        writeConcern: { w: 3 }
+        writeConcernDocument: { w: 3 }
+        isServerDefault: false
+        isAcknowledged: true
+    -
+        description: "W as an invalid number"
+        valid: false
+        writeConcern: { w: -3 }
+        writeConcernDocument: ~
+        isServerDefault: ~
+        isAcknowledged: ~
+    -
+        description: "W as majority"
+        valid: true
+        writeConcern: { w: "majority" }
+        writeConcernDocument: { w: "majority" }
+        isServerDefault: false
+        isAcknowledged: true
+    -
+        description: "W as a custom string"
+        valid: true
+        writeConcern: { w: "my_mode" }
+        writeConcernDocument: { w: "my_mode" }
+        isServerDefault: false
+        isAcknowledged: true
+    -
+        description: "WTimeoutMS"
+        valid: true
+        writeConcern: { wtimeoutMS: 1000 }
+        writeConcernDocument: { wtimeout: 1000 }
+        isServerDefault: false
+        isAcknowledged: true
+    -
+        description: "WTimeoutMS as an invalid number"
+        valid: false
+        writeConcern: { wtimeoutMS: -1000 }
+        writeConcernDocument: ~
+        isServerDefault: ~
+        isAcknowledged: ~
+    -
+        description: "Journal as true"
+        valid: true
+        writeConcern: { journal: true }
+        writeConcernDocument: { j: true }
+        isServerDefault: false
+        isAcknowledged: true
+    -
+        description: "Journal as false"
+        valid: true
+        writeConcern: { journal: false }
+        writeConcernDocument: { j: false }
+        isServerDefault: false
+        isAcknowledged: true
+    -
+        description: "Unacknowledged with only w"
+        valid: true
+        writeConcern: { w: 0 }
+        writeConcernDocument: { w: 0 }
+        isServerDefault: false
+        isAcknowledged: false
+    -
+        description: "Unacknowledged with wtimeoutMS"
+        valid: true
+        writeConcern: { w: 0, wtimeoutMS: 500 }
+        writeConcernDocument: { w: 0, wtimeout: 500 }
+        isServerDefault: false
+        isAcknowledged: false
+    -
+        description: "Unacknowledged with journal"
+        valid: true
+        writeConcern: { w: 0, journal: false }
+        writeConcernDocument: { w: 0, j: false }
+        isServerDefault: false
+        isAcknowledged: false
+    -
+        description: "W is 0 with journal true"
+        valid: false
+        writeConcern: { w: 0, journal: true }
+        writeConcernDocument: { w: 0, j: true }
+        isServerDefault: false
+        isAcknowledged: true
+    -
+        description: "Everything"
+        valid: true
+        writeConcern: { w: 3, wtimeoutMS: 1000, journal: true }
+        writeConcernDocument: { w: 3, wtimeout: 1000, j: true }
+        isServerDefault: false
+        isAcknowledged: true


### PR DESCRIPTION
## Description

**What changed?**
I added a runner for the read/write concern spec tests. I also updated the uri_parser to ensure it throws errors for invalid write concerns. This was present in the old url_parser, but seems to have been missed in the new core/uri_parser. I also changed `mongoclient.s.writeConcern` to be constructed from either the `options` object or the provided `url`.

**Are there any files to ignore?**
No.