### PR TITLE
Node 2074/aggregate callback

### DIFF
--- a/docs/reference/content/tutorials/aggregation.md
+++ b/docs/reference/content/tutorials/aggregation.md
@@ -43,20 +43,15 @@ grouped by restaurant category.
 
 function simplePipeline(db, callback) {
   const collection = db.collection( 'restaurants' );
-  collection.aggregate(
-      [ { '$match': { "borough": "Bronx" } },
-        { '$unwind': '$categories'},
-        { '$group': { '_id': "$categories", 'Bronx restaurants': { '$sum': 1 } } }
-      ],
-    function(err, cursor) {
-        assert.equal(err, null);
-
-        cursor.toArray(function(err, documents) {
-          console.log(documents)
-          callback(documents);
-        });
-      }
-  );
+  const cursor = collection.aggregate([
+    { '$match': { "borough": "Bronx" } },
+    { '$unwind': '$categories'},
+    { '$group': { '_id': "$categories", 'Bronx restaurants': { '$sum': 1 } } }
+  ]);
+  cursor.toArray(function(err, documents) {
+    console.log(documents)
+    callback(documents);
+  });
 }
 ```
 

--- a/docs/reference/content/tutorials/collations.md
+++ b/docs/reference/content/tutorials/collations.md
@@ -361,7 +361,7 @@ results by German phonebook order.
   });
 });
 
-async function countNames(db, callback) {
+function countNames(db, callback) {
   const collection = db.collection( 'names' );
   const cursor = collection.aggregate([ 
     { '$group': { '_id': "$first_name", 'nameCount': { '$sum': 1 } } },

--- a/docs/reference/content/tutorials/collations.md
+++ b/docs/reference/content/tutorials/collations.md
@@ -361,20 +361,18 @@ results by German phonebook order.
   });
 });
 
-function countNames(db, callback) {
+async function countNames(db, callback) {
   const collection = db.collection( 'names' );
-  collection.aggregate( 
-      [ 
-        { '$group': { '_id': "$first_name", 'nameCount': { '$sum': 1 } } },
-        { '$sort' : { '_id' : 1 } }
-      ], { collation : { locale : 'de@collation=phonebook' } },
-
-      function(err, docs) {
-        assert.equal(err, null);
-        console.log("Found the following records");
-        console.log(docs)
-        callback(docs);
-      }
-  );
+  const cursor = collection.aggregate([ 
+    { '$group': { '_id': "$first_name", 'nameCount': { '$sum': 1 } } },
+    { '$sort' : { '_id' : 1 } }
+  ],
+  {
+    collation : { locale : 'de@collation=phonebook' }
+  })
+  cursor.toArray(function(err, documents) {
+    console.log(documents)
+    callback(documents);
+  });
 }
 ```

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -324,20 +324,14 @@ Collection.prototype.find = deprecateOptions(
     deprecatedOptions: DEPRECATED_FIND_OPTIONS,
     optionsIndex: 1
   },
