### PR TITLE
fix(execute-operation): return promise on session support check

### DIFF
--- a/lib/operations/execute_operation.js
+++ b/lib/operations/execute_operation.js
@@ -35,18 +35,7 @@ function executeOperation(topology, operation, callback) {
     !operation.hasAspect(Aspect.SKIP_SESSION) &&
     topology.shouldCheckForSessionSupport()
   ) {
-    // TODO: this is only supported for unified topology, the first part of this check
-    //       should go away when we drop legacy topology types.
-    topology.selectServer(ReadPreference.primaryPreferred, err => {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      executeOperation(topology, operation, callback);
-    });
-
-    return;
+    return selectServerForSessionSupport(topology, operation, callback);
   }
 
   const Promise = topology.s.promiseLibrary;
@@ -177,6 +166,33 @@ function executeWithServerSelection(topology, operation, callback) {
 
     operation.execute(server, callback);
   });
+}
+
+// TODO: This is only supported for unified topology, it should go away once
+//       we remove support for legacy topology types.
+function selectServerForSessionSupport(topology, operation, callback) {
+  const Promise = topology.s.promiseLibrary;
+
+  let result;
+  if (typeof callback !== 'function') {
+    result = new Promise((resolve, reject) => {
+      callback = (err, result) => {
+        if (err) return reject(err);
+        resolve(result);
+      };
+    });
+  }
+
+  topology.selectServer(ReadPreference.primaryPreferred, err => {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    executeOperation(topology, operation, callback);
+  });
+
+  return result;
 }
 
 module.exports = executeOperation;


### PR DESCRIPTION
3.3.0 introduced an extra roundtrip of selection in order to
accurately determine if sessions were supported by the topology.
Unfortunately, the fix only supported callbacks. So, if a server
wasn't actually available immediately, we would return `undefined`
in cases when promises were requested for operation execution.

NODE-2136