### PR TITLE
NODE-2295: create collections in transactions

### DIFF
--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -487,30 +487,57 @@ function resolveOperationArgs(operationName, operationArgs, context) {
 const CURSOR_COMMANDS = new Set(['find', 'aggregate', 'listIndexes', 'listCollections']);
 const ADMIN_COMMANDS = new Set(['listDatabases']);
 
+function maybeSession(operation, context) {
+  return (
+    operation &&
+    operation.arguments &&
+    operation.arguments.session &&
+    context[operation.arguments.session]
+  );
+}
+
 const kOperations = new Map([
   [
     'createIndex',
-    (operation, collection /*, context, options */) => {
+    (operation, collection, context /*, options */) => {
       const fieldOrSpec = operation.arguments.keys;
-      return collection.createIndex(fieldOrSpec);
+      const options = { session: maybeSession(operation, context) };
+      if (operation.arguments.name) options.name = operation.arguments.name;
+      return collection.createIndex(fieldOrSpec, options);
+    }
+  ],
+  [
+    'createCollection',
+    (operation, db, context /*, options */) => {
+      const collectionName = operation.arguments.collection;
+      const session = maybeSession(operation, context);
+      return db.createCollection(collectionName, { session });
+    }
+  ],
+  [
+    'dropCollection',
+    (operation, db, context /*, options */) => {
+      const collectionName = operation.arguments.collection;
+      const session = maybeSession(operation, context);
+      return db.dropCollection(collectionName, { session });
     }
   ],
   [
     'dropIndex',
     (operation, collection /*, context, options */) => {
       const indexName = operation.arguments.name;
-      return collection.dropIndex(indexName);
+      const session = maybeSession(operation, context);
+      return collection.dropIndex(indexName, { session });
     }
   ],
   [
     'mapReduce',
-    (operation, collection /*, context, options */) => {
+    (operation, collection, context /*, options */) => {
       const args = operation.arguments;
       const map = args.map;
       const reduce = args.reduce;
-      const options = {};
+      const options = { session: maybeSession(operation, context) };
       if (args.out) options.out = args.out;
-
       return collection.mapReduce(map, reduce, options);
     }
   ]

--- a/test/spec/transactions/README.rst
+++ b/test/spec/transactions/README.rst
@@ -61,10 +61,11 @@ control the fail point's behavior. ``failCommand`` supports the following
 
 - ``failCommands``: Required, the list of command names to fail.
 - ``closeConnection``: Boolean option, which defaults to ``false``. If
-  ``true``, the connection on which the command is executed will be closed
-  and the client will see a network error.
-- ``errorCode``: Integer option, which is unset by default. If set, the
-  specified command error code will be returned as a command error.
+  ``true``, the command will not be executed, the connection will be closed, and
+  the client will see a network error.
+- ``errorCode``: Integer option, which is unset by default. If set, the command
+  will not be executed and the specified command error code will be returned as
+  a command error.
 - ``writeConcernError``: A document, which is unset by default. If set, the
   server will return this document in the "writeConcernError" field. This
   failure response only applies to commands that support write concern and
@@ -121,8 +122,8 @@ Each YAML file has the following keys:
     configureFailPoint command to run on the admin database. This option and
     ``useMultipleMongoses: true`` are mutually exclusive.
 
-  - ``sessionOptions``: Optional, parameters to pass to
-    MongoClient.startSession().
+  - ``sessionOptions``: Optional, map of session names (e.g. "session0") to
+    parameters to pass to MongoClient.startSession() when creating that session.
 
   - ``operations``: Array of documents, each describing an operation to be
     executed. Each document has the following fields:
@@ -136,11 +137,17 @@ Each YAML file has the following keys:
     - ``collectionOptions``: Optional, parameters to pass to the Collection()
       used for this operation.
 
+    - ``databaseOptions``: Optional, parameters to pass to the Database()
+      used for this operation.
+
     - ``command_name``: Present only when ``name`` is "runCommand". The name
       of the command to run. Required for languages that are unable preserve
       the order keys in the "command" argument when parsing JSON/YAML.
 
     - ``arguments``: Optional, the names and values of arguments.
+
+    - ``error``: Optional. If true, the test should expect an error or
+      exception. This could be a server-generated or a driver-generated error.
 
     - ``result``: The return value from the operation, if any. This field may
       be a single document or an array of documents in the case of a
@@ -191,7 +198,8 @@ Then for each element in ``tests``:
 #. If the ``skipReason`` field is present, skip this test completely.
 #. Create a MongoClient and call
    ``client.admin.runCommand({killAllSessions: []})`` to clean up any open
-   transactions from previous test failures.
+   transactions from previous test failures. Ignore a command failure with
+   error code 11601 ("Interrupted") to work around `SERVER-38335`_.
 
    - Running ``killAllSessions`` cleans up any open transactions from
      a previously failed test to prevent the current test from blocking.
@@ -225,7 +233,7 @@ Then for each element in ``tests``:
 #. Call ``client.startSession`` twice to create ClientSession objects
    ``session0`` and ``session1``, using the test's "sessionOptions" if they
    are present. Save their lsids so they are available after calling
-   ``endSession``, see `Logical Session Id`.
+   ``endSession``, see `Logical Session Id`_.
 #. For each element in ``operations``:
 
    - If the operation ``name`` is a special test operation type, execute it and
@@ -235,8 +243,9 @@ Then for each element in ``tests``:
      field at the top level of the test file.
    - Create a Collection object from the Database, using the
      ``collection_name`` field at the top level of the test file.
-     If ``collectionOptions`` is present create the Collection object with the
-     provided options. Otherwise create the object with the default options.
+     If ``collectionOptions`` or ``databaseOptions`` is present, create the
+     Collection or Database object with the provided options, respectively.
+     Otherwise create the object with the default options.
    - Execute the named method on the provided ``object``, passing the
      arguments listed. Pass ``session0`` or ``session1`` to the method,
      depending on which session's name is in the arguments list.
@@ -244,6 +253,8 @@ Then for each element in ``tests``:
      method.
    - If the driver throws an exception / returns an error while executing this
      series of operations, store the error message and server error code.
+   - If the operation's ``error`` field is ``true``, verify that the method
+     threw an exception or returned an error.
    - If the result document has an "errorContains" field, verify that the
      method threw an exception or returned an error, and that the value of the
      "errorContains" field matches the error string. "errorContains" is a
@@ -289,6 +300,8 @@ Then for each element in ``tests``:
      **local read concern** even when the MongoClient is configured with
      another read preference or read concern.
 
+.. _SERVER-38335: https://jira.mongodb.org/browse/SERVER-38335
+
 Special Test Operations
 ```````````````````````
 
@@ -329,6 +342,26 @@ fail point on the mongos server which "session0" is pinned to::
               failCommands: ["commitTransaction"]
               closeConnection: true
 
+Tests that use the "targetedFailPoint" operation do not include
+``configureFailPoint`` commands in their command expectations. Drivers MUST
+ensure that ``configureFailPoint`` commands do not appear in the list of logged
+commands, either by manually filtering it from the list of observed commands or
+by using a different MongoClient to execute ``configureFailPoint``.
+
+assertSessionTransactionState
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The "assertSessionTransactionState" operation instructs the test runner to
+assert that the transaction state of the given session is equal to the
+specified value. The possible values are as follows: ``none``, ``starting``,
+``in_progress``, ``committed``, ``aborted``::
+
+      - name: assertSessionTransactionState
+        object: testRunner
+        arguments:
+          session: session0
+          state: in_progress
+
 assertSessionPinned
 ~~~~~~~~~~~~~~~~~~~
 
@@ -350,6 +383,70 @@ the given session is not pinned to a mongos::
         object: testRunner
         arguments:
           session: session0
+
+assertCollectionExists
+~~~~~~~~~~~~~~~~~~~~~~
+
+The "assertCollectionExists" operation instructs the test runner to assert that
+the given collection exists in the database::
+
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: db
+          collection: test
+
+Use a ``listCollections`` command to check whether the collection exists. Note
+that it is currently not possible to run ``listCollections`` from within a
+transaction.
+
+assertCollectionNotExists
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The "assertCollectionNotExists" operation instructs the test runner to assert
+that the given collection does not exist in the database::
+
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: db
+          collection: test
+
+Use a ``listCollections`` command to check whether the collection exists. Note
+that it is currently not possible to run ``listCollections`` from within a
+transaction.
+
+assertIndexExists
+~~~~~~~~~~~~~~~~~
+
+The "assertIndexExists" operation instructs the test runner to assert that the
+index with the given name exists on the collection::
+
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: db
+          collection: test
+          index: t_1
+
+Use a ``listIndexes`` command to check whether the index exists. Note that it is
+currently not possible to run ``listIndexes`` from within a transaction.
+
+assertIndexNotExists
+~~~~~~~~~~~~~~~~~~~~
+
+The "assertIndexNotExists" operation instructs the test runner to assert that
+the index with the given name does not exist on the collection::
+
+      - name: assertIndexNotExists
+        object: testRunner
+        arguments:
+          database: db
+          collection: test
+          index: t_1
+
+Use a ``listIndexes`` command to check whether the index exists. Note that it is
+currently not possible to run ``listIndexes`` from within a transaction.
 
 Command-Started Events
 ``````````````````````
@@ -524,6 +621,7 @@ is the only command allowed in a sharded transaction that uses the
 Changelog
 =========
 
+:2019-05-15: Add operation level ``error`` field to assert any error.
 :2019-03-25: Add workaround for StaleDbVersion on distinct.
 :2019-03-01: Add top-level ``runOn`` field to denote server version and/or
              topology requirements requirements for the test file. Removes the

--- a/test/spec/transactions/abort.json
+++ b/test/spec/transactions/abort.json
@@ -458,7 +458,8 @@
             "errorLabelsOmit": [
               "TransientTransactionError",
               "UnknownTransactionCommitResult"
-            ]
+            ],
+            "errorContains": "E11000"
           }
         },
         {

--- a/test/spec/transactions/abort.yml
+++ b/test/spec/transactions/abort.yml
@@ -305,10 +305,10 @@ tests:
           document:
             _id: 1
         result:
-          # Don't assert on errorCodeName because (after SERVER-38583) the
-          # DuplicateKey is reported in writeErrors, not as a top-level
-          # command error.
           errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+          # DuplicateKey error code included in the bulk write error message
+          # returned by the server
+          errorContains: E11000
       # Make sure the server aborted the transaction.
       - name: insertOne
         object: collection

--- a/test/spec/transactions/bulk.json
+++ b/test/spec/transactions/bulk.json
@@ -304,9 +304,7 @@
                     "$set": {
                       "x": 1
                     }
-                  },
-                  "multi": false,
-                  "upsert": false
+                  }
                 },
                 {
                   "q": {
@@ -317,7 +315,6 @@
                       "x": 2
                     }
                   },
-                  "multi": false,
                   "upsert": true
                 }
               ],
@@ -379,9 +376,7 @@
                   },
                   "u": {
                     "y": 1
-                  },
-                  "multi": false,
-                  "upsert": false
+                  }
                 },
                 {
                   "q": {
@@ -389,9 +384,7 @@
                   },
                   "u": {
                     "y": 2
-                  },
-                  "multi": false,
-                  "upsert": false
+                  }
                 }
               ],
               "ordered": true,
@@ -454,8 +447,7 @@
                       "z": 1
                     }
                   },
-                  "multi": true,
-                  "upsert": false
+                  "multi": true
                 }
               ],
               "ordered": true,

--- a/test/spec/transactions/bulk.yml
+++ b/test/spec/transactions/bulk.yml
@@ -153,11 +153,8 @@ tests:
             updates:
               - q: {_id: 1}
                 u: {$set: {x: 1}}
-                multi: false
-                upsert: false
               - q: {_id: 2}
                 u: {$set: {x: 2}}
-                multi: false
                 upsert: true
             ordered: true
             lsid: session0
@@ -192,12 +189,8 @@ tests:
             updates:
               - q: {_id: 1}
                 u: {y: 1}
-                multi: false
-                upsert: false
               - q: {_id: 2}
                 u: {y: 2}
-                multi: false
-                upsert: false
             ordered: true
             lsid: session0
             txnNumber:
@@ -231,7 +224,6 @@ tests:
               - q: {_id: {$gte: 2}}
                 u: {$set: {z: 1}}
                 multi: true
-                upsert: false
             ordered: true
             lsid: session0
             txnNumber:

--- a/test/spec/transactions/causal-consistency.json
+++ b/test/spec/transactions/causal-consistency.json
@@ -40,8 +40,7 @@
               "$inc": {
                 "count": 1
               }
-            },
-            "upsert": false
+            }
           },
           "result": {
             "matchedCount": 1,
@@ -65,8 +64,7 @@
               "$inc": {
                 "count": 1
               }
-            },
-            "upsert": false
+            }
           },
           "result": {
             "matchedCount": 1,
@@ -93,9 +91,7 @@
                     "$inc": {
                       "count": 1
                     }
-                  },
-                  "multi": false,
-                  "upsert": false
+                  }
                 }
               ],
               "ordered": true,
@@ -123,9 +119,7 @@
                     "$inc": {
                       "count": 1
                     }
-                  },
-                  "multi": false,
-                  "upsert": false
+                  }
                 }
               ],
               "ordered": true,
@@ -212,8 +206,7 @@
               "$inc": {
                 "count": 1
               }
-            },
-            "upsert": false
+            }
           },
           "result": {
             "matchedCount": 1,
@@ -260,9 +253,7 @@
                     "$inc": {
                       "count": 1
                     }
-                  },
-                  "multi": false,
-                  "upsert": false
+                  }
                 }
               ],
               "ordered": true,

--- a/test/spec/transactions/causal-consistency.yml
+++ b/test/spec/transactions/causal-consistency.yml
@@ -27,7 +27,6 @@ tests:
           filter: {_id: 1}
           update:
             $inc: {count: 1}
-          upsert: false
         result:
           matchedCount: 1
           modifiedCount: 1
@@ -48,8 +47,6 @@ tests:
             updates:
               - q: {_id: 1}
                 u: {$inc: {count: 1}}
-                multi: false
-                upsert: false
             ordered: true
             lsid: session0
             readConcern:
@@ -65,8 +62,6 @@ tests:
             updates:
               - q: {_id: 1}
                 u: {$inc: {count: 1}}
-                multi: false
-                upsert: false
             ordered: true
             readConcern:
               afterClusterTime: 42
@@ -122,7 +117,6 @@ tests:
           filter: {_id: 1}
           update:
             $inc: {count: 1}
-          upsert: false
         result:
           matchedCount: 1
           modifiedCount: 1
@@ -150,8 +144,6 @@ tests:
             updates:
               - q: {_id: 1}
                 u: {$inc: {count: 1}}
-                multi: false
-                upsert: false
             ordered: true
             # No afterClusterTime
             readConcern:

--- a/test/spec/transactions/convenient-api/README.rst
+++ b/test/spec/transactions/convenient-api/README.rst
@@ -129,7 +129,7 @@ following fields:
     executed. Elements in this array will follow the same structure as the
     ``operations`` field defined above (and in the CRUD and Transactions specs).
 
-    Note that drivers are expected to evaluate ``error` and ``result``
+    Note that drivers are expected to evaluate ``error`` and ``result``
     assertions when executing operations within ``callback.operations``.
 
 - ``options`` (optional): Names and values of options to pass to

--- a/test/spec/transactions/convenient-api/callback-retry.json
+++ b/test/spec/transactions/convenient-api/callback-retry.json
@@ -235,7 +235,8 @@
             "errorLabelsOmit": [
               "TransientTransactionError",
               "UnknownTransactionCommitResult"
-            ]
+            ],
+            "errorContains": "E11000"
           }
         }
       ],

--- a/test/spec/transactions/convenient-api/callback-retry.yml
+++ b/test/spec/transactions/convenient-api/callback-retry.yml
@@ -160,10 +160,10 @@ tests:
                 result:
                   errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
         result:
-          # Don't assert on errorCodeName because (after SERVER-38583) the
-          # DuplicateKey is reported in writeErrors, not as a top-level
-          # command error.
           errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+          # DuplicateKey error code included in the bulk write error message
+          # returned by the server
+          errorContains: E11000
     expectations:
       -
         command_started_event:

--- a/test/spec/transactions/convenient-api/commit-retry.json
+++ b/test/spec/transactions/convenient-api/commit-retry.json
@@ -304,6 +304,9 @@
             "commitTransaction"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },

