### PR TITLE
test: only test client-side encryption in certain build variants

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -84,9 +84,31 @@ functions:
     - command: shell.exec
       type: test
       params:
+        silent: true
+        working_dir: src
+        script: |
+          if [ -n "${CLIENT_ENCRYPTION}" ]; then
+            cat <<EOT > prepare_client_encryption.sh
+            export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
+            export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+            export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+          EOT
+          fi
+    - command: shell.exec
+      type: test
+      params:
         working_dir: src
         script: >
           ${PREPARE_SHELL}
+
+
+          if [ -n "${CLIENT_ENCRYPTION}" ]; then
+            # Disable xtrace (just in case it was accidentally set).
+            set +x
+            . ./prepare_client_encryption.sh
+            rm -f ./prepare_client_encryption.sh
+          fi
+
 
           AUTH=${AUTH} SSL=${SSL} UNIFIED=${UNIFIED} MONGODB_URI="${MONGODB_URI}" bash
           ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
@@ -1092,24 +1114,28 @@ buildvariants:
     run_on: ubuntu1604-test
     expansions:
       NODE_LTS_NAME: dubnium
+      CLIENT_ENCRYPTION: true
     tasks: *ref_4
   - name: ubuntu-16.04-carbon
     display_name: Ubuntu 16.04 Node Carbon
     run_on: ubuntu1604-test
     expansions:
       NODE_LTS_NAME: carbon
+      CLIENT_ENCRYPTION: true
     tasks: *ref_4
   - name: ubuntu-16.04-boron
     display_name: Ubuntu 16.04 Node Boron
     run_on: ubuntu1604-test
     expansions:
       NODE_LTS_NAME: boron
+      CLIENT_ENCRYPTION: true
     tasks: *ref_4
   - name: ubuntu-16.04-argon
     display_name: Ubuntu 16.04 Node Argon
     run_on: ubuntu1604-test
     expansions:
       NODE_LTS_NAME: argon
+      CLIENT_ENCRYPTION: true
     tasks: *ref_4
   - name: ubuntu1604-arm64-small-dubnium
     display_name: Ubuntu 16.04 (ARM64) Node Dubnium

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -104,9 +104,30 @@ functions:
     - command: shell.exec
       type: test
       params:
+        silent: true
+        working_dir: "src"
+        script: |
+          if [ -n "${CLIENT_ENCRYPTION}" ]; then
+            cat <<EOT > prepare_client_encryption.sh
+            export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
+            export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+            export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+          EOT
+          fi
+    - command: shell.exec
+      type: test
+      params:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
+
+          if [ -n "${CLIENT_ENCRYPTION}" ]; then
+            # Disable xtrace (just in case it was accidentally set).
+            set +x
+            . ./prepare_client_encryption.sh
+            rm -f ./prepare_client_encryption.sh
+          fi
+
           AUTH=${AUTH} SSL=${SSL} UNIFIED=${UNIFIED} MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "cleanup":

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -88,7 +88,8 @@ const OPERATING_SYSTEMS = [
     name: 'ubuntu-16.04',
     display_name: 'Ubuntu 16.04',
     run_on: 'ubuntu1604-test',
-    mongoVersion: '>=3.2'
+    mongoVersion: '>=3.2',
+    clientEncryption: true
   },
   {
     name: 'ubuntu1604-arm64-small',
@@ -227,7 +228,8 @@ OPERATING_SYSTEMS.forEach(
     display_name: osDisplayName,
     run_on,
     mongoVersion = '>=2.6',
-    nodeVersions = NODE_VERSIONS
+    nodeVersions = NODE_VERSIONS,
+    clientEncryption
   }) => {
     const testedNodeVersions = NODE_VERSIONS.filter(version => nodeVersions.includes(version));
     const tasks = getTaskList(mongoVersion);
@@ -237,6 +239,11 @@ OPERATING_SYSTEMS.forEach(
       const name = `${osName}-${NODE_LTS_NAME}`;
       const display_name = `${osDisplayName} ${nodeLtsDisplayName}`;
       const expansions = { NODE_LTS_NAME };
+
+      if (clientEncryption) {
+        expansions.CLIENT_ENCRYPTION = true;
+      }
+
       BUILD_VARIANTS.push({ name, display_name, run_on, expansions, tasks });
     });
   }

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -21,4 +21,13 @@ export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+# only run FLE tets on hosts we explicitly choose to test on
+if [[ -z "${CLIENT_ENCRYPTION}" ]]; then
+  unset AWS_ACCESS_KEY_ID;
+  unset AWS_SECRET_ACCESS_KEY;
+else
+  npm install mongodb-client-encryption
+fi
+
 MONGODB_UNIFIED_TOPOLOGY=${UNIFIED} MONGODB_URI=${MONGODB_URI} npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1738,9 +1738,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -2448,18 +2448,18 @@
       }
     },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.42.0"
       }
     },
     "mimic-fn": {
@@ -2592,18 +2592,6 @@
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
-    },
-    "mongodb-client-encryption": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-0.3.1.tgz",
-      "integrity": "sha512-7buhGNyDH4IjDJxP8NdaBBV8CSt9GKnrCmxULzRadxtn5s0810XxjPPuwFYMWPZ+3lFUCL7odiki2Q4PeWOqQA==",
-      "dev": true,
-      "requires": {
-        "bindings": "^1.5.0",
-        "bson": "^1.0.5",
-        "nan": "^2.14.0",
-        "prebuild-install": "^5.3.0"
-      }
     },
     "mongodb-extjson": {
       "version": "2.1.4",
@@ -3990,9 +3978,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4184,9 +4172,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
-      "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.1.tgz",
+      "integrity": "sha512-rZ00XIuGAoI58F0weHyCP3PAN17wJqdN/pF8eMp+imuP+jSdMCD5t4bSf5d5FKPvEDrK9zYlnhO7bFYKQ5UYow==",
       "dev": true,
       "requires": {
         "cliui": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "lodash.camelcase": "^4.3.0",
     "mocha": "5.2.0",
     "mocha-sinon": "^2.1.0",
-    "mongodb-client-encryption": "^0.3.1",
     "mongodb-extjson": "^2.1.1",
     "mongodb-mock-server": "^1.0.1",
     "prettier": "~1.12.0",

--- a/test/runner/filters/client_encryption_filter.js
+++ b/test/runner/filters/client_encryption_filter.js
@@ -35,6 +35,7 @@ class ClientSideEncryptionFilter {
 
     callback();
   }
+
   filter(test) {
     const clientSideEncryption =
       test.metadata && test.metadata.requires && test.metadata.requires.clientSideEncryption;


### PR DESCRIPTION
We only want to test client-side encryption where we actively
provide prebuilds, and where the server is testing it. This reduces
the test matrix to those variants

NODE-2100