### PR TITLE
refactor: read pref tags must be array

### DIFF
--- a/lib/read_preference.js
+++ b/lib/read_preference.js
@@ -5,7 +5,7 @@
  * used to construct connections.
  * @class
  * @param {string} mode A string describing the read preference mode (primary|primaryPreferred|secondary|secondaryPreferred|nearest)
- * @param {array} [tags] The tags object
+ * @param {object[]} [tags] A tag set used to target reads to members with the specified tag(s). tagSet is not available if using read preference mode primary.
  * @param {object} [options] Additional read preference options
  * @param {number} [options.maxStalenessSeconds] Max secondary read staleness in seconds, Minimum value is 90 seconds.
  * @see https://docs.mongodb.com/manual/core/read-preference/

--- a/lib/read_preference.js
+++ b/lib/read_preference.js
@@ -16,19 +16,14 @@ const ReadPreference = function(mode, tags, options) {
     throw new TypeError(`Invalid read preference mode ${mode}`);
   }
 
-  // TODO(major): tags MUST be an array of tagsets
   if (tags && !Array.isArray(tags)) {
-    console.warn(
-      'ReadPreference tags must be an array, this will change in the next major version'
-    );
+    throw new TypeError('ReadPreference tags must be an array');
+  }
 
-    if (typeof tags.maxStalenessSeconds !== 'undefined') {
-      // this is likely an options object
-      options = tags;
-      tags = undefined;
-    } else {
-      tags = [tags];
-    }
+  if (tags && typeof tags.maxStalenessSeconds !== 'undefined') {
+    // this is likely an options object
+    options = tags;
+    tags = undefined;
   }
 
   this.mode = mode;

--- a/lib/read_preference.js
+++ b/lib/read_preference.js
@@ -5,7 +5,7 @@
  * used to construct connections.
  * @class
  * @param {string} mode A string describing the read preference mode (primary|primaryPreferred|secondary|secondaryPreferred|nearest)
- * @param {array} tags The tags object
+ * @param {array} [tags] The tags object
  * @param {object} [options] Additional read preference options
  * @param {number} [options.maxStalenessSeconds] Max secondary read staleness in seconds, Minimum value is 90 seconds.
  * @see https://docs.mongodb.com/manual/core/read-preference/
@@ -16,7 +16,7 @@ const ReadPreference = function(mode, tags, options) {
     throw new TypeError(`Invalid read preference mode ${mode}`);
   }
 
