### PR TITLE
fix(connect): Switch new Buffer(size) -> Buffer.alloc(size)

### DIFF
--- a/lib/core/connection/msg.js
+++ b/lib/core/connection/msg.js
@@ -27,6 +27,7 @@
 //   [uint32     checksum;]
 // };
 
+const Buffer = require('safe-buffer').Buffer;
 const opcodes = require('../wireprotocol/shared').opcodes;
 const databaseNamespace = require('../wireprotocol/shared').databaseNamespace;
 const ReadPreference = require('../topologies/read_preference');
@@ -90,7 +91,7 @@ class Msg {
       flags |= OPTS_EXHAUST_ALLOWED;
     }
 
-    const header = new Buffer(
+    const header = Buffer.alloc(
       4 * 4 + // Header
         4 // Flags
     );
@@ -110,7 +111,7 @@ class Msg {
   }
 
   makeDocumentSegment(buffers, document) {
-    const payloadTypeBuffer = new Buffer(1);
+    const payloadTypeBuffer = Buffer.alloc(1);
     payloadTypeBuffer[0] = 0;
 
     const documentBuffer = this.serializeBson(document);


### PR DESCRIPTION
## Description
Addresses https://github.com/mongodb-js/mongodb-core/issues/456
**What changed?**
The `new Buffer(size)` syntax is deprecated in favor of `Buffer.alloc(size)` by node.
**Are there any files to ignore?**
