### PR TITLE
chore(pool): s/passPhrase/passphrase/

### DIFF
--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -60,7 +60,7 @@ var _id = 0;
  * @param {Buffer} [options.crl] SSL Certificate revocation store binary buffer
  * @param {Buffer} [options.cert] SSL Certificate binary buffer
  * @param {Buffer} [options.key] SSL Key file binary buffer
- * @param {string} [options.passPhrase] SSL Certificate pass phrase
+ * @param {string} [options.passphrase] SSL Certificate pass phrase
  * @param {boolean} [options.rejectUnauthorized=false] Reject unauthorized server certificates
  * @param {boolean} [options.promoteLongs=true] Convert Long values from the db into Numbers if they fit into 53 bits
  * @param {boolean} [options.promoteValues=true] Promotes BSON values to native types where possible, set to false to only receive wrapper types.
@@ -103,7 +103,7 @@ var Pool = function(topology, options) {
       crl: null,
       cert: null,
       key: null,
-      passPhrase: null,
+      passphrase: null,
       rejectUnauthorized: false,
       promoteLongs: true,
       promoteValues: true,


### PR DESCRIPTION
We're actually using "passphrase" and not "passPhrase", so we are
updating the docs and default value to reflect this.

Fixes NODE-1762

**Are there any files to ignore?**
No
