### PR TITLE
fix(server): avoid setting `serverSession.isDirty` if `serverSession` is null

### DIFF
--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -466,7 +466,7 @@ function makeOperationHandler(server, options, callback) {
   return function handleOperationResult(err, result) {
     if (err) {
       if (err instanceof MongoNetworkError) {
-        if (options && options.session) {
+        if (options && options.session && options.session.serverSession) {
           options.session.serverSession.isDirty = true;
         }
 


### PR DESCRIPTION
## Description

Re: Automattic/mongoose#8719 . I haven't been able to repro this issue, but the user claims they're seeing this issue consistently. Is there any harm in just skipping setting `isDirty` if for some reason `serverSession = null`?

**What changed?**

Quick one-liner to check for a property not being null

**Are there any files to ignore?**
