### PR TITLE
docs: add example for find's projection exclude + include options

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -252,7 +252,7 @@ const DEPRECATED_FIND_OPTIONS = ['maxScan', 'fields', 'snapshot'];
  * @param {object} [options] Optional settings.
  * @param {number} [options.limit=0] Sets the limit of documents returned in the query.
  * @param {(array|object)} [options.sort] Set to sort the documents coming back from the query. Array of indexes, [['a', 1]] etc.
- * @param {object} [options.projection] The fields to return in the query. Object of fields to include or exclude (not both), {'a':1}
+ * @param {object} [options.projection] The fields to return in the query. Object of fields to either include or exclude (one of, not both), {'a':1, 'b': 1} **or** {'a': 0, 'b': 0}
  * @param {object} [options.fields] **Deprecated** Use `options.projection` instead
  * @param {number} [options.skip=0] Set to skip N documents ahead in your query (useful for pagination).
  * @param {Object} [options.hint] Tell the query to use specific indexes in the query. Object of indexes to use, {'_id':1}


### PR DESCRIPTION
## Description
Adds a more detailed example to `coll.find({}, { projection: { a: 0, b: 0 } })` to have both an include and exclude versions. Hopefully it clarifies a bit more that you can't have both.

**What changed?**
JSDoc documentation in `collection.js`. 

Thanks!