--- a/test/spec/transactions/convenient-api/commit-retry.yml
+++ b/test/spec/transactions/convenient-api/commit-retry.yml
@@ -192,6 +192,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 10107 # NotMaster
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
     operations:
       - *withTransaction

--- a/test/spec/transactions/convenient-api/transaction-options.json
+++ b/test/spec/transactions/convenient-api/transaction-options.json
@@ -5,6 +5,12 @@
       "topology": [
         "replicaset"
       ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "withTransaction-tests",
@@ -186,7 +192,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "snapshot"
+              "level": "majority"
             },
             "writeConcern": {
               "w": 1
@@ -237,7 +243,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null
             },
@@ -302,7 +308,7 @@
             },
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": {
                 "w": 1
@@ -329,7 +335,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null
             },
@@ -374,7 +380,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "majority"
+              "level": "snapshot"
             },
             "writeConcern": {
               "w": "majority"
@@ -406,7 +412,7 @@
             },
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": {
                 "w": 1
@@ -433,7 +439,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null
             },
@@ -475,7 +481,7 @@
       "description": "withTransaction explicit transaction options override client options",
       "useMultipleMongoses": true,
       "clientOptions": {
-        "readConcernLevel": "majority",
+        "readConcernLevel": "local",
         "w": "majority"
       },
       "operations": [
@@ -502,7 +508,7 @@
             },
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": {
                 "w": 1
