### PR TITLE
Node 2506/3.6/write concern error propagate

### DIFF
--- a/test/unit/core/write_concern_error.test.js
+++ b/test/unit/core/write_concern_error.test.js
@@ -152,11 +152,8 @@ describe('WriteConcernError', function() {
         try {
           expect(err).to.be.an.instanceOf(MongoWriteConcernError);
           expect(err.result).to.exist;
-          expect(err.result.writeConcernError).to.exist;
-          expect(err.result.writeConcernError.errInfo).to.exist;
-          expect(err.result.writeConcernError.errInfo.writeConcern).to.exist;
-          expect(err.result.writeConcernError.errInfo.writeConcern.provenance).to.equal(
-            RAW_USER_WRITE_CONCERN_ERROR_INFO.writeConcernError.errInfo.writeConcern.provenance
+          expect(err.result.writeConcernError).to.deep.equal(
+            RAW_USER_WRITE_CONCERN_ERROR_INFO.writeConcernError
           );
         } catch (e) {
           _err = e;

--- a/test/unit/core/write_concern_error.test.js
+++ b/test/unit/core/write_concern_error.test.js
@@ -120,6 +120,7 @@ describe('WriteConcernError', function() {
           expect(err.result).to.not.have.property('errmsg');
           expect(err.result).to.not.have.property('code');
           expect(err.result).to.not.have.property('codeName');
+          expect(err.result).to.have.property('writeConcernError');
         } catch (e) {
           _err = e;
         } finally {


### PR DESCRIPTION
## Description

[NODE-2506](https://jira.mongodb.org/browse/NODE-2506)

**What changed?**

Added test to see if entire `writeConcernError` is propagated in the mocks.

**Are there any files to ignore?**
