### PR TITLE
fix(cursor): transforms should only be applied once to documents

### DIFF
--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -359,15 +359,6 @@ class CoreCursor extends Readable {
         return this.push(this.cursorState.streamOptions.transform(result));
       }
 
-      // If we provided a map function
-      if (
-        this.cursorState.transforms &&
-        typeof this.cursorState.transforms.doc === 'function' &&
-        result != null
-      ) {
-        return this.push(this.cursorState.transforms.doc(result));
-      }
-
       // Return the result
       this.push(result);
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -819,6 +819,7 @@ class Cursor extends CoreCursor {
         driver: true
       });
     }
+
     return maybePromise(this, callback, cb => {
       const cursor = this;
       const items = [];
@@ -846,12 +847,6 @@ class Cursor extends CoreCursor {
           // Get all buffered objects
           if (cursor.bufferedCount() > 0) {
             let docs = cursor.readBufferedDocuments(cursor.bufferedCount());
-
-            // Transform the doc if transform method added
-            if (cursor.s.transforms && typeof cursor.s.transforms.doc === 'function') {
-              docs = docs.map(cursor.s.transforms.doc);
-            }
-
             Array.prototype.push.apply(items, docs);
           }
 


### PR DESCRIPTION
A regression in merging the core cursor into the native codebase
resultied in a document transform (set with the `.map` helper) to
be applied to incoming documents twice.

NODE-2503