@@ -529,7 +535,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null
             },

--- a/test/spec/transactions/convenient-api/transaction-options.yml
+++ b/test/spec/transactions/convenient-api/transaction-options.yml
@@ -2,6 +2,9 @@ runOn:
     -
         minServerVersion: "4.0"
         topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
 
 database_name: &database_name "withTransaction-tests"
 collection_name: &collection_name "test"
@@ -105,7 +108,7 @@ tests:
     sessionOptions:
       session0:
         defaultTransactionOptions:
-          readConcern: { level: snapshot }
+          readConcern: { level: majority }
           writeConcern: { w: 1 }
     operations: *operations
     expectations:
@@ -120,7 +123,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             startTransaction: true
             autocommit: false
-            readConcern: { level: snapshot }
+            readConcern: { level: majority }
             # omitted fields
             writeConcern: ~
           command_name: insert
@@ -158,7 +161,7 @@ tests:
                 result:
                   insertedId: 1
           options:
-            readConcern: { level: snapshot }
+            readConcern: { level: majority }
             writeConcern: { w: 1 }
     expectations:
       -
@@ -172,7 +175,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             startTransaction: true
             autocommit: false
-            readConcern: { level: snapshot }
+            readConcern: { level: majority }
             # omitted fields
             writeConcern: ~
           command_name: insert
@@ -197,7 +200,7 @@ tests:
     sessionOptions:
       session0:
         defaultTransactionOptions:
-          readConcern: { level: majority }
+          readConcern: { level: snapshot }
           writeConcern: { w: majority }
     operations: *operations_explicit_transactionOptions
     expectations:
@@ -212,7 +215,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             startTransaction: true
             autocommit: false
-            readConcern: { level: snapshot }
+            readConcern: { level: majority }
             # omitted fields
             writeConcern: ~
           command_name: insert
@@ -235,7 +238,7 @@ tests:
     description: withTransaction explicit transaction options override client options
     useMultipleMongoses: true
     clientOptions:
-      readConcernLevel: majority
+      readConcernLevel: local
       w: majority
     operations: *operations_explicit_transactionOptions
     expectations:
@@ -250,7 +253,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             startTransaction: true
             autocommit: false
-            readConcern: { level: snapshot }
+            readConcern: { level: majority }
             # omitted fields
             writeConcern: ~
           command_name: insert

