### PR TITLE
Perf: Fix undefined intervalMS in srv_polling.js

### DIFF
--- a/lib/core/sdam/srv_polling.js
+++ b/lib/core/sdam/srv_polling.js
@@ -59,7 +59,7 @@ class SrvPoller extends EventEmitter {
   }
 
   get intervalMS() {
-    return this.haMode ? this.heartbeatFrequencyMS : this.rescanSrvIntervalMs;
+    return this.haMode ? this.heartbeatFrequencyMS : this.rescanSrvIntervalMS;
   }
 
   start() {


### PR DESCRIPTION
## Description

We started seeing a sudden spike in CPU usage once we switched to a certain `mongodb+srv` / sharding combination.

It turns out there is a bug in `srv_polling.js` that tries to access the wrong variable name (due to a capitalization error), which meant the rescan interval was `undefined` i.e. `0`.

In our production system, this means our server performs millions of DNS requests per hour to our mongodb srv records (many thousand per second), which is costly and breaks server monitoring in various ways.

**What changed?**

The current commit fixes that issue by correcting the capitalization of the variable name.

**Are there any files to ignore?**

No