### PR TITLE
fix(sessions): wait for `abortTransaction` before calling back

### DIFF
--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -115,24 +115,34 @@ class ClientSession extends EventEmitter {
     options = options || {};
 
     if (this.hasEnded) {
-      if (typeof callback === 'function') callback(null, null);
+      if (typeof callback === 'function') {
+        callback(null, null);
+      }
+
       return;
     }
 
+    const completeEndSession = () => {
+      // mark the session as ended, and emit a signal
+      this.hasEnded = true;
+      this.emit('ended', this);
+
+      // release the server session back to the pool
+      this.sessionPool.release(this.serverSession);
+      this.serverSession = null;
+
+      // spec indicates that we should ignore all errors for `endSessions`
+      if (typeof callback === 'function') {
+        callback(null, null);
+      }
+    };
+
     if (this.serverSession && this.inTransaction()) {
-      this.abortTransaction(); // pass in callback?
+      this.abortTransaction(completeEndSession);
+      return;
     }
 
-    // mark the session as ended, and emit a signal
-    this.hasEnded = true;
-    this.emit('ended', this);
-
-    // release the server session back to the pool
-    this.sessionPool.release(this.serverSession);
-    this.serverSession = null;
-
-    // spec indicates that we should ignore all errors for `endSessions`
-    if (typeof callback === 'function') callback(null, null);
+    completeEndSession();
   }
 
   /**

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -114,12 +114,19 @@ class ClientSession extends EventEmitter {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    if (this.hasEnded) {
-      if (typeof callback === 'function') {
-        callback(null, null);
-      }
+    let result;
+    if (typeof callback !== 'function') {
+      result = new Promise((resolve, reject) => {
+        callback = (err, res) => {
+          if (err) return reject(err);
+          resolve(res);
+        };
+      });
+    }
 
-      return;
+    if (this.hasEnded) {
+      callback(null, null);
+      return result;
     }
 
     const completeEndSession = () => {
@@ -132,17 +139,16 @@ class ClientSession extends EventEmitter {
       this.serverSession = null;
 
       // spec indicates that we should ignore all errors for `endSessions`
-      if (typeof callback === 'function') {
-        callback(null, null);
-      }
+      callback(null, null);
     };
 
     if (this.serverSession && this.inTransaction()) {
       this.abortTransaction(completeEndSession);
-      return;
+    } else {
+      completeEndSession();
     }
 
-    completeEndSession();
+    return result;
   }
 
   /**

--- a/test/functional/sessions_tests.js
+++ b/test/functional/sessions_tests.js
@@ -56,6 +56,20 @@ describe('Sessions', function() {
     }
   });
 
+  it('endSession should return a Promise if no callback is provided', {
+    metadata: {
+      requires: { topology: ['replicaset'], mongodb: '>3.6.0' }
+    },
+
+    test: function() {
+      const client = test.client;
+      let session = client.startSession();
+      const promise = session.endSession();
+      expect(promise).to.be.instanceOf(Promise);
+      return promise.then(() => client.close());
+    }
+  });
+
   describe('withSession', {
     metadata: { requires: { mongodb: '>3.6.0' } },
     test: function() {


### PR DESCRIPTION
`Session.endSession` will implicitly call `abortTransaction` if one
is running when the method is called. We neglected to wait for the
result of the async method when returning, now we do.

NODE-2152