--- a/test/spec/transactions/create-collection.json
+++ b/test/spec/transactions/create-collection.json
@@ -1,0 +1,204 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.4",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "explicitly create collection using create command",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "session": "session0",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "test",
+              "writeConcern": null
+            },
+            "command_name": "drop",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "test",
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "create",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    },
+    {
+      "description": "implicitly create collection using insert",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "test",
+              "writeConcern": null
+            },
+            "command_name": "drop",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/transactions/create-collection.yml
+++ b/test/spec/transactions/create-collection.yml
@@ -1,0 +1,131 @@
+runOn:
+  -
+    minServerVersion: "4.3.4"
+    topology: ["replicaset", "sharded"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  - description: explicitly create collection using create command
+
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: *collection_name
+      - name: startTransaction
+        object: session0
+      - name: createCollection
+        object: database
+        arguments:
+          session: session0
+          collection: *collection_name
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+      - name: commitTransaction
+        object: session0
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+
+    expectations:
+      - command_started_event:
+          command:
+            drop: *collection_name
+            writeConcern:
+          command_name: drop
+          database_name: *database_name
+      - command_started_event:
+          command:
+            create: *collection_name
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: create
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+
+  - description: implicitly create collection using insert
+
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: *collection_name
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+      - name: commitTransaction
+        object: session0
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+
+    expectations:
+      - command_started_event:
+          command:
+            drop: *collection_name
+            writeConcern:
+          command_name: drop
+          database_name: *database_name
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin

--- a/test/spec/transactions/create-index.json
+++ b/test/spec/transactions/create-index.json
@@ -1,0 +1,237 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.4",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "create index on a non-existing collection",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createIndex",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "name": "t_1",
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "assertIndexNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test",
+            "index": "t_1"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test",
+            "index": "t_1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "test",
+              "writeConcern": null
+            },
+            "command_name": "drop",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "test",
+              "indexes": [
+                {
+                  "name": "t_1",
+                  "key": {
+                    "x": 1
+                  }
+                }
+              ],
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "createIndexes",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    },
+    {
+      "description": "create index on a collection created within the same transaction",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "session": "session0",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createIndex",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "name": "t_1",
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "assertIndexNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test",
+            "index": "t_1"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test",
+            "index": "t_1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "test",
+              "writeConcern": null
+            },
+            "command_name": "drop",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "test",
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "create",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "test",
+              "indexes": [
+                {
+                  "name": "t_1",
+                  "key": {
+                    "x": 1
+                  }
+                }
+              ],
+              "lsid": "session0",
+              "writeConcern": null
+            },
+            "command_name": "createIndexes",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/transactions/create-index.yml
+++ b/test/spec/transactions/create-index.yml
@@ -1,0 +1,152 @@
+runOn:
+  -
+    minServerVersion: "4.3.4"
+    topology: ["replicaset", "sharded"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  - description: create index on a non-existing collection
+
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: *collection_name
+      - name: startTransaction
+        object: session0
+      - name: createIndex
+        object: collection
+        arguments:
+          session: session0
+          name: &index_name "t_1"
+          keys:
+            x: 1
+      - name: assertIndexNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+          index: *index_name
+      - name: commitTransaction
+        object: session0
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+          index: *index_name
+
+    expectations:
+      - command_started_event:
+          command:
+            drop: *collection_name
+            writeConcern:
+          command_name: drop
+          database_name: *database_name
+      - command_started_event:
+          command:
+            createIndexes: *collection_name
+            indexes:
+              - name: *index_name
+                key:
+                  x: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: createIndexes
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+
+  - description: create index on a collection created within the same transaction
+
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: *collection_name
+      - name: startTransaction
+        object: session0
+      - name: createCollection
+        object: database
+        arguments:
+          session: session0
+          collection: *collection_name
+      - name: createIndex
+        object: collection
+        arguments:
+          session: session0
+          name: *index_name
+          keys:
+            x: 1
+      - name: assertIndexNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+          index: *index_name
+      - name: commitTransaction
+        object: session0
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+          index: *index_name
+
+    expectations:
+      - command_started_event:
+          command:
+            drop: *collection_name
+            writeConcern:
+          command_name: drop
+          database_name: *database_name
+      - command_started_event:
+          command:
+            create: *collection_name
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: create
+          database_name: *database_name
+      - command_started_event:
+          command:
+            createIndexes: *collection_name
+            indexes:
+              - name: *index_name
+                key:
+                  x: 1
+            lsid: session0
+            writeConcern:
+          command_name: createIndexes
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin

--- a/test/spec/transactions/error-labels.json
+++ b/test/spec/transactions/error-labels.json
@@ -42,7 +42,8 @@
             "errorLabelsOmit": [
               "TransientTransactionError",
               "UnknownTransactionCommitResult"
-            ]
+            ],
+            "errorContains": "E11000"
           }
         },
         {
@@ -407,6 +408,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -460,7 +462,7 @@
       }
     },
     {
-      "description": "add transient label to connection errors",
+      "description": "add TransientTransactionError label to connection errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -662,7 +664,7 @@
       }
     },
     {
-      "description": "add unknown commit label to connection errors",
+      "description": "add RetryableWriteError and UnknownTransactionCommitResult labels to connection errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -698,6 +700,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -800,7 +803,7 @@
       }
     },
     {
-      "description": "add unknown commit label to retryable commit errors",
+      "description": "add RetryableWriteError and UnknownTransactionCommitResult labels to retryable commit errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -810,7 +813,10 @@
           "failCommands": [
             "commitTransaction"
           ],
-          "errorCode": 11602
+          "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operations": [
@@ -836,6 +842,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -938,7 +945,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError ShutdownInProgress",
+      "description": "add RetryableWriteError and UnknownTransactionCommitResult labels to writeConcernError ShutdownInProgress",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -950,7 +957,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -984,6 +994,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -1088,7 +1099,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError WriteConcernFailed",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1137,6 +1148,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }
@@ -1219,7 +1231,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError WriteConcernFailed with wtimeout",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed with wtimeout",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1272,6 +1284,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }
@@ -1354,7 +1367,7 @@
       }
     },
     {
-      "description": "omit unknown commit label to writeConcernError UnsatisfiableWriteConcern",
+      "description": "omit UnknownTransactionCommitResult label from writeConcernError UnsatisfiableWriteConcern",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1400,6 +1413,7 @@
           "object": "session0",
           "result": {
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError",
               "UnknownTransactionCommitResult"
             ]
@@ -1460,7 +1474,7 @@
       }
     },
     {
-      "description": "omit unknown commit label to writeConcernError UnknownReplWriteConcern",
+      "description": "omit UnknownTransactionCommitResult label from writeConcernError UnknownReplWriteConcern",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1506,6 +1520,7 @@
           "object": "session0",
           "result": {
             "errorLabelsOmit": [
+              "RetryableWriteConcern",
               "TransientTransactionError",
               "UnknownTransactionCommitResult"
             ]
@@ -1566,7 +1581,7 @@
       }
     },
     {
-      "description": "do not add unknown commit label to MaxTimeMSExpired inside transactions",
+      "description": "do not add UnknownTransactionCommitResult label to MaxTimeMSExpired inside transactions",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1613,6 +1628,7 @@
           },
           "result": {
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult",
               "TransientTransactionError"
             ]
@@ -1695,7 +1711,7 @@
       }
     },
     {
-      "description": "add unknown commit label to MaxTimeMSExpired",
+      "description": "add UnknownTransactionCommitResult label to MaxTimeMSExpired",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1742,6 +1758,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }
@@ -1826,7 +1843,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError MaxTimeMSExpired",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError MaxTimeMSExpired",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1876,6 +1893,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }

--- a/test/spec/transactions/error-labels.yml
+++ b/test/spec/transactions/error-labels.yml
@@ -25,10 +25,10 @@ tests:
             - _id: 1
             - _id: 1
         result:
-          # Don't assert on errorCodeName because (after SERVER-38583) the
-          # DuplicateKey is reported in writeErrors, not as a top-level
-          # command error.
           errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+          # DuplicateKey error code included in the bulk write error message
+          # returned by the server
+          errorContains: E11000
       - name: abortTransaction
         object: session0
 
@@ -261,7 +261,7 @@ tests:
         result:
           # Note, the server will return the errorLabel in this case.
           errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
 
     expectations:
       - command_started_event:
@@ -295,7 +295,7 @@ tests:
       collection:
         data: []
 
-  - description: add transient label to connection errors
+  - description: add TransientTransactionError label to connection errors
 
     failPoint:
       configureFailPoint: failCommand
@@ -408,7 +408,7 @@ tests:
       collection:
         data: []
 
-  - description: add unknown commit label to connection errors
+  - description: add RetryableWriteError and UnknownTransactionCommitResult labels to connection errors
 
     failPoint:
       configureFailPoint: failCommand
