### PR TITLE
docs(guide): convert /reference/connection-settings/ to rst

### DIFF
--- a/docs/guide/connection-settings.txt
+++ b/docs/guide/connection-settings.txt
@@ -1,3 +1,286 @@
 =======================
 URI Connection Settings
 =======================
+
+Optional connection settings are settings not covered by the :manual:`URI Connection String </reference/connection-string/>`. The following options are passed in the options parameter when you create a mongo client.
+
+.. code-block:: js
+
+   const { MongoClient } = require('mongodb');
+   const assert = require('assert');
+
+   // Connection URL
+   const url = 'mongodb://localhost:50000,localhost:50001';
+   // Database Name
+   const dbName = 'myproject';
+
+   // create a client, passing in additional options
+   const client = new MongoClient(url, {
+     poolSize: 10, ssl: true
+   });
+
+   // Use connect method to connect to the server
+   client.connect.then(async function() {
+     console.log("Connected correctly to server");
+
+     await client.close();
+   });
+
+The table below shows all settings and what topology they affect.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Affects
+     - Type
+     - Default
+     - Description
+   * - **useNewUrlParser**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - Opt-in to the new MongoDB URI parser, which conforms to the common cross-driver URI parser specification. The new URI parser will become the only URI parser in the next major version of the driver.
+   * - **useUnifiedTopology**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - Opt-in to the new Server Discovery and Monitoring engine that is more stable and aligns with other drivers. This engine will become the only SDAM engine in the next major version of the driver.
+   * - **validateOptions**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - If true, the driver will error if it detects an option that it does not recognize. If false, the driver will merely warn.
+   * - **poolSize**
+     - Server, ReplicaSet, Mongos
+     - integer
+     - 5
+     - Is an alias to :manual:`maxPoolSize </reference/connection-string/#urioption.maxPoolSize>`
+   * - **minSize**
+     - Server, ReplicaSet, Mongos
+     - integer
+     - 0
+     - Is an alias to :manual:`maxPoolSize </reference/connection-string/#urioption.minPoolSize>`
+   * - **sslValidate**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - Validate mongod server certificate against ca. Is equivalent to :manual:`tlsInsecure </reference/connection-string/#urioption.tlsInsecure>`
+   * - **family**
+     - Server, ReplicaSet, Mongos
+     - number
+     - 0
+     - Version of IP stack. Can be 4, 6, 0 or null (default). If 0 or null, will attempt to connect with IPv6, and will fall back to IPv4 on failure.
+   * - **sslCA**
+     - Server, ReplicaSet, Mongos
+     - Array
+     - null
+     - Array of valid certificates either as Buffers or Strings
+   * - **sslCert**
+     - Server, ReplicaSet, Mongos
+     - Buffer/String
+     - null
+     - String or buffer containing the certificate we wish to present
+   * - **sslKey**
+     - Server, ReplicaSet, Mongos
+     - Buffer/String
+     - null
+     - String or buffer containing the certificate private key we wish to present
+   * - **sslPass**
+     - Server, ReplicaSet, Mongos
+     - Buffer/String
+     - null
+     - String or buffer containing the certificate password
+   * - **sslCRL**
+     - Server, ReplicaSet, Mongos
+     - Buffer[]/Buffer/string[]/string
+     - null
+     - Certificate Revocation Lists. See `tls.createSecureContext <https://nodejs.org/dist/latest-v10.x/docs/api/tls.html#tls_tls_createsecurecontext_options>`_
+   * - **checkServerIdentity**
+     - Server, ReplicaSet, Mongos
+     - function/boolean
+     - true
+     - If a function, overrides built-in `tls.checkServerIdentity <https://nodejs.org/dist/latest-v10.x/docs/api/tls.html#tls_tls_checkserveridentity_hostname_cert>`_. See `tls.connect <https://nodejs.org/dist/latest-v10.x/docs/api/tls.html#tls_tls_connect_options_callback>`_. If ``false``, automatically verifies all certificates and servernames.
+   * - **noDelay**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - true
+     - TCP Socket NoDelay option. See `socket.setNoDelay <https://nodejs.org/dist/latest-v10.x/docs/api/net.html#net_socket_setnodelay_nodelay>`_
+   * - **keepAlive**
+     - Server, ReplicaSet, Mongos
+     - integer
+     - 30000
+     - Enables ``keepAlive`` on the TCP socket. See `the first parameter of socket.setKeepAlive <https://nodejs.org/dist/latest-v10.x/docs/api/net.html#net_socket_setkeepalive_enable_initialdelay>`_
+   * - **keepAliveInitialDelay**
+     - Server, ReplicaSet, Mongos
+     - integer
+     - 30000
+     - The number of milliseconds to wait before initiating keepAlive on the TCP socket. See `the second parameter of socket.setKeepAlive <https://nodejs.org/dist/latest-v10.x/docs/api/net.html#net_socket_setkeepalive_enable_initialdelay>`_
+   * - **connectTimeoutMS**
+     - Server, ReplicaSet, Mongos
+     - integer
+     - 30000
+     - TCP Connection timeout setting. The same as :manual:`connectTimeoutMS </reference/connection-string/#urioption.connectTimeoutMS>`
+   * - **socketTimeoutMS**
+     - Server, ReplicaSet, Mongos
+     - integer
+     - 360000
+     - TCP Socket timeout setting. The same as :manual:`socketTimeoutMS </reference/connection-string/#urioption.socketTimeoutMS>`
+   * - **acceptableLatencyMS**
+     - Mongos
+     - integer
+     - 15
+     - Deprecated alias to :manual:`localThresholdMS </reference/connection-string/#urioption.heartbeatFrequencyMS>`
+   * - **w**
+     - Server, ReplicaSet, Mongos
+     - string, integer
+     - null
+     - The write concern.
+   * - **wtimeout**
+     - Server, ReplicaSet, Mongos
+     - integer
+     - null
+     - Deprecated alias to :manual:`wtimeoutMS </reference/connection-string/#urioption.wtimeoutMS>`
+   * - **j**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - Deprecated alias to :manual:`journal <https://docs.mongodb.com/manual/reference/connection-string/#urioption.journal>`
+   * - **forceServerObjectId**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - Force server to assign _id values instead of driver.
+   * - **serializeFunctions**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - Serialize functions on any object.
+   * - **ignoreUndefined**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - Specify if the BSON serializer should ignore undefined fields.
+   * - **raw**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - Return document results as raw BSON buffers.
+   * - **promoteLongs**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - true
+     - Promotes Long values to number if they fit inside the 53 bits resolution.
+   * - **promoteBuffers**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - Promotes Binary BSON values to native Node Buffers.
+   * - **promoteValues**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - true
+     - Promotes BSON values to native types where possible, set to false to only receive wrapper types.
+   * - **domainsEnabled**
+     - Server, ReplicaSet, Mongos
+     - boolean
+     - false
+     - Deprecated. Enable the wrapping of the callback in the current domain, disabled by default to avoid perf hit.
+   * - **pkFactory**
+     - Server, ReplicaSet, Mongos
+     - object
+     - null
+     - A primary key factory object for generation of custom _id keys.
+   * - **promiseLibrary**
+     - Server, ReplicaSet, Mongos
+     - object
+     - null
+     - A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible.
+   * - **loggerLevel**
+     - Server, Replicaset, Mongos
+     - string
+     - null
+     - Specify the log level used by the driver logger (error/warn/info/debug)
+   * - **logger**
+     - Server, Replicaset, Mongos
+     - object
+     - null
+     - Specify a customer logger mechanism, can be used to log using your app level logger
+
+The following options do not work with ``useUnifiedTopology: true`` and are consider deprecated:
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Affects
+     - Type
+     - Default
+     - Description
+   * - **autoReconnect**
+     - Server
+     - boolean
+     - true
+     - Enables autoReconnecting when using a standalone server in the legacy topology setup
+   * - **reconnectTries**
+     - Server
+     - integer
+     - 30
+     - When ``autoReconnect`` is enabled, the server attempt to reconnect #times.
+   * - **reconnectInterval**
+     - Server
+     - integer
+     - 1000
+     - When ``autoReconnect`` is enabled, the server will wait # milliseconds between retries.
+   * - **haInterval**
+     - ReplicaSet, Mongos
+     - integer
+     - 10000,5000
+     - Time between each replicaset status check.
+   * - **secondaryAcceptableLatencyMS**
+     - ReplicaSet
+     - integer
+     - 15
+     - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency fence, ex: range of 1 to (1 + 15) ms).
+   * - **connectWithNoPrimary**
+     - ReplicaSet
+     - boolean
+     - false
+     - Sets if the driver should connect even if no primary is available.
+   * - **bufferMaxEntries**
+     - Server, ReplicaSet, Mongos
+     - integer
+     - -1
+     - Sets a cap on how many operations the driver will buffer up before giving up on getting a working connection, default is -1 which is unlimited.
+
+
+
+Ensure your connection string is valid for Replica Sets
+=======================================================
+
+The connection string passed to the driver must use the fully qualified host names for the servers as set in the replicaset config. Given the following configuration settings for your replicaset.
+
+.. code-block:: js
+
+   {
+       "_id" : "testSet",
+       "version" : 1,
+       "protocolVersion" : 1,
+       "members" : [
+           {
+               "_id" : 1,
+               "host" : "server1:31000",
+           },
+           {
+               "_id" : 2,
+               "host" : "server2:31001",
+           },
+           {
+               "_id" : 3,
+               "host" : "server3:31002",
+           }
+       ]
+   }
+
+You must ensure ``server1``, ``server2`` and ``server3`` are resolvable from the driver for the Replicaset discovery and failover to work correctly.

