### PR TITLE
feat: allow hinting the delete command

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -11,7 +11,6 @@ const applyRetryableWrites = require('../utils').applyRetryableWrites;
 const applyWriteConcern = require('../utils').applyWriteConcern;
 const executeLegacyOperation = require('../utils').executeLegacyOperation;
 const isPromiseLike = require('../utils').isPromiseLike;
-const maxWireVersion = require('../core/utils').maxWireVersion;
 
 // Error codes
 const WRITE_CONCERN_ERROR = 64;
@@ -952,9 +951,6 @@ class BulkOperationBase {
       };
 
       if (op[key].hint) {
-        if (maxWireVersion(this.s.topology) < 5) {
-          throw new MongoError(`The current topology does not support a hint on ${key} commands`);
-        }
         operation.hint = op[key].hint;
       }
 
@@ -984,9 +980,6 @@ class BulkOperationBase {
       const limit = op.deleteOne ? 1 : 0;
       const operation = { q: op[key].filter, limit: limit };
       if (op[key].hint) {
-        if (maxWireVersion(this.s.topology) < 5) {
-          throw new MongoError(`The current topology does not support a hint on ${key} commands`);
-        }
         operation.hint = op[key].hint;
       }
       if (this.isOrdered) {

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -979,6 +979,7 @@ class BulkOperationBase {
     if (op.deleteOne || op.deleteMany) {
       const limit = op.deleteOne ? 1 : 0;
       const operation = { q: op[key].filter, limit: limit };
+      if (op[key].hint) operation.hint = op[key].hint;
       if (this.isOrdered) {
         if (op.collation) operation.collation = op.collation;
       }

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -11,6 +11,7 @@ const applyRetryableWrites = require('../utils').applyRetryableWrites;
 const applyWriteConcern = require('../utils').applyWriteConcern;
 const executeLegacyOperation = require('../utils').executeLegacyOperation;
 const isPromiseLike = require('../utils').isPromiseLike;
+const isHintSupported = require('../core/utils').isHintSupported;
 
 // Error codes
 const WRITE_CONCERN_ERROR = 64;
@@ -951,6 +952,9 @@ class BulkOperationBase {
       };
 
       if (op[key].hint) {
+        if (!isHintSupported(this.s.topology)) {
+          throw new MongoError(`The current topology does not support a hint on ${key} commands`);
+        }
         operation.hint = op[key].hint;
       }
 
@@ -979,7 +983,12 @@ class BulkOperationBase {
     if (op.deleteOne || op.deleteMany) {
       const limit = op.deleteOne ? 1 : 0;
       const operation = { q: op[key].filter, limit: limit };
-      if (op[key].hint) operation.hint = op[key].hint;
+      if (op[key].hint) {
+        if (!isHintSupported(this.s.topology)) {
+          throw new MongoError(`The current topology does not support a hint on ${key} commands`);
+        }
+        operation.hint = op[key].hint;
+      }
       if (this.isOrdered) {
         if (op.collation) operation.collation = op.collation;
       }

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -11,7 +11,7 @@ const applyRetryableWrites = require('../utils').applyRetryableWrites;
 const applyWriteConcern = require('../utils').applyWriteConcern;
 const executeLegacyOperation = require('../utils').executeLegacyOperation;
 const isPromiseLike = require('../utils').isPromiseLike;
-const isHintSupported = require('../core/utils').isHintSupported;
+const maxWireVersion = require('../core/utils').maxWireVersion;
 
 // Error codes
 const WRITE_CONCERN_ERROR = 64;
@@ -952,7 +952,7 @@ class BulkOperationBase {
       };
 
       if (op[key].hint) {
-        if (!isHintSupported(this.s.topology)) {
+        if (maxWireVersion(this.s.topology) < 5) {
           throw new MongoError(`The current topology does not support a hint on ${key} commands`);
         }
         operation.hint = op[key].hint;
@@ -984,7 +984,7 @@ class BulkOperationBase {
       const limit = op.deleteOne ? 1 : 0;
       const operation = { q: op[key].filter, limit: limit };
       if (op[key].hint) {
-        if (!isHintSupported(this.s.topology)) {
+        if (maxWireVersion(this.s.topology) < 5) {
           throw new MongoError(`The current topology does not support a hint on ${key} commands`);
         }
         operation.hint = op[key].hint;

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -918,6 +918,7 @@ Collection.prototype.update = deprecate(function(selector, update, options, call
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {string|object} [options.hint] optional index hint for optimizing the filter query
  * @param {Collection~deleteWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
@@ -951,6 +952,7 @@ Collection.prototype.removeOne = Collection.prototype.deleteOne;
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
+ * @param {string|object} [options.hint] optional index hint for optimizing the filter query
  * @param {Collection~deleteWriteOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -455,6 +455,11 @@ function executeWriteOperation(args, options, callback) {
     return;
   }
 
+  if ((op === 'update' || op === 'remove') && ops.find(o => o.hint) && maxWireVersion(server) < 5) {
+    callback(new MongoError(`servers < 3.4 do not support hint on ${op}`));
+    return;
+  }
+
   server.s.pool.withConnection((err, conn, cb) => {
     if (err) {
       markServerUnknown(server, err);

--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -454,10 +454,11 @@ function executeWriteOperation(args, options, callback) {
     callback(new MongoError(`server ${server.name} does not support collation`));
     return;
   }
-
-  if ((op === 'update' || op === 'remove') && ops.find(o => o.hint) && maxWireVersion(server) < 5) {
-    callback(new MongoError(`servers < 3.4 do not support hint on ${op}`));
-    return;
+  if (maxWireVersion(server) < 5) {
+    if ((op === 'update' || op === 'remove') && ops.find(o => o.hint)) {
+      callback(new MongoError(`servers < 3.4 do not support hint on ${op}`));
+      return;
+    }
   }
 
   server.s.pool.withConnection((err, conn, cb) => {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -101,6 +101,15 @@ function maxWireVersion(topologyOrServer) {
   return null;
 }
 
+/**
+ * Ensure the hint is supported by the current topology
+ *
+ * @param {Topoligy|Server} topologyOrServer
+ */
+function isHintSupported(topologyOrServer) {
+  return maxWireVersion(topologyOrServer) >= 8;
+}
+
 /*
  * Checks that collation is supported by server.
  *
@@ -265,6 +274,7 @@ module.exports = {
   retrieveEJSON,
   retrieveKerberos,
   maxWireVersion,
+  isHintSupported,
   isPromiseLike,
   eachAsync,
   isUnifiedTopology,

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -101,15 +101,6 @@ function maxWireVersion(topologyOrServer) {
   return null;
 }
 
-/**
- * Ensure the hint is supported by the current topology
- *
- * @param {Topoligy|Server} topologyOrServer
- */
-function isHintSupported(topologyOrServer) {
-  return maxWireVersion(topologyOrServer) >= 8;
-}
-
 /*
  * Checks that collation is supported by server.
  *
@@ -274,7 +265,6 @@ module.exports = {
   retrieveEJSON,
   retrieveKerberos,
   maxWireVersion,
-  isHintSupported,
   isPromiseLike,
   eachAsync,
   isUnifiedTopology,

--- a/lib/operations/common_functions.js
+++ b/lib/operations/common_functions.js
@@ -297,6 +297,9 @@ function removeDocuments(coll, selector, options, callback) {
   } else if (finalOptions.retryWrites) {
     finalOptions.retryWrites = false;
   }
+  if (options.hint) {
+    op.hint = options.hint;
+  }
 
   // Have we specified collation
   try {

--- a/lib/operations/common_functions.js
+++ b/lib/operations/common_functions.js
@@ -11,7 +11,7 @@ const MongoError = require('../core').MongoError;
 const ReadPreference = require('../core').ReadPreference;
 const toError = require('../utils').toError;
 const CursorState = require('../core/cursor').CursorState;
-const isHintSupported = require('../core/utils').isHintSupported;
+const maxWireVersion = require('../core/utils').maxWireVersion;
 
 /**
  * Build the count command.
@@ -299,7 +299,7 @@ function removeDocuments(coll, selector, options, callback) {
     finalOptions.retryWrites = false;
   }
   if (options.hint) {
-    if (!isHintSupported(coll.s.topology)) {
+    if (maxWireVersion(coll.s.topology) < 5) {
       throw new MongoError(`The current topology does not support a hint on delete commands`);
     }
     op.hint = options.hint;
@@ -354,7 +354,7 @@ function updateDocuments(coll, selector, document, options, callback) {
   op.multi = options.multi !== void 0 ? !!options.multi : false;
 
   if (options.hint) {
-    if (!isHintSupported(coll.s.topology)) {
+    if (maxWireVersion(coll.s.topology) < 5) {
       throw new MongoError(`The current topology does not support a hint on update commands`);
     }
     op.hint = options.hint;

--- a/lib/operations/common_functions.js
+++ b/lib/operations/common_functions.js
@@ -11,6 +11,7 @@ const MongoError = require('../core').MongoError;
 const ReadPreference = require('../core').ReadPreference;
 const toError = require('../utils').toError;
 const CursorState = require('../core/cursor').CursorState;
+const isHintSupported = require('../core/utils').isHintSupported;
 
 /**
  * Build the count command.
@@ -298,6 +299,9 @@ function removeDocuments(coll, selector, options, callback) {
     finalOptions.retryWrites = false;
   }
   if (options.hint) {
+    if (!isHintSupported(coll.s.topology)) {
+      throw new MongoError(`The current topology does not support a hint on delete commands`);
+    }
     op.hint = options.hint;
   }
 
@@ -350,6 +354,9 @@ function updateDocuments(coll, selector, document, options, callback) {
   op.multi = options.multi !== void 0 ? !!options.multi : false;
 
   if (options.hint) {
+    if (!isHintSupported(coll.s.topology)) {
+      throw new MongoError(`The current topology does not support a hint on update commands`);
+    }
     op.hint = options.hint;
   }
 

--- a/lib/operations/common_functions.js
+++ b/lib/operations/common_functions.js
@@ -11,7 +11,6 @@ const MongoError = require('../core').MongoError;
 const ReadPreference = require('../core').ReadPreference;
 const toError = require('../utils').toError;
 const CursorState = require('../core/cursor').CursorState;
-const maxWireVersion = require('../core/utils').maxWireVersion;
 
 /**
  * Build the count command.
@@ -299,9 +298,6 @@ function removeDocuments(coll, selector, options, callback) {
     finalOptions.retryWrites = false;
   }
   if (options.hint) {
-    if (maxWireVersion(coll.s.topology) < 5) {
-      throw new MongoError(`The current topology does not support a hint on delete commands`);
-    }
     op.hint = options.hint;
   }
 
@@ -354,9 +350,6 @@ function updateDocuments(coll, selector, document, options, callback) {
   op.multi = options.multi !== void 0 ? !!options.multi : false;
 
   if (options.hint) {
-    if (maxWireVersion(coll.s.topology) < 5) {
-      throw new MongoError(`The current topology does not support a hint on update commands`);
-    }
     op.hint = options.hint;
   }
 

--- a/lib/operations/find_and_modify.js
+++ b/lib/operations/find_and_modify.js
@@ -8,7 +8,7 @@ const executeCommand = require('./db_ops').executeCommand;
 const formattedOrderClause = require('../utils').formattedOrderClause;
 const handleCallback = require('../utils').handleCallback;
 const ReadPreference = require('../core').ReadPreference;
-const maxWireVersion = require('../core/utils').maxWireVersion;
+const isHintSupported = require('../core/utils').isHintSupported;
 const MongoError = require('../error').MongoError;
 
 class FindAndModifyOperation extends OperationBase {
@@ -92,7 +92,7 @@ class FindAndModifyOperation extends OperationBase {
       // TODO: once this method becomes a CommandOperationV2 we will have the server
       // in place to check.
       const topology = coll.s.topology;
-      if (maxWireVersion(topology) < 8) {
+      if (!isHintSupported(topology)) {
         callback(
           new MongoError('The current topology does not support a hint on findAndModify commands')
         );

--- a/lib/operations/find_and_modify.js
+++ b/lib/operations/find_and_modify.js
@@ -8,7 +8,7 @@ const executeCommand = require('./db_ops').executeCommand;
 const formattedOrderClause = require('../utils').formattedOrderClause;
 const handleCallback = require('../utils').handleCallback;
 const ReadPreference = require('../core').ReadPreference;
-const isHintSupported = require('../core/utils').isHintSupported;
+const maxWireVersion = require('../core/utils').maxWireVersion;
 const MongoError = require('../error').MongoError;
 
 class FindAndModifyOperation extends OperationBase {
@@ -92,7 +92,7 @@ class FindAndModifyOperation extends OperationBase {
       // TODO: once this method becomes a CommandOperationV2 we will have the server
       // in place to check.
       const topology = coll.s.topology;
-      if (!isHintSupported(topology)) {
+      if (maxWireVersion(topology) < 8) {
         callback(
           new MongoError('The current topology does not support a hint on findAndModify commands')
         );

--- a/test/functional/crud_spec.test.js
+++ b/test/functional/crud_spec.test.js
@@ -12,6 +12,19 @@ const TestRunnerContext = require('./spec-runner').TestRunnerContext;
 const gatherTestSuites = require('./spec-runner').gatherTestSuites;
 const generateTopologyTests = require('./spec-runner').generateTopologyTests;
 
+function enforceServerVersionLimits(requires, scenario) {
+  const versionLimits = [];
+  if (scenario.minServerVersion) {
+    versionLimits.push(`>=${scenario.minServerVersion}`);
+  }
+  if (scenario.maxServerVersion) {
+    versionLimits.push(`<=${scenario.maxServerVersion}`);
+  }
+  if (versionLimits.length) {
+    requires.mongodb = versionLimits.join(' ');
+  }
+}
+
 function findScenarios() {
   const route = [__dirname, '..', 'spec', 'crud'].concat(Array.from(arguments));
   return fs
@@ -53,9 +66,7 @@ describe('CRUD spec', function() {
         }
       };
 
-      if (scenario.minServerVersion) {
-        metadata.requires.mongodb = `>=${scenario.minServerVersion}`;
-      }
+      enforceServerVersionLimits(metadata.requires, scenario);
 
       describe(scenarioName, function() {
         scenario.tests.forEach(scenarioTest => {
@@ -83,9 +94,7 @@ describe('CRUD spec', function() {
         }
       };
 
-      if (scenario.minServerVersion) {
-        metadata.requires.mongodb = `>=${scenario.minServerVersion}`;
-      }
+      enforceServerVersionLimits(metadata.requires, scenario);
 
       describe(scenarioName, function() {
         beforeEach(() => testContext.db.dropDatabase());

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -110,8 +110,10 @@ function generateTopologyTests(testSuites, testContext, filter) {
     let runOn = testSuite.runOn;
     if (!testSuite.runOn) {
       runOn = [{ minServerVersion: testSuite.minServerVersion }];
+      if (testSuite.maxServerVersion) {
+        runOn.push({ maxServerVersion: testSuite.maxServerVersion });
+      }
     }
-
     const environmentRequirementList = parseRunOn(runOn);
 
     environmentRequirementList.forEach(requires => {

--- a/test/spec/crud/v2/bulkWrite-arrayFilters.json
+++ b/test/spec/crud/v2/bulkWrite-arrayFilters.json
@@ -32,7 +32,7 @@
   "database_name": "crud-tests",
   "tests": [
     {
-      "description": "BulkWrite with arrayFilters",
+      "description": "BulkWrite updateOne with arrayFilters",
       "operations": [
         {
           "name": "bulkWrite",
@@ -53,7 +53,86 @@
                     }
                   ]
                 }
-              },
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "result": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {},
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "updates": [
+                {
+                  "q": {},
+                  "u": {
+                    "$set": {
+                      "y.$[i].b": 2
+                    }
+                  },
+                  "arrayFilters": [
+                    {
+                      "i.b": 3
+                    }
+                  ]
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "update",
+            "database_name": "crud-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "y": [
+                {
+                  "b": 2
+                },
+                {
+                  "b": 1
+                }
+              ]
+            },
+            {
+              "_id": 2,
+              "y": [
+                {
+                  "b": 0
+                },
+                {
+                  "b": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite updateMany with arrayFilters",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
               {
                 "name": "updateMany",
                 "arguments": {
@@ -79,8 +158,8 @@
             "deletedCount": 0,
             "insertedCount": 0,
             "insertedIds": {},
-            "matchedCount": 3,
-            "modifiedCount": 3,
+            "matchedCount": 2,
+            "modifiedCount": 2,
             "upsertedCount": 0,
             "upsertedIds": {}
           }
@@ -92,19 +171,6 @@
             "command": {
               "update": "test",
               "updates": [
-                {
-                  "q": {},
-                  "u": {
-                    "$set": {
-                      "y.$[i].b": 2
-                    }
-                  },
-                  "arrayFilters": [
-                    {
-                      "i.b": 3
-                    }
-                  ]
-                },
                 {
                   "q": {},
                   "u": {
@@ -134,7 +200,7 @@
               "_id": 1,
               "y": [
                 {
-                  "b": 2
+                  "b": 3
                 },
                 {
                   "b": 2

--- a/test/spec/crud/v2/bulkWrite-arrayFilters.yml
+++ b/test/spec/crud/v2/bulkWrite-arrayFilters.yml
@@ -11,7 +11,7 @@ database_name: &database_name "crud-tests"
 
 tests:
   -
-    description: "BulkWrite with arrayFilters"
+    description: "BulkWrite updateOne with arrayFilters"
     operations:
       -
         name: "bulkWrite"
@@ -24,20 +24,13 @@ tests:
                 filter: {}
                 update: { $set: { "y.$[i].b": 2 } }
                 arrayFilters: [ { "i.b": 3 } ]
-            -
-              # UpdateMany when multiple documents match arrayFilters
-              name: "updateMany"
-              arguments:
-                filter: {}
-                update: { $set: { "y.$[i].b": 2 } }
-                arrayFilters: [ { "i.b": 1 } ]
           options: { ordered: true }
         result:
           deletedCount: 0
           insertedCount: 0
           insertedIds: {}
-          matchedCount: 3
-          modifiedCount: 3
+          matchedCount: 1
+          modifiedCount: 1
           upsertedCount: 0
           upsertedIds: {}
     expectations:
@@ -50,6 +43,47 @@ tests:
                 q: {}
                 u: { $set: { "y.$[i].b": 2 } }
                 arrayFilters: [ { "i.b": 3 } ]
+            ordered: true
+            # TODO: check that these fields do not exist once
+            # https://jira.mongodb.org/browse/SPEC-1215 has been resolved.
+            # writeConcern: null
+            # bypassDocumentValidation: null
+          command_name: update
+          database_name: *database_name
+    outcome:
+      collection:
+        data:
+          - {_id: 1, y: [{b: 2}, {b: 1}]}
+          - {_id: 2, y: [{b: 0}, {b: 1}]}
+  -
+    description: "BulkWrite updateMany with arrayFilters"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              # UpdateMany when multiple documents match arrayFilters
+              name: "updateMany"
+              arguments:
+                filter: {}
+                update: { $set: { "y.$[i].b": 2 } }
+                arrayFilters: [ { "i.b": 1 } ]
+          options: { ordered: true }
+        result:
+          deletedCount: 0
+          insertedCount: 0
+          insertedIds: {}
+          matchedCount: 2
+          modifiedCount: 2
+          upsertedCount: 0
+          upsertedIds: {}
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
               -
                 q: {}
                 u: { $set: { "y.$[i].b": 2 } }
@@ -65,5 +99,5 @@ tests:
     outcome:
       collection:
         data:
-          - {_id: 1, y: [{b: 2}, {b: 2}]}
+          - {_id: 1, y: [{b: 3}, {b: 2}]}
           - {_id: 2, y: [{b: 0}, {b: 2}]}

--- a/test/spec/crud/v2/bulkWrite-delete-hint-clientError.json
+++ b/test/spec/crud/v2/bulkWrite-delete-hint-clientError.json
@@ -1,0 +1,150 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "3.3.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    },
+    {
+      "_id": 4,
+      "x": 44
+    }
+  ],
+  "collection_name": "BulkWrite_delete_hint",
+  "tests": [
+    {
+      "description": "BulkWrite deleteOne with hints unsupported (client-side error)",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 2
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite deleteMany with hints unsupported (client-side error)",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "deleteMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "deleteMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$gte": 4
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/bulkWrite-delete-hint-clientError.yml
+++ b/test/spec/crud/v2/bulkWrite-delete-hint-clientError.yml
@@ -1,0 +1,63 @@
+runOn:
+  # Server versions >= 3.4.0 will return an error response for unrecognized
+  # deleteOne options. These tests check that the driver will raise an error
+  # if a hint is provided on a server version < 3.4.
+  - { maxServerVersion: "3.3.99" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+  - {_id: 4, x: 44}
+
+collection_name: &collection_name 'BulkWrite_delete_hint'
+
+tests:
+  -
+    description: "BulkWrite deleteOne with hints unsupported (client-side error)"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "deleteOne"
+              arguments:
+                filter: &deleteOne_filter1 { _id: 1 }
+                hint: &hint_string "_id_"
+            -
+              name: "deleteOne"
+              arguments:
+                filter: &deleteOne_filter2 { _id: 2 }
+                hint: &hint_doc { _id: 1 }
+          options: { ordered: true }
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
+          - {_id: 3, x: 33 }
+          - {_id: 4, x: 44 }
+  -
+    description: "BulkWrite deleteMany with hints unsupported (client-side error)"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "deleteMany"
+              arguments:
+                filter: &deleteMany_filter1 { _id: { $lt: 3 } }
+                hint: *hint_string
+            -
+              name: "deleteMany"
+              arguments:
+                filter: &deleteMany_filter2 { _id: { $gte: 4 } }
+                hint: *hint_doc
+          options: { ordered: true }
+        error: true
+    expectations: []
+    outcome: *outcome

--- a/test/spec/crud/v2/bulkWrite-delete-hint-serverError.json
+++ b/test/spec/crud/v2/bulkWrite-delete-hint-serverError.json
@@ -1,0 +1,209 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.4.0",
+      "maxServerVersion": "4.3.3"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    },
+    {
+      "_id": 4,
+      "x": 44
+    }
+  ],
+  "collection_name": "BulkWrite_delete_hint",
+  "tests": [
+    {
+      "description": "BulkWrite deleteOne with hints unsupported (server-side error)",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 2
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "BulkWrite_delete_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "hint": "_id_",
+                  "limit": 1
+                },
+                {
+                  "q": {
+                    "_id": 2
+                  },
+                  "hint": {
+                    "_id": 1
+                  },
+                  "limit": 1
+                }
+              ],
+              "ordered": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite deleteMany with hints unsupported (server-side error)",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "deleteMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "deleteMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$gte": 4
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "BulkWrite_delete_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "hint": "_id_",
+                  "limit": 0
+                },
+                {
+                  "q": {
+                    "_id": {
+                      "$gte": 4
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  },
+                  "limit": 0
+                }
+              ],
+              "ordered": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/bulkWrite-delete-hint-serverError.yml
+++ b/test/spec/crud/v2/bulkWrite-delete-hint-serverError.yml
@@ -1,0 +1,92 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 3.4.0
+  # raise errors for unknown deleteOne options, and server versions >= 4.3.4
+  # support the hint option in deleteOne.
+  - { minServerVersion: "3.4.0", maxServerVersion: "4.3.3" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+  - {_id: 4, x: 44}
+
+collection_name: &collection_name 'BulkWrite_delete_hint'
+
+tests:
+  -
+    description: "BulkWrite deleteOne with hints unsupported (server-side error)"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "deleteOne"
+              arguments:
+                filter: &deleteOne_filter1 { _id: 1 }
+                hint: &hint_string "_id_"
+            -
+              name: "deleteOne"
+              arguments:
+                filter: &deleteOne_filter2 { _id: 2 }
+                hint: &hint_doc { _id: 1 }
+          options: { ordered: true }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *deleteOne_filter1
+                hint: *hint_string
+                limit: 1
+              -
+                q: *deleteOne_filter2
+                hint: *hint_doc
+                limit: 1
+            ordered: true
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
+          - {_id: 3, x: 33 }
+          - {_id: 4, x: 44 }
+  -
+    description: "BulkWrite deleteMany with hints unsupported (server-side error)"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "deleteMany"
+              arguments:
+                filter: &deleteMany_filter1 { _id: { $lt: 3 } }
+                hint: *hint_string
+            -
+              name: "deleteMany"
+              arguments:
+                filter: &deleteMany_filter2 { _id: { $gte: 4 } }
+                hint: *hint_doc
+          options: { ordered: true }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *deleteMany_filter1
+                hint: *hint_string
+                limit: 0
+              -
+                q: *deleteMany_filter2
+                hint: *hint_doc
+                limit: 0
+            ordered: true
+    outcome: *outcome

--- a/test/spec/crud/v2/bulkWrite-delete-hint.json
+++ b/test/spec/crud/v2/bulkWrite-delete-hint.json
@@ -1,0 +1,204 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.4"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    },
+    {
+      "_id": 4,
+      "x": 44
+    }
+  ],
+  "collection_name": "BulkWrite_delete_hint",
+  "tests": [
+    {
+      "description": "BulkWrite deleteOne with hints",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "deleteOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 2
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "result": {
+            "deletedCount": 2,
+            "insertedCount": 0,
+            "insertedIds": {},
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "BulkWrite_delete_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "hint": "_id_",
+                  "limit": 1
+                },
+                {
+                  "q": {
+                    "_id": 2
+                  },
+                  "hint": {
+                    "_id": 1
+                  },
+                  "limit": 1
+                }
+              ],
+              "ordered": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite deleteMany with hints",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "deleteMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "deleteMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$gte": 4
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "result": {
+            "deletedCount": 3,
+            "insertedCount": 0,
+            "insertedIds": {},
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "BulkWrite_delete_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "hint": "_id_",
+                  "limit": 0
+                },
+                {
+                  "q": {
+                    "_id": {
+                      "$gte": 4
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  },
+                  "limit": 0
+                }
+              ],
+              "ordered": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/bulkWrite-delete-hint.yml
+++ b/test/spec/crud/v2/bulkWrite-delete-hint.yml
@@ -1,0 +1,103 @@
+runOn:
+  - { minServerVersion: "4.3.4" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+  - {_id: 4, x: 44}
+
+collection_name: &collection_name 'BulkWrite_delete_hint'
+
+tests:
+  -
+    description: "BulkWrite deleteOne with hints"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "deleteOne"
+              arguments:
+                filter: &deleteOne_filter1 { _id: 1 }
+                hint: &hint_string "_id_"
+            -
+              name: "deleteOne"
+              arguments:
+                filter: &deleteOne_filter2 { _id: 2 }
+                hint: &hint_doc { _id: 1 }
+          options: { ordered: true }
+        result:
+          deletedCount: 2
+          insertedCount: 0
+          insertedIds: {}
+          matchedCount: 0
+          modifiedCount: 0
+          upsertedCount: 0
+          upsertedIds: {}
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *deleteOne_filter1
+                hint: *hint_string
+                limit: 1
+              -
+                q: *deleteOne_filter2
+                hint: *hint_doc
+                limit: 1
+            ordered: true
+    outcome:
+      collection:
+        data:
+          - {_id: 3, x: 33 }
+          - {_id: 4, x: 44 }
+  -
+    description: "BulkWrite deleteMany with hints"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "deleteMany"
+              arguments:
+                filter: &deleteMany_filter1 { _id: { $lt: 3 } }
+                hint: *hint_string
+            -
+              name: "deleteMany"
+              arguments:
+                filter: &deleteMany_filter2 { _id: { $gte: 4 } }
+                hint: *hint_doc
+          options: { ordered: true }
+        result:
+          deletedCount: 3
+          insertedCount: 0
+          insertedIds: {}
+          matchedCount: 0
+          modifiedCount: 0
+          upsertedCount: 0
+          upsertedIds: {}
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *deleteMany_filter1
+                hint: *hint_string
+                limit: 0
+              -
+                q: *deleteMany_filter2
+                hint: *hint_doc
+                limit: 0
+            ordered: true
+    outcome:
+      collection:
+        data:
+          - {_id: 3, x: 33 }

--- a/test/spec/crud/v2/bulkWrite-update-hint-clientError.json
+++ b/test/spec/crud/v2/bulkWrite-update-hint-clientError.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.2.0"
+      "maxServerVersion": "3.3.99"
     }
   ],
   "data": [
@@ -25,7 +25,7 @@
   "collection_name": "test_bulkwrite_update_hint",
   "tests": [
     {
-      "description": "BulkWrite updateOne with update hints",
+      "description": "BulkWrite updateOne with update hints unsupported (client-side error)",
       "operations": [
         {
           "name": "bulkWrite",
@@ -66,279 +66,10 @@
               "ordered": true
             }
           },
-          "result": {
-            "deletedCount": 0,
-            "insertedCount": 0,
-            "insertedIds": {},
-            "matchedCount": 2,
-            "modifiedCount": 2,
-            "upsertedCount": 0,
-            "upsertedIds": {}
-          }
+          "error": true
         }
       ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "update": "test_bulkwrite_update_hint",
-              "updates": [
-                {
-                  "q": {
-                    "_id": 1
-                  },
-                  "u": {
-                    "$inc": {
-                      "x": 1
-                    }
-                  },
-                  "hint": "_id_"
-                },
-                {
-                  "q": {
-                    "_id": 1
-                  },
-                  "u": {
-                    "$inc": {
-                      "x": 1
-                    }
-                  },
-                  "hint": {
-                    "_id": 1
-                  }
-                }
-              ],
-              "ordered": true
-            }
-          }
-        }
-      ],
-      "outcome": {
-        "collection": {
-          "data": [
-            {
-              "_id": 1,
-              "x": 13
-            },
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
-            },
-            {
-              "_id": 4,
-              "x": 44
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "BulkWrite updateMany with update hints",
-      "operations": [
-        {
-          "name": "bulkWrite",
-          "arguments": {
-            "requests": [
-              {
-                "name": "updateMany",
-                "arguments": {
-                  "filter": {
-                    "_id": {
-                      "$lt": 3
-                    }
-                  },
-                  "update": {
-                    "$inc": {
-                      "x": 1
-                    }
-                  },
-                  "hint": "_id_"
-                }
-              },
-              {
-                "name": "updateMany",
-                "arguments": {
-                  "filter": {
-                    "_id": {
-                      "$lt": 3
-                    }
-                  },
-                  "update": {
-                    "$inc": {
-                      "x": 1
-                    }
-                  },
-                  "hint": {
-                    "_id": 1
-                  }
-                }
-              }
-            ],
-            "options": {
-              "ordered": true
-            }
-          },
-          "result": {
-            "deletedCount": 0,
-            "insertedCount": 0,
-            "insertedIds": {},
-            "matchedCount": 4,
-            "modifiedCount": 4,
-            "upsertedCount": 0,
-            "upsertedIds": {}
-          }
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "update": "test_bulkwrite_update_hint",
-              "updates": [
-                {
-                  "q": {
-                    "_id": {
-                      "$lt": 3
-                    }
-                  },
-                  "u": {
-                    "$inc": {
-                      "x": 1
-                    }
-                  },
-                  "multi": true,
-                  "hint": "_id_"
-                },
-                {
-                  "q": {
-                    "_id": {
-                      "$lt": 3
-                    }
-                  },
-                  "u": {
-                    "$inc": {
-                      "x": 1
-                    }
-                  },
-                  "multi": true,
-                  "hint": {
-                    "_id": 1
-                  }
-                }
-              ],
-              "ordered": true
-            }
-          }
-        }
-      ],
-      "outcome": {
-        "collection": {
-          "data": [
-            {
-              "_id": 1,
-              "x": 13
-            },
-            {
-              "_id": 2,
-              "x": 24
-            },
-            {
-              "_id": 3,
-              "x": 33
-            },
-            {
-              "_id": 4,
-              "x": 44
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "BulkWrite replaceOne with update hints",
-      "operations": [
-        {
-          "name": "bulkWrite",
-          "arguments": {
-            "requests": [
-              {
-                "name": "replaceOne",
-                "arguments": {
-                  "filter": {
-                    "_id": 3
-                  },
-                  "replacement": {
-                    "x": 333
-                  },
-                  "hint": "_id_"
-                }
-              },
-              {
-                "name": "replaceOne",
-                "arguments": {
-                  "filter": {
-                    "_id": 4
-                  },
-                  "replacement": {
-                    "x": 444
-                  },
-                  "hint": {
-                    "_id": 1
-                  }
-                }
-              }
-            ],
-            "options": {
-              "ordered": true
-            }
-          },
-          "result": {
-            "deletedCount": 0,
-            "insertedCount": 0,
-            "insertedIds": {},
-            "matchedCount": 2,
-            "modifiedCount": 2,
-            "upsertedCount": 0,
-            "upsertedIds": {}
-          }
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "update": "test_bulkwrite_update_hint",
-              "updates": [
-                {
-                  "q": {
-                    "_id": 3
-                  },
-                  "u": {
-                    "x": 333
-                  },
-                  "hint": "_id_"
-                },
-                {
-                  "q": {
-                    "_id": 4
-                  },
-                  "u": {
-                    "x": 444
-                  },
-                  "hint": {
-                    "_id": 1
-                  }
-                }
-              ],
-              "ordered": true
-            }
-          }
-        }
-      ],
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -352,11 +83,149 @@
             },
             {
               "_id": 3,
-              "x": 333
+              "x": 33
             },
             {
               "_id": 4,
-              "x": 444
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite updateMany with update hints unsupported (client-side error)",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite replaceOne with update hints unsupported (client-side error)",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 3
+                  },
+                  "replacement": {
+                    "x": 333
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 4
+                  },
+                  "replacement": {
+                    "x": 444
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
             }
           ]
         }

--- a/test/spec/crud/v2/bulkWrite-update-hint-clientError.yml
+++ b/test/spec/crud/v2/bulkWrite-update-hint-clientError.yml
@@ -1,0 +1,90 @@
+runOn:
+  # Server versions >= 3.4.0 will return an error response for unrecognized
+  # updateOne options. These tests check that the driver will raise an error
+  # if a hint is provided on a server version < 3.4.
+  - { maxServerVersion: "3.3.99" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+  - {_id: 4, x: 44}
+
+collection_name: &collection_name 'test_bulkwrite_update_hint'
+
+tests:
+  -
+    description: "BulkWrite updateOne with update hints unsupported (client-side error)"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "updateOne"
+              arguments:
+                filter: &updateOne_filter { _id: 1 }
+                update: &updateOne_update { $inc: { x: 1 } }
+                hint: &hint_string "_id_"
+            -
+              name: "updateOne"
+              arguments:
+                filter: *updateOne_filter
+                update: *updateOne_update
+                hint: &hint_doc { _id: 1 }
+          options: { ordered: true }
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
+          - {_id: 3, x: 33 }
+          - {_id: 4, x: 44 }
+  -
+    description: "BulkWrite updateMany with update hints unsupported (client-side error)"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "updateMany"
+              arguments:
+                filter: &updateMany_filter { _id: { $lt: 3 } }
+                update: &updateMany_update { $inc: { x: 1 } }
+                hint: *hint_string
+            -
+              name: "updateMany"
+              arguments:
+                filter: *updateMany_filter
+                update: *updateMany_update
+                hint: *hint_doc
+          options: { ordered: true }
+        error: true
+    expectations: []
+    outcome: *outcome
+  -
+    description: "BulkWrite replaceOne with update hints unsupported (client-side error)"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "replaceOne"
+              arguments:
+                filter: { _id: 3 }
+                replacement: { x: 333 }
+                hint: *hint_string
+            -
+              name: "replaceOne"
+              arguments:
+                filter: { _id: 4 }
+                replacement: { x: 444 }
+                hint: *hint_doc
+          options: { ordered: true }
+        error: true
+    expectations: []
+    outcome: *outcome

--- a/test/spec/crud/v2/bulkWrite-update-hint-serverError.json
+++ b/test/spec/crud/v2/bulkWrite-update-hint-serverError.json
@@ -1,7 +1,8 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.2.0"
+      "minServerVersion": "3.4.0",
+      "maxServerVersion": "4.1.9"
     }
   ],
   "data": [
@@ -25,7 +26,7 @@
   "collection_name": "test_bulkwrite_update_hint",
   "tests": [
     {
-      "description": "BulkWrite updateOne with update hints",
+      "description": "BulkWrite updateOne with update hints unsupported (server-side error)",
       "operations": [
         {
           "name": "bulkWrite",
@@ -66,15 +67,7 @@
               "ordered": true
             }
           },
-          "result": {
-            "deletedCount": 0,
-            "insertedCount": 0,
-            "insertedIds": {},
-            "matchedCount": 2,
-            "modifiedCount": 2,
-            "upsertedCount": 0,
-            "upsertedIds": {}
-          }
+          "error": true
         }
       ],
       "expectations": [
@@ -118,7 +111,7 @@
           "data": [
             {
               "_id": 1,
-              "x": 13
+              "x": 11
             },
             {
               "_id": 2,
@@ -137,7 +130,7 @@
       }
     },
     {
-      "description": "BulkWrite updateMany with update hints",
+      "description": "BulkWrite updateMany with update hints unsupported (server-side error)",
       "operations": [
         {
           "name": "bulkWrite",
@@ -182,15 +175,7 @@
               "ordered": true
             }
           },
-          "result": {
-            "deletedCount": 0,
-            "insertedCount": 0,
-            "insertedIds": {},
-            "matchedCount": 4,
-            "modifiedCount": 4,
-            "upsertedCount": 0,
-            "upsertedIds": {}
-          }
+          "error": true
         }
       ],
       "expectations": [
@@ -240,11 +225,11 @@
           "data": [
             {
               "_id": 1,
-              "x": 13
+              "x": 11
             },
             {
               "_id": 2,
-              "x": 24
+              "x": 22
             },
             {
               "_id": 3,
@@ -259,7 +244,7 @@
       }
     },
     {
-      "description": "BulkWrite replaceOne with update hints",
+      "description": "BulkWrite replaceOne with update hints unsupported (server-side error)",
       "operations": [
         {
           "name": "bulkWrite",
@@ -296,15 +281,7 @@
               "ordered": true
             }
           },
-          "result": {
-            "deletedCount": 0,
-            "insertedCount": 0,
-            "insertedIds": {},
-            "matchedCount": 2,
-            "modifiedCount": 2,
-            "upsertedCount": 0,
-            "upsertedIds": {}
-          }
+          "error": true
         }
       ],
       "expectations": [
@@ -352,11 +329,11 @@
             },
             {
               "_id": 3,
-              "x": 333
+              "x": 33
             },
             {
               "_id": 4,
-              "x": 444
+              "x": 44
             }
           ]
         }

--- a/test/spec/crud/v2/bulkWrite-update-hint-serverError.yml
+++ b/test/spec/crud/v2/bulkWrite-update-hint-serverError.yml
@@ -1,5 +1,9 @@
 runOn:
-  - { minServerVersion: "4.2.0" }
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 3.4.0
+  # raise errors for unknown updateOne options, and server versions >= 4.2.0
+  # support the hint option in updateOne.
+  - { minServerVersion: "3.4.0", maxServerVersion: "4.1.9" }
 
 data:
   - {_id: 1, x: 11}
@@ -11,7 +15,7 @@ collection_name: &collection_name 'test_bulkwrite_update_hint'
 
 tests:
   -
-    description: "BulkWrite updateOne with update hints"
+    description: "BulkWrite updateOne with update hints unsupported (server-side error)"
     operations:
       -
         name: "bulkWrite"
@@ -30,14 +34,7 @@ tests:
                 update: *updateOne_update
                 hint: &hint_doc { _id: 1 }
           options: { ordered: true }
-        result:
-          deletedCount: 0
-          insertedCount: 0
-          insertedIds: {}
-          matchedCount: 2
-          modifiedCount: 2
-          upsertedCount: 0
-          upsertedIds: {}
+        error: true
     expectations:
       -
         command_started_event:
@@ -56,12 +53,12 @@ tests:
     outcome:
       collection:
         data:
-          - {_id: 1, x: 13 }
+          - {_id: 1, x: 11 }
           - {_id: 2, x: 22 }
           - {_id: 3, x: 33 }
           - {_id: 4, x: 44 }
   -
-    description: "BulkWrite updateMany with update hints"
+    description: "BulkWrite updateMany with update hints unsupported (server-side error)"
     operations:
       -
         name: "bulkWrite"
@@ -80,14 +77,7 @@ tests:
                 update: *updateMany_update
                 hint: *hint_doc
           options: { ordered: true }
-        result:
-          deletedCount: 0
-          insertedCount: 0
-          insertedIds: {}
-          matchedCount: 4
-          modifiedCount: 4
-          upsertedCount: 0
-          upsertedIds: {}
+        error: true
     expectations:
       -
         command_started_event:
@@ -108,12 +98,12 @@ tests:
     outcome:
       collection:
         data:
-          - {_id: 1, x: 13 }
-          - {_id: 2, x: 24 }
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
           - {_id: 3, x: 33 }
           - {_id: 4, x: 44 }
   -
-    description: "BulkWrite replaceOne with update hints"
+    description: "BulkWrite replaceOne with update hints unsupported (server-side error)"
     operations:
       -
         name: "bulkWrite"
@@ -132,14 +122,7 @@ tests:
                 replacement: { x: 444 }
                 hint: *hint_doc
           options: { ordered: true }
-        result:
-          deletedCount: 0
-          insertedCount: 0
-          insertedIds: {}
-          matchedCount: 2
-          modifiedCount: 2
-          upsertedCount: 0
-          upsertedIds: {}
+        error: true
     expectations:
       -
         command_started_event:
@@ -160,5 +143,5 @@ tests:
         data:
           - {_id: 1, x: 11 }
           - {_id: 2, x: 22 }
-          - {_id: 3, x: 333 }
-          - {_id: 4, x: 444 }
+          - {_id: 3, x: 33 }
+          - {_id: 4, x: 44 }

--- a/test/spec/crud/v2/deleteMany-hint-clientError.json
+++ b/test/spec/crud/v2/deleteMany-hint-clientError.json
@@ -1,0 +1,100 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "3.3.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "DeleteMany_hint",
+  "tests": [
+    {
+      "description": "DeleteMany with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "DeleteMany with hint document unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/deleteMany-hint-clientError.yml
+++ b/test/spec/crud/v2/deleteMany-hint-clientError.yml
@@ -1,0 +1,43 @@
+runOn:
+  # Server versions >= 3.4.0 will return an error response for unrecognized
+  # deleteMany options. These tests check that the driver will raise an error
+  # if a hint is provided on a server version < 3.4.
+  - { maxServerVersion: "3.3.99" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+  - { _id: 3, x: 33 }
+
+collection_name: &collection_name 'DeleteMany_hint'
+
+tests:
+  -
+    description: "DeleteMany with hint string unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: deleteMany
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          hint: "_id_"
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+  -
+    description: "DeleteMany with hint document unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: deleteMany
+        arguments:
+          filter: *filter
+          hint: { _id: 1 }
+        error: true
+    expectations: []
+    outcome: *outcome

--- a/test/spec/crud/v2/deleteMany-hint-serverError.json
+++ b/test/spec/crud/v2/deleteMany-hint-serverError.json
@@ -1,0 +1,139 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.4.0",
+      "maxServerVersion": "4.3.3"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "DeleteMany_hint",
+  "tests": [
+    {
+      "description": "DeleteMany with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "DeleteMany_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "DeleteMany with hint document unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "DeleteMany_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/deleteMany-hint-serverError.yml
+++ b/test/spec/crud/v2/deleteMany-hint-serverError.yml
@@ -1,0 +1,60 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 3.4.0
+  # raise errors for unknown deleteMany options, and server versions >= 4.3.4
+  # support the hint option in deleteMany.
+  - { minServerVersion: "3.4.0", maxServerVersion: "4.3.3" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+  - { _id: 3, x: 33 }
+
+collection_name: &collection_name 'DeleteMany_hint'
+
+tests:
+  -
+    description: "DeleteMany with hint string unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: deleteMany
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          hint: "_id_"
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *filter
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+  -
+    description: "DeleteMany with hint document unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: deleteMany
+        arguments:
+          filter: *filter
+          hint: { _id: 1 }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *filter
+                hint: { _id: 1 }
+    outcome: *outcome

--- a/test/spec/crud/v2/deleteMany-hint.json
+++ b/test/spec/crud/v2/deleteMany-hint.json
@@ -1,0 +1,126 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.4"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "DeleteMany_hint",
+  "tests": [
+    {
+      "description": "DeleteMany with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "deletedCount": 2
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "DeleteMany_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "DeleteMany with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "deletedCount": 2
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "DeleteMany_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/deleteMany-hint.yml
+++ b/test/spec/crud/v2/deleteMany-hint.yml
@@ -1,0 +1,56 @@
+runOn:
+  - { minServerVersion: "4.3.4" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+
+collection_name: &collection_name 'DeleteMany_hint'
+
+tests:
+  -
+    description: "DeleteMany with hint string"
+    operations:
+      -
+        object: collection
+        name: deleteMany
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          hint: "_id_"
+        result: &result
+          deletedCount: 2
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *filter
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+  -
+    description: "DeleteMany with hint document"
+    operations:
+      -
+        object: collection
+        name: deleteMany
+        arguments:
+          filter: *filter
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *filter
+                hint: { _id: 1 }
+    outcome: *outcome
+

--- a/test/spec/crud/v2/deleteOne-hint-clientError.json
+++ b/test/spec/crud/v2/deleteOne-hint-clientError.json
@@ -1,0 +1,84 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "3.3.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "DeleteOne_hint",
+  "tests": [
+    {
+      "description": "DeleteOne with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "DeleteOne with hint document unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/deleteOne-hint-clientError.yml
+++ b/test/spec/crud/v2/deleteOne-hint-clientError.yml
@@ -1,0 +1,41 @@
+runOn:
+  # Server versions >= 3.4.0 will return an error response for unrecognized
+  # deleteOne options. These tests check that the driver will raise an error
+  # if a hint is provided on a server version < 3.4.
+  - { maxServerVersion: "3.3.99" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'DeleteOne_hint'
+
+tests:
+  -
+    description: "DeleteOne with hint string unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: deleteOne
+        arguments:
+          filter: &filter { _id: 1 }
+          hint: "_id_"
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "DeleteOne with hint document unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: deleteOne
+        arguments:
+          filter: *filter
+          hint: { _id: 1 }
+        error: true
+    expectations: []
+    outcome: *outcome

--- a/test/spec/crud/v2/deleteOne-hint-serverError.json
+++ b/test/spec/crud/v2/deleteOne-hint-serverError.json
@@ -1,0 +1,119 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.4.0",
+      "maxServerVersion": "4.3.3"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "DeleteOne_hint",
+  "tests": [
+    {
+      "description": "DeleteOne with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "DeleteOne_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "DeleteOne with hint document unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "DeleteOne_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/deleteOne-hint-serverError.yml
+++ b/test/spec/crud/v2/deleteOne-hint-serverError.yml
@@ -1,0 +1,58 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 3.4.0
+  # raise errors for unknown deleteOne options, and server versions >= 4.3.4
+  # support the hint option in deleteOne.
+  - { minServerVersion: "3.4.0", maxServerVersion: "4.3.3" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'DeleteOne_hint'
+
+tests:
+  -
+    description: "DeleteOne with hint string unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: deleteOne
+        arguments:
+          filter: &filter { _id: 1 }
+          hint: "_id_"
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *filter
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "DeleteOne with hint document unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: deleteOne
+        arguments:
+          filter: *filter
+          hint: { _id: 1 }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *filter
+                hint: { _id: 1 }
+    outcome: *outcome

--- a/test/spec/crud/v2/deleteOne-hint.json
+++ b/test/spec/crud/v2/deleteOne-hint.json
@@ -1,0 +1,114 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.4"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "DeleteOne_hint",
+  "tests": [
+    {
+      "description": "DeleteOne with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "deletedCount": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "DeleteOne_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "deleteOne with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "deleteOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "deletedCount": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "DeleteOne_hint",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/deleteOne-hint.yml
+++ b/test/spec/crud/v2/deleteOne-hint.yml
@@ -1,0 +1,55 @@
+runOn:
+  - { minServerVersion: "4.3.4" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+
+collection_name: &collection_name 'DeleteOne_hint'
+
+tests:
+  -
+    description: "DeleteOne with hint string"
+    operations:
+      -
+        object: collection
+        name: deleteOne
+        arguments:
+          filter: &filter { _id: 1 }
+          hint: "_id_"
+        result: &result
+          deletedCount: 1
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *filter
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 2, x: 22 }
+  -
+    description: "deleteOne with hint document"
+    operations:
+      -
+        object: collection
+        name: deleteOne
+        arguments:
+          filter: *filter
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              -
+                q: *filter
+                hint: { _id: 1 }
+    outcome: *outcome
+

--- a/test/spec/crud/v2/findOneAndDelete-hint-clientError.json
+++ b/test/spec/crud/v2/findOneAndDelete-hint-clientError.json
@@ -1,0 +1,84 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndDelete_hint",
+  "tests": [
+    {
+      "description": "FindOneAndDelete with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndDelete",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndDelete with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndDelete",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/findOneAndDelete-hint-clientError.yml
+++ b/test/spec/crud/v2/findOneAndDelete-hint-clientError.yml
@@ -1,0 +1,45 @@
+runOn:
+  # Server versions >= 4.2.0 will return an error response for unrecognized
+  # findAndMOdify options. These tests check that the driver will raise an error
+  # if a hint is provided on a server version < 4.2.
+  - { maxServerVersion: "4.0.99" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndDelete_hint'
+
+tests:
+  -
+    description: "FindOneAndDelete with hint string unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndDelete
+        arguments:
+          filter: &filter { _id: 1 }
+          hint: "_id_"
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndDelete with hint document"
+    operations:
+      -
+        object: collection
+        name: findOneAndDelete
+        arguments:
+          filter: &filter { _id: 1 }
+          hint: { _id: 1 }
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }

--- a/test/spec/crud/v2/findOneAndDelete-hint-serverError.json
+++ b/test/spec/crud/v2/findOneAndDelete-hint-serverError.json
@@ -1,0 +1,113 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0",
+      "maxServerVersion": "4.3.3"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndDelete_hint",
+  "tests": [
+    {
+      "description": "FindOneAndDelete with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndDelete",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndDelete_hint",
+              "query": {
+                "_id": 1
+              },
+              "hint": "_id_",
+              "remove": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndDelete with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndDelete",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndDelete_hint",
+              "query": {
+                "_id": 1
+              },
+              "hint": {
+                "_id": 1
+              },
+              "remove": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/findOneAndDelete-hint-serverError.yml
+++ b/test/spec/crud/v2/findOneAndDelete-hint-serverError.yml
@@ -1,0 +1,60 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 4.2.0
+  # raise errors for unknown findOneAndModify options, and server versions >= 4.3.4
+  # support the hint option in findOneAndModify when remove is true.
+  - { minServerVersion: "4.2.0", maxServerVersion: "4.3.3" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndDelete_hint'
+
+tests:
+  -
+    description: "FindOneAndDelete with hint string unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndDelete
+        arguments:
+          filter: &filter { _id: 1 }
+          hint: "_id_"
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            hint: "_id_"
+            remove: true
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndDelete with hint document"
+    operations:
+      -
+        object: collection
+        name: findOneAndDelete
+        arguments:
+          filter: &filter { _id: 1 }
+          hint: { _id: 1 }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            hint: { _id: 1 }
+            remove: true
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }

--- a/test/spec/crud/v2/findOneAndDelete-hint.json
+++ b/test/spec/crud/v2/findOneAndDelete-hint.json
@@ -1,0 +1,110 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.4"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndDelete_hint",
+  "tests": [
+    {
+      "description": "FindOneAndDelete with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndDelete",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndDelete_hint",
+              "query": {
+                "_id": 1
+              },
+              "hint": "_id_",
+              "remove": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndDelete with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndDelete",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndDelete_hint",
+              "query": {
+                "_id": 1
+              },
+              "hint": {
+                "_id": 1
+              },
+              "remove": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/findOneAndDelete-hint.yml
+++ b/test/spec/crud/v2/findOneAndDelete-hint.yml
@@ -1,0 +1,56 @@
+runOn:
+  - { minServerVersion: "4.3.4" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndDelete_hint'
+
+tests:
+  -
+    description: "FindOneAndDelete with hint string"
+    operations:
+      -
+        object: collection
+        name: findOneAndDelete
+        arguments:
+          filter: &filter { _id: 1 }
+          hint: "_id_"
+        # original document is returned by default
+        result: &result { _id: 1, x: 11 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            hint: "_id_"
+            remove: true
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndDelete with hint document"
+    operations:
+      -
+        object: collection
+        name: findOneAndDelete
+        arguments:
+          filter: &filter { _id: 1 }
+          hint: { _id: 1 }
+        # original document is returned by default
+        result: &result { _id: 1, x: 11 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            hint: { _id: 1 }
+            remove: true
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 2, x: 22 }

--- a/test/spec/crud/v2/updateMany-hint-clientError.json
+++ b/test/spec/crud/v2/updateMany-hint-clientError.json
@@ -1,0 +1,110 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "3.3.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "test_updatemany_hint",
+  "tests": [
+    {
+      "description": "UpdateMany with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateMany with hint document unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/updateMany-hint-clientError.yml
+++ b/test/spec/crud/v2/updateMany-hint-clientError.yml
@@ -1,0 +1,45 @@
+runOn:
+  # Server versions >= 3.4.0 will return an error response for unrecognized
+  # updateMany options. These tests check that the driver will raise an error
+  # if a hint is provided on a server version < 3.4.
+  - { maxServerVersion: "3.3.99" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+
+collection_name: &collection_name 'test_updatemany_hint'
+
+tests:
+  -
+    description: "UpdateMany with hint string unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: updateMany
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          update: &update { $inc: { x: 1 } }
+          hint: "_id_"
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+  -
+    description: "UpdateMany with hint document unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: updateMany
+        arguments:
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        error: true
+    expectations: []
+    outcome: *outcome

--- a/test/spec/crud/v2/updateMany-hint-serverError.json
+++ b/test/spec/crud/v2/updateMany-hint-serverError.json
@@ -1,0 +1,161 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.4.0",
+      "maxServerVersion": "4.1.9"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "test_updatemany_hint",
+  "tests": [
+    {
+      "description": "UpdateMany with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updatemany_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateMany with hint document unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updatemany_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/updateMany-hint-serverError.yml
+++ b/test/spec/crud/v2/updateMany-hint-serverError.yml
@@ -1,0 +1,66 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 3.4.0
+  # raise errors for unknown updateMany options, and server versions >= 4.2.0
+  # support the hint option in updateMany.
+  - { minServerVersion: "3.4.0", maxServerVersion: "4.1.9" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+
+collection_name: &collection_name 'test_updatemany_hint'
+
+tests:
+  -
+    description: "UpdateMany with hint string unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: updateMany
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          update: &update { $inc: { x: 1 } }
+          hint: "_id_"
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                multi: true
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11}
+          - {_id: 2, x: 22}
+          - {_id: 3, x: 33}
+  -
+    description: "UpdateMany with hint document unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: updateMany
+        arguments:
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                multi: true
+                hint: { _id: 1 }
+    outcome: *outcome

--- a/test/spec/crud/v2/updateOne-hint-clientError.json
+++ b/test/spec/crud/v2/updateOne-hint-clientError.json
@@ -1,0 +1,98 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "3.3.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "test_updateone_hint",
+  "tests": [
+    {
+      "description": "UpdateOne with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateOne with hint document unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/updateOne-hint-clientError.yml
+++ b/test/spec/crud/v2/updateOne-hint-clientError.yml
@@ -1,0 +1,43 @@
+runOn:
+  # Server versions >= 3.4.0 will return an error response for unrecognized
+  # updateOne options. These tests check that the driver will raise an error
+  # if a hint is provided on a server version < 3.4.
+  - { maxServerVersion: "3.3.99" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+
+collection_name: &collection_name 'test_updateone_hint'
+
+tests:
+  -
+    description: "UpdateOne with hint string unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: updateOne
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          update: &update { $inc: { x: 1 } }
+          hint: "_id_"
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
+  -
+    description: "UpdateOne with hint document unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: updateOne
+        arguments:
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        error: true
+    expectations: []
+    outcome: *outcome

--- a/test/spec/crud/v2/updateOne-hint-serverError.json
+++ b/test/spec/crud/v2/updateOne-hint-serverError.json
@@ -1,0 +1,147 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.4.0",
+      "maxServerVersion": "4.1.9"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "test_updateone_hint",
+  "tests": [
+    {
+      "description": "UpdateOne with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updateone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateOne with hint document unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updateone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/updateOne-hint-serverError.yml
+++ b/test/spec/crud/v2/updateOne-hint-serverError.yml
@@ -1,0 +1,62 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 3.4.0
+  # raise errors for unknown updateOne options, and server versions >= 4.2.0
+  # support the hint option in updateOne.
+  - { minServerVersion: "3.4.0", maxServerVersion: "4.1.9" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+
+collection_name: &collection_name 'test_updateone_hint'
+
+tests:
+  -
+    description: "UpdateOne with hint string unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: updateOne
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          update: &update { $inc: { x: 1 } }
+          hint: "_id_"
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11}
+          - {_id: 2, x: 22}
+  -
+    description: "UpdateOne with hint document unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: updateOne
+        arguments:
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                hint: { _id: 1 }
+    outcome: *outcome


### PR DESCRIPTION
## Description

This change adds a new hint parameter to each statement of the delete command, which works just like hinting in update.

[NODE-2477](https://jira.mongodb.org/browse/NODE-2477)

**What changed?**

**Are there any files to ignore?**

Filtering out `.json` and `.yml` files will hide the updates copied from [specifications](https://github.com/mongodb/specifications); should help when reviewing the PR.