### PR TITLE
fix: remove check for NonResumableChangeStreamError label

### DIFF
--- a/lib/cursor/core_cursor.js
+++ b/lib/cursor/core_cursor.js
@@ -6,7 +6,7 @@ const { collationNotSupported, SUPPORTS, MongoDBNamespace } = require('../utils'
 const executeOperation = require('../operations/execute_operation');
 const { Readable } = require('stream');
 const { OperationBase } = require('../operations/operation');
-const { MongoError, MongoNetworkError, mongoErrorContextSymbol } = require('../error');
+const { MongoError, MongoNetworkError } = require('../error');
 const {
   BSON: { Long }
 } = require('../deps');
@@ -793,10 +793,6 @@ function nextFunction(self, callback) {
     // Execute the next get more
     self._getMore(function(err, doc, connection) {
       if (err) {
-        if (err instanceof MongoError) {
-          err[mongoErrorContextSymbol].isGetMore = true;
-        }
-
         return handleCallback(callback, err);
       }
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -2,11 +2,7 @@
 
 const mongoErrorContextSymbol = Symbol('mongoErrorContextSymbol');
 const kErrorLabels = Symbol('errorLabels');
-const GET_MORE_NON_RESUMABLE_CODES = new Set([
-  136, // CappedPositionLost
-  237, // CursorKilled
-  11601 // Interrupted
-]);
+
 // From spec@https://github.com/mongodb/specifications/blob/f93d78191f3db2898a59013a7ed5650352ef6da8/source/change-streams/change-streams.rst#resumable-error
 const GET_MORE_RESUMABLE_CODES = new Set([
   6, // HostUnreachable
@@ -362,14 +358,10 @@ function isResumableError(error, wireVersion) {
     return error.hasErrorLabel('ResumableChangeStreamError');
   }
 
-  return (
-    GET_MORE_RESUMABLE_CODES.has(error.code) &&
-    !error.hasErrorLabel('NonResumableChangeStreamError')
-  );
+  return GET_MORE_RESUMABLE_CODES.has(error.code);
 }
 
 module.exports = {
-  GET_MORE_NON_RESUMABLE_CODES,
   GET_MORE_RESUMABLE_CODES,
   MongoError,
   MongoNetworkError,

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const mongoErrorContextSymbol = Symbol('mongoErrorContextSymbol');
 const kErrorLabels = Symbol('errorLabels');
 
 // From spec@https://github.com/mongodb/specifications/blob/f93d78191f3db2898a59013a7ed5650352ef6da8/source/change-streams/change-streams.rst#resumable-error
@@ -56,7 +55,6 @@ class MongoError extends Error {
     }
 
     this.name = 'MongoError';
-    this[mongoErrorContextSymbol] = this[mongoErrorContextSymbol] || {};
   }
 
   /**
@@ -339,17 +337,7 @@ function isNetworkTimeoutError(err) {
 //
 // An error on an aggregate command is not a resumable error. Only errors on a getMore command may be considered resumable errors.
 
-function isGetMoreError(error) {
-  if (error[mongoErrorContextSymbol]) {
-    return error[mongoErrorContextSymbol].isGetMore;
-  }
-}
-
 function isResumableError(error, wireVersion) {
-  if (!isGetMoreError(error)) {
-    return false;
-  }
-
   if (error instanceof MongoNetworkError) {
     return true;
   }
@@ -369,7 +357,6 @@ module.exports = {
   MongoTimeoutError,
   MongoServerSelectionError,
   MongoWriteConcernError,
-  mongoErrorContextSymbol,
   isRetryableError,
   isSDAMUnrecoverableError,
   isNodeShuttingDownError,

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -1,12 +1,7 @@
 'use strict';
 const assert = require('assert');
 const { Transform } = require('stream');
-const {
-  MongoError,
-  MongoNetworkError,
-  mongoErrorContextSymbol,
-  isResumableError
-} = require('../../lib/error');
+const { MongoError, MongoNetworkError } = require('../../lib/error');
 const { setupDatabase, delay } = require('./shared');
 const co = require('co');
 const mock = require('mongodb-mock-server');
@@ -31,7 +26,6 @@ function triggerResumableError(changeStream, onCursorClosed) {
     changeStream.cursor.close(callback);
   };
   const fakeResumableError = new MongoNetworkError('fake error');
-  fakeResumableError[mongoErrorContextSymbol] = { isGetMore: true };
   changeStream.cursor.emit('error', fakeResumableError);
 }
 
@@ -2796,11 +2790,5 @@ describe('Change Streams', function() {
         );
       }
     });
-  });
-});
-
-describe('Change Stream Resume Error Tests', function() {
-  it('should properly process errors that lack the `mongoErrorContextSymbol`', function() {
-    expect(() => isResumableError(new Error())).to.not.throw();
   });
 });


### PR DESCRIPTION
## Description

The `isResumableError` function should not check for the
`NonResumableChangeStreamError` label. Per the change streams spec,
resumability is determined by the `ResumableChangeStreamError` label
for servers >= 4.4 and the manually maintained whitelist for
servers < 4.4.

[NODE-2565](https://jira.mongodb.org/browse/NODE-2565)

**What changed?**

**Are there any files to ignore?**
