### PR TITLE
fix: single `readPreferenceTags` should be parsed as an array

### DIFF
--- a/lib/core/uri_parser.js
+++ b/lib/core/uri_parser.js
@@ -285,8 +285,8 @@ function applyConnectionStringOption(obj, key, value, options) {
     }
   }
 
-  if (key === 'readpreferencetags' && Array.isArray(value)) {
-    value = splitArrayOfMultipleReadPreferenceTags(value);
+  if (key === 'readpreferencetags') {
+    value = Array.isArray(value) ? splitArrayOfMultipleReadPreferenceTags(value) : [value];
   }
 
   // set the actual value

--- a/test/spec/uri-options/read-preference-options.json
+++ b/test/spec/uri-options/read-preference-options.json
@@ -22,6 +22,21 @@
       }
     },
     {
+      "description": "Single readPreferenceTags is parsed as array of size one",
+      "uri": "mongodb://example.com/?readPreferenceTags=dc:ny",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "readPreferenceTags": [
+          {
+            "dc": "ny"
+          }
+        ]
+      }
+    },
+    {
       "description": "Invalid readPreferenceTags causes a warning",
       "uri": "mongodb://example.com/?readPreferenceTags=invalid",
       "valid": true,

--- a/test/spec/uri-options/read-preference-options.yml
+++ b/test/spec/uri-options/read-preference-options.yml
@@ -9,12 +9,23 @@ tests:
         options:
             readPreference: "primaryPreferred"
             readPreferenceTags:
-                - 
+                -
                     dc: "ny"
                     rack: "1"
                 -
                     dc: "ny"
             maxStalenessSeconds: 120
+    -
+        description: "Single readPreferenceTags is parsed as array of size one"
+        uri: "mongodb://example.com/?readPreferenceTags=dc:ny"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
+            readPreferenceTags:
+                -
+                    dc: "ny"
     -
         description: "Invalid readPreferenceTags causes a warning"
         uri: "mongodb://example.com/?readPreferenceTags=invalid"


### PR DESCRIPTION
ReadPreference tags must be an array in order for matching to
succeed during server selection. If a single value is entered for
the `readPreferenceTags` uri option, it should be parsed as an
array of size one.

NODE-2541