### PR TITLE
NODE-2348: warn on deprecated event and options

### DIFF
--- a/docs/reference/content/reference/unified-topology/index.md
+++ b/docs/reference/content/reference/unified-topology/index.md
@@ -29,6 +29,21 @@ const client = MongoClient('mongodb://localhost:27017', { useUnifiedTopology: tr
 
 ## Behavioral Changes
 
+## Deprecated events and options
+
+The unified topology no longer supports the following events:
+- `reconnect`
+- `reconnectFailed`
+- `attemptReconnect`
+
+It also deprecates the following options passed into the `MongoClient`:
+- `autoReconnect`
+- `reconnectTries`
+- `reconnectInterval`
+- `bufferMaxEntries`
+
+The following sections will go into detail about why tese values are no longer used.
+
 ### `MongoClient.connect`, `isConnected`
 
 The unified topology is the first step in a paradigm shift away from a concept of "connecting" to a MongoDB deployment using a `connect` method. Consider for a moment what it means to be connected to a replica set: do we trigger this state when connected to a primary? A primary and one secondary? When connected to all known nodes? It's unclear whether its possible to answer this without introducing something like a `ReadPreference` parameter to the `connect` method. At this point "connecting" is just one half of "operation execution" - you pass a `ReadPreference` in, and await a selectable server for the operation, now we're connected!

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -23,6 +23,7 @@ const SrvPoller = require('./srv_polling').SrvPoller;
 const getMMAPError = require('../topologies/shared').getMMAPError;
 const makeStateMachine = require('../utils').makeStateMachine;
 const eachAsync = require('../utils').eachAsync;
+const emitDeprecationWarning = require('../../utils').emitDeprecationWarning;
 
 const common = require('./common');
 const drainTimerQueue = common.drainTimerQueue;
@@ -69,6 +70,13 @@ const stateTransition = makeStateMachine({
   [STATE_CLOSING]: [STATE_CLOSING, STATE_CLOSED]
 });
 
+const DEPRECATED_OPTIONS = new Set([
+  'autoReconnect',
+  'reconnectTries',
+  'reconnectInterval',
+  'bufferMaxEntries'
+]);
+
 /**
  * A container of server instances representing a connection to a MongoDB topology.
  *
@@ -110,6 +118,14 @@ class Topology extends EventEmitter {
     }
 
     options = Object.assign({}, common.TOPOLOGY_DEFAULTS, options);
+    DEPRECATED_OPTIONS.forEach(optionName => {
+      if (options[optionName]) {
+        emitDeprecationWarning(
+          `The option \`${optionName}\` is incompatible with the unified topology, please read more by visiting http://bit.ly/2D8WfT6`,
+          'DeprecationWarning'
+        );
+      }
+    });
 
     const topologyType = topologyTypeFromSeedlist(seedlist, options);
     const topologyId = globalTopologyCounter++;

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -15,6 +15,7 @@ const ReadPreference = require('../core').ReadPreference;
 const ReplSet = require('../topologies/replset');
 const Server = require('../topologies/server');
 const ServerSessionPool = require('../core').Sessions.ServerSessionPool;
+const emitDeprecationWarning = require('../utils').emitDeprecationWarning;
 
 let client;
 function loadClient() {
@@ -438,6 +439,18 @@ function createServer(mongoClient, options, callback) {
   });
 }
 
+const DEPRECATED_UNIFIED_EVENTS = new Set(['reconnect', 'reconnectFailed', 'attemptReconnect']);
+function registerDeprecatedEventNotifiers(client) {
+  client.on('newListener', eventName => {
+    if (DEPRECATED_UNIFIED_EVENTS.has(eventName)) {
+      emitDeprecationWarning(
+        `The \`${eventName}\` event is no longer supported by the unified topology, please read more by visiting http://bit.ly/2D8WfT6`,
+        'DeprecationWarning'
+      );
+    }
+  });
+}
+
 function createTopology(mongoClient, topologyType, options, callback) {
   // Pass in the promise library
   options.promiseLibrary = mongoClient.s.promiseLibrary;
@@ -456,6 +469,7 @@ function createTopology(mongoClient, topologyType, options, callback) {
     topology = new ReplSet(servers, options);
   } else if (topologyType === 'unified') {
     topology = new NativeTopology(options.servers, options);
+    registerDeprecatedEventNotifiers(mongoClient);
   }
 
   // Add listeners

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -712,5 +712,6 @@ module.exports = {
   deprecateOptions,
   SUPPORTS,
   MongoDBNamespace,
-  resolveReadPreference
+  resolveReadPreference,
+  emitDeprecationWarning
 };


### PR DESCRIPTION
When using the unified topology, a number of options and events are now deprecated. This will notify users of that, and point them to our documentation, which now contains information about deprecations.