@@ -431,7 +431,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsContain: ["RetryableWriteError", "UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
       - name: commitTransaction
         object: session0
@@ -492,14 +492,15 @@ tests:
         data:
           - _id: 1
 
-  - description: add unknown commit label to retryable commit errors
+  - description: add RetryableWriteError and UnknownTransactionCommitResult labels to retryable commit errors
 
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
           failCommands: ["commitTransaction"]
-          errorCode: 11602  # InterruptedDueToReplStateChange 
+          errorCode: 11602  # InterruptedDueToReplStateChange
+          errorLabels: ["RetryableWriteError"]
 
     operations:
       - name: startTransaction
@@ -515,7 +516,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsContain: ["RetryableWriteError", "UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
       - name: commitTransaction
         object: session0
@@ -576,7 +577,7 @@ tests:
         data:
           - _id: 1
 
-  - description: add unknown commit label to writeConcernError ShutdownInProgress
+  - description: add RetryableWriteError and UnknownTransactionCommitResult labels to writeConcernError ShutdownInProgress
 
     failPoint:
       configureFailPoint: failCommand
@@ -586,6 +587,7 @@ tests:
           writeConcernError:
             code: 91
             errmsg: Replication is being shut down
+            errorLabels: ["RetryableWriteError"]
 
     operations:
       - name: startTransaction
@@ -605,7 +607,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsContain: ["RetryableWriteError", "UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
       - name: commitTransaction
         object: session0
@@ -668,7 +670,7 @@ tests:
         data:
           - _id: 1
 
-  - description: add unknown commit label to writeConcernError WriteConcernFailed
+  - description: add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed
 
     failPoint:
       configureFailPoint: failCommand
@@ -698,7 +700,7 @@ tests:
         object: session0
         result:
           errorLabelsContain: ["UnknownTransactionCommitResult"]
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError"]
       - name: commitTransaction
         object: session0
 
@@ -748,7 +750,7 @@ tests:
         data:
           - _id: 1
 
-  - description: add unknown commit label to writeConcernError WriteConcernFailed with wtimeout
+  - description: add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed with wtimeout
 
     failPoint:
       configureFailPoint: failCommand
@@ -780,7 +782,7 @@ tests:
         object: session0
         result:
           errorLabelsContain: ["UnknownTransactionCommitResult"]
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError"]
       - name: commitTransaction
         object: session0
 
@@ -830,7 +832,7 @@ tests:
         data:
           - _id: 1
 
-  - description: omit unknown commit label to writeConcernError UnsatisfiableWriteConcern
+  - description: omit UnknownTransactionCommitResult label from writeConcernError UnsatisfiableWriteConcern
 
     failPoint:
       configureFailPoint: failCommand
@@ -859,7 +861,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError", "UnknownTransactionCommitResult"]
 
     expectations:
       - command_started_event:
@@ -895,7 +897,7 @@ tests:
         data:
           - _id: 1
 
-  - description: omit unknown commit label to writeConcernError UnknownReplWriteConcern
+  - description: omit UnknownTransactionCommitResult label from writeConcernError UnknownReplWriteConcern
 
     failPoint:
       configureFailPoint: failCommand
@@ -924,7 +926,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteConcern", "TransientTransactionError", "UnknownTransactionCommitResult"]
 
     expectations:
       - command_started_event:
@@ -960,7 +962,7 @@ tests:
         data:
           - _id: 1
 
-  - description: do not add unknown commit label to MaxTimeMSExpired inside transactions
+  - description: do not add UnknownTransactionCommitResult label to MaxTimeMSExpired inside transactions
 
     failPoint:
       configureFailPoint: failCommand
@@ -989,7 +991,7 @@ tests:
           maxTimeMS: 60000
           session: session0
         result:
-          errorLabelsOmit: ["UnknownTransactionCommitResult", "TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult", "TransientTransactionError"]
       - name: abortTransaction
         object: session0
 
@@ -1040,7 +1042,7 @@ tests:
       collection:
         data: []
 
-  - description: add unknown commit label to MaxTimeMSExpired
+  - description: add UnknownTransactionCommitResult label to MaxTimeMSExpired
 
     failPoint:
       configureFailPoint: failCommand
@@ -1069,7 +1071,7 @@ tests:
         object: session0
         result:
           errorLabelsContain: ["UnknownTransactionCommitResult"]
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError"]
       - name: commitTransaction
         object: session0
 
@@ -1121,7 +1123,7 @@ tests:
         data:
           - _id: 1
 
-  - description: add unknown commit label to writeConcernError MaxTimeMSExpired
+  - description: add UnknownTransactionCommitResult label to writeConcernError MaxTimeMSExpired
 
     failPoint:
       configureFailPoint: failCommand
@@ -1152,7 +1154,7 @@ tests:
         object: session0
         result:
           errorLabelsContain: ["UnknownTransactionCommitResult"]
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError"]
       - name: commitTransaction
         object: session0
 

--- a/test/spec/transactions/errors-client.json
+++ b/test/spec/transactions/errors-client.json
@@ -1,0 +1,94 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "Client side error in command starting transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": {
+                ".": "."
+              }
+            }
+          },
+          "error": true
+        },
+        {
+          "name": "assertSessionTransactionState",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "state": "starting"
+          }
+        }
+      ]
+    },
+    {
+      "description": "Client side error when transaction is in progress",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "insertedId": 4
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": {
+                ".": "."
+              }
+            }
+          },
+          "error": true
+        },
+        {
+          "name": "assertSessionTransactionState",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "state": "in_progress"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/transactions/errors-client.yml
+++ b/test/spec/transactions/errors-client.yml
@@ -1,0 +1,56 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+tests:
+  - description: Client side error in command starting transaction
+
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: {.: .}
+        error: true
+      - name: assertSessionTransactionState
+        object: testRunner
+        arguments:
+          session: session0
+          state: starting
+
+  - description: Client side error when transaction is in progress
+
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 4
+        result:
+          insertedId: 4
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: {.: .}
+        error: true
+      - name: assertSessionTransactionState
+        object: testRunner
+        arguments:
+          session: session0
+          state: in_progress

--- a/test/spec/transactions/mongos-recovery-token.json
+++ b/test/spec/transactions/mongos-recovery-token.json
@@ -181,7 +181,10 @@
                 ],
                 "writeConcernError": {
                   "code": 91,
-                  "errmsg": "Replication is being shut down"
+                  "errmsg": "Replication is being shut down",
+                  "errorLabels": [
+                    "RetryableWriteError"
+                  ]
                 }
               }
             }

--- a/test/spec/transactions/mongos-recovery-token.yml
+++ b/test/spec/transactions/mongos-recovery-token.yml
@@ -119,6 +119,7 @@ tests:
               writeConcernError:
                 code: 91
                 errmsg: Replication is being shut down
+                errorLabels: ["RetryableWriteError"]
       # The client sees a retryable writeConcernError on the first
       # commitTransaction due to the fail point but it actually succeeds on the
       # server (SERVER-39346). The retry will succeed both on a new mongos and

--- a/test/spec/transactions/pin-mongos.json
+++ b/test/spec/transactions/pin-mongos.json
@@ -875,7 +875,7 @@
                 "failCommands": [
                   "commitTransaction"
                 ],
-                "errorCode": 50
+                "errorCode": 51
               }
             }
           }
@@ -887,7 +887,7 @@
             "errorLabelsOmit": [
               "TransientTransactionError"
             ],
-            "errorCode": 50
+            "errorCode": 51
           }
         },
         {

--- a/test/spec/transactions/pin-mongos.yml
+++ b/test/spec/transactions/pin-mongos.yml
@@ -317,7 +317,7 @@ tests:
           insertedIds: {0: 3, 1: 4}
       # Session is pinned.
       - *assertSessionPinned
-      # Fail the commit with a non-transient error, eg MaxTimeMSExpired.
+      # Fail the commit with a non-transient error.
       - name: targetedFailPoint
         object: testRunner
         arguments:
@@ -327,12 +327,12 @@ tests:
             mode: { times: 1 }
             data:
               failCommands: ["commitTransaction"]
-              errorCode: 50 # MaxTimeMSExpired
+              errorCode: 51 # ManualInterventionRequired
       - name: commitTransaction
         object: session0
         result:
           errorLabelsOmit: ["TransientTransactionError"]
-          errorCode: 50
+          errorCode: 51
       - *assertSessionPinned
       # The next commit should succeed.
       - name: commitTransaction

--- a/test/spec/transactions/read-concern.json
+++ b/test/spec/transactions/read-concern.json
@@ -39,7 +39,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               }
             }
           }
@@ -110,7 +110,7 @@
               "cursor": {},
               "lsid": "session0",
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "txnNumber": {
                 "$numberLong": "1"
@@ -202,7 +202,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               }
             }
           }
@@ -274,7 +274,7 @@
               "batchSize": 3,
               "lsid": "session0",
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "txnNumber": {
                 "$numberLong": "1"
@@ -389,7 +389,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               }
             }
           }
@@ -484,7 +484,7 @@
               },
               "lsid": "session0",
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "txnNumber": {
                 "$numberLong": "1"
@@ -608,7 +608,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               }
             }
           }
@@ -664,7 +664,7 @@
               "key": "_id",
               "lsid": "session0",
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "txnNumber": {
                 "$numberLong": "1"
@@ -741,7 +741,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               }
             }
           }
