### PR TITLE
docs(batchSize): add documentation links for batchSize

### DIFF
--- a/lib/aggregation_cursor.js
+++ b/lib/aggregation_cursor.js
@@ -61,7 +61,7 @@ class AggregationCursor extends Cursor {
   /**
    * Set the batch size for the cursor.
    * @method
-   * @param {number} value The batchSize for the cursor.
+   * @param {number} value The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
    * @throws {MongoError}
    * @return {AggregationCursor}
    */

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -39,7 +39,7 @@ const CHANGE_DOMAIN_TYPES = {
  * @property {ResumeToken} [resumeAfter] Allows you to start a changeStream after a specified event. See {@link https://docs.mongodb.com/master/changeStreams/#resumeafter-for-change-streams|ChangeStream documentation}.
  * @property {ResumeToken} [startAfter] Similar to resumeAfter, but will allow you to start after an invalidated event. See {@link https://docs.mongodb.com/master/changeStreams/#startafter-for-change-streams|ChangeStream documentation}.
  * @property {OperationTime} [startAtOperationTime] Will start the changeStream after the specified operationTime.
- * @property {number} [batchSize] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
+ * @property {number} [batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @property {object} [collation] Specify collation settings for operation. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @property {ReadPreference} [readPreference] The read preference. Defaults to the read preference of the database or collection. See {@link https://docs.mongodb.com/manual/reference/read-preference|read preference documentation}.
  */

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -260,7 +260,7 @@ const DEPRECATED_FIND_OPTIONS = ['maxScan', 'fields', 'snapshot'];
  * @param {boolean} [options.snapshot=false] DEPRECATED: Snapshot query.
  * @param {boolean} [options.timeout=false] Specify if the cursor can timeout.
  * @param {boolean} [options.tailable=false] Specify if the cursor is tailable.
- * @param {number} [options.batchSize=0] Set the batchSize for the getMoreCommand when iterating over the query results.
+ * @param {number} [options.batchSize=1000] Set the batchSize for the getMoreCommand when iterating over the query results.
  * @param {boolean} [options.returnKey=false] Only return the index key.
  * @param {number} [options.maxScan] DEPRECATED: Limit the number of items to scan.
  * @param {number} [options.min] Set index bounds.
@@ -985,7 +985,7 @@ Collection.prototype.save = deprecate(function(doc, options, callback) {
  * @param {boolean} [options.snapshot=false] DEPRECATED: Snapshot query.
  * @param {boolean} [options.timeout=false] Specify if the cursor can timeout.
  * @param {boolean} [options.tailable=false] Specify if the cursor is tailable.
- * @param {number} [options.batchSize=0] Set the batchSize for the getMoreCommand when iterating over the query results.
+ * @param {number} [options.batchSize=1] Set the batchSize for the getMoreCommand when iterating over the query results.
  * @param {boolean} [options.returnKey=false] Only return the index key.
  * @param {number} [options.maxScan] DEPRECATED: Limit the number of items to scan.
  * @param {number} [options.min] Set index bounds.
@@ -1302,7 +1302,7 @@ Collection.prototype.reIndex = function(options, callback) {
  *
  * @method
  * @param {object} [options] Optional settings.
- * @param {number} [options.batchSize] The batchSize for the returned command cursor or if pre 2.8 the systems batch collection
+ * @param {number} [options.batchSize=1000] The batchSize for the returned command cursor or if pre 2.8 the systems batch collection
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {CommandCursor}
@@ -1762,7 +1762,7 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
  * @param {object} [options] Optional settings.
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  * @param {object} [options.cursor] Return the query as cursor, on 2.6 > it returns as a real cursor on pre 2.6 it returns as an emulated cursor.
- * @param {number} [options.cursor.batchSize] The batchSize for the cursor
+ * @param {number} [options.cursor.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {boolean} [options.explain=false] Explain returns the aggregation execution plan (requires mongodb 2.6 >).
  * @param {boolean} [options.allowDiskUse=false] allowDiskUse lets the server know if it can use disk to store temporary results for the aggregation (requires mongodb 2.6 >).
  * @param {number} [options.maxTimeMS] maxTimeMS specifies a cumulative time limit in milliseconds for processing operations on the cursor. MongoDB interrupts the operation at the earliest following interrupt point.
@@ -1838,7 +1838,7 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
  * @param {string} [options.fullDocument='default'] Allowed values: ‘default’, ‘updateLookup’. When set to ‘updateLookup’, the change stream will include both a delta describing the changes to the document, as well as a copy of the entire document that was changed from some time after the change occurred.
  * @param {object} [options.resumeAfter] Specifies the logical starting point for the new change stream. This should be the _id field from a previously returned change stream document.
  * @param {number} [options.maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a change stream query
- * @param {number} [options.batchSize] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
+ * @param {number} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {object} [options.collation] Specify collation settings for operation. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {ReadPreference} [options.readPreference] The read preference. Defaults to the read preference of the database or collection. See {@link https://docs.mongodb.com/manual/reference/read-preference|read preference documentation}.
  * @param {Timestamp} [options.startAtOperationTime] receive change events that occur after the specified timestamp
@@ -1871,7 +1871,7 @@ Collection.prototype.watch = function(pipeline, options) {
  * @method
  * @param {object} [options] Optional settings.
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
- * @param {number} [options.batchSize] Set the batchSize for the getMoreCommand when iterating over the query results.
+ * @param {number} [options.batchSize=1000] Set the batchSize for the getMoreCommand when iterating over the query results.
  * @param {number} [options.numCursors=1] The maximum number of parallel command cursors to return (the number of returned cursors will be in the range 1:numCursors)
  * @param {boolean} [options.raw=false] Return all BSON documents as Raw Buffer documents.
  * @param {Collection~parallelCollectionScanCallback} [callback] The command result callback

--- a/lib/command_cursor.js
+++ b/lib/command_cursor.js
@@ -90,7 +90,7 @@ class CommandCursor extends Cursor {
   /**
    * Set the batch size for the cursor.
    * @method
-   * @param {number} value The batchSize for the cursor.
+   * @param {number} value The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find/|find documentation}.
    * @throws {MongoError}
    * @return {CommandCursor}
    */

--- a/lib/command_cursor.js
+++ b/lib/command_cursor.js
@@ -90,7 +90,7 @@ class CommandCursor extends Cursor {
   /**
    * Set the batch size for the cursor.
    * @method
-   * @param {number} value The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find/|find documentation}.
+   * @param {number} value The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find/|find command documentation}.
    * @throws {MongoError}
    * @return {CommandCursor}
    */

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -68,7 +68,7 @@ class CoreCursor extends Readable {
    * @param {string} ns The MongoDB fully qualified namespace (ex: db1.collection1)
    * @param {{object}|Long} cmd The selector (can be a command or a cursorId)
    * @param {object} [options=null] Optional settings.
-   * @param {object} [options.batchSize=1000] Batchsize for the operation
+   * @param {object} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find/| find documentation} and {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
    * @param {array} [options.documents=[]] Initial documents list for cursor
    * @param {object} [options.transforms=null] Transform methods for the cursor results
    * @param {function} [options.transforms.query] Transform the value returned from the initial query

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -68,7 +68,7 @@ class CoreCursor extends Readable {
    * @param {string} ns The MongoDB fully qualified namespace (ex: db1.collection1)
    * @param {{object}|Long} cmd The selector (can be a command or a cursorId)
    * @param {object} [options=null] Optional settings.
-   * @param {object} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find/| find documentation} and {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
+   * @param {object} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find/| find command documentation} and {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
    * @param {array} [options.documents=[]] Initial documents list for cursor
    * @param {object} [options.transforms=null] Transform methods for the cursor results
    * @param {function} [options.transforms.query] Transform the value returned from the initial query

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -543,7 +543,7 @@ class Cursor extends CoreCursor {
   /**
    * Set the batch size for the cursor.
    * @method
-   * @param {number} value The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find/|find documentation}.
+   * @param {number} value The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find/|find command documentation}.
    * @throws {MongoError}
    * @return {Cursor}
    */

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -543,7 +543,7 @@ class Cursor extends CoreCursor {
   /**
    * Set the batch size for the cursor.
    * @method
-   * @param {number} value The batchSize for the cursor.
+   * @param {number} value The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find/|find documentation}.
    * @throws {MongoError}
    * @return {Cursor}
    */

--- a/lib/db.js
+++ b/lib/db.js
@@ -302,7 +302,7 @@ Db.prototype.command = function(command, options, callback) {
  * @param {object} [options] Optional settings.
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  * @param {object} [options.cursor] Return the query as cursor, on 2.6 > it returns as a real cursor on pre 2.6 it returns as an emulated cursor.
- * @param {number} [options.cursor.batchSize] The batchSize for the cursor
+ * @param {number} [options.cursor.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {boolean} [options.explain=false] Explain returns the aggregation execution plan (requires mongodb 2.6 >).
  * @param {boolean} [options.allowDiskUse=false] allowDiskUse lets the server know if it can use disk to store temporary results for the aggregation (requires mongodb 2.6 >).
  * @param {number} [options.maxTimeMS] maxTimeMS specifies a cumulative time limit in milliseconds for processing operations on the cursor. MongoDB interrupts the operation at the earliest following interrupt point.
@@ -563,7 +563,7 @@ Db.prototype.stats = function(options, callback) {
  * @param {object} [filter={}] Query to filter collections by
  * @param {object} [options] Optional settings.
  * @param {boolean} [options.nameOnly=false] Since 4.0: If true, will only return the collection name in the response, and will omit additional info
- * @param {number} [options.batchSize] The batchSize for the returned command cursor or if pre 2.8 the systems batch collection
+ * @param {number} [options.batchSize=1000] The batchSize for the returned command cursor or if pre 2.8 the systems batch collection
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {CommandCursor}
@@ -930,7 +930,7 @@ Db.prototype.unref = function() {
  * @param {string} [options.fullDocument='default'] Allowed values: ‘default’, ‘updateLookup’. When set to ‘updateLookup’, the change stream will include both a delta describing the changes to the document, as well as a copy of the entire document that was changed from some time after the change occurred.
  * @param {object} [options.resumeAfter] Specifies the logical starting point for the new change stream. This should be the _id field from a previously returned change stream document.
  * @param {number} [options.maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a change stream query
- * @param {number} [options.batchSize] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
+ * @param {number} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {object} [options.collation] Specify collation settings for operation. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {ReadPreference} [options.readPreference] The read preference. Defaults to the read preference of the database. See {@link https://docs.mongodb.com/manual/reference/read-preference|read preference documentation}.
  * @param {Timestamp} [options.startAtOperationTime] receive change events that occur after the specified timestamp

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -198,7 +198,7 @@ function _delete(_this, id, callback) {
  * @method
  * @param {Object} filter
  * @param {Object} [options] Optional settings for cursor
- * @param {number} [options.batchSize] Optional batch size for cursor
+ * @param {number} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find|find documentation}.
  * @param {number} [options.limit] Optional limit for cursor
  * @param {number} [options.maxTimeMS] Optional maxTimeMS for cursor
  * @param {boolean} [options.noCursorTimeout] Optionally set cursor's `noCursorTimeout` flag

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -198,7 +198,7 @@ function _delete(_this, id, callback) {
  * @method
  * @param {Object} filter
  * @param {Object} [options] Optional settings for cursor
- * @param {number} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find|find documentation}.
+ * @param {number} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/find|find command documentation}.
  * @param {number} [options.limit] Optional limit for cursor
  * @param {number} [options.maxTimeMS] Optional maxTimeMS for cursor
  * @param {boolean} [options.noCursorTimeout] Optionally set cursor's `noCursorTimeout` flag

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -446,7 +446,7 @@ MongoClient.prototype.withSession = function(options, operation) {
  * @param {string} [options.fullDocument='default'] Allowed values: ‘default’, ‘updateLookup’. When set to ‘updateLookup’, the change stream will include both a delta describing the changes to the document, as well as a copy of the entire document that was changed from some time after the change occurred.
  * @param {object} [options.resumeAfter] Specifies the logical starting point for the new change stream. This should be the _id field from a previously returned change stream document.
  * @param {number} [options.maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a change stream query
- * @param {number} [options.batchSize] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
+ * @param {number} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {object} [options.collation] Specify collation settings for operation. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {ReadPreference} [options.readPreference] The read preference. See {@link https://docs.mongodb.com/manual/reference/read-preference|read preference documentation}.
  * @param {Timestamp} [options.startAtOperationTime] receive change events that occur after the specified timestamp


### PR DESCRIPTION
Add links to our documentation on batchSize in locations where
batchSize can be specified.

Fixes NODE-1967
Fixes NODE-1987

**Are there any files to ignore?**
No
