### PR TITLE
NODE-2363: allow connect cancellation

### DIFF
--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -14,14 +14,19 @@ const MIN_SUPPORTED_WIRE_VERSION = WIRE_CONSTANTS.MIN_SUPPORTED_WIRE_VERSION;
 const MIN_SUPPORTED_SERVER_VERSION = WIRE_CONSTANTS.MIN_SUPPORTED_SERVER_VERSION;
 let AUTH_PROVIDERS;
 
-function connect(options, callback) {
+function connect(options, cancellationToken, callback) {
+  if (typeof cancellationToken === 'function') {
+    callback = cancellationToken;
+    cancellationToken = undefined;
+  }
+
   const ConnectionType = options && options.connectionType ? options.connectionType : Connection;
   if (AUTH_PROVIDERS == null) {
     AUTH_PROVIDERS = defaultAuthProviders(options.bson);
   }
 
   const family = options.family !== void 0 ? options.family : 0;
-  makeConnection(family, options, (err, socket) => {
+  makeConnection(family, options, cancellationToken, (err, socket) => {
     if (err) {
       callback(err, socket); // in the error case, `socket` is the originating error event name
       return;
@@ -219,7 +224,7 @@ function parseSslOptions(family, options) {
 }
 
 const SOCKET_ERROR_EVENTS = new Set(['error', 'close', 'timeout', 'parseError']);
-function makeConnection(family, options, _callback) {
+function makeConnection(family, options, cancellationToken, _callback) {
   const useSsl = typeof options.ssl === 'boolean' ? options.ssl : false;
   const keepAlive = typeof options.keepAlive === 'boolean' ? options.keepAlive : true;
   let keepAliveInitialDelay =
@@ -240,6 +245,7 @@ function makeConnection(family, options, _callback) {
     if (err && socket) {
       socket.destroy();
     }
+
     _callback(err, ret);
   };
 
@@ -264,7 +270,7 @@ function makeConnection(family, options, _callback) {
     return err => {
       SOCKET_ERROR_EVENTS.forEach(event => socket.removeAllListeners(event));
       socket.removeListener('connect', connectHandler);
-      callback(connectionFailureError(eventName, err), eventName);
+      callback(connectionFailureError(eventName, err));
     };
   }
 
@@ -279,6 +285,10 @@ function makeConnection(family, options, _callback) {
   }
 
   SOCKET_ERROR_EVENTS.forEach(event => socket.once(event, errorHandler(event)));
+  if (cancellationToken) {
+    cancellationToken.once('cancel', errorHandler('cancel'));
+  }
+
   socket.once('connect', connectHandler);
 }
 
@@ -359,6 +369,8 @@ function connectionFailureError(type, err) {
       return new MongoNetworkError(`connection timed out`);
     case 'close':
       return new MongoNetworkError(`connection closed`);
+    case 'cancel':
+      return new MongoNetworkError(`connection establishment was cancelled`);
     default:
       return new MongoNetworkError(`unknown network error`);
   }

--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -266,9 +266,14 @@ function makeConnection(family, options, cancellationToken, _callback) {
   socket.setTimeout(connectionTimeout);
   socket.setNoDelay(noDelay);
 
+  let cancellationHandler;
   function errorHandler(eventName) {
     return err => {
       SOCKET_ERROR_EVENTS.forEach(event => socket.removeAllListeners(event));
+      if (cancellationHandler) {
+        cancellationToken.removeListener('cancel', cancellationHandler);
+      }
+
       socket.removeListener('connect', connectHandler);
       callback(connectionFailureError(eventName, err));
     };
@@ -276,6 +281,10 @@ function makeConnection(family, options, cancellationToken, _callback) {
 
   function connectHandler() {
     SOCKET_ERROR_EVENTS.forEach(event => socket.removeAllListeners(event));
+    if (cancellationHandler) {
+      cancellationToken.removeListener('cancel', cancellationHandler);
+    }
+
     if (socket.authorizationError && rejectUnauthorized) {
       return callback(socket.authorizationError);
     }
@@ -286,7 +295,8 @@ function makeConnection(family, options, cancellationToken, _callback) {
 
   SOCKET_ERROR_EVENTS.forEach(event => socket.once(event, errorHandler(event)));
   if (cancellationToken) {
-    cancellationToken.once('cancel', errorHandler('cancel'));
+    cancellationHandler = errorHandler('cancel');
+    cancellationToken.once('cancel', cancellationHandler);
   }
 
   socket.once('connect', connectHandler);

--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -20,34 +20,14 @@ function connect(options, callback) {
     AUTH_PROVIDERS = defaultAuthProviders(options.bson);
   }
 
-  if (options.family !== void 0) {
-    makeConnection(options.family, options, (err, socket) => {
-      if (err) {
-        callback(err, socket); // in the error case, `socket` is the originating error event name
-        return;
-      }
-
-      performInitialHandshake(new ConnectionType(socket, options), options, callback);
-    });
-
-    return;
-  }
-
-  return makeConnection(6, options, (err, ipv6Socket) => {
+  const family = options.family !== void 0 ? options.family : 0;
+  makeConnection(family, options, (err, socket) => {
     if (err) {
-      makeConnection(0, options, (err, ipv4Socket) => {
-        if (err) {
-          callback(err, ipv4Socket); // in the error case, `ipv4Socket` is the originating error event name
-          return;
-        }
-
-        performInitialHandshake(new ConnectionType(ipv4Socket, options), options, callback);
-      });
-
+      callback(err, socket); // in the error case, `socket` is the originating error event name
       return;
     }
 
-    performInitialHandshake(new ConnectionType(ipv6Socket, options), options, callback);
+    performInitialHandshake(new ConnectionType(socket, options), options, callback);
   });
 }
 
@@ -238,6 +218,7 @@ function parseSslOptions(family, options) {
   return result;
 }
 
+const SOCKET_ERROR_EVENTS = new Set(['error', 'close', 'timeout', 'parseError']);
 function makeConnection(family, options, _callback) {
   const useSsl = typeof options.ssl === 'boolean' ? options.ssl : false;
   const keepAlive = typeof options.keepAlive === 'boolean' ? options.keepAlive : true;
@@ -279,17 +260,16 @@ function makeConnection(family, options, _callback) {
   socket.setTimeout(connectionTimeout);
   socket.setNoDelay(noDelay);
 
-  const errorEvents = ['error', 'close', 'timeout', 'parseError'];
   function errorHandler(eventName) {
     return err => {
-      errorEvents.forEach(event => socket.removeAllListeners(event));
+      SOCKET_ERROR_EVENTS.forEach(event => socket.removeAllListeners(event));
       socket.removeListener('connect', connectHandler);
       callback(connectionFailureError(eventName, err), eventName);
     };
   }
 
   function connectHandler() {
-    errorEvents.forEach(event => socket.removeAllListeners(event));
+    SOCKET_ERROR_EVENTS.forEach(event => socket.removeAllListeners(event));
     if (socket.authorizationError && rejectUnauthorized) {
       return callback(socket.authorizationError);
     }
@@ -298,10 +278,7 @@ function makeConnection(family, options, _callback) {
     callback(null, socket);
   }
 
-  socket.once('error', errorHandler('error'));
-  socket.once('close', errorHandler('close'));
-  socket.once('timeout', errorHandler('timeout'));
-  socket.once('parseError', errorHandler('parseError'));
+  SOCKET_ERROR_EVENTS.forEach(event => socket.once(event, errorHandler(event)));
   socket.once('connect', connectHandler);
 }
 

--- a/lib/core/connection/pool.js
+++ b/lib/core/connection/pool.js
@@ -91,8 +91,12 @@ var Pool = function(topology, options) {
   this.topology = topology;
 
   this.s = {
-    state: DISCONNECTED
+    state: DISCONNECTED,
+    cancellationToken: new EventEmitter()
   };
+
+  // we don't care how many connections are listening for cancellation
+  this.s.cancellationToken.setMaxListeners(Infinity);
 
   // Add the options
   this.options = Object.assign(
@@ -629,6 +633,9 @@ Pool.prototype.unref = function() {
 function destroy(self, connections, options, callback) {
   stateTransition(self, DESTROYING);
 
+  // indicate that in-flight connections should cancel
+  self.s.cancellationToken.emit('cancel');
+
   eachAsync(
     connections,
     (conn, cb) => {
@@ -748,6 +755,10 @@ Pool.prototype.reset = function(callback) {
     return;
   }
 
+  // signal in-flight connections should be cancelled
+  this.s.cancellationToken.emit('cancel');
+
+  // destroy existing connections
   const connections = this.availableConnections.concat(this.inUseConnections);
   eachAsync(
     connections,
@@ -984,7 +995,7 @@ function createConnection(pool, callback) {
   }
 
   pool.connectingConnections++;
-  connect(pool.options, (err, connection) => {
+  connect(pool.options, pool.s.cancellationToken, (err, connection) => {
     pool.connectingConnections--;
 
     if (err) {

--- a/test/unit/core/connect.test.js
+++ b/test/unit/core/connect.test.js
@@ -129,6 +129,19 @@ describe('Connect Tests', function() {
     }
   );
 
+  it('should allow a cancellaton token', function(done) {
+    const cancellationToken = new EventEmitter();
+    setTimeout(() => cancellationToken.emit('cancel'), 100);
+    // set no response handler for mock server, effecively blackhole requests
+
+    connect(test.connectOptions, cancellationToken, (err, conn) => {
+      expect(err).to.exist;
+      expect(err).to.match(/connection establishment was cancelled/);
+      expect(conn).to.not.exist;
+      done();
+    });
+  });
+
   describe('runCommand', function() {
     const metadata = { requires: { topology: 'single' } };
     class MockConnection extends EventEmitter {

--- a/test/unit/core/connect.test.js
+++ b/test/unit/core/connect.test.js
@@ -131,10 +131,10 @@ describe('Connect Tests', function() {
 
   it('should allow a cancellaton token', function(done) {
     const cancellationToken = new EventEmitter();
-    setTimeout(() => cancellationToken.emit('cancel'), 100);
+    setTimeout(() => cancellationToken.emit('cancel'), 500);
     // set no response handler for mock server, effecively blackhole requests
 
-    connect(test.connectOptions, cancellationToken, (err, conn) => {
+    connect({ host: '240.0.0.1' }, cancellationToken, (err, conn) => {
       expect(err).to.exist;
       expect(err).to.match(/connection establishment was cancelled/);
       expect(conn).to.not.exist;


### PR DESCRIPTION
## Description
Sometimes connections are inflight during pool destruction. Introducing a cancellation token to the `connect` method allows us to proactive terminate connections which are being established during these destroy events