### PR TITLE
NODE-2332: introduce drain mode for connection pool in unified mode

### DIFF
--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -256,6 +256,15 @@ function connectionFailureHandler(pool, event, err, conn) {
       const workItem = conn.workItems.shift();
       if (workItem.cb) workItem.cb(err);
     }
+
+    if (pool.state !== DRAINING && pool.options.legacyCompatMode === false) {
+      // since an error/close/timeout means pool invalidation in a
+      // pre-CMAP world, we will issue a custom `drain` event here to
+      // signal that the server should be recycled
+      stateTransition(pool, DRAINING);
+      pool.emit('drain', err);
+      return;
+    }
   }
 
   // Did we catch a timeout, increment the numberOfConsecutiveTimeouts

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -435,7 +435,7 @@ class CoreCursor extends Readable {
           return;
         }
 
-        cursor._next(callback);
+        this._initializeCursor(callback);
       });
 
       return;

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -207,7 +207,9 @@ function isNodeShuttingDownError(err) {
  * @param {Server} server
  */
 function isSDAMUnrecoverableError(error, server) {
-  if (error instanceof MongoParseError) {
+  // NOTE: null check is here for a strictly pre-CMAP world, a timeout or
+  //       close event are considered unrecoverable
+  if (error instanceof MongoParseError || error == null) {
     return true;
   }
 

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -158,6 +158,10 @@ class Server extends EventEmitter {
     // setup listeners
     this.s.pool.on('parseError', parseErrorEventHandler(this));
 
+    this.s.pool.on('drain', err => {
+      this.emit('error', err);
+    });
+
     // it is unclear whether consumers should even know about these events
     // this.s.pool.on('timeout', timeoutEventHandler(this));
     // this.s.pool.on('reconnect', reconnectEventHandler(this));

--- a/lib/core/sdam/server_selection.js
+++ b/lib/core/sdam/server_selection.js
@@ -8,8 +8,6 @@ const MongoTimeoutError = require('../error').MongoTimeoutError;
 
 const common = require('./common');
 const STATE_CLOSED = common.STATE_CLOSED;
-const TOPOLOGY_DEFAULTS = common.TOPOLOGY_DEFAULTS;
-const drainTimerQueue = common.drainTimerQueue;
 const clearAndRemoveTimerFrom = common.clearAndRemoveTimerFrom;
 
 // max staleness constants
@@ -183,7 +181,8 @@ function readPreferenceServerSelector(readPreference) {
     const commonWireVersion = topologyDescription.commonWireVersion;
     if (
       commonWireVersion &&
-      (readPreference.minWireVersion && readPreference.minWireVersion > commonWireVersion)
+      readPreference.minWireVersion &&
+      readPreference.minWireVersion > commonWireVersion
     ) {
       throw new MongoError(
         `Minimum wire version '${
@@ -298,18 +297,10 @@ function selectServers(topology, selector, timeout, start, callback) {
   }
 
   const retrySelection = () => {
-    // clear all existing monitor timers
-    drainTimerQueue(topology.s.monitorTimers);
-
     // ensure all server monitors attempt monitoring soon
-    topology.s.servers.forEach(server => {
-      const timer = setTimeout(
-        () => server.monitor({ heartbeatFrequencyMS: topology.description.heartbeatFrequencyMS }),
-        TOPOLOGY_DEFAULTS.minHeartbeatFrequencyMS
-      );
-
-      topology.s.monitorTimers.add(timer);
-    });
+    topology.s.servers.forEach(server =>
+      server.monitor({ heartbeatFrequencyMS: topology.description.heartbeatFrequencyMS })
+    );
 
     const iterationTimer = setTimeout(() => {
       topology.removeListener('topologyDescriptionChanged', descriptionChangedHandler);

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -420,8 +420,6 @@ class Topology extends EventEmitter {
       return;
     }
 
-    drainTimerQueue(this.s.iterationTimers);
-
     selectServers(
       this,
       selector,

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -175,7 +175,6 @@ class Topology extends EventEmitter {
       clusterTime: null,
 
       // timer management
-      monitorTimers: new Set(),
       iterationTimers: new Set(),
       connectionTimers: new Set()
     };
@@ -334,7 +333,6 @@ class Topology extends EventEmitter {
     }
 
     // clear all existing monitor timers
-    drainTimerQueue(this.s.monitorTimers);
     drainTimerQueue(this.s.iterationTimers);
     drainTimerQueue(this.s.connectionTimers);
 

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -221,7 +221,7 @@ function parseSessionOptions(options) {
   return result;
 }
 
-const IGNORED_COMMANDS = new Set(['ismaster', 'configureFailPoint']);
+const IGNORED_COMMANDS = new Set(['ismaster', 'configureFailPoint', 'endSessions']);
 
 let displayCommands = false;
 function runTestSuiteTest(configuration, spec, context) {

--- a/test/tools/sdam_viz
+++ b/test/tools/sdam_viz
@@ -94,16 +94,16 @@ async function run() {
       await wait(2000);
 
       try {
-        print('issuing find...');
+        print(`${chalk.yellow('workload')} issuing find...`);
         const result = await client
           .db('test')
           .collection('test')
           .find({})
           .limit(1)
           .toArray();
-        print(`  > find completed: ${JSON.stringify(result)}`);
+        print(`${chalk.yellow('workload')} find completed: ${JSON.stringify(result)}`);
       } catch (e) {
-        print(`  > find failed: ${e.message}`);
+        print(`${chalk.yellow('workload')} find failed: ${e.message}`);
       }
     }
   }


### PR DESCRIPTION
## Description
Until we integrate the new connection pool conforming to the CMAP specification, any type of error/close/timeout coming from a pool signals pool invalidation. If the pool is configured for unified then it should invalidate the server by emitting a `drain` event which is translated to an `error in the `Server` instance, causing the topology to cycle the server.

**What changed?**
The `Pool` gains a new event `drain` which is emitted when some connection error occurs. This causes an `error` event and cycles the server for rechecking (and subsequent server selection). A superfluous timer queue was removed for `monitorIntervals`, which turns out to be a needless timed action. 

Extra small changes:
  - `sdam_viz` now has a nicely formatted message for `workload` events

**Are there any files to ignore?**
none