### PR TITLE
default useNewUrlParser to true

### DIFF
--- a/lib/core/uri_parser.js
+++ b/lib/core/uri_parser.js
@@ -534,6 +534,10 @@ function parseConnectionString(uri, options, callback) {
     if (parsedOptions.auth.username) auth.username = parsedOptions.auth.username;
     if (parsedOptions.auth.user) auth.username = parsedOptions.auth.user;
     if (parsedOptions.auth.password) auth.password = parsedOptions.auth.password;
+  } else {
+    if (parsedOptions.username) auth.username = parsedOptions.username;
+    if (parsedOptions.user) auth.username = parsedOptions.user;
+    if (parsedOptions.password) auth.password = parsedOptions.password;
   }
 
   if (cap[4].split('?')[0].indexOf('@') !== -1) {
@@ -551,8 +555,8 @@ function parseConnectionString(uri, options, callback) {
       return callback(new MongoParseError('Unescaped colon in authority section'));
     }
 
-    auth.username = qs.unescape(authParts[0]);
-    auth.password = authParts[1] ? qs.unescape(authParts[1]) : null;
+    if (!auth.username) auth.username = qs.unescape(authParts[0]);
+    if (!auth.password) auth.password = authParts[1] ? qs.unescape(authParts[1]) : null;
   }
 
   let hostParsingError = null;

--- a/lib/core/uri_parser.js
+++ b/lib/core/uri_parser.js
@@ -621,6 +621,8 @@ function parseConnectionString(uri, options, callback) {
 
   if (result.auth && result.auth.db) {
     result.defaultDatabase = result.auth.db;
+  } else {
+    result.defaultDatabase = 'test';
   }
 
   try {

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -140,7 +140,7 @@ const CloseOperation = require('./operations/close');
  * @param {boolean} [options.auto_reconnect=true] Enable auto reconnecting for single server instances
  * @param {boolean} [options.monitorCommands=false] Enable command monitoring for this client
  * @param {number} [options.minSize] If present, the connection pool will be initialized with minSize connections, and will never dip below minSize connections
- * @param {boolean} [options.useNewUrlParser=false] Determines whether or not to use the new url parser. Enables the new, spec-compliant, url parser shipped in the core driver. This url parser fixes a number of problems with the original parser, and aims to outright replace that parser in the near future.
+ * @param {boolean} [options.useNewUrlParser=true] Determines whether or not to use the new url parser. Enables the new, spec-compliant, url parser shipped in the core driver. This url parser fixes a number of problems with the original parser, and aims to outright replace that parser in the near future. Defaults to true, and must be explicitly set to false to use the legacy url parser.
  * @param {boolean} [options.useUnifiedTopology] Enables the new unified topology layer
  * @param {AutoEncryptionOptions} [options.autoEncryption] Optionally enable client side auto encryption
  * @param {MongoClient~connectCallback} [callback] The command result callback

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -280,6 +280,7 @@ function connect(mongoClient, url, options, callback) {
     if (_finalOptions.connectTimeoutMS == null) _finalOptions.connectTimeoutMS = 30000;
     if (_finalOptions.retryWrites == null) _finalOptions.retryWrites = true;
     if (_finalOptions.useRecoveryToken == null) _finalOptions.useRecoveryToken = true;
+    if (_finalOptions.readPreference == null) _finalOptions.readPreference = 'primary';
 
     if (_finalOptions.db_options && _finalOptions.db_options.auth) {
       delete _finalOptions.db_options.auth;

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -260,8 +260,10 @@ function connect(mongoClient, url, options, callback) {
     return connectWithUrl(mongoClient, url, options, connectCallback);
   }
 
-  const parseFn = options.useNewUrlParser ? parse : legacyParse;
-  const transform = options.useNewUrlParser ? transformUrlOptions : legacyTransformUrlOptions;
+  const useNewUrlParser = options.useNewUrlParser !== false;
+
+  const parseFn = useNewUrlParser ? parse : legacyParse;
+  const transform = useNewUrlParser ? transformUrlOptions : legacyTransformUrlOptions;
 
   parseFn(url, options, (err, _object) => {
     // Do not attempt to connect if parsing error
@@ -650,16 +652,16 @@ function transformUrlOptions(_object) {
     object.dbName = _object.defaultDatabase;
   }
 
-  if (object.maxpoolsize) {
-    object.poolSize = object.maxpoolsize;
+  if (object.maxPoolSize) {
+    object.poolSize = object.maxPoolSize;
   }
 
-  if (object.readconcernlevel) {
-    object.readConcern = new ReadConcern(object.readconcernlevel);
+  if (object.readConcernLevel) {
+    object.readConcern = new ReadConcern(object.readConcernLevel);
   }
 
-  if (object.wtimeoutms) {
-    object.wtimeout = object.wtimeoutms;
+  if (object.wTimeoutMS) {
+    object.wtimeout = object.wTimeoutMS;
   }
 
   if (_object.srvHost) {

--- a/test/functional/mongo_client_tests.js
+++ b/test/functional/mongo_client_tests.js
@@ -435,7 +435,7 @@ describe('MongoClient', function() {
       const client = configuration.newClient('user:password@localhost:27017/test');
 
       client.connect(function(err) {
-        test.equal(err.message, 'Invalid schema, expected `mongodb` or `mongodb+srv`');
+        expect(err).to.exist.and.to.have.property('message', 'Invalid connection string');
         done();
       });
     }


### PR DESCRIPTION
## Description

Defaults useNewUrlParser to true, and patches any bugs that result from that

**What changed?**
A few things:

- We were previously expecting some parsed options to come back in lowercase, when they were actually coming back in camelCase. So in `lib/operations/connect.js` we now check for the camelCase fields
- we set a default readPreference of `primary` if no readPreference is parsed out.
- We always return a `defaultDatabase` from the url parser. If we do not get it from the auth object, we set the value to `test`. **Appreciate Scrutiny here**
- We change the rules for parsing auth fields like `username` and `password`. **Appreciate Scrutiny here**

**Are there any files to ignore?**
- `lib/mongo_client.js`: doc changes
- `test/functional/mongo_client_tests.js`: minor test output change

Replaces #2057 