### PR TITLE
fix(connection): Do not add setTimeouts if minPoolSize is not set

### DIFF
--- a/lib/cmap/connection_pool.js
+++ b/lib/cmap/connection_pool.js
@@ -362,7 +362,7 @@ class ConnectionPool extends EventEmitter {
 }
 
 function ensureMinPoolSize(pool) {
-  if (pool.closed) {
+  if (pool.closed || pool.options.minPoolSize === 0) {
     return;
   }
 


### PR DESCRIPTION
## Description
`setTimeout`s have a non-trivial overhead in node.  Adding one every 10ms that will ultimately result in nothing but another `setTimeout` is an unnecessary operation and takes up vital time that the event loop could otherwise use for something else.

**What changed?**
Short circuits the `ensureMinPoolSize` function if the `minPoolSize` option is set to `0` (the default).

**Are there any files to ignore?**
No