### PR TITLE
NODE-2416/Confusing documentation for collection.aggregate collation option

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1871,7 +1871,7 @@ Collection.prototype.findAndRemove = deprecate(function(query, sort, options, ca
  * @param {boolean} [options.promoteLongs=true] Promotes Long values to number if they fit inside the 53 bits resolution.
  * @param {boolean} [options.promoteValues=true] Promotes BSON values to native types where possible, set to false to only receive wrapper types.
  * @param {boolean} [options.promoteBuffers=false] Promotes Binary BSON values to native Node Buffers.
- * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
+ * @param {object} [options.collation] Specify collation settings for operation. See {@link https://docs.mongodb.com/manual/reference/command/aggregate|aggregation documentation}.
  * @param {string} [options.comment] Add a comment to an aggregation command
  * @param {string|object} [options.hint] Add an index selection hint to an aggregation command
  * @param {ClientSession} [options.session] optional session to use for this operation


### PR DESCRIPTION
## Confusing documentation for collection.aggregate collation option
https://jira.mongodb.org/browse/NODE-2416
**What changed?**
Fix an error in the docs for the aggregate op on a collection. Specifically the collation options did not have the correct text.