### PR TITLE
fix(change-stream): default to server default batch size

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -367,10 +367,9 @@ function createChangeStreamCursor(self, options) {
 
   const pipeline = [{ $changeStream: changeStreamStageOptions }].concat(self.pipeline);
   const cursorOptions = applyKnownOptions({}, options, CURSOR_OPTIONS);
-  const changeStreamOptions = Object.assign({ batchSize: 1 }, options);
   const changeStreamCursor = new ChangeStreamCursor(
     self.topology,
-    new AggregateOperation(self.parent, pipeline, changeStreamOptions),
+    new AggregateOperation(self.parent, pipeline, options),
     cursorOptions
   );
 

--- a/test/functional/change_stream_tests.js
+++ b/test/functional/change_stream_tests.js
@@ -543,7 +543,9 @@ describe('Change Streams', function() {
         assert.ifError(err);
 
         var database = client.db('integration_tests');
-        var changeStream = database.collection('invalidateListeners').watch(pipeline);
+        var changeStream = database
+          .collection('invalidateListeners')
+          .watch(pipeline, { batchSize: 1 });
 
         // Attach first event listener
         changeStream.once('change', function(change) {


### PR DESCRIPTION
We should not default our change streams to a batch size of one,
but rather send no value and accept the server default.

NODE-2137
