### PR TITLE
docs(replaceOne): documents replaceOne response

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -667,7 +667,7 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @property {Object} upsertedId The upserted id.
  * @property {ObjectId} upsertedId._id The upserted _id returned from the server.
  * @property {Object} message
- * @property {Array} ops
+ * @property {object[]} [ops] In a response to {@link Collection#replaceOne replaceOne}, contains the new value of the document on the server. This is the same document that was originally passed in, and is only here for legacy purposes.
  */
 
 /**
@@ -729,7 +729,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
- * @return {Promise<Collection~updatewriteOpResultObject>} returns Promise if no callback passed
+ * @return {Promise<Collection~updateWriteOpResult>} returns Promise if no callback passed
  */
 Collection.prototype.replaceOne = function(filter, doc, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
@@ -759,7 +759,7 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
- * @return {Promise<Collection~updateWriteOpResultObject>} returns Promise if no callback passed
+ * @return {Promise<Collection~updateWriteOpResult>} returns Promise if no callback passed
  */
 Collection.prototype.updateMany = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});

--- a/lib/operations/replace_one.js
+++ b/lib/operations/replace_one.js
@@ -40,7 +40,7 @@ function replaceCallback(err, r, doc, callback) {
     Array.isArray(r.result.upserted) && r.result.upserted.length ? r.result.upserted.length : 0;
   r.matchedCount =
     Array.isArray(r.result.upserted) && r.result.upserted.length > 0 ? 0 : r.result.n;
-  r.ops = [doc];
+  r.ops = [doc]; // TODO: Should we still have this?
   if (callback) callback(null, r);
 }
 


### PR DESCRIPTION
Fixes NODE-1991

## Description

**What changed?**
- Added docs for the `ops` array.
- Added a note that we might not want to have the `ops` array anymore
- Fixed some broken jsdoc links.

**Are there any files to ignore?**
No