### PR TITLE
docs(BulkWrite): adds documentation to BulkWrite

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -55,60 +55,69 @@ class Batch {
 }
 
 /**
- * Create a new BulkWriteResult instance (INTERNAL TYPE, do not instantiate directly)
- *
- * @class
- * @return {BulkWriteResult} a BulkWriteResult instance
+ * @classdesc
+ * The result of a bulk write.
  */
 class BulkWriteResult {
+  /**
+   * Create a new BulkWriteResult instance (INTERNAL TYPE, do not instantiate directly)
+   *
+   * @class
+   */
   constructor(bulkResult) {
     this.result = bulkResult;
   }
 
   /**
-   * @return {boolean} ok Did bulk operation correctly execute
+   * Is true if the bulk operation correctly execute
+   * @type {boolean}
    */
   get ok() {
     return this.result.ok;
   }
 
   /**
-   * @return {number} nInserted number of inserted documents
+   * The number of inserted documents
+   * @type {number}
    */
   get nInserted() {
     return this.result.nInserted;
   }
 
   /**
-   * @return {number} nUpserted Number of upserted documents
+   * Number of upserted documents
+   * @type {number}
    */
   get nUpserted() {
     return this.result.nUpserted;
   }
 
   /**
-   * @return {number} nMatched Number of matched documents
+   * Number of matched documents
+   * @type {number}
    */
   get nMatched() {
     return this.result.nMatched;
   }
 
   /**
-   * @return {number} nModified Number of documents updated physically on disk
+   * Number of documents updated physically on disk
+   * @type {number}
    */
   get nModified() {
     return this.result.nModified;
   }
 
   /**
-   * @return {number} nRemoved Number of removed documents
+   * Number of removed documents
+   * @type {number}
    */
   get nRemoved() {
     return this.result.nRemoved;
   }
 
   /**
-   * Return an array of inserted ids
+   * Returns an array of all inserted ids
    *
    * @return {object[]}
    */
@@ -117,7 +126,7 @@ class BulkWriteResult {
   }
 
   /**
-   * Return an array of upserted ids
+   * Returns an array of all upserted ids
    *
    * @return {object[]}
    */
@@ -126,7 +135,7 @@ class BulkWriteResult {
   }
 
   /**
-   * Return the upserted id at position x
+   * Returns the upserted id at the given index
    *
    * @param {number} index the number of the upserted id to return, returns undefined if no result for passed in index
    * @return {object}
@@ -136,7 +145,7 @@ class BulkWriteResult {
   }
 
   /**
-   * Return raw internal result
+   * Returns raw internal result
    *
    * @return {object}
    */
@@ -178,7 +187,7 @@ class BulkWriteResult {
   /**
    * Retrieve all write errors
    *
-   * @return {object[]}
+   * @return {WriteError[]}
    */
   getWriteErrors() {
     return this.result.writeErrors;
@@ -220,7 +229,7 @@ class BulkWriteResult {
   }
 
   /**
-   * @return {BulkWriteResult} a BulkWriteResult instance
+   * @return {object}
    */
   toJSON() {
     return this.result;
@@ -242,25 +251,30 @@ class BulkWriteResult {
 }
 
 /**
- * Create a new WriteConcernError instance (INTERNAL TYPE, do not instantiate directly)
- *
- * @class
- * @return {WriteConcernError} a WriteConcernError instance
+ * @classdesc An error representing a failure by the server to apply the requested write concern to the bulk operation.
  */
 class WriteConcernError {
+  /**
+   * Create a new WriteConcernError instance (INTERNAL TYPE, do not instantiate directly)
+   *
+   * @class
+   * @return {WriteConcernError} a WriteConcernError instance
+   */
   constructor(err) {
     this.err = err;
   }
 
   /**
-   * @return {number} code Write concern error code.
+   * Write concern error code.
+   * @type {number}
    */
   get code() {
     return this.err.code;
   }
 
   /**
-   * @return {string} errmsg Write concern error message.
+   * Write concern error message.
+   * @type {string}
    */
   get errmsg() {
     return this.err.errmsg;
@@ -282,39 +296,44 @@ class WriteConcernError {
 }
 
 /**
- * Create a new WriteError instance (INTERNAL TYPE, do not instantiate directly)
- *
- * @class
- * @return {WriteConcernError} a WriteConcernError instance
+ * @classdesc An error that occurred during a BulkWrite on the server.
  */
 class WriteError {
+  /**
+   * Create a new WriteError instance (INTERNAL TYPE, do not instantiate directly)
+   *
+   * @class
+   */
   constructor(err) {
     this.err = err;
   }
 
   /**
-   * @return {number} code Write concern error code.
+   * Write error code.
+   * @type {number}
    */
   get code() {
     return this.err.code;
   }
 
   /**
-   * @return {number} index Write concern error original bulk operation index.
+   * Write error original bulk operation index.
+   * @type {number}
    */
   get index() {
     return this.err.index;
   }
 
   /**
-   * @return {string} errmsg Write concern error message.
+   * Write  error message.
+   * @type {string}
    */
   get errmsg() {
     return this.err.errmsg;
   }
 
   /**
-   * Define access methods
+   * Returns the underlying operation that caused the error
    * @return {object}
    */
   getOperation() {
@@ -510,6 +529,7 @@ function executeCommands(bulkOperation, options, callback) {
 /**
  * handles write concern error
  *
+ * @ignore
  * @param {object} batch
  * @param {object} bulkResult
  * @param {boolean} ordered
@@ -531,15 +551,17 @@ function handleMongoWriteConcernError(batch, bulkResult, err, callback) {
 }
 
 /**
- * Creates a new BulkWriteError
- *
- * @class
- * @param {Error|string|object} message The error message
- * @param {BulkWriteResult} result The result of the bulk write operation
- * @return {BulkWriteError} A BulkWriteError instance
- * @extends {MongoError}
+ * @classdesc An error indicating an unsuccessful Bulk Write
  */
 class BulkWriteError extends MongoError {
+  /**
+   * Creates a new BulkWriteError
+   *
+   * @class
+   * @param {Error|string|object} message The error message
+   * @param {BulkWriteResult} result The result of the bulk write operation
+   * @extends {MongoError}
+   */
   constructor(error, result) {
     const message = error.err || error.errmsg || error.errMessage || error;
     super(message);
@@ -552,11 +574,12 @@ class BulkWriteError extends MongoError {
 }
 
 /**
- * Handles the find operators for the bulk operations
- * @class
+ * @classdesc A builder object that is returned from {@link BulkOperationBase#find}.
+ * Is used to build a write operation that involves a query filter.
  */
 class FindOperators {
   /**
+   * Creates a new FindOperators object. For internal use only. Do not invoke directly.
    * @param {OrderedBulkOperation|UnorderedBulkOperation} bulkOperation
    */
   constructor(bulkOperation) {
@@ -564,12 +587,12 @@ class FindOperators {
   }
 
   /**
-   * Add a single update document to the bulk operation
+   * Add a multiple update operation to the bulk operation
    *
    * @method
-   * @param {object} updateDocument update operations
-   * @throws {MongoError}
-   * @return {OrderedBulkOperation|UnordedBulkOperation}
+   * @param {object} updateDocument An update field for an update operation. See {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-u u documentation}
+   * @throws {MongoError} If operation cannot be added to bulk write
+   * @return {OrderedBulkOperation|UnorderedBulkOperation} A reference to the parent BulkOperation
    */
   update(updateDocument) {
     // Perform upsert
@@ -589,12 +612,12 @@ class FindOperators {
   }
 
   /**
-   * Add a single update one document to the bulk operation
+   * Add a single update operation to the bulk operation
    *
    * @method
-   * @param {object} updateDocument update operations
-   * @throws {MongoError}
-   * @return {OrderedBulkOperation|UnordedBulkOperation}
+   * @param {object} updateDocument An update field for an update operation. See {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-u u documentation}
+   * @throws {MongoError} If operation cannot be added to bulk write
+   * @return {OrderedBulkOperation|UnorderedBulkOperation} A reference to the parent BulkOperation
    */
   updateOne(updateDocument) {
     // Perform upsert
@@ -618,19 +641,19 @@ class FindOperators {
    *
    * @method
    * @param {object} updateDocument the new document to replace the existing one with
-   * @throws {MongoError}
-   * @return {OrderedBulkOperation|UnorderedBulkOperation}
+   * @throws {MongoError} If operation cannot be added to bulk write
+   * @return {OrderedBulkOperation|UnorderedBulkOperation} A reference to the parent BulkOperation
    */
   replaceOne(updateDocument) {
     this.updateOne(updateDocument);
   }
 
   /**
-   * Upsert modifier for update bulk operation
+   * Upsert modifier for update bulk operation, noting that this operation is an upsert.
    *
    * @method
-   * @throws {MongoError}
-   * @return {FindOperators}
+   * @throws {MongoError} If operation cannot be added to bulk write
+   * @return {this} reference to self
    */
   upsert() {
     this.s.currentOp.upsert = true;
@@ -641,8 +664,8 @@ class FindOperators {
    * Add a delete one operation to the bulk operation
    *
    * @method
-   * @throws {MongoError}
-   * @return {OrderedBulkOperation|UnordedBulkOperation}
+   * @throws {MongoError} If operation cannot be added to bulk write
+   * @return {OrderedBulkOperation|UnorderedBulkOperation} A reference to the parent BulkOperation
    */
   deleteOne() {
     // Establish the update command
@@ -657,11 +680,11 @@ class FindOperators {
   }
 
   /**
-   * Add a delete operation to the bulk operation
+   * Add a delete many operation to the bulk operation
    *
    * @method
-   * @throws {MongoError}
-   * @return {OrderedBulkOperation|UnordedBulkOperation}
+   * @throws {MongoError} If operation cannot be added to bulk write
+   * @return {OrderedBulkOperation|UnorderedBulkOperation} A reference to the parent BulkOperation
    */
   delete() {
     // Establish the update command
@@ -691,15 +714,13 @@ class FindOperators {
 }
 
 /**
- * Parent class to OrderedBulkOperation and UnorderedBulkOperation
- * @class
+ * @classdesc Parent class to OrderedBulkOperation and UnorderedBulkOperation (INTERNAL TYPE, do not instantiate directly)
  */
 class BulkOperationBase {
   /**
-   * Create a new OrderedBulkOperation or UnorderedBulkOperation instance (INTERNAL TYPE, do not instantiate directly)
+   * Create a new OrderedBulkOperation or UnorderedBulkOperation instance
    * @class
    * @property {number} length Get the number of operations in the bulk.
-   * @return {OrderedBulkOperation|UnordedBulkOperation}
    */
   constructor(topology, collection, options, isOrdered) {
     // determine whether bulkOperation is ordered or unordered
@@ -809,7 +830,16 @@ class BulkOperationBase {
    *
    * @param {object} document the document to insert
    * @throws {MongoError}
-   * @return {OrderedBulkOperation|UnorderedBulkOperation}
+   * @return {this} A reference to self
+   *
+   * @example
+   * const bulkOp = collection.initializeOrderedBulkOp();
+   * // Adds three inserts to the bulkOp.
+   * bulkOp
+   *   .insert({ a: 1 })
+   *   .insert({ b: 2 })
+   *   .insert({ c: 3 });
+   * await bulkOp.execute();
    */
   insert(document) {
     if (this.s.collection.s.db.options.forceServerObjectId !== true && document._id == null)
@@ -818,11 +848,34 @@ class BulkOperationBase {
   }
 
   /**
-   * Initiate a find operation for an update/updateOne/remove/removeOne/replaceOne
+   * Builds a find operation for an update/updateOne/remove/removeOne/replaceOne.
+   * Returns a builder object used to complete the definition of the operation.
    *
    * @method
-   * @param {object} selector The selector for the bulk operation.
-   * @throws {MongoError}
+   * @param {object} selector The selector for the bulk operation. See {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-q q documentation}
+   * @throws {MongoError} if a selector is not specified
+   * @returns {FindOperators} A helper object with which the write operation can be defined.
+   *
+   * @example
+   * const bulkOp = collection.initializeOrderedBulkOp();
+   *
+   * // Add an updateOne to the bulkOp
+   * bulkOp.find({ a: 1 }).updateOne({ $set: { b: 2 } });
+   *
+   * // Add an updateMany to the bulkOp
+   * bulkOp.find({ c: 3 }).update({ $set: { d: 4 } });
+   *
+   * // Add an upsert
+   * bulkOp.find({ e: 5 }).upsert().updateOne({ $set: { f: 6 } });
+   *
+   * // Add a deletion
+   * bulkOp.find({ g: 7 }).deleteOne();
+   *
+   * // Add a multi deletion
+   * bulkOp.find({ h: 8 }).delete();
+   *
+   * // All of the ops will now be executed
+   * await bulkOp.execute();
    */
   find(selector) {
     if (!selector) {
@@ -838,11 +891,11 @@ class BulkOperationBase {
   }
 
   /**
-   * Raw performs the bulk operation
+   * Specifies a raw operation to perform in the bulk write.
    *
    * @method
-   * @param {object} op operation
-   * @return {OrderedBulkOperation|UnorderedBulkOperation}
+   * @param {object} op The raw operation to perform.
+   * @return {this} A reference to self
    */
   raw(op) {
     const key = Object.keys(op)[0];
@@ -929,6 +982,12 @@ class BulkOperationBase {
     );
   }
 
+  /**
+   * helper function to assist with promiseOrCallback behavior
+   * @ignore
+   * @param {*} err
+   * @param {*} callback
+   */
   _handleEarlyError(err, callback) {
     if (typeof callback === 'function') {
       callback(err, null);
@@ -939,8 +998,9 @@ class BulkOperationBase {
   }
 
   /**
-   * Execute next write command in a chain
+   * An internal helper method. Do not invoke directly. Will be going away in the future
    *
+   * @ignore
    * @method
    * @param {class} bulk either OrderedBulkOperation or UnorderdBulkOperation
    * @param {object} writeConcern
@@ -984,19 +1044,21 @@ class BulkOperationBase {
    * @param {MongoError} error An error instance representing the error during the execution.
    * @param {BulkWriteResult} result The bulk write result.
    */
+
   /**
-   * Execute the ordered bulk operation
+   * Execute the bulk operation
    *
    * @method
+   * @param {WriteConcern} [_writeConcern] Optional write concern. Can also be specified through options.
    * @param {object} [options] Optional settings.
    * @param {(number|string)} [options.w] The write concern.
    * @param {number} [options.wtimeout] The write concern timeout.
    * @param {boolean} [options.j=false] Specify a journal write concern.
    * @param {boolean} [options.fsync=false] Specify a file sync write concern.
-   * @param {BulkOperationBase~resultCallback} [callback] The result callback
+   * @param {BulkOperationBase~resultCallback} [callback] A callback that will be invoked when bulkWrite finishes/errors
    * @throws {MongoError} Throws error if the bulk object has already been executed
    * @throws {MongoError} Throws error if the bulk object does not have any operations
-   * @return {Promise} returns Promise if no callback passed
+   * @return {Promise|void} returns Promise if no callback passed
    */
   execute(_writeConcern, options, callback) {
     const ret = this.bulkExecute(_writeConcern, options, callback);
@@ -1013,6 +1075,9 @@ class BulkOperationBase {
   /**
    * Handles final options before executing command
    *
+   * An internal method. Do not invoke. Will not be accessible in the future
+   *
+   * @ignore
    * @param {object} config
    * @param {object} config.options
    * @param {number} config.batch
@@ -1100,6 +1165,9 @@ class BulkOperationBase {
   /**
    * Handles the write error before executing commands
    *
+   * An internal helper method. Do not invoke directly. Will be going away in the future
+   *
+   * @ignore
    * @param {function} callback
    * @param {BulkWriteResult} writeResult
    * @param {class} self either OrderedBulkOperation or UnorderdBulkOperation

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -69,7 +69,7 @@ class BulkWriteResult {
   }
 
   /**
-   * Evaluates to true if the bulk operation correctly execute
+   * Evaluates to true if the bulk operation correctly executes
    * @type {boolean}
    */
   get ok() {
@@ -308,7 +308,7 @@ class WriteError {
   }
 
   /**
-   * Write error code.
+   * WriteError code.
    * @type {number}
    */
   get code() {
@@ -316,7 +316,7 @@ class WriteError {
   }
 
   /**
-   * Write error original bulk operation index.
+   * WriteError original bulk operation index.
    * @type {number}
    */
   get index() {
@@ -324,7 +324,7 @@ class WriteError {
   }
 
   /**
-   * Write  error message.
+   * WriteError message.
    * @type {string}
    */
   get errmsg() {
@@ -556,7 +556,6 @@ class BulkWriteError extends MongoError {
   /**
    * Creates a new BulkWriteError
    *
-   * @class
    * @param {Error|string|object} message The error message
    * @param {BulkWriteResult} result The result of the bulk write operation
    * @extends {MongoError}
@@ -850,7 +849,7 @@ class BulkOperationBase {
   }
 
   /**
-   * Builds a find operation for an update/updateOne/remove/removeOne/replaceOne.
+   * Builds a find operation for an update/updateOne/delete/deleteOne/replaceOne.
    * Returns a builder object used to complete the definition of the operation.
    *
    * @method
@@ -875,6 +874,14 @@ class BulkOperationBase {
    *
    * // Add a multi deletion
    * bulkOp.find({ h: 8 }).delete();
+   *
+   * // Add a replaceOne
+   * bulkOp.find({ i: 9 }).replaceOne({ j: 10 });
+   *
+   * // Update using a pipeline (requires Mongodb 4.2 or higher)
+   * bulk.find({ k: 11, y: { $exists: true }, z: { $exists: true } }).updateOne([
+   *   { $set: { total: { $sum: [ '$y', '$z' ] } } }
+   * ]);
    *
    * // All of the ops will now be executed
    * await bulkOp.execute();

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -60,16 +60,16 @@ class Batch {
  */
 class BulkWriteResult {
   /**
-   * Create a new BulkWriteResult instance (INTERNAL TYPE, do not instantiate directly)
+   * Create a new BulkWriteResult instance
    *
-   * @class
+   * **NOTE:** Internal Type, do not instantiate directly
    */
   constructor(bulkResult) {
     this.result = bulkResult;
   }
 
   /**
-   * Is true if the bulk operation correctly execute
+   * Evaluates to true if the bulk operation correctly execute
    * @type {boolean}
    */
   get ok() {
@@ -255,10 +255,9 @@ class BulkWriteResult {
  */
 class WriteConcernError {
   /**
-   * Create a new WriteConcernError instance (INTERNAL TYPE, do not instantiate directly)
+   * Create a new WriteConcernError instance
    *
-   * @class
-   * @return {WriteConcernError} a WriteConcernError instance
+   * **NOTE:** Internal Type, do not instantiate directly
    */
   constructor(err) {
     this.err = err;
@@ -300,9 +299,9 @@ class WriteConcernError {
  */
 class WriteError {
   /**
-   * Create a new WriteError instance (INTERNAL TYPE, do not instantiate directly)
+   * Create a new WriteError instance
    *
-   * @class
+   * **NOTE:** Internal Type, do not instantiate directly
    */
   constructor(err) {
     this.err = err;
@@ -579,7 +578,9 @@ class BulkWriteError extends MongoError {
  */
 class FindOperators {
   /**
-   * Creates a new FindOperators object. For internal use only. Do not invoke directly.
+   * Creates a new FindOperators object.
+   *
+   * **NOTE:** Internal Type, do not instantiate directly
    * @param {OrderedBulkOperation|UnorderedBulkOperation} bulkOperation
    */
   constructor(bulkOperation) {
@@ -653,7 +654,7 @@ class FindOperators {
    *
    * @method
    * @throws {MongoError} If operation cannot be added to bulk write
-   * @return {this} reference to self
+   * @return {FindOperators} reference to self
    */
   upsert() {
     this.s.currentOp.upsert = true;
@@ -714,12 +715,13 @@ class FindOperators {
 }
 
 /**
- * @classdesc Parent class to OrderedBulkOperation and UnorderedBulkOperation (INTERNAL TYPE, do not instantiate directly)
+ * @classdesc Parent class to OrderedBulkOperation and UnorderedBulkOperation
+ *
+ * **NOTE:** Internal Type, do not instantiate directly
  */
 class BulkOperationBase {
   /**
    * Create a new OrderedBulkOperation or UnorderedBulkOperation instance
-   * @class
    * @property {number} length Get the number of operations in the bulk.
    */
   constructor(topology, collection, options, isOrdered) {
@@ -830,7 +832,7 @@ class BulkOperationBase {
    *
    * @param {object} document the document to insert
    * @throws {MongoError}
-   * @return {this} A reference to self
+   * @return {BulkOperationBase} A reference to self
    *
    * @example
    * const bulkOp = collection.initializeOrderedBulkOp();
@@ -854,7 +856,7 @@ class BulkOperationBase {
    * @method
    * @param {object} selector The selector for the bulk operation. See {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-q q documentation}
    * @throws {MongoError} if a selector is not specified
-   * @returns {FindOperators} A helper object with which the write operation can be defined.
+   * @return {FindOperators} A helper object with which the write operation can be defined.
    *
    * @example
    * const bulkOp = collection.initializeOrderedBulkOp();
@@ -895,7 +897,7 @@ class BulkOperationBase {
    *
    * @method
    * @param {object} op The raw operation to perform.
-   * @return {this} A reference to self
+   * @return {BulkOperationBase} A reference to self
    */
   raw(op) {
     const key = Object.keys(op)[0];

--- a/lib/bulk/ordered.js
+++ b/lib/bulk/ordered.js
@@ -10,6 +10,7 @@ const toError = utils.toError;
 /**
  * Add to internal list of Operations
  *
+ * @ignore
  * @param {OrderedBulkOperation} bulkOperation
  * @param {number} docType number indicating the document type
  * @param {object} document
@@ -82,7 +83,6 @@ function addToOperationsList(bulkOperation, docType, document) {
  * @property {number} length Get the number of operations in the bulk.
  * @return {OrderedBulkOperation} a OrderedBulkOperation instance.
  */
-
 class OrderedBulkOperation extends BulkOperationBase {
   constructor(topology, collection, options) {
     options = options || {};

--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -10,6 +10,7 @@ const toError = utils.toError;
 /**
  * Add to internal list of Operations
  *
+ * @ignore
  * @param {UnorderedBulkOperation} bulkOperation
  * @param {number} docType number indicating the document type
  * @param {object} document


### PR DESCRIPTION
## Description

Adds documentation for multiple methods and properties
associated with bulk writes. Also marks certain methods as
internal.

Fixes NODE-1800
Fixes NODE-1938

**What changed?**

Added more documentation to the BulkOperationBase. Includes, but is not limited to:
- Updating language
- Adding examples for how to add various operations to the bulk op
- Correcting the jsdoc for getters such that the description and type actually show up
- Marking certain methods as internal by adding an `@ignore` tag

**Are there any files to ignore?**
- `lib/bulk/ordered.js` and `lib/bulk/unordered.js` have trivial changes.