@@ -780,7 +780,7 @@
               "find": "test",
               "lsid": "session0",
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "txnNumber": {
                 "$numberLong": "1"

--- a/test/spec/transactions/read-concern.yml
+++ b/test/spec/transactions/read-concern.yml
@@ -25,7 +25,7 @@ tests:
         arguments:
           options:
             readConcern:
-              level: snapshot
+              level: majority
       - &countDocuments
         name: countDocuments
         object: collection
@@ -51,7 +51,7 @@ tests:
             cursor: {}
             lsid: session0
             readConcern:
-              level: snapshot
+              level: majority
             txnNumber:
               $numberLong: "1"
             startTransaction: true
@@ -116,7 +116,7 @@ tests:
             batchSize: 3
             lsid: session0
             readConcern:
-              level: snapshot
+              level: majority
             txnNumber:
               $numberLong: "1"
             startTransaction: true
@@ -202,7 +202,7 @@ tests:
               batchSize: 3
             lsid: session0
             readConcern:
-              level: snapshot
+              level: majority
             txnNumber:
               $numberLong: "1"
             startTransaction: true
@@ -282,7 +282,7 @@ tests:
             key: _id
             lsid: session0
             readConcern:
-              level: snapshot
+              level: majority
             txnNumber:
               $numberLong: "1"
             startTransaction: true
@@ -328,7 +328,7 @@ tests:
             find: *collection_name
             lsid: session0
             readConcern:
-              level: snapshot
+              level: majority
             txnNumber:
               $numberLong: "1"
             startTransaction: true

--- a/test/spec/transactions/retryable-abort-errorLabels.json
+++ b/test/spec/transactions/retryable-abort-errorLabels.json
@@ -1,0 +1,204 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "abortTransaction only retries once with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "abortTransaction"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "abortTransaction does not retry without RetryableWriteError label",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "abortTransaction"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/transactions/retryable-abort-errorLabels.yml
+++ b/test/spec/transactions/retryable-abort-errorLabels.yml
@@ -1,0 +1,124 @@
+runOn:
+    -
+        minServerVersion: "4.3.1"
+        topology: ["replicaset", "sharded"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+tests:
+  - description: abortTransaction only retries once with RetryableWriteError from server
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["abortTransaction"]
+          errorCode: 112 # WriteConflict, not a retryable error code
+          errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: abortTransaction
+        object: session0
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+      - command_started_event: # Driver retries abort once
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data: []
+
+  - description: abortTransaction does not retry without RetryableWriteError label
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["abortTransaction"]
+          errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+          errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: abortTransaction
+        object: session0
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+    outcome: # Driver does not retry abort
+      collection:
+          data: []

--- a/test/spec/transactions/retryable-abort.json
+++ b/test/spec/transactions/retryable-abort.json
@@ -413,6 +413,9 @@
             "abortTransaction"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -514,6 +517,9 @@
             "abortTransaction"
           ],
           "errorCode": 13436,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -615,6 +621,9 @@
             "abortTransaction"
           ],
           "errorCode": 13435,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -705,7 +714,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after InterruptedDueToStepDown",
+      "description": "abortTransaction succeeds after InterruptedDueToReplStateChange",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -716,6 +725,9 @@
             "abortTransaction"
           ],
           "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -817,6 +829,9 @@
             "abortTransaction"
           ],
           "errorCode": 11600,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -918,6 +933,9 @@
             "abortTransaction"
           ],
           "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1019,6 +1037,9 @@
             "abortTransaction"
           ],
           "errorCode": 91,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1120,6 +1141,9 @@
             "abortTransaction"
           ],
           "errorCode": 7,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1221,6 +1245,9 @@
             "abortTransaction"
           ],
           "errorCode": 6,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1322,6 +1349,9 @@
             "abortTransaction"
           ],
           "errorCode": 9001,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1423,6 +1453,9 @@
             "abortTransaction"
           ],
           "errorCode": 89,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1525,6 +1558,9 @@
           ],
           "writeConcernError": {
             "code": 11600,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1627,7 +1663,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after WriteConcernError InterruptedDueToStepDown",
+      "description": "abortTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1639,6 +1675,9 @@
           ],
           "writeConcernError": {
             "code": 11602,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1753,6 +1792,9 @@
           ],
           "writeConcernError": {
             "code": 189,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1867,6 +1909,9 @@
           ],
           "writeConcernError": {
             "code": 91,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/test/spec/transactions/retryable-abort.yml
+++ b/test/spec/transactions/retryable-abort.yml
@@ -274,6 +274,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 10107
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -341,6 +342,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 13436
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -408,6 +410,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 13435
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -467,7 +470,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after InterruptedDueToStepDown 
+  - description: abortTransaction succeeds after InterruptedDueToReplStateChange
 
     failPoint:
       configureFailPoint: failCommand
@@ -475,6 +478,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 11602
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -542,6 +546,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 11600
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -609,6 +614,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 189
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -676,6 +682,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 91
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -743,6 +750,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 7
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -810,6 +818,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 6
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -877,6 +886,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 9001
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -944,6 +954,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 89
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -1012,6 +1023,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 11600
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1077,7 +1089,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after WriteConcernError InterruptedDueToStepDown 
+  - description: abortTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange
 
     failPoint:
       configureFailPoint: failCommand
@@ -1086,6 +1098,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 11602
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1160,6 +1173,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 189
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1234,6 +1248,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 91
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:

--- a/test/spec/transactions/retryable-commit-errorLabels.json
+++ b/test/spec/transactions/retryable-commit-errorLabels.json
@@ -1,0 +1,223 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "commitTransaction does not retry error without RetryableWriteError label",
+      "clientOptions": {
+        "retryWrites": false
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsOmit": [
+              "RetryableWriteError",
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "commitTransaction retries once with RetryableWriteError from server",
+      "clientOptions": {
+        "retryWrites": false
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/transactions/retryable-commit-errorLabels.yml
+++ b/test/spec/transactions/retryable-commit-errorLabels.yml
@@ -1,0 +1,132 @@
+runOn:
+    -
+        minServerVersion: "4.3.1"
+        topology: ["replicaset", "sharded"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  - description: commitTransaction does not retry error without RetryableWriteError label
+    clientOptions:
+      retryWrites: false
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+          errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+        result:
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError"]
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+    outcome: # Driver does not retry commit because there was no RetryableWriteError label on response
+      collection:
+        data: []
+
+  - description: commitTransaction retries once with RetryableWriteError from server
+    clientOptions:
+      retryWrites: false
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 112 # WriteConflict, not a retryable error code
+          errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern: { w: majority, wtimeout: 10000 }
+          command_name: commitTransaction
+          database_name: admin
+    outcome: # Driver retries commit and it succeeds
+      collection:
+        data:
+          - _id: 1

--- a/test/spec/transactions/retryable-commit.json
+++ b/test/spec/transactions/retryable-commit.json
@@ -57,6 +57,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -207,6 +208,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -353,7 +355,9 @@
           "result": {
             "errorCodeName": "Interrupted",
             "errorLabelsOmit": [
-              "TransientTransactionError"
+              "RetryableWriteError",
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
             ]
           }
         }
@@ -406,7 +410,7 @@
       }
     },
     {
-      "description": "commitTransaction fails after WriteConcernError Interrupted",
+      "description": "commitTransaction is not retried after UnsatisfiableWriteConcern error",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -417,8 +421,8 @@
             "commitTransaction"
           ],
           "writeConcernError": {
-            "code": 11601,
-            "errmsg": "operation was interrupted"
+            "code": 100,
+            "errmsg": "Not enough data-bearing nodes"
           }
         }
       },
@@ -452,7 +456,9 @@
           "object": "session0",
           "result": {
             "errorLabelsOmit": [
-              "TransientTransactionError"
+              "RetryableWriteError",
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
             ]
           }
         }
@@ -629,6 +635,9 @@
             "commitTransaction"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -737,6 +746,9 @@
             "commitTransaction"
           ],
           "errorCode": 13436,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -845,6 +857,9 @@
             "commitTransaction"
           ],
           "errorCode": 13435,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -942,7 +957,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after InterruptedDueToStepDown",
