### PR TITLE
NODE-2257: add server description equality checks

### DIFF
--- a/lib/core/sdam/server_description.js
+++ b/lib/core/sdam/server_description.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const arrayStrictEqual = require('../utils').arrayStrictEqual;
+const tagsStrictEqual = require('../utils').tagsStrictEqual;
+
 // An enumeration of server types we know about
 const ServerType = {
   Standalone: 'Standalone',
@@ -118,6 +121,31 @@ class ServerDescription {
    */
   get isWritable() {
     return WRITABLE_SERVER_TYPES.has(this.type);
+  }
+
+  /**
+   * Determines if another `ServerDescription` is equal to this one per the rules defined
+   * in the {@link https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#serverdescription|SDAM spec}
+   *
+   * @param {ServerDescription} other
+   * @return {Boolean}
+   */
+  equals(other) {
+    return (
+      other != null &&
+      this.type === other.type &&
+      this.minWireVersion === other.minWireVersion &&
+      this.me === other.me &&
+      arrayStrictEqual(this.hosts, other.hosts) &&
+      tagsStrictEqual(this.tags, other.tags) &&
+      this.setName === other.setName &&
+      this.setVersion === other.setVersion &&
+      (this.electionId
+        ? other.electionId && this.electionId.equals(other.electionId)
+        : this.electionId === other.electionId) &&
+      this.primary === other.primary &&
+      this.logicalSessionTimeoutMinutes === other.logicalSessionTimeoutMinutes
+    );
   }
 }
 

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -489,6 +489,23 @@ class Topology extends EventEmitter {
     const previousTopologyDescription = this.s.description;
     const previousServerDescription = this.s.description.servers.get(serverDescription.address);
 
+    // Driver Sessions Spec: "Whenever a driver receives a cluster time from
+    // a server it MUST compare it to the current highest seen cluster time
+    // for the deployment. If the new cluster time is higher than the
+    // highest seen cluster time it MUST become the new highest seen cluster
+    // time. Two cluster times are compared using only the BsonTimestamp
+    // value of the clusterTime embedded field."
+    const clusterTime = serverDescription.$clusterTime;
+    if (clusterTime) {
+      resolveClusterTime(this, clusterTime);
+    }
+
+    // If we already know all the information contained in this updated description, then
+    // we don't need to update anything or emit SDAM events
+    if (previousServerDescription && previousServerDescription.equals(serverDescription)) {
+      return;
+    }
+
     // first update the TopologyDescription
     this.s.description = this.s.description.update(serverDescription);
     if (this.s.description.compatibilityError) {
@@ -509,17 +526,6 @@ class Topology extends EventEmitter {
 
     // update server list from updated descriptions
     updateServers(this, serverDescription);
-
-    // Driver Sessions Spec: "Whenever a driver receives a cluster time from
-    // a server it MUST compare it to the current highest seen cluster time
-    // for the deployment. If the new cluster time is higher than the
-    // highest seen cluster time it MUST become the new highest seen cluster
-    // time. Two cluster times are compared using only the BsonTimestamp
-    // value of the clusterTime embedded field."
-    const clusterTime = serverDescription.$clusterTime;
-    if (clusterTime) {
-      resolveClusterTime(this, clusterTime);
-    }
 
     this.emit(
       'topologyDescriptionChanged',

--- a/lib/core/sdam/topology_description.js
+++ b/lib/core/sdam/topology_description.js
@@ -55,9 +55,11 @@ class TopologyDescription {
     this.logicalSessionTimeoutMinutes = null;
     this.heartbeatFrequencyMS = options.heartbeatFrequencyMS || 0;
     this.localThresholdMS = options.localThresholdMS || 0;
-    this.options = options;
     this.error = error;
     this.commonWireVersion = commonWireVersion || null;
+
+    // save this locally, but don't display when printing the instance out
+    Object.defineProperty(this, 'options', { value: options, enumberable: false });
 
     // determine server compatibility
     for (const serverDescription of this.servers.values()) {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -163,6 +163,20 @@ function isUnifiedTopology(topology) {
   return topology.description != null;
 }
 
+function arrayStrictEqual(arr, arr2) {
+  if (!Array.isArray(arr) || !Array.isArray(arr2)) {
+    return false;
+  }
+
+  return arr.length === arr2.length && arr.every((elt, idx) => elt === arr2[idx]);
+}
+
+function tagsStrictEqual(tags, tags2) {
+  const tagsKeys = Object.keys(tags);
+  const tags2Keys = Object.keys(tags2);
+  return tagsKeys.length === tags2Keys.length && tagsKeys.every(key => tags2[key] === tags[key]);
+}
+
 module.exports = {
   uuidV4,
   calculateDurationInMs,
@@ -173,5 +187,7 @@ module.exports = {
   maxWireVersion,
   isPromiseLike,
   eachAsync,
-  isUnifiedTopology
+  isUnifiedTopology,
+  arrayStrictEqual,
+  tagsStrictEqual
 };

--- a/test/core/spec/server-discovery-and-monitoring/monitoring/standalone_debounce_description_updates.json
+++ b/test/core/spec/server-discovery-and-monitoring/monitoring/standalone_debounce_description_updates.json
@@ -1,0 +1,113 @@
+{
+  "description": "Monitoring a standalone connection - multiple equal description updates are debounced",
+  "uri": "mongodb://a:27017",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 4
+          }
+        ],
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 4
+          }
+        ]
+      ],
+      "outcome": {
+        "events": [
+          {
+            "topology_opening_event": {
+              "topologyId": "42"
+            }
+          },
+          {
+            "topology_description_changed_event": {
+              "topologyId": "42",
+              "previousDescription": {
+                "topologyType": "Unknown",
+                "servers": []
+              },
+              "newDescription": {
+                "topologyType": "Single",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Unknown"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "server_opening_event": {
+              "topologyId": "42",
+              "address": "a:27017"
+            }
+          },
+          {
+            "server_description_changed_event": {
+              "topologyId": "42",
+              "address": "a:27017",
+              "previousDescription": {
+                "address": "a:27017",
+                "arbiters": [],
+                "hosts": [],
+                "passives": [],
+                "type": "Unknown"
+              },
+              "newDescription": {
+                "address": "a:27017",
+                "arbiters": [],
+                "hosts": [],
+                "passives": [],
+                "type": "Standalone"
+              }
+            }
+          },
+          {
+            "topology_description_changed_event": {
+              "topologyId": "42",
+              "previousDescription": {
+                "topologyType": "Single",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Unknown"
+                  }
+                ]
+              },
+              "newDescription": {
+                "topologyType": "Single",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Standalone"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/core/spec/server-discovery-and-monitoring/monitoring/standalone_debounce_description_updates.yml
+++ b/test/core/spec/server-discovery-and-monitoring/monitoring/standalone_debounce_description_updates.yml
@@ -1,0 +1,73 @@
+description: "Monitoring a standalone connection - multiple equal description updates are debounced"
+uri: "mongodb://a:27017"
+phases:
+  -
+    responses:
+      -
+        - "a:27017"
+        - { ok: 1, ismaster: true, minWireVersion: 0, maxWireVersion: 4 }
+      -
+        - "a:27017"
+        - { ok: 1, ismaster: true, minWireVersion: 0, maxWireVersion: 4 }
+
+    outcome:
+      events:
+        -
+          topology_opening_event:
+            topologyId: "42"
+        -
+          topology_description_changed_event:
+            topologyId: "42"
+            previousDescription:
+              topologyType: "Unknown"
+              servers: []
+            newDescription:
+              topologyType: "Single"
+              servers:
+                -
+                  address: "a:27017"
+                  arbiters: []
+                  hosts: []
+                  passives: []
+                  type: "Unknown"
+        -
+          server_opening_event:
+            topologyId: "42"
+            address: "a:27017"
+        -
+          server_description_changed_event:
+            topologyId: "42"
+            address: "a:27017"
+            previousDescription:
+              address: "a:27017"
+              arbiters: []
+              hosts: []
+              passives: []
+              type: "Unknown"
+            newDescription:
+              address: "a:27017"
+              arbiters: []
+              hosts: []
+              passives: []
+              type: "Standalone"
+        -
+          topology_description_changed_event:
+            topologyId: "42"
+            previousDescription:
+              topologyType: "Single"
+              servers:
+                -
+                  address: "a:27017"
+                  arbiters: []
+                  hosts: []
+                  passives: []
+                  type: "Unknown"
+            newDescription:
+              topologyType: "Single"
+              servers:
+                -
+                  address: "a:27017"
+                  arbiters: []
+                  hosts: []
+                  passives: []
+                  type: "Standalone"

--- a/test/tools/sdam_viz
+++ b/test/tools/sdam_viz
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+'use strict';
+
+const { MongoClient } = require('../..');
+const arrayStrictEqual = require('../../lib/core/utils').arrayStrictEqual;
+const chalk = require('chalk');
+
+function print(msg) {
+  console.log(`${chalk.white(new Date().toISOString())} ${msg}`);
+}
+
+const uri = process.argv[2];
+const client = new MongoClient(uri, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+});
+
+async function run() {
+  print(`connecting to: ${uri}`);
+  client.on('serverHeartbeatSucceeded', event =>
+    print(
+      `${chalk.yellow('heartbeat')} ${chalk.green('succeeded')} host: '${
+        event.connectionId
+      }' ${chalk.gray(`(${event.duration} ms)`)}`
+    )
+  );
+
+  client.on('serverHeartbeatFailed', event =>
+    print(
+      `${chalk.yellow('heartbeat')} ${chalk.red('failed')} host: '${
+        event.connectionId
+      }' ${chalk.gray(`(${event.duration} ms)`)}`
+    )
+  );
+
+  // server information
+  client.on('serverOpening', event => {
+    print(`${chalk.cyan('server')} [${event.address}] added to topology#${event.topologyId}`);
+  });
+
+  client.on('serverClosed', event => {
+    print(`${chalk.cyan('server')} [${event.address}] removed from topology#${event.topologyId}`);
+  });
+
+  client.on('serverDescriptionChanged', event => {
+    print(`${chalk.cyan('server')} [${event.address}] changed:`);
+    console.log(serverDescriptionDiff(event.previousDescription, event.newDescription));
+  });
+
+  // topology information
+  client.on('topologyOpening', event => {
+    print(`${chalk.magenta('topology')} adding topology#${event.topologyId}`);
+  });
+
+  client.on('topologyClosed', event => {
+    print(`${chalk.magenta('topology')} removing topology#${event.topologyId}`);
+  });
+
+  client.on('topologyDescriptionChanged', event => {
+    const diff = topologyDescriptionDiff(event.previousDescription, event.newDescription);
+    if (diff !== '') {
+      print(`${chalk.magenta('topology')} [topology#${event.topologyId}] changed:`);
+      console.log(diff);
+    }
+  });
+
+  await client.connect();
+}
+
+function diff(lhs, rhs, fields, comparator) {
+  return fields.reduce((diff, field) => {
+    if (lhs[field] == null || rhs[field] == null) {
+      return diff;
+    }
+
+    if (!comparator(lhs[field], rhs[field])) {
+      diff.push(
+        `  ${field}: ${chalk.green(`[${lhs[field]}]`)} => ${chalk.green(`[${rhs[field]}]`)}`
+      );
+    }
+
+    return diff;
+  }, []);
+}
+
+function serverDescriptionDiff(lhs, rhs) {
+  const objectIdFields = ['electionId'];
+  const arrayFields = ['hosts', 'tags'];
+  const simpleFields = [
+    'type',
+    'minWireVersion',
+    'me',
+    'setName',
+    'setVersion',
+    'electionId',
+    'primary',
+    'logicalSessionTimeoutMinutes'
+  ];
+
+  return diff(lhs, rhs, simpleFields, (x, y) => x === y)
+    .concat(diff(lhs, rhs, arrayFields, (x, y) => arrayStrictEqual(x, y)))
+    .concat(diff(lhs, rhs, objectIdFields, (x, y) => x.equals(y)))
+    .join(',\n');
+}
+
+function topologyDescriptionDiff(lhs, rhs) {
+  const simpleFields = [
+    'type',
+    'setName',
+    'maxSetVersion',
+    'stale',
+    'compatible',
+    'compatibilityError',
+    'logicalSessionTimeoutMinutes',
+    'error',
+    'commonWireVersion'
+  ];
+
+  return diff(lhs, rhs, simpleFields, (x, y) => x === y).join(',\n');
+}
+
+run().catch(error => console.log('Caught', error));
+process.on('SIGINT', async function() {
+  await client.close();
+});


### PR DESCRIPTION
## Description
`ServerDescription` gains an `equals` method, which allows us to compare against another description for equality. The new operator is used in the `Topology` update path in order to debounce topology update events when nothing of note has actually changed.

Additionally, a tool is introduced with this PR called `sdam_viz` which allows us see changes to a cluster in realtime. It's in a very nascent state, but it's very useful for watching topology changes

**NOTE:** I'd prefer not get into review of the `sdam_viz` tool, we can improve that incrementally. 