### PR TITLE
test: correct CSFLE tests to work with BSONv4 changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -604,9 +604,9 @@
       "dev": true
     },
     "bson": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.3.tgz",
-      "integrity": "sha512-7uBjjxwOSuGLmoqGI1UXWpDGc0K2WjR7dC6iaOg4iriNZo6M2EEBb8co4dEPJ5ArYCebPMie0ecgX0TWF+ZUrQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
+      "integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
       "requires": {
         "buffer": "^5.1.0",
         "long": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "bl": "^2.2.0",
-    "bson": "^4.0.3",
+    "bson": "^4.0.4",
     "denque": "^1.4.1",
     "madge": "^3.7.0",
     "safe-buffer": "^5.1.2"

--- a/test/functional/client_side_encryption/corpus.test.js
+++ b/test/functional/client_side_encryption/corpus.test.js
@@ -4,6 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const BSON = require('bson');
 const { EJSON } = require('bson');
 const chai = require('chai');
 const expect = chai.expect;
@@ -21,13 +22,13 @@ describe('Client Side Encryption Corpus', function() {
 
   const corpusDir = path.resolve(__dirname, '../../spec/client-side-encryption/corpus');
   function loadCorpusData(filename) {
-    return EJSON.parse(fs.readFileSync(path.resolve(corpusDir, filename), { strict: true }));
+    return EJSON.parse(fs.readFileSync(path.resolve(corpusDir, filename)), { relaxed: false });
   }
 
   // TODO: build this into EJSON
   // TODO: make a custom chai assertion for this
   function toComparableExtendedJSON(value) {
-    return JSON.parse(EJSON.stringify({ value }, { strict: true }));
+    return JSON.parse(EJSON.stringify({ value }, { relaxed: false }));
   }
 
   const localKey = Buffer.from(
@@ -193,6 +194,7 @@ describe('Client Side Encryption Corpus', function() {
 
           return clientEncrypted.connect().then(() => {
             clientEncryption = new mongodbClientEncryption.ClientEncryption(client, {
+              bson: BSON,
               keyVaultNamespace,
               kmsProviders: this.configuration.kmsProviders(null, localKey)
             });

--- a/test/functional/client_side_encryption/driver.test.js
+++ b/test/functional/client_side_encryption/driver.test.js
@@ -48,6 +48,7 @@ describe('Client Side Encryption Functional', function() {
         .connect()
         .then(() => {
           encryption = new mongodbClientEncryption.ClientEncryption(this.client, {
+            bson: BSON,
             keyVaultNamespace,
             kmsProviders
           });

--- a/test/functional/client_side_encryption/prose.test.js
+++ b/test/functional/client_side_encryption/prose.test.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const BSON = require('bson');
 const chai = require('chai');
 const expect = chai.expect;
 chai.use(require('chai-subset'));
@@ -94,6 +94,7 @@ describe('Client Side Encryption Prose Tests', function() {
           //   Configure ``client_encryption`` with the ``keyVaultClient`` of the previously created ``client``.
           .then(() => {
             this.clientEncryption = new mongodbClientEncryption.ClientEncryption(this.client, {
+              bson: BSON,
               kmsProviders: this.configuration.kmsProviders(null, localKey),
               keyVaultNamespace
             });
@@ -316,6 +317,7 @@ describe('Client Side Encryption Prose Tests', function() {
       return this.client.connect().then(() => {
         const mongodbClientEncryption = this.configuration.mongodbClientEncryption;
         this.clientEncryption = new mongodbClientEncryption.ClientEncryption(this.client, {
+          bson: BSON,
           keyVaultNamespace,
           kmsProviders: this.configuration.kmsProviders('aws')
         });
@@ -443,7 +445,7 @@ describe('Client Side Encryption Prose Tests', function() {
   describe('BSON size limits and batch splitting', function() {
     const fs = require('fs');
     const path = require('path');
-    const { EJSON } = require('bson');
+    const { EJSON } = BSON;
     function loadLimits(file) {
       return EJSON.parse(
         fs.readFileSync(path.resolve(__dirname, '../../spec/client-side-encryption/limits', file))
@@ -708,7 +710,7 @@ describe('Client Side Encryption Prose Tests', function() {
   describe('External Key Vault', function() {
     const fs = require('fs');
     const path = require('path');
-    const { EJSON } = require('bson');
+    const { EJSON } = BSON;
     function loadExternal(file) {
       return EJSON.parse(
         fs.readFileSync(path.resolve(__dirname, '../../spec/client-side-encryption/external', file))
@@ -786,6 +788,7 @@ describe('Client Side Encryption Prose Tests', function() {
               //    Configure ``client_encrypted`` to use the schema `external/external-schema.json <../external/external-schema.json>`_  for ``db.coll`` by setting a schema map like: ``{ "db.coll": <contents of external-schema.json>}``
               .then(() => {
                 const options = {
+                  bson: BSON,
                   keyVaultNamespace,
                   kmsProviders: this.configuration.kmsProviders('local', localKey)
                 };

--- a/test/functional/client_side_encryption/spec.test.js
+++ b/test/functional/client_side_encryption/spec.test.js
@@ -33,6 +33,10 @@ describe('Client Side Encryption', function() {
   generateTopologyTests(testSuites, testContext, spec => {
     // Note: we are skipping regex tests b/c we currently deserialize straight to native
     // regex representation instead of to BSONRegExp.
-    return !spec.description.match(/type=regex/) && !spec.description.match(/maxWireVersion < 8/);
+    return (
+      !spec.description.match(/type=regex/) &&
+      !spec.description.match(/type=symbol/) &&
+      !spec.description.match(/maxWireVersion < 8/)
+    );
   });
 });


### PR DESCRIPTION
Most notably we are now skipping `symbol` tests because BSONv4
promotes them to string when `promoteValues: true` (the default).
Since this is a deprecated type, there is less concern that this
will be an issue for users.

NODE-2517