### PR TITLE
Prereq spec testing for NODE-2452

### DIFF
--- a/test/spec/initial-dns-seedlist-discovery/direct-connection-false.json
+++ b/test/spec/initial-dns-seedlist-discovery/direct-connection-false.json
@@ -1,0 +1,14 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?directConnection=false",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "ssl": true
+  }
+}

--- a/test/spec/initial-dns-seedlist-discovery/direct-connection-false.yml
+++ b/test/spec/initial-dns-seedlist-discovery/direct-connection-false.yml
@@ -1,0 +1,9 @@
+uri: "mongodb+srv://test3.test.build.10gen.cc/?directConnection=false"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    ssl: true

--- a/test/spec/initial-dns-seedlist-discovery/direct-connection-true.json
+++ b/test/spec/initial-dns-seedlist-discovery/direct-connection-true.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?directConnection=true",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because directConnection=true is incompatible with SRV URIs."
+}

--- a/test/spec/initial-dns-seedlist-discovery/direct-connection-true.yml
+++ b/test/spec/initial-dns-seedlist-discovery/direct-connection-true.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test3.test.build.10gen.cc/?directConnection=true"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because directConnection=true is incompatible with SRV URIs.

--- a/test/spec/server-discovery-and-monitoring/rs/compatible.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/compatible.yml
@@ -1,5 +1,7 @@
 description: "Replica set member with large maxWireVersion"
+
 uri: "mongodb://a,b/?replicaSet=rs"
