### PR TITLE
NODE-2474: update equal server description

### DIFF
--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -519,10 +519,12 @@ class Topology extends EventEmitter {
     }
 
     // If we already know all the information contained in this updated description, then
-    // we don't need to update anything or emit SDAM events
-    if (previousServerDescription && previousServerDescription.equals(serverDescription)) {
-      return;
-    }
+    // we don't need to emit SDAM events, but still need to update the description, in order
+    // to keep client-tracked attributes like last update time and round trip time up to date
+    const areEqual =
+      previousServerDescription && previousServerDescription.equals(serverDescription)
+        ? true
+        : false;
 
     // first update the TopologyDescription
     this.s.description = this.s.description.update(serverDescription);
@@ -532,15 +534,17 @@ class Topology extends EventEmitter {
     }
 
     // emit monitoring events for this change
-    this.emit(
-      'serverDescriptionChanged',
-      new events.ServerDescriptionChangedEvent(
-        this.s.id,
-        serverDescription.address,
-        previousServerDescription,
-        this.s.description.servers.get(serverDescription.address)
-      )
-    );
+    if (!areEqual) {
+      this.emit(
+        'serverDescriptionChanged',
+        new events.ServerDescriptionChangedEvent(
+          this.s.id,
+          serverDescription.address,
+          previousServerDescription,
+          this.s.description.servers.get(serverDescription.address)
+        )
+      );
+    }
 
     // update server list from updated descriptions
     updateServers(this, serverDescription);
@@ -550,14 +554,16 @@ class Topology extends EventEmitter {
       processWaitQueue(this);
     }
 
-    this.emit(
-      'topologyDescriptionChanged',
-      new events.TopologyDescriptionChangedEvent(
-        this.s.id,
-        previousTopologyDescription,
-        this.s.description
-      )
-    );
+    if (!areEqual) {
+      this.emit(
+        'topologyDescriptionChanged',
+        new events.TopologyDescriptionChangedEvent(
+          this.s.id,
+          previousTopologyDescription,
+          this.s.description
+        )
+      );
+    }
   }
 
   auth(credentials, callback) {

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -521,10 +521,8 @@ class Topology extends EventEmitter {
     // If we already know all the information contained in this updated description, then
     // we don't need to emit SDAM events, but still need to update the description, in order
     // to keep client-tracked attributes like last update time and round trip time up to date
-    const areEqual =
-      previousServerDescription && previousServerDescription.equals(serverDescription)
-        ? true
-        : false;
+    const equalDescriptions =
+      previousServerDescription && previousServerDescription.equals(serverDescription);
 
     // first update the TopologyDescription
     this.s.description = this.s.description.update(serverDescription);
@@ -534,7 +532,7 @@ class Topology extends EventEmitter {
     }
 
     // emit monitoring events for this change
-    if (!areEqual) {
+    if (!equalDescriptions) {
       this.emit(
         'serverDescriptionChanged',
         new events.ServerDescriptionChangedEvent(
@@ -554,7 +552,7 @@ class Topology extends EventEmitter {
       processWaitQueue(this);
     }
 
-    if (!areEqual) {
+    if (!equalDescriptions) {
       this.emit(
         'topologyDescriptionChanged',
         new events.TopologyDescriptionChangedEvent(

--- a/test/functional/core/replset_state.test.js
+++ b/test/functional/core/replset_state.test.js
@@ -12,6 +12,7 @@ describe('ReplicaSet state', function() {
 
   fs.readdirSync(path)
     .filter(x => x.indexOf('.json') !== -1)
+    .filter(x => !x.includes('repeated'))
     .forEach(x => {
       var testData = require(f('%s/%s', path, x));
 

--- a/test/spec/server-discovery-and-monitoring/rs/repeated.json
+++ b/test/spec/server-discovery-and-monitoring/rs/repeated.json
@@ -1,0 +1,140 @@
+{
+  "description": "Repeated ismaster response must be processed",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/repeated.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/repeated.yml
@@ -1,0 +1,101 @@
+description: Repeated ismaster response must be processed
+
+uri: "mongodb://a,b/?replicaSet=rs"
+
+phases:
+  # Phase 1 - a says it's not primary and suggests c may be the primary
+  - responses:
+    -
+      - "a:27017"
+      - ok: 1
+        ismaster: false
+        secondary: true
+        hidden: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+        
+        "c:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 2 - c says it's a standalone, is removed
+  - responses:
+    -
+      - "c:27017"
+      - ok: 1
+        ismaster: true
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 3 - response from a is repeated, and must be processed; c added again
+  - responses:
+    -
+      - "a:27017"
+      - ok: 1
+        ismaster: false
+        secondary: true
+        hidden: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+        
+        "c:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 4 - c is now a primary
+  - responses:
+    -
+      - "c:27017"
+      - ok: 1
+        ismaster: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "c:27017":
+          type: RSPrimary
+          setName: rs
+      topologyType: "ReplicaSetWithPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"


### PR DESCRIPTION
## Description

[NODE-2474](https://jira.mongodb.org/browse/NODE-2474) - Server_Description update with lastUpdateTime / lastWriteDate fields is ignored in topology

The SDAM spec says:

> Each time the client checks a server, it MUST replace its description of that server with a new one. This replacement MUST happen even if the new server description compares equal to the previous one, in order to keep client-tracked attributes like last update time and round trip time up to date.

This PR ensures the server description is updated even when equal.

**What changed?**

**Are there any files to ignore?**
