### PR TITLE
docs(guide): converting installation-guide to rst

### DIFF
--- a/docs/guide/installation-guide.txt
+++ b/docs/guide/installation-guide.txt
@@ -1,3 +1,128 @@
 ==================
 Installation Guide
 ==================
+
+The recommended way to get started using the Node.js driver is by using ``NPM`` (Node Package Manager) to install the dependency in your project.
+
+MongoDB Driver
+--------------
+
+After you've created your project with ``npm init`` , you can install the MongoDB driver and its dependencies with the command:
+
+.. code-block:: sh
+
+   npm install mongodb --save
+
+This will download the MongoDB driver and add a dependency entry in your ``package.json`` file.
+
+Troubleshooting
+---------------
+
+The MongoDB driver depends on several other packages, including:
+
+* `bson <https://www.npmjs.com/package/bson>`_
+* `require_optional <https://www.npmjs.com/package/require_optional>`_
+* `safe-buffer <https://www.npmjs.com/package/safe-buffer>`_
+* `saslprep <https://www.npmjs.com/package/saslprep>`_
+
+Additionally, there are multiple optional dependencies that can be installed alongside the driver:
+
+* `bson-ext <https://www.npmjs.com/package/bson-ext>`_
+* `kerberos <https://www.npmjs.com/package/kerberos>`_
+* `mongodb-client-encryption <https://www.npmjs.com/package/mongodb-client-encryption>`_
+* `snappy <https://www.npmjs.com/package/snappy>`_
+
+These optional modules are all native C++ extensions. They are optional extensions and are not required for the driver to function.
+
+bson-ext Module
+---------------
+
+The ``bson-ext`` module is an alternative **BSON** parser that is written in C++. If you wish to use the ``bson-ext`` module you will need to add the ``bson-ext`` module to your module's dependencies.
+
+.. code-block::
+
+   npm install bson-ext --save
+
+kerberos Module
+---------------
+
+If you need to use ``kerberos`` module you will need to add the ``kerberos`` module to your module's dependencies.
+
+.. code-block::
+
+   npm install kerberos --save
+
+The ``kerberos`` package is a C++ extension that requires a build environment to be installed on your system. You must be able to build Node.js itself to be able to compile and install the ``kerberos`` module. Furthermore the ``kerberos`` module requires the MIT Kerberos package to correctly compile on UNIX operating systems. Consult your UNIX operating system package manager for what libraries to install.
+
+.. note::
+
+   Windows already contains the SSPI API used for Kerberos authentication. However, you will need to install a full compiler toolchain
+   using Visual Studio to correctly install the ``kerberos`` extension.
+
+Diagnosing on UNIX
+^^^^^^^^^^^^^^^^^^
+
+If you don’t have the build essentials it won’t build. In the case of linux you will need gcc and g++, Node.js with all the headers and Python. The easiest way to figure out what’s missing is by trying to build the kerberos project. You can do this by performing the following steps.
+
+.. code-block::
+
+   git clone https://github.com/mongodb-js/kerberos.git
+   cd kerberos
+   npm install
+
+If all the steps complete you have the right toolchain installed. If you get ``node-gyp not found`` you need to install it globally by doing:
+
+.. code-block::
+
+   npm install -g node-gyp
+
+If it compiles correctly, you're ready to proceed. You can now try to install the MongoDB driver with the following command:
+
+.. code-block::
+
+   cd yourproject
+   npm install mongodb --save
+
+If it still fails the next step is to examine the npm log. Re-run the command in verbose mode.
+
+.. code-block::
+
+   npm --loglevel verbose install mongodb
+
+This will print out all the steps npm is performing while trying to install the module.
+
+Diagnosing on Windows
+^^^^^^^^^^^^^^^^^^^^^
+
+A compiler toolchain known to work for compiling ``kerberos`` on Windows is the following:
+
+
+* Visual Studio 2010 (do not use higher versions)
+* Windows 7 64bit SDK
+* Python 2.7 or higher
+
+Open Visual Studio command prompt. Ensure node.exe is in your path and install node-gyp.
+
+.. code-block::
+
+   npm install -g node-gyp
+
+Next you will have to build the project manually to test it. Use any tool you use with git and grab the repo.
+
+.. code-block::
+
+   git clone https://github.com/christkv/kerberos.git
+   cd kerberos
+   npm install
+   node-gyp rebuild
+
+This should rebuild the driver successfully if you have everything set up correctly.
+
+Other possible issues
+^^^^^^^^^^^^^^^^^^^^^
+
+If Python is installed incorrectly, it can cause problems for ``gyp``. It's a good idea to test your
+deployment environment first by trying to build Node.js itself on the server in question, as this should unearth
+any issues with broken packages (and there are a lot of broken packages out there).
+
+Another thing is to ensure your user has write permission to wherever the Node.js modules are being installed.

