### PR TITLE
Node 2429/3.6/gridfs support indexes

### DIFF
--- a/test/functional/gridfs.test.js
+++ b/test/functional/gridfs.test.js
@@ -3884,4 +3884,37 @@ describe('GridFS', function() {
       });
     }
   });
+
+  /**
+   * @ignore
+   */
+  it('should correctly create index', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    // The actual test we wish to run
+    test: function(done) {
+      var configuration = this.configuration;
+      var GridStore = configuration.require.GridStore;
+      var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
+
+      client.connect(function(err, client) {
+        expect(err).to.not.exist;
+        var db = client.db(configuration.db);
+        var gridStore = new GridStore(db, 'test_gs_save_empty_file', 'w');
+        gridStore.open(function(err) {
+          expect(err).to.not.exist;
+          db.collection('fs.files').createIndex({ filename: 1, uploadDate: 1 }, {}, (err, val) => {
+            expect(err).to.not.exist;
+            expect(val).to.equal('filename_1_uploadDate_1');
+            gridStore.close(function(err) {
+              expect(err).to.not.exist;
+              client.close(done);
+            });
+          });
+        });
+      });
+    }
+  });
 });

--- a/test/functional/gridfs.test.js
+++ b/test/functional/gridfs.test.js
@@ -3889,7 +3889,7 @@ describe('GridFS', function() {
    * @ignore
    */
   it('should correctly create an index', function(done) {
-    const { configuration } = this;
+    const configuration = this.configuration;
     const client = configuration.newClient();
 
     client.connect((err, client) => {
@@ -3898,7 +3898,7 @@ describe('GridFS', function() {
       const gridStore = new GridStore(db, 'test_gs_save_empty_file', 'w');
       gridStore.open(err => {
         expect(err).to.not.exist;
-        db.collection('fs.files').createIndex({ filename: 1, uploadDate: 1 }, {}, (err, val) => {
+        db.collection('fs.files').createIndex({ filename: 1, uploadDate: 1 }, (err, val) => {
           expect(err).to.not.exist;
           expect(val).to.equal('filename_1_uploadDate_1');
           gridStore.close(err => {

--- a/test/functional/gridfs.test.js
+++ b/test/functional/gridfs.test.js
@@ -1,11 +1,12 @@
 'use strict';
 
-const { setupDatabase, assert: test } = require('./shared');
+const test = require('./shared').assert;
+const setupDatabase = require('./shared').setupDatabase;
 const fs = require('fs');
-const { format } = require('util');
+const format = require('util').format;
 const child_process = require('child_process');
-const { expect } = require('chai');
-const { Buffer } = require('safe-buffer');
+const expect = require('chai').expect;
+const Buffer = require('safe-buffer').Buffer;
 const GridStore = require('../../lib/gridfs/grid_store');
 
 describe('GridFS', function() {
@@ -3885,9 +3886,6 @@ describe('GridFS', function() {
     }
   });
 
-  /**
-   * @ignore
-   */
   it('should correctly create an index', function(done) {
     const configuration = this.configuration;
     const client = configuration.newClient();


### PR DESCRIPTION
I created a test to ensure driver doesn't fail when creating an index with:

```js
db.collection('fs.files').createIndex({ filename: 1, uploadDate: 1 })
```

* https://jira.mongodb.org/browse/NODE-2429
* https://jira.mongodb.org/browse/DRIVERS-789