### PR TITLE
NODE-2483: cursor limit regression

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -210,7 +210,13 @@ class Cursor extends CoreCursor {
         }
 
         cursor.s.state = CursorState.OPEN;
+
+        // NODE-2482: merge this into the core cursor implementation
         cursor.cursorState.cursorIndex--;
+        if (cursor.cursorState.limit > 0) {
+          cursor.cursorState.currentLimit--;
+        }
+
         cb(null, true);
       });
     });

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -4569,4 +4569,44 @@ describe('Cursor', function() {
       });
     });
   });
+
+  it('should correctly iterate all documents with a limit set', function(done) {
+    const configuration = this.configuration;
+    const client = configuration.newClient();
+
+    client.connect(err => {
+      expect(err).to.not.exist;
+      this.defer(() => client.close());
+
+      const collection = client.db().collection('documents');
+      collection.drop(() => {
+        const docs = [{ a: 1 }, { a: 2 }, { a: 3 }];
+        collection.insertMany(docs, err => {
+          expect(err).to.not.exist;
+
+          let cursor = collection.find({}).limit(5);
+
+          let bag = [];
+          function iterate() {
+            if (bag.length === docs.length) {
+              expect(bag).to.eql(docs);
+              return done();
+            }
+
+            cursor.hasNext((err, hasNext) => {
+              expect(err).to.not.exist;
+              expect(hasNext).to.be.true;
+              cursor.next((err, doc) => {
+                expect(err).to.not.exist;
+                bag.push(doc);
+                iterate();
+              });
+            });
+          }
+
+          iterate();
+        });
+      });
+    });
+  });
 });

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -233,6 +233,7 @@ function runTestSuiteTest(configuration, spec, context) {
   // test-specific client options
   clientOptions.autoReconnect = false;
   clientOptions.haInterval = 100;
+  clientOptions.minHeartbeatFrequencyMS = 100;
   clientOptions.useRecoveryToken = true;
 
   // TODO: this should be configured by `newClient` and env variables


### PR DESCRIPTION
A recent change to allow use of `hasNext` with a cursor that is piped as a stream introduced a regression when a cursor with a limit is iterated. Until the cursor is rewritten, we will manually decrement the local `currentLimit` on calls to `hasNext`.

https://jira.mongodb.org/browse/NODE-2483
