### PR TITLE
docs: mark query as optional in JSDocs

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1502,7 +1502,7 @@ Collection.prototype.countDocuments = function(query, options, callback) {
  * The distinct command returns a list of distinct values for the given key across a collection.
  * @method
  * @param {string} key Field of the document to find distinct values for.
- * @param {object} query The query for filtering the set of documents to which we apply the distinct filter.
+ * @param {object} [query] The query for filtering the set of documents to which we apply the distinct filter.
  * @param {object} [options] Optional settings.
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  * @param {number} [options.maxTimeMS] Number of milliseconds to wait before aborting the query.


### PR DESCRIPTION
As can be seen in the function body, the `query` parameter is optional and will default to an empty object if not provided.

https://github.com/mongodb/node-mongodb-native/blob/0463f7838dbfc0740f6fa52174b96241eb0c3980/lib/collection.js#L1516

## Description

**What changed?**

The JSDoc was updated to reflect the optionalness of the parameter.

**Are there any files to ignore?**

No