### PR TITLE
fix(auth): throw more readable error if username or password isn't a string

### DIFF
--- a/lib/core/auth/scram.js
+++ b/lib/core/auth/scram.js
@@ -29,8 +29,8 @@ var parsePayload = function(payload) {
 };
 
 var passwordDigest = function(username, password) {
-  if (typeof username !== 'string') throw new MongoError('username must be a string');
-  if (typeof password !== 'string') throw new MongoError('password must be a string');
+  if (typeof username !== 'string') throw new MongoError('username must be a string, got: "' + username + '"');
+  if (typeof password !== 'string') throw new MongoError('password must be a string, got: "' + password + '"');
   if (password.length === 0) throw new MongoError('password cannot be empty');
   // Use node md5 generator
   var md5 = crypto.createHash('md5');

--- a/lib/core/auth/scram.js
+++ b/lib/core/auth/scram.js
@@ -29,8 +29,8 @@ var parsePayload = function(payload) {
 };
 
 var passwordDigest = function(username, password) {
-  if (typeof username !== 'string') throw new MongoError('username must be a string, got: "' + username + '"');
-  if (typeof password !== 'string') throw new MongoError('password must be a string, got: "' + password + '"');
+  if (typeof username !== 'string') throw new MongoError('username must be a string, got: "' + typeof username + '"');
+  if (typeof password !== 'string') throw new MongoError('password must be a string, got: "' + typeof password + '"');
   if (password.length === 0) throw new MongoError('password cannot be empty');
   // Use node md5 generator
   var md5 = crypto.createHash('md5');

--- a/lib/core/auth/scram.js
+++ b/lib/core/auth/scram.js
@@ -29,8 +29,12 @@ var parsePayload = function(payload) {
 };
 
 var passwordDigest = function(username, password) {
-  if (typeof username !== 'string') throw new MongoError('username must be a string, got: "' + typeof username + '"');
-  if (typeof password !== 'string') throw new MongoError('password must be a string, got: "' + typeof password + '"');
+  if (typeof username !== 'string') {
+    throw new MongoError('username must be a string, got: "' + typeof username + '"');
+  }
+  if (typeof password !== 'string') {
+    throw new MongoError('password must be a string, got: "' + typeof password + '"');
+  }
   if (password.length === 0) throw new MongoError('password cannot be empty');
   // Use node md5 generator
   var md5 = crypto.createHash('md5');


### PR DESCRIPTION
## Description

**What changed?**

If username or password isn't a string, it's a little tricky to debug what actually the parameter actually was. This will make it a little easier to debug issues like Automattic/mongoose#8176

**Are there any files to ignore?**
