### PR TITLE
NODE-2121: respect selection timeout ms on connect

### DIFF
--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -146,9 +146,6 @@ var Pool = function(topology, options) {
   // Operation work queue
   this.queue = [];
 
-  // Contains the reconnect connection
-  this.reconnectConnection = null;
-
   // Number of consecutive timeouts caught
   this.numberOfConsecutiveTimeouts = 0;
   // Current pool Index
@@ -214,7 +211,6 @@ function resetPoolState(pool) {
   pool.availableConnections = [];
   pool.connectingConnections = 0;
   pool.executing = false;
-  pool.reconnectConnection = null;
   pool.numberOfConsecutiveTimeouts = 0;
   pool.connectionIndex = 0;
   pool.retriesLeft = pool.options.reconnectTries;
@@ -299,68 +295,45 @@ function connectionFailureHandler(pool, event, err, conn) {
   // Do we need to do anything to maintain the minimum pool size
   const totalConnections = totalConnectionCount(pool);
   if (totalConnections < pool.minSize) {
-    _createConnection(pool);
+    createConnection(pool);
   }
 }
 
-function attemptReconnect(self) {
+function attemptReconnect(pool, callback) {
   return function() {
-    self.emit('attemptReconnect', self);
-    if (self.state === DESTROYED || self.state === DESTROYING) return;
+    pool.emit('attemptReconnect', pool);
 
-    // We are connected do not try again
-    if (self.isConnected()) {
-      self.reconnectId = null;
+    if (pool.state === DESTROYED || pool.state === DESTROYING) {
+      if (typeof callback === 'function') {
+        callback(new MongoError('Cannot create connection when pool is destroyed'));
+      }
+
       return;
     }
 
-    self.connectingConnections++;
-    connect(self.options, (err, connection) => {
-      self.connectingConnections--;
+    pool.retriesLeft = pool.retriesLeft - 1;
+    if (pool.retriesLeft <= 0) {
+      pool.destroy();
 
-      if (err) {
-        if (self.logger.isDebug()) {
-          self.logger.debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
-        }
+      const error = new MongoNetworkError(
+        `failed to reconnect after ${pool.options.reconnectTries} attempts with interval ${
+          pool.options.reconnectInterval
+        } ms`
+      );
 
-        self.retriesLeft = self.retriesLeft - 1;
-        if (self.retriesLeft <= 0) {
-          self.destroy();
-          self.emit(
-            'reconnectFailed',
-            new MongoNetworkError(
-              f(
-                'failed to reconnect after %s attempts with interval %s ms',
-                self.options.reconnectTries,
-                self.options.reconnectInterval
-              )
-            )
-          );
-        } else {
-          self.reconnectId = setTimeout(attemptReconnect(self), self.options.reconnectInterval);
-        }
-
-        return;
+      pool.emit('reconnectFailed', error);
+      if (typeof callback === 'function') {
+        callback(error);
       }
 
-      if (self.state === DESTROYED || self.state === DESTROYING) {
-        return connection.destroy();
-      }
+      return;
+    }
 
-      self.reconnectId = null;
-      handlers.forEach(event => connection.removeAllListeners(event));
-      connection.on('error', self._connectionErrorHandler);
-      connection.on('close', self._connectionCloseHandler);
-      connection.on('timeout', self._connectionTimeoutHandler);
-      connection.on('parseError', self._connectionParseErrorHandler);
-      connection.on('message', self._messageHandler);
+    // clear the reconnect id on retry
+    pool.reconnectId = null;
 
-      self.retriesLeft = self.options.reconnectTries;
-      self.availableConnections.push(connection);
-      self.reconnectConnection = null;
-      self.emit('reconnect', self);
-      _execute(self)();
-    });
+    // now retry creating a connection
+    createConnection(pool, callback);
   };
 }
 
@@ -564,64 +537,26 @@ Pool.prototype.connect = function() {
     throw new MongoError('connection in unlawful state ' + this.state);
   }
 
-  const self = this;
   stateTransition(this, CONNECTING);
-
-  self.connectingConnections++;
-  connect(self.options, (err, connection) => {
-    self.connectingConnections--;
-
+  createConnection(this, (err, conn) => {
     if (err) {
-      if (self.logger.isDebug()) {
-        self.logger.debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
+      if (this.state === CONNECTING) {
+        this.emit('error', err);
       }
 
-      if (self.state === CONNECTING) {
-        self.emit('error', err);
-      }
-
+      this.destroy();
       return;
     }
 
-    if (self.state === DESTROYED || self.state === DESTROYING) {
-      return self.destroy();
-    }
+    stateTransition(this, CONNECTED);
+    this.emit('connect', this, conn);
 
-    // attach event handlers
-    connection.on('error', self._connectionErrorHandler);
-    connection.on('close', self._connectionCloseHandler);
-    connection.on('timeout', self._connectionTimeoutHandler);
-    connection.on('parseError', self._connectionParseErrorHandler);
-    connection.on('message', self._messageHandler);
-
-    // If we are in a topology, delegate the auth to it
-    // This is to avoid issues where we would auth against an
-    // arbiter
-    if (self.options.inTopology) {
-      stateTransition(self, CONNECTED);
-      self.availableConnections.push(connection);
-      return self.emit('connect', self, connection);
-    }
-
-    if (self.state === DESTROYED || self.state === DESTROYING) {
-      return self.destroy();
-    }
-
-    if (err) {
-      self.destroy();
-      return self.emit('error', err);
-    }
-
-    stateTransition(self, CONNECTED);
-    self.availableConnections.push(connection);
-
-    if (self.minSize) {
-      for (let i = 0; i < self.minSize; i++) {
-        _createConnection(self);
+    // create min connections
+    if (this.minSize) {
+      for (let i = 0; i < this.minSize; i++) {
+        createConnection(this);
       }
     }
-
-    self.emit('connect', self, connection);
   });
 };
 
@@ -718,12 +653,6 @@ Pool.prototype.destroy = function(force, callback) {
     clearTimeout(this.reconnectId);
   }
 
-  // If we have a reconnect connection running, close
-  // immediately
-  if (this.reconnectConnection) {
-    this.reconnectConnection.destroy();
-  }
-
   // Wait for the operations to drain before we close the pool
   function checkStatus() {
     flushMonitoringOperations(self.queue);
@@ -782,7 +711,7 @@ Pool.prototype.reset = function(callback) {
       resetPoolState(this);
 
       // create an initial connection, and kick off execution again
-      _createConnection(this);
+      createConnection(this);
 
       if (typeof callback === 'function') {
         callback(null, null);
@@ -996,55 +925,73 @@ function removeConnection(self, connection) {
   if (remove(connection, self.inUseConnections)) return;
 }
 
-const handlers = ['close', 'message', 'error', 'timeout', 'parseError', 'connect'];
-function _createConnection(self) {
-  if (self.state === DESTROYED || self.state === DESTROYING) {
+function createConnection(pool, callback) {
+  if (pool.state === DESTROYED || pool.state === DESTROYING) {
+    if (typeof callback === 'function') {
+      callback(new MongoError('Cannot create connection when pool is destroyed'));
+    }
+
     return;
   }
 
-  self.connectingConnections++;
-  connect(self.options, (err, connection) => {
-    self.connectingConnections--;
+  pool.connectingConnections++;
+  connect(pool.options, (err, connection) => {
+    pool.connectingConnections--;
 
     if (err) {
-      if (self.logger.isDebug()) {
-        self.logger.debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
+      if (pool.logger.isDebug()) {
+        pool.logger.debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
       }
 
-      if (!self.reconnectId && self.options.reconnect) {
-        self.reconnectId = setTimeout(attemptReconnect(self), self.options.reconnectInterval);
+      if (!pool.reconnectId && pool.options.reconnect) {
+        pool.reconnectId = setTimeout(
+          attemptReconnect(pool, callback),
+          pool.options.reconnectInterval
+        );
+
+        return;
+      }
+
+      if (typeof callback === 'function') {
+        callback(err);
       }
 
       return;
     }
 
-    if (self.state === DESTROYED || self.state === DESTROYING) {
-      removeConnection(self, connection);
-      return connection.destroy();
+    // the pool might have been closed since we started creating the connection
+    if (pool.state === DESTROYED || pool.state === DESTROYING) {
+      if (typeof callback === 'function') {
+        callback(new MongoError('Pool was destroyed after connection creation'));
+      }
+
+      connection.destroy();
+      return;
     }
 
-    connection.on('error', self._connectionErrorHandler);
-    connection.on('close', self._connectionCloseHandler);
-    connection.on('timeout', self._connectionTimeoutHandler);
-    connection.on('parseError', self._connectionParseErrorHandler);
-    connection.on('message', self._messageHandler);
+    // otherwise, connect relevant event handlers and add it to our available connections
+    connection.on('error', pool._connectionErrorHandler);
+    connection.on('close', pool._connectionCloseHandler);
+    connection.on('timeout', pool._connectionTimeoutHandler);
+    connection.on('parseError', pool._connectionParseErrorHandler);
+    connection.on('message', pool._messageHandler);
 
-    if (self.state === DESTROYED || self.state === DESTROYING) {
-      return connection.destroy();
+    pool.availableConnections.push(connection);
+
+    // if there is a reconnect in progress, reset state and emit event
+    if (pool.reconnectId) {
+      pool.reconnectId = null;
+      pool.retriesLeft = pool.options.reconnectTries;
+      pool.emit('reconnect', pool);
     }
 
-    // Remove the connection from the connectingConnections list
-    removeConnection(self, connection);
-
-    // Handle error
-    if (err) {
-      return connection.destroy();
+    // if a callback was provided, return the connection
+    if (typeof callback === 'function') {
+      callback(null, connection);
     }
 
-    // Push to available
-    self.availableConnections.push(connection);
-    // Execute any work waiting
-    _execute(self)();
+    // immediately execute any waiting work
+    _execute(pool)();
   });
 }
 
@@ -1146,7 +1093,7 @@ function _execute(self) {
           // Attempt to grow the pool if it's not yet maxsize
           if (totalConnections < self.options.size && self.queue.length > 0) {
             // Create a new connection
-            _createConnection(self);
+            createConnection(self);
           }
 
           // Re-execute the operation
@@ -1166,7 +1113,7 @@ function _execute(self) {
           // Lets put the workItem back on the list
           self.queue.unshift(workItem);
           // Create a new connection
-          _createConnection(self);
+          createConnection(self);
           // Break from the loop
           break;
         }

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -3,7 +3,7 @@
 const inherits = require('util').inherits;
 const EventEmitter = require('events').EventEmitter;
 const MongoError = require('../error').MongoError;
-const MongoNetworkError = require('../error').MongoNetworkError;
+const MongoTimeoutError = require('../error').MongoTimeoutError;
 const MongoWriteConcernError = require('../error').MongoWriteConcernError;
 const Logger = require('./logger');
 const f = require('util').format;
@@ -113,7 +113,9 @@ var Pool = function(topology, options) {
       reconnectInterval: 1000,
       reconnectTries: 30,
       // Enable domains
-      domainsEnabled: false
+      domainsEnabled: false,
+      // feature flag for determining if we are running with the unified topology or not
+      legacyCompatMode: true
     },
     options
   );
@@ -123,6 +125,7 @@ var Pool = function(topology, options) {
   // Current reconnect retries
   this.retriesLeft = this.options.reconnectTries;
   this.reconnectId = null;
+  this.reconnectError = null;
   // No bson parser passed in
   if (
     !options.bson ||
@@ -289,6 +292,7 @@ function connectionFailureHandler(pool, event, err, conn) {
 
   // Start reconnection attempts
   if (!pool.reconnectId && pool.options.reconnect) {
+    pool.reconnectError = err;
     pool.reconnectId = setTimeout(attemptReconnect(pool), pool.options.reconnectInterval);
   }
 
@@ -315,10 +319,11 @@ function attemptReconnect(pool, callback) {
     if (pool.retriesLeft <= 0) {
       pool.destroy();
 
-      const error = new MongoNetworkError(
+      const error = new MongoTimeoutError(
         `failed to reconnect after ${pool.options.reconnectTries} attempts with interval ${
           pool.options.reconnectInterval
-        } ms`
+        } ms`,
+        pool.reconnectError
       );
 
       pool.emit('reconnectFailed', error);
@@ -333,7 +338,17 @@ function attemptReconnect(pool, callback) {
     pool.reconnectId = null;
 
     // now retry creating a connection
-    createConnection(pool, callback);
+    createConnection(pool, (err, conn) => {
+      if (err == null) {
+        pool.reconnectId = null;
+        pool.retriesLeft = pool.options.reconnectTries;
+        pool.emit('reconnect', pool);
+      }
+
+      if (typeof callback === 'function') {
+        callback(err, conn);
+      }
+    });
   };
 }
 
@@ -943,7 +958,23 @@ function createConnection(pool, callback) {
         pool.logger.debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
       }
 
+      if (pool.options.legacyCompatMode === false) {
+        // The unified topology uses the reported `error` from a pool to track what error
+        // reason is returned to the user during selection timeout. We only want to emit
+        // this if the pool is active because the listeners are removed on destruction.
+        if (pool.state !== DESTROYED && pool.state !== DESTROYING) {
+          pool.emit('error', err);
+        }
+      }
+
+      // check if reconnect is enabled, and attempt retry if so
       if (!pool.reconnectId && pool.options.reconnect) {
+        if (pool.state === CONNECTING && pool.options.legacyCompatMode) {
+          callback(err);
+          return;
+        }
+
+        pool.reconnectError = err;
         pool.reconnectId = setTimeout(
           attemptReconnect(pool, callback),
           pool.options.reconnectInterval
@@ -977,13 +1008,6 @@ function createConnection(pool, callback) {
     connection.on('message', pool._messageHandler);
 
     pool.availableConnections.push(connection);
-
-    // if there is a reconnect in progress, reset state and emit event
-    if (pool.reconnectId) {
-      pool.reconnectId = null;
-      pool.retriesLeft = pool.options.reconnectTries;
-      pool.emit('reconnect', pool);
-    }
 
     // if a callback was provided, return the connection
     if (typeof callback === 'function') {

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -83,12 +83,17 @@ class MongoParseError extends MongoError {
  * An error signifying a timeout event
  *
  * @param {Error|string|object} message The error message
+ * @param {string|object} [reason] The reason the timeout occured
  * @property {string} message The error message
+ * @property {string} [reason] An optional reason context for the timeout, generally an error saved during flow of monitoring and selecting servers
  */
 class MongoTimeoutError extends MongoError {
-  constructor(message) {
+  constructor(message, reason) {
     super(message);
     this.name = 'MongoTimeoutError';
+    if (reason != null) {
+      this.reason = reason;
+    }
   }
 }
 

--- a/lib/core/sdam/monitoring.js
+++ b/lib/core/sdam/monitoring.js
@@ -162,7 +162,7 @@ function monitorServer(server, options) {
 
         const isMaster = result.result;
         server.emit(
-          'serverHeartbeatSucceded',
+          'serverHeartbeatSucceeded',
           new ServerHeartbeatSucceededEvent(duration, isMaster, server.name)
         );
 

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -125,6 +125,7 @@ class Server extends EventEmitter {
 
     // NOTE: this should only be the case if we are connecting to a single server
     poolOptions.reconnect = true;
+    poolOptions.legacyCompatMode = false;
 
     this.s.pool = new Pool(this, poolOptions);
 

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -842,6 +842,7 @@ function selectServers(topology, selector, timeout, start, callback) {
 
     const iterationTimer = setTimeout(() => {
       topology.removeListener('topologyDescriptionChanged', descriptionChangedHandler);
+
       callback(
         new MongoTimeoutError(
           `Server selection timed out after ${timeout} ms`,

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -930,13 +930,8 @@ function serverConnectEventHandler(server, topology) {
   };
 }
 
-function serverErrorEventHandler(server, topology) {
+function serverErrorEventHandler(server /*, topology */) {
   return function(err) {
-    topology.emit(
-      'serverClosed',
-      new monitoring.ServerClosedEvent(topology.s.id, server.description.address)
-    );
-
     if (isSDAMUnrecoverableError(err, server)) {
       resetServerState(server, err, { clearPool: true });
       return;

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -836,18 +836,18 @@ function selectServers(topology, selector, timeout, start, callback) {
       clearTimeout(iterationTimer);
       topology.s.iterationTimers.splice(timerIndex, 1);
 
-      if (topology.description.error) {
-        callback(topology.description.error, null);
-        return;
-      }
-
       // topology description has changed due to monitoring, reattempt server selection
       selectServers(topology, selector, timeout, start, callback);
     };
 
     const iterationTimer = setTimeout(() => {
       topology.removeListener('topologyDescriptionChanged', descriptionChangedHandler);
-      callback(new MongoTimeoutError(`Server selection timed out after ${timeout} ms`));
+      callback(
+        new MongoTimeoutError(
+          `Server selection timed out after ${timeout} ms`,
+          topology.description.error
+        )
+      );
     }, timeout - duration);
 
     // track this timer in case we need to clean it up outside this loop

--- a/test/core/functional/server_tests.js
+++ b/test/core/functional/server_tests.js
@@ -993,12 +993,17 @@ describe('Server tests', function() {
         });
 
         const config = this.configuration;
-        var client = config.newTopology(server.address().host, server.address().port);
+        var client = config.newTopology(server.address().host, server.address().port, {
+          serverSelectionTimeoutMS: 10
+        });
+
         client.on('error', error => {
           let err;
           try {
             expect(error).to.be.an.instanceOf(Error);
-            expect(error.message).to.match(/but this version of the Node.js Driver requires/);
+
+            const errorMessage = error.reason ? error.reason.message : error.message;
+            expect(errorMessage).to.match(/but this version of the Node.js Driver requires/);
           } catch (e) {
             err = e;
           }

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -423,7 +423,9 @@ describe('Connection', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      const client = configuration.newClient(configuration.url('slithy', 'toves'));
+      const client = configuration.newClient(configuration.url('slithy', 'toves'), {
+        serverSelectionTimeoutMS: 10
+      });
 
       client.connect(function(err, client) {
         expect(err).to.exist;

--- a/test/functional/db_tests.js
+++ b/test/functional/db_tests.js
@@ -243,7 +243,8 @@ describe('Db', function() {
     test: function(done) {
       var configuration = this.configuration;
       var fs_client = configuration.newClient('mongodb://127.0.0.1:25117/test', {
-        auto_reconnect: false
+        auto_reconnect: false,
+        serverSelectionTimeoutMS: 10
       });
 
       fs_client.connect(function(err) {
@@ -435,7 +436,8 @@ describe('Db', function() {
       var configuration = this.configuration;
       var client = configuration.newClient(`mongodb://127.0.0.1:27088/test`, {
         auto_reconnect: false,
-        poolSize: 4
+        poolSize: 4,
+        serverSelectionTimeoutMS: 10
       });
 
       // Establish connection to db

--- a/test/functional/mongo_client_tests.js
+++ b/test/functional/mongo_client_tests.js
@@ -474,7 +474,10 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      const client = configuration.newClient('mongodb://localhost:27088/test');
+      const client = configuration.newClient('mongodb://localhost:27088/test', {
+        serverSelectionTimeoutMS: 10
+      });
+
       client.connect(function(err) {
         test.ok(err != null);
 
@@ -508,7 +511,10 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      const client = configuration.newClient('mongodb://test.does.not.exist.com:80/test');
+      const client = configuration.newClient('mongodb://test.does.not.exist.com:80/test', {
+        serverSelectionTimeoutMS: 10
+      });
+
       client.connect(function(err) {
         test.ok(err != null);
 
@@ -593,7 +599,10 @@ describe('MongoClient', function() {
     // The actual test we wish to run
     test: function(done) {
       var configuration = this.configuration;
-      const client = configuration.newClient('mongodb://unknownhost:36363/ddddd');
+      const client = configuration.newClient('mongodb://unknownhost:36363/ddddd', {
+        serverSelectionTimeoutMS: 10
+      });
+
       client.connect(function(err) {
         test.ok(err != null);
         done();

--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -4027,7 +4027,8 @@ describe('Operation Examples', function() {
 
                 const oldClient = secondClient;
                 const thirdClient = configuration.newClient(
-                  'mongodb://user:name@localhost:27017/integration_tests'
+                  'mongodb://user:name@localhost:27017/integration_tests',
+                  { serverSelectionTimeoutMS: 10 }
                 );
 
                 // Authenticate

--- a/test/functional/operation_generators_example_tests.js
+++ b/test/functional/operation_generators_example_tests.js
@@ -2966,7 +2966,10 @@ describe('Operation (Generators)', function() {
 
         try {
           // Authenticate
-          const client = configuration.newClient('mongodb://user:name@localhost:27017/admin');
+          const client = configuration.newClient('mongodb://user:name@localhost:27017/admin', {
+            serverSelectionTimeoutMS: 10
+          });
+
           yield client.connect();
           test.ok(false);
         } catch (err) {} // eslint-disable-line

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -3174,7 +3174,8 @@ describe('Operation (Promises)', function() {
 
             // Should error out due to user no longer existing
             const thirdClient = configuration.newClient(
-              'mongodb://user3:name@localhost:27017/integration_tests'
+              'mongodb://user3:name@localhost:27017/integration_tests',
+              { serverSelectionTimeoutMS: 10 }
             );
 
             return thirdClient.connect();

--- a/test/functional/scram_sha_256_tests.js
+++ b/test/functional/scram_sha_256_tests.js
@@ -179,13 +179,17 @@ describe('SCRAM-SHA-256 auth', function() {
           password: userMap.sha256.password
         },
         authSource: this.configuration.db,
-        authMechanism: 'SCRAM-SHA-1'
+        authMechanism: 'SCRAM-SHA-1',
+        serverSelectionTimeoutMS: 10
       };
 
       return withClient(
         this.configuration.newClient({}, options),
         () => Promise.reject(new Error('This request should have failed to authenticate')),
-        err => expect(err).to.match(/Authentication failed/)
+        err => {
+          const errMessage = err.reason ? err.reason.message : err;
+          expect(errMessage).to.match(/Authentication failed/);
+        }
       );
     }
   });
@@ -202,7 +206,8 @@ describe('SCRAM-SHA-256 auth', function() {
           user: 'roth',
           password: 'pencil'
         },
-        authSource: 'admin'
+        authSource: 'admin',
+        serverSelectionTimeoutMS: 1000
       };
 
       const badPasswordOptions = {
@@ -210,14 +215,18 @@ describe('SCRAM-SHA-256 auth', function() {
           user: 'both',
           password: 'pencil'
         },
-        authSource: 'admin'
+        authSource: 'admin',
+        serverSelectionTimeoutMS: 1000
       };
 
       const getErrorMsg = options =>
         withClient(
           this.configuration.newClient({}, options),
           () => Promise.reject(new Error('This request should have failed to authenticate')),
-          err => expect(err).to.match(/Authentication failed/)
+          err => {
+            const errMessage = err.reason ? err.reason.message : err;
+            expect(errMessage).to.match(/Authentication failed/);
+          }
         );
 
       return Promise.all([getErrorMsg(noUsernameOptions), getErrorMsg(badPasswordOptions)]);

--- a/test/functional/scram_sha_256_tests.js
+++ b/test/functional/scram_sha_256_tests.js
@@ -180,7 +180,7 @@ describe('SCRAM-SHA-256 auth', function() {
         },
         authSource: this.configuration.db,
         authMechanism: 'SCRAM-SHA-1',
-        serverSelectionTimeoutMS: 10
+        serverSelectionTimeoutMS: 2000
       };
 
       return withClient(
@@ -207,7 +207,7 @@ describe('SCRAM-SHA-256 auth', function() {
           password: 'pencil'
         },
         authSource: 'admin',
-        serverSelectionTimeoutMS: 1000
+        serverSelectionTimeoutMS: 2000
       };
 
       const badPasswordOptions = {
@@ -216,7 +216,7 @@ describe('SCRAM-SHA-256 auth', function() {
           password: 'pencil'
         },
         authSource: 'admin',
-        serverSelectionTimeoutMS: 1000
+        serverSelectionTimeoutMS: 2000
       };
 
       const getErrorMsg = options =>


### PR DESCRIPTION
## Description
Our FLE implementation of autospawning ran into an issue with the fact that the unified topology did not respect the `serverSelectionTimeoutMS` on initial connect to a topology. This was for two reasons:
  - The unified topology implementation incorrectly reported errors encountered during the server selection loop immediately, rather than when the loop was completed.

  - The driver _always_ erroneously reported error on connect immediately, even if `auto_reconnect` was specified. We now respect these settings, an in the process much of the code to create connections in the pool has been cleaned up, deduplicated and consolidated.

**What changed?**
The server selection loop will now save the error on the topology description, and report the error _after_ the server selection loop has timed out. `MongoTimeoutError` gains a new field in this case: `reason`, which contains the last encountered error saved on the topology description.

`createConnection` in `pool.js` now optionally accepts a callback (for use explicitly with the `connect` case), and code in `Pool.prototype.connect` and `attemptRetry` were deduplicated to reuse the same `createConnection` code that was copied and pasted throughout the file.

There were some other side-effect fixes in this process:
  - the `ServerClosedEvent` was being incorrectly emitted multiple times in the unified topology
  - the `heartbeatSucceeded` event was missing an `e`, and therefore would be missed (according to our documented event name)

**Are there any files to ignore?**
No, but there are some things to note:
  - `serverSelectionTimeoutMS` was added to many tests because the unified topology will now wait up to this many milliseconds before failing to select a server on connect now. This behavior is available to the legacy topologies behind an internal feature flag `legacyCompatMode`