### PR TITLE
fix(mongos): disconnect proxies which are not mongos instances

### DIFF
--- a/lib/core/topologies/mongos.js
+++ b/lib/core/topologies/mongos.js
@@ -366,7 +366,8 @@ function handleInitialConnectEvent(self, event) {
           self.s.logger.warn(f(message, _this.name));
         }
 
-        // This is not a mongos proxy, remove it completely
+        // This is not a mongos proxy, destroy and remove it completely
+        _this.destroy(true);
         removeProxyFrom(self.connectingProxies, _this);
         // Emit the left event
         self.emit('left', 'server', _this);
@@ -445,10 +446,9 @@ function connectProxies(self, servers) {
       server.connect(self.s.connectOptions);
     }, timeoutInterval);
   }
+
   // Start all the servers
-  while (servers.length > 0) {
-    connect(servers.shift(), timeoutInterval++);
-  }
+  servers.forEach(server => connect(server, timeoutInterval++));
 }
 
 function pickProxy(self, session) {


### PR DESCRIPTION
We were leaving servers in an open, leaked state if they were determined not to be mongos instances on connect.

NODE-2232
