### PR TITLE
NODE-2316: fix client metadata for unified topology

### DIFF
--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -33,6 +33,7 @@ let globalTopologyCounter = 0;
 
 // Constants
 const TOPOLOGY_DEFAULTS = {
+  useUnifiedTopology: true,
   localThresholdMS: 15,
   serverSelectionTimeoutMS: 30000,
   heartbeatFrequencyMS: 10000,

--- a/lib/core/topologies/shared.js
+++ b/lib/core/topologies/shared.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const os = require('os');
-const f = require('util').format;
 const ReadPreference = require('./read_preference');
 const Buffer = require('safe-buffer').Buffer;
 const TopologyType = require('../sdam/topology_description').TopologyType;
@@ -20,20 +19,19 @@ function emitSDAMEvent(self, event, description) {
 }
 
 // Get package.json variable
-var driverVersion = require('../../../package.json').version;
-var nodejsversion = f('Node.js %s, %s', process.version, os.endianness());
-var type = os.type();
-var name = process.platform;
-var architecture = process.arch;
-var release = os.release();
+const driverVersion = require('../../../package.json').version;
+const nodejsVersion = `'Node.js ${process.version}, ${os.endianness}`;
+const type = os.type();
+const name = process.platform;
+const architecture = process.arch;
+const release = os.release();
 
 function createClientInfo(options) {
-  // Build default client information
-  var clientInfo = options.clientInfo
+  const clientInfo = options.clientInfo
     ? clone(options.clientInfo)
     : {
         driver: {
-          name: 'nodejs-core',
+          name: 'nodejs',
           version: driverVersion
         },
         os: {
@@ -44,11 +42,8 @@ function createClientInfo(options) {
         }
       };
 
-  // Is platform specified
-  if (clientInfo.platform && clientInfo.platform.indexOf('mongodb-core') === -1) {
-    clientInfo.platform = f('%s, mongodb-core: %s', clientInfo.platform, driverVersion);
-  } else if (!clientInfo.platform) {
-    clientInfo.platform = nodejsversion;
+  if (options.useUnifiedTopology) {
+    clientInfo.platform = `${nodejsVersion} (${options.useUnifiedTopology ? 'unified' : 'legacy'})`;
   }
 
   // Do we have an application specific string

--- a/test/core/unit/connect_tests.js
+++ b/test/core/unit/connect_tests.js
@@ -100,6 +100,35 @@ describe('Connect Tests', function() {
     });
   });
 
+  it(
+    'should report the correct metadata for unified topology',
+    { requires: { unifiedTopology: true, topology: ['single'] } },
+    function(done) {
+      let ismaster;
+      test.server.setMessageHandler(request => {
+        const doc = request.document;
+        const $clusterTime = genClusterTime(Date.now());
+        if (doc.ismaster) {
+          ismaster = doc;
+          request.reply(
+            Object.assign({}, mock.DEFAULT_ISMASTER, {
+              $clusterTime,
+              arbiterOnly: true
+            })
+          );
+        }
+      });
+
+      const topology = this.configuration.newTopology(test.connectOptions);
+      topology.connect(test.connectOptions, err => {
+        expect(err).to.not.exist;
+        const platform = ismaster.client.platform;
+        expect(platform).to.match(/unified/);
+        topology.close(done);
+      });
+    }
+  );
+
   describe('runCommand', function() {
     class MockConnection extends EventEmitter {
       constructor(conn) {

--- a/test/runner/config.js
+++ b/test/runner/config.js
@@ -96,6 +96,12 @@ class NativeConfiguration {
   }
 
   newTopology(host, port, options) {
+    if (typeof host === 'object') {
+      options = host;
+      host = null;
+      port = null;
+    }
+
     options = Object.assign({}, options);
     const hosts = host == null ? [].concat(this.options.hosts) : [{ host, port }];
     if (this.usingUnifiedTopology()) {

--- a/test/runner/filters/unified_filter.js
+++ b/test/runner/filters/unified_filter.js
@@ -17,7 +17,7 @@ class UnifiedTopologyFilter {
 
     return (
       typeof unifiedTopology !== 'boolean' ||
-      unifiedTopology === process.env.MONGODB_UNIFIED_TOPOLOGY
+      unifiedTopology === !!process.env.MONGODB_UNIFIED_TOPOLOGY
     );
   }
 }


### PR DESCRIPTION
The unified topology has been incorrectly reporting itself as `nodejs-core` in client metadata. This correct that to report just `nodejs`, but to include the unified or legacy type in the platform data.

NODE-2316
