### PR TITLE
docs(guide): convert reference/management/sdam-monitoring to rst

### DIFF
--- a/docs/guide/management/sdam-monitoring.txt
+++ b/docs/guide/management/sdam-monitoring.txt
@@ -1,3 +1,438 @@
 ===============
 SDAM Monitoring
 ===============
+
+The Node.js driver  features SDAM Monitoring events,
+allowing an application or tool to monitor changes in the drivers
+view of a single server, replica set or ``mongos``. This allows an
+application to react to changes of topology, such as a secondary
+joining or leaving a replica set.
+
+Overview of SDAM events
+-----------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Event
+     - Applies To
+     - Description
+   * - serverOpening
+     - Server, Replicaset, Mongos
+     - Emitted when server connection is established.
+   * - serverClosed
+     - Server, Replicaset, Mongos
+     - Emitted when server connection gets closed.
+   * - serverDescriptionChanged
+     - Server, Replicaset, Mongos
+     - Emitted when server state changes (such as from secondary to primary).
+   * - topologyOpening
+     - Server, Replicaset, Mongos
+     - Emitted before any server connections are performed.
+   * - topologyClosed
+     - Server, Replicaset, Mongos
+     - Emitted when topology connections have all closed.
+   * - topologyDescriptionChanged
+     - Replicaset, Mongos
+     - Emitted when the topology shape changes, such as a new primary being elected or a mongos proxy disconnecting.
+   * - serverHeartbeatStarted
+     - Replicaset, Mongos
+     - Emitted before the ismaster command is issued to a MongoDB server.
+   * - serverHeartbeatSucceeded
+     - Replicaset, Mongos
+     - Emitted after a successful ismaster command was issued to a MongoDB server.
+   * - serverHeartbeatFailed
+     - Replicaset, Mongos
+     - Emitted if a ismaster command failed against a specific MongoDB server.
+
+
+Simple Code Example
+-------------------
+
+The following example demonstrates how to connect to a replica set and monitor all the events that are emitted by the replica set topology.
+
+.. code-block:: js
+
+   const { MongoClient } = require('mongodb');
+
+   const url = 'mongodb://localhost:31000,localhost:31001/?replicaSet=rs';
+   const client = new MongoClient(url);
+
+   client.on('serverDescriptionChanged', function(event) {
+     console.log('received serverDescriptionChanged');
+     console.log(JSON.stringify(event, null, 2));
+   });
+
+   client.on('serverHeartbeatStarted', function(event) {
+     console.log('received serverHeartbeatStarted');
+     console.log(JSON.stringify(event, null, 2));
+   });
+
+   client.on('serverHeartbeatSucceeded', function(event) {
+     console.log('received serverHeartbeatSucceeded');
+     console.log(JSON.stringify(event, null, 2));
+   });
+
+   client.on('serverHeartbeatFailed', function(event) {
+     console.log('received serverHeartbeatFailed');
+     console.log(JSON.stringify(event, null, 2));
+   });
+
+   client.on('serverOpening', function(event) {
+     console.log('received serverOpening');
+     console.log(JSON.stringify(event, null, 2));
+   });
+
+   client.on('serverClosed', function(event) {
+     console.log('received serverClosed');
+     console.log(JSON.stringify(event, null, 2));
+   });
+
+   client.on('topologyOpening', function(event) {
+     console.log('received topologyOpening');
+     console.log(JSON.stringify(event, null, 2));
+   });
+
+   client.on('topologyClosed', function(event) {
+     console.log('received topologyClosed');
+     console.log(JSON.stringify(event, null, 2));
+   });
+
+   client.on('topologyDescriptionChanged', function(event) {
+     console.log('received topologyDescriptionChanged');
+     console.log(JSON.stringify(event, null, 2));
+   });
+
+   client.connect().then(async function() {
+     console.log('successfully connected');
+     await client.close();
+   });
+
+Example Documents Returned For Each Event Type
+----------------------------------------------
+
+The following examples serve as a guide to the format of the returned documents.
+
+serverDescriptionChanged
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: js
+
+  {
+    "topologyId": 0,
+    "address": "localhost:27017",
+    "previousDescription": {
+      "address": "localhost:27017",
+      "error": null,
+      "roundTripTime": 0,
+      "lastUpdateTime": 1570830309832,
+      "lastWriteDate": "2019-10-11T21:45:02.000Z",
+      "opTime": {
+        "ts": "6746664774655803393",
+        "t": 16
+      },
+      "type": "RSPrimary",
+      "minWireVersion": 0,
+      "maxWireVersion": 7,
+      "maxBsonObjectSize": 16777216,
+      "maxMessageSizeBytes": 48000000,
+      "maxWriteBatchSize": 100000,
+      "me": "localhost:27017",
+      "hosts": [
+        "localhost:27017"
+      ],
+      "passives": [],
+      "arbiters": [],
+      "tags": [],
+      "setName": "rs",
+      "setVersion": 1,
+      "electionId": "7fffffff0000000000000010",
+      "primary": "localhost:27017",
+      "logicalSessionTimeoutMinutes": 30,
+      "$clusterTime": {
+        "clusterTime": "6746664774655803393",
+        "signature": {
+          "hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "keyId": 0
+        }
+      }
+    },
+    "newDescription": {
+      "address": "localhost:27017",
+      "error": null,
+      "roundTripTime": 0,
+      "lastUpdateTime": 1570830310333,
+      "lastWriteDate": "2019-10-11T21:45:02.000Z",
+      "opTime": {
+        "ts": "6746664774655803393",
+        "t": 16
+      },
+      "type": "RSPrimary",
+      "minWireVersion": 0,
+      "maxWireVersion": 7,
+      "maxBsonObjectSize": 16777216,
+      "maxMessageSizeBytes": 48000000,
+      "maxWriteBatchSize": 100000,
+      "me": "localhost:27017",
+      "hosts": [
+        "localhost:27017"
+      ],
+      "passives": [],
+      "arbiters": [],
+      "tags": [],
+      "setName": "rs",
+      "setVersion": 1,
+      "electionId": "7fffffff0000000000000010",
+      "primary": "localhost:27017",
+      "logicalSessionTimeoutMinutes": 30,
+      "$clusterTime": {
+        "clusterTime": "6746664774655803393",
+        "signature": {
+          "hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "keyId": 0
+        }
+      }
+    }
+  }
+
+The type can be one of the following values.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Type
+     - Description
+   * - Unknown
+     - Unknown server
+   * - Standalone
+     - Standalone server
+   * - Mongos
+     - Mongos proxy
+   * - PossiblePrimary
+     - Not checked yet, but another server thinks this is a primary
+   * - RSPrimary
+     - Primary server
+   * - RSSecondary
+     - Secondary server
+   * - RSArbiter
+     - Arbiter
+   * - RSOther
+     - See `the spec <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#rsghost-and-rsother>`_ for more details
+   * - RSGhost
+     - See `the spec <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#rsghost-and-rsother>`_ for more details
+
+serverHeartbeatStarted
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: js
+
+   { connectionId: 'localhost:27017' }
+
+serverHeartbeatSucceeded
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: js
+
+   { durationMS: 20,
+     reply: {
+       setName: "rs", setVersion: 1, electionId: new ObjectId(),
+       maxBsonObjectSize : 16777216, maxMessageSizeBytes : 48000000,
+       maxWriteBatchSize : 1000, localTime : new Date(),
+       maxWireVersion : 4, minWireVersion : 0, ok : 1,
+       hosts: ["localhost:32000", "localhost:32001"],
+       arbiters: ["localhost:32002"]
+     },
+     connectionId: 'localhost:27017' }
+
+serverHeartbeatFailed
+^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: js
+
+   { durationMS: 20,
+     failure: new MongoError('some error'),
+     connectionId: 'localhost:27017' }
+
+serverOpening
+^^^^^^^^^^^^^
+
+.. code-block:: js
+
+   { topologyId: 0, name: 'localhost:27017' }
+
+serverClosed
+^^^^^^^^^^^^
+
+.. code-block:: js
+
+   { topologyId: 0, name: 'localhost:27017' }
+
+topologyOpening
+^^^^^^^^^^^^^^^
+
+.. code-block:: js
+
+   { topologyId: 0 }
+
+topologyClosed
+^^^^^^^^^^^^^^
+
+.. code-block:: js
+
+   { topologyId: 0 }
+
+topologyDescriptionChanged
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: js
+
+   {
+     "topologyId": 0,
+     "previousDescription": {
+       "type": "ReplicaSetWithPrimary",
+       "setName": "rs",
+       "maxSetVersion": 1,
+       "maxElectionId": null,
+       // Note: this field is a Map of server address to serverDescriptions, which
+       // does not serialize in JSON.stringify(). Check out the serverDescriptions
+       // from the serverDescriptionChanged event above to see the contents
+       "servers": {},
+       "stale": false,
+       "compatible": true,
+       "compatibilityError": null,
+       "logicalSessionTimeoutMinutes": 30,
+       "heartbeatFrequencyMS": 30000,
+       "localThresholdMS": 15,
+       "options": {
+         "localThresholdMS": 15,
+         "serverSelectionTimeoutMS": 10000,
+         "heartbeatFrequencyMS": 30000,
+         "minHeartbeatFrequencyMS": 500,
+         "reconnect": false,
+         "emitError": true,
+         "size": 5,
+         "monitorCommands": false,
+         "socketOptions": {},
+         "read_preference_tags": null,
+         "readPreference": {
+           "mode": "primary"
+         },
+         "useUnifiedTopology": true,
+         "setName": "rs",
+         "dbName": "admin",
+         "servers": [
+           {
+             "host": "localhost",
+             "port": 27017
+           }
+         ],
+         "server_options": {
+           "socketOptions": {}
+         },
+         "db_options": {
+           "read_preference_tags": null,
+           "readPreference": "primary",
+           "useUnifiedTopology": true
+         },
+         "rs_options": {
+           "socketOptions": {},
+           "rs_name": "rs"
+         },
+         "mongos_options": {
+           "socketOptions": {}
+         },
+         "socketTimeout": 360000,
+         "connectionTimeout": 30000,
+         "retryWrites": true,
+         "useRecoveryToken": true,
+         "compression": {
+           "compressors": []
+         }
+       },
+       "error": null,
+       "commonWireVersion": 7
+     },
+     "newDescription": {
+       "type": "ReplicaSetWithPrimary",
+       "setName": "rs",
+       "maxSetVersion": 1,
+       "maxElectionId": null,
+       // Note: this field is a Map of server address to serverDescriptions, which
+       // does not serialize in JSON.stringify(). Check out the serverDescriptions
+       // from the serverDescriptionChanged event above to see the contents
+       "servers": {},
+       "stale": false,
+       "compatible": true,
+       "compatibilityError": null,
+       "logicalSessionTimeoutMinutes": 30,
+       "heartbeatFrequencyMS": 30000,
+       "localThresholdMS": 15,
+       "options": {
+         "localThresholdMS": 15,
+         "serverSelectionTimeoutMS": 10000,
+         "heartbeatFrequencyMS": 30000,
+         "minHeartbeatFrequencyMS": 500,
+         "reconnect": false,
+         "emitError": true,
+         "size": 5,
+         "monitorCommands": false,
+         "socketOptions": {},
+         "read_preference_tags": null,
+         "readPreference": {
+           "mode": "primary"
+         },
+         "useUnifiedTopology": true,
+         "setName": "rs",
+         "dbName": "admin",
+         "servers": [
+           {
+             "host": "localhost",
+             "port": 27017
+           }
+         ],
+         "server_options": {
+           "socketOptions": {}
+         },
+         "db_options": {
+           "read_preference_tags": null,
+           "readPreference": "primary",
+           "useUnifiedTopology": true
+         },
+         "rs_options": {
+           "socketOptions": {},
+           "rs_name": "rs"
+         },
+         "mongos_options": {
+           "socketOptions": {}
+         },
+         "socketTimeout": 360000,
+         "connectionTimeout": 30000,
+         "retryWrites": true,
+         "useRecoveryToken": true,
+         "compression": {
+           "compressors": []
+         }
+       },
+       "error": null,
+       "commonWireVersion": 7
+     }
+   }
+     
+
+The ``topologyType`` field can be one of the following values:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Type
+     - Description
+   * - Single
+     - A single standalone server
+   * - ReplicaSetWithPrimary
+     - Replica set with a primary
+   * - ReplicaSetNoPrimary
+     - Replica set with no primary
+   * - Sharded
+     - A sharded cluster
+   * - Unknown
+     - Unknown topology

--- a/docs/guide/management/sdam-monitoring.txt
+++ b/docs/guide/management/sdam-monitoring.txt
@@ -2,7 +2,7 @@
 SDAM Monitoring
 ===============
 
-The Node.js driver  features SDAM Monitoring events,
+The Node.js driver features SDAM Monitoring events,
 allowing an application or tool to monitor changes in the drivers
 view of a single server, replica set or ``mongos``. This allows an
 application to react to changes of topology, such as a secondary
@@ -118,84 +118,52 @@ serverDescriptionChanged
 
 .. code-block:: js
 
-  {
-    "topologyId": 0,
-    "address": "localhost:27017",
-    "previousDescription": {
-      "address": "localhost:27017",
-      "error": null,
-      "roundTripTime": 0,
-      "lastUpdateTime": 1570830309832,
-      "lastWriteDate": "2019-10-11T21:45:02.000Z",
-      "opTime": {
-        "ts": "6746664774655803393",
-        "t": 16
-      },
-      "type": "RSPrimary",
-      "minWireVersion": 0,
-      "maxWireVersion": 7,
-      "maxBsonObjectSize": 16777216,
-      "maxMessageSizeBytes": 48000000,
-      "maxWriteBatchSize": 100000,
-      "me": "localhost:27017",
-      "hosts": [
-        "localhost:27017"
-      ],
-      "passives": [],
-      "arbiters": [],
-      "tags": [],
-      "setName": "rs",
-      "setVersion": 1,
-      "electionId": "7fffffff0000000000000010",
-      "primary": "localhost:27017",
-      "logicalSessionTimeoutMinutes": 30,
-      "$clusterTime": {
-        "clusterTime": "6746664774655803393",
-        "signature": {
-          "hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-          "keyId": 0
-        }
-      }
-    },
-    "newDescription": {
-      "address": "localhost:27017",
-      "error": null,
-      "roundTripTime": 0,
-      "lastUpdateTime": 1570830310333,
-      "lastWriteDate": "2019-10-11T21:45:02.000Z",
-      "opTime": {
-        "ts": "6746664774655803393",
-        "t": 16
-      },
-      "type": "RSPrimary",
-      "minWireVersion": 0,
-      "maxWireVersion": 7,
-      "maxBsonObjectSize": 16777216,
-      "maxMessageSizeBytes": 48000000,
-      "maxWriteBatchSize": 100000,
-      "me": "localhost:27017",
-      "hosts": [
-        "localhost:27017"
-      ],
-      "passives": [],
-      "arbiters": [],
-      "tags": [],
-      "setName": "rs",
-      "setVersion": 1,
-      "electionId": "7fffffff0000000000000010",
-      "primary": "localhost:27017",
-      "logicalSessionTimeoutMinutes": 30,
-      "$clusterTime": {
-        "clusterTime": "6746664774655803393",
-        "signature": {
-          "hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-          "keyId": 0
-        }
-      }
-    }
-  }
+  ServerDescriptionChangedEvent {
+     topologyId: 0,
+     address: 'localhost:27017',
+     previousDescription: ServerDescription {
+       address: 'localhost:27017',
+       error: null,
+       roundTripTime: 0,
+       lastUpdateTime: 1571251089030,
+       lastWriteDate: null,
+       opTime: null,
+       type: 'Unknown',
+       minWireVersion: 0,
+       maxWireVersion: 0,
+       hosts: [],
+       passives: [],
+       arbiters: [],
+       tags: []
+     },
+     newDescription: ServerDescription {
+       address: 'localhost:27017',
+       error: null,
+       roundTripTime: 0,
+       lastUpdateTime: 1571251089051,
+       lastWriteDate: 2019-10-16T18:38:07.000Z,
+       opTime: { ts: Timestamp, t: 18 },
+       type: 'RSPrimary',
+       minWireVersion: 0,
+       maxWireVersion: 7,
+       maxBsonObjectSize: 16777216,
+       maxMessageSizeBytes: 48000000,
+       maxWriteBatchSize: 100000,
+       me: 'localhost:27017',
+       hosts: [ 'localhost:27017' ],
+       passives: [],
+       arbiters: [],
+       tags: [],
+       setName: 'rs',
+       setVersion: 1,
+       electionId: ObjectID,
+       primary: 'localhost:27017',
+       logicalSessionTimeoutMinutes: 30,
+       '$clusterTime': ClusterTime
+     }
+   }
 
-The type can be one of the following values.
+The ``type`` of the ``ServerDescription`` can be one of the following values:
 
 .. list-table::
    :header-rows: 1
@@ -226,200 +194,143 @@ serverHeartbeatStarted
 
 .. code-block:: js
 
-   { connectionId: 'localhost:27017' }
+   ServerHeartbeatStartedEvent {
+     connectionId: 'localhost:27017'
+   }
 
 serverHeartbeatSucceeded
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: js
 
-   { durationMS: 20,
-     reply: {
-       setName: "rs", setVersion: 1, electionId: new ObjectId(),
-       maxBsonObjectSize : 16777216, maxMessageSizeBytes : 48000000,
-       maxWriteBatchSize : 1000, localTime : new Date(),
-       maxWireVersion : 4, minWireVersion : 0, ok : 1,
-       hosts: ["localhost:32000", "localhost:32001"],
-       arbiters: ["localhost:32002"]
+   ServerHeartbeatSucceededEvent {
+     duration: 1.939997,
+     reply:{
+       hosts: [ 'localhost:27017' ],
+       setName: 'rs',
+       setVersion: 1,
+       ismaster: true,
+       secondary: false,
+       primary: 'localhost:27017',
+       me: 'localhost:27017',
+       electionId: ObjectID,
+       lastWrite: {
+         opTime: { ts: [Timestamp], t: 18 },
+         lastWriteDate: 2019-10-16T18:38:17.000Z,
+         majorityOpTime: { ts: [Timestamp], t: 18 },
+         majorityWriteDate: 2019-10-16T18:38:17.000Z
+       },
+       maxBsonObjectSize: 16777216,
+       maxMessageSizeBytes: 48000000,
+       maxWriteBatchSize: 100000,
+       localTime: 2019-10-16T18:38:19.589Z,
+       logicalSessionTimeoutMinutes: 30,
+       minWireVersion: 0,
+       maxWireVersion: 7,
+       readOnly: false,
+       ok: 1,
+       operationTime: Timestamp,
+       '$clusterTime': ClusterTime
      },
-     connectionId: 'localhost:27017' }
+     connectionId: 'localhost:27017'
+   }
 
 serverHeartbeatFailed
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: js
 
-   { durationMS: 20,
-     failure: new MongoError('some error'),
-     connectionId: 'localhost:27017' }
+   ServerHeartbeatFailed {
+     duration: 20,
+     failure: MongoError('some error'),
+     connectionId: 'localhost:27017'
+   }
 
 serverOpening
 ^^^^^^^^^^^^^
 
 .. code-block:: js
 
-   { topologyId: 0, name: 'localhost:27017' }
+   ServerOpeningEvent {
+     topologyId: 0,
+     address: 'localhost:27017'
+   }
 
 serverClosed
 ^^^^^^^^^^^^
 
 .. code-block:: js
 
-   { topologyId: 0, name: 'localhost:27017' }
+   ServerClosedEvent {
+     topologyId: 0,
+     address: 'localhost:27017' 
+   }
 
 topologyOpening
 ^^^^^^^^^^^^^^^
 
 .. code-block:: js
 
-   { topologyId: 0 }
+   TopologyOpeningEvent {
+     topologyId: 0
+   }
 
 topologyClosed
 ^^^^^^^^^^^^^^
 
 .. code-block:: js
 
-   { topologyId: 0 }
+   TopologyClosedEvent {
+     topologyId: 0
+   }
 
 topologyDescriptionChanged
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: js
 
-   {
-     "topologyId": 0,
-     "previousDescription": {
-       "type": "ReplicaSetWithPrimary",
-       "setName": "rs",
-       "maxSetVersion": 1,
-       "maxElectionId": null,
-       // Note: this field is a Map of server address to serverDescriptions, which
-       // does not serialize in JSON.stringify(). Check out the serverDescriptions
-       // from the serverDescriptionChanged event above to see the contents
-       "servers": {},
-       "stale": false,
-       "compatible": true,
-       "compatibilityError": null,
-       "logicalSessionTimeoutMinutes": 30,
-       "heartbeatFrequencyMS": 30000,
-       "localThresholdMS": 15,
-       "options": {
-         "localThresholdMS": 15,
-         "serverSelectionTimeoutMS": 10000,
-         "heartbeatFrequencyMS": 30000,
-         "minHeartbeatFrequencyMS": 500,
-         "reconnect": false,
-         "emitError": true,
-         "size": 5,
-         "monitorCommands": false,
-         "socketOptions": {},
-         "read_preference_tags": null,
-         "readPreference": {
-           "mode": "primary"
-         },
-         "useUnifiedTopology": true,
-         "setName": "rs",
-         "dbName": "admin",
-         "servers": [
-           {
-             "host": "localhost",
-             "port": 27017
-           }
-         ],
-         "server_options": {
-           "socketOptions": {}
-         },
-         "db_options": {
-           "read_preference_tags": null,
-           "readPreference": "primary",
-           "useUnifiedTopology": true
-         },
-         "rs_options": {
-           "socketOptions": {},
-           "rs_name": "rs"
-         },
-         "mongos_options": {
-           "socketOptions": {}
-         },
-         "socketTimeout": 360000,
-         "connectionTimeout": 30000,
-         "retryWrites": true,
-         "useRecoveryToken": true,
-         "compression": {
-           "compressors": []
-         }
+   TopologyDescriptionChangedEvent {
+     topologyId: 0,
+     previousDescription: TopologyDescription {
+       type: 'ReplicaSetNoPrimary',
+       setName: null,
+       maxSetVersion: null,
+       maxElectionId: null,
+       servers: Map {
+         'localhost:27017' => ServerDescription
        },
-       "error": null,
-       "commonWireVersion": 7
+       stale: false,
+       compatible: true,
+       compatibilityError: null,
+       logicalSessionTimeoutMinutes: null,
+       heartbeatFrequencyMS: 10000,
+       localThresholdMS: 15,
+       options: Object,
+       error: undefined,
+       commonWireVersion: null
      },
-     "newDescription": {
-       "type": "ReplicaSetWithPrimary",
-       "setName": "rs",
-       "maxSetVersion": 1,
-       "maxElectionId": null,
-       // Note: this field is a Map of server address to serverDescriptions, which
-       // does not serialize in JSON.stringify(). Check out the serverDescriptions
-       // from the serverDescriptionChanged event above to see the contents
-       "servers": {},
-       "stale": false,
-       "compatible": true,
-       "compatibilityError": null,
-       "logicalSessionTimeoutMinutes": 30,
-       "heartbeatFrequencyMS": 30000,
-       "localThresholdMS": 15,
-       "options": {
-         "localThresholdMS": 15,
-         "serverSelectionTimeoutMS": 10000,
-         "heartbeatFrequencyMS": 30000,
-         "minHeartbeatFrequencyMS": 500,
-         "reconnect": false,
-         "emitError": true,
-         "size": 5,
-         "monitorCommands": false,
-         "socketOptions": {},
-         "read_preference_tags": null,
-         "readPreference": {
-           "mode": "primary"
-         },
-         "useUnifiedTopology": true,
-         "setName": "rs",
-         "dbName": "admin",
-         "servers": [
-           {
-             "host": "localhost",
-             "port": 27017
-           }
-         ],
-         "server_options": {
-           "socketOptions": {}
-         },
-         "db_options": {
-           "read_preference_tags": null,
-           "readPreference": "primary",
-           "useUnifiedTopology": true
-         },
-         "rs_options": {
-           "socketOptions": {},
-           "rs_name": "rs"
-         },
-         "mongos_options": {
-           "socketOptions": {}
-         },
-         "socketTimeout": 360000,
-         "connectionTimeout": 30000,
-         "retryWrites": true,
-         "useRecoveryToken": true,
-         "compression": {
-           "compressors": []
-         }
+     newDescription: TopologyDescription {
+       type: 'ReplicaSetWithPrimary',
+       setName: 'rs',
+       maxSetVersion: 1,
+       maxElectionId: null,
+       servers: Map {
+         'localhost:27017' => ServerDescription
        },
-       "error": null,
-       "commonWireVersion": 7
+       stale: false,
+       compatible: true,
+       compatibilityError: null,
+       logicalSessionTimeoutMinutes: 30,
+       heartbeatFrequencyMS: 10000,
+       localThresholdMS: 15,
+       options: Object,
+       error: undefined,
+       commonWireVersion: 7
      }
    }
      
 
-The ``topologyType`` field can be one of the following values:
+The ``type`` field can be one of the following values:
 
 .. list-table::
    :header-rows: 1

--- a/docs/guide/management/sdam-monitoring.txt
+++ b/docs/guide/management/sdam-monitoring.txt
@@ -58,55 +58,61 @@ The following example demonstrates how to connect to a replica set and monitor a
    const url = 'mongodb://localhost:31000,localhost:31001/?replicaSet=rs';
    const client = new MongoClient(url);
 
-   client.on('serverDescriptionChanged', function(event) {
+   client.on('serverDescriptionChanged', event => {
      console.log('received serverDescriptionChanged');
      console.log(JSON.stringify(event, null, 2));
    });
 
-   client.on('serverHeartbeatStarted', function(event) {
+   client.on('serverHeartbeatStarted', event => {
      console.log('received serverHeartbeatStarted');
      console.log(JSON.stringify(event, null, 2));
    });
 
-   client.on('serverHeartbeatSucceeded', function(event) {
+   client.on('serverHeartbeatSucceeded', event => {
      console.log('received serverHeartbeatSucceeded');
      console.log(JSON.stringify(event, null, 2));
    });
 
-   client.on('serverHeartbeatFailed', function(event) {
+   client.on('serverHeartbeatFailed', event => {
      console.log('received serverHeartbeatFailed');
      console.log(JSON.stringify(event, null, 2));
    });
 
-   client.on('serverOpening', function(event) {
+   client.on('serverOpening', event => {
      console.log('received serverOpening');
      console.log(JSON.stringify(event, null, 2));
    });
 
-   client.on('serverClosed', function(event) {
+   client.on('serverClosed', event => {
      console.log('received serverClosed');
      console.log(JSON.stringify(event, null, 2));
    });
 
-   client.on('topologyOpening', function(event) {
+   client.on('topologyOpening', event => {
      console.log('received topologyOpening');
      console.log(JSON.stringify(event, null, 2));
    });
 
-   client.on('topologyClosed', function(event) {
+   client.on('topologyClosed', event => {
      console.log('received topologyClosed');
      console.log(JSON.stringify(event, null, 2));
    });
 
-   client.on('topologyDescriptionChanged', function(event) {
+   client.on('topologyDescriptionChanged', event => {
      console.log('received topologyDescriptionChanged');
      console.log(JSON.stringify(event, null, 2));
    });
 
-   client.connect().then(async function() {
-     console.log('successfully connected');
-     await client.close();
-   });
+   async function run() {
+     try {
+       await client.connect();
+       console.log('successfully connected');
+     } finally {
+       await client.close();
+     }
+   }
+
+   run();
 
 Example Documents Returned For Each Event Type
 ----------------------------------------------


### PR DESCRIPTION
Fixes NODE-2193

## Description

**What changed?**

I tried to update the structure of the SDAM notifications as best as possible. The problem is that `JSON.stringify` will not stringify `Map` and `Set`, so those show up as `{}`. If this is still adequate, then it's fine, but we might want to switch to something like ts interfaces?

**Are there any files to ignore?**
