### PR TITLE
docs(count): more explicit documentation that count is deprecated

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1401,7 +1401,12 @@ Collection.prototype.indexInformation = function(options, callback) {
  */
 
 /**
- * Count number of matching documents in the db to a query.
+ * An estimated count of matching documents in the db to a query.
+ *
+ * **NOTE:** This method has been deprecated, since it does not provide an accurate count of the documents
+ * in a collection. To obtain an accurate count of documents in the collection, use {@link Collection#countDocuments countDocuments}.
+ * To obtain an estimated count of all documents in the collection, use {@link Collection#estimatedDocumentCount estimatedDocumentCount}.
+ *
  * @method
  * @param {object} [query={}] The query for the count.
  * @param {object} [options] Optional settings.


### PR DESCRIPTION
## Description

Adds explicit docs that count is deprecated, with instructions
to use estimatedDocumentCount or countDocuments instead.

Fixes NODE-2224

What it looks like:

![Screen Shot 2019-10-03 at 3 16 08 PM](https://user-images.githubusercontent.com/7957497/66157156-27419800-e5f1-11e9-976f-982ae638b4b7.png)

If this is approved, it needs to be backported to the documentation for `3.2` and `3.1`

**What changed?**
Documentation for `Collection#count`

**Are there any files to ignore?**
No