### PR TITLE
NODE-2310: introduce modern connection type

### DIFF
--- a/lib/core/cmap/connection.js
+++ b/lib/core/cmap/connection.js
@@ -7,6 +7,7 @@ const MongoWriteConcernError = require('../error').MongoWriteConcernError;
 const wp = require('../wireprotocol');
 const apm = require('../connection/apm');
 const updateSessionFromResponse = require('../sessions').updateSessionFromResponse;
+const uuidV4 = require('../utils').uuidV4;
 
 const kStream = Symbol('stream');
 const kQueue = Symbol('queue');
@@ -16,7 +17,7 @@ class Connection extends EventEmitter {
   constructor(stream, options) {
     super(options);
 
-    this.id = `${stream.address().address}:${stream.address().port}`;
+    this.id = streamIdentifier(stream);
     this.bson = options.bson;
     this.description = null;
     this.socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 360000;
@@ -142,6 +143,14 @@ function messageHandler(conn) {
 
     callback(null, operationDescription.fullResult ? message : message.documents[0]);
   };
+}
+
+function streamIdentifier(stream) {
+  if (typeof stream.address === 'function') {
+    return `${stream.address().address}:${stream.address().port}`;
+  }
+
+  return uuidV4().toString('hex');
 }
 
 // Not meant to be called directly, the wire protocol methods call this assuming it is a `Pool` instance

--- a/lib/core/cmap/connection.js
+++ b/lib/core/cmap/connection.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const EventEmitter = require('events');
+const MessageStream = require('./message_stream');
+const MongoError = require('../error').MongoError;
+const MongoWriteConcernError = require('../error').MongoWriteConcernError;
+const wp = require('../wireprotocol');
+const apm = require('../connection/apm');
+const updateSessionFromResponse = require('../sessions').updateSessionFromResponse;
+
+const kStream = Symbol('stream');
+const kQueue = Symbol('queue');
+const kMessageStream = Symbol('messageStream');
+
+class Connection extends EventEmitter {
+  constructor(stream, options) {
+    super(options);
+
+    this.bson = options.bson;
+    this.description = { maxWireVersion: 5 };
+    this.socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 360000;
+    this.monitorCommands =
+      typeof options.monitorCommands === 'boolean' ? options.monitorCommands : false;
+
+    // setup parser stream and message handling
+    this[kQueue] = new Map();
+    this[kMessageStream] = new MessageStream(options);
+    this[kMessageStream].on('message', messageHandler(this));
+    this[kStream] = stream;
+    stream.on('error', () => {
+      /* ignore errors, listen to `close` instead */
+    });
+
+    stream.on('close', () => {
+      this[kQueue].forEach(op => op.callback(new MongoError('Connection closed')));
+      this[kQueue].clear();
+
+      this.emit('close');
+    });
+
+    // hook the message stream up to the passed in stream
+    stream.pipe(this[kMessageStream]);
+    this[kMessageStream].pipe(stream);
+  }
+
+  // the `connect` method stores the result of the handshake ismaster on the connection
+  set ismaster(response) {
+    this.description = response;
+  }
+
+  destroy(options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    options = Object.assign({ force: false }, options);
+    if (this[kStream] == null || this.destroyed) {
+      this.destroyed = true;
+      return;
+    }
+
+    if (options.force) {
+      this[kStream].destroy();
+      this.destroyed = true;
+      if (typeof callback === 'function') {
+        callback(null, null);
+      }
+
+      return;
+    }
+
+    this[kStream].end(err => {
+      this.destroyed = true;
+      if (typeof callback === 'function') {
+        callback(err, null);
+      }
+    });
+  }
+
+  command(ns, cmd, options, callback) {
+    // NOTE: The wire protocol methods will eventually be migrated to this class, but for now
+    //       we need to pretend we _are_ a server.
+    const server = {
+      description: this.description,
+      s: {
+        bson: this.bson,
+        pool: { write: write.bind(this) }
+      }
+    };
+
+    wp.command(server, ns, cmd, options, callback);
+  }
+}
+
+function messageHandler(conn) {
+  return function(message) {
+    // always emit the message, in case we are streaming
+    conn.emit('message', message);
+    if (!conn[kQueue].has(message.responseTo)) {
+      return;
+    }
+
+    const operationDescription = conn[kQueue].get(message.responseTo);
+    conn[kQueue].delete(message.responseTo);
+
+    const callback = operationDescription.cb;
+    if (operationDescription.socketTimeoutOverride) {
+      this[kStream].setSocketTimeout(this.socketTimeout);
+    }
+
+    try {
+      // Pass in the entire description because it has BSON parsing options
+      message.parse(operationDescription);
+    } catch (err) {
+      callback(new MongoError(err));
+      return;
+    }
+
+    if (message.documents[0]) {
+      const document = message.documents[0];
+      const session = operationDescription.session;
+      if (session) {
+        updateSessionFromResponse(session, document);
+      }
+
+      if (document.$clusterTime) {
+        this.emit('clusterTimeReceived', document.$clusterTime);
+      }
+
+      if (document.writeConcernError) {
+        callback(new MongoWriteConcernError(document.writeConcernError, document));
+        return;
+      }
+
+      if (document.ok === 0 || document.$err || document.errmsg || document.code) {
+        callback(new MongoError(document));
+        return;
+      }
+    }
+
+    callback(null, operationDescription.fullResult ? message : message.documents[0]);
+  };
+}
+
+// Not meant to be called directly, the wire protocol methods call this assuming it is a `Pool` instance
+function write(command, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+  }
+
+  options = options || {};
+  const operationDescription = {
+    requestId: command.requestId,
+    cb: callback,
+    fullResult: typeof options.fullResult === 'boolean' ? options.fullResult : false,
+    session: options.session,
+
+    // For BSON parsing
+    promoteLongs: typeof options.promoteLongs === 'boolean' ? options.promoteLongs : true,
+    promoteValues: typeof options.promoteValues === 'boolean' ? options.promoteValues : true,
+    promoteBuffers: typeof options.promoteBuffers === 'boolean' ? options.promoteBuffers : false,
+    raw: typeof options.raw === 'boolean' ? options.raw : false,
+
+    // NOTE: This property is set on the connection as part of `connect`, but should
+    //       eventually live in the `StreamDescription` attached to this connection.
+    agreedCompressor: this.agreedCompressor
+  };
+
+  if (typeof options.socketTimeout === 'number') {
+    operationDescription.socketTimeoutOverride = true;
+    this[kStream].setSocketTimeout(options.socketTimeout);
+  }
+
+  // if command monitoring is enabled we need to modify the callback here
+  if (this.monitorCommands) {
+    this.emit('commandStarted', new apm.CommandStartedEvent(this, command));
+
+    operationDescription.started = process.hrtime();
+    operationDescription.cb = (err, reply) => {
+      if (err) {
+        this.emit(
+          'commandFailed',
+          new apm.CommandFailedEvent(this, command, err, operationDescription.started)
+        );
+      } else {
+        if (reply && reply.result && (reply.result.ok === 0 || reply.result.$err)) {
+          this.emit(
+            'commandFailed',
+            new apm.CommandFailedEvent(this, command, reply.result, operationDescription.started)
+          );
+        } else {
+          this.emit(
+            'commandSucceeded',
+            new apm.CommandSucceededEvent(this, command, reply, operationDescription.started)
+          );
+        }
+      }
+
+      if (typeof cb === 'function') {
+        callback(err, reply);
+      }
+    };
+  }
+
+  this[kQueue].set(operationDescription.requestId, operationDescription);
+  this[kMessageStream].writeCommand(command, operationDescription);
+}
+
+module.exports = Connection;

