### PR TITLE
docs(links): do not link to java docs

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -19,7 +19,7 @@ To run the server call the hugo command:
 | Options explained           ||
 | --------------------------- |--------------------------------------------------------------------------|
 | server                      | Hugo runs its own webserver to render the files                          |
-| --baseUrl=http://localhost/ | Normally the base url will be /mongo-java-driver for gh-pages            |
+| --baseUrl=http://localhost/ | Normally the base url will be /node-mongodb-native for gh-pages            |
 | --buildDrafts               | Include draft posts in the output - these won't be published to gh-pages |
 | -- watch                    | Automatically reloads on file change                                     |
 

--- a/docs/reference/static/js/java.js
+++ b/docs/reference/static/js/java.js
@@ -13,7 +13,7 @@ jQuery(document).ready(function(){
   jQuery.getJSON(DOCUMENTATION_OPTIONS.URL_ROOT + "/../versions.json").done(function( data ) {
 
     $.each(data, function( index, value ) {
-      var versionUrl = "//mongodb.github.io/mongo-java-driver/" + value.version;
+      var versionUrl = "//mongodb.github.io/node-mongodb-native/" + value.version;
       var liClass = DOCUMENTATION_OPTIONS.VERSION ==  value.version ? ' class="active"' : '';
       jQuery("#optionsVersionsMenu").append('<li'+liClass+'><a href="'+ versionUrl +'" data-path="manual">'+ value.version +'</a></li>');
     });

--- a/docs/reference/themes/mongodb/README.md
+++ b/docs/reference/themes/mongodb/README.md
@@ -22,7 +22,7 @@ To run the server call the hugo command:
 | Options explained           ||
 | --------------------------- |--------------------------------------------------------------------------|
 | server                      | Hugo runs its own webserver to render the files                          |
-| --baseUrl=http://localhost/ | Normally the base url will be /mongo-java-driver for gh-pages            |
+| --baseUrl=http://localhost/ | Normally the base url will be /node-mongodb-native for gh-pages            |
 | --buildDrafts               | Include draft posts in the output - these won't be published to gh-pages |
 | -- watch                    | Automatically reloads on file change                                     |
 

--- a/docs/reference/themes/mongodb/theme.toml
+++ b/docs/reference/themes/mongodb/theme.toml
@@ -2,11 +2,11 @@ name = "MongoDB"
 license = "Creative Commons Attribution NonCommercial ShareAlike 3.0 Unported"
 licenselink = "http://creativecommons.org/licenses/by-nc-sa/3.0/"
 description = "A standalone mongodb docs theme, for individual driver homepages"
-homepage = "http://mongodb.github.io/mongo-java-driver"
+homepage = "http://mongodb.github.io/node-mongodb-native"
 
 [author]
   name = "MongoDB Java driver authors"
-  homepage = "http://mongodb.github.io/mongo-java-driver"
+  homepage = "http://mongodb.github.io/node-mongodb-native"
 
 [original]
   name = "MongoDB Docs"


### PR DESCRIPTION
Fixes NODE-1818

## Description

**What changed?**

**Are there any files to ignore?**