-  if (!Array.isArray(tags)) {
+  if (tags && !Array.isArray(tags)) {
     throw new TypeError('ReadPreference tags must be an array');
   }
 

--- a/lib/read_preference.js
+++ b/lib/read_preference.js
@@ -16,14 +16,15 @@ const ReadPreference = function(mode, tags, options) {
     throw new TypeError(`Invalid read preference mode ${mode}`);
   }
 
-  if (tags && !Array.isArray(tags)) {
-    throw new TypeError('ReadPreference tags must be an array');
-  }
-
-  if (tags && typeof tags.maxStalenessSeconds !== 'undefined') {
-    // this is likely an options object
-    options = tags;
-    tags = undefined;
+  if (tags) {
+    if (!Array.isArray(tags)) {
+      throw new TypeError('ReadPreference tags must be an array');
+    }
+    if (typeof tags.maxStalenessSeconds !== 'undefined') {
+      // this is likely an options object
+      options = tags;
+      tags = undefined;
+    }
   }
 
   this.mode = mode;

--- a/lib/read_preference.js
+++ b/lib/read_preference.js
@@ -16,15 +16,8 @@ const ReadPreference = function(mode, tags, options) {
     throw new TypeError(`Invalid read preference mode ${mode}`);
   }
 
-  if (tags) {
-    if (!Array.isArray(tags)) {
-      throw new TypeError('ReadPreference tags must be an array');
-    }
-    if (typeof tags.maxStalenessSeconds !== 'undefined') {
-      // this is likely an options object
-      options = tags;
-      tags = undefined;
-    }
+  if (tags && !Array.isArray(tags)) {
+    throw new TypeError('ReadPreference tags must be an array');
   }
 
   this.mode = mode;

--- a/lib/read_preference.js
+++ b/lib/read_preference.js
@@ -15,8 +15,10 @@ const ReadPreference = function(mode, tags, options) {
   if (!ReadPreference.isValid(mode)) {
     throw new TypeError(`Invalid read preference mode ${mode}`);
   }
-
-  if (tags && !Array.isArray(tags)) {
+  if (options === undefined && typeof tags === 'object' && !Array.isArray(tags)) {
+    options = tags;
+    tags = undefined;
+  } else if (tags && !Array.isArray(tags)) {
     throw new TypeError('ReadPreference tags must be an array');
   }
 

--- a/lib/read_preference.js
+++ b/lib/read_preference.js
@@ -16,7 +16,7 @@ const ReadPreference = function(mode, tags, options) {
     throw new TypeError(`Invalid read preference mode ${mode}`);
   }
 
-  if (tags && !Array.isArray(tags)) {
+  if (!Array.isArray(tags)) {
     throw new TypeError('ReadPreference tags must be an array');
   }
 

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -73,9 +73,6 @@ describe('ReadPreference', function() {
     });
   });
 
-  /**
-   * @ignore
-   */
   it('Should correctly apply collection level read Preference to count', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
@@ -113,9 +110,6 @@ describe('ReadPreference', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it('Should correctly apply collection level read Preference to group', {
     metadata: { requires: { mongodb: '>=2.6.0,<=4.0.x', topology: ['single', 'ssl'] } },
 
@@ -156,9 +150,6 @@ describe('ReadPreference', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it('Should correctly apply collection level read Preference to geoHaystackSearch', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
@@ -200,9 +191,6 @@ describe('ReadPreference', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it('Should correctly apply collection level read Preference to mapReduce', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
@@ -251,9 +239,6 @@ describe('ReadPreference', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it(
     'Should correctly apply collection level read Preference to mapReduce backward compatibility',
     {
@@ -303,9 +288,6 @@ describe('ReadPreference', function() {
     }
   );
 
-  /**
-   * @ignore
-   */
   it('Should fail due to not using mapReduce inline with read preference', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
@@ -339,9 +321,6 @@ describe('ReadPreference', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it('Should correctly apply collection level read Preference to aggregate', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
@@ -394,9 +373,6 @@ describe('ReadPreference', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it('Should correctly apply collection level read Preference to stats', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
@@ -433,9 +409,6 @@ describe('ReadPreference', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it('Should correctly honor the readPreferences at DB and individual command level', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
@@ -479,9 +452,6 @@ describe('ReadPreference', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it('Should correctly apply readPreferences specified as objects', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
@@ -502,9 +472,6 @@ describe('ReadPreference', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it('Should correctly pass readPreferences specified as objects to cursors', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
@@ -525,9 +492,6 @@ describe('ReadPreference', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it('Should correctly pass readPreferences specified as objects to collection methods', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -521,4 +521,11 @@ describe('ReadPreference', function() {
       client.close(done);
     });
   });
+
+  it('Should only accept an array for readPreferenceTags', function() {
+    expect(() => new ReadPreference('primary', 'invalid')).to.throw(
+      'ReadPreference tags must be an array'
+    );
+    expect(new ReadPreference('primary', [])).to.be.an.instanceOf(ReadPreference);
+  });
 });

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -9,6 +9,70 @@ describe('ReadPreference', function() {
     return setupDatabase(this.configuration);
   });
 
+  describe('::constructor', function() {
+    const maxStalenessSeconds = 1234;
+    const { PRIMARY, SECONDARY, NEAREST } = ReadPreference;
+    const TAGS = [{ loc: 'dc' }];
+
+    it('should accept (mode)', function() {
+      expect(new ReadPreference(PRIMARY)).to.be.an.instanceOf(ReadPreference);
+    });
+
+    it('should accept valid (mode, tags)', function() {
+      expect(new ReadPreference(PRIMARY, [])).to.be.an.instanceOf(ReadPreference);
+      const p0 = new ReadPreference(NEAREST, TAGS);
+      expect(p0.mode).to.equal(NEAREST);
+    });
+
+    it('should not accept invalid tags', function() {
+      expect(() => new ReadPreference(PRIMARY, 'invalid')).to.throw(
+        'ReadPreference tags must be an array'
+      );
+      expect(() => new ReadPreference(PRIMARY, { loc: 'dc' }, { maxStalenessSeconds })).to.throw(
+        'ReadPreference tags must be an array'
+      );
+    });
+
+    it('should accept (mode, options)', function() {
+      const p1 = new ReadPreference(SECONDARY, { maxStalenessSeconds });
+      expect(p1.mode).to.equal(SECONDARY);
+      expect(p1.maxStalenessSeconds).to.equal(maxStalenessSeconds);
+    });
+
+    it('should not accept mode=primary + tags', function() {
+      expect(() => new ReadPreference(PRIMARY, TAGS)).to.throw(
+        'Primary read preference cannot be combined with tags'
+      );
+    });
+
+    it('should not accept mode=primary + options.maxStalenessSeconds', function() {
+      expect(() => new ReadPreference(PRIMARY, null, { maxStalenessSeconds })).to.throw(
+        'Primary read preference cannot be combined with maxStalenessSeconds'
+      );
+    });
+
+    it('should accept (mode=secondary, tags=null, options)', function() {
+      const p2 = new ReadPreference(SECONDARY, null, { maxStalenessSeconds });
+      expect(p2).to.be.an.instanceOf(ReadPreference);
+      expect(p2.mode).to.equal(SECONDARY);
+      expect(p2.maxStalenessSeconds).to.equal(maxStalenessSeconds);
+    });
+
+    it('should accept (mode=secondary, tags, options)', function() {
+      const p3 = new ReadPreference(SECONDARY, TAGS, { maxStalenessSeconds });
+      expect(p3).to.be.an.instanceOf(ReadPreference);
+      expect(p3.mode).to.equal(SECONDARY);
+      expect(p3.tags).to.eql(TAGS);
+      expect(p3.maxStalenessSeconds).to.equal(maxStalenessSeconds);
+    });
+
+    it('should not accept (mode, options, tags)', function() {
+      expect(() => new ReadPreference(PRIMARY, { maxStalenessSeconds }, TAGS)).to.throw(
+        'ReadPreference tags must be an array'
+      );
+    });
+  });
+
   /**
    * @ignore
    */
@@ -514,70 +578,6 @@ describe('ReadPreference', function() {
       );
 
       client.close(done);
-    });
-  });
-
-  describe('ReadPreference construction', function() {
-    const maxStalenessSeconds = 1234;
-    const { PRIMARY, SECONDARY, NEAREST } = ReadPreference;
-    const TAGS = [{ loc: 'dc' }];
-
-    it('should accept (mode)', function() {
-      expect(new ReadPreference(PRIMARY)).to.be.an.instanceOf(ReadPreference);
-    });
-
-    it('should accept valid (mode, tags)', function() {
-      expect(new ReadPreference(PRIMARY, [])).to.be.an.instanceOf(ReadPreference);
-      const p0 = new ReadPreference(NEAREST, TAGS);
-      expect(p0.mode).to.equal(NEAREST);
-    });
-
-    it('should not accept invalid tags', function() {
-      expect(() => new ReadPreference(PRIMARY, 'invalid')).to.throw(
-        'ReadPreference tags must be an array'
-      );
-      expect(() => new ReadPreference(PRIMARY, { loc: 'dc' }, { maxStalenessSeconds })).to.throw(
-        'ReadPreference tags must be an array'
-      );
-    });
-
-    it('should accept (mode, options)', function() {
-      const p1 = new ReadPreference(SECONDARY, { maxStalenessSeconds });
-      expect(p1.mode).to.equal(SECONDARY);
-      expect(p1.maxStalenessSeconds).to.equal(maxStalenessSeconds);
-    });
-
-    it('should not accept mode=primary + tags', function() {
-      expect(() => new ReadPreference(PRIMARY, TAGS)).to.throw(
-        'Primary read preference cannot be combined with tags'
-      );
-    });
-
-    it('should not accept mode=primary + options.maxStalenessSeconds', function() {
-      expect(() => new ReadPreference(PRIMARY, null, { maxStalenessSeconds })).to.throw(
-        'Primary read preference cannot be combined with maxStalenessSeconds'
-      );
-    });
-
-    it('should accept (mode=secondary, tags=null, options)', function() {
-      const p2 = new ReadPreference(SECONDARY, null, { maxStalenessSeconds });
-      expect(p2).to.be.an.instanceOf(ReadPreference);
-      expect(p2.mode).to.equal(SECONDARY);
-      expect(p2.maxStalenessSeconds).to.equal(maxStalenessSeconds);
-    });
-
-    it('should accept (mode=secondary, tags, options)', function() {
-      const p3 = new ReadPreference(SECONDARY, TAGS, { maxStalenessSeconds });
-      expect(p3).to.be.an.instanceOf(ReadPreference);
-      expect(p3.mode).to.equal(SECONDARY);
-      expect(p3.tags).to.eql(TAGS);
-      expect(p3.maxStalenessSeconds).to.equal(maxStalenessSeconds);
-    });
-
-    it('should not accept (mode, options, tags)', function() {
-      expect(() => new ReadPreference(PRIMARY, { maxStalenessSeconds }, TAGS)).to.throw(
-        'ReadPreference tags must be an array'
-      );
     });
   });
 });

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -517,10 +517,67 @@ describe('ReadPreference', function() {
     });
   });
 
-  it('Should only accept an array for readPreferenceTags', function() {
-    expect(() => new ReadPreference('primary', 'invalid')).to.throw(
-      'ReadPreference tags must be an array'
-    );
-    expect(new ReadPreference('primary', [])).to.be.an.instanceOf(ReadPreference);
+  describe('ReadPreference construction', function() {
+    const maxStalenessSeconds = 1234;
+    const { PRIMARY, SECONDARY, NEAREST } = ReadPreference;
+    const TAGS = [{ loc: 'dc' }];
+
+    it('should accept (mode)', function() {
+      expect(new ReadPreference(PRIMARY)).to.be.an.instanceOf(ReadPreference);
+    });
+
+    it('should accept valid (mode, tags)', function() {
+      expect(new ReadPreference(PRIMARY, [])).to.be.an.instanceOf(ReadPreference);
+      const p0 = new ReadPreference(NEAREST, TAGS);
+      expect(p0.mode).to.equal(NEAREST);
+    });
+
+    it('should not accept invalid tags', function() {
+      expect(() => new ReadPreference(PRIMARY, 'invalid')).to.throw(
+        'ReadPreference tags must be an array'
+      );
+      expect(() => new ReadPreference(PRIMARY, { loc: 'dc' }, { maxStalenessSeconds })).to.throw(
+        'ReadPreference tags must be an array'
+      );
+    });
+
+    it('should accept (mode, options)', function() {
+      const p1 = new ReadPreference(SECONDARY, { maxStalenessSeconds });
+      expect(p1.mode).to.equal(SECONDARY);
+      expect(p1.maxStalenessSeconds).to.equal(maxStalenessSeconds);
+    });
+
+    it('should not accept mode=primary + tags', function() {
+      expect(() => new ReadPreference(PRIMARY, TAGS)).to.throw(
+        'Primary read preference cannot be combined with tags'
+      );
+    });
+
+    it('should not accept mode=primary + options.maxStalenessSeconds', function() {
+      expect(() => new ReadPreference(PRIMARY, null, { maxStalenessSeconds })).to.throw(
+        'Primary read preference cannot be combined with maxStalenessSeconds'
+      );
+    });
+
+    it('should accept (mode=secondary, tags=null, options)', function() {
+      const p2 = new ReadPreference(SECONDARY, null, { maxStalenessSeconds });
+      expect(p2).to.be.an.instanceOf(ReadPreference);
+      expect(p2.mode).to.equal(SECONDARY);
+      expect(p2.maxStalenessSeconds).to.equal(maxStalenessSeconds);
+    });
+
+    it('should accept (mode=secondary, tags, options)', function() {
+      const p3 = new ReadPreference(SECONDARY, TAGS, { maxStalenessSeconds });
+      expect(p3).to.be.an.instanceOf(ReadPreference);
+      expect(p3.mode).to.equal(SECONDARY);
+      expect(p3.tags).to.eql(TAGS);
+      expect(p3.maxStalenessSeconds).to.equal(maxStalenessSeconds);
+    });
+
+    it('should not accept (mode, options, tags)', function() {
+      expect(() => new ReadPreference(PRIMARY, { maxStalenessSeconds }, TAGS)).to.throw(
+        'ReadPreference tags must be an array'
+      );
+    });
   });
 });


### PR DESCRIPTION
## Description

lib/core/topologies/read_preference.js: TODO(major): tags MUST be an array of tagsets

NODE-2323

**What changed?**

Previously if a non-array was passed in, it would implicitly be converted into a 1-element array containing that value.

Now it will throw a TypeError.

~~**Are there any files to ignore?**~~
