### PR TITLE
Node 2217/normalize api

### DIFF
--- a/docs/lib/jsdoc/merge_params.js
+++ b/docs/lib/jsdoc/merge_params.js
@@ -1,7 +1,7 @@
 'use strict';
 
 exports.defineTags = function(dictionary) {
-  dictionary.defineTag('merge-props', {
+  dictionary.defineTag('mergeProps', {
     mustHaveValue: true,
     canHaveName: true,
     onTagged: function(doclet, tag) {
@@ -10,7 +10,7 @@ exports.defineTags = function(dictionary) {
     }
   });
 
-  dictionary.defineTag('merge-params', {
+  dictionary.defineTag('mergeParams', {
     mustHaveValue: true,
     canHaveType: true,
     canHaveName: true,

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -99,12 +99,6 @@ const mergeKeys = ['ignoreUndefined'];
 /**
  * Create a new Collection instance (INTERNAL TYPE, do not instantiate directly)
  * @class
- * @property {string} collectionName Get the collection name.
- * @property {string} namespace Get the full collection namespace.
- * @property {object} writeConcern The current write concern values.
- * @property {object} readConcern The current read concern values.
- * @property {object} hint Get current index hint for collection.
- * @return {Collection} a Collection instance.
  */
 function Collection(db, topology, dbName, name, pkFactory, options) {
   checkCollectionName(name);
@@ -178,6 +172,12 @@ function Collection(db, topology, dbName, name, pkFactory, options) {
   };
 }
 
+/**
+ * The name of the database this collection belongs to
+ * @member {string} dbName
+ * @memberof Collection#
+ * @readonly
+ */
 Object.defineProperty(Collection.prototype, 'dbName', {
   enumerable: true,
   get: function() {
@@ -185,6 +185,12 @@ Object.defineProperty(Collection.prototype, 'dbName', {
   }
 });
 
+/**
+ * The name of this collection
+ * @member {string} collectionName
+ * @memberof Collection#
+ * @readonly
+ */
 Object.defineProperty(Collection.prototype, 'collectionName', {
   enumerable: true,
   get: function() {
@@ -192,6 +198,12 @@ Object.defineProperty(Collection.prototype, 'collectionName', {
   }
 });
 
+/**
+ * The namespace of this collection, in the format `${this.dbName}.${this.collectionName}`
+ * @member {string} namespace
+ * @memberof Collection#
+ * @readonly
+ */
 Object.defineProperty(Collection.prototype, 'namespace', {
   enumerable: true,
   get: function() {
@@ -199,6 +211,13 @@ Object.defineProperty(Collection.prototype, 'namespace', {
   }
 });
 
+/**
+ * The current readConcern of the collection. If not explicitly defined for
+ * this collection, will be inherited from the parent DB
+ * @member {ReadConcern} [readConcern]
+ * @memberof Collection#
+ * @readonly
+ */
 Object.defineProperty(Collection.prototype, 'readConcern', {
   enumerable: true,
   get: function() {
@@ -209,6 +228,13 @@ Object.defineProperty(Collection.prototype, 'readConcern', {
   }
 });
 
+/**
+ * The current readPreference of the collection. If not explicitly defined for
+ * this collection, will be inherited from the parent DB
+ * @member {ReadPreference} [readPreference]
+ * @memberof Collection#
+ * @readonly
+ */
 Object.defineProperty(Collection.prototype, 'readPreference', {
   enumerable: true,
   get: function() {
@@ -220,6 +246,13 @@ Object.defineProperty(Collection.prototype, 'readPreference', {
   }
 });
 
+/**
+ * The current writeConcern of the collection. If not explicitly defined for
+ * this collection, will be inherited from the parent DB
+ * @member {WriteConcern} [writeConcern]
+ * @memberof Collection#
+ * @readonly
+ */
 Object.defineProperty(Collection.prototype, 'writeConcern', {
   enumerable: true,
   get: function() {
@@ -231,7 +264,9 @@ Object.defineProperty(Collection.prototype, 'writeConcern', {
 });
 
 /**
- * @ignore
+ * The current index hint for the collection
+ * @member {object} [hint]
+ * @memberof Collection#
  */
 Object.defineProperty(Collection.prototype, 'hint', {
   enumerable: true,
@@ -260,6 +295,7 @@ const DEPRECATED_FIND_OPTIONS = ['maxScan', 'fields', 'snapshot'];
  * @param {boolean} [options.snapshot=false] DEPRECATED: Snapshot query.
  * @param {boolean} [options.timeout=false] Specify if the cursor can timeout.
  * @param {boolean} [options.tailable=false] Specify if the cursor is tailable.
+ * @param {boolean} [options.awaitData=false] Specify if the cursor is a a tailable-await cursor. Requires `tailable` to be true
  * @param {number} [options.batchSize=1000] Set the batchSize for the getMoreCommand when iterating over the query results.
  * @param {boolean} [options.returnKey=false] Only return the index key.
  * @param {number} [options.maxScan] DEPRECATED: Limit the number of items to scan.
@@ -274,6 +310,8 @@ const DEPRECATED_FIND_OPTIONS = ['maxScan', 'fields', 'snapshot'];
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  * @param {boolean} [options.partial=false] Specify if the cursor should return partial results when querying against a sharded system
  * @param {number} [options.maxTimeMS] Number of milliseconds to wait before aborting the query.
+ * @param {number} [options.maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query. Requires `taiable` and `awaitData` to be true
+ * @param {boolean} [options.noCursorTimeout] The server normally times out idle cursors after an inactivity period (10 minutes) to prevent excess memory use. Set this option to prevent that.
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @throws {MongoError}
@@ -451,12 +489,14 @@ Collection.prototype.find = deprecateOptions(
  * @method
  * @param {object} doc Document to insert.
  * @param {object} [options] Optional settings.
+ * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {boolean} [options.checkKeys=true] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
- * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
- * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~insertOneWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -484,13 +524,15 @@ Collection.prototype.insertOne = function(doc, options, callback) {
  * @method
  * @param {object[]} docs Documents to insert.
  * @param {object} [options] Optional settings.
+ * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {boolean} [options.ordered=true] If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails.
+ * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {boolean} [options.checkKeys=true] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
- * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
- * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
- * @param {boolean} [options.ordered=true] If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~insertWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -549,13 +591,15 @@ Collection.prototype.insertMany = function(docs, options, callback) {
  * @method
  * @param {object[]} operations Bulk operations to perform.
  * @param {object} [options] Optional settings.
+ * @param {boolean} [options.ordered=true] Execute write operation in ordered or unordered fashion.
+ * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {object[]} [options.arrayFilters] Determines which array elements to modify for update operation in MongoDB 3.6 or higher.
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
- * @param {boolean} [options.ordered=true] Execute write operation in ordered or unordered fashion.
- * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~bulkWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -589,24 +633,24 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
 
 /**
  * @typedef {Object} Collection~insertWriteOpResult
- * @property {Number} insertedCount The total amount of documents inserted.
+ * @property {number} insertedCount The total amount of documents inserted.
  * @property {object[]} ops All the documents inserted using insertOne/insertMany/replaceOne. Documents contain the _id field if forceServerObjectId == false for insertOne/insertMany
  * @property {Object.<Number, ObjectId>} insertedIds Map of the index of the inserted document to the id of the inserted document.
  * @property {object} connection The connection object used for the operation.
  * @property {object} result The raw command result object returned from MongoDB (content might vary by server version).
- * @property {Number} result.ok Is 1 if the command executed correctly.
- * @property {Number} result.n The total count of documents inserted.
+ * @property {number} result.ok Is 1 if the command executed correctly.
+ * @property {number} result.n The total count of documents inserted.
  */
 
 /**
  * @typedef {Object} Collection~insertOneWriteOpResult
- * @property {Number} insertedCount The total amount of documents inserted.
+ * @property {number} insertedCount The total amount of documents inserted.
  * @property {object[]} ops All the documents inserted using insertOne/insertMany/replaceOne. Documents contain the _id field if forceServerObjectId == false for insertOne/insertMany
  * @property {ObjectId} insertedId The driver generated ObjectId for the insert operation.
  * @property {object} connection The connection object used for the operation.
  * @property {object} result The raw command result object returned from MongoDB (content might vary by server version).
- * @property {Number} result.ok Is 1 if the command executed correctly.
- * @property {Number} result.n The total count of documents inserted.
+ * @property {number} result.ok Is 1 if the command executed correctly.
+ * @property {number} result.n The total count of documents inserted.
  */
 
 /**
@@ -666,7 +710,7 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @property {Number} upsertedCount The number of documents upserted.
  * @property {Object} upsertedId The upserted id.
  * @property {ObjectId} upsertedId._id The upserted _id returned from the server.
- * @property {Object} message
+ * @property {Object} message The raw msg response wrapped in an internal class
  * @property {object[]} [ops] In a response to {@link Collection#replaceOne replaceOne}, contains the new value of the document on the server. This is the same document that was originally passed in, and is only here for legacy purposes.
  */
 
@@ -683,14 +727,18 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @param {object} filter The Filter used to select the document to update
  * @param {object} update The update operations to be applied to the document
  * @param {object} [options] Optional settings.
- * @param {boolean} [options.upsert=false] Update operation is an upsert.
+ * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
+ * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
+ * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
+ * @param {boolean} [options.upsert=false] When true, creates a new document if no document matches the query..
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
- * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
+ * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
+ * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
- * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
@@ -723,13 +771,17 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
  * @param {object} filter The Filter used to select the document to replace
  * @param {object} doc The Document that replaces the matching document
  * @param {object} [options] Optional settings.
- * @param {boolean} [options.upsert=false] Update operation is an upsert.
+ * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
+ * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
+ * @param {boolean} [options.upsert=false] When true, creates a new document if no document matches the query.
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
+ * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
- * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise<Collection~updateWriteOpResult>} returns Promise if no callback passed
  */
@@ -754,13 +806,18 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  * @param {object} filter The Filter used to select the documents to update
  * @param {object} update The update operations to be applied to the documents
  * @param {object} [options] Optional settings.
- * @param {boolean} [options.upsert=false] Update operation is an upsert.
+ * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
+ * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
+ * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
+ * @param {boolean} [options.upsert=false] When true, creates a new document if no document matches the query..
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
+ * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
+ * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
- * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {Collection~updateWriteOpCallback} [callback] The command result callback
  * @return {Promise<Collection~updateWriteOpResult>} returns Promise if no callback passed
  */
@@ -837,7 +894,7 @@ Collection.prototype.update = deprecate(function(selector, update, options, call
  */
 
 /**
- * The callback format for inserts
+ * The callback format for deletes
  * @callback Collection~deleteWriteOpCallback
  * @param {MongoError} error An error instance representing the error during the execution.
  * @param {Collection~deleteWriteOpResult} result The result object if the command was executed successfully.
@@ -848,9 +905,13 @@ Collection.prototype.update = deprecate(function(selector, update, options, call
  * @method
  * @param {object} filter The Filter used to select the document to remove
  * @param {object} [options] Optional settings.
+ * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
+ * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~deleteWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -877,9 +938,13 @@ Collection.prototype.removeOne = Collection.prototype.deleteOne;
  * @method
  * @param {object} filter The Filter used to select the documents to remove
  * @param {object} [options] Optional settings.
+ * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
+ * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~deleteWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -906,6 +971,7 @@ Collection.prototype.removeMany = Collection.prototype.deleteMany;
  * @method
  * @param {object} selector The selector for the update operation.
  * @param {object} [options] Optional settings.
+ * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {(number|string)} [options.w] The write concern.
  * @param {number} [options.wtimeout] The write concern timeout.
  * @param {boolean} [options.j=false] Specify a journal write concern.
@@ -1414,6 +1480,7 @@ Collection.prototype.indexInformation = function(options, callback) {
  * @method
  * @param {object} [query={}] The query for the count.
  * @param {object} [options] Optional settings.
+ * @param {object} [options.collation] Specify collation settings for operation. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {boolean} [options.limit] The limit of documents to count.
  * @param {boolean} [options.skip] The number of documents to skip for the count.
  * @param {string} [options.hint] An index name hint for the query.
@@ -1510,6 +1577,7 @@ Collection.prototype.countDocuments = function(query, options, callback) {
  * @param {object} [options] Optional settings.
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  * @param {number} [options.maxTimeMS] Number of milliseconds to wait before aborting the query.
+ * @param {object} [options.collation] Specify collation settings for operation. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -1582,9 +1650,13 @@ Collection.prototype.stats = function(options, callback) {
  * @method
  * @param {object} filter The Filter used to select the document to remove
  * @param {object} [options] Optional settings.
+ * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {object} [options.projection] Limits the fields to return for all matching documents.
  * @param {object} [options.sort] Determines which document the operation modifies if the query selects multiple documents.
  * @param {number} [options.maxTimeMS] The maximum amount of time to allow the query to run.
+ * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
+ * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
  * @return {Promise<Collection~findAndModifyWriteOpResultObject>} returns Promise if no callback passed
@@ -1609,11 +1681,16 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
  * @param {object} filter The Filter used to select the document to replace
  * @param {object} replacement The Document that replaces the matching document
  * @param {object} [options] Optional settings.
+ * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
+ * @param {number} [options.maxTimeMS] The maximum amount of time to allow the query to run.
  * @param {object} [options.projection] Limits the fields to return for all matching documents.
  * @param {object} [options.sort] Determines which document the operation modifies if the query selects multiple documents.
- * @param {number} [options.maxTimeMS] The maximum amount of time to allow the query to run.
  * @param {boolean} [options.upsert=false] Upsert the document if it does not exist.
  * @param {boolean} [options.returnOriginal=true] When false, returns the updated document rather than the original. The default is true.
+ * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
+ * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
  * @return {Promise<Collection~findAndModifyWriteOpResultObject>} returns Promise if no callback passed
@@ -1652,13 +1729,18 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
  * @param {object} filter The Filter used to select the document to update
  * @param {object} update Update operations to be performed on the document
  * @param {object} [options] Optional settings.
+ * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
+ * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+ * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
+ * @param {number} [options.maxTimeMS] The maximum amount of time to allow the query to run.
  * @param {object} [options.projection] Limits the fields to return for all matching documents.
  * @param {object} [options.sort] Determines which document the operation modifies if the query selects multiple documents.
- * @param {number} [options.maxTimeMS] The maximum amount of time to allow the query to run.
  * @param {boolean} [options.upsert=false] Upsert the document if it does not exist.
  * @param {boolean} [options.returnOriginal=true] When false, returns the updated document rather than the original. The default is true.
+ * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
+ * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
+ * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
- * @param {Array} [options.arrayFilters] optional list of array filters referenced in filtered positional operators
  * @param {Collection~findAndModifyCallback} [callback] The collection result callback
  * @return {Promise<Collection~findAndModifyWriteOpResultObject>} returns Promise if no callback passed
  */
@@ -1770,11 +1852,13 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
  * @param {object} [pipeline=[]] Array containing all the aggregation framework commands for the execution.
  * @param {object} [options] Optional settings.
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
+ * @param {number} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {object} [options.cursor] Return the query as cursor, on 2.6 > it returns as a real cursor on pre 2.6 it returns as an emulated cursor.
- * @param {number} [options.cursor.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
+ * @param {number} [options.cursor.batchSize=1000] Deprecated. Use `options.batchSize`
  * @param {boolean} [options.explain=false] Explain returns the aggregation execution plan (requires mongodb 2.6 >).
  * @param {boolean} [options.allowDiskUse=false] allowDiskUse lets the server know if it can use disk to store temporary results for the aggregation (requires mongodb 2.6 >).
  * @param {number} [options.maxTimeMS] maxTimeMS specifies a cumulative time limit in milliseconds for processing operations on the cursor. MongoDB interrupts the operation at the earliest following interrupt point.
+ * @param {number} [options.maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {boolean} [options.raw=false] Return document results as raw BSON buffers.
  * @param {boolean} [options.promoteLongs=true] Promotes Long values to number if they fit inside the 53 bits resolution.

--- a/lib/core/connection/logger.js
+++ b/lib/core/connection/logger.js
@@ -13,13 +13,18 @@ var pid = process.pid;
 var currentLogger = null;
 
 /**
+ * @callback Logger~loggerCallback
+ * @param {string} msg message being logged
+ * @param {object} state an object containing more metadata about the logging message
+ */
+
+/**
  * Creates a new Logger instance
  * @class
  * @param {string} className The Class name associated with the logging instance
  * @param {object} [options=null] Optional settings.
- * @param {Function} [options.logger=null] Custom logger function;
+ * @param {Logger~loggerCallback} [options.logger=null] Custom logger function;
  * @param {string} [options.loggerLevel=error] Override default global log level.
- * @return {Logger} a Logger instance.
  */
 var Logger = function(className, options) {
   if (!(this instanceof Logger)) return new Logger(className, options);
@@ -195,7 +200,7 @@ Logger.reset = function() {
 /**
  * Get the current logger function
  * @method
- * @return {function}
+ * @return {Logger~loggerCallback}
  */
 Logger.currentLogger = function() {
   return currentLogger;
@@ -204,7 +209,7 @@ Logger.currentLogger = function() {
 /**
  * Set the current logger function
  * @method
- * @param {function} logger Logger function.
+ * @param {Logger~loggerCallback} logger Logger function.
  * @return {null}
  */
 Logger.setCurrentLogger = function(logger) {

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -44,17 +44,24 @@ class MongoError extends Error {
     return new MongoError(options);
   }
 
+  /**
+   * Checks the error to see if it has an error label
+   * @param {string} label The error label to check for
+   * @returns {boolean} returns true if the error has the provided error label
+   */
   hasErrorLabel(label) {
     return this.errorLabels && this.errorLabels.indexOf(label) !== -1;
   }
 }
 
 /**
- * Creates a new MongoNetworkError
+ * An error indicating an issue with the network, including TCP
+ * errors and timeouts.
  *
  * @param {Error|string|object} message The error message
  * @property {string} message The error message
  * @property {string} stack The error call stack
+ * @extends MongoError
  */
 class MongoNetworkError extends MongoError {
   constructor(message) {
@@ -68,6 +75,7 @@ class MongoNetworkError extends MongoError {
  *
  * @param {Error|string|object} message The error message
  * @property {string} message The error message
+ * @extends MongoError
  */
 class MongoParseError extends MongoError {
   constructor(message) {
@@ -77,12 +85,13 @@ class MongoParseError extends MongoError {
 }
 
 /**
- * An error signifying a timeout event
+ * An error signifying a client-side timeout event
  *
  * @param {Error|string|object} message The error message
  * @param {string|object} [reason] The reason the timeout occured
  * @property {string} message The error message
  * @property {string} [reason] An optional reason context for the timeout, generally an error saved during flow of monitoring and selecting servers
+ * @extends MongoError
  */
 class MongoTimeoutError extends MongoError {
   constructor(message, reason) {
@@ -114,6 +123,7 @@ function makeWriteConcernResultObject(input) {
  * @param {object} result The result document (provided if ok: 1)
  * @property {string} message The error message
  * @property {object} [result] The result document (provided if ok: 1)
+ * @extends MongoError
  */
 class MongoWriteConcernError extends MongoError {
   constructor(message, result) {
@@ -144,6 +154,7 @@ const RETRYABLE_ERROR_CODES = new Set([
 /**
  * Determines whether an error is something the driver should attempt to retry
  *
+ * @ignore
  * @param {MongoError|Error} error
  */
 function isRetryableError(error) {
@@ -202,6 +213,7 @@ function isNodeShuttingDownError(err) {
  * then the pool will be cleared, and server state will completely reset
  * locally.
  *
+ * @ignore
  * @see https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#not-master-and-node-is-recovering
  * @param {MongoError|Error} error
  * @param {Server} server

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -674,6 +674,7 @@ function commandSupportsReadConcern(command, options) {
 /**
  * Optionally decorate a command with sessions specific keys
  *
+ * @ignore
  * @param {ClientSession} session the session tracking transaction state
  * @param {Object} command the command to decorate
  * @param {Object} topology the topology for tracking the cluster time

--- a/lib/db.js
+++ b/lib/db.js
@@ -301,11 +301,13 @@ Db.prototype.command = function(command, options, callback) {
  * @param {object} [pipeline=[]] Array containing all the aggregation framework commands for the execution.
  * @param {object} [options] Optional settings.
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
+ * @param {number} [options.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {object} [options.cursor] Return the query as cursor, on 2.6 > it returns as a real cursor on pre 2.6 it returns as an emulated cursor.
- * @param {number} [options.cursor.batchSize=1000] The number of documents to return per batch. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
+ * @param {number} [options.cursor.batchSize=1000] Deprecated. Use `options.batchSize`
  * @param {boolean} [options.explain=false] Explain returns the aggregation execution plan (requires mongodb 2.6 >).
  * @param {boolean} [options.allowDiskUse=false] allowDiskUse lets the server know if it can use disk to store temporary results for the aggregation (requires mongodb 2.6 >).
  * @param {number} [options.maxTimeMS] maxTimeMS specifies a cumulative time limit in milliseconds for processing operations on the cursor. MongoDB interrupts the operation at the earliest following interrupt point.
+ * @param {number} [options.maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {boolean} [options.raw=false] Return document results as raw BSON buffers.
  * @param {boolean} [options.promoteLongs=true] Promotes Long values to number if they fit inside the 53 bits resolution.

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -11,6 +11,7 @@ module.exports = GridFSBucketReadStream;
  * Do not instantiate this class directly. Use `openDownloadStream()` instead.
  *
  * @class
+ * @extends external:Readable
  * @param {Collection} chunks Handle for chunks collection
  * @param {Collection} files Handle for files collection
  * @param {Object} readPreference The read preference to use
@@ -22,9 +23,7 @@ module.exports = GridFSBucketReadStream;
  * @param {Number} [options.end] Optional 0-based offset in bytes to stop streaming before
  * @fires GridFSBucketReadStream#error
  * @fires GridFSBucketReadStream#file
- * @return {GridFSBucketReadStream} a GridFSBucketReadStream instance.
  */
-
 function GridFSBucketReadStream(chunks, files, readPreference, filter, options) {
   this.s = {
     bytesRead: 0,
@@ -83,6 +82,8 @@ util.inherits(GridFSBucketReadStream, stream.Readable);
 
 /**
  * Reads from the cursor and pushes to the stream.
+ * Private Impl, do not call directly
+ * @ignore
  * @method
  */
 
@@ -103,7 +104,7 @@ GridFSBucketReadStream.prototype._read = function() {
  * (e.g. if you've already called `on('data')`)
  * @method
  * @param {Number} start Offset in bytes to start reading at
- * @return {GridFSBucketReadStream}
+ * @return {GridFSBucketReadStream} Reference to Self
  */
 
 GridFSBucketReadStream.prototype.start = function(start) {
@@ -118,7 +119,7 @@ GridFSBucketReadStream.prototype.start = function(start) {
  * (e.g. if you've already called `on('data')`)
  * @method
  * @param {Number} end Offset in bytes to stop reading at
- * @return {GridFSBucketReadStream}
+ * @return {GridFSBucketReadStream} Reference to self
  */
 
 GridFSBucketReadStream.prototype.end = function(end) {

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -18,6 +18,7 @@ module.exports = GridFSBucket;
 /**
  * Constructor for a streaming GridFS interface
  * @class
+ * @extends external:EventEmitter
  * @param {Db} db A db handle
  * @param {object} [options] Optional settings.
  * @param {string} [options.bucketName="fs"] The 'files' and 'chunks' collections will be prefixed with the bucket name followed by a dot.
@@ -25,7 +26,6 @@ module.exports = GridFSBucket;
  * @param {object} [options.writeConcern] Optional write concern to be passed to write operations, for instance `{ w: 1 }`
  * @param {object} [options.readPreference] Optional read preference to be passed to read operations
  * @fires GridFSBucketWriteStream#index
- * @return {GridFSBucket}
  */
 
 function GridFSBucket(db, options) {
@@ -354,5 +354,6 @@ function _drop(_this, callback) {
 /**
  * Callback format for all GridFSBucket methods that can accept a callback.
  * @callback GridFSBucket~errorCallback
- * @param {MongoError} error An error instance representing any errors that occurred
+ * @param {MongoError|undefined} error If present, an error instance representing any errors that occurred
+ * @param {*} result If present, a returned result for the method
  */

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -16,6 +16,7 @@ module.exports = GridFSBucketWriteStream;
  * Do not instantiate this class directly. Use `openUploadStream()` instead.
  *
  * @class
+ * @extends external:Writable
  * @param {GridFSBucket} bucket Handle for this stream's corresponding bucket
  * @param {string} filename The value of the 'filename' key in the files doc
  * @param {object} [options] Optional settings.
@@ -27,7 +28,6 @@ module.exports = GridFSBucketWriteStream;
  * @param {boolean} [options.disableMD5=false] If true, disables adding an md5 field to file data
  * @fires GridFSBucketWriteStream#error
  * @fires GridFSBucketWriteStream#finish
- * @return {GridFSBucketWriteStream} a GridFSBucketWriteStream instance.
  */
 
 function GridFSBucketWriteStream(bucket, filename, options) {
@@ -89,7 +89,7 @@ util.inherits(GridFSBucketWriteStream, stream.Writable);
  * @method
  * @param {Buffer} chunk Buffer to write
  * @param {String} encoding Optional encoding for the buffer
- * @param {Function} callback Function to call when the chunk was added to the buffer, or if the entire chunk was persisted to MongoDB if this chunk caused a flush.
+ * @param {GridFSBucket~errorCallback} callback Function to call when the chunk was added to the buffer, or if the entire chunk was persisted to MongoDB if this chunk caused a flush.
  * @return {Boolean} False if this write required flushing a chunk to MongoDB. True otherwise.
  */
 
@@ -138,7 +138,7 @@ GridFSBucketWriteStream.prototype.abort = function(callback) {
  * @method
  * @param {Buffer} chunk Buffer to write
  * @param {String} encoding Optional encoding for the buffer
- * @param {Function} callback Function to call when all files and chunks have been persisted to MongoDB
+ * @param {GridFSBucket~errorCallback} callback Function to call when all files and chunks have been persisted to MongoDB
  */
 
 GridFSBucketWriteStream.prototype.end = function(chunk, encoding, callback) {


### PR DESCRIPTION
## Description

Does a couple of things:

1. Changes the names of `@merge-props` and `@merge-params` to `@mergeProps` and `@mergeParams` respectively. This is mostly to help with syntax highlighting
2. Does a little bit of cleanup on the jsdoc in `Logger`, `Session`, `Error`, `GridFS`, and `Collection`
3. Does a more in-depth dive into `Collection` to try to properly align with CRUD spec. In general, this resulted in:
    - Verifying that parameters defined in crud spec were properly documented in `Collection`
    - Adding as many known BSON options as possible to write operations (helps with NODE-1652)
    - Rearranging some options so that cross-cutting fields (`session`, `WriteConcern`, bson options, etc) were at the bottom, and spec defined fields were at the top.

The following fields were not added for a variety of reasons:
- `Collection.prototype.find`:
    - `allowPartialResults` - no record of this in codebase
    - `cursorType` - we use `tailable` and `awaitData` instead
    -` showRecordId` - we use `showDiscLoc` instead
- WriteResults:
    - `acknowledged`: we do not appear to support this anywhere
- `Collection.prototype.findOneAndReplace`:
    - `returnDocument`: we already know about this, we use 
- `Collection.prototype.findOneAndfindOneAnd*`:
    - Was not sure if these fields supported writeConcern options


Future work:

- Synchronize the `find` and `findOne` documentation.
- Leverage `@mergeParams` to break out all options objects into their own `@typedef`s, and then use `@mergeProps` to compose common fields
    ```js
    /**
     * @typedef {object} propSession
     * @ignore
     * @prop {ClientSession} [session] optional session to use for this operation
     */
    
    /**
     * @typedef {object} propWriteConcern
     * @ignore
     * @prop {(number|string)} [w] The write concern.
     * @prop {number} [wtimeout] The write concern timeout.
     * @prop {boolean} [j=false] Specify a journal write concern.
     */
    
    /** 
     * @typedef {object} propBSONWrite
     * @ignore
     * @prop {boolean} [checkKeys=true] If true, will throw if bson documents start with `$` or include a `.` in any key value
     * @prop {boolean} [serializeFunctions=false] Serialize functions on any object.
     * @prop {boolean} [ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
     */
    
    /**
     * @typedef {object} Collection~insertOneOptions
     * @prop {boolean} [bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
     * @prop {boolean} [forceServerObjectId=false] Force server to assign _id values instead of driver.
     * @mergeProps propWriteConcern
     * @mergeProps propBSONWrite
     * @mergeProps propSession
     */
    
    /**
     * Inserts a single document into MongoDB. If documents passed in do not contain the **_id** field,
     * one will be added to each of the documents missing it by the driver, mutating the document. This behavior
     * can be overridden by setting the **forceServerObjectId** flag.
     *
     * @method
     * @param {object} doc Document to insert.
     * @mergeParams {Collection~insertOneOptions} [options] Optional settings.
     * @param {Collection~insertOneWriteOpCallback} [callback] The command result callback
     * @return {Promise} returns Promise if no callback passed
     */
    ```
- Document BSON read options in read methods (ex: `promoteLongs`)
- Apply this review to any methods not defined in the CRUD spec
- Do this review for all other publicly exposed APIs