### PR TITLE
NODE-2397: improve selection timeout errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const connect = require('./lib/mongo_client').connect;
 connect.MongoError = core.MongoError;
 connect.MongoNetworkError = core.MongoNetworkError;
 connect.MongoTimeoutError = core.MongoTimeoutError;
+connect.MongoServerSelectionError = core.MongoServerSelectionError;
 connect.MongoParseError = core.MongoParseError;
 connect.MongoWriteConcernError = core.MongoWriteConcernError;
 connect.MongoBulkWriteError = require('./lib/bulk/common').BulkWriteError;

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -96,7 +96,7 @@ class MongoParseError extends MongoError {
 class MongoTimeoutError extends MongoError {
   constructor(message, reason) {
     if (reason && reason.error) {
-      super(reason.error);
+      super(reason.error.message || reason.error);
     } else {
       super(message);
     }
@@ -105,6 +105,22 @@ class MongoTimeoutError extends MongoError {
     if (reason) {
       this.reason = reason;
     }
+  }
+}
+
+/**
+ * An error signifying a client-side server selection error
+ *
+ * @param {Error|string|object} message The error message
+ * @param {string|object} [reason] The reason the timeout occured
+ * @property {string} message The error message
+ * @property {string} [reason] An optional reason context for the timeout, generally an error saved during flow of monitoring and selecting servers
+ * @extends MongoError
+ */
+class MongoServerSelectionError extends MongoTimeoutError {
+  constructor(message, reason) {
+    super(message, reason);
+    this.name = 'MongoServerSelectionError';
   }
 }
 
@@ -246,6 +262,7 @@ module.exports = {
   MongoNetworkError,
   MongoParseError,
   MongoTimeoutError,
+  MongoServerSelectionError,
   MongoWriteConcernError,
   mongoErrorContextSymbol,
   isRetryableError,

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -95,9 +95,14 @@ class MongoParseError extends MongoError {
  */
 class MongoTimeoutError extends MongoError {
   constructor(message, reason) {
-    super(message);
+    if (reason && reason.error) {
+      super(reason.error);
+    } else {
+      super(message);
+    }
+
     this.name = 'MongoTimeoutError';
-    if (reason != null) {
+    if (reason) {
       this.reason = reason;
     }
   }

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -20,6 +20,7 @@ module.exports = {
   MongoNetworkError: require('./error').MongoNetworkError,
   MongoParseError: require('./error').MongoParseError,
   MongoTimeoutError: require('./error').MongoTimeoutError,
+  MongoServerSelectionError: require('./error').MongoServerSelectionError,
   MongoWriteConcernError: require('./error').MongoWriteConcernError,
   mongoErrorContextSymbol: require('./error').mongoErrorContextSymbol,
   // Core

--- a/lib/core/sdam/server_description.js
+++ b/lib/core/sdam/server_description.js
@@ -2,6 +2,7 @@
 
 const arrayStrictEqual = require('../utils').arrayStrictEqual;
 const tagsStrictEqual = require('../utils').tagsStrictEqual;
+const errorStrictEqual = require('../utils').errorStrictEqual;
 const ServerType = require('./common').ServerType;
 
 const WRITABLE_SERVER_TYPES = new Set([
@@ -121,7 +122,7 @@ class ServerDescription {
   equals(other) {
     return (
       other != null &&
-      this.error === other.error &&
+      errorStrictEqual(this.error, other.error) &&
       this.type === other.type &&
       this.minWireVersion === other.minWireVersion &&
       this.me === other.me &&

--- a/lib/core/sdam/server_selection.js
+++ b/lib/core/sdam/server_selection.js
@@ -4,7 +4,7 @@ const TopologyType = require('./common').TopologyType;
 const ReadPreference = require('../topologies/read_preference');
 const MongoError = require('../error').MongoError;
 const calculateDurationInMs = require('../utils').calculateDurationInMs;
-const MongoTimeoutError = require('../error').MongoTimeoutError;
+const MongoServerSelectionError = require('../error').MongoServerSelectionError;
 
 const common = require('./common');
 const STATE_CLOSED = common.STATE_CLOSED;
@@ -260,7 +260,7 @@ function selectServers(topology, selector, timeout, start, callback) {
   const duration = calculateDurationInMs(start);
   if (duration >= timeout) {
     return callback(
-      new MongoTimeoutError(`Server selection timed out after ${timeout} ms`),
+      new MongoServerSelectionError(`Server selection timed out after ${timeout} ms`),
       topology.description
     );
   }
@@ -306,7 +306,7 @@ function selectServers(topology, selector, timeout, start, callback) {
     const iterationTimer = setTimeout(() => {
       topology.removeListener('topologyDescriptionChanged', descriptionChangedHandler);
       callback(
-        new MongoTimeoutError(
+        new MongoServerSelectionError(
           `Server selection timed out after ${timeout} ms`,
           topology.description
         )

--- a/lib/core/sdam/server_selection.js
+++ b/lib/core/sdam/server_selection.js
@@ -261,7 +261,7 @@ function selectServers(topology, selector, timeout, start, callback) {
   if (duration >= timeout) {
     return callback(
       new MongoTimeoutError(`Server selection timed out after ${timeout} ms`),
-      topology.description.error
+      topology.description
     );
   }
 
@@ -308,7 +308,7 @@ function selectServers(topology, selector, timeout, start, callback) {
       callback(
         new MongoTimeoutError(
           `Server selection timed out after ${timeout} ms`,
-          topology.description.error
+          topology.description
         )
       );
     }, timeout - duration);

--- a/lib/core/sdam/topology_description.js
+++ b/lib/core/sdam/topology_description.js
@@ -28,8 +28,7 @@ class TopologyDescription {
     maxSetVersion,
     maxElectionId,
     commonWireVersion,
-    options,
-    error
+    options
   ) {
     options = options || {};
 
@@ -47,7 +46,6 @@ class TopologyDescription {
     this.logicalSessionTimeoutMinutes = null;
     this.heartbeatFrequencyMS = options.heartbeatFrequencyMS || 0;
     this.localThresholdMS = options.localThresholdMS || 0;
-    this.error = error;
     this.commonWireVersion = commonWireVersion || null;
 
     // save this locally, but don't display when printing the instance out
@@ -133,7 +131,6 @@ class TopologyDescription {
     let maxSetVersion = this.maxSetVersion;
     let maxElectionId = this.maxElectionId;
     let commonWireVersion = this.commonWireVersion;
-    let error = serverDescription.error || this.error;
 
     const serverType = serverDescription.type;
     let serverDescriptions = new Map(this.servers);
@@ -159,8 +156,7 @@ class TopologyDescription {
         maxSetVersion,
         maxElectionId,
         commonWireVersion,
-        this.options,
-        error
+        this.options
       );
     }
 
@@ -241,9 +237,15 @@ class TopologyDescription {
       maxSetVersion,
       maxElectionId,
       commonWireVersion,
-      this.options,
-      error
+      this.options
     );
+  }
+
+  get error() {
+    const descriptionsWithError = Array.from(this.servers.values()).filter(sd => sd.error);
+    if (descriptionsWithError.length > 0) {
+      return descriptionsWithError[0].error;
+    }
   }
 
   /**

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -176,6 +176,26 @@ function tagsStrictEqual(tags, tags2) {
   return tagsKeys.length === tags2Keys.length && tagsKeys.every(key => tags2[key] === tags[key]);
 }
 
+function errorStrictEqual(lhs, rhs) {
+  if (lhs === rhs) {
+    return true;
+  }
+
+  if ((lhs == null && rhs != null) || (lhs != null && rhs == null)) {
+    return false;
+  }
+
+  if (lhs.constructor.name !== rhs.constructor.name) {
+    return false;
+  }
+
+  if (lhs.message !== rhs.message) {
+    return false;
+  }
+
+  return true;
+}
+
 function makeStateMachine(stateTable) {
   return function stateTransition(target, newState) {
     const legalStates = stateTable[target.s.state];
@@ -203,5 +223,6 @@ module.exports = {
   isUnifiedTopology,
   arrayStrictEqual,
   tagsStrictEqual,
+  errorStrictEqual,
   makeStateMachine
 };

--- a/test/functional/core/server.test.js
+++ b/test/functional/core/server.test.js
@@ -1002,8 +1002,7 @@ describe('Server tests', function() {
           let err;
           try {
             expect(error).to.be.an.instanceOf(Error);
-            const errorMessage = error.reason ? error.reason.message : error.message;
-            expect(errorMessage).to.match(/but this version of the Node.js Driver requires/);
+            expect(error).to.match(/but this version of the Node.js Driver requires/);
           } catch (e) {
             err = e;
           }

--- a/test/functional/scram_sha_256.test.js
+++ b/test/functional/scram_sha_256.test.js
@@ -186,10 +186,7 @@ describe('SCRAM-SHA-256 auth', function() {
       return withClient(
         this.configuration.newClient({}, options),
         () => Promise.reject(new Error('This request should have failed to authenticate')),
-        err => {
-          const errMessage = err.reason ? err.reason.message : err;
-          expect(errMessage).to.match(/Authentication failed/);
-        }
+        err => expect(err).to.match(/Authentication failed/)
       );
     }
   });
@@ -223,10 +220,7 @@ describe('SCRAM-SHA-256 auth', function() {
         withClient(
           this.configuration.newClient({}, options),
           () => Promise.reject(new Error('This request should have failed to authenticate')),
-          err => {
-            const errMessage = err.reason ? err.reason.message : err;
-            expect(errMessage).to.match(/Authentication failed/);
-          }
+          err => expect(err).to.match(/Authentication failed/)
         );
 
       return Promise.all([getErrorMsg(noUsernameOptions), getErrorMsg(badPasswordOptions)]);

--- a/test/unit/sdam/server_description.test.js
+++ b/test/unit/sdam/server_description.test.js
@@ -1,0 +1,44 @@
+'use strict';
+const ServerDescription = require('../../../lib/core/sdam/server_description').ServerDescription;
+const expect = require('chai').expect;
+
+describe('ServerDescription', function() {
+  describe('error equality', function() {
+    [
+      {
+        description: 'equal error types and messages',
+        lhs: new ServerDescription('127.0.0.1:27017', null, { error: new Error('test') }),
+        rhs: new ServerDescription('127.0.0.1:27017', null, { error: new Error('test') }),
+        equal: true
+      },
+      {
+        description: 'equal error types and unequal messages',
+        lhs: new ServerDescription('127.0.0.1:27017', null, { error: new Error('test') }),
+        rhs: new ServerDescription('127.0.0.1:27017', null, { error: new Error('blah') }),
+        equal: false
+      },
+      {
+        description: 'unequal error types and equal messages',
+        lhs: new ServerDescription('127.0.0.1:27017', null, { error: new TypeError('test') }),
+        rhs: new ServerDescription('127.0.0.1:27017', null, { error: new Error('test') }),
+        equal: false
+      },
+      {
+        description: 'null lhs',
+        lhs: new ServerDescription('127.0.0.1:27017', null, { error: null }),
+        rhs: new ServerDescription('127.0.0.1:27017', null, { error: new Error('test') }),
+        equal: false
+      },
+      {
+        description: 'null rhs',
+        lhs: new ServerDescription('127.0.0.1:27017', null, { error: new TypeError('test') }),
+        rhs: new ServerDescription('127.0.0.1:27017', null, { error: undefined }),
+        equal: false
+      }
+    ].forEach(test => {
+      it(test.description, function() {
+        expect(test.lhs.equals(test.rhs)).to.equal(test.equal);
+      });
+    });
+  });
+});

--- a/test/unit/sdam/server_selection/select_servers.test.js
+++ b/test/unit/sdam/server_selection/select_servers.test.js
@@ -35,7 +35,7 @@ describe('selectServers', function() {
     selectServers(topology, ReadPreference.primary, 500, process.hrtime(), err => {
       expect(err).to.exist;
       expect(err).to.match(/Server selection timed out/);
-      expect(err).to.not.have.property('reason');
+      expect(err).to.have.property('reason');
 
       done();
     });
@@ -60,7 +60,7 @@ describe('selectServers', function() {
       selectServers(topology, ReadPreference.primary, 1000, process.hrtime(), err => {
         expect(err).to.exist;
         expect(err).to.match(/Server selection timed out/);
-        expect(err).to.not.have.property('reason');
+        expect(err).to.have.property('reason');
 
         // expect a call to monitor for initial server creation, and another for the server selection
         expect(serverMonitor)

--- a/test/unit/sdam/server_selection/spec.test.js
+++ b/test/unit/sdam/server_selection/spec.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const core = require('../../../../lib/core');
 const Topology = core.Topology;
-const MongoTimeoutError = core.MongoTimeoutError;
+const MongoServerSelectionError = core.MongoServerSelectionError;
 const ReadPreference = core.ReadPreference;
 
 // TODO: these should be from `core` when legacy topologies are removed
@@ -275,7 +275,7 @@ function executeServerSelectionTest(testDefinition, options, testDone) {
   }
 
   // default to serverSelectionTimeoutMS of `100` for unit tests
-  topology.selectServer(selector, { serverSelectionTimeoutMS: 100 }, (err, server) => {
+  topology.selectServer(selector, { serverSelectionTimeoutMS: 50 }, (err, server) => {
     // are we expecting an error?
     if (testDefinition.error) {
       if (!err) {
@@ -287,7 +287,7 @@ function executeServerSelectionTest(testDefinition, options, testDone) {
 
     if (err) {
       // this is another expected error case
-      if (expectedServers.length === 0 && err instanceof MongoTimeoutError) return done();
+      if (expectedServers.length === 0 && err instanceof MongoServerSelectionError) return done();
       return done(err);
     }
 


### PR DESCRIPTION
## Description
There are a lot of reasons a server selection timeout error might occur, and even though we include the reason in an attached field, most people only see `Server selection timed out after 30000ms`. We will now surface the first encountered error in the set of known server descriptions as the primary error message for a timeout error. The `reason` field for server selection errors will now include the `TopologyDescription` for better traceability
