### PR TITLE
fix(topology): set max listeners to infinity for db event relay

### DIFF
--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -211,6 +211,9 @@ class Topology extends EventEmitter {
 
       this.on('topologyDescriptionChanged', this.s.detectTopologyDescriptionChange);
     }
+
+    // NOTE: remove this when NODE-1709 is resolved
+    this.setMaxListeners(Infinity);
   }
 
   /**


### PR DESCRIPTION
We relay topology events on the `Db` class for legacy compat, so
we need to remove limitations on max listeners in case users are
operating across many instances.

NODE-2123