### PR TITLE
Fix docs

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -25,15 +25,6 @@ import PromiseProvider = require('./promise_provider');
  * @property {string} [platform] Optional platform information
  */
 
-/**
- * Configuration options for drivers wrapping the node driver.
- *
- * @typedef {object} DriverInfoOptions
- * @property {string} [name] The name of the driver
- * @property {string} [version] The version of the driver
- * @property {string} [platform] Optional platform information
- */
-
 interface MongoClient {
   logout(options: any, callback: Function): void;
 }


### PR DESCRIPTION
## Description

- remove duplicated DriverInfoOptions typedef
- reflect possible Db options for MongoClient db method
Copied options params from https://github.com/mongodb/node-mongodb-native/blob/52c2bf3/lib/db.js#L105-L121 except `promiseLibrary` which is overwritten at https://github.com/mongodb/node-mongodb-native/blob/52c2bf3a2d8458d216420d0539c7672ad6a6e770/lib/mongo_client.js#L289