### PR TITLE
fix(changeStream): hasNext should handle resume attempts

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -127,7 +127,31 @@ class ChangeStream extends EventEmitter {
    * @returns {Promise} returns Promise if no callback passed
    */
   hasNext(callback) {
-    return this.cursor.hasNext(callback);
+    // intercept and ignore errors during resume attempts
+    if (this.attemptingResume) {
+      return;
+    }
+    if (callback) {
+      const original = callback;
+      callback = (err, result) => {
+        if (err && this.attemptingResume) {
+          // ignore any errors until the change stream has resumed
+          this.onCursorRecreated(() => this.cursor.hasNext(original));
+        } else {
+          original(err, result);
+        }
+      };
+      return this.cursor.hasNext(callback);
+    }
+    return this.cursor.hasNext().catch(error => {
+      if (!this.attemptingResume) {
+        throw error;
+      } else {
+        return new Promise(resolve => this.onCursorRecreated(resolve)).then(() =>
+          this.cursor.hasNext()
+        );
+      }
+    });
   }
 
   /**
@@ -158,6 +182,9 @@ class ChangeStream extends EventEmitter {
    * @returns {boolean}
    */
   isClosed() {
+    if (this.attemptingResume) {
+      return false;
+    }
     if (this.cursor) {
       return this.cursor.isClosed();
     }

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -260,6 +260,9 @@ class ChangeStream extends EventEmitter {
   resume() {
     return this.cursor.resume();
   }
+  onCursorRecreated(cb) {
+    this.onRecoverCallback = cb;
+  }
 }
 
 class ChangeStreamCursor extends Cursor {
@@ -498,57 +501,55 @@ function processNewChange(args) {
       : changeStream.promiseLibrary.reject(error);
   }
 
-  const topology = changeStream.topology;
-  const options = changeStream.cursor.options;
-  const wireVersion = maxWireVersion(cursor.server);
+  function recreateCursor(resolve, reject) {
+    const topology = changeStream.topology;
+    const options = changeStream.cursor.options;
+
+    changeStream.attemptingResume = true;
+
+    // stop listening to all events from old cursor
+    ['data', 'close', 'end', 'error'].forEach(event =>
+      changeStream.cursor.removeAllListeners(event)
+    );
+
+    // close internal cursor, ignore errors
+    changeStream.cursor.close();
+
+    return waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
+      if (err) {
+        return reject(err);
+      }
+      changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
+      if (changeStream.onRecoverCallback) {
+        changeStream.onRecoverCallback();
+        delete changeStream.onRecoverCallback;
+      }
+      return resolve();
+    });
+  }
 
   if (error) {
-    if (isResumableError(error, wireVersion) && !changeStream.attemptingResume) {
-      changeStream.attemptingResume = true;
-
-      // stop listening to all events from old cursor
-      ['data', 'close', 'end', 'error'].forEach(event =>
-        changeStream.cursor.removeAllListeners(event)
-      );
-
-      // close internal cursor, ignore errors
-      changeStream.cursor.close();
-
-      // attempt recreating the cursor
+    if (isResumableError(error, maxWireVersion(cursor.server)) && !changeStream.attemptingResume) {
       if (eventEmitter) {
-        waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-          if (err) {
+        return recreateCursor(
+          function() {},
+          function(err) {
             changeStream.emit('error', err);
             changeStream.emit('close');
-            return;
           }
-          changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
-        });
-
-        return;
+        );
       }
-
       if (callback) {
-        waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-          if (err) return callback(err, null);
-
-          changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
-          changeStream.next(callback);
-        });
-
-        return;
+        return recreateCursor(
+          function() {
+            changeStream.next(callback);
+          },
+          function(err) {
+            return callback(err, null);
+          }
+        );
       }
-
-      return new Promise((resolve, reject) => {
-        waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-          if (err) return reject(err);
-          resolve();
-        });
-      })
-        .then(
-          () => (changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions))
-        )
-        .then(() => changeStream.next());
+      return new Promise(recreateCursor).then(() => changeStream.next());
     }
 
     if (eventEmitter) return changeStream.emit('error', error);

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -132,16 +132,14 @@ class ChangeStream extends EventEmitter {
       return;
     }
     if (callback) {
-      const original = callback;
-      callback = (err, result) => {
+      return this.cursor.hasNext((err, result) => {
         if (err && this.attemptingResume) {
           // ignore any errors until the change stream has resumed
-          this.onCursorRecreated(() => this.cursor.hasNext(original));
+          this.onCursorRecreated(() => this.cursor.hasNext(callback));
         } else {
-          original(err, result);
+          callback(err, result);
         }
-      };
-      return this.cursor.hasNext(callback);
+      });
     }
     return this.cursor.hasNext().catch(error => {
       if (!this.attemptingResume) {

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2795,29 +2795,83 @@ describe('Change Streams', function() {
 });
 
 describe('Change Stream Resume Error Tests', function() {
-  it('(events) should continue iterating after a resumable error', function(done) {
-    const configuration = this.configuration;
-    const client = configuration.newClient();
-    client.connect(err => {
-      expect(err).to.not.exist;
+  it('(events) should continue iterating after a resumable error', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    test: function(done) {
+      const configuration = this.configuration;
+      const client = configuration.newClient();
+      client.connect(err => {
+        expect(err).to.not.exist;
+        const collection = client.db().collection('test');
+        const changeStream = collection.watch();
+        const docs = [];
+        changeStream.on('change', change => {
+          expect(change).to.exist;
+          docs.push(change);
+          if (docs.length === 2) {
+            expect(docs[0]).to.containSubset({
+              operationType: 'insert',
+              fullDocument: { a: 42 }
+            });
+            expect(docs[1]).to.containSubset({
+              operationType: 'insert',
+              fullDocument: { b: 24 }
+            });
+            changeStream.close(() => client.close(done));
+          }
+        });
+        waitForStarted(changeStream, () => {
+          collection.insertOne({ a: 42 }, err => {
+            expect(err).to.not.exist;
+            triggerResumableError(changeStream, () => {
+              collection.insertOne({ b: 24 }, err => {
+                expect(err).to.not.exist;
+              });
+            });
+          });
+        });
+      });
+    }
+  });
+
+  it('(promises) hasNext should work after a resumable error', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    test: function(done) {
+      const configuration = this.configuration;
+      const client = configuration.newClient();
+      client.connect(err => {
+        expect(err).to.not.exist;
+        const collection = client.db().collection('test');
+        const changeStream = collection.watch();
+        waitForStarted(changeStream, () => {
+          collection.insertOne({ a: 42 }, err => {
+            expect(err).to.not.exist;
+            triggerResumableError(changeStream, () => {
+              changeStream.hasNext((err1, hasNext) => {
+                expect(err).to.not.exist;
+                expect(hasNext).to.be.true;
+                changeStream.close(() => client.close(done));
+              });
+            });
+          });
+        });
+        changeStream.hasNext((err, hasNext) => {
+          expect(err).to.not.exist;
+          expect(hasNext).to.be.true;
+          changeStream.close(() => client.close(done));
+        });
+      });
+    }
+  });
+
+  it('(promises) should continue iterating after a resumable error', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    test: async function() {
+      const configuration = this.configuration;
+      const client = configuration.newClient();
+      await client.connect();
       const collection = client.db().collection('test');
       const changeStream = collection.watch();
-      const docs = [];
-      changeStream.on('change', change => {
-        expect(change).to.exist;
-        docs.push(change);
-        if (docs.length === 2) {
-          expect(docs[0]).to.containSubset({
-            operationType: 'insert',
-            fullDocument: { a: 42 }
-          });
-          expect(docs[1]).to.containSubset({
-            operationType: 'insert',
-            fullDocument: { b: 24 }
-          });
-          changeStream.close(() => client.close(done));
-        }
-      });
       waitForStarted(changeStream, () => {
         collection.insertOne({ a: 42 }, err => {
           expect(err).to.not.exist;
@@ -2828,65 +2882,20 @@ describe('Change Stream Resume Error Tests', function() {
           });
         });
       });
-    });
-  });
-
-  it('(promises) hasNext should work after a resumable error', function(done) {
-    const configuration = this.configuration;
-    const client = configuration.newClient();
-    client.connect(err => {
-      expect(err).to.not.exist;
-      const collection = client.db().collection('test');
-      const changeStream = collection.watch();
-      waitForStarted(changeStream, () => {
-        collection.insertOne({ a: 42 }, err => {
-          expect(err).to.not.exist;
-          triggerResumableError(changeStream, () => {
-            changeStream.hasNext((err1, hasNext) => {
-              expect(err).to.not.exist;
-              expect(hasNext).to.be.true;
-              changeStream.close(() => client.close(done));
-            });
-          });
-        });
-      });
-      changeStream.hasNext((err, hasNext) => {
-        expect(err).to.not.exist;
-        expect(hasNext).to.be.true;
-        changeStream.close(() => client.close(done));
-      });
-    });
-  });
-
-  it('(promises) should continue iterating after a resumable error', async function() {
-    const configuration = this.configuration;
-    const client = configuration.newClient();
-    await client.connect();
-    const collection = client.db().collection('test');
-    const changeStream = collection.watch();
-    waitForStarted(changeStream, () => {
-      collection.insertOne({ a: 42 }, err => {
-        expect(err).to.not.exist;
-        triggerResumableError(changeStream, () => {
-          collection.insertOne({ b: 24 }, err => {
-            expect(err).to.not.exist;
-          });
-        });
-      });
-    });
-    const docs = [];
-    while (await changeStream.hasNext()) {
-      const change = await changeStream.next();
-      docs.push(change.fullDocument);
-      if (change.fullDocument.b === 24) {
-        break;
+      const docs = [];
+      while (await changeStream.hasNext()) {
+        const change = await changeStream.next();
+        docs.push(change.fullDocument);
+        if (change.fullDocument.b === 24) {
+          break;
+        }
       }
-    }
-    expect(docs)
-      .to.be.an('array')
-      .with.lengthOf(2);
+      expect(docs)
+        .to.be.an('array')
+        .with.lengthOf(2);
 
-    await changeStream.close();
-    await client.close();
+      await changeStream.close();
+      await client.close();
+    }
   });
 });


### PR DESCRIPTION
## Description

`changeStream.hasNext` would return an error after a resumable error. This is because the `hasNext` method just wrapped the internal cursor, which gets recreated during a resumable error. 

[NODE-2548](https://jira.mongodb.org/browse/NODE-2548)

**What changed?**

This PR introduces a `onCursorRecreated` method and refactors `hasNext` to wait for cursor recreation during resume attempts, and ignore any errors that pop up on the old cursor after the resumable error.

**Are there any files to ignore?**