--- a/docs/guide/connection-settings.txt
+++ b/docs/guide/connection-settings.txt
@@ -7,24 +7,29 @@ Optional connection settings are settings not covered by the :manual:`URI Connec
 .. code-block:: js
 
    const { MongoClient } = require('mongodb');
-   const assert = require('assert');
 
    // Connection URL
    const url = 'mongodb://localhost:50000,localhost:50001';
-   // Database Name
-   const dbName = 'myproject';
 
    // create a client, passing in additional options
    const client = new MongoClient(url, {
      poolSize: 10, ssl: true
    });
 
-   // Use connect method to connect to the server
-   client.connect.then(async function() {
-     console.log("Connected correctly to server");
+   // Function to connect to the server and run your code
+   async function run() {
+     try {
+       // Connect the client to the server
+       await client.connect();
+       console.log('Connected successfully to server');
+     } finally {
+       // Ensures that the client will close when you finish/error
+       await client.close();
+     }
+   }
 
-     await client.close();
-   });
+   // Runs your code
+   run();
 
 The table below shows all settings and what topology they affect.
 
@@ -264,21 +269,21 @@ The connection string passed to the driver must use the fully qualified host nam
 .. code-block:: js
 
    {
-       "_id" : "testSet",
-       "version" : 1,
-       "protocolVersion" : 1,
-       "members" : [
+       _id: 'testSet',
+       version: 1,
+       protocolVersion: 1,
+       members: [
            {
-               "_id" : 1,
-               "host" : "server1:31000",
+               _id: 1,
+               host: 'server1:31000',
            },
            {
-               "_id" : 2,
-               "host" : "server2:31001",
+               _id: 2,
+               host: 'server2:31001',
            },
            {
-               "_id" : 3,
-               "host" : "server3:31002",
+               _id: 3,
+               host: 'server3:31002',
            }
        ]
    }


### PR DESCRIPTION
Fixes NODE-2183

## Description

**What changed?**

* I added `useNewUrlParser` and `useUnifiedTopology` to the top
* Where possible, I removed items that were made redundant by docs.mongodb.com
* I moved any options that specifically applied to the legacy topologies to a separate table at the bottom.

**Are there any files to ignore?**
