### PR TITLE
fix(sessions): don't throw if `withTransaction()` callback rejects with a null reason

### DIFF
--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -304,6 +304,7 @@ function isUnknownTransactionCommitResult(err) {
 }
 
 function isMaxTimeMSExpiredError(err) {
+  if (err == null) return false;
   return (
     err.code === MAX_TIME_MS_EXPIRED_CODE ||
     (err.writeConcernError && err.writeConcernError.code === MAX_TIME_MS_EXPIRED_CODE)


### PR DESCRIPTION
 Description

See: https://github.com/Automattic/mongoose/issues/8637 . The issue is that if you do `session.withTransaction(() => Promise.reject())`, you get a `TypeError: Cannot read property 'code' of undefined` error.

**What changed?**

One liner checking for `null`

**Are there any files to ignore?**

No.
