### PR TITLE
fix(connect): connect with family 0 instead of family 4

### DIFF
--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -35,7 +35,7 @@ function connect(options, callback) {
 
   return makeConnection(6, options, (err, ipv6Socket) => {
     if (err) {
-      makeConnection(4, options, (err, ipv4Socket) => {
+      makeConnection(0, options, (err, ipv4Socket) => {
         if (err) {
           callback(err, ipv4Socket); // in the error case, `ipv4Socket` is the originating error event name
           return;


### PR DESCRIPTION
This is a fix for a hard-to-reproduce bug that occurs in
certain network setups on Windows 10. In  those cases,
attempting an IPv6 lookup with a shortname will somehow cause the
subsequent IPv4 lookup to also fail, even though it can succeed
independently. For some reason, this does NOT happen with family: 0.

This really should be fixed in either Node or in Windows itself,
but since we cannot create a stable reproducer, we will use this
fix short-term while we come up with a more stable solution.

Fixes NODE-1747
Fixes NODE-2143

## Description

**What changed?**

**Are there any files to ignore?**
