### PR TITLE
fix(bulk): use original indexes as map for current op index

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -475,7 +475,7 @@ function mergeBatchResults(batch, bulkResult, err, result) {
   if (Array.isArray(result.writeErrors)) {
     for (let i = 0; i < result.writeErrors.length; i++) {
       const writeError = {
-        index: batch.originalIndexes[i],
+        index: batch.originalIndexes[result.writeErrors[i].index],
         code: result.writeErrors[i].code,
         errmsg: result.writeErrors[i].errmsg,
         op: batch.operations[result.writeErrors[i].index]


### PR DESCRIPTION
The fix for bulk introduced in v3.4.0 did not take into account
the index of the operation result when referring to the original
stored index map.

NODE-2383