+      "description": "commitTransaction succeeds after InterruptedDueToReplStateChange",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -953,6 +968,9 @@
             "commitTransaction"
           ],
           "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1061,6 +1079,9 @@
             "commitTransaction"
           ],
           "errorCode": 11600,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1169,6 +1190,9 @@
             "commitTransaction"
           ],
           "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1277,6 +1301,9 @@
             "commitTransaction"
           ],
           "errorCode": 91,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1385,6 +1412,9 @@
             "commitTransaction"
           ],
           "errorCode": 7,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1493,6 +1523,9 @@
             "commitTransaction"
           ],
           "errorCode": 6,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1601,6 +1634,9 @@
             "commitTransaction"
           ],
           "errorCode": 9001,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1709,6 +1745,9 @@
             "commitTransaction"
           ],
           "errorCode": 89,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1818,6 +1857,9 @@
           ],
           "writeConcernError": {
             "code": 11600,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1925,7 +1967,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after WriteConcernError InterruptedDueToStepDown",
+      "description": "commitTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1937,6 +1979,9 @@
           ],
           "writeConcernError": {
             "code": 11602,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2056,6 +2101,9 @@
           ],
           "writeConcernError": {
             "code": 189,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2175,6 +2223,9 @@
           ],
           "writeConcernError": {
             "code": 91,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/test/spec/transactions/retryable-commit.yml
+++ b/test/spec/transactions/retryable-commit.yml
@@ -39,7 +39,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsContain: ["RetryableWriteError", "UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
       # Second call to commit succeeds because the failpoint was disabled.
       - name: commitTransaction
@@ -131,7 +131,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsContain: ["RetryableWriteError", "UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
       # Second call to commit succeeds because the failpoint was disabled.
       - name: commitTransaction
@@ -218,7 +218,7 @@ tests:
         object: session0
         result:
           errorCodeName: Interrupted
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError", "UnknownTransactionCommitResult"]
 
     expectations:
       - command_started_event:
@@ -252,7 +252,7 @@ tests:
       collection:
         data: []
 
-  - description: commitTransaction fails after WriteConcernError Interrupted
+  - description: commitTransaction is not retried after UnsatisfiableWriteConcern error
 
     failPoint:
       configureFailPoint: failCommand
@@ -260,8 +260,8 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           writeConcernError:
-            code: 11601
-            errmsg: operation was interrupted
+            code: 100
+            errmsg: Not enough data-bearing nodes
 
     operations:
       - name: startTransaction
@@ -281,7 +281,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError", "UnknownTransactionCommitResult"]
 
     expectations:
       - command_started_event:
@@ -393,6 +393,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 10107
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -462,6 +463,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 13436
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -531,6 +533,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 13435
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -592,7 +595,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after InterruptedDueToStepDown 
+  - description: commitTransaction succeeds after InterruptedDueToReplStateChange
 
     failPoint:
       configureFailPoint: failCommand
@@ -600,6 +603,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 11602
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -669,6 +673,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 11600
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -738,6 +743,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 189
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -807,6 +813,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 91
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -876,6 +883,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 7
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -945,6 +953,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 6
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -1014,6 +1023,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 9001
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -1083,6 +1093,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 89
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -1153,6 +1164,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 11600
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1219,7 +1231,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after WriteConcernError InterruptedDueToStepDown 
+  - description: commitTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange
 
     failPoint:
       configureFailPoint: failCommand
@@ -1228,6 +1240,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 11602
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1303,6 +1316,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 189
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1378,6 +1392,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 91
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:

--- a/test/spec/transactions/transaction-options-repl.json
+++ b/test/spec/transactions/transaction-options-repl.json
@@ -1,0 +1,181 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "readConcern snapshot in startTransaction options",
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot",
+                "afterClusterTime": 42
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/transactions/transaction-options-repl.yml
+++ b/test/spec/transactions/transaction-options-repl.yml
@@ -1,0 +1,117 @@
+runOn:
+  - minServerVersion: "4.0"
+    topology: ["replicaset"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+
+  - description: readConcern snapshot in startTransaction options
+
+    sessionOptions:
+      session0:
+        defaultTransactionOptions:
+          readConcern:
+            level: majority # Overridden.
+
+    operations:
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            readConcern:
+              level: snapshot
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+      # Now test abort.
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            readConcern:
+              level: snapshot
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 2
+        result:
+          insertedId: 2
+      - name: abortTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            readConcern:
+              level: snapshot
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 2
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "2"
+            startTransaction: true
+            autocommit: false
+            readConcern:
+              level: snapshot
+              afterClusterTime: 42
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "2"
+            startTransaction:
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1

--- a/test/spec/transactions/transaction-options.json
+++ b/test/spec/transactions/transaction-options.json
@@ -5,6 +5,12 @@
       "topology": [
         "replicaset"
       ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "transaction-tests",
@@ -316,7 +322,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "snapshot"
+              "level": "majority"
             },
             "writeConcern": {
               "w": 1
@@ -387,7 +393,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null
             },
@@ -432,7 +438,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot",
+                "level": "majority",
                 "afterClusterTime": 42
               },
               "writeConcern": null
@@ -481,7 +487,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "majority"
+              "level": "snapshot"
             },
             "writeConcern": {
               "w": 1
@@ -497,7 +503,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": {
                 "w": "majority"
@@ -529,7 +535,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": {
                 "w": "majority"
@@ -573,7 +579,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null,
               "maxTimeMS": null
@@ -619,7 +625,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot",
+                "level": "majority",
                 "afterClusterTime": 42
               },
               "writeConcern": null,
@@ -670,7 +676,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "snapshot"
+              "level": "majority"
             },
             "writeConcern": {
               "w": "majority"
@@ -741,7 +747,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null,
               "maxTimeMS": null
@@ -787,7 +793,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot",
+                "level": "majority",
                 "afterClusterTime": 42
               },
               "writeConcern": null,
@@ -971,172 +977,6 @@
               "writeConcern": {
                 "w": 1
               }
-            },
-            "command_name": "abortTransaction",
-            "database_name": "admin"
-          }
-        }
-      ],
-      "outcome": {
-        "collection": {
-          "data": [
-            {
-              "_id": 1
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "readConcern snapshot in startTransaction options",
-      "sessionOptions": {
-        "session0": {
-          "defaultTransactionOptions": {
-            "readConcern": {
-              "level": "majority"
-            }
-          }
-        }
-      },
-      "operations": [
-        {
-          "name": "startTransaction",
-          "object": "session0",
-          "arguments": {
-            "options": {
-              "readConcern": {
-                "level": "snapshot"
-              }
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session0",
-            "document": {
-              "_id": 1
-            }
-          },
-          "result": {
-            "insertedId": 1
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session0"
-        },
-        {
-          "name": "startTransaction",
-          "object": "session0",
-          "arguments": {
-            "options": {
-              "readConcern": {
-                "level": "snapshot"
-              }
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session0",
-            "document": {
-              "_id": 2
-            }
-          },
-          "result": {
-            "insertedId": 2
-          }
-        },
-        {
-          "name": "abortTransaction",
-          "object": "session0"
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "test",
-              "documents": [
-                {
-                  "_id": 1
-                }
-              ],
-              "ordered": true,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": true,
-              "autocommit": false,
-              "readConcern": {
-                "level": "snapshot"
-              },
-              "writeConcern": null
-            },
-            "command_name": "insert",
-            "database_name": "transaction-tests"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "commitTransaction": 1,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": null,
-              "autocommit": false,
-              "readConcern": null,
-              "writeConcern": null
-            },
-            "command_name": "commitTransaction",
-            "database_name": "admin"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "test",
-              "documents": [
-                {
-                  "_id": 2
-                }
-              ],
-              "ordered": true,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "2"
-              },
-              "startTransaction": true,
-              "autocommit": false,
-              "readConcern": {
-                "level": "snapshot",
-                "afterClusterTime": 42
-              },
-              "writeConcern": null
-            },
-            "command_name": "insert",
-            "database_name": "transaction-tests"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "abortTransaction": 1,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "2"
-              },
-              "startTransaction": null,
-              "autocommit": false,
-              "readConcern": null,
-              "writeConcern": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/test/spec/transactions/transaction-options.yml
+++ b/test/spec/transactions/transaction-options.yml
@@ -2,6 +2,9 @@ runOn:
     -
         minServerVersion: "4.0"
         topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
 
 database_name: &database_name "transaction-tests"
 collection_name: &collection_name "test"
@@ -185,7 +188,7 @@ tests:
       session0:
         defaultTransactionOptions:
           readConcern:
-            level: snapshot
+            level: majority
           writeConcern:
             w: 1
           maxCommitTimeMS: 60000
@@ -205,7 +208,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
             writeConcern:
           command_name: insert
           database_name: *database_name
@@ -235,7 +238,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
               afterClusterTime: 42
             writeConcern:
           command_name: insert
@@ -266,7 +269,7 @@ tests:
       session0:
         defaultTransactionOptions:
           readConcern:
-            level: majority
+            level: snapshot
           writeConcern:
             w: 1
           maxCommitTimeMS: 30000
@@ -277,7 +280,7 @@ tests:
         arguments:
           options:
             readConcern:
-              level: snapshot
+              level: majority
             writeConcern:
               w: majority
             maxCommitTimeMS: 60000
@@ -296,7 +299,7 @@ tests:
         arguments:
           options:
             readConcern:
-              level: snapshot
+              level: majority
             writeConcern:
               w: majority
       - name: insertOne
@@ -323,7 +326,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
             writeConcern:
             maxTimeMS:
           command_name: insert
@@ -354,7 +357,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
               afterClusterTime: 42
             writeConcern:
             maxTimeMS:
@@ -387,7 +390,7 @@ tests:
       session0:
         defaultTransactionOptions:
           readConcern:
-            level: snapshot
+            level: majority
           writeConcern:
             w: majority
           maxCommitTimeMS: 60000
@@ -407,7 +410,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
             writeConcern:
             maxTimeMS:
           command_name: insert
@@ -438,7 +441,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
               afterClusterTime: 42
             writeConcern:
             maxTimeMS:
@@ -532,110 +535,6 @@ tests:
             readConcern:
             writeConcern:
               w: 1
-          command_name: abortTransaction
-          database_name: admin
-
-    outcome: *outcome
-
-  - description: readConcern snapshot in startTransaction options
-
-    sessionOptions:
-      session0:
-        defaultTransactionOptions:
-          readConcern:
-            level: majority # Overridden.
-
-    operations:
-      - name: startTransaction
-        object: session0
-        arguments:
-          options:
-            readConcern:
-              level: snapshot
-      - name: insertOne
-        object: collection
-        arguments:
-          session: session0
-          document:
-            _id: 1
-        result:
-          insertedId: 1
-      - name: commitTransaction
-        object: session0
-      # Now test abort.
-      - name: startTransaction
-        object: session0
-        arguments:
-          options:
-            readConcern:
-              level: snapshot
-      - name: insertOne
-        object: collection
-        arguments:
-          session: session0
-          document:
-            _id: 2
-        result:
-          insertedId: 2
-      - name: abortTransaction
-        object: session0
-
-    expectations:
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - _id: 1
-            ordered: true
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            readConcern:
-              level: snapshot
-            writeConcern:
-          command_name: insert
-          database_name: *database_name
-      - command_started_event:
-          command:
-            commitTransaction: 1
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction:
-            autocommit: false
-            readConcern:
-            writeConcern:
-          command_name: commitTransaction
-          database_name: admin
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - _id: 2
-            ordered: true
-            lsid: session0
-            txnNumber:
-              $numberLong: "2"
-            startTransaction: true
-            autocommit: false
-            readConcern:
-              level: snapshot
-              afterClusterTime: 42
-            writeConcern:
-          command_name: insert
-          database_name: *database_name
-      - command_started_event:
-          command:
-            abortTransaction: 1
-            lsid: session0
-            txnNumber:
-              $numberLong: "2"
-            startTransaction:
-            autocommit: false
-            readConcern:
-            writeConcern:
           command_name: abortTransaction
           database_name: admin
 

--- a/test/spec/transactions/update.json
+++ b/test/spec/transactions/update.json
@@ -116,7 +116,6 @@
                       "x": 1
                     }
                   },
-                  "multi": false,
                   "upsert": true
                 }
               ],
