### PR TITLE
fix(connect): prevent multiple callbacks in error scenarios

### DIFF
--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -15,6 +15,7 @@ const MIN_SUPPORTED_SERVER_VERSION = WIRE_CONSTANTS.MIN_SUPPORTED_SERVER_VERSION
 let AUTH_PROVIDERS;
 
 function connect(options, callback) {
+  const ConnectionType = options && options.connectionType ? options.connectionType : Connection;
   if (AUTH_PROVIDERS == null) {
     AUTH_PROVIDERS = defaultAuthProviders(options.bson);
   }
@@ -26,7 +27,7 @@ function connect(options, callback) {
         return;
       }
 
-      performInitialHandshake(new Connection(socket, options), options, callback);
+      performInitialHandshake(new ConnectionType(socket, options), options, callback);
     });
 
     return;
@@ -40,13 +41,13 @@ function connect(options, callback) {
           return;
         }
 
-        performInitialHandshake(new Connection(ipv4Socket, options), options, callback);
+        performInitialHandshake(new ConnectionType(ipv4Socket, options), options, callback);
       });
 
       return;
     }
 
-    performInitialHandshake(new Connection(ipv6Socket, options), options, callback);
+    performInitialHandshake(new ConnectionType(ipv6Socket, options), options, callback);
   });
 }
 

--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -315,11 +315,25 @@ function runCommand(conn, ns, command, options, callback) {
     numberToReturn: 1
   });
 
+  const noop = () => {};
+  function _callback(err, result) {
+    callback(err, result);
+    callback = noop;
+  }
+
   function errorHandler(err) {
     conn.resetSocketTimeout();
     CONNECTION_ERROR_EVENTS.forEach(eventName => conn.removeListener(eventName, errorHandler));
     conn.removeListener('message', messageHandler);
-    callback(err, null);
+
+    if (err == null) {
+      err = new MongoError(`runCommand failed for connection to '${conn.address}'`);
+    }
+
+    // ignore all future errors
+    conn.on('error', noop);
+
+    _callback(err, null);
   }
 
   function messageHandler(msg) {
@@ -332,7 +346,7 @@ function runCommand(conn, ns, command, options, callback) {
     conn.removeListener('message', messageHandler);
 
     msg.parse({ promoteValues: true });
-    callback(null, msg.documents[0]);
+    _callback(null, msg.documents[0]);
   }
 
   conn.setSocketTimeout(socketTimeout);


### PR DESCRIPTION
We treat `close`/`timeout`/`parseError`/`error` as error cases
during initial handshake, but some of these do not generate errors.
Additionally, in some cases multiple of these events may be emitted
which leaves us in a bad state if a subsequent `error` message is
emitted, since that will crash the node process.

NODE-2277