### PR TITLE
fix: missing optionName in MongoParseError message

### DIFF
--- a/lib/connection_string.js
+++ b/lib/connection_string.js
@@ -523,7 +523,7 @@ function assertTlsOptionsAreEqual(optionName, queryString, queryStringKeys) {
       const firstValue = queryString[optionName][0];
       queryString[optionName].forEach(tlsValue => {
         if (tlsValue !== firstValue) {
-          throw new MongoParseError('All values of ${optionName} must be the same.');
+          throw new MongoParseError(`All values of ${optionName} must be the same.`);
         }
       });
     }

--- a/test/unit/core/connection_string.test.js
+++ b/test/unit/core/connection_string.test.js
@@ -203,6 +203,13 @@ describe('Connection String', function() {
         done();
       });
     });
+
+    it('should validate non-equal tls values', function(done) {
+      parseConnectionString('mongodb://localhost/?tls=true&tls=false', err => {
+        expect(err).to.have.property('message', 'All values of tls must be the same.');
+        done();
+      });
+    });
   });
 
   describe('spec tests', function() {


### PR DESCRIPTION
## Description

We observed errors thrown from `assertTlsOptionsAreEqual()` when using a badly formed connection string, but the error message did not convey the name of the option (either `tls` or `ssl`).

**What changed?**

A Template Literal should have been used to declare the error message, to interpolate the value of `${optionName}`.

This has been observed using mongodb@3.4.1, but the issue appears to still be present on `master`. It is a very minor issue, but figured it could be valuable to fix this nonetheless.

**Are there any files to ignore?**
