### PR TITLE
refactor: throw if 3rd arg to findOne passed but not callback

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1072,9 +1072,8 @@ Collection.prototype.findOne = deprecateOptions(
     optionsIndex: 1
   },
   function(query, options, callback) {
-    if (typeof callback === 'object') {
-      // TODO(MAJOR): throw in the future
-      console.warn('Third parameter to `findOne()` must be a callback or undefined');
+    if (callback !== undefined && typeof callback !== 'function') {
+      throw new TypeError('Third parameter to `findOne()` must be a callback or undefined');
     }
 
     if (typeof query === 'function') (callback = query), (query = {}), (options = {});


### PR DESCRIPTION
## Description

NODE-2322

**What changed?**

Previously, would console.warn if callback to findOne was a bad type, now it will throw a TypeError.

~~**Are there any files to ignore?**~~
