### PR TITLE
docs: Fix typo in Collection#find param

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -329,7 +329,7 @@ const DEPRECATED_FIND_OPTIONS = ['maxScan', 'fields', 'snapshot', 'oplogReplay']
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
  * @param {boolean} [options.partial=false] Specify if the cursor should return partial results when querying against a sharded system
  * @param {number} [options.maxTimeMS] Number of milliseconds to wait before aborting the query.
- * @param {number} [options.maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query. Requires `taiable` and `awaitData` to be true
+ * @param {number} [options.maxAwaitTimeMS] The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query. Requires `tailable` and `awaitData` to be true
  * @param {boolean} [options.noCursorTimeout] The server normally times out idle cursors after an inactivity period (10 minutes) to prevent excess memory use. Set this option to prevent that.
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {boolean} [options.allowDiskUse] Enables writing to temporary files on the server.


### PR DESCRIPTION
## Description
Just fixing a minor typo I noticed while browsing the docs.

**What changed?**
http://mongodb.github.io/node-mongodb-native/3.5//api/Collection.html#find shows the existing typo. This PR should remove it :smile: 

**Are there any files to ignore?**
Nope!