### PR TITLE
Fixes NODE-2214 and NODE-2215

### DIFF
--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -281,7 +281,7 @@ function connectionFailureHandler(pool, event, err, conn) {
 
   // No more socket available propegate the event
   if (pool.socketCount() === 0) {
-    if (pool.state !== DESTROYED && pool.state !== DESTROYING) {
+    if (pool.state === CONNECTED) {
       stateTransition(pool, DISCONNECTED);
     }
 
@@ -358,7 +358,11 @@ function attemptReconnect(self) {
       self.retriesLeft = self.options.reconnectTries;
       self.availableConnections.push(connection);
       self.reconnectConnection = null;
-      self.emit('reconnect', self);
+
+      const wasConnecting = self.state === CONNECTING;
+      stateTransition(self, CONNECTED);
+      if (wasConnecting) self.emit('connect', self, connection);
+      else self.emit('reconnect', self);
       _execute(self)();
     });
   };
@@ -578,6 +582,7 @@ Pool.prototype.connect = function() {
 
       if (self.state === CONNECTING) {
         self.emit('error', err);
+        connectionFailureHandler(self, 'error', err, null);
       }
 
       return;

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -832,17 +832,27 @@ function selectServers(topology, selector, timeout, start, callback) {
     });
 
     const descriptionChangedHandler = () => {
-      // successful iteration, clear the check timer
-      clearTimeout(iterationTimer);
-      topology.s.iterationTimers.splice(timerIndex, 1);
+      const STATE_CONNECTING = 1;
+      const hasError = topology.description.error;
+      const servers = Array.from(topology.s.servers.values());
+      const connecting = servers.filter(server => server.s.state === STATE_CONNECTING);
+      const stillConnecting = !!connecting.length;
 
-      if (topology.description.error) {
-        callback(topology.description.error, null);
-        return;
+      if (hasError && stillConnecting) {
+        // Continue trying if any servers are still connecting
+        topology.once('topologyDescriptionChanged', descriptionChangedHandler);
+      } else {
+        // successful iteration, clear the check timer
+        clearTimeout(iterationTimer);
+        topology.s.iterationTimers.splice(timerIndex, 1);
+
+        if (hasError) {
+          callback(topology.description.error, null);
+        } else {
+          // topology description has changed due to monitoring, reattempt server selection
+          selectServers(topology, selector, timeout, start, callback);
+        }
       }
-
-      // topology description has changed due to monitoring, reattempt server selection
-      selectServers(topology, selector, timeout, start, callback);
     };
 
     const iterationTimer = setTimeout(() => {
@@ -865,7 +875,14 @@ function createAndConnectServer(topology, serverDescription) {
     new monitoring.ServerOpeningEvent(topology.s.id, serverDescription.address)
   );
 
-  const server = new Server(serverDescription, topology.s.options, topology);
+  const options = Object.assign({}, topology.s.options, {
+    // Server should attempt to reconnect until it is removed
+    // from the topology and explicitly destroyed
+    reconnectTries: Number.MAX_SAFE_INTEGER,
+    reconnectInterval: 500
+  });
+
+  const server = new Server(serverDescription, options, topology);
   relayEvents(server, topology, SERVER_RELAY_EVENTS);
 
   server.once('connect', serverConnectEventHandler(server, topology));

--- a/lib/core/sdam/topology_description.js
+++ b/lib/core/sdam/topology_description.js
@@ -189,7 +189,7 @@ class TopologyDescription {
     }
 
     if (topologyType === TopologyType.ReplicaSetNoPrimary) {
-      if ([ServerType.Mongos, ServerType.Unknown].indexOf(serverType) >= 0) {
+      if ([ServerType.Mongos].indexOf(serverType) >= 0) {
         serverDescriptions.delete(address);
       }
 

--- a/test/core/functional/rs_mocks/connection_tests.js
+++ b/test/core/functional/rs_mocks/connection_tests.js
@@ -358,12 +358,12 @@ describe('ReplSet Connection Tests (mocks)', function() {
         // Joined
         server.on('joined', function() {
           numberOfEvents = numberOfEvents + 1;
-          if (numberOfEvents === 3) validations();
+          if (numberOfEvents === 4) validations();
         });
 
         server.on('failed', function() {
           numberOfEvents = numberOfEvents + 1;
-          if (numberOfEvents === 3) validations();
+          if (numberOfEvents === 4) validations();
         });
 
         server.connect();

--- a/test/core/functional/server_tests.js
+++ b/test/core/functional/server_tests.js
@@ -994,7 +994,7 @@ describe('Server tests', function() {
 
         const config = this.configuration;
         var client = config.newTopology(server.address().host, server.address().port);
-        client.on('error', error => {
+        client.once('error', error => {
           let err;
           try {
             expect(error).to.be.an.instanceOf(Error);


### PR DESCRIPTION
## Description

**What changed?**
This PR  fixes [NODE-2215](https://jira.mongodb.org/browse/NODE-2215) updates the connection logic to prevent premature failure when a server in the seedlist is not available. As part of this change, Servers created by the SDAM topology are configured to automatically reconnect indefinitely until they are explicitly removed from the topology and destroyed, otherwise the monitoring pool for servers that fail to connect will be destroyed and the driver would be unable to detect if/when the server becomes available.

Also, a trivial change was included to resolve [NODE-2214](https://jira.mongodb.org/browse/NODE-2214) and leave `Unknown` server types in topologies of type `ReplicaSetNoPrimary`.

**Are there any files to ignore?**
No