### PR TITLE
fix(pkFactory): use pkFactory for operations with insert as side effect

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -611,6 +611,15 @@ class FindOperators {
       document.hint = updateDocument.hint;
     }
 
+    if (document.upsert) {
+      document.u = document.u || {};
+      document.u.$setOnInsert = document.u.$setOnInsert || {};
+
+      if (!document.u.$setOnInsert._id) {
+        document.u.$setOnInsert._id = this.s.collection.s.pkFactory.createPk();
+      }
+    }
+
     // Clear out current Op
     this.s.currentOp = null;
     return this.s.options.addToOperationsList(this, UPDATE, document);
@@ -854,7 +863,7 @@ class BulkOperationBase {
    */
   insert(document) {
     if (this.s.collection.s.db.options.forceServerObjectId !== true && document._id == null)
-      document._id = new ObjectID();
+      document._id = this.s.collection.s.pkFactory.createPk();
     return this.s.options.addToOperationsList(this, INSERT, document);
   }
 
@@ -983,18 +992,18 @@ class BulkOperationBase {
     // Insert operations
     if (op.insertOne && op.insertOne.document == null) {
       if (forceServerObjectId !== true && op.insertOne._id == null)
-        op.insertOne._id = new ObjectID();
+        op.insertOne._id = this.s.collection.s.pkFactory.createPk();
       return this.s.options.addToOperationsList(this, INSERT, op.insertOne);
     } else if (op.insertOne && op.insertOne.document) {
       if (forceServerObjectId !== true && op.insertOne.document._id == null)
-        op.insertOne.document._id = new ObjectID();
+        op.insertOne.document._id = this.s.collection.s.pkFactory.createPk();
       return this.s.options.addToOperationsList(this, INSERT, op.insertOne.document);
     }
 
     if (op.insertMany) {
       for (let i = 0; i < op.insertMany.length; i++) {
         if (forceServerObjectId !== true && op.insertMany[i]._id == null)
-          op.insertMany[i]._id = new ObjectID();
+          op.insertMany[i]._id = this.s.collection.s.pkFactory.createPk();
         this.s.options.addToOperationsList(this, INSERT, op.insertMany[i]);
       }
 

--- a/lib/operations/find_and_modify.js
+++ b/lib/operations/find_and_modify.js
@@ -54,6 +54,15 @@ class FindAndModifyOperation extends OperationBase {
       queryObject.update = doc;
     }
 
+    if (doc && options.upsert) {
+      queryObject.update = queryObject.update || {};
+      queryObject.update.$setOnInsert = queryObject.update.$setOnInsert || {};
+
+      if (!queryObject.update.$setOnInsert._id) {
+        queryObject.update.$setOnInsert._id = this.collection.s.pkFactory.createPk();
+      }
+    }
+
     if (options.maxTimeMS) queryObject.maxTimeMS = options.maxTimeMS;
 
     // Either use override on the function, or go back to default on either the collection


### PR DESCRIPTION
## Description
As described in issue [`NODE-2275`](https://jira.mongodb.org/projects/NODE/issues/NODE-2275), the provided `pkFactory` is not being used for all `_id` generating methods. Or better said, all methods that can insert a document in some way.

It's being used for `col.insertOne` and `col.insertMany`, but not for `findOneAndUpdate`, `bulk.insert` or `bulk.find.upsert`.

This is my attempt to fix that. 

Small reproduction to experience the issue yourself:

```js
const Client = require('mongodb');
 
function CustomPKFactory() {}
CustomPKFactory.prototype = new Object();
CustomPKFactory.count = 0;
CustomPKFactory.createPk = function() {
return ++CustomPKFactory.count;
};
 
const host = 'mongodb://localhost:27017';
const options = { pkFactory: CustomPKFactory };
 
Client.connect(host, options, async (err, client) => {
  const db = client.db('pkFactory');
  const col = db.collection('test_custom_key');
  await col.deleteMany({});
 
  // ✓ expected _id: 1 | received _id: 1
  await col.insertOne({ a: 1 });
 
  // ⨉ expected _id: 2 | received _id: ObjectId(…)
  await col.findOneAndUpdate({ a: 2 }, { $set: { b: 2 } }, { upsert: true });
 
  const bulk = col.initializeUnorderedBulkOp();
 
  // ⨉ expected _id: 3 | received _id: ObjectId(…)
  bulk.insert({ a: 3 });
 
  // ⨉ expected _id: 4 | received _id: ObjectId(…)
  bulk
    .find({ a: 4 })
    .upsert()
    .update({ $set: { b: 4 } });
 
  await bulk.execute();
});
```

**What changed?**
Instead of simply using `ObjectId` to generate the `id`, the `pkFactory` is now being used.

**Are there any files to ignore?**
Not really, I only changed two files. Existing of 22 additions and 4 deletions. The change isn't that big.

---

fixes https://jira.mongodb.org/projects/NODE/issues/NODE-2275