### PR TITLE
fix(sessions): don't throw if `withTransaction()` callback rejects with a null reason

### DIFF
--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -304,6 +304,7 @@ function isUnknownTransactionCommitResult(err) {
 }
 
 function isMaxTimeMSExpiredError(err) {
+  if (err == null) return false;
   return (
     err.code === MAX_TIME_MS_EXPIRED_CODE ||
     (err.writeConcernError && err.writeConcernError.code === MAX_TIME_MS_EXPIRED_CODE)

--- a/test/functional/transactions.test.js
+++ b/test/functional/transactions.test.js
@@ -75,6 +75,23 @@ describe('Transactions', function() {
         session.endSession(done);
       }
     });
+
+    it('should return readable error if promise rejected with no reason', {
+      metadata: { requires: { topology: ['replicaset', 'sharded'], mongodb: '>=4.0.2' } },
+      test: function(done) {
+        function fnThatReturnsBadPromise() {
+          return Promise.reject();
+        }
+
+        session
+          .withTransaction(fnThatReturnsBadPromise)
+          .then(() => done(Error('Expected error')))
+          .catch(err => {
+            expect(err).to.equal(undefined);
+            session.endSession(done);
+          });
+      }
+    });
   });
 
   describe('startTransaction', function() {


### PR DESCRIPTION

## Description

See: Automattic/mongoose#8637 . The issue is that if you do session.withTransaction(() => Promise.reject()), you get a TypeError: Cannot read property 'code' of undefined error.

Re: #2252, just against 3.5 branch so it can land in 3.5.6.

**What changed?**

One liner checking for null

**Are there any files to ignore?**

Nope
