### PR TITLE
refactor: remove selectServerForSessionSupport

### DIFF
--- a/lib/operations/execute_operation.js
+++ b/lib/operations/execute_operation.js
@@ -27,10 +27,6 @@ function executeOperation(topology, operation, callback) {
     throw new TypeError('This method requires a valid operation instance');
   }
 
-  if (topology.shouldCheckForSessionSupport()) {
-    return selectServerForSessionSupport(topology, operation, callback);
-  }
-
   const Promise = topology.s.promiseLibrary;
 
   // The driver sessions spec mandates that we implicitly create sessions for operations
@@ -151,33 +147,6 @@ function executeWithServerSelection(topology, operation, callback) {
 
     operation.execute(server, callback);
   });
-}
-
-// TODO: This is only supported for unified topology, it should go away once
-//       we remove support for legacy topology types.
-function selectServerForSessionSupport(topology, operation, callback) {
-  const Promise = topology.s.promiseLibrary;
-
-  let result;
-  if (typeof callback !== 'function') {
-    result = new Promise((resolve, reject) => {
-      callback = (err, result) => {
-        if (err) return reject(err);
-        resolve(result);
-      };
-    });
-  }
-
-  topology.selectServer(ReadPreference.primaryPreferred, err => {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    executeOperation(topology, operation, callback);
-  });
-
-  return result;
 }
 
 module.exports = executeOperation;


### PR DESCRIPTION
## Description

This note was attached to the `selectServerForSessionSupport` function of `lib/operation/execute_operation.js`.

```
// TODO: This is only supported for unified topology, it should go away once
//       we remove support for legacy topology types.
```

[NODE-2325](https://jira.mongodb.org/browse/NODE-2325)

**What changed?**

`selectServerForSessionSupport` was removed.

**Are there any files to ignore?**