@@ -145,9 +144,7 @@
                   },
                   "u": {
                     "y": 1
-                  },
-                  "multi": false,
-                  "upsert": false
+                  }
                 }
               ],
               "ordered": true,
@@ -179,8 +176,7 @@
                       "z": 1
                     }
                   },
-                  "multi": true,
-                  "upsert": false
+                  "multi": true
                 }
               ],
               "ordered": true,
@@ -346,7 +342,6 @@
                       "x": 1
                     }
                   },
-                  "multi": false,
                   "upsert": true
                 }
               ],
@@ -375,9 +370,7 @@
                   },
                   "u": {
                     "y": 1
-                  },
-                  "multi": false,
-                  "upsert": false
+                  }
                 }
               ],
               "ordered": true,
@@ -409,8 +402,7 @@
                       "z": 1
                     }
                   },
-                  "multi": true,
-                  "upsert": false
+                  "multi": true
                 }
               ],
               "ordered": true,

--- a/test/spec/transactions/update.yml
+++ b/test/spec/transactions/update.yml
@@ -65,7 +65,6 @@ tests:
             updates:
               - q: {_id: 4}
                 u: {$inc: {x: 1}}
-                multi: false
                 upsert: true
             ordered: true
             readConcern:
@@ -83,8 +82,6 @@ tests:
             updates:
               - q: {x: 1}
                 u: {y: 1}
-                multi: false
-                upsert: false
             ordered: true
             lsid: session0
             txnNumber:
@@ -101,7 +98,6 @@ tests:
               - q: {_id: {$gte: 3}}
                 u: {$set: {z: 1}}
                 multi: true
-                upsert: false
             ordered: true
             lsid: session0
             txnNumber:
@@ -194,7 +190,6 @@ tests:
             updates:
               - q: {_id: 4}
                 u: {$inc: {x: 1}}
-                multi: false
                 upsert: true
             ordered: true
             readConcern:
@@ -212,8 +207,6 @@ tests:
             updates:
               - q: {x: 1}
                 u: {y: 1}
-                multi: false
-                upsert: false
             ordered: true
             lsid: session0
             txnNumber:
@@ -230,7 +223,6 @@ tests:
               - q: {_id: {$gte: 3}}
                 u: {$set: {z: 1}}
                 multi: true
-                upsert: false
             ordered: true
             lsid: session0
             txnNumber:

--- a/test/spec/transactions/write-concern.json
+++ b/test/spec/transactions/write-concern.json
@@ -877,7 +877,6 @@
                       "x": 1
                     }
                   },
-                  "multi": false,
                   "upsert": true
                 }
               ],

--- a/test/spec/transactions/write-concern.yml
+++ b/test/spec/transactions/write-concern.yml
@@ -413,7 +413,6 @@ tests:
             updates:
               - q: {_id: 0}
                 u: {$inc: {x: 1}}
-                multi: false
                 upsert: true
             ordered: true
             <<: *transactionCommandArgs


### PR DESCRIPTION
## Description
Adds support for creating collections and indexes within transactions, as well as updating the transactions spec test suite.

**Are there any files to ignore?**
I split the commits for syncing the spec tests, so you can safely ignore those. 
