### PR TITLE
feat(geoHaystackSearch): deprecate geoHaystackSearch

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2018,6 +2018,7 @@ Collection.prototype.parallelCollectionScan = deprecate(function(options, callba
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
+ * @deprecated
  */
 Collection.prototype.geoHaystackSearch = deprecate(function(x, y, options, callback) {
   const args = Array.prototype.slice.call(arguments, 2);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2019,7 +2019,7 @@ Collection.prototype.parallelCollectionScan = deprecate(function(options, callba
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-Collection.prototype.geoHaystackSearch = function(x, y, options, callback) {
+Collection.prototype.geoHaystackSearch = deprecate(function(x, y, options, callback) {
   const args = Array.prototype.slice.call(arguments, 2);
   callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   options = args.length ? args.shift() || {} : {};
@@ -2027,7 +2027,7 @@ Collection.prototype.geoHaystackSearch = function(x, y, options, callback) {
   const geoHaystackSearchOperation = new GeoHaystackSearchOperation(this, x, y, options);
 
   return executeOperation(this.s.topology, geoHaystackSearchOperation, callback);
-};
+}, 'geoHaystackSearch is deprecated, and will be removed in a future version.');
 
 /**
  * Run a group command across a collection

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2018,7 +2018,7 @@ Collection.prototype.parallelCollectionScan = deprecate(function(options, callba
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
- * @deprecated
+ * @deprecated See {@link https://docs.mongodb.com/manual/geospatial-queries/|geospatial queries docs} for current geospatial support
  */
 Collection.prototype.geoHaystackSearch = deprecate(function(x, y, options, callback) {
   const args = Array.prototype.slice.call(arguments, 2);


### PR DESCRIPTION
## Description

[NODE-2546](https://jira.mongodb.org/browse/NODE-2546)

**What changed?**

`Collection.geoHaystackSearch` was deprecated.

**Are there any files to ignore?**
