### PR TITLE
Update doc link version

### DIFF
--- a/docs/reference/content/tutorials/crud.md
+++ b/docs/reference/content/tutorials/crud.md
@@ -711,7 +711,7 @@ All options are chainable, so you can combine settings in the following way:
 collection.find({}).maxTimeMS(1000).skip(1).toArray(..)
 ```
 
-More information can be found in the [Cursor API documentation](/node-mongodb-native/2.0/api/Cursor.html).
+More information can be found in the [Cursor API documentation](/node-mongodb-native/3.4/api/Cursor.html).
 
 The following example uses the ``next`` method.
 


### PR DESCRIPTION
Update link about `Cursor API documentation` in
https://github.com/mongodb/node-mongodb-native/edit/master/docs/reference/content/tutorials/crud.md

## Description

**What changed?**

From:
[Cursor API documentation](/node-mongodb-native/2.0/api/Cursor.html)
To:
[Cursor API documentation](/node-mongodb-native/3.4/api/Cursor.html)
In:
https://github.com/mongodb/node-mongodb-native/edit/master/docs/reference/content/tutorials/crud.md

**Are there any files to ignore?**

No
