### PR TITLE
doc: clarify where to pass `useUnifiedTopology: true`

### DIFF
--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -242,7 +242,7 @@ function collectEvents(mongoClient, topology) {
 }
 
 const emitDeprecationForNonUnifiedTopology = deprecate(() => {},
-'current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. ' + 'To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to MongoClient.connect.');
+'current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. ' + 'To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.');
 
 function connect(mongoClient, url, options, callback) {
   options = Object.assign({}, options);


### PR DESCRIPTION
The current deprecation warning tells users to pass this value to
`MongoClient.connect`, which is the static method on the client
class. This can be confusing to users, as they might assume that
the value should be passed to the `connect` method on the client
instance. Instead, we should guide users to pass the option to
the `MongoClient` constructor.

NODE-2138
