### PR TITLE
docs(reference): fix typo in unified-topology

### DIFF
--- a/docs/reference/content/reference/unified-topology/index.md
+++ b/docs/reference/content/reference/unified-topology/index.md
@@ -69,7 +69,7 @@ We think the ambiguity of what it means to be "connected" can lead to far more p
 
 ### Server Selection
 
-The psuedocode for operation execution looks something like this:
+The pseudocode for operation execution looks something like this:
 
 ```js
 function executeOperation(topology, operation, callback) {


### PR DESCRIPTION
Fixes typo in docs: ~psuedocode~ pseudocode