### PR TITLE
NODE-2472: double wait queue drain regression

### DIFF
--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -378,6 +378,8 @@ class Topology extends EventEmitter {
         let readPreference;
         if (selector instanceof ReadPreference) {
           readPreference = selector;
+        } else if (typeof selector === 'string') {
+          readPreference = new ReadPreference(selector);
         } else {
           translateReadPreference(options);
           readPreference = options.readPreference || ReadPreference.primary;
@@ -997,10 +999,9 @@ function processWaitQueue(topology) {
     return;
   }
 
-  const isSharded = topology.description.type === TopologyType.Sharded;
   const serverDescriptions = Array.from(topology.description.servers.values());
   const membersToProcess = topology[kWaitQueue].length;
-  for (let i = 0; i < membersToProcess; ++i) {
+  for (let i = 0; i < membersToProcess && topology[kWaitQueue].length; ++i) {
     const waitQueueMember = topology[kWaitQueue].shift();
     if (waitQueueMember[kCancelled]) {
       continue;
@@ -1026,6 +1027,7 @@ function processWaitQueue(topology) {
     const selectedServerDescription = randomSelection(selectedDescriptions);
     const selectedServer = topology.s.servers.get(selectedServerDescription.address);
     const transaction = waitQueueMember.transaction;
+    const isSharded = topology.description.type === TopologyType.Sharded;
     if (isSharded && transaction && transaction.isActive) {
       transaction.pinServer(selectedServer);
     }

--- a/test/unit/cmap/connection.test.js
+++ b/test/unit/cmap/connection.test.js
@@ -9,9 +9,7 @@ const expect = require('chai').expect;
 describe('Connection', function() {
   let server;
   after(() => mock.cleanup());
-  before(() =>
-    mock.createServer().then(s => (server = s))
-  );
+  before(() => mock.createServer().then(s => (server = s)));
 
   it('should support fire-and-forget messages', function(done) {
     server.setMessageHandler(request => {


### PR DESCRIPTION
In certain failover events, multiple entities may signal that the
server selection queue should be processed. This is problematic
because the queue is processed serially per invocation, even though
the queue may grow during processing. Likely a more robust solution
is required in the future, but for now we can prevent issues by
ensuring the loop breaks if no more wait queue members are present.

NODE-2472