### PR TITLE
fix: remove check for NonResumableChangeStreamError label

### DIFF
--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -4,7 +4,6 @@ const Logger = require('./connection/logger');
 const retrieveBSON = require('./connection/utils').retrieveBSON;
 const MongoError = require('./error').MongoError;
 const MongoNetworkError = require('./error').MongoNetworkError;
-const mongoErrorContextSymbol = require('./error').mongoErrorContextSymbol;
 const collationNotSupported = require('./utils').collationNotSupported;
 const ReadPreference = require('./topologies/read_preference');
 const isUnifiedTopology = require('./utils').isUnifiedTopology;
@@ -774,10 +773,6 @@ function nextFunction(self, callback) {
     // Execute the next get more
     self._getMore(function(err, doc, connection) {
       if (err) {
-        if (err instanceof MongoError) {
-          err[mongoErrorContextSymbol].isGetMore = true;
-        }
-
         return handleCallback(callback, err);
       }
 

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const mongoErrorContextSymbol = Symbol('mongoErrorContextSymbol');
 const kErrorLabels = Symbol('errorLabels');
 
 /**
@@ -35,7 +34,6 @@ class MongoError extends Error {
     }
 
     this.name = 'MongoError';
-    this[mongoErrorContextSymbol] = this[mongoErrorContextSymbol] || {};
   }
 
   /**
@@ -314,7 +312,6 @@ module.exports = {
   MongoTimeoutError,
   MongoServerSelectionError,
   MongoWriteConcernError,
-  mongoErrorContextSymbol,
   isRetryableError,
   isSDAMUnrecoverableError,
   isNodeShuttingDownError,

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -22,7 +22,6 @@ module.exports = {
   MongoTimeoutError: require('./error').MongoTimeoutError,
   MongoServerSelectionError: require('./error').MongoServerSelectionError,
   MongoWriteConcernError: require('./error').MongoWriteConcernError,
-  mongoErrorContextSymbol: require('./error').mongoErrorContextSymbol,
   // Core
   Connection: require('./connection/connection'),
   Server: require('./topologies/server'),

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const MongoNetworkError = require('./core').MongoNetworkError;
-const mongoErrorContextSymbol = require('./core').mongoErrorContextSymbol;
 
 // From spec@https://github.com/mongodb/specifications/blob/f93d78191f3db2898a59013a7ed5650352ef6da8/source/change-streams/change-streams.rst#resumable-error
 const GET_MORE_RESUMABLE_CODES = new Set([
@@ -24,17 +23,7 @@ const GET_MORE_RESUMABLE_CODES = new Set([
   133 // FailedToSatisfyReadPreference
 ]);
 
-function isGetMoreError(error) {
-  if (error[mongoErrorContextSymbol]) {
-    return error[mongoErrorContextSymbol].isGetMore;
-  }
-}
-
 function isResumableError(error, wireVersion) {
-  if (!isGetMoreError(error)) {
-    return false;
-  }
-
   if (error instanceof MongoNetworkError) {
     return true;
   }

--- a/lib/error.js
+++ b/lib/error.js
@@ -3,12 +3,6 @@
 const MongoNetworkError = require('./core').MongoNetworkError;
 const mongoErrorContextSymbol = require('./core').mongoErrorContextSymbol;
 
-const GET_MORE_NON_RESUMABLE_CODES = new Set([
-  136, // CappedPositionLost
-  237, // CursorKilled
-  11601 // Interrupted
-]);
-
 // From spec@https://github.com/mongodb/specifications/blob/f93d78191f3db2898a59013a7ed5650352ef6da8/source/change-streams/change-streams.rst#resumable-error
 const GET_MORE_RESUMABLE_CODES = new Set([
   6, // HostUnreachable
@@ -49,10 +43,7 @@ function isResumableError(error, wireVersion) {
     return error.hasErrorLabel('ResumableChangeStreamError');
   }
 
-  return (
-    GET_MORE_RESUMABLE_CODES.has(error.code) &&
-    !error.hasErrorLabel('NonResumableChangeStreamError')
-  );
+  return GET_MORE_RESUMABLE_CODES.has(error.code);
 }
 
-module.exports = { GET_MORE_NON_RESUMABLE_CODES, GET_MORE_RESUMABLE_CODES, isResumableError };
+module.exports = { GET_MORE_RESUMABLE_CODES, isResumableError };

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -3,7 +3,6 @@ var assert = require('assert');
 var Transform = require('stream').Transform;
 const MongoError = require('../../lib/core').MongoError;
 var MongoNetworkError = require('../../lib/core').MongoNetworkError;
-const mongoErrorContextSymbol = require('../../lib/core').mongoErrorContextSymbol;
 const isResumableError = require('../../lib/error').isResumableError;
 var setupDatabase = require('./shared').setupDatabase;
 var delay = require('./shared').delay;
@@ -29,7 +28,6 @@ function triggerResumableError(changeStream, onCursorClosed) {
     changeStream.cursor.close(callback);
   };
   const fakeResumableError = new MongoNetworkError('fake error');
-  fakeResumableError[mongoErrorContextSymbol] = { isGetMore: true };
   changeStream.cursor.emit('error', fakeResumableError);
 }
 
@@ -2825,11 +2823,5 @@ describe('Change Streams', function() {
         );
       }
     });
-  });
-});
-
-describe('Change Stream Resume Error Tests', function() {
-  it('should properly process errors that lack the `mongoErrorContextSymbol`', function() {
-    expect(() => isResumableError(new Error())).to.not.throw();
   });
 });


### PR DESCRIPTION
## Description

The `isResumableError` function should not check for the
`NonResumableChangeStreamError` label. Per the change streams spec,
resumability is determined by the `ResumableChangeStreamError` label
for servers >= 4.4 and the manually maintained whitelist for
servers < 4.4.

[NODE-2565](https://jira.mongodb.org/browse/NODE-2565)

**What changed?**

**Are there any files to ignore?**
