### PR TITLE
Cork uncork if buffer is an array

### DIFF
--- a/lib/core/connection/connection.js
+++ b/lib/core/connection/connection.js
@@ -251,10 +251,12 @@ class Connection extends EventEmitter {
         return true;
       }
 
+      this.socket.cork();
       // Iterate over all buffers and write them in order to the socket
       for (let i = 0; i < buffer.length; i++) {
         this.socket.write(buffer[i], 'binary');
       }
+      this.socket.uncork();
 
       return true;
     }


### PR DESCRIPTION
## Description
Socket writes have s cost. `cork` and `uncork` speed up the connection writes.