+
 phases: [
     {
         responses: [

--- a/test/spec/server-discovery-and-monitoring/rs/compatible_unknown.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/compatible_unknown.yml
@@ -1,5 +1,7 @@
 description: "Replica set member and an unknown server"
+
 uri: "mongodb://a,b/?replicaSet=rs"
+
 phases: [
     {
         responses: [

--- a/test/spec/server-discovery-and-monitoring/rs/discover_arbiters.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_arbiters.json
@@ -1,6 +1,6 @@
 {
-  "description": "Discover arbiters",
-  "uri": "mongodb://a/?replicaSet=rs",
+  "description": "Discover arbiters with directConnection URI option",
+  "uri": "mongodb://a/?directConnection=false",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/rs/discover_arbiters.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_arbiters.yml
@@ -1,6 +1,6 @@
-description: "Discover arbiters"
+description: "Discover arbiters with directConnection URI option"
 
-uri: "mongodb://a/?replicaSet=rs"
+uri: "mongodb://a/?directConnection=false"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/rs/discover_arbiters_replicaset.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_arbiters_replicaset.json
@@ -1,0 +1,41 @@
+{
+  "description": "Discover arbiters with replicaSet URI option",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "arbiters": [
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/discover_arbiters_replicaset.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_arbiters_replicaset.yml
@@ -1,0 +1,43 @@
+description: "Discover arbiters with replicaSet URI option"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    hosts: ["a:27017"],
+                    arbiters: ["b:27017"],
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/discover_ghost.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_ghost.json
@@ -1,6 +1,6 @@
 {
-  "description": "Ghost discovered",
-  "uri": "mongodb://a,b/?replicaSet=rs",
+  "description": "Discover ghost with directConnection URI option",
+  "uri": "mongodb://b/?directConnection=false",
   "phases": [
     {
       "responses": [
@@ -17,18 +17,14 @@
       ],
       "outcome": {
         "servers": {
-          "a:27017": {
-            "type": "Unknown",
-            "setName": null
-          },
           "b:27017": {
             "type": "RSGhost",
             "setName": null
           }
         },
-        "topologyType": "ReplicaSetNoPrimary",
+        "topologyType": "Unknown",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": null
       }
     }
   ]

--- a/test/spec/server-discovery-and-monitoring/rs/discover_ghost.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_ghost.yml
@@ -1,0 +1,35 @@
+description: "Discover ghost with directConnection URI option"
+
+uri: "mongodb://b/?directConnection=false"
+
+phases: [
+
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    isreplicaset: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "b:27017": {
+
+                    type: "RSGhost",
+                    setName:
+                }
+            },
+            topologyType: "Unknown",
+            logicalSessionTimeoutMinutes: null,
+            setName:
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/discover_ghost_replicaset.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_ghost_replicaset.json
@@ -1,0 +1,35 @@
+{
+  "description": "Discover ghost with replicaSet URI option",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "isreplicaset": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "RSGhost",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/discover_ghost_replicaset.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_ghost_replicaset.yml
@@ -1,0 +1,41 @@
+description: "Discover ghost with replicaSet URI option"
+
+uri: "mongodb://a,b/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    isreplicaset: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "Unknown",
+                    setName:
+                },
+
+                "b:27017": {
+
+                    type: "RSGhost",
+                    setName:
+                }
+            },
+            topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/discover_hidden.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_hidden.json
@@ -1,0 +1,45 @@
+{
+  "description": "Discover hidden with directConnection URI option",
+  "uri": "mongodb://a/?directConnection=false",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "c:27017",
+              "d:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "d:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/discover_hidden.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_hidden.yml
@@ -1,0 +1,50 @@
+description: "Discover hidden with directConnection URI option"
+
+uri: "mongodb://a/?directConnection=false"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    hidden: true,
+                    hosts: ["c:27017", "d:27017"],
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }],
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSOther",
+                    setName: "rs"
+                },
+
+                "c:27017": {
+
+                    type: "Unknown",
+                    setName: 
+                },
+
+                "d:27017": {
+
+                    type: "Unknown",
+                    setName: 
+                }
+            },
+            topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/discover_hidden_replicaset.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_hidden_replicaset.json
@@ -1,6 +1,6 @@
 {
-  "description": "RSOther discovered",
-  "uri": "mongodb://a,b/?replicaSet=rs",
+  "description": "Discover hidden with replicaSet URI option",
+  "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
       "responses": [
@@ -19,30 +19,11 @@
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
-        ],
-        [
-          "b:27017",
-          {
-            "ok": 1,
-            "ismaster": false,
-            "secondary": false,
-            "hosts": [
-              "c:27017",
-              "d:27017"
-            ],
-            "setName": "rs",
-            "minWireVersion": 0,
-            "maxWireVersion": 6
-          }
         ]
       ],
       "outcome": {
         "servers": {
           "a:27017": {
-            "type": "RSOther",
-            "setName": "rs"
-          },
-          "b:27017": {
             "type": "RSOther",
             "setName": "rs"
           },

--- a/test/spec/server-discovery-and-monitoring/rs/discover_hidden_replicaset.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_hidden_replicaset.yml
@@ -1,6 +1,6 @@
-description: "RSOther discovered"
+description: "Discover hidden with replicaSet URI option"
 
-uri: "mongodb://a,b/?replicaSet=rs"
+uri: "mongodb://a/?replicaSet=rs"
 
 phases: [
 
@@ -18,16 +18,6 @@ phases: [
                     minWireVersion: 0,
                     maxWireVersion: 6
                 }],
-                ["b:27017", {
-
-                    ok: 1,
-                    ismaster: false,
-                    secondary: false,
-                    hosts: ["c:27017", "d:27017"],
-                    setName: "rs",
-                    minWireVersion: 0,
-                    maxWireVersion: 6
-                }]
         ],
 
         outcome: {
@@ -35,12 +25,6 @@ phases: [
             servers: {
 
                 "a:27017": {
-
-                    type: "RSOther",
-                    setName: "rs"
-                },
-
-                "b:27017": {
 
                     type: "RSOther",
                     setName: "rs"

--- a/test/spec/server-discovery-and-monitoring/rs/discover_passives.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_passives.json
@@ -1,6 +1,6 @@
 {
-  "description": "Discover passives",
-  "uri": "mongodb://a/?replicaSet=rs",
+  "description": "Discover passives with directConnection URI option",
+  "uri": "mongodb://a/?directConnection=false",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/rs/discover_passives.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_passives.yml
@@ -1,6 +1,6 @@
-description: "Discover passives"
+description: "Discover passives with directConnection URI option"
 
-uri: "mongodb://a/?replicaSet=rs"
+uri: "mongodb://a/?directConnection=false"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/rs/discover_passives_replicaset.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_passives_replicaset.json
@@ -1,0 +1,78 @@
+{
+  "description": "Discover passives with replicaSet URI option",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "passives": [
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "passive": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "passives": [
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/discover_passives_replicaset.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_passives_replicaset.yml
@@ -1,0 +1,81 @@
+description: "Discover passives with replicaSet URI option"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    hosts: ["a:27017"],
+                    passives: ["b:27017"],
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    },
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    passive: true,
+                    hosts: ["a:27017"],
+                    passives: ["b:27017"],
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/discover_primary.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_primary.json
@@ -1,6 +1,6 @@
 {
-  "description": "Replica set discovery from primary",
-  "uri": "mongodb://a/?replicaSet=rs",
+  "description": "Discover primary with directConnection URI option",
+  "uri": "mongodb://a/?directConnection=false",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/rs/discover_primary.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_primary.yml
@@ -1,6 +1,6 @@
-description: "Replica set discovery from primary"
+description: "Discover primary with directConnection URI option"
 
-uri: "mongodb://a/?replicaSet=rs"
+uri: "mongodb://a/?directConnection=false"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/rs/discover_primary_replicaset.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_primary_replicaset.json
@@ -1,0 +1,39 @@
+{
+  "description": "Discover primary with replicaSet URI option",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/discover_primary_replicaset.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_primary_replicaset.yml
@@ -1,0 +1,42 @@
+description: "Discover primary with replicaSet URI option"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/discover_rsother.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_rsother.json
@@ -1,0 +1,44 @@
+{
+  "description": "Discover RSOther with directConnection URI option",
+  "uri": "mongodb://b/?directConnection=false",
+  "phases": [
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": false,
+            "hosts": [
+              "c:27017",
+              "d:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "b:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "d:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/discover_rsother.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_rsother.yml
@@ -1,6 +1,6 @@
-description: "Ghost discovered"
+description: "Discover RSOther with directConnection URI option"
 
-uri: "mongodb://a,b/?replicaSet=rs"
+uri: "mongodb://b/?directConnection=false"
 
 phases: [
 
@@ -11,7 +11,9 @@ phases: [
 
                     ok: 1,
                     ismaster: false,
-                    isreplicaset: true,
+                    secondary: false,
+                    hosts: ["c:27017", "d:27017"],
+                    setName: "rs",
                     minWireVersion: 0,
                     maxWireVersion: 6
                 }]
@@ -21,16 +23,22 @@ phases: [
 
             servers: {
 
-                "a:27017": {
-
-                    type: "Unknown",
-                    setName:
-                },
-
                 "b:27017": {
 
-                    type: "RSGhost",
-                    setName:
+                    type: "RSOther",
+                    setName: "rs"
+                },
+
+                "c:27017": {
+
+                    type: "Unknown",
+                    setName: 
+                },
+
+                "d:27017": {
+
+                    type: "Unknown",
+                    setName: 
                 }
             },
             topologyType: "ReplicaSetNoPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/discover_rsother_replicaset.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_rsother_replicaset.json
@@ -1,0 +1,64 @@
+{
+  "description": "Discover RSOther with replicaSet URI option",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "c:27017",
+              "d:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": false,
+            "hosts": [
+              "c:27017",
+              "d:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "d:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/discover_rsother_replicaset.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_rsother_replicaset.yml
@@ -1,0 +1,66 @@
+description: "Discover RSOther with replicaSet URI option"
+
+uri: "mongodb://a,b/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    hidden: true,
+                    hosts: ["c:27017", "d:27017"],
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }],
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: false,
+                    hosts: ["c:27017", "d:27017"],
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSOther",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSOther",
+                    setName: "rs"
+                },
+
+                "c:27017": {
+
+                    type: "Unknown",
+                    setName: 
+                },
+
+                "d:27017": {
+
+                    type: "Unknown",
+                    setName: 
+                }
+            },
+            topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/discover_secondary.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_secondary.json
@@ -1,6 +1,6 @@
 {
-  "description": "Replica set discovery from secondary",
-  "uri": "mongodb://b/?replicaSet=rs",
+  "description": "Discover secondary with directConnection URI option",
+  "uri": "mongodb://b/?directConnection=false",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/rs/discover_secondary.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_secondary.yml
@@ -1,6 +1,6 @@
-description: "Replica set discovery from secondary"
+description: "Discover secondary with directConnection URI option"
 
-uri: "mongodb://b/?replicaSet=rs"
+uri: "mongodb://b/?directConnection=false"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/rs/discover_secondary_replicaset.json
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_secondary_replicaset.json
@@ -1,0 +1,40 @@
+{
+  "description": "Discover secondary with replicaSet URI option",
+  "uri": "mongodb://b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/discover_secondary_replicaset.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/discover_secondary_replicaset.yml
@@ -1,0 +1,43 @@
+description: "Discover secondary with replicaSet URI option"
+
+uri: "mongodb://b/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "Unknown",
+                    setName:
+                },
+
+                "b:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/incompatible_arbiter.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/incompatible_arbiter.yml
@@ -1,5 +1,7 @@
 description: "Incompatible arbiter"
+
 uri: "mongodb://a,b/?replicaSet=rs"
+
 phases:
   - responses:
       -

--- a/test/spec/server-discovery-and-monitoring/rs/incompatible_ghost.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/incompatible_ghost.yml
@@ -1,5 +1,7 @@
 description: "Incompatible ghost"
+
 uri: "mongodb://a,b/?replicaSet=rs"
+
 phases:
   - responses:
       -

--- a/test/spec/server-discovery-and-monitoring/rs/incompatible_other.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/incompatible_other.yml
@@ -1,5 +1,7 @@
 description: "Incompatible other"
+
 uri: "mongodb://a,b/?replicaSet=rs"
+
 phases:
   - responses:
       -

--- a/test/spec/server-discovery-and-monitoring/rs/primary_mismatched_me_not_removed.json
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_mismatched_me_not_removed.json
@@ -1,0 +1,77 @@
+{
+  "description": "Primary mismatched me is not removed",
+  "uri": "mongodb://localhost:27017,localhost:27018/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "localhost:27017",
+          {
+            "ok": 1,
+            "hosts": [
+              "localhost:27017",
+              "localhost:27018"
+            ],
+            "ismaster": true,
+            "setName": "rs",
+            "primary": "localhost:27017",
+            "me": "a:27017",
+            "minWireVersion": 0,
+            "maxWireVersion": 7
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "localhost:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "localhost:27018": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "localhost:27018",
+          {
+            "ok": 1,
+            "hosts": [
+              "localhost:27017",
+              "localhost:27018"
+            ],
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "primary": "localhost:27017",
+            "me": "localhost:27018",
+            "minWireVersion": 0,
+            "maxWireVersion": 7
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "localhost:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "localhost:27018": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/primary_mismatched_me_not_removed.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_mismatched_me_not_removed.yml
@@ -1,0 +1,73 @@
+description: Primary mismatched me is not removed
+uri: mongodb://localhost:27017,localhost:27018/?replicaSet=rs
+
+phases: [
+  {
+    responses: [
+      ["localhost:27017", {
+        ok: 1,
+        hosts: [
+          "localhost:27017",
+          "localhost:27018"
+        ],
+        ismaster: true,
+        setName: "rs",
+        primary: "localhost:27017",
+        # me does not match the primary responder's address, but the server
+        # is still added because we don't me mismatch check the primary and all
+        # servers from a primary ismaster are added to the working server set
+        me: "a:27017",
+        minWireVersion: 0,
+        maxWireVersion: 7
+      }]
+    ],
+    outcome: {
+      servers: {
+        "localhost:27017": {
+          type: "RSPrimary",
+          setName: "rs"
+        },
+        "localhost:27018": {
+          type: "Unknown",
+          setName: null
+        }
+      },
+      topologyType: "ReplicaSetWithPrimary",
+      logicalSessionTimeoutMinutes: null,
+      setName: "rs"
+    }
+  },
+  {
+    responses: [
+      ["localhost:27018", {
+        ok: 1,
+        hosts: [
+          "localhost:27017",
+          "localhost:27018"
+        ],
+        ismaster: false,
+        secondary: true,
+        setName: "rs",
+        primary: "localhost:27017",
+        me: "localhost:27018",
+        minWireVersion: 0,
+        maxWireVersion: 7
+      }]
+    ],
+    outcome: {
+      servers: {
+        "localhost:27017": {
+          type: "RSPrimary",
+          setName: "rs"
+        },
+        "localhost:27018": {
+          type: "RSSecondary",
+          setName: "rs"
+        }
+      },
+      topologyType: "ReplicaSetWithPrimary",
+      logicalSessionTimeoutMinutes: null,
+      setName: "rs"
+    }
+  }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/repeated.json
+++ b/test/spec/server-discovery-and-monitoring/rs/repeated.json
@@ -1,0 +1,140 @@
+{
+  "description": "Repeated ismaster response must be processed",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/repeated.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/repeated.yml
@@ -1,0 +1,101 @@
+description: Repeated ismaster response must be processed
+
+uri: "mongodb://a,b/?replicaSet=rs"
+
+phases:
+  # Phase 1 - a says it's not primary and suggests c may be the primary
+  - responses:
+    -
+      - "a:27017"
+      - ok: 1
+        ismaster: false
+        secondary: true
+        hidden: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+        
+        "c:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 2 - c says it's a standalone, is removed
+  - responses:
+    -
+      - "c:27017"
+      - ok: 1
+        ismaster: true
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 3 - response from a is repeated, and must be processed; c added again
+  - responses:
+    -
+      - "a:27017"
+      - ok: 1
+        ismaster: false
+        secondary: true
+        hidden: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+        
+        "c:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 4 - c is now a primary
+  - responses:
+    -
+      - "c:27017"
+      - ok: 1
+        ismaster: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "c:27017":
+          type: RSPrimary
+          setName: rs
+      topologyType: "ReplicaSetWithPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"

--- a/test/spec/server-discovery-and-monitoring/rs/replicaset_rsnp.json
+++ b/test/spec/server-discovery-and-monitoring/rs/replicaset_rsnp.json
@@ -1,0 +1,25 @@
+{
+  "description": "replicaSet URI option causes starting topology to be RSNP",
+  "uri": "mongodb://a/?replicaSet=rs&directConnection=false",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {},
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/replicaset_rsnp.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/replicaset_rsnp.yml
@@ -1,0 +1,20 @@
+description: replicaSet URI option causes starting topology to be RSNP
+
+uri: "mongodb://a/?replicaSet=rs&directConnection=false"
+
+phases:
+  # We are connecting to a standalone
+  - responses:
+    -
+      - "a:27017"
+      - ok: 1
+        ismaster: true
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      # Server is removed because it's a standalone and the driver
+      # started in RSNP topology
+      servers: {}
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"

--- a/test/spec/server-discovery-and-monitoring/rs/secondary_mismatched_me.json
+++ b/test/spec/server-discovery-and-monitoring/rs/secondary_mismatched_me.json
@@ -1,5 +1,6 @@
 {
   "description": "Secondary mismatched me",
+  "uri": "mongodb://localhost:27017/?replicaSet=rs",
   "phases": [
     {
       "outcome": {
@@ -35,6 +36,5 @@
         ]
       ]
     }
-  ],
-  "uri": "mongodb://localhost:27017/?replicaSet=rs"
+  ]
 }

--- a/test/spec/server-discovery-and-monitoring/rs/secondary_mismatched_me.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/secondary_mismatched_me.yml
@@ -1,4 +1,7 @@
 description: Secondary mismatched me
+
+uri: 'mongodb://localhost:27017/?replicaSet=rs'
+
 phases:
   - outcome:
       servers:
@@ -22,5 +25,3 @@ phases:
           setName: rs
           minWireVersion: 0
           maxWireVersion: 6
-uri: 'mongodb://localhost:27017/?replicaSet=rs'
-

--- a/test/spec/server-discovery-and-monitoring/rs/too_new.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/too_new.yml
@@ -1,5 +1,7 @@
 description: "Replica set member with large minWireVersion"
+
 uri: "mongodb://a,b/?replicaSet=rs"
+
 phases: [
     {
         responses: [

--- a/test/spec/server-discovery-and-monitoring/sharded/discover_single_mongos.json
+++ b/test/spec/server-discovery-and-monitoring/sharded/discover_single_mongos.json
@@ -1,0 +1,30 @@
+{
+  "description": "Discover single mongos",
+  "uri": "mongodb://a/?directConnection=false",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "setName": null
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/sharded/discover_single_mongos.yml
+++ b/test/spec/server-discovery-and-monitoring/sharded/discover_single_mongos.yml
@@ -1,0 +1,23 @@
+description: "Discover single mongos"
+
+uri: "mongodb://a/?directConnection=false"
+
+phases:
+
+  - responses:
+    -
+      - "a:27017"
+      -
+        ok: 1
+        ismaster: true
+        msg: "isdbgrid"
+        minWireVersion: 0
+        maxWireVersion: 6
+    
+    outcome:
+      servers:
+        "a:27017":
+          type: "Mongos"
+          setName:
+      topologyType: "Sharded"
+      setName:

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_external_ip.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_external_ip.json
@@ -1,6 +1,6 @@
 {
   "description": "Direct connection to RSPrimary via external IP",
-  "uri": "mongodb://a",
+  "uri": "mongodb://a/?directConnection=true",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_external_ip.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_external_ip.yml
@@ -1,6 +1,6 @@
 description: "Direct connection to RSPrimary via external IP"
 
-uri: "mongodb://a"
+uri: "mongodb://a/?directConnection=true"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_mongos.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_mongos.json
@@ -1,6 +1,6 @@
 {
-  "description": "Connect to mongos",
-  "uri": "mongodb://a",
+  "description": "Direct connection to mongos",
+  "uri": "mongodb://a/?directConnection=true",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_mongos.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_mongos.yml
@@ -1,6 +1,6 @@
-description: "Connect to mongos"
+description: "Direct connection to mongos"
 
-uri: "mongodb://a"
+uri: "mongodb://a/?directConnection=true"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_replicaset.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_replicaset.json
@@ -1,0 +1,31 @@
+{
+  "description": "Direct connection with replicaSet URI option",
+  "uri": "mongodb://a/?replicaSet=rs&directConnection=true",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_replicaset.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_replicaset.yml
@@ -1,0 +1,22 @@
+description: Direct connection with replicaSet URI option
+
+uri: "mongodb://a/?replicaSet=rs&directConnection=true"
+
+phases:
+  # We are connecting to a replica set member
+  - responses:
+    -
+      - "a:27017"
+      - ok: 1
+        ismaster: true
+        setName: rs
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSPrimary"
+          setName: "rs"
+      topologyType: "Single"
+      logicalSessionTimeoutMinutes:
+      setName: rs

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_rsarbiter.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_rsarbiter.json
@@ -1,6 +1,6 @@
 {
-  "description": "Connect to RSArbiter",
-  "uri": "mongodb://a",
+  "description": "Direct connection to RSArbiter",
+  "uri": "mongodb://a/?directConnection=true",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_rsarbiter.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_rsarbiter.yml
@@ -1,6 +1,6 @@
-description: "Connect to RSArbiter"
+description: "Direct connection to RSArbiter"
 
-uri: "mongodb://a"
+uri: "mongodb://a/?directConnection=true"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_rsprimary.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_rsprimary.json
@@ -1,6 +1,6 @@
 {
-  "description": "Connect to RSPrimary",
-  "uri": "mongodb://a",
+  "description": "Direct connection to RSPrimary",
+  "uri": "mongodb://a/?directConnection=true",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_rsprimary.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_rsprimary.yml
@@ -1,6 +1,6 @@
-description: "Connect to RSPrimary"
+description: "Direct connection to RSPrimary"
 
-uri: "mongodb://a"
+uri: "mongodb://a/?directConnection=true"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_rssecondary.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_rssecondary.json
@@ -1,6 +1,6 @@
 {
-  "description": "Connect to RSSecondary",
-  "uri": "mongodb://a",
+  "description": "Direct connection to RSSecondary",
+  "uri": "mongodb://a/?directConnection=true",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_rssecondary.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_rssecondary.yml
@@ -1,6 +1,6 @@
-description: "Connect to RSSecondary"
+description: "Direct connection to RSSecondary"
 
-uri: "mongodb://a"
+uri: "mongodb://a/?directConnection=true"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_slave.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_slave.json
@@ -1,6 +1,6 @@
 {
   "description": "Direct connection to slave",
-  "uri": "mongodb://a",
+  "uri": "mongodb://a/?directConnection=true",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_slave.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_slave.yml
@@ -1,6 +1,6 @@
 description: "Direct connection to slave"
 
-uri: "mongodb://a"
+uri: "mongodb://a/?directConnection=true"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_standalone.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_standalone.json
@@ -1,6 +1,6 @@
 {
-  "description": "Connect to standalone",
-  "uri": "mongodb://a",
+  "description": "Direct connection to standalone",
+  "uri": "mongodb://a/?directConnection=true",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_standalone.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_standalone.yml
@@ -1,6 +1,6 @@
-description: "Connect to standalone"
+description: "Direct connection to standalone"
 
-uri: "mongodb://a"
+uri: "mongodb://a/?directConnection=true"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_unavailable_seed.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_unavailable_seed.json
@@ -1,6 +1,6 @@
 {
-  "description": "Unavailable seed",
-  "uri": "mongodb://a",
+  "description": "Direct connection to unavailable seed",
+  "uri": "mongodb://a/?directConnection=true",
   "phases": [
     {
       "responses": [

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_unavailable_seed.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_unavailable_seed.yml
@@ -1,6 +1,6 @@
-description: "Unavailable seed"
+description: "Direct connection to unavailable seed"
 
-uri: "mongodb://a"
+uri: "mongodb://a/?directConnection=true"
 
 phases: [
 

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_wrong_set_name.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_wrong_set_name.json
@@ -1,0 +1,35 @@
+{
+  "description": "Direct connection to RSPrimary with wrong set name",
+  "uri": "mongodb://a/?directConnection=true&replicaSet=wrong",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "wrong"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_wrong_set_name.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_wrong_set_name.yml
@@ -1,0 +1,36 @@
+description: "Direct connection to RSPrimary with wrong set name"
+
+uri: "mongodb://a/?directConnection=true&replicaSet=wrong"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                   ok: 1,
+                   ismaster: true,
+                   hosts: ["a:27017", "b:27017"],
+                   setName: "rs",
+                   minWireVersion: 0,
+                   maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
+            setName: wrong
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/single/discover_standalone.json
+++ b/test/spec/server-discovery-and-monitoring/single/discover_standalone.json
@@ -1,0 +1,30 @@
+{
+  "description": "Discover standalone",
+  "uri": "mongodb://a/?directConnection=false",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/single/discover_standalone.yml
+++ b/test/spec/server-discovery-and-monitoring/single/discover_standalone.yml
@@ -1,0 +1,34 @@
+description: "Discover standalone"
+
+uri: "mongodb://a/?directConnection=false"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "Standalone",
+                    setName:
+                }
+            },
+            topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
+            setName:
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/single/discover_unavailable_seed.json
+++ b/test/spec/server-discovery-and-monitoring/single/discover_unavailable_seed.json
@@ -1,0 +1,25 @@
+{
+  "description": "Discover unavailable seed",
+  "uri": "mongodb://a/?directConnection=false",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {}
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "Unknown",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/single/discover_unavailable_seed.yml
+++ b/test/spec/server-discovery-and-monitoring/single/discover_unavailable_seed.yml
@@ -1,0 +1,28 @@
+description: "Discover unavailable seed"
+
+uri: "mongodb://a/?directConnection=false"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {}]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+            },
+            topologyType: "Unknown",
+            logicalSessionTimeoutMinutes: null,
+            setName:
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/single/too_old_then_upgraded.json
+++ b/test/spec/server-discovery-and-monitoring/single/too_old_then_upgraded.json
@@ -1,0 +1,54 @@
+{
+  "description": "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 6",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": false
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/single/too_old_then_upgraded.yml
+++ b/test/spec/server-discovery-and-monitoring/single/too_old_then_upgraded.yml
@@ -1,0 +1,46 @@
+description: "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 6"
+uri: "mongodb://a"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Standalone",
+                    setName:
+                }
+            },
+            topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
+            setName: ,
+            compatible: false
+        }
+    },
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Standalone",
+                    setName:
+                }
+            },
+            topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
+            setName: ,
+            compatible: true
+        }
+    }
+]

--- a/test/spec/uri-options/README.rst
+++ b/test/spec/uri-options/README.rst
@@ -21,10 +21,7 @@ array of test case objects, each of which have the following keys:
 
 - ``description``: A string describing the test.
 - ``uri``: A string containing the URI to be parsed.
-- ``valid``: A boolean indicating if the URI should be considered valid. 
-  This will always be true, as the Connection String spec tests the validity of the structure, but 
-  it's still included to make it easier to reuse the connection string spec test runners that 
-  drivers already have.
+- ``valid``: A boolean indicating if the URI should be considered valid.
 - ``warning``: A boolean indicating whether URI parsing should emit a warning.
 - ``hosts``: Included for compatibility with the Connection String spec tests. This will always be ``~``.
 - ``auth``: Included for compatibility with the Connection String spec tests. This will always be ``~``.

--- a/test/spec/uri-options/auth-options.json
+++ b/test/spec/uri-options/auth-options.json
@@ -1,7 +1,7 @@
 {
   "tests": [
     {
-      "description": "Valid auth options are parsed correctly",
+      "description": "Valid auth options are parsed correctly (GSSAPI)",
       "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external",
       "valid": true,
       "warning": false,
@@ -14,6 +14,18 @@
           "CANONICALIZE_HOST_NAME": true
         },
         "authSource": "$external"
+      }
+    },
+    {
+      "description": "Valid auth options are parsed correctly (SCRAM-SHA-1)",
+      "uri": "mongodb://foo:bar@example.com/?authMechanism=SCRAM-SHA-1&authSource=authSourceDB",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "authMechanism": "SCRAM-SHA-1",
+        "authSource": "authSourceDB"
       }
     }
   ]

--- a/test/spec/uri-options/auth-options.yml
+++ b/test/spec/uri-options/auth-options.yml
@@ -1,6 +1,6 @@
 tests:
     -
-        description: "Valid auth options are parsed correctly"
+        description: "Valid auth options are parsed correctly (GSSAPI)"
         uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external"
         valid: true
         warning: false
@@ -12,3 +12,13 @@ tests:
                 SERVICE_NAME: "other"
                 CANONICALIZE_HOST_NAME: true
             authSource: "$external"
+    -
+        description: "Valid auth options are parsed correctly (SCRAM-SHA-1)"
+        uri: "mongodb://foo:bar@example.com/?authMechanism=SCRAM-SHA-1&authSource=authSourceDB"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
+            authMechanism: "SCRAM-SHA-1"
+            authSource: "authSourceDB"

--- a/test/spec/uri-options/concern-options.json
+++ b/test/spec/uri-options/concern-options.json
@@ -37,15 +37,6 @@
       }
     },
     {
-      "description": "Too low w causes a warning",
-      "uri": "mongodb://example.com/?w=-2",
-      "valid": true,
-      "warning": true,
-      "hosts": null,
-      "auth": null,
-      "options": {}
-    },
-    {
       "description": "Non-numeric wTimeoutMS causes a warning",
       "uri": "mongodb://example.com/?wTimeoutMS=invalid",
       "valid": true,

--- a/test/spec/uri-options/connection-options.json
+++ b/test/spec/uri-options/connection-options.json
@@ -117,6 +117,56 @@
       "hosts": null,
       "auth": null,
       "options": {}
+    },
+    {
+      "description": "directConnection=true",
+      "uri": "mongodb://example.com/?directConnection=true",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "directConnection": true
+      }
+    },
+    {
+      "description": "directConnection=true with multiple seeds",
+      "uri": "mongodb://example1.com,example2.com/?directConnection=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null
+    },
+    {
+      "description": "directConnection=false",
+      "uri": "mongodb://example.com/?directConnection=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "directConnection": false
+      }
+    },
+    {
+      "description": "directConnection=false with multiple seeds",
+      "uri": "mongodb://example1.com,example2.com/?directConnection=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "directConnection": false
+      }
+    },
+    {
+      "description": "Invalid directConnection value",
+      "uri": "mongodb://example.com/?directConnection=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
     }
   ]
 }

--- a/test/spec/uri-options/connection-options.yml
+++ b/test/spec/uri-options/connection-options.yml
@@ -104,3 +104,46 @@ tests:
         hosts: ~
         auth: ~
         options: {}
+
+    -
+      description: directConnection=true
+      uri: "mongodb://example.com/?directConnection=true"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          directConnection: true
+    -
+      description: directConnection=true with multiple seeds
+      uri: "mongodb://example1.com,example2.com/?directConnection=true"
+      valid: false
+      warning: false
+      hosts: ~
+      auth: ~
+    -
+      description: directConnection=false
+      uri: "mongodb://example.com/?directConnection=false"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          directConnection: false
+    -
+      description: directConnection=false with multiple seeds
+      uri: "mongodb://example1.com,example2.com/?directConnection=false"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          directConnection: false
+    -
+      description: Invalid directConnection value
+      uri: "mongodb://example.com/?directConnection=invalid"
+      valid: true
+      warning: true
+      hosts: ~
+      auth: ~
+      options: {}

--- a/test/spec/uri-options/tls-options.json
+++ b/test/spec/uri-options/tls-options.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "Valid required tls options are parsed correctly",
-      "uri": "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem&tlsCertificateKeyFilePassword=hunter2",
+      "uri": "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem",
       "valid": true,
       "warning": false,
       "hosts": null,
@@ -10,7 +10,17 @@
       "options": {
         "tls": true,
         "tlsCAFile": "ca.pem",
-        "tlsCertificateKeyFile": "cert.pem",
+        "tlsCertificateKeyFile": "cert.pem"
+      }
+    },
+    {
+      "description": "Valid tlsCertificateKeyFilePassword is parsed correctly",
+      "uri": "mongodb://example.com/?tlsCertificateKeyFilePassword=hunter2",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
         "tlsCertificateKeyFilePassword": "hunter2"
       }
     },
@@ -75,8 +85,8 @@
       }
     },
     {
-      "description": "Invalid tlsAllowInsecure causes a warning",
-      "uri": "mongodb://example.com/?tlsAllowInsecure=invalid",
+      "description": "Invalid tlsInsecure causes a warning",
+      "uri": "mongodb://example.com/?tlsInsecure=invalid",
       "valid": true,
       "warning": true,
       "hosts": null,
@@ -221,6 +231,414 @@
     {
       "description": "ssl=true and tls=false raises error",
       "uri": "mongodb://example.com/?ssl=true&tls=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck can be set to true",
+      "uri": "mongodb://example.com/?tls=true&tlsDisableCertificateRevocationCheck=true",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "tls": true,
+        "tlsDisableCertificateRevocationCheck": true
+      }
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck can be set to false",
+      "uri": "mongodb://example.com/?tls=true&tlsDisableCertificateRevocationCheck=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "tls": true,
+        "tlsDisableCertificateRevocationCheck": false
+      }
+    },
+    {
+      "description": "tlsAllowInvalidCertificates and tlsDisableCertificateRevocationCheck both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsDisableCertificateRevocationCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidCertificates=true and tlsDisableCertificateRevocationCheck=false raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsDisableCertificateRevocationCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidCertificates=false and tlsDisableCertificateRevocationCheck=true raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableCertificateRevocationCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidCertificates and tlsDisableCertificateRevocationCheck both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableCertificateRevocationCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck and tlsAllowInvalidCertificates both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsAllowInvalidCertificates=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck=true and tlsAllowInvalidCertificates=false raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsAllowInvalidCertificates=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck=false and tlsAllowInvalidCertificates=true raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsAllowInvalidCertificates=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck and tlsAllowInvalidCertificates both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsAllowInvalidCertificates=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsInsecure and tlsDisableCertificateRevocationCheck both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=true&tlsDisableCertificateRevocationCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsInsecure=true and tlsDisableCertificateRevocationCheck=false raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=true&tlsDisableCertificateRevocationCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsInsecure=false and tlsDisableCertificateRevocationCheck=true raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=false&tlsDisableCertificateRevocationCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsInsecure and tlsDisableCertificateRevocationCheck both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=false&tlsDisableCertificateRevocationCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck and tlsInsecure both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsInsecure=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck=true and tlsInsecure=false raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsInsecure=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck=false and tlsInsecure=true raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsInsecure=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck and tlsInsecure both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsInsecure=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck and tlsDisableOCSPEndpointCheck both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsDisableOCSPEndpointCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck=true and tlsDisableOCSPEndpointCheck=false raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsDisableOCSPEndpointCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck=false and tlsDisableOCSPEndpointCheck=true raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsDisableOCSPEndpointCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableCertificateRevocationCheck and tlsDisableOCSPEndpointCheck both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsDisableOCSPEndpointCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck and tlsDisableCertificateRevocationCheck both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsDisableCertificateRevocationCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck=true and tlsDisableCertificateRevocationCheck=false raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsDisableCertificateRevocationCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck=false and tlsDisableCertificateRevocationCheck=true raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsDisableCertificateRevocationCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck and tlsDisableCertificateRevocationCheck both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsDisableCertificateRevocationCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck can be set to true",
+      "uri": "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=true",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "tls": true,
+        "tlsDisableOCSPEndpointCheck": true
+      }
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck can be set to false",
+      "uri": "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "tls": true,
+        "tlsDisableOCSPEndpointCheck": false
+      }
+    },
+    {
+      "description": "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=true&tlsDisableOCSPEndpointCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsInsecure=true and tlsDisableOCSPEndpointCheck=false raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=true&tlsDisableOCSPEndpointCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsInsecure=false and tlsDisableOCSPEndpointCheck=true raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=false&tlsDisableOCSPEndpointCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=false&tlsDisableOCSPEndpointCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsInsecure=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck=true and tlsInsecure=false raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsInsecure=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck=false and tlsInsecure=true raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsInsecure=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsInsecure=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidCertificates and tlsDisableOCSPEndpointCheck both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsDisableOCSPEndpointCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidCertificates=true and tlsDisableOCSPEndpointCheck=false raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsDisableOCSPEndpointCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidCertificates=false and tlsDisableOCSPEndpointCheck=true raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableOCSPEndpointCheck=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidCertificates and tlsDisableOCSPEndpointCheck both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableOCSPEndpointCheck=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck and tlsAllowInvalidCertificates both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsAllowInvalidCertificates=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck=true and tlsAllowInvalidCertificates=false raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsAllowInvalidCertificates=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck=false and tlsAllowInvalidCertificates=true raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsAllowInvalidCertificates=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck and tlsAllowInvalidCertificates both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsAllowInvalidCertificates=false",
       "valid": false,
       "warning": false,
       "hosts": null,

--- a/test/spec/uri-options/tls-options.yml
+++ b/test/spec/uri-options/tls-options.yml
@@ -1,7 +1,7 @@
 tests:
     -
         description: "Valid required tls options are parsed correctly"
-        uri: "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem&tlsCertificateKeyFilePassword=hunter2"
+        uri: "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem"
         valid: true
         warning: false
         hosts: ~
@@ -10,8 +10,16 @@ tests:
             tls: true
             tlsCAFile: "ca.pem"
             tlsCertificateKeyFile: "cert.pem"
+    -
+        description: "Valid tlsCertificateKeyFilePassword is parsed correctly"
+        uri: "mongodb://example.com/?tlsCertificateKeyFilePassword=hunter2"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
             tlsCertificateKeyFilePassword: "hunter2"
-    -  
+    -
         description: "Invalid tlsAllowInvalidCertificates causes a warning"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=invalid"
         valid: true
@@ -28,7 +36,7 @@ tests:
         auth: ~
         options:
             tlsAllowInvalidCertificates: true
-    -  
+    -
         description: "Invalid tlsAllowInvalidCertificates causes a warning"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=invalid"
         valid: true
@@ -45,7 +53,7 @@ tests:
         auth: ~
         options:
             tlsAllowInvalidHostnames: true
-    -  
+    -
         description: "Invalid tlsAllowInvalidHostnames causes a warning"
         uri: "mongodb://example.com/?tlsAllowInvalidHostnames=invalid"
         valid: true
@@ -62,9 +70,9 @@ tests:
         auth: ~
         options:
             tlsInsecure: true
-    -  
-        description: "Invalid tlsAllowInsecure causes a warning"
-        uri: "mongodb://example.com/?tlsAllowInsecure=invalid"
+    -
+        description: "Invalid tlsInsecure causes a warning"
+        uri: "mongodb://example.com/?tlsInsecure=invalid"
         valid: true
         warning: true
         hosts: ~
@@ -193,6 +201,376 @@ tests:
     -
         description: "ssl=true and tls=false raises error"
         uri: "mongodb://example.com/?ssl=true&tls=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableCertificateRevocationCheck can be set to true"
+        uri: "mongodb://example.com/?tls=true&tlsDisableCertificateRevocationCheck=true"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
+            tls: true
+            tlsDisableCertificateRevocationCheck: true
+    -
+        description: "tlsDisableCertificateRevocationCheck can be set to false"
+        uri: "mongodb://example.com/?tls=true&tlsDisableCertificateRevocationCheck=false"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
+            tls: true
+            tlsDisableCertificateRevocationCheck: false
+    # 4 permutations of [tlsAllowInvalidCertificates=true/false, tlsDisableCertificateRevocationCheck=true/false]
+    -
+        description: "tlsAllowInvalidCertificates and tlsDisableCertificateRevocationCheck both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsDisableCertificateRevocationCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsAllowInvalidCertificates=true and tlsDisableCertificateRevocationCheck=false raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsDisableCertificateRevocationCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsAllowInvalidCertificates=false and tlsDisableCertificateRevocationCheck=true raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableCertificateRevocationCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsAllowInvalidCertificates and tlsDisableCertificateRevocationCheck both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableCertificateRevocationCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    # 4 permutations of [tlsDisableCertificateRevocationCheck=true/false, tlsAllowInvalidCertificates=true/false]
+    -
+        description: "tlsDisableCertificateRevocationCheck and tlsAllowInvalidCertificates both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsAllowInvalidCertificates=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableCertificateRevocationCheck=true and tlsAllowInvalidCertificates=false raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsAllowInvalidCertificates=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableCertificateRevocationCheck=false and tlsAllowInvalidCertificates=true raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsAllowInvalidCertificates=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableCertificateRevocationCheck and tlsAllowInvalidCertificates both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsAllowInvalidCertificates=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    # 4 permutations of [tlsInsecure=true/false, tlsDisableCertificateRevocationCheck=true/false]
+    -
+        description: "tlsInsecure and tlsDisableCertificateRevocationCheck both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableCertificateRevocationCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsInsecure=true and tlsDisableCertificateRevocationCheck=false raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableCertificateRevocationCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsInsecure=false and tlsDisableCertificateRevocationCheck=true raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableCertificateRevocationCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsInsecure and tlsDisableCertificateRevocationCheck both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableCertificateRevocationCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    # 4 permutations of [tlsDisableCertificateRevocationCheck=true/false, tlsInsecure=true/false]
+    -
+        description: "tlsDisableCertificateRevocationCheck and tlsInsecure both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsInsecure=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableCertificateRevocationCheck=true and tlsInsecure=false raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsInsecure=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableCertificateRevocationCheck=false and tlsInsecure=true raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsInsecure=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableCertificateRevocationCheck and tlsInsecure both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsInsecure=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    # 4 permutations of [tlsDisableCertificateRevocationCheck=true/false, tlsDisableOCSPEndpointCheck=true/false]
+    -
+        description: "tlsDisableCertificateRevocationCheck and tlsDisableOCSPEndpointCheck both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsDisableOCSPEndpointCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableCertificateRevocationCheck=true and tlsDisableOCSPEndpointCheck=false raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsDisableOCSPEndpointCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableCertificateRevocationCheck=false and tlsDisableOCSPEndpointCheck=true raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsDisableOCSPEndpointCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableCertificateRevocationCheck and tlsDisableOCSPEndpointCheck both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsDisableOCSPEndpointCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    # 4 permutations of [tlsDisableOCSPEndpointCheck=true/false, tlsDisableCertificateRevocationCheck=true/false]
+    -
+        description: "tlsDisableOCSPEndpointCheck and tlsDisableCertificateRevocationCheck both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsDisableCertificateRevocationCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableOCSPEndpointCheck=true and tlsDisableCertificateRevocationCheck=false raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsDisableCertificateRevocationCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableOCSPEndpointCheck=false and tlsDisableCertificateRevocationCheck=true raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsDisableCertificateRevocationCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableOCSPEndpointCheck and tlsDisableCertificateRevocationCheck both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsDisableCertificateRevocationCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableOCSPEndpointCheck can be set to true"
+        uri: "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=true"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
+            tls: true
+            tlsDisableOCSPEndpointCheck: true
+    -
+        description: "tlsDisableOCSPEndpointCheck can be set to false"
+        uri: "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=false"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
+            tls: true
+            tlsDisableOCSPEndpointCheck: false
+    # 4 permutations of [tlsInsecure=true/false, tlsDisableOCSPEndpointCheck=true/false]
+    -
+        description: "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableOCSPEndpointCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsInsecure=true and tlsDisableOCSPEndpointCheck=false raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableOCSPEndpointCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsInsecure=false and tlsDisableOCSPEndpointCheck=true raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableOCSPEndpointCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableOCSPEndpointCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    # 4 permutations of [tlsDisableOCSPEndpointCheck=true/false, tlsInsecure=true/false]
+    -
+        description: "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsInsecure=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableOCSPEndpointCheck=true and tlsInsecure=false raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsInsecure=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableOCSPEndpointCheck=false and tlsInsecure=true raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsInsecure=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsInsecure=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    # 4 permutations of [tlsAllowInvalidCertificates=true/false, tlsDisableOCSPEndpointCheck=true/false]
+    -
+        description: "tlsAllowInvalidCertificates and tlsDisableOCSPEndpointCheck both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsDisableOCSPEndpointCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsAllowInvalidCertificates=true and tlsDisableOCSPEndpointCheck=false raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsDisableOCSPEndpointCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsAllowInvalidCertificates=false and tlsDisableOCSPEndpointCheck=true raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableOCSPEndpointCheck=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsAllowInvalidCertificates and tlsDisableOCSPEndpointCheck both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableOCSPEndpointCheck=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    # 4 permutations of [tlsDisableOCSPEndpointCheck=true/false, tlsAllowInvalidCertificates=true/false]
+    -
+        description: "tlsDisableOCSPEndpointCheck and tlsAllowInvalidCertificates both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsAllowInvalidCertificates=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableOCSPEndpointCheck=true and tlsAllowInvalidCertificates=false raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsAllowInvalidCertificates=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableOCSPEndpointCheck=false and tlsAllowInvalidCertificates=true raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsAllowInvalidCertificates=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsDisableOCSPEndpointCheck and tlsAllowInvalidCertificates both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsAllowInvalidCertificates=false"
         valid: false
         warning: false
         hosts: ~


### PR DESCRIPTION
## Description

**What changed?**

I took a [checkout of the mongo/specifications](https://github.com/mongodb/specifications/commit/a49bb906a160e85a0ad303eb0de10957e079b3d6) right before [the changes for the "SPEC-1248 Unify behavior around configuration for replica set" ](https://github.com/mongodb/specifications/commit/e56f5eceed7729f8b9b43a4a1f76c7e5840db49f). 

This ticket / PR is an effort to isolate the prerequisite tests required to get https://jira.mongodb.org/browse/NODE-2452 up and running.

https://jira.mongodb.org/browse/NODE-2520

