### PR TITLE
NODE-2274: unified failover server loss

### DIFF
--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -537,7 +537,7 @@ Pool.prototype.isDisconnected = function() {
 /**
  * Connect pool
  */
-Pool.prototype.connect = function() {
+Pool.prototype.connect = function(callback) {
   if (this.state !== DISCONNECTED) {
     throw new MongoError('connection in unlawful state ' + this.state);
   }
@@ -545,6 +545,12 @@ Pool.prototype.connect = function() {
   stateTransition(this, CONNECTING);
   createConnection(this, (err, conn) => {
     if (err) {
+      if (typeof callback === 'function') {
+        this.destroy();
+        callback(err);
+        return;
+      }
+
       if (this.state === CONNECTING) {
         this.emit('error', err);
       }
@@ -554,7 +560,11 @@ Pool.prototype.connect = function() {
     }
 
     stateTransition(this, CONNECTED);
-    this.emit('connect', this, conn);
+    if (typeof callback === 'function') {
+      callback(null, conn);
+    } else {
+      this.emit('connect', this, conn);
+    }
 
     // create min connections
     if (this.minSize) {

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -241,7 +241,10 @@ function resetPoolState(pool) {
 
 function connectionFailureHandler(pool, event, err, conn) {
   if (conn) {
-    if (conn._connectionFailHandled) return;
+    if (conn._connectionFailHandled) {
+      return;
+    }
+
     conn._connectionFailHandled = true;
     conn.destroy();
 
@@ -430,7 +433,7 @@ function messageHandler(self) {
           updateSessionFromResponse(session, document);
         }
 
-        if (document.$clusterTime) {
+        if (self.topology && document.$clusterTime) {
           self.topology.clusterTime = document.$clusterTime;
         }
       }
@@ -752,11 +755,12 @@ Pool.prototype.reset = function(callback) {
 
       resetPoolState(this);
 
-      // attempt reexecution
-      process.nextTick(() => _execute(this)());
-      if (typeof callback === 'function') {
-        callback(null, null);
-      }
+      // create a new connection, this will ultimately trigger execution
+      createConnection(this, () => {
+        if (typeof callback === 'function') {
+          callback(null, null);
+        }
+      });
     }
   );
 };
@@ -877,10 +881,6 @@ Pool.prototype.write = function(command, options, cb) {
   // Optional per operation socketTimeout
   operation.socketTimeout = options.socketTimeout;
   operation.monitoring = options.monitoring;
-  // Custom socket Timeout
-  if (options.socketTimeout) {
-    operation.socketTimeout = options.socketTimeout;
-  }
 
   // Get the requestId
   operation.requestId = command.requestId;

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -273,7 +273,9 @@ function connectionFailureHandler(pool, event, err, conn) {
   // No more socket available propegate the event
   if (pool.socketCount() === 0) {
     if (pool.state !== DESTROYED && pool.state !== DESTROYING && pool.state !== DRAINING) {
-      stateTransition(pool, DISCONNECTED);
+      if (pool.options.reconnect) {
+        stateTransition(pool, DISCONNECTED);
+      }
     }
 
     // Do not emit error events, they are always close events

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -725,10 +725,6 @@ Pool.prototype.reset = function(callback) {
       }
 
       resetPoolState(this);
-
-      // create an initial connection, and kick off execution again
-      createConnection(this);
-
       if (typeof callback === 'function') {
         callback(null, null);
       }

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -560,17 +560,18 @@ Pool.prototype.connect = function(callback) {
     }
 
     stateTransition(this, CONNECTED);
-    if (typeof callback === 'function') {
-      callback(null, conn);
-    } else {
-      this.emit('connect', this, conn);
-    }
 
     // create min connections
     if (this.minSize) {
       for (let i = 0; i < this.minSize; i++) {
         createConnection(this);
       }
+    }
+
+    if (typeof callback === 'function') {
+      callback(null, conn);
+    } else {
+      this.emit('connect', this, conn);
     }
   });
 };
@@ -687,7 +688,6 @@ Pool.prototype.destroy = function(force, callback) {
       }
 
       destroy(self, connections, { force: false }, callback);
-      // } else if (self.queue.length > 0 && !this.reconnectId) {
     } else {
       // Ensure we empty the queue
       _execute(self)();
@@ -942,7 +942,7 @@ function removeConnection(self, connection) {
 }
 
 function createConnection(pool, callback) {
-  if (pool.state === DESTROYED || pool.state === DESTROYING) {
+  if (pool.state === DESTROYED) {
     if (typeof callback === 'function') {
       callback(new MongoError('Cannot create connection when pool is destroyed'));
     }
@@ -983,7 +983,7 @@ function createConnection(pool, callback) {
     }
 
     // the pool might have been closed since we started creating the connection
-    if (pool.state === DESTROYED || pool.state === DESTROYING) {
+    if (pool.state === DESTROYED) {
       if (typeof callback === 'function') {
         callback(new MongoError('Pool was destroyed after connection creation'));
       }
@@ -1050,6 +1050,12 @@ function _execute(self) {
       if (self.availableConnections.length === 0) {
         // Flush any monitoring operations
         flushMonitoringOperations(self.queue);
+
+        // attempt to grow the pool
+        if (totalConnections < self.options.size) {
+          createConnection(self);
+        }
+
         break;
       }
 
@@ -1114,10 +1120,7 @@ function _execute(self) {
           }
 
           // Re-execute the operation
-          setTimeout(function() {
-            _execute(self)();
-          }, 10);
-
+          setTimeout(() => _execute(self)(), 10);
           break;
         }
       }

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -636,6 +636,7 @@ function destroy(self, connections, options, callback) {
  */
 Pool.prototype.destroy = function(force, callback) {
   var self = this;
+
   // Do not try again if the pool is already dead
   if (this.state === DESTROYED || self.state === DESTROYING) {
     if (typeof callback === 'function') callback(null, null);
@@ -958,15 +959,6 @@ function createConnection(pool, callback) {
         pool.logger.debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
       }
 
-      if (pool.options.legacyCompatMode === false) {
-        // The unified topology uses the reported `error` from a pool to track what error
-        // reason is returned to the user during selection timeout. We only want to emit
-        // this if the pool is active because the listeners are removed on destruction.
-        if (pool.state !== DESTROYED && pool.state !== DESTROYING) {
-          pool.emit('error', err);
-        }
-      }
-
       // check if reconnect is enabled, and attempt retry if so
       if (!pool.reconnectId && pool.options.reconnect) {
         if (pool.state === CONNECTING && pool.options.legacyCompatMode) {
@@ -1044,6 +1036,7 @@ function _execute(self) {
     // operations
     if (self.connectingConnections > 0) {
       self.executing = false;
+      setTimeout(() => _execute(self)(), 10);
       return;
     }
 

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -643,6 +643,10 @@ function destroy(self, connections, options, callback) {
  */
 Pool.prototype.destroy = function(force, callback) {
   var self = this;
+  if (typeof force === 'function') {
+    callback = force;
+    force = false;
+  }
 
   // Do not try again if the pool is already dead
   if (this.state === DESTROYED || self.state === DESTROYING) {

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -25,12 +25,14 @@ const makeStateMachine = require('../utils').makeStateMachine;
 const DISCONNECTED = 'disconnected';
 const CONNECTING = 'connecting';
 const CONNECTED = 'connected';
+const DRAINING = 'draining';
 const DESTROYING = 'destroying';
 const DESTROYED = 'destroyed';
 const stateTransition = makeStateMachine({
-  [DISCONNECTED]: [CONNECTING, DESTROYING, DISCONNECTED],
-  [CONNECTING]: [CONNECTING, DESTROYING, CONNECTED, DISCONNECTED],
-  [CONNECTED]: [CONNECTED, DISCONNECTED, DESTROYING],
+  [DISCONNECTED]: [CONNECTING, DRAINING, DISCONNECTED],
+  [CONNECTING]: [CONNECTING, CONNECTED, DRAINING, DISCONNECTED],
+  [CONNECTED]: [CONNECTED, DISCONNECTED, DRAINING],
+  [DRAINING]: [DRAINING, DESTROYING, DESTROYED],
   [DESTROYING]: [DESTROYING, DESTROYED],
   [DESTROYED]: [DESTROYED]
 });
@@ -270,7 +272,7 @@ function connectionFailureHandler(pool, event, err, conn) {
 
   // No more socket available propegate the event
   if (pool.socketCount() === 0) {
-    if (pool.state !== DESTROYED && pool.state !== DESTROYING) {
+    if (pool.state !== DESTROYED && pool.state !== DESTROYING && pool.state !== DRAINING) {
       stateTransition(pool, DISCONNECTED);
     }
 
@@ -607,6 +609,8 @@ Pool.prototype.unref = function() {
 
 // Destroy the connections
 function destroy(self, connections, options, callback) {
+  stateTransition(self, DESTROYING);
+
   eachAsync(
     connections,
     (conn, cb) => {
@@ -644,8 +648,8 @@ Pool.prototype.destroy = function(force, callback) {
     return;
   }
 
-  // Set state to destroyed
-  stateTransition(this, DESTROYING);
+  // Set state to draining
+  stateTransition(this, DRAINING);
 
   // Are we force closing
   if (force) {
@@ -672,6 +676,14 @@ Pool.prototype.destroy = function(force, callback) {
 
   // Wait for the operations to drain before we close the pool
   function checkStatus() {
+    if (self.state === DESTROYED || self.state === DESTROYING) {
+      if (typeof callback === 'function') {
+        callback();
+      }
+
+      return;
+    }
+
     flushMonitoringOperations(self.queue);
 
     if (self.queue.length === 0) {
@@ -795,17 +807,12 @@ Pool.prototype.write = function(command, options, cb) {
 
   // Pool was destroyed error out
   if (this.state === DESTROYED || this.state === DESTROYING) {
-    // Callback with an error
-    if (cb) {
-      try {
-        cb(new MongoError('pool destroyed'));
-      } catch (err) {
-        process.nextTick(function() {
-          throw err;
-        });
-      }
-    }
+    cb(new MongoError('pool destroyed'));
+    return;
+  }
 
+  if (this.state === DRAINING) {
+    cb(new MongoError('pool is draining, new operations prohibited'));
     return;
   }
 
@@ -938,7 +945,7 @@ function removeConnection(self, connection) {
 }
 
 function createConnection(pool, callback) {
-  if (pool.state === DESTROYED) {
+  if (pool.state === DESTROYED || pool.state === DESTROYING) {
     if (typeof callback === 'function') {
       callback(new MongoError('Cannot create connection when pool is destroyed'));
     }
@@ -979,7 +986,7 @@ function createConnection(pool, callback) {
     }
 
     // the pool might have been closed since we started creating the connection
-    if (pool.state === DESTROYED) {
+    if (pool.state === DESTROYED || pool.state === DESTROYING) {
       if (typeof callback === 'function') {
         callback(new MongoError('Pool was destroyed after connection creation'));
       }
@@ -1032,7 +1039,6 @@ function _execute(self) {
     // operations
     if (self.connectingConnections > 0) {
       self.executing = false;
-      setTimeout(() => _execute(self)(), 10);
       return;
     }
 
@@ -1047,8 +1053,8 @@ function _execute(self) {
         // Flush any monitoring operations
         flushMonitoringOperations(self.queue);
 
-        // attempt to grow the pool
-        if (totalConnections < self.options.size) {
+        // Try to create a new connection to execute stuck operation
+        if (totalConnections < self.options.size && self.queue.length > 0) {
           createConnection(self);
         }
 

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -720,6 +720,14 @@ Pool.prototype.destroy = function(force, callback) {
  * @param {function} [callback]
  */
 Pool.prototype.reset = function(callback) {
+  if (this.s.state !== CONNECTED) {
+    if (typeof callback === 'function') {
+      callback(new MongoError('pool is not connected, reset aborted'));
+    }
+
+    return;
+  }
+
   const connections = this.availableConnections.concat(this.inUseConnections);
   eachAsync(
     connections,
@@ -739,6 +747,9 @@ Pool.prototype.reset = function(callback) {
       }
 
       resetPoolState(this);
+
+      // attempt reexecution
+      process.nextTick(() => _execute(this)());
       if (typeof callback === 'function') {
         callback(null, null);
       }

--- a/lib/core/sdam/monitoring.js
+++ b/lib/core/sdam/monitoring.js
@@ -4,8 +4,8 @@ const ServerDescription = require('./server_description').ServerDescription;
 const calculateDurationInMs = require('../utils').calculateDurationInMs;
 
 // pulled from `Server` implementation
-const STATE_DISCONNECTED = 'disconnected';
-const STATE_DISCONNECTING = 'disconnecting';
+const STATE_CLOSED = 'closed';
+const STATE_CLOSING = 'closing';
 
 /**
  * Published when server description changes, but does NOT include changes to the RTT.
@@ -180,7 +180,7 @@ function monitorServer(server, options) {
 
     // emit an event indicating that our description has changed
     server.emit('descriptionReceived', new ServerDescription(server.description.address, isMaster));
-    if (server.s.state === STATE_DISCONNECTED || server.s.state === STATE_DISCONNECTING) {
+    if (server.s.state === STATE_CLOSED || server.s.state === STATE_CLOSING) {
       return;
     }
 

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -148,16 +148,13 @@ class Server extends EventEmitter {
       { bson: this.s.bson }
     );
 
-    // NOTE: this should only be the case if we are connecting to a single server
-    poolOptions.reconnect = true;
+    // NOTE: reconnect is explicitly false because of the server selection loop
+    poolOptions.reconnect = false;
     poolOptions.legacyCompatMode = false;
 
     this.s.pool = new Pool(this, poolOptions);
 
     // setup listeners
-    this.s.pool.on('connect', connectEventHandler(this));
-    this.s.pool.on('close', errorEventHandler(this));
-    this.s.pool.on('error', errorEventHandler(this));
     this.s.pool.on('parseError', parseErrorEventHandler(this));
 
     // it is unclear whether consumers should even know about these events
@@ -169,14 +166,7 @@ class Server extends EventEmitter {
     relayEvents(this.s.pool, this, ['commandStarted', 'commandSucceeded', 'commandFailed']);
 
     stateTransition(this, STATE_CONNECTING);
-
-    // If auth settings have been provided, use them
-    if (options.auth) {
-      this.s.pool.connect.apply(this.s.pool, options.auth);
-      return;
-    }
-
-    this.s.pool.connect();
+    this.s.pool.connect(connectEventHandler(this));
   }
 
   /**
@@ -474,7 +464,13 @@ function executeWriteOperation(args, options, callback) {
 }
 
 function connectEventHandler(server) {
-  return function(pool, conn) {
+  return function(err, conn) {
+    if (err) {
+      server.emit('error', new MongoNetworkError(err));
+      server.emit('close');
+      return;
+    }
+
     const ismaster = conn.ismaster;
     server.s.lastIsMasterMS = conn.lastIsMasterMS;
     if (conn.agreedCompressor) {
@@ -503,16 +499,6 @@ function connectEventHandler(server) {
 
     // emit an event indicating that our description has changed
     server.emit('descriptionReceived', new ServerDescription(server.description.address, ismaster));
-  };
-}
-
-function errorEventHandler(server) {
-  return function(err) {
-    if (err) {
-      server.emit('error', new MongoNetworkError(err));
-    }
-
-    server.emit('close');
   };
 }
 

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -166,6 +166,7 @@ class Server extends EventEmitter {
     relayEvents(this.s.pool, this, ['commandStarted', 'commandSucceeded', 'commandFailed']);
 
     stateTransition(this, STATE_CONNECTING);
+
     this.s.pool.connect(connectEventHandler(this));
   }
 
@@ -465,10 +466,14 @@ function executeWriteOperation(args, options, callback) {
 
 function connectEventHandler(server) {
   return function(err, conn) {
+    if (server.s.state === STATE_CLOSING || server.s.state === STATE_CLOSED) {
+      return;
+    }
+
     if (err) {
       server.emit('error', new MongoNetworkError(err));
 
-      stateTransition(this, STATE_CLOSED);
+      stateTransition(server, STATE_CLOSED);
       server.emit('close');
       return;
     }

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -467,6 +467,8 @@ function connectEventHandler(server) {
   return function(err, conn) {
     if (err) {
       server.emit('error', new MongoNetworkError(err));
+
+      stateTransition(this, STATE_CLOSED);
       server.emit('close');
       return;
     }

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -240,6 +240,11 @@ class Server extends EventEmitter {
       (callback = options), (options = {}), (options = options || {});
     }
 
+    if (this.s.state === STATE_CLOSING || this.s.state === STATE_CLOSED) {
+      callback(new MongoError('server is closed'));
+      return;
+    }
+
     const error = basicReadValidations(this, options);
     if (error) {
       return callback(error, null);
@@ -289,6 +294,11 @@ class Server extends EventEmitter {
    * @param {function} callback
    */
   query(ns, cmd, cursorState, options, callback) {
+    if (this.s.state === STATE_CLOSING || this.s.state === STATE_CLOSED) {
+      callback(new MongoError('server is closed'));
+      return;
+    }
+
     wireProtocol.query(this, ns, cmd, cursorState, options, (err, result) => {
       if (err) {
         if (options.session && err instanceof MongoNetworkError) {
@@ -313,6 +323,11 @@ class Server extends EventEmitter {
    * @param {function} callback
    */
   getMore(ns, cursorState, batchSize, options, callback) {
+    if (this.s.state === STATE_CLOSING || this.s.state === STATE_CLOSED) {
+      callback(new MongoError('server is closed'));
+      return;
+    }
+
     wireProtocol.getMore(this, ns, cursorState, batchSize, options, (err, result) => {
       if (err) {
         if (options.session && err instanceof MongoNetworkError) {
@@ -336,6 +351,14 @@ class Server extends EventEmitter {
    * @param {function} callback
    */
   killCursors(ns, cursorState, callback) {
+    if (this.s.state === STATE_CLOSING || this.s.state === STATE_CLOSED) {
+      if (typeof callback === 'function') {
+        callback(new MongoError('server is closed'));
+      }
+
+      return;
+    }
+
     wireProtocol.killCursors(this, ns, cursorState, (err, result) => {
       if (err && isSDAMUnrecoverableError(err, this)) {
         this.emit('error', err);
@@ -437,6 +460,11 @@ function executeWriteOperation(args, options, callback) {
   const op = args.op;
   const ns = args.ns;
   const ops = Array.isArray(args.ops) ? args.ops : [args.ops];
+
+  if (server.s.state === STATE_CLOSING || server.s.state === STATE_CLOSED) {
+    callback(new MongoError('server is closed'));
+    return;
+  }
 
   const error = basicWriteValidations(server, options);
   if (error) {

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -179,7 +179,8 @@ class Topology extends EventEmitter {
 
       // timer management
       monitorTimers: [],
-      iterationTimers: []
+      iterationTimers: [],
+      connectionTimers: []
     };
 
     // amend options for server instance creation
@@ -338,6 +339,9 @@ class Topology extends EventEmitter {
 
     this.s.iterationTimers.map(timer => clearTimeout(timer));
     this.s.iterationTimers = [];
+
+    this.s.connectionTimers.map(timer => clearTimeout(timer));
+    this.s.connectionTimers = [];
 
     if (this.s.sessionPool) {
       this.s.sessions.forEach(session => session.endSession());
@@ -936,11 +940,11 @@ function createAndConnectServer(topology, serverDescription, connectDelay) {
 
   if (connectDelay) {
     const connectTimer = setTimeout(() => {
-      removeTimerFrom(connectTimer, topology.s.iterationTimers);
+      removeTimerFrom(connectTimer, topology.s.connectionTimers);
       server.connect();
     }, connectDelay);
 
-    topology.s.iterationTimers.push(connectTimer);
+    topology.s.connectionTimers.push(connectTimer);
     return server;
   }
 
@@ -961,7 +965,7 @@ function resetServer(topology, serverDescription) {
   const newServer = createAndConnectServer(
     topology,
     serverDescription,
-    topology.s.heartbeatFrequencyMS
+    topology.s.minHeartbeatFrequencyMS
   );
 
   topology.s.servers.set(serverDescription.address, newServer);

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -26,6 +26,7 @@ const resolveClusterTime = require('../topologies/shared').resolveClusterTime;
 const SrvPoller = require('./srv_polling').SrvPoller;
 const getMMAPError = require('../topologies/shared').getMMAPError;
 const makeStateMachine = require('../utils').makeStateMachine;
+const eachAsync = require('../utils').eachAsync;
 
 // Global state
 let globalTopologyCounter = 0;
@@ -360,31 +361,22 @@ class Topology extends EventEmitter {
     // defer state transition because we may need to send an `endSessions` command above
     stateTransition(this, STATE_CLOSING);
 
-    const servers = this.s.servers;
-    if (servers.size === 0) {
-      stateTransition(this, STATE_CLOSED);
-      if (typeof callback === 'function') {
-        callback(null, null);
-      }
+    eachAsync(
+      Array.from(this.s.servers.values()),
+      (server, cb) => destroyServer(server, this, options, cb),
+      () => {
+        this.s.servers.clear();
 
-      return;
-    }
+        // emit an event for close
+        this.emit('topologyClosed', new monitoring.TopologyClosedEvent(this.s.id));
 
-    // destroy all child servers
-    let destroyed = 0;
-    servers.forEach(server =>
-      destroyServer(server, this, options, () => {
-        destroyed++;
-        if (destroyed === servers.size) {
-          // emit an event for close
-          this.emit('topologyClosed', new monitoring.TopologyClosedEvent(this.s.id));
+        stateTransition(this, STATE_CLOSED);
+        this.emit('close');
 
-          stateTransition(this, STATE_CLOSED);
-          if (typeof callback === 'function') {
-            callback(null, null);
-          }
+        if (typeof callback === 'function') {
+          callback();
         }
-      })
+      }
     );
   }
 
@@ -942,7 +934,6 @@ function createAndConnectServer(topology, serverDescription) {
   server.once('connect', serverConnectEventHandler(server, topology));
   server.on('descriptionReceived', topology.serverUpdateHandler.bind(topology));
   server.on('error', serverErrorEventHandler(server, topology));
-  server.on('close', () => topology.emit('close', server));
   server.connect();
   return server;
 }

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -894,15 +894,6 @@ function selectServers(topology, selector, timeout, start, callback) {
       topology.s.monitorTimers.push(timer);
     });
 
-    const descriptionChangedHandler = () => {
-      // successful iteration, clear the check timer
-      clearTimeout(iterationTimer);
-      topology.s.iterationTimers.splice(timerIndex, 1);
-
-      // topology description has changed due to monitoring, reattempt server selection
-      selectServers(topology, selector, timeout, start, callback);
-    };
-
     const iterationTimer = setTimeout(() => {
       topology.removeListener('topologyDescriptionChanged', descriptionChangedHandler);
       callback(
@@ -913,8 +904,17 @@ function selectServers(topology, selector, timeout, start, callback) {
       );
     }, timeout - duration);
 
+    const descriptionChangedHandler = () => {
+      // successful iteration, clear the check timer
+      removeTimerFrom(iterationTimer, topology.s.iterationTimers);
+      clearTimeout(iterationTimer);
+
+      // topology description has changed due to monitoring, reattempt server selection
+      selectServers(topology, selector, timeout, start, callback);
+    };
+
     // track this timer in case we need to clean it up outside this loop
-    const timerIndex = topology.s.iterationTimers.push(iterationTimer);
+    topology.s.iterationTimers.push(iterationTimer);
 
     topology.once('topologyDescriptionChanged', descriptionChangedHandler);
   };
@@ -922,7 +922,7 @@ function selectServers(topology, selector, timeout, start, callback) {
   retrySelection();
 }
 
-function createAndConnectServer(topology, serverDescription) {
+function createAndConnectServer(topology, serverDescription, connectDelay) {
   topology.emit(
     'serverOpening',
     new monitoring.ServerOpeningEvent(topology.s.id, serverDescription.address)
@@ -934,8 +934,43 @@ function createAndConnectServer(topology, serverDescription) {
   server.once('connect', serverConnectEventHandler(server, topology));
   server.on('descriptionReceived', topology.serverUpdateHandler.bind(topology));
   server.on('error', serverErrorEventHandler(server, topology));
+
+  if (connectDelay) {
+    const connectTimer = setTimeout(() => {
+      removeTimerFrom(connectTimer, topology.s.iterationTimers);
+      server.connect();
+    }, connectDelay);
+
+    topology.s.iterationTimers.push(connectTimer);
+    return server;
+  }
+
   server.connect();
   return server;
+}
+
+function resetServer(topology, serverDescription) {
+  if (!topology.s.servers.has(serverDescription.address)) {
+    return;
+  }
+
+  // first remove the old server
+  const server = topology.s.servers.get(serverDescription.address);
+  destroyServer(server, topology);
+
+  // add the new server, and attempt connection after a delay
+  const newServer = createAndConnectServer(
+    topology,
+    serverDescription,
+    topology.s.heartbeatFrequencyMS
+  );
+
+  topology.s.servers.set(serverDescription.address, newServer);
+}
+
+function removeTimerFrom(timer, timers) {
+  const idx = timers.findIndex(t => t === timer);
+  timers.splice(idx, 1);
 }
 
 /**
@@ -954,6 +989,15 @@ function connectServers(topology, serverDescriptions) {
 }
 
 function updateServers(topology, incomingServerDescription) {
+  // if the server was reset internally because of an error, we need to replace the
+  // `Server` instance for it so we can attempt reconnect.
+  //
+  // TODO: this logical can change once CMAP is put in place
+  if (incomingServerDescription && incomingServerDescription.error) {
+    resetServer(topology, incomingServerDescription);
+    return;
+  }
+
   // update the internal server's description
   if (incomingServerDescription && topology.s.servers.has(incomingServerDescription.address)) {
     const server = topology.s.servers.get(incomingServerDescription.address);

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -144,7 +144,7 @@ class Topology extends EventEmitter {
       ),
       serverSelectionTimeoutMS: options.serverSelectionTimeoutMS,
       heartbeatFrequencyMS: options.heartbeatFrequencyMS,
-      minHeartbeatIntervalMS: options.minHeartbeatIntervalMS,
+      minHeartbeatFrequencyMS: options.minHeartbeatFrequencyMS,
       // allow users to override the cursor factory
       Cursor: options.cursorFactory || CoreCursor,
       // the bson parser

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -178,9 +178,9 @@ class Topology extends EventEmitter {
       clusterTime: null,
 
       // timer management
-      monitorTimers: [],
-      iterationTimers: [],
-      connectionTimers: []
+      monitorTimers: new Set(),
+      iterationTimers: new Set(),
+      connectionTimers: new Set()
     };
 
     // amend options for server instance creation
@@ -334,14 +334,9 @@ class Topology extends EventEmitter {
     }
 
     // clear all existing monitor timers
-    this.s.monitorTimers.map(timer => clearTimeout(timer));
-    this.s.monitorTimers = [];
-
-    this.s.iterationTimers.map(timer => clearTimeout(timer));
-    this.s.iterationTimers = [];
-
-    this.s.connectionTimers.map(timer => clearTimeout(timer));
-    this.s.connectionTimers = [];
+    drainTimerQueue(this.s.monitorTimers);
+    drainTimerQueue(this.s.iterationTimers);
+    drainTimerQueue(this.s.connectionTimers);
 
     if (this.s.sessionPool) {
       this.s.sessions.forEach(session => session.endSession());
@@ -427,9 +422,7 @@ class Topology extends EventEmitter {
       return;
     }
 
-    // clear out any existing iteration timers
-    this.s.iterationTimers.map(timer => clearTimeout(timer));
-    this.s.iterationTimers = [];
+    drainTimerQueue(this.s.iterationTimers);
 
     selectServers(
       this,
@@ -848,10 +841,11 @@ function selectServers(topology, selector, timeout, start, callback) {
     }, timeout - duration);
 
     const connectHandler = () => {
-      clearTimeout(failToConnectTimer);
+      clearAndRemoveTimerFrom(failToConnectTimer, topology.s.connectionTimers);
       selectServers(topology, selector, timeout, process.hrtime(), callback);
     };
 
+    topology.s.connectionTimers.add(failToConnectTimer);
     topology.once('connect', connectHandler);
     return;
   }
@@ -884,8 +878,7 @@ function selectServers(topology, selector, timeout, start, callback) {
 
   const retrySelection = () => {
     // clear all existing monitor timers
-    topology.s.monitorTimers.map(timer => clearTimeout(timer));
-    topology.s.monitorTimers = [];
+    drainTimerQueue(topology.s.monitorTimers);
 
     // ensure all server monitors attempt monitoring soon
     topology.s.servers.forEach(server => {
@@ -894,7 +887,7 @@ function selectServers(topology, selector, timeout, start, callback) {
         TOPOLOGY_DEFAULTS.minHeartbeatFrequencyMS
       );
 
-      topology.s.monitorTimers.push(timer);
+      topology.s.monitorTimers.add(timer);
     });
 
     const iterationTimer = setTimeout(() => {
@@ -909,15 +902,14 @@ function selectServers(topology, selector, timeout, start, callback) {
 
     const descriptionChangedHandler = () => {
       // successful iteration, clear the check timer
-      removeTimerFrom(iterationTimer, topology.s.iterationTimers);
-      clearTimeout(iterationTimer);
+      clearAndRemoveTimerFrom(iterationTimer, topology.s.iterationTimers);
 
       // topology description has changed due to monitoring, reattempt server selection
       selectServers(topology, selector, timeout, start, callback);
     };
 
     // track this timer in case we need to clean it up outside this loop
-    topology.s.iterationTimers.push(iterationTimer);
+    topology.s.iterationTimers.add(iterationTimer);
 
     topology.once('topologyDescriptionChanged', descriptionChangedHandler);
   };
@@ -940,11 +932,11 @@ function createAndConnectServer(topology, serverDescription, connectDelay) {
 
   if (connectDelay) {
     const connectTimer = setTimeout(() => {
-      removeTimerFrom(connectTimer, topology.s.connectionTimers);
+      clearAndRemoveTimerFrom(connectTimer, topology.s.connectionTimers);
       server.connect();
     }, connectDelay);
 
-    topology.s.connectionTimers.push(connectTimer);
+    topology.s.connectionTimers.add(connectTimer);
     return server;
   }
 
@@ -971,9 +963,14 @@ function resetServer(topology, serverDescription) {
   topology.s.servers.set(serverDescription.address, newServer);
 }
 
-function removeTimerFrom(timer, timers) {
-  const idx = timers.findIndex(t => t === timer);
-  timers.splice(idx, 1);
+function drainTimerQueue(queue) {
+  queue.forEach(clearTimeout);
+  queue.clear();
+}
+
+function clearAndRemoveTimerFrom(timer, timers) {
+  clearTimeout(timer);
+  return timers.delete(timer);
 }
 
 /**

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -423,7 +423,7 @@ class Topology extends EventEmitter {
     const transaction = session && session.transaction;
 
     if (isSharded && transaction && transaction.server) {
-      callback(undefined, transaction.server);
+      callback(null, transaction.server);
       return;
     }
 
@@ -444,7 +444,7 @@ class Topology extends EventEmitter {
           transaction.pinServer(selectedServer);
         }
 
-        callback(undefined, selectedServer);
+        callback(null, selectedServer);
       }
     );
   }
@@ -567,11 +567,11 @@ class Topology extends EventEmitter {
 
   auth(credentials, callback) {
     if (typeof credentials === 'function') (callback = credentials), (credentials = null);
-    if (typeof callback === 'function') callback(undefined, true);
+    if (typeof callback === 'function') callback(null, true);
   }
 
   logout(callback) {
-    if (typeof callback === 'function') callback(undefined, true);
+    if (typeof callback === 'function') callback(null, true);
   }
 
   // Basic operation support. Eventually this should be moved into command construction
@@ -664,7 +664,7 @@ class Topology extends EventEmitter {
         isWriteCommand(cmd);
 
       const cb = (err, result) => {
-        if (!err) return callback(undefined, result);
+        if (!err) return callback(null, result);
         if (!isRetryableError(err)) {
           return callback(err);
         }

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -272,7 +272,6 @@ class Topology extends EventEmitter {
 
     translateReadPreference(options);
     const readPreference = options.readPreference || ReadPreference.primary;
-
     this.selectServer(readPreferenceServerSelector(readPreference), options, (err, server) => {
       if (err) {
         stateTransition(this, STATE_CLOSED);
@@ -420,7 +419,7 @@ class Topology extends EventEmitter {
     const transaction = session && session.transaction;
 
     if (isSharded && transaction && transaction.server) {
-      callback(null, transaction.server);
+      callback(undefined, transaction.server);
       return;
     }
 
@@ -434,14 +433,14 @@ class Topology extends EventEmitter {
       options.serverSelectionTimeoutMS,
       process.hrtime(),
       (err, servers) => {
-        if (err) return callback(err, null);
+        if (err) return callback(err);
 
         const selectedServer = randomSelection(servers);
         if (isSharded && transaction && transaction.isActive) {
           transaction.pinServer(selectedServer);
         }
 
-        callback(null, selectedServer);
+        callback(undefined, selectedServer);
       }
     );
   }
@@ -564,11 +563,11 @@ class Topology extends EventEmitter {
 
   auth(credentials, callback) {
     if (typeof credentials === 'function') (callback = credentials), (credentials = null);
-    if (typeof callback === 'function') callback(null, true);
+    if (typeof callback === 'function') callback(undefined, true);
   }
 
   logout(callback) {
-    if (typeof callback === 'function') callback(null, true);
+    if (typeof callback === 'function') callback(undefined, true);
   }
 
   // Basic operation support. Eventually this should be moved into command construction
@@ -648,7 +647,7 @@ class Topology extends EventEmitter {
 
     this.selectServer(readPreferenceServerSelector(readPreference), options, (err, server) => {
       if (err) {
-        callback(err, null);
+        callback(err);
         return;
       }
 
@@ -661,7 +660,7 @@ class Topology extends EventEmitter {
         isWriteCommand(cmd);
 
       const cb = (err, result) => {
-        if (!err) return callback(null, result);
+        if (!err) return callback(undefined, result);
         if (!isRetryableError(err)) {
           return callback(err);
         }

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -1043,7 +1043,9 @@ function serverErrorEventHandler(server, topology) {
     }
 
     if (isSDAMUnrecoverableError(err, server)) {
-      resetServerState(server, err, { clearPool: true });
+      // NOTE: this must be commented out until we switch to the new CMAP pool because
+      //       we presently _always_ clear the pool on error.
+      resetServerState(server, err /*, { clearPool: true } */);
       return;
     }
 

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -1039,8 +1039,12 @@ function serverConnectEventHandler(server, topology) {
   };
 }
 
-function serverErrorEventHandler(server /*, topology */) {
+function serverErrorEventHandler(server, topology) {
   return function(err) {
+    if (topology.s.state === STATE_CLOSING || topology.s.state === STATE_CLOSED) {
+      return;
+    }
+
     if (isSDAMUnrecoverableError(err, server)) {
       resetServerState(server, err, { clearPool: true });
       return;

--- a/lib/core/sdam/topology_description.js
+++ b/lib/core/sdam/topology_description.js
@@ -191,7 +191,7 @@ class TopologyDescription {
     }
 
     if (topologyType === TopologyType.ReplicaSetNoPrimary) {
-      if ([ServerType.Mongos, ServerType.Unknown].indexOf(serverType) >= 0) {
+      if ([ServerType.Standalone, ServerType.Mongos].indexOf(serverType) >= 0) {
         serverDescriptions.delete(address);
       }
 

--- a/lib/operations/close.js
+++ b/lib/operations/close.js
@@ -3,6 +3,7 @@
 const Aspect = require('./operation').Aspect;
 const defineAspects = require('./operation').defineAspects;
 const OperationBase = require('./operation').OperationBase;
+const NativeTopology = require('../topologies/native_topology');
 
 class CloseOperation extends OperationBase {
   constructor(client, force) {
@@ -16,8 +17,11 @@ class CloseOperation extends OperationBase {
     const force = this.force;
     const completeClose = err => {
       client.emit('close', client);
-      for (const item of client.s.dbCache) {
-        item[1].emit('close', client);
+
+      if (!(client.topology instanceof NativeTopology)) {
+        for (const item of client.s.dbCache) {
+          item[1].emit('close', client);
+        }
       }
 
       client.removeAllListeners('close');

--- a/test/core/functional/pool_tests.js
+++ b/test/core/functional/pool_tests.js
@@ -167,7 +167,7 @@ describe('Pool tests', function() {
       var pool = new Pool(null, {
         host: this.configuration.host,
         port: this.configuration.port,
-        socketTimeout: 3000,
+        socketTimeout: 500,
         bson: new Bson(),
         reconnect: false
       });
@@ -1139,6 +1139,25 @@ describe('Pool tests', function() {
       });
 
       pool.connect();
+    }
+  });
+
+  it('should support callback mode for connect', {
+    metadata: { requires: { topology: 'single' } },
+    test: function(done) {
+      const pool = new Pool(null, {
+        host: this.configuration.host,
+        port: this.configuration.port,
+        bson: new Bson()
+      });
+
+      pool.on('connect', () => done(new Error('connect was emitted')));
+      pool.connect(err => {
+        expect(err).to.not.exist;
+        setTimeout(() => {
+          pool.destroy(true, done);
+        }, 100); // wait to ensure event is not emitted
+      });
     }
   });
 });

--- a/test/core/functional/server_tests.js
+++ b/test/core/functional/server_tests.js
@@ -995,7 +995,7 @@ describe('Server tests', function() {
 
         const config = this.configuration;
         var client = config.newTopology(server.address().host, server.address().port, {
-          serverSelectionTimeoutMS: 10
+          serverSelectionTimeoutMS: 500
         });
 
         client.on('error', error => {

--- a/test/functional/spec/transactions/convenient-api/transaction-options.json
+++ b/test/functional/spec/transactions/convenient-api/transaction-options.json
@@ -5,12 +5,6 @@
       "topology": [
         "replicaset"
       ]
-    },
-    {
-      "minServerVersion": "4.1.8",
-      "topology": [
-        "sharded"
-      ]
     }
   ],
   "database_name": "withTransaction-tests",

--- a/test/functional/spec/transactions/convenient-api/transaction-options.yml
+++ b/test/functional/spec/transactions/convenient-api/transaction-options.yml
@@ -2,9 +2,6 @@ runOn:
     -
         minServerVersion: "4.0"
         topology: ["replicaset"]
-    -
-        minServerVersion: "4.1.8"
-        topology: ["sharded"]
 
 database_name: &database_name "withTransaction-tests"
 collection_name: &collection_name "test"

--- a/test/functional/spec/transactions/transaction-options.json
+++ b/test/functional/spec/transactions/transaction-options.json
@@ -5,12 +5,6 @@
       "topology": [
         "replicaset"
       ]
-    },
-    {
-      "minServerVersion": "4.1.8",
-      "topology": [
-        "sharded"
-      ]
     }
   ],
   "database_name": "transaction-tests",

--- a/test/functional/spec/transactions/transaction-options.yml
+++ b/test/functional/spec/transactions/transaction-options.yml
@@ -2,9 +2,6 @@ runOn:
     -
         minServerVersion: "4.0"
         topology: ["replicaset"]
-    -
-        minServerVersion: "4.1.8"
-        topology: ["sharded"]
 
 database_name: &database_name "transaction-tests"
 collection_name: &collection_name "test"

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
+  --recursive
   --timeout 60000
   --file test/runner
   --ui test/runner/metadata_ui.js

--- a/test/runner/config.js
+++ b/test/runner/config.js
@@ -97,9 +97,6 @@ class NativeConfiguration {
 
   newTopology(host, port, options) {
     options = Object.assign({}, options);
-    host = host || this.options.host;
-    port = port || this.options.port;
-
     const hosts = host == null ? [].concat(this.options.hosts) : [{ host, port }];
     if (this.usingUnifiedTopology()) {
       return new core.Topology(hosts, options);

--- a/test/runner/filters/unified_filter.js
+++ b/test/runner/filters/unified_filter.js
@@ -14,9 +14,10 @@ class UnifiedTopologyFilter {
   filter(test) {
     if (!test.metadata) return true;
     if (!test.metadata.requires) return true;
-    if (!test.metadata.requires.unifiedTopology) return true;
+    if (typeof test.metadata.requires.unifiedTopology !== 'boolean') return true;
 
-    return !!process.env.MONGODB_UNIFIED_TOPOLOGY;
+    const requireUnifiedTopology = !!test.metadata.requires.unifiedTopology;
+    return requireUnifiedTopology === !!process.env.MONGODB_UNIFIED_TOPOLOGY;
   }
 }
 

--- a/test/runner/filters/unified_filter.js
+++ b/test/runner/filters/unified_filter.js
@@ -12,12 +12,13 @@
  */
 class UnifiedTopologyFilter {
   filter(test) {
-    if (!test.metadata) return true;
-    if (!test.metadata.requires) return true;
-    if (typeof test.metadata.requires.unifiedTopology !== 'boolean') return true;
+    const unifiedTopology =
+      test.metadata && test.metadata.requires && test.metadata.requires.unifiedTopology;
 
-    const requireUnifiedTopology = !!test.metadata.requires.unifiedTopology;
-    return requireUnifiedTopology === !!process.env.MONGODB_UNIFIED_TOPOLOGY;
+    return (
+      typeof unifiedTopology !== 'boolean' ||
+      unifiedTopology === process.env.MONGODB_UNIFIED_TOPOLOGY
+    );
   }
 }
 

--- a/test/tools/run_each_test.sh
+++ b/test/tools/run_each_test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: run_each_test <test path>"
+    exit
+fi
+
+TEST_PATH=$1
+find $TEST_PATH -type f \( -iname "*_tests.js" ! -iname "*atlas*" ! -path "*node-next*" \) -exec npx mocha {} \;


### PR DESCRIPTION
## Description
The fundamental issue here is that when using the unified topology, if a node is "lost" (due to some network error, etc) it is never regained. This was due to some complicated error handling, primarily around the events propagated from the connection pool. I'll try to summarize in the next section what changed (or needed to be changed)

**What changed?**
- State machines for the `Pool`, `Server` and `Topology` types were formalized, now using the same method to generate the machines. The `Pool` gained a new state `DRAINING` which is used to distinguish whether new commands can be written to the pool or not, in particular during a scenario when fire-and-forget messages are sent right before pool destruction
- The `Topology` no longer listens for `error` or `close` events from the `Pool`. All errors are propagated through callbacks now, which allows us to be very specific about how we handle types of errors. This was the root cause of the issue addressed by this PR, all errors used to be funneled through a common error handler which would reset the server in SDAM flow, even during monitoring checks
- `Topology` no longer uses a pool in forced `reconnect` mode. This was the second part of the root cause, failed attempts to do something like monitoring would cause retries which would trigger the SDAM flow. We now depend on the retry loop of retryable operations for retries explicitly. 
- The logic for "resetting a server" was factored, and made explicit during a server description update handling process. 
- As a part of this change NODE-2214 was resolved, where `Unknown` servers were erroneously removed from the topology description

**Are there any files to ignore?**
A number of test changes were required that were out of scope for this change, but caused test failures nonetheless. Specifically, ignore changes to the transactions tests, and an added tool called `run_each_test.sh` which is just a helper for identifying individual test files which leak handles in node