### PR TITLE
fix(bulk): use operation index from input to report operation error

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -475,7 +475,7 @@ function mergeBatchResults(batch, bulkResult, err, result) {
   if (Array.isArray(result.writeErrors)) {
     for (let i = 0; i < result.writeErrors.length; i++) {
       const writeError = {
-        index: batch.originalZeroIndex + result.writeErrors[i].index,
+        index: batch.originalIndexes[i],
         code: result.writeErrors[i].code,
         errmsg: result.writeErrors[i].errmsg,
         op: batch.operations[result.writeErrors[i].index]


### PR DESCRIPTION
The bulk spec requires that the driver report the index of a failed
operation according to it's input to the unordered bulk operation.

NODE-2308
