### PR TITLE
test: remove replicaset reIndex tests

### DIFF
--- a/test/functional/db.test.js
+++ b/test/functional/db.test.js
@@ -313,7 +313,7 @@ describe('Db', function() {
    */
   it('shouldCorrectlyForceReindexOnCollection', {
     metadata: {
-      requires: { topology: ['single', 'replicaset'] }
+      requires: { topology: ['single'] }
     },
 
     // The actual test we wish to run

--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -2855,7 +2855,7 @@ describe('Operation Examples', function() {
    */
   it('shouldCorrectlyIndexAndForceReindexOnCollection', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] }
+      requires: { topology: ['single', 'ssl', 'heap', 'wiredtiger'] }
     },
 
     // The actual test we wish to run


### PR DESCRIPTION
## Description
`reIndex` commands should only be run against standalone servers.

**What changed?**
Remove `replicaset` topology from tests running the `reIndex` command.

**Are there any files to ignore?**