--- a/lib/core/cmap/connection.js
+++ b/lib/core/cmap/connection.js
@@ -16,6 +16,7 @@ class Connection extends EventEmitter {
   constructor(stream, options) {
     super(options);
 
+    this.id = `${stream.address().address}:${stream.address().port}`;
     this.bson = options.bson;
     this.description = null;
     this.socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 360000;
@@ -197,7 +198,7 @@ function write(command, options, callback) {
         }
       }
 
-      if (typeof cb === 'function') {
+      if (typeof callback === 'function') {
         callback(err, reply);
       }
     };

--- a/lib/core/cmap/connection.js
+++ b/lib/core/cmap/connection.js
@@ -17,7 +17,7 @@ class Connection extends EventEmitter {
     super(options);
 
     this.bson = options.bson;
-    this.description = { maxWireVersion: 5 };
+    this.description = null;
     this.socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 360000;
     this.monitorCommands =
       typeof options.monitorCommands === 'boolean' ? options.monitorCommands : false;

--- a/lib/core/cmap/message_stream.js
+++ b/lib/core/cmap/message_stream.js
@@ -131,7 +131,7 @@ function processMessage(stream, message, callback) {
     opCode: message.readInt32LE(12)
   };
 
-  const ResponseType = messageHeader.opCode === OP_MSG ? BinMsg : Response;
+  let ResponseType = messageHeader.opCode === OP_MSG ? BinMsg : Response;
   const responseOptions = stream.responseOptions;
   if (messageHeader.opCode !== OP_COMPRESSED) {
     const messageBody = message.slice(MESSAGE_HEADER_SIZE);
@@ -150,6 +150,8 @@ function processMessage(stream, message, callback) {
   const compressorID = message[MESSAGE_HEADER_SIZE + 8];
   const compressedBuffer = message.slice(MESSAGE_HEADER_SIZE + 9);
 
+  // recalculate based on wrapped opcode
+  ResponseType = messageHeader.opCode === OP_MSG ? BinMsg : Response;
   decompress(compressorID, compressedBuffer, (err, messageBody) => {
     if (err) {
       callback(err);

--- a/lib/core/cmap/message_stream.js
+++ b/lib/core/cmap/message_stream.js
@@ -36,10 +36,11 @@ class MessageStream extends Duplex {
   }
 
   _write(chunk, _, callback) {
-    this[kBuffer].append(chunk);
+    const buffer = this[kBuffer];
+    buffer.append(chunk);
 
-    while (this[kBuffer].length >= 4) {
-      const sizeOfMessage = this[kBuffer].readInt32LE(0);
+    while (buffer.length >= 4) {
+      const sizeOfMessage = buffer.readInt32LE(0);
       if (sizeOfMessage < 0) {
         callback(new MongoParseError(`Invalid message size: ${sizeOfMessage}`));
         return;
@@ -54,14 +55,14 @@ class MessageStream extends Duplex {
         return;
       }
 
-      if (sizeOfMessage > this[kBuffer].length) {
+      if (sizeOfMessage > buffer.length) {
         callback();
         return;
       }
 
-      const messageBuffer = this[kBuffer].slice(0, sizeOfMessage);
+      const messageBuffer = buffer.slice(0, sizeOfMessage);
       processMessage(this, messageBuffer, callback);
-      this[kBuffer].consume(sizeOfMessage);
+      buffer.consume(sizeOfMessage);
     }
   }
 

--- a/lib/core/cmap/message_stream.js
+++ b/lib/core/cmap/message_stream.js
@@ -81,7 +81,7 @@ class MessageStream extends Duplex {
     }
 
     // otherwise, compress the message
-    const concatenatedOriginalCommandBuffer = Buffer.concat(command.toBind());
+    const concatenatedOriginalCommandBuffer = Buffer.concat(command.toBin());
     const messageToBeCompressed = concatenatedOriginalCommandBuffer.slice(MESSAGE_HEADER_SIZE);
 
     // Extract information needed for OP_COMPRESSED from the uncompressed message

--- a/lib/core/cmap/message_stream.js
+++ b/lib/core/cmap/message_stream.js
@@ -71,9 +71,9 @@ class MessageStream extends Duplex {
     return;
   }
 
-  writeCommand(command, options, callback) {
+  writeCommand(command, operationDescription) {
     // TODO: agreed compressor should live in `StreamDescription`
-    const shouldCompress = options && !!options.agreedCompressor;
+    const shouldCompress = operationDescription && !!operationDescription.agreedCompressor;
     if (!shouldCompress || !canCompress(command)) {
       this.push(Buffer.concat(command.toBin()));
       return;
@@ -87,9 +87,9 @@ class MessageStream extends Duplex {
     const originalCommandOpCode = concatenatedOriginalCommandBuffer.readInt32LE(12);
 
     // Compress the message body
-    compress({ options }, messageToBeCompressed, (err, compressedMessage) => {
+    compress({ options: operationDescription }, messageToBeCompressed, (err, compressedMessage) => {
       if (err) {
-        callback(err, null);
+        operationDescription.cb(err, null);
         return;
       }
 
@@ -107,7 +107,7 @@ class MessageStream extends Duplex {
       const compressionDetails = Buffer.alloc(COMPRESSION_DETAILS_SIZE);
       compressionDetails.writeInt32LE(originalCommandOpCode, 0); // originalOpcode
       compressionDetails.writeInt32LE(messageToBeCompressed.length, 4); // Size of the uncompressed compressedMessage, excluding the MsgHeader
-      compressionDetails.writeUInt8(compressorIDs[options.agreedCompressor], 8); // compressorID
+      compressionDetails.writeUInt8(compressorIDs[operationDescription.agreedCompressor], 8); // compressorID
 
       this.push(Buffer.concat([msgHeader, compressionDetails, compressedMessage]));
     });

--- a/lib/core/cmap/message_stream.js
+++ b/lib/core/cmap/message_stream.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const Duplex = require('stream').Duplex;
+const BufferList = require('bl');
+const MongoParseError = require('../error').MongoParseError;
+const decompress = require('../wireprotocol/compression').decompress;
+const Response = require('../connection/commands').Response;
+const BinMsg = require('../connection/msg').BinMsg;
+const MongoError = require('../error').MongoError;
+const OP_COMPRESSED = require('../wireprotocol/shared').opcodes.OP_COMPRESSED;
+const OP_MSG = require('../wireprotocol/shared').opcodes.OP_MSG;
+const MESSAGE_HEADER_SIZE = require('../wireprotocol/shared').MESSAGE_HEADER_SIZE;
+const COMPRESSION_DETAILS_SIZE = require('../wireprotocol/shared').COMPRESSION_DETAILS_SIZE;
+const opcodes = require('../wireprotocol/shared').opcodes;
+const compress = require('../wireprotocol/compression').compress;
+const compressorIDs = require('../wireprotocol/compression').compressorIDs;
+const uncompressibleCommands = require('../wireprotocol/compression').uncompressibleCommands;
+const Msg = require('../connection/msg').Msg;
+
+const kDefaultMaxBsonMessageSize = 1024 * 1024 * 16 * 4;
+const kBuffer = Symbol('buffer');
+
+/**
+ * A duplex stream that is capable of reading and writing raw wire protocol messages, with
+ * support for optional compression
+ */
+class MessageStream extends Duplex {
+  constructor(options) {
+    options = options || {};
+    super(options);
+
+    this.bson = options.bson;
+    this.maxBsonMessageSize = options.maxBsonMessageSize || kDefaultMaxBsonMessageSize;
+
+    this[kBuffer] = new BufferList();
+  }
+
+  _write(chunk, _, callback) {
+    this[kBuffer].append(chunk);
+
+    while (this[kBuffer].length >= 4) {
+      const sizeOfMessage = this[kBuffer].readInt32LE(0);
+      if (sizeOfMessage < 0) {
+        callback(new MongoParseError(`Invalid message size: ${sizeOfMessage}`));
+        return;
+      }
+
+      if (sizeOfMessage > this.maxBsonMessageSize) {
+        callback(
+          new MongoParseError(
+            `Invalid message size: ${sizeOfMessage}, max allowed: ${this.maxBsonMessageSize}`
+          )
+        );
+        return;
+      }
+
+      if (sizeOfMessage > this[kBuffer].length) {
+        callback();
+        return;
+      }
+
+      const messageBuffer = this[kBuffer].slice(0, sizeOfMessage);
+      processMessage(this, messageBuffer, callback);
+      this[kBuffer].consume(sizeOfMessage);
+    }
+  }
+
+  _read(/* size */) {
+    // NOTE: This implementation is empty because we explicitly push data to be read
+    //       when `writeMessage` is called.
+    return;
+  }
+
+  writeCommand(command, options, callback) {
+    // TODO: agreed compressor should live in `StreamDescription`
+    const shouldCompress = options && !!options.agreedCompressor;
+    if (!shouldCompress || !canCompress(command)) {
+      this.push(Buffer.concat(command.toBin()));
+      return;
+    }
+
+    // otherwise, compress the message
+    const concatenatedOriginalCommandBuffer = Buffer.concat(command.toBind());
+    const messageToBeCompressed = concatenatedOriginalCommandBuffer.slice(MESSAGE_HEADER_SIZE);
+
+    // Extract information needed for OP_COMPRESSED from the uncompressed message
+    const originalCommandOpCode = concatenatedOriginalCommandBuffer.readInt32LE(12);
+
+    // Compress the message body
+    compress({ options }, messageToBeCompressed, (err, compressedMessage) => {
+      if (err) {
+        callback(err, null);
+        return;
+      }
+
+      // Create the msgHeader of OP_COMPRESSED
+      const msgHeader = Buffer.alloc(MESSAGE_HEADER_SIZE);
+      msgHeader.writeInt32LE(
+        MESSAGE_HEADER_SIZE + COMPRESSION_DETAILS_SIZE + compressedMessage.length,
+        0
+      ); // messageLength
+      msgHeader.writeInt32LE(command.requestId, 4); // requestID
+      msgHeader.writeInt32LE(0, 8); // responseTo (zero)
+      msgHeader.writeInt32LE(opcodes.OP_COMPRESSED, 12); // opCode
+
+      // Create the compression details of OP_COMPRESSED
+      const compressionDetails = Buffer.alloc(COMPRESSION_DETAILS_SIZE);
+      compressionDetails.writeInt32LE(originalCommandOpCode, 0); // originalOpcode
+      compressionDetails.writeInt32LE(messageToBeCompressed.length, 4); // Size of the uncompressed compressedMessage, excluding the MsgHeader
+      compressionDetails.writeUInt8(compressorIDs[options.agreedCompressor], 8); // compressorID
+
+      this.push(Buffer.concat([msgHeader, compressionDetails, compressedMessage]));
+    });
+  }
+}
+
+// Return whether a command contains an uncompressible command term
+// Will return true if command contains no uncompressible command terms
+function canCompress(command) {
+  const commandDoc = command instanceof Msg ? command.command : command.query;
+  const commandName = Object.keys(commandDoc)[0];
+  return uncompressibleCommands.indexOf(commandName) === -1;
+}
+
+function processMessage(stream, message, callback) {
+  const messageHeader = {
+    messageLength: message.readInt32LE(0),
+    requestId: message.readInt32LE(4),
+    responseTo: message.readInt32LE(8),
+    opCode: message.readInt32LE(12)
+  };
+
+  const ResponseType = messageHeader.opCode === OP_MSG ? BinMsg : Response;
+  const responseOptions = stream.responseOptions;
+  if (messageHeader.opCode !== OP_COMPRESSED) {
+    const messageBody = message.slice(MESSAGE_HEADER_SIZE);
+    stream.emit(
+      'message',
+      new ResponseType(stream.bson, message, messageHeader, messageBody, responseOptions)
+    );
+
+    callback();
+    return;
+  }
+
+  messageHeader.fromCompressed = true;
+  messageHeader.opCode = message.readInt32LE(MESSAGE_HEADER_SIZE);
+  messageHeader.length = message.readInt32LE(MESSAGE_HEADER_SIZE + 4);
+  const compressorID = message[MESSAGE_HEADER_SIZE + 8];
+  const compressedBuffer = message.slice(MESSAGE_HEADER_SIZE + 9);
+
+  decompress(compressorID, compressedBuffer, (err, messageBody) => {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    if (messageBody.length !== messageHeader.length) {
+      callback(
+        new MongoError(
+          'Decompressing a compressed message from the server failed. The message is corrupt.'
+        )
+      );
+
+      return;
+    }
+
+    stream.emit(
+      'message',
+      new ResponseType(stream.bson, message, messageHeader, messageBody, responseOptions)
+    );
+
+    callback();
+  });
+}
+
+module.exports = MessageStream;

--- a/lib/core/cmap/message_stream.js
+++ b/lib/core/cmap/message_stream.js
@@ -120,7 +120,7 @@ class MessageStream extends Duplex {
 function canCompress(command) {
   const commandDoc = command instanceof Msg ? command.command : command.query;
   const commandName = Object.keys(commandDoc)[0];
-  return uncompressibleCommands.indexOf(commandName) === -1;
+  return !uncompressibleCommands.has(commandName);
 }
 
 function processMessage(stream, message, callback) {
@@ -152,6 +152,7 @@ function processMessage(stream, message, callback) {
 
   // recalculate based on wrapped opcode
   ResponseType = messageHeader.opCode === OP_MSG ? BinMsg : Response;
+
   decompress(compressorID, compressedBuffer, (err, messageBody) => {
     if (err) {
       callback(err);

--- a/lib/core/connection/apm.js
+++ b/lib/core/connection/apm.js
@@ -22,7 +22,8 @@ const extractCommandName = commandDoc => Object.keys(commandDoc)[0];
 const namespace = command => command.ns;
 const databaseName = command => command.ns.split('.')[0];
 const collectionName = command => command.ns.split('.')[1];
-const generateConnectionId = pool => `${pool.options.host}:${pool.options.port}`;
+const generateConnectionId = pool =>
+  pool.options ? `${pool.options.host}:${pool.options.port}` : pool.id;
 const maybeRedact = (commandName, result) => (SENSITIVE_COMMANDS.has(commandName) ? {} : result);
 
 const LEGACY_FIND_QUERY_MAP = {
@@ -147,10 +148,7 @@ const extractReply = (command, reply) => {
     };
   }
 
-  // in the event of a `noResponse` command, just return
-  if (reply === null) return reply;
-
-  return reply.result;
+  return reply && reply.result ? reply.result : reply;
 };
 
 /** An event indicating the start of a given command */
@@ -172,11 +170,11 @@ class CommandStartedEvent {
     }
 
     Object.assign(this, {
-      command: cmd,
+      connectionId: generateConnectionId(pool),
+      requestId: command.requestId,
       databaseName: databaseName(command),
       commandName,
-      requestId: command.requestId,
-      connectionId: generateConnectionId(pool)
+      command: cmd
     });
   }
 }
@@ -196,11 +194,11 @@ class CommandSucceededEvent {
     const commandName = extractCommandName(cmd);
 
     Object.assign(this, {
-      duration: calculateDurationInMs(started),
-      commandName,
-      reply: maybeRedact(commandName, extractReply(command, reply)),
+      connectionId: generateConnectionId(pool),
       requestId: command.requestId,
-      connectionId: generateConnectionId(pool)
+      commandName,
+      duration: calculateDurationInMs(started),
+      reply: maybeRedact(commandName, extractReply(command, reply)),
     });
   }
 }
@@ -220,11 +218,11 @@ class CommandFailedEvent {
     const commandName = extractCommandName(cmd);
 
     Object.assign(this, {
-      duration: calculateDurationInMs(started),
-      commandName,
-      failure: maybeRedact(commandName, error),
+      connectionId: generateConnectionId(pool),
       requestId: command.requestId,
-      connectionId: generateConnectionId(pool)
+      commandName,
+      duration: calculateDurationInMs(started),
+      failure: maybeRedact(commandName, error),
     });
   }
 }

--- a/lib/core/connection/apm.js
+++ b/lib/core/connection/apm.js
@@ -198,7 +198,7 @@ class CommandSucceededEvent {
       requestId: command.requestId,
       commandName,
       duration: calculateDurationInMs(started),
-      reply: maybeRedact(commandName, extractReply(command, reply)),
+      reply: maybeRedact(commandName, extractReply(command, reply))
     });
   }
 }
@@ -222,7 +222,7 @@ class CommandFailedEvent {
       requestId: command.requestId,
       commandName,
       duration: calculateDurationInMs(started),
-      failure: maybeRedact(commandName, error),
+      failure: maybeRedact(commandName, error)
     });
   }
 }

--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -307,6 +307,11 @@ function makeConnection(family, options, _callback) {
 
 const CONNECTION_ERROR_EVENTS = ['error', 'close', 'timeout', 'parseError'];
 function runCommand(conn, ns, command, options, callback) {
+  if (typeof conn.command === 'function') {
+    conn.command(ns, command, options, callback);
+    return;
+  }
+
   if (typeof options === 'function') (callback = options), (options = {});
   const socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 360000;
   const bson = conn.options.bson;

--- a/lib/core/connection/msg.js
+++ b/lib/core/connection/msg.js
@@ -59,7 +59,7 @@ class Msg {
     this.options = options || {};
 
     // Additional options
-    this.requestId = Msg.getRequestId();
+    this.requestId = options.requestId ? options.requestId : Msg.getRequestId();
 
     // Serialization option
     this.serializeFunctions =

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -943,7 +943,7 @@ Pool.prototype.write = function(command, options, cb) {
 function canCompress(command) {
   const commandDoc = command instanceof Msg ? command.command : command.query;
   const commandName = Object.keys(commandDoc)[0];
-  return uncompressibleCommands.indexOf(commandName) === -1;
+  return !uncompressibleCommands.has(commandName);
 }
 
 // Remove connection method

--- a/lib/core/wireprotocol/compression.js
+++ b/lib/core/wireprotocol/compression.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var Snappy = require('../connection/utils').retrieveSnappy(),
-  zlib = require('zlib');
+const Snappy = require('../connection/utils').retrieveSnappy();
+const zlib = require('zlib');
 
-var compressorIDs = {
+const compressorIDs = {
   snappy: 1,
   zlib: 2
 };
 
-var uncompressibleCommands = [
+const uncompressibleCommands = new Set([
   'ismaster',
   'saslStart',
   'saslContinue',
@@ -19,10 +19,10 @@ var uncompressibleCommands = [
   'copydbSaslStart',
   'copydbgetnonce',
   'copydb'
-];
+]);
 
 // Facilitate compressing a message using an agreed compressor
-var compress = function(self, dataToBeCompressed, callback) {
+function compress(self, dataToBeCompressed, callback) {
   switch (self.options.agreedCompressor) {
     case 'snappy':
       Snappy.compress(dataToBeCompressed, callback);
@@ -42,10 +42,10 @@ var compress = function(self, dataToBeCompressed, callback) {
           '".'
       );
   }
-};
+}
 
 // Decompress a message using the given compressor
-var decompress = function(compressorID, compressedData, callback) {
+function decompress(compressorID, compressedData, callback) {
   if (compressorID < 0 || compressorID > compressorIDs.length) {
     throw new Error(
       'Server sent message compressed using an unsupported compressor. (Received compressor ID ' +
@@ -63,11 +63,11 @@ var decompress = function(compressorID, compressedData, callback) {
     default:
       callback(null, compressedData);
   }
-};
+}
 
 module.exports = {
-  compressorIDs: compressorIDs,
-  uncompressibleCommands: uncompressibleCommands,
-  compress: compress,
-  decompress: decompress
+  compressorIDs,
+  uncompressibleCommands,
+  compress,
+  decompress
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,38 @@
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "argparse": {
@@ -287,25 +319,11 @@
       }
     },
     "bl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.0.tgz",
+      "integrity": "sha512-QwQvAZZA1Bw1FWnhNj2X5lu+sPxxB2ITH3mqEqYyahN6JZR13ONjk+XiTnBaGEzMPUrAgOkaD68pBH1rvPRPsw==",
       "requires": {
-        "readable-stream": "^3.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
+        "readable-stream": "^3.4.0"
       }
     },
     "bluebird": {
@@ -340,9 +358,9 @@
       "dev": true
     },
     "bson": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
-      "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -568,6 +586,38 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "console-control-strings": {
@@ -1656,9 +1706,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
-      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1848,8 +1898,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -2772,17 +2821,17 @@
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "os-locale": {
@@ -2879,9 +2928,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dev": true,
       "requires": {
         "isarray": "0.0.1"
@@ -3146,26 +3195,13 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "redent": {
@@ -3707,20 +3743,11 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
+        "safe-buffer": "~5.2.0"
       }
     },
     "stringstream": {
@@ -3816,15 +3843,13 @@
         "readable-stream": "^3.1.1"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+        "bl": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+          "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "readable-stream": "^3.0.1"
           }
         }
       }
@@ -3855,6 +3880,38 @@
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "tmp": {
@@ -3949,8 +4006,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.3",
@@ -4016,6 +4072,12 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bson-ext": "^2.0.0"
   },
   "dependencies": {
+    "bl": "^4.0.0",
     "bson": "^1.1.1",
     "require_optional": "^1.0.1",
     "safe-buffer": "^5.1.2"

--- a/test/functional/cmap/connection_tests.js
+++ b/test/functional/cmap/connection_tests.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Connection = require('../../../lib/core/cmap/connection');
+const connect = require('../../../lib/core/connection/connect');
+const expect = require('chai').expect;
+const BSON = require('bson');
+
+describe('Connection', function() {
+  it('should execute a command against a server', function(done) {
+    const connectOptions = Object.assign(
+      { connectionType: Connection, bson: new BSON() },
+      this.configuration.options
+    );
+
+    connect(connectOptions, (err, conn) => {
+      expect(err).to.not.exist;
+
+      conn.command('admin.$cmd', { ismaster: 1 }, (err, ismaster) => {
+        expect(err).to.not.exist;
+        expect(ismaster).to.exist;
+        expect(ismaster.ok).to.equal(1);
+
+        conn.destroy(done);
+      });
+    });
+  });
+});

--- a/test/functional/cmap/connection_tests.js
+++ b/test/functional/cmap/connection_tests.js
@@ -14,13 +14,13 @@ describe('Connection', function() {
 
     connect(connectOptions, (err, conn) => {
       expect(err).to.not.exist;
+      this.defer(_done => conn.destroy(_done));
 
       conn.command('admin.$cmd', { ismaster: 1 }, (err, ismaster) => {
         expect(err).to.not.exist;
         expect(ismaster).to.exist;
         expect(ismaster.ok).to.equal(1);
-
-        conn.destroy(done);
+        done();
       });
     });
   });
@@ -33,6 +33,7 @@ describe('Connection', function() {
 
     connect(connectOptions, (err, conn) => {
       expect(err).to.not.exist;
+      this.defer(_done => conn.destroy(_done));
 
       const events = [];
       conn.on('commandStarted', event => events.push(event));
@@ -43,11 +44,8 @@ describe('Connection', function() {
         expect(err).to.not.exist;
         expect(ismaster).to.exist;
         expect(ismaster.ok).to.equal(1);
-
         expect(events).to.have.length(2);
-        console.dir({ events }, { depth: 3 });
-
-        conn.destroy(done);
+        done();
       });
     });
   });

--- a/test/functional/cmap/connection_tests.js
+++ b/test/functional/cmap/connection_tests.js
@@ -24,4 +24,31 @@ describe('Connection', function() {
       });
     });
   });
+
+  it('should emit command monitoring events', function(done) {
+    const connectOptions = Object.assign(
+      { connectionType: Connection, bson: new BSON(), monitorCommands: true },
+      this.configuration.options
+    );
+
+    connect(connectOptions, (err, conn) => {
+      expect(err).to.not.exist;
+
+      const events = [];
+      conn.on('commandStarted', event => events.push(event));
+      conn.on('commandSucceeded', event => events.push(event));
+      conn.on('commandFailed', event => events.push(event));
+
+      conn.command('admin.$cmd', { ismaster: 1 }, (err, ismaster) => {
+        expect(err).to.not.exist;
+        expect(ismaster).to.exist;
+        expect(ismaster.ok).to.equal(1);
+
+        expect(events).to.have.length(2);
+        console.dir({ events }, { depth: 3 });
+
+        conn.destroy(done);
+      });
+    });
+  });
 });

--- a/test/runner/index.js
+++ b/test/runner/index.js
@@ -95,5 +95,6 @@ before(function(_done) {
 after(() => mock.cleanup());
 
 // optionally enable test runner-wide plugins
+require('./plugins/deferred');
 require('./plugins/session_leak_checker');
 require('./plugins/client_leak_checker');

--- a/test/runner/plugins/deferred.js
+++ b/test/runner/plugins/deferred.js
@@ -1,0 +1,50 @@
+'use strict';
+const kDeferred = Symbol('deferred');
+
+(mocha => {
+  const Context = mocha.Context;
+  function makeExecuteDeferred(test) {
+    return () => {
+      const deferredActions = test[kDeferred];
+
+      return Promise.all(
+        Array.from(deferredActions).map(action => {
+          if (action.length > 0) {
+            // assume these are async methods with provided `done`
+            return new Promise((resolve, reject) => {
+              function done(err) {
+                if (err) return reject(err);
+                resolve();
+              }
+
+              action(done);
+            });
+          }
+
+          // otherwise assume a Promise is returned
+          action();
+        })
+      ).then(() => {
+        test[kDeferred].clear();
+      });
+    };
+  }
+
+  Context.prototype.defer = function(fn) {
+    const test = this.test;
+    if (test[kDeferred] == null) {
+      test[kDeferred] = new Set();
+
+      const parentSuite = test.parent;
+      const afterEachHooks = parentSuite._afterEach;
+      if (afterEachHooks[0] == null || afterEachHooks[0].title !== kDeferred) {
+        const deferredHook = parentSuite._createHook('"deferred" hook', makeExecuteDeferred(test));
+
+        afterEachHooks.unshift(deferredHook);
+      }
+    }
+
+    test[kDeferred].add(fn);
+    return this;
+  };
+})(require('mocha'));

--- a/test/runner/plugins/deferred.js
+++ b/test/runner/plugins/deferred.js
@@ -22,7 +22,7 @@ const kDeferred = Symbol('deferred');
           }
 
           // otherwise assume a Promise is returned
-          action();
+          return action();
         })
       ).then(() => {
         test[kDeferred].clear();

--- a/test/unit/cmap/message_stream_tests.js
+++ b/test/unit/cmap/message_stream_tests.js
@@ -58,8 +58,9 @@ describe('Message Stream', function() {
           msg.parse();
 
           if (test.documents) {
-            expect(msg).to.have.property('documents');
-            expect(msg.documents).to.eql(test.documents);
+            expect(msg)
+              .to.have.property('documents')
+              .that.deep.equals(test.documents);
           }
 
           done();
@@ -71,7 +72,10 @@ describe('Message Stream', function() {
             return;
           }
 
-          expect(err.message).to.equal(error);
+          expect(err)
+            .to.have.property('message')
+            .that.equals(error);
+
           done();
         });
 

--- a/test/unit/cmap/message_stream_tests.js
+++ b/test/unit/cmap/message_stream_tests.js
@@ -106,7 +106,7 @@ describe('Message Stream', function() {
       const messageStream = new MessageStream({ bson });
       messageStream.pipe(writeableStream);
 
-      const command = new Msg(bson, 'admin.$cmd', { ismaster: 1 }, {});
+      const command = new Msg(bson, 'admin.$cmd', { ismaster: 1 }, { requestId: 3 });
       messageStream.writeCommand(command, null, err => {
         done(err);
       });

--- a/test/unit/cmap/message_stream_tests.js
+++ b/test/unit/cmap/message_stream_tests.js
@@ -1,0 +1,120 @@
+'use strict';
+const BSON = require('bson');
+const Readable = require('stream').Readable;
+const Writable = require('stream').Writable;
+const MessageStream = require('../../../lib/core/cmap/message_stream');
+const Msg = require('../../../lib/core/connection/msg').Msg;
+const expect = require('chai').expect;
+
+function bufferToStream(buffer) {
+  const stream = new Readable();
+  stream.push(buffer);
+  stream.push(null);
+  return stream;
+}
+
+function streamToBuffer(stream) {
+  return new Promise((resolve, reject) => {
+    let buffers = [];
+    stream.on('error', reject);
+    stream.on('data', data => buffers.push(data));
+    stream.on('end', () => resolve(Buffer.concat(buffers)));
+  });
+}
+
+describe('Message Stream', function() {
+  describe('reading', function() {
+    [
+      {
+        description: 'valid OP_REPLY',
+        data: Buffer.from(
+          '370000000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000',
+          'hex'
+        ),
+        documents: [{ ismaster: 1 }]
+      },
+      {
+        description: 'valid OP_MSG',
+        data: Buffer.from(
+          '370000000100000000000000dd0700000000000000220000001069736d6173746572000100000002246462000600000061646d696e0000',
+          'hex'
+        ),
+        documents: [{ $db: 'admin', ismaster: 1 }]
+      },
+      {
+        description: 'Invalid message size (negative)',
+        data: Buffer.from('ffffffff', 'hex'),
+        error: 'Invalid message size: -1'
+      },
+      {
+        description: 'Invalid message size (exceeds maximum)',
+        data: Buffer.from('01000004', 'hex'),
+        error: 'Invalid message size: 67108865, max allowed: 67108864'
+      }
+    ].forEach(test => {
+      it(test.description, function(done) {
+        const bson = new BSON();
+        const error = test.error;
+        const inputStream = bufferToStream(test.data);
+        const messageStream = new MessageStream({ bson });
+
+        messageStream.on('message', msg => {
+          if (error) {
+            done(new Error(`expected error: ${error}`));
+            return;
+          }
+
+          msg.parse();
+
+          if (test.documents) {
+            expect(msg).to.have.property('documents');
+            expect(msg.documents).to.eql(test.documents);
+          }
+
+          done();
+        });
+
+        messageStream.on('error', err => {
+          if (error == null) {
+            done(err);
+            return;
+          }
+
+          expect(err.message).to.equal(error);
+          done();
+        });
+
+        inputStream.pipe(messageStream);
+      });
+    });
+  });
+
+  describe('writing', function() {
+    it('should write a message to the stream', function(done) {
+      const readableStream = new Readable({ read() {} });
+      const writeableStream = new Writable({
+        write: (chunk, _, callback) => {
+          readableStream.push(chunk);
+          callback();
+        }
+      });
+
+      readableStream.on('data', data => {
+        expect(data.toString('hex')).to.eql(
+          '370000000300000000000000dd0700000000000000220000001069736d6173746572000100000002246462000600000061646d696e0000'
+        );
+
+        done();
+      });
+
+      const bson = new BSON();
+      const messageStream = new MessageStream({ bson });
+      messageStream.pipe(writeableStream);
+
+      const command = new Msg(bson, 'admin.$cmd', { ismaster: 1 }, {});
+      messageStream.writeMessage(command, null, err => {
+        done(err);
+      });
+    });
+  });
+});

--- a/test/unit/cmap/message_stream_tests.js
+++ b/test/unit/cmap/message_stream_tests.js
@@ -13,15 +13,6 @@ function bufferToStream(buffer) {
   return stream;
 }
 
-function streamToBuffer(stream) {
-  return new Promise((resolve, reject) => {
-    let buffers = [];
-    stream.on('error', reject);
-    stream.on('data', data => buffers.push(data));
-    stream.on('end', () => resolve(Buffer.concat(buffers)));
-  });
-}
-
 describe('Message Stream', function() {
   describe('reading', function() {
     [
@@ -112,7 +103,7 @@ describe('Message Stream', function() {
       messageStream.pipe(writeableStream);
 
       const command = new Msg(bson, 'admin.$cmd', { ismaster: 1 }, {});
-      messageStream.writeMessage(command, null, err => {
+      messageStream.writeCommand(command, null, err => {
         done(err);
       });
     });


### PR DESCRIPTION
## Description
This changeset introduces a new `Connection` type for use with the forthcoming CMAP implementation. It is strictly callback-based, which is in line with expectations of CMAP and SDAM. It is still an `EventEmitter`, but strictly for command monitoring events and coordinating events such as the receipt of the cluster time.

**What changed?**
Nothing changed per se, since this is a new class, but I will describe some of the design choices here. 

All code related to serializing wire protocol messages, and concerns like compression, have been relegated to the newly introduced `MessageStream` class. It's a `Duplex` stream that parses incoming messages, and marshalls outgoing commands. I think there is potential for further refactorings here (we could move _all_ the `OP_QUERY` and `OP_MSG` code here, and the stream would only accept commands as objects, for instance), but I've deferred that to future work. The `MessageStream` uses the `bl` module to make buffer management much easier for us, however, the module does a lot of things we don't actually need. We could consider an in-house implementation of a buffer list, but I've also chosen to defer that work for the time being.

The `Connection` class itself has some interesting design choices at present time. In order to reuse the existing wire protocol methods we need to pretend that a `Connection` is actually a `Server`, so you will see a strange dance in the `command` implementation. This is clearly not desirable for the future, but would have required at very least duplicating all these methods which seemed less desirable. The class also has a very limited API, which is intentional - you can only run commands, or destroy a `Connection`, as well as inspect its "description". 

Finally, there might be some contention around the use of symbols for private members. We briefly discussed this the other day, but I was trying to stick with node-core's conventions here. The idea here was not to symbol-ify everything, but rather make symbols for core, non-copiable object instances (net.Socket, MessageStream, BufferList), while letting other properties hang normally off the class. I think it has an added benefit of making console inspection of the connection and message stream look nicer. I'm flexible here, but I'd like to just decide on something and stick with it. 

Ah, one last deviation: even though the types live in `lib/core/cmap`, I opted to place the tests in `test/function/cmap` and `test/unit/cmap`. My thought is that having an extra layer of depth for these types makes our test infrastructure harder to reason about. I imagine us slowly migrating tests from `core` into the top level structure (throwing away what no longer makes sense). Also flexible here, but interested in having a discussion about it.

**Are there any files to ignore?**
