### PR TITLE
docs(encryption): leverage mongodb-client-encryption docs

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -36,12 +36,7 @@
       "node_modules/bson/lib/bson/min_key.js",
       "node_modules/bson/lib/bson/decimal128.js",
       "node_modules/bson/lib/bson/int_32.js",
-      "node_modules/bson/lib/bson/regexp.js",
-      "test/functional/authentication_tests.js",
-      "test/functional/gridfs_stream_tests.js",
-      "test/functional/operation_example_tests.js",
-      "test/functional/operation_generators_example_tests.js",
-      "test/functional/operation_promises_example_tests.js"
+      "node_modules/bson/lib/bson/regexp.js"
     ]
   },
   "templates": {

--- a/conf.json
+++ b/conf.json
@@ -36,7 +36,10 @@
       "node_modules/bson/lib/bson/min_key.js",
       "node_modules/bson/lib/bson/decimal128.js",
       "node_modules/bson/lib/bson/int_32.js",
-      "node_modules/bson/lib/bson/regexp.js"
+      "node_modules/bson/lib/bson/regexp.js",
+      "node_modules/mongodb-client-encryption/lib/autoEncrypter.js",
+      "node_modules/mongodb-client-encryption/lib/clientEncryption.js",
+      "node_modules/mongodb-client-encryption/lib/common.js"
     ]
   },
   "templates": {

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -55,29 +55,6 @@ const CloseOperation = require('./operations/close');
  */
 
 /**
- * Configuration options for a automatic client encryption.
- *
- * **NOTE**: Support for client side encryption is in beta. Backwards-breaking changes may be made before the final release.
- *
- * @typedef {Object} AutoEncryptionOptions
- * @property {MongoClient} [keyVaultClient] A `MongoClient` used to fetch keys from a key vault
- * @property {string} [keyVaultNamespace] The namespace where keys are stored in the key vault
- * @property {object} [kmsProviders] Provider details for the desired Key Management Service to use for encryption
- * @property {object} [kmsProviders.aws] Optional settings for the AWS KMS provider
- * @property {string} [kmsProviders.aws.accessKeyId] The access key used for the AWS KMS provider
- * @property {string} [kmsProviders.aws.secretAccessKey] The secret access key used for the AWS KMS provider
- * @property {object} [kmsProviders.local] Optional settings for the local KMS provider
- * @property {string} [kmsProviders.local.key] The master key used to encrypt/decrypt data keys
- * @property {object} [schemaMap] A map of namespaces to a local JSON schema for encryption
- * @property {boolean} [bypassAutoEncryption] Allows the user to bypass auto encryption, maintaining implicit decryption
- * @property {object} [extraOptions] Extra options related to the mongocryptd process
- * @property {string} [extraOptions.mongocryptURI] A local process the driver communicates with to determine how to encrypt values in a command. Defaults to "mongodb://%2Fvar%2Fmongocryptd.sock" if domain sockets are available or "mongodb://localhost:27020" otherwise
- * @property {boolean} [extraOptions.mongocryptdBypassSpawn=false] If true, autoEncryption will not attempt to spawn a mongocryptd before connecting
- * @property {string} [extraOptions.mongocryptdSpawnPath] The path to the mongocryptd executable on the system
- * @property {string[]} [extraOptions.mongocryptdSpawnArgs] Command line arguments to use when auto-spawning a mongocryptd
- */
-
-/**
  * Creates a new MongoClient instance
  * @class
  * @param {string} url The connection URI string
@@ -142,7 +119,7 @@ const CloseOperation = require('./operations/close');
  * @param {number} [options.minSize] If present, the connection pool will be initialized with minSize connections, and will never dip below minSize connections
  * @param {boolean} [options.useNewUrlParser=true] Determines whether or not to use the new url parser. Enables the new, spec-compliant, url parser shipped in the core driver. This url parser fixes a number of problems with the original parser, and aims to outright replace that parser in the near future. Defaults to true, and must be explicitly set to false to use the legacy url parser.
  * @param {boolean} [options.useUnifiedTopology] Enables the new unified topology layer
- * @param {AutoEncryptionOptions} [options.autoEncryption] Optionally enable client side auto encryption
+ * @param {AutoEncrypter~AutoEncryptionOptions} [options.autoEncryption] Optionally enable client side auto encryption
  * @param {MongoClient~connectCallback} [callback] The command result callback
  * @return {MongoClient} a MongoClient instance
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -2593,6 +2593,18 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "mongodb-client-encryption": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-0.3.1.tgz",
+      "integrity": "sha512-7buhGNyDH4IjDJxP8NdaBBV8CSt9GKnrCmxULzRadxtn5s0810XxjPPuwFYMWPZ+3lFUCL7odiki2Q4PeWOqQA==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bson": "^1.0.5",
+        "nan": "^2.14.0",
+        "prebuild-install": "^5.3.0"
+      }
+    },
     "mongodb-extjson": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/mongodb-extjson/-/mongodb-extjson-2.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lodash.camelcase": "^4.3.0",
     "mocha": "5.2.0",
     "mocha-sinon": "^2.1.0",
+    "mongodb-client-encryption": "^0.3.1",
     "mongodb-extjson": "^2.1.1",
     "mongodb-mock-server": "^1.0.1",
     "prettier": "~1.12.0",
@@ -51,9 +52,9 @@
     "sinon-chai": "^3.2.0",
     "snappy": "^6.1.2",
     "standard-version": "^4.4.0",
-    "yargs": "^14.2.0",
     "worker-farm": "^1.5.0",
-    "wtfnode": "^0.8.0"
+    "wtfnode": "^0.8.0",
+    "yargs": "^14.2.0"
   },
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
## Description
Pull in the documentation from mongodb-client-encryption and
use that instead of duplicating it across.

Fixes NODE-2298

NOTE: will not really work until we cut a new version of `mongodb-client-encryption` that has the updated jsdoc.