--- a/docs/guide/installation-guide.txt
+++ b/docs/guide/installation-guide.txt
@@ -39,7 +39,7 @@ bson-ext Module
 
 The ``bson-ext`` module is an alternative **BSON** parser that is written in C++. If you wish to use the ``bson-ext`` module you will need to add the ``bson-ext`` module to your module's dependencies.
 
-.. code-block::
+.. code-block:: sh
 
    npm install bson-ext --save
 
@@ -48,7 +48,7 @@ kerberos Module
 
 If you need to use ``kerberos`` module you will need to add the ``kerberos`` module to your module's dependencies.
 
-.. code-block::
+.. code-block:: sh
 
    npm install kerberos --save
 
@@ -64,7 +64,7 @@ Diagnosing on UNIX
 
 If you don’t have the build essentials it won’t build. In the case of linux you will need gcc and g++, Node.js with all the headers and Python. The easiest way to figure out what’s missing is by trying to build the kerberos project. You can do this by performing the following steps.
 
-.. code-block::
+.. code-block:: sh
 
    git clone https://github.com/mongodb-js/kerberos.git
    cd kerberos
@@ -72,20 +72,20 @@ If you don’t have the build essentials it won’t build. In the case of linux 
 
 If all the steps complete you have the right toolchain installed. If you get ``node-gyp not found`` you need to install it globally by doing:
 
-.. code-block::
+.. code-block:: sh
 
    npm install -g node-gyp
 
 If it compiles correctly, you're ready to proceed. You can now try to install the MongoDB driver with the following command:
 
-.. code-block::
+.. code-block:: sh
 
    cd yourproject
    npm install mongodb --save
 
 If it still fails the next step is to examine the npm log. Re-run the command in verbose mode.
 
-.. code-block::
+.. code-block:: sh
 
    npm --loglevel verbose install mongodb
 
@@ -103,13 +103,13 @@ A compiler toolchain known to work for compiling ``kerberos`` on Windows is the 
 
 Open Visual Studio command prompt. Ensure node.exe is in your path and install node-gyp.
 
-.. code-block::
+.. code-block:: sh
 
    npm install -g node-gyp
 
 Next you will have to build the project manually to test it. Use any tool you use with git and grab the repo.
 
-.. code-block::
+.. code-block:: sh
 
    git clone https://github.com/christkv/kerberos.git
    cd kerberos

--- a/docs/guide/installation-guide.txt
+++ b/docs/guide/installation-guide.txt
@@ -32,7 +32,7 @@ Additionally, there are multiple optional dependencies that can be installed alo
 * `mongodb-client-encryption <https://www.npmjs.com/package/mongodb-client-encryption>`_
 * `snappy <https://www.npmjs.com/package/snappy>`_
 
-These optional modules are all native C++ extensions. They are optional extensions and are not required for the driver to function.
+These optional modules are all native C++ extensions. They are optional extensions and are not required for the driver to function. Most of these modules use the `prebuild <https://www.npmjs.com/package/prebuild>`_ package to generate pre-built binaries for various operating systems and versions of node. This pre-built version will be downloaded during the ``postinstall`` stage, removing the need to build the native bindings on the system.
 
 bson-ext Module
 ---------------
@@ -46,83 +46,11 @@ The ``bson-ext`` module is an alternative **BSON** parser that is written in C++
 kerberos Module
 ---------------
 
-If you need to use ``kerberos`` module you will need to add the ``kerberos`` module to your module's dependencies.
+If you need support for connecting to an LDAP environment, you will need to add the ``kerberos`` module to your module's dependencies.
 
 .. code-block:: sh
 
    npm install kerberos --save
 
-The ``kerberos`` package is a C++ extension that requires a build environment to be installed on your system. You must be able to build Node.js itself to be able to compile and install the ``kerberos`` module. Furthermore the ``kerberos`` module requires the MIT Kerberos package to correctly compile on UNIX operating systems. Consult your UNIX operating system package manager for what libraries to install.
-
-.. note::
-
-   Windows already contains the SSPI API used for Kerberos authentication. However, you will need to install a full compiler toolchain
-   using Visual Studio to correctly install the ``kerberos`` extension.
-
-Diagnosing on UNIX
-^^^^^^^^^^^^^^^^^^
-
-If you don’t have the build essentials it won’t build. In the case of linux you will need gcc and g++, Node.js with all the headers and Python. The easiest way to figure out what’s missing is by trying to build the kerberos project. You can do this by performing the following steps.
-
-.. code-block:: sh
-
-   git clone https://github.com/mongodb-js/kerberos.git
-   cd kerberos
-   npm install
-
-If all the steps complete you have the right toolchain installed. If you get ``node-gyp not found`` you need to install it globally by doing:
-
-.. code-block:: sh
-
-   npm install -g node-gyp
-
-If it compiles correctly, you're ready to proceed. You can now try to install the MongoDB driver with the following command:
-
-.. code-block:: sh
-
-   cd yourproject
-   npm install mongodb --save
-
-If it still fails the next step is to examine the npm log. Re-run the command in verbose mode.
-
-.. code-block:: sh
-
-   npm --loglevel verbose install mongodb
-
-This will print out all the steps npm is performing while trying to install the module.
-
-Diagnosing on Windows
-^^^^^^^^^^^^^^^^^^^^^
-
-A compiler toolchain known to work for compiling ``kerberos`` on Windows is the following:
-
-
-* Visual Studio 2010 (do not use higher versions)
-* Windows 7 64bit SDK
-* Python 2.7 or higher
-
-Open Visual Studio command prompt. Ensure node.exe is in your path and install node-gyp.
-
-.. code-block:: sh
-
-   npm install -g node-gyp
-
-Next you will have to build the project manually to test it. Use any tool you use with git and grab the repo.
-
-.. code-block:: sh
-
-   git clone https://github.com/mongodb-js/kerberos.git
-   cd kerberos
-   npm install
-   node-gyp rebuild
-
-This should rebuild the driver successfully if you have everything set up correctly.
-
-Other possible issues
-^^^^^^^^^^^^^^^^^^^^^
-
-If Python is installed incorrectly, it can cause problems for ``gyp``. It's a good idea to test your
-deployment environment first by trying to build Node.js itself on the server in question, as this should unearth
-any issues with broken packages (and there are a lot of broken packages out there).
-
-Another thing is to ensure your user has write permission to wherever the Node.js modules are being installed.
+For most versions of node and most operating systems, ``kerberos`` will download a binary generated with ``prebuild``, removing the need to compile the native bindings. If your setup is not included in our pre-built binaries, or if you need to build
+kerberos without network access, please see `the kerberos README <https://github.com/mongodb-js/kerberos/blob/master/README.md#requirements>`_ for instructions on how to build the library manually.

--- a/docs/guide/installation-guide.txt
+++ b/docs/guide/installation-guide.txt
@@ -111,7 +111,7 @@ Next you will have to build the project manually to test it. Use any tool you us
 
 .. code-block:: sh
 
-   git clone https://github.com/christkv/kerberos.git
+   git clone https://github.com/mongodb-js/kerberos.git
    cd kerberos
    npm install
    node-gyp rebuild


### PR DESCRIPTION
Fixes NODE-2180

I modified and updated up to the `Kerberos` section. Everything after the `Kerberos` heading I left mostly as is. I'm not sure we should actually include the section on `Kerberos`. We might be better off writing a separate guide on native extensions, how to install them, etc. What do y'all think?