-  function(query, options, callback) {
-    if (typeof callback === 'object') {
-      // TODO(MAJOR): throw in the future
-      console.warn('Third parameter to `find()` must be a callback or undefined');
-    }
+  function(query, options) {
 
     let selector = query;
     // figuring out arguments
     if (typeof callback !== 'function') {
       if (typeof options === 'function') {
-        callback = options;
         options = undefined;
       } else if (options == null) {
-        callback = typeof selector === 'function' ? selector : undefined;
         selector = typeof selector === 'object' ? selector : undefined;
       }
     }
@@ -464,23 +458,13 @@ Collection.prototype.find = deprecateOptions(
     decorateWithReadConcern(findCommand, this, options);
 
     // Decorate find command with collation options
-    try {
-      decorateWithCollation(findCommand, this, options);
-    } catch (err) {
-      if (typeof callback === 'function') return callback(err, null);
-      throw err;
-    }
+
+    decorateWithCollation(findCommand, this, options);
 
     const cursor = this.s.topology.cursor(
       new FindOperation(this, this.s.namespace, findCommand, newOptions),
       newOptions
     );
-
-    // TODO: remove this when NODE-2074 is resolved
-    if (typeof callback === 'function') {
-      callback(null, cursor);
-      return;
-    }
 
     return cursor;
   }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1878,24 +1878,16 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
  * @param {Collection~aggregationCallback} callback The command result callback
  * @return {(null|AggregationCursor)}
  */
-Collection.prototype.aggregate = function(pipeline, options, callback) {
+Collection.prototype.aggregate = function(pipeline, options) {
   if (Array.isArray(pipeline)) {
-    // Set up callback if one is provided
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
     // If we have no options or callback we are doing
     // a cursor based aggregation
-    if (options == null && callback == null) {
+    if (options == null) {
       options = {};
     }
   } else {
     // Aggregation pipeline passed as arguments on the method
     const args = Array.prototype.slice.call(arguments, 0);
-    // Get the callback
-    callback = args.pop();
     // Get the possible options object
     const opts = args[args.length - 1];
     // If it contains any of the admissible options pop it of the args
@@ -1919,12 +1911,6 @@ Collection.prototype.aggregate = function(pipeline, options, callback) {
     new AggregateOperation(this, pipeline, options),
     options
   );
-
-  // TODO: remove this when NODE-2074 is resolved
-  if (typeof callback === 'function') {
-    callback(null, cursor);
-    return;
-  }
 
   return cursor;
 };

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -328,17 +328,16 @@ Collection.prototype.find = deprecateOptions(
     if (arguments.length > 2) {
       throw new TypeError('Third parameter to `collection.find()` must be undefined');
     }
-
-    let selector = query;
-    // figuring out arguments
+    if (typeof query === 'function') {
+      throw new TypeError('`query` parameter must not be function');
+    }
     if (typeof options === 'function') {
-      options = undefined;
-    } else if (options == null) {
-      selector = typeof selector === 'object' ? selector : undefined;
+      throw new TypeError('`options` parameter must not be function');
     }
 
-    // Ensure selector is not null
-    selector = selector == null ? {} : selector;
+    let selector =
+      query !== null && typeof query === 'object' && Array.isArray(query) === false ? query : {};
+
     // Validate correctness off the selector
     const object = selector;
     if (Buffer.isBuffer(object)) {
@@ -1866,6 +1865,12 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
 Collection.prototype.aggregate = function(pipeline, options) {
   if (arguments.length > 2) {
     throw new TypeError('Third parameter to `collection.aggregate()` must be undefined');
+  }
+  if (typeof pipeline === 'function') {
+    throw new TypeError('`pipeline` parameter must not be function');
+  }
+  if (typeof options === 'function') {
+    throw new TypeError('`options` parameter must not be function');
   }
 
   if (Array.isArray(pipeline)) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -326,7 +326,7 @@ Collection.prototype.find = deprecateOptions(
   },
   function(query, options) {
     if (arguments.length > 2) {
-      throw new Error('Third parameter to `collection.find()` must be undefined');
+      throw new TypeError('Third parameter to `collection.find()` must be undefined');
     }
 
     let selector = query;
@@ -1865,7 +1865,7 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
  */
 Collection.prototype.aggregate = function(pipeline, options) {
   if (arguments.length > 2) {
-    throw new Error('Third parameter to `collection.aggregate()` must be undefined');
+    throw new TypeError('Third parameter to `collection.aggregate()` must be undefined');
   }
 
   if (Array.isArray(pipeline)) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1876,7 +1876,7 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
  * @param {string|object} [options.hint] Add an index selection hint to an aggregation command
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~aggregationCallback} callback The command result callback
- * @return {(null|AggregationCursor)}
+ * @return {AggregationCursor}
  */
 Collection.prototype.aggregate = function(pipeline, options) {
   if (Array.isArray(pipeline)) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -325,14 +325,16 @@ Collection.prototype.find = deprecateOptions(
     optionsIndex: 1
   },
   function(query, options) {
+    if (arguments.length > 2) {
+      throw new Error('Third parameter to `collection.find()` must be undefined');
+    }
+
     let selector = query;
     // figuring out arguments
-    if (typeof callback !== 'function') {
-      if (typeof options === 'function') {
-        options = undefined;
-      } else if (options == null) {
-        selector = typeof selector === 'object' ? selector : undefined;
-      }
+    if (typeof options === 'function') {
+      options = undefined;
+    } else if (options == null) {
+      selector = typeof selector === 'object' ? selector : undefined;
     }
 
     // Ensure selector is not null
@@ -1862,6 +1864,10 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
  * @return {AggregationCursor}
  */
 Collection.prototype.aggregate = function(pipeline, options) {
+  if (arguments.length > 2) {
+    throw new Error('Third parameter to `collection.aggregate()` must be undefined');
+  }
+
   if (Array.isArray(pipeline)) {
     // If we have no options or callback we are doing
     // a cursor based aggregation

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -325,7 +325,6 @@ Collection.prototype.find = deprecateOptions(
     optionsIndex: 1
   },
   function(query, options) {
-
     let selector = query;
     // figuring out arguments
     if (typeof callback !== 'function') {

--- a/lib/db.js
+++ b/lib/db.js
@@ -322,7 +322,7 @@ Db.prototype.command = function(command, options, callback) {
  */
 Db.prototype.aggregate = function(pipeline, options) {
   if (arguments.length > 2) {
-    throw new Error('Third parameter to `db.aggregate()` must be undefined');
+    throw new TypeError('Third parameter to `db.aggregate()` must be undefined');
   }
 
   if (options == null) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -318,17 +318,10 @@ Db.prototype.command = function(command, options, callback) {
  * @param {string|object} [options.hint] Add an index selection hint to an aggregation command
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Database~aggregationCallback} callback The command result callback
- * @return {(null|AggregationCursor)}
+ * @return {AggregationCursor}
  */
-Db.prototype.aggregate = function(pipeline, options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-
-  // If we have no options or callback we are doing
-  // a cursor based aggregation
-  if (options == null && callback == null) {
+Db.prototype.aggregate = function(pipeline, options) {
+  if (options == null) {
     options = {};
   }
 
@@ -337,12 +330,6 @@ Db.prototype.aggregate = function(pipeline, options, callback) {
     new AggregateOperation(this, pipeline, options),
     options
   );
-
-  // TODO: remove this when NODE-2074 is resolved
-  if (typeof callback === 'function') {
-    callback(null, cursor);
-    return;
-  }
 
   return cursor;
 };

--- a/lib/db.js
+++ b/lib/db.js
@@ -321,7 +321,6 @@ Db.prototype.command = function(command, options, callback) {
  * @return {AggregationCursor}
  */
 Db.prototype.aggregate = function(pipeline, options) {
-
   if (arguments.length > 2) {
     throw new Error('Third parameter to `db.aggregate()` must be undefined');
   }

--- a/lib/db.js
+++ b/lib/db.js
@@ -324,10 +324,14 @@ Db.prototype.aggregate = function(pipeline, options) {
   if (arguments.length > 2) {
     throw new TypeError('Third parameter to `db.aggregate()` must be undefined');
   }
-
-  if (options == null) {
-    options = {};
+  if (typeof pipeline === 'function') {
+    throw new TypeError('`pipeline` parameter must not be function');
   }
+  if (typeof options === 'function') {
+    throw new TypeError('`options` parameter must not be function');
+  }
+
+  if (!options) options = {};
 
   const cursor = new AggregationCursor(
     this.s.topology,

--- a/lib/db.js
+++ b/lib/db.js
@@ -321,6 +321,11 @@ Db.prototype.command = function(command, options, callback) {
  * @return {AggregationCursor}
  */
 Db.prototype.aggregate = function(pipeline, options) {
+
+  if (arguments.length > 2) {
+    throw new Error('Third parameter to `db.aggregate()` must be undefined');
+  }
+
   if (options == null) {
     options = {};
   }

--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -1384,16 +1384,14 @@ var list = function(db, rootCollection, options, callback) {
   db.collection(rootCollectionFinal + '.files', function(err, collection) {
     if (err) return callback(err);
 
-    collection.find({}, { readPreference: readPreference }, function(err, cursor) {
-      if (err) return callback(err);
+    const cursor = collection.find({}, { readPreference: readPreference });
 
-      cursor.each(function(err, item) {
-        if (item != null) {
-          items.push(byId ? item._id : item.filename);
-        } else {
-          callback(err, items);
-        }
-      });
+    cursor.each(function(err, item) {
+      if (item != null) {
+        items.push(byId ? item._id : item.filename);
+      } else {
+        callback(err, items);
+      }
     });
   });
 };

--- a/test/functional/aggregation.test.js
+++ b/test/functional/aggregation.test.js
@@ -1137,7 +1137,6 @@ describe('Aggregation', function() {
               db.command = cmd;
               cursor.close();
               client.close(done);
-
             });
           });
         });

--- a/test/functional/aggregation.test.js
+++ b/test/functional/aggregation.test.js
@@ -57,37 +57,32 @@ describe('Aggregation', function() {
           expect(err).to.be.null;
 
           // Execute aggregate, notice the pipeline is expressed as an Array
-          collection.aggregate(
-            [
-              {
-                $project: {
-                  author: 1,
-                  tags: 1
-                }
-              },
-              { $unwind: '$tags' },
-              {
-                $group: {
-                  _id: { tags: '$tags' },
-                  authors: { $addToSet: '$author' }
-                }
-              },
-              { $sort: { _id: -1 } }
-            ],
-            function(err, cursor) {
-              expect(err).to.be.null;
+          const cursor = collection.aggregate([
+            {
+              $project: {
+                author: 1,
+                tags: 1
+              }
+            },
+            { $unwind: '$tags' },
+            {
+              $group: {
+                _id: { tags: '$tags' },
+                authors: { $addToSet: '$author' }
+              }
+            },
+            { $sort: { _id: -1 } }
+          ]);
 
-              cursor.toArray(function(err, result) {
-                expect(err).to.be.null;
-                expect(result[0]._id.tags).to.equal('good');
-                expect(result[0].authors).to.eql(['bob']);
-                expect(result[1]._id.tags).to.equal('fun');
-                expect(result[1].authors).to.eql(['bob']);
+          cursor.toArray(function(err, result) {
+            expect(err).to.be.null;
+            expect(result[0]._id.tags).to.equal('good');
+            expect(result[0].authors).to.eql(['bob']);
+            expect(result[1]._id.tags).to.equal('fun');
+            expect(result[1].authors).to.eql(['bob']);
 
-                client.close(done);
-              });
-            }
-          );
+            client.close(done);
+          });
         });
       });
       // END
@@ -188,37 +183,32 @@ describe('Aggregation', function() {
 
           // Execute aggregate, notice the pipeline is expressed as function call parameters
           // instead of an Array.
-          collection.aggregate(
-            [
-              {
-                $project: {
-                  author: 1,
-                  tags: 1
-                }
-              },
-              { $unwind: '$tags' },
-              {
-                $group: {
-                  _id: { tags: '$tags' },
-                  authors: { $addToSet: '$author' }
-                }
-              },
-              { $sort: { _id: -1 } }
-            ],
-            function(err, cursor) {
-              expect(err).to.be.null;
+          const cursor = collection.aggregate([
+            {
+              $project: {
+                author: 1,
+                tags: 1
+              }
+            },
+            { $unwind: '$tags' },
+            {
+              $group: {
+                _id: { tags: '$tags' },
+                authors: { $addToSet: '$author' }
+              }
+            },
+            { $sort: { _id: -1 } }
+          ]);
 
-              cursor.toArray(function(err, result) {
-                expect(err).to.be.null;
-                expect(result[0]._id.tags).to.equal('good');
-                expect(result[0].authors).to.eql(['bob']);
-                expect(result[1]._id.tags).to.equal('fun');
-                expect(result[1].authors).to.eql(['bob']);
+          cursor.toArray(function(err, result) {
+            expect(err).to.be.null;
+            expect(result[0]._id.tags).to.equal('good');
+            expect(result[0].authors).to.eql(['bob']);
+            expect(result[1]._id.tags).to.equal('fun');
+            expect(result[1].authors).to.eql(['bob']);
 
-                client.close(done);
-              });
-            }
-          );
+            client.close(done);
+          });
         });
       });
       // END
@@ -283,37 +273,32 @@ describe('Aggregation', function() {
 
           // Execute aggregate, notice the pipeline is expressed as function call parameters
           // instead of an Array.
-          collection.aggregate(
-            [
-              {
-                $project: {
-                  author: 1,
-                  tags: 1
-                }
-              },
-              { $unwind: '$tags' },
-              {
-                $group: {
-                  _id: { tags: '$tags' },
-                  authors: { $addToSet: '$author' }
-                }
-              },
-              { $sort: { _id: -1 } }
-            ],
-            function(err, cursor) {
-              expect(err).to.be.null;
+          const cursor = collection.aggregate([
+            {
+              $project: {
+                author: 1,
+                tags: 1
+              }
+            },
+            { $unwind: '$tags' },
+            {
+              $group: {
+                _id: { tags: '$tags' },
+                authors: { $addToSet: '$author' }
+              }
+            },
+            { $sort: { _id: -1 } }
+          ]);
 
-              cursor.toArray(function(err, result) {
-                expect(err).to.be.null;
-                expect(result[0]._id.tags).to.equal('good');
-                expect(result[0].authors).to.eql(['bob']);
-                expect(result[1]._id.tags).to.equal('fun');
-                expect(result[1].authors).to.eql(['bob']);
+          cursor.toArray(function(err, result) {
+            expect(err).to.be.null;
+            expect(result[0]._id.tags).to.equal('good');
+            expect(result[0].authors).to.eql(['bob']);
+            expect(result[1]._id.tags).to.equal('fun');
+            expect(result[1].authors).to.eql(['bob']);
 
-                client.close(done);
-              });
-            }
-          );
+            client.close(done);
+          });
         });
       });
       // END
@@ -643,7 +628,7 @@ describe('Aggregation', function() {
           expect(err).to.be.null;
 
           // Execute aggregate, notice the pipeline is expressed as an Array
-          collection.aggregate(
+          const cursor = collection.aggregate(
             [
               {
                 $project: {
@@ -661,18 +646,14 @@ describe('Aggregation', function() {
             ],
             {
               out: 'testingOutCollectionForAggregation'
-            },
-            function(err, cursor) {
-              expect(err).to.be.null;
-
-              cursor.toArray(function(err, results) {
-                expect(err).to.be.null;
-                expect(results).to.be.empty;
-
-                client.close(done);
-              });
             }
           );
+          cursor.toArray(function(err, results) {
+            expect(err).to.be.null;
+            expect(results).to.be.empty;
+
+            client.close(done);
+          });
         });
       });
       // END
@@ -734,7 +715,7 @@ describe('Aggregation', function() {
           expect(err).to.be.null;
 
           // Execute aggregate, notice the pipeline is expressed as an Array
-          collection.aggregate(
+          const cursor = collection.aggregate(
             [
               {
                 $project: {
@@ -753,21 +734,17 @@ describe('Aggregation', function() {
             ],
             {
               allowDiskUse: true
-            },
-            function(err, cursor) {
-              expect(err).to.be.null;
-
-              cursor.toArray(function(err, results) {
-                expect(err).to.be.null;
-                expect(results[0]._id.tags).to.equal('good');
-                expect(results[0].authors).to.eql(['bob']);
-                expect(results[1]._id.tags).to.equal('fun');
-                expect(results[1].authors).to.eql(['bob']);
-
-                client.close(done);
-              });
             }
           );
+          cursor.toArray(function(err, results) {
+            expect(err).to.be.null;
+            expect(results[0]._id.tags).to.equal('good');
+            expect(results[0].authors).to.eql(['bob']);
+            expect(results[1]._id.tags).to.equal('fun');
+            expect(results[1].authors).to.eql(['bob']);
+
+            client.close(done);
+          });
         });
       });
       // END
@@ -862,31 +839,28 @@ describe('Aggregation', function() {
             expect(err).to.be.null;
             expect(r.result.n).to.equal(3);
 
-            //Using callback - OK
-            col.aggregate([{ $project: { a: 1 } }], function(err, cursor) {
+            const cursor = col.aggregate([{ $project: { a: 1 } }]);
+
+            cursor.toArray(function(err, docs) {
               expect(err).to.be.null;
+              expect(docs.length).to.be.greaterThan(0);
 
-              cursor.toArray(function(err, docs) {
-                expect(err).to.be.null;
-                expect(docs.length).to.be.greaterThan(0);
+              //Using cursor - KO
+              col
+                .aggregate([{ $project: { a: 1 } }], {
+                  cursor: { batchSize: 10000 }
+                })
+                .forEach(
+                  function() {
+                    count = count + 1;
+                  },
+                  function(err) {
+                    expect(err).to.be.null;
+                    expect(count).to.be.greaterThan(0);
 
-                //Using cursor - KO
-                col
-                  .aggregate([{ $project: { a: 1 } }], {
-                    cursor: { batchSize: 10000 }
-                  })
-                  .forEach(
-                    function() {
-                      count = count + 1;
-                    },
-                    function(err) {
-                      expect(err).to.be.null;
-                      expect(count).to.be.greaterThan(0);
-
-                      client.close(done);
-                    }
-                  );
-              });
+                    client.close(done);
+                  }
+                );
             });
           });
         });
@@ -1140,7 +1114,7 @@ describe('Aggregation', function() {
               };
 
               // Execute aggregate, notice the pipeline is expressed as an Array
-              collection.aggregate(
+              const secondCursor = collection.aggregate(
                 [
                   {
                     $project: {
@@ -1158,17 +1132,16 @@ describe('Aggregation', function() {
                 ],
                 {
                   maxTimeMS: 1000
-                },
-                function(err, r) {
-                  expect(err).to.not.exist;
-                  expect(r).to.exist;
-
-                  // Return the command
-                  db.command = cmd;
-                  cursor.close();
-                  client.close(done);
                 }
               );
+
+              expect(secondCursor).to.exist;
+
+              // Return the command
+              db.command = cmd;
+              cursor.close();
+              client.close(done);
+
             });
           });
         });
@@ -1207,11 +1180,10 @@ describe('Aggregation', function() {
           command.apply(db, Array.prototype.slice.call(arguments, 0));
         };
 
-        collection.aggregate([{ $project: { _id: 1 } }], { comment }, function(err, r) {
-          expect(err).to.be.null;
-          expect(r).to.not.be.null;
-          client.close(done);
-        });
+        const cursor = collection.aggregate([{ $project: { _id: 1 } }], { comment });
+
+        expect(cursor).to.not.be.null;
+        client.close(done);
       });
     }
   });

--- a/test/functional/aggregation.test.js
+++ b/test/functional/aggregation.test.js
@@ -104,22 +104,18 @@ describe('Aggregation', function() {
         expect(err).to.not.exist;
 
         const db = client.db('admin');
-        db.aggregate([{ $currentOp: { localOps: true } }], (err, cursor) => {
+        const cursor = db.aggregate([{ $currentOp: { localOps: true } }]);
+
+        cursor.toArray((err, result) => {
           expect(err).to.not.exist;
 
-          cursor.toArray((err, result) => {
-            expect(err).to.not.exist;
+          const aggregateOperation = result.filter(op => op.command && op.command.aggregate)[0];
+          expect(aggregateOperation.command.aggregate).to.equal(1);
+          expect(aggregateOperation.command.pipeline).to.eql([{ $currentOp: { localOps: true } }]);
+          expect(aggregateOperation.command.cursor).to.deep.equal({});
+          expect(aggregateOperation.command['$db']).to.equal('admin');
 
-            const aggregateOperation = result.filter(op => op.command && op.command.aggregate)[0];
-            expect(aggregateOperation.command.aggregate).to.equal(1);
-            expect(aggregateOperation.command.pipeline).to.eql([
-              { $currentOp: { localOps: true } }
-            ]);
-            expect(aggregateOperation.command.cursor).to.deep.equal({});
-            expect(aggregateOperation.command['$db']).to.equal('admin');
-
-            client.close(done);
-          });
+          client.close(done);
         });
       });
     }

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -860,13 +860,11 @@ describe('Cursor', function() {
           }
 
           function finished() {
-            (function() {
-              const cursor = collection.find();
-              cursor.count(function(err, count) {
-                test.equal(null, err);
-                test.equal(10, count);
-              });
-            })();
+            const cursor = collection.find();
+            cursor.count(function(err, count) {
+              test.equal(null, err);
+              test.equal(10, count);
+            });
 
             (function() {
               const cursor = collection.find();

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -556,15 +556,13 @@ describe('Cursor', function() {
           }
 
           function finished() {
-            (function() {
-              const cursor = collection.find();
+            const cursor = collection.find();
 
-              test.throws(function() {
-                cursor.each();
-              });
+            test.throws(function() {
+              cursor.each();
+            });
 
-              client.close(done);
-            })();
+            client.close(done);
           }
 
           insert(function() {
@@ -2775,7 +2773,7 @@ describe('Cursor', function() {
             test.equal(null, err);
 
             collection
-              .find({ _keywords: 'red' }, {}, { explain: true })
+              .find({ _keywords: 'red' })
               .limit(10)
               .toArray(function(err, result) {
                 test.equal(null, err);
@@ -2822,7 +2820,7 @@ describe('Cursor', function() {
           test.equal(null, err);
 
           collection
-            .find({ _keywords: 'red' }, {}, { explain: false })
+            .find({ _keywords: 'red' })
             .limit(10)
             .toArray(function(err, result) {
               test.equal(null, err);

--- a/test/functional/document_validation.test.js
+++ b/test/functional/document_validation.test.js
@@ -311,7 +311,7 @@ describe('Document Validation', function() {
                 test.equal(null, err);
 
                 // Execute aggregate, notice the pipeline is expressed as an Array
-                col.aggregate(
+                const cursor = col.aggregate(
                   [
                     {
                       $project: {
@@ -328,17 +328,14 @@ describe('Document Validation', function() {
                     },
                     { $out: 'createValidationCollectionOut' }
                   ],
-                  { bypassDocumentValidation: true },
-                  function(err, cursor) {
-                    test.equal(null, err);
-
-                    cursor.toArray(function(err) {
-                      test.equal(null, err);
-
-                      client.close(done);
-                    });
-                  }
+                  { bypassDocumentValidation: true }
                 );
+
+                cursor.toArray(function(err) {
+                  test.equal(null, err);
+
+                  client.close(done);
+                });
               });
             }
           );

--- a/test/functional/find.test.js
+++ b/test/functional/find.test.js
@@ -1200,19 +1200,22 @@ describe('Find', function() {
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.createCollection('timeoutFalse', function(err, collection) {
-          collection.find({}, { timeout: false }, function(err, cursor) {
+          (function() {
+            const cursor = collection.find({}, { timeout: false });
             test.equal(false, cursor.cmd.noCursorTimeout);
 
-            collection.find({}, { timeout: true }, function(err, cursor) {
+            (function() {
+              const cursor = collection.find({}, { timeout: true });
               test.equal(true, cursor.cmd.noCursorTimeout);
 
-              collection.find({}, {}, function(err, cursor) {
+              (function() {
+                const cursor = collection.find({}, {});
                 test.ok(!cursor.cmd.noCursorTimeout);
 
                 client.close(done);
-              });
-            });
-          });
+              })();
+            })();
+          })();
         });
       });
     }
@@ -2710,13 +2713,11 @@ describe('Find', function() {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldNotMutateUserOptions');
         var options = { raw: 'TEST' };
-        collection.find({}, options, function(error) {
-          test.equal(null, error);
-          test.equal(undefined, options.skip);
-          test.equal(undefined, options.limit);
-          test.equal('TEST', options.raw);
-          client.close(done);
-        });
+        collection.find({}, options);
+        test.equal(undefined, options.skip);
+        test.equal(undefined, options.limit);
+        test.equal('TEST', options.raw);
+        client.close(done);
       });
     }
   });

--- a/test/functional/find.test.js
+++ b/test/functional/find.test.js
@@ -1188,7 +1188,7 @@ describe('Find', function() {
   /**
    * @ignore
    */
-  it('Should correctly pass timeout options to cursor', {
+  it('Should correctly pass timeout options to cursor noCursorTimeout', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
@@ -1200,22 +1200,55 @@ describe('Find', function() {
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
         db.createCollection('timeoutFalse', function(err, collection) {
-          (function() {
-            const cursor = collection.find({}, { timeout: false });
-            test.equal(false, cursor.cmd.noCursorTimeout);
+          const cursor = collection.find({}, {});
+          test.ok(!cursor.cmd.noCursorTimeout);
+          client.close(done);
+        });
+      });
+    }
+  });
 
-            (function() {
-              const cursor = collection.find({}, { timeout: true });
-              test.equal(true, cursor.cmd.noCursorTimeout);
+  /**
+   * @ignore
+   */
+  it('Should correctly pass timeout options to cursor is false', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
 
-              (function() {
-                const cursor = collection.find({}, {});
-                test.ok(!cursor.cmd.noCursorTimeout);
+    // The actual test we wish to run
+    test: function(done) {
+      var configuration = this.configuration;
+      var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+        db.createCollection('timeoutFalse', function(err, collection) {
+          const cursor = collection.find({}, { timeout: false });
+          test.equal(false, cursor.cmd.noCursorTimeout);
+          client.close(done);
+        });
+      });
+    }
+  });
 
-                client.close(done);
-              })();
-            })();
-          })();
+  /**
+   * @ignore
+   */
+  it('Should correctly pass timeout options to cursor is true', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    // The actual test we wish to run
+    test: function(done) {
+      var configuration = this.configuration;
+      var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+      client.connect(function(err, client) {
+        var db = client.db(configuration.db);
+        db.createCollection('timeoutFalse', function(err, collection) {
+          const cursor = collection.find({}, { timeout: true });
+          test.equal(true, cursor.cmd.noCursorTimeout);
+          client.close(done);
         });
       });
     }

--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -76,37 +76,31 @@ describe('Operation Examples', function() {
           test.ok(result);
 
           // Execute aggregate, notice the pipeline is expressed as an Array
-          collection.aggregate(
-            [
-              {
-                $project: {
-                  author: 1,
-                  tags: 1
-                }
-              },
-              { $unwind: '$tags' },
-              {
-                $group: {
-                  _id: { tags: '$tags' },
-                  authors: { $addToSet: '$author' }
-                }
-              },
-              { $sort: { _id: -1 } }
-            ],
-            function(err, cursor) {
-              test.equal(null, err);
+          const cursor = collection.aggregate([
+            {
+              $project: {
+                author: 1,
+                tags: 1
+              }
+            },
+            { $unwind: '$tags' },
+            {
+              $group: {
+                _id: { tags: '$tags' },
+                authors: { $addToSet: '$author' }
+              }
+            },
+            { $sort: { _id: -1 } }
+          ]);
+          cursor.toArray(function(err, result) {
+            test.equal(null, err);
+            test.equal('good', result[0]._id.tags);
+            test.deepEqual(['bob'], result[0].authors);
+            test.equal('fun', result[1]._id.tags);
+            test.deepEqual(['bob'], result[1].authors);
 
-              cursor.toArray(function(err, result) {
-                test.equal(null, err);
-                test.equal('good', result[0]._id.tags);
-                test.deepEqual(['bob'], result[0].authors);
-                test.equal('fun', result[1]._id.tags);
-                test.deepEqual(['bob'], result[1].authors);
-
-                client.close(done);
-              });
-            }
-          );
+            client.close(done);
+          });
         });
       });
       // END

--- a/test/functional/raw.test.js
+++ b/test/functional/raw.test.js
@@ -96,8 +96,8 @@ describe('Raw', function() {
           // Insert some documents
           collection.insert([{ a: 1 }, { b: 2000 }, { c: 2.3 }], { w: 1 }, function(err) {
             test.equal(null, err);
-            // You have to pass at least query + fields before passing options
-            collection.find({}, null, { batchSize: 2 }).toArray(function(err, items) {
+
+            collection.find({}, { batchSize: 2 }).toArray(function(err, items) {
               var objects = [];
               for (var i = 0; i < items.length; i++) {
                 test.ok(Buffer.isBuffer(items[i]));

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -324,33 +324,28 @@ describe('ReadPreference', function() {
           return command.apply(db.serverConfig, args);
         };
 
-        collection.aggregate(
-          [
-            {
-              $project: {
-                author: 1,
-                tags: 1
-              }
-            },
-            { $unwind: '$tags' },
-            {
-              $group: {
-                _id: { tags: '$tags' },
-                authors: { $addToSet: '$author' }
-              }
+        const cursor = collection.aggregate([
+          {
+            $project: {
+              author: 1,
+              tags: 1
             }
-          ],
-          function(err, cursor) {
-            test.equal(null, err);
-
-            cursor.toArray(function(err) {
-              test.equal(null, err);
-              client.topology.command = command;
-
-              client.close(done);
-            });
+          },
+          { $unwind: '$tags' },
+          {
+            $group: {
+              _id: { tags: '$tags' },
+              authors: { $addToSet: '$author' }
+            }
           }
-        );
+        ]);
+
+        cursor.toArray(function(err) {
+          test.equal(null, err);
+          client.topology.command = command;
+
+          client.close(done);
+        });
       });
     }
   });


### PR DESCRIPTION
## Description

Functions returning `cursor` should not return them within callback.

**What changed?**

* Removes callback for `collection.aggregate`
* Removes callback for `db.aggregate`
* Removes callback fro `collection.find`

**Are there any files to ignore?**

No

Jira Ticket https://jira.mongodb.org/browse/NODE-2074