### PR TITLE
SPEC-1334: support hint for update commands

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -591,6 +591,7 @@ class FindOperators {
    *
    * @method
    * @param {object} updateDocument An update field for an update operation. See {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-u u documentation}
+   * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
    * @throws {MongoError} If operation cannot be added to bulk write
    * @return {OrderedBulkOperation|UnorderedBulkOperation} A reference to the parent BulkOperation
    */
@@ -606,6 +607,10 @@ class FindOperators {
       upsert: upsert
     };
 
+    if (updateDocument.hint) {
+      document.hint = updateDocument.hint;
+    }
+
     // Clear out current Op
     this.s.currentOp = null;
     return this.s.options.addToOperationsList(this, UPDATE, document);
@@ -616,6 +621,7 @@ class FindOperators {
    *
    * @method
    * @param {object} updateDocument An update field for an update operation. See {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-u u documentation}
+   * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
    * @throws {MongoError} If operation cannot be added to bulk write
    * @return {OrderedBulkOperation|UnorderedBulkOperation} A reference to the parent BulkOperation
    */
@@ -630,6 +636,10 @@ class FindOperators {
       multi: false,
       upsert: upsert
     };
+
+    if (updateDocument.hint) {
+      document.hint = updateDocument.hint;
+    }
 
     // Clear out current Op
     this.s.currentOp = null;
@@ -904,6 +914,7 @@ class BulkOperationBase {
    *
    * @method
    * @param {object} op The raw operation to perform.
+   * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
    * @return {BulkOperationBase} A reference to self
    */
   raw(op) {
@@ -933,6 +944,11 @@ class BulkOperationBase {
         u: op[key].update || op[key].replacement,
         multi: multi
       };
+
+      if (op[key].hint) {
+        operation.hint = op[key].hint;
+      }
+
       if (this.isOrdered) {
         operation.upsert = op[key].upsert ? true : false;
         if (op.collation) operation.collation = op.collation;

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -690,6 +690,7 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
@@ -728,6 +729,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
  * @param {boolean} [options.j=false] Specify a journal write concern.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise<Collection~updateWriteOpResult>} returns Promise if no callback passed
  */
@@ -758,6 +760,7 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  * @param {boolean} [options.j=false] Specify a journal write concern.
  * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise<Collection~updateWriteOpResult>} returns Promise if no callback passed
  */
@@ -799,6 +802,7 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {Collection~writeOpCallback} [callback] The command result callback
  * @throws {MongoError}
  * @return {Promise} returns Promise if no callback passed

--- a/lib/operations/common_functions.js
+++ b/lib/operations/common_functions.js
@@ -347,6 +347,10 @@ function updateDocuments(coll, selector, document, options, callback) {
   op.upsert = options.upsert !== void 0 ? !!options.upsert : false;
   op.multi = options.multi !== void 0 ? !!options.multi : false;
 
+  if (options.hint) {
+    op.hint = options.hint;
+  }
+
   if (finalOptions.arrayFilters) {
     op.arrayFilters = finalOptions.arrayFilters;
     delete finalOptions.arrayFilters;

--- a/test/functional/spec/crud/v2/bulkWrite-update-hint.json
+++ b/test/functional/spec/crud/v2/bulkWrite-update-hint.json
@@ -1,0 +1,250 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    },
+    {
+      "_id": 4,
+      "x": 44
+    }
+  ],
+  "collection_name": "test_bulkwrite_update_hint",
+  "tests": [
+    {
+      "description": "BulkWrite with update hints",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              },
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 3
+                  },
+                  "replacement": {
+                    "x": 333
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 4
+                  },
+                  "replacement": {
+                    "x": 444
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "result": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {},
+            "matchedCount": 8,
+            "modifiedCount": 8,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_bulkwrite_update_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                },
+                {
+                  "q": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": {
+                    "_id": 1
+                  }
+                },
+                {
+                  "q": {
+                    "_id": 3
+                  },
+                  "u": {
+                    "x": 333
+                  },
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": 4
+                  },
+                  "u": {
+                    "x": 444
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "ordered": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 15
+            },
+            {
+              "_id": 2,
+              "x": 24
+            },
+            {
+              "_id": 3,
+              "x": 333
+            },
+            {
+              "_id": 4,
+              "x": 444
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/crud/v2/bulkWrite-update-hint.yml
+++ b/test/functional/spec/crud/v2/bulkWrite-update-hint.yml
@@ -1,0 +1,104 @@
+runOn:
+  - { minServerVersion: "4.2.0" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+  - {_id: 4, x: 44}
+
+collection_name: &collection_name 'test_bulkwrite_update_hint'
+
+tests:
+  -
+    description: "BulkWrite with update hints"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "updateOne"
+              arguments:
+                filter: &updateOne_filter { _id: 1 }
+                update: &updateOne_update { $inc: { x: 1 } }
+                hint: &hint_string "_id_"
+            -
+              name: "updateOne"
+              arguments:
+                filter: *updateOne_filter
+                update: *updateOne_update
+                hint: &hint_doc { _id: 1 }
+            -
+              name: "updateMany"
+              arguments:
+                filter: &updateMany_filter { _id: { $lt: 3 } }
+                update: &updateMany_update { $inc: { x: 1 } }
+                hint: *hint_string
+            -
+              name: "updateMany"
+              arguments:
+                filter: *updateMany_filter
+                update: *updateMany_update
+                hint: *hint_doc
+            -
+              name: "replaceOne"
+              arguments:
+                filter: { _id: 3 }
+                replacement: { x: 333 }
+                hint: *hint_string
+            -
+              name: "replaceOne"
+              arguments:
+                filter: { _id: 4 }
+                replacement: { x: 444 }
+                hint: *hint_doc
+          options: { ordered: true }
+        result:
+          deletedCount: 0
+          insertedCount: 0
+          insertedIds: {}
+          matchedCount: 8
+          modifiedCount: 8
+          upsertedCount: 0
+          upsertedIds: {}
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *updateOne_filter
+                u: *updateOne_update
+                hint: *hint_string
+              -
+                q: *updateOne_filter
+                u: *updateOne_update
+                hint: *hint_doc
+              -
+                q: *updateMany_filter
+                u: *updateMany_update
+                multi: true
+                hint: *hint_string
+              -
+                q: *updateMany_filter
+                u: *updateMany_update
+                multi: true
+                hint: *hint_doc
+              -
+                q: { _id: 3 }
+                u: { x: 333 }
+                hint: *hint_string
+              -
+                q: { _id: 4 }
+                u: { x: 444 }
+                hint: *hint_doc
+            ordered: true
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 15 }
+          - {_id: 2, x: 24 }
+          - {_id: 3, x: 333 }
+          - {_id: 4, x: 444 }

--- a/test/functional/spec/crud/v2/replaceOne-hint.json
+++ b/test/functional/spec/crud/v2/replaceOne-hint.json
@@ -1,0 +1,146 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "test_replaceone_hint",
+  "tests": [
+    {
+      "description": "ReplaceOne with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "replacement": {
+              "x": 111
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_replaceone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "x": 111
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 111
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ReplaceOne with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "replacement": {
+              "x": 111
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_replaceone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "x": 111
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 111
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/crud/v2/replaceOne-hint.yml
+++ b/test/functional/spec/crud/v2/replaceOne-hint.yml
@@ -1,0 +1,61 @@
+runOn:
+  - { minServerVersion: "4.2.0" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+
+collection_name: &collection_name 'test_replaceone_hint'
+
+tests:
+  -
+    description: "ReplaceOne with hint string"
+    operations:
+      -
+        object: collection
+        name: replaceOne
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          replacement: &replacement {x: 111}
+          hint: "_id_"
+        result: &result
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *replacement
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 111 }
+  -
+    description: "ReplaceOne with hint document"
+    operations:
+      -
+        object: collection
+        name: replaceOne
+        arguments: 
+          filter: *filter
+          replacement: *replacement
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *replacement
+                hint: { _id: 1 }
+    outcome: *outcome

--- a/test/functional/spec/crud/v2/updateMany-hint.json
+++ b/test/functional/spec/crud/v2/updateMany-hint.json
@@ -1,0 +1,168 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "test_updatemany_hint",
+  "tests": [
+    {
+      "description": "UpdateMany with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updatemany_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 34
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateMany with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updatemany_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 34
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/crud/v2/updateMany-hint.yml
+++ b/test/functional/spec/crud/v2/updateMany-hint.yml
@@ -1,0 +1,65 @@
+runOn:
+  - { minServerVersion: "4.2.0" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+
+collection_name: &collection_name 'test_updatemany_hint'
+
+tests:
+  -
+    description: "UpdateMany with hint string"
+    operations:
+      -
+        object: collection
+        name: updateMany
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          update: &update { $inc: { x: 1 } }
+          hint: "_id_"
+        result: &result
+          matchedCount: 2
+          modifiedCount: 2
+          upsertedCount: 0
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                multi: true
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 23 }
+          - { _id: 3, x: 34 }
+  -
+    description: "UpdateMany with hint document"
+    operations:
+      -
+        object: collection
+        name: updateMany
+        arguments: 
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                multi: true
+                hint: { _id: 1 }
+    outcome: *outcome

--- a/test/functional/spec/crud/v2/updateOne-hint.json
+++ b/test/functional/spec/crud/v2/updateOne-hint.json
@@ -1,0 +1,154 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "test_updateone_hint",
+  "tests": [
+    {
+      "description": "UpdateOne with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updateone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateOne with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updateone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/functional/spec/crud/v2/updateOne-hint.yml
+++ b/test/functional/spec/crud/v2/updateOne-hint.yml
@@ -1,0 +1,61 @@
+runOn:
+  - { minServerVersion: "4.2.0" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+
+collection_name: &collection_name 'test_updateone_hint'
+
+tests:
+  -
+    description: "UpdateOne with hint string"
+    operations:
+      -
+        object: collection
+        name: updateOne
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          update: &update { $inc: { x: 1 } }
+          hint: "_id_"
+        result: &result
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 23 }
+  -
+    description: "UpdateOne with hint document"
+    operations:
+      -
+        object: collection
+        name: updateOne
+        arguments: 
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                hint: { _id: 1 }
+    outcome: *outcome


### PR DESCRIPTION
## Description
This is effectively a POC for the changes added in https://github.com/mongodb/specifications/pull/596.

**What changed?**
`hint` is now supported on all update related commands. CRUDv2 spec tests have been added, and everything passes

**Are there any files to ignore?**
