### PR TITLE
fix(sdam): respect `connectTimeoutMS` and let topology set defaults

### DIFF
--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -32,6 +32,7 @@ let globalTopologyCounter = 0;
 // Constants
 const TOPOLOGY_DEFAULTS = {
   localThresholdMS: 15,
+  connectTimeoutMS: 10000,
   serverSelectionTimeoutMS: 30000,
   heartbeatFrequencyMS: 10000,
   minHeartbeatFrequencyMS: 500
@@ -127,6 +128,7 @@ class Topology extends EventEmitter {
         null,
         options
       ),
+      connectTimeoutMS: options.connectTimeoutMS,
       serverSelectionTimeoutMS: options.serverSelectionTimeoutMS,
       heartbeatFrequencyMS: options.heartbeatFrequencyMS,
       minHeartbeatIntervalMS: options.minHeartbeatIntervalMS,
@@ -251,40 +253,47 @@ class Topology extends EventEmitter {
 
     translateReadPreference(options);
     const readPreference = options.readPreference || ReadPreference.primary;
+    const selectionOptions = {
+      serverSelectionTimeoutMS: options.connectTimeoutMS || this.s.connectTimeoutMS
+    };
 
-    this.selectServer(readPreferenceServerSelector(readPreference), options, (err, server) => {
-      if (err) {
-        if (typeof callback === 'function') {
-          callback(err, null);
-        } else {
-          this.emit('error', err);
+    this.selectServer(
+      readPreferenceServerSelector(readPreference),
+      selectionOptions,
+      (err, server) => {
+        if (err) {
+          if (typeof callback === 'function') {
+            callback(err, null);
+          } else {
+            this.emit('error', err);
+          }
+
+          return;
         }
 
-        return;
+        const errorHandler = err => {
+          server.removeListener('connect', connectHandler);
+          if (typeof callback === 'function') callback(err, null);
+        };
+
+        const connectHandler = (_, err) => {
+          server.removeListener('error', errorHandler);
+          this.emit('open', err, this);
+          this.emit('connect', this);
+
+          if (typeof callback === 'function') callback(err, this);
+        };
+
+        const STATE_CONNECTING = 1;
+        if (server.s.state === STATE_CONNECTING) {
+          server.once('error', errorHandler);
+          server.once('connect', connectHandler);
+          return;
+        }
+
+        connectHandler();
       }
-
-      const errorHandler = err => {
-        server.removeListener('connect', connectHandler);
-        if (typeof callback === 'function') callback(err, null);
-      };
-
-      const connectHandler = (_, err) => {
-        server.removeListener('error', errorHandler);
-        this.emit('open', err, this);
-        this.emit('connect', this);
-
-        if (typeof callback === 'function') callback(err, this);
-      };
-
-      const STATE_CONNECTING = 1;
-      if (server.s.state === STATE_CONNECTING) {
-        server.once('error', errorHandler);
-        server.once('connect', connectHandler);
-        return;
-      }
-
-      connectHandler();
-    });
+    );
   }
 
   /**

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -277,7 +277,10 @@ function connect(mongoClient, url, options, callback) {
 
     // Check if we have connection and socket timeout set
     if (_finalOptions.socketTimeoutMS == null) _finalOptions.socketTimeoutMS = 360000;
-    if (_finalOptions.connectTimeoutMS == null) _finalOptions.connectTimeoutMS = 30000;
+    if (_finalOptions.connectTimeoutMS == null && _finalOptions.useUnifiedTopology == null) {
+      _finalOptions.connectTimeoutMS = 30000;
+    }
+
     if (_finalOptions.retryWrites == null) _finalOptions.retryWrites = true;
     if (_finalOptions.useRecoveryToken == null) _finalOptions.useRecoveryToken = true;
     if (_finalOptions.readPreference == null) _finalOptions.readPreference = 'primary';
@@ -692,7 +695,9 @@ function translateOptions(options, translationOptions) {
 
   // Set the socket and connection timeouts
   if (options.socketTimeoutMS == null) options.socketTimeoutMS = 360000;
-  if (options.connectTimeoutMS == null) options.connectTimeoutMS = 30000;
+  if (options.connectTimeoutMS == null && options.useUnifiedTopology == null) {
+    options.connectTimeoutMS = 30000;
+  }
 
   if (!translationOptions.createServers) {
     return;


### PR DESCRIPTION
The unified topology `Topology` class will now respect the value for `connectTimeoutMS` during initial connect. Additionally, the path for setting defaults for this value in the `connect` operation is now bypassed, respecting the defaults defined in the `Topology`s constructor

NODE-2250