### PR TITLE
Fixes NODE-2335 (non-compliant DNS Seedlist Discovery parsing.)

### DIFF
--- a/lib/core/uri_parser.js
+++ b/lib/core/uri_parser.js
@@ -100,7 +100,7 @@ function parseSrvConnectionString(uri, options, callback) {
           );
         }
 
-        Object.assign(result.query, record);
+        result.query = Object.assign({}, record, result.query);
       }
 
       // Set completed options back into the URL object.

--- a/test/core/unit/mongodb_srv_tests.js
+++ b/test/core/unit/mongodb_srv_tests.js
@@ -45,6 +45,10 @@ describe('mongodb+srv', function() {
                 expect(result.options.ssl).to.equal(test[1].options.ssl);
               }
 
+              if (test[1].options && test[1].options.authSource) {
+                expect(result.options.authsource).to.equal(test[1].options.authSource);
+              }
+
               if (
                 test[1].parsed_options &&
                 test[1].parsed_options.user &&


### PR DESCRIPTION
## Description

See: https://jira.mongodb.org/browse/NODE-2335

This PR fixes Fixes non-compliant DNS Seedlist Discovery parsing.

**What changed?**
Currently the TXT record values override the querystring values, spec states the opposite must be true, so the uri parser was fixed.

The spec test was also not being performed properly so that was fixed as well to add coverage.
