### PR TITLE
feat(sdam): ignore stale topology updates

### DIFF
--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -474,7 +474,10 @@ function executeWriteOperation(args, options, callback) {
 function markServerUnknown(server, error) {
   server.emit(
     'descriptionReceived',
-    new ServerDescription(server.description.address, null, { error })
+    new ServerDescription(server.description.address, null, {
+      error,
+      topologyVersion: server.description.topologyVersion
+    })
   );
 }
 

--- a/lib/core/sdam/server_description.js
+++ b/lib/core/sdam/server_description.js
@@ -74,6 +74,7 @@ class ServerDescription {
     this.lastWriteDate = ismaster.lastWrite ? ismaster.lastWrite.lastWriteDate : null;
     this.opTime = ismaster.lastWrite ? ismaster.lastWrite.opTime : null;
     this.type = parseServerType(ismaster);
+    this.topologyVersion = options.topologyVersion || ismaster.topologyVersion;
 
     // direct mappings
     ISMASTER_FIELDS.forEach(field => {
@@ -134,7 +135,8 @@ class ServerDescription {
         ? other.electionId && this.electionId.equals(other.electionId)
         : this.electionId === other.electionId) &&
       this.primary === other.primary &&
-      this.logicalSessionTimeoutMinutes === other.logicalSessionTimeoutMinutes
+      this.logicalSessionTimeoutMinutes === other.logicalSessionTimeoutMinutes &&
+      compareTopologyVersion(this.topologyVersion, other.topologyVersion) === 0
     );
   }
 }
@@ -175,7 +177,38 @@ function parseServerType(ismaster) {
   return ServerType.Standalone;
 }
 
+/**
+ * Compares two topology versions.
+ *
+ * @param {object} lhs
+ * @param {object} rhs
+ * @returns A negative number if `lhs` is older than `rhs`; positive if `lhs` is newer than `rhs`; 0 if they are equivalent.
+ */
+function compareTopologyVersion(lhs, rhs) {
+  if (lhs == null && rhs == null) {
+    return 0;
+  }
+
+  if (lhs == null || rhs == null) {
+    return -1;
+  }
+
+  if (lhs.processId.equals(rhs.processId)) {
+    // TODO: handle counters as Longs
+    if (lhs.counter === rhs.counter) {
+      return 0;
+    } else if (lhs.counter < rhs.counter) {
+      return -1;
+    }
+
+    return 1;
+  }
+
+  return -1;
+}
+
 module.exports = {
   ServerDescription,
-  parseServerType
+  parseServerType,
+  compareTopologyVersion
 };

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -26,6 +26,7 @@ const emitDeprecationWarning = require('../../utils').emitDeprecationWarning;
 const ServerSessionPool = require('../sessions').ServerSessionPool;
 const makeClientMetadata = require('../utils').makeClientMetadata;
 const CMAP_EVENT_NAMES = require('../../cmap/events').CMAP_EVENT_NAMES;
+const compareTopologyVersion = require('./server_description').compareTopologyVersion;
 
 const common = require('./common');
 const drainTimerQueue = common.drainTimerQueue;
@@ -512,6 +513,11 @@ class Topology extends EventEmitter {
       return;
     }
 
+    // ignore this server update if its from an outdated topologyVersion
+    if (isStaleServerDescription(this.s.description, serverDescription)) {
+      return;
+    }
+
     // these will be used for monitoring events later
     const previousTopologyDescription = this.s.description;
     const previousServerDescription = this.s.description.servers.get(serverDescription.address);
@@ -776,6 +782,16 @@ Topology.prototype.destroy = deprecate(
 const RETRYABLE_WRITE_OPERATIONS = ['findAndModify', 'insert', 'update', 'delete'];
 function isWriteCommand(command) {
   return RETRYABLE_WRITE_OPERATIONS.some(op => command[op]);
+}
+
+function isStaleServerDescription(topologyDescription, incomingServerDescription) {
+  const currentServerDescription = topologyDescription.servers.get(
+    incomingServerDescription.address
+  );
+  const currentTopologyVersion = currentServerDescription.topologyVersion;
+  return (
+    compareTopologyVersion(currentTopologyVersion, incomingServerDescription.topologyVersion) > 0
+  );
 }
 
 /**

--- a/test/functional/core/replset_state.test.js
+++ b/test/functional/core/replset_state.test.js
@@ -21,7 +21,8 @@ describe('ReplicaSet state', function() {
           description.match(/Primary mismatched me is not removed/) ||
           description.match(/replicaSet URI option causes starting topology to be RSNP/) ||
           description.match(/Discover secondary with directConnection URI option/) ||
-          description.match(/Discover ghost with directConnection URI option/)
+          description.match(/Discover ghost with directConnection URI option/) ||
+          description.match(/topologyVersion/)
         ) {
           this.skip();
           return;

--- a/test/spec/server-discovery-and-monitoring/README.rst
+++ b/test/spec/server-discovery-and-monitoring/README.rst
@@ -63,6 +63,7 @@ current TopologyDescription. It has the following keys:
 - logicalSessionTimeoutMinutes: absent, null, or an integer.
 - minWireVersion: absent or an integer.
 - maxWireVersion: absent or an integer.
+- topologyVersion: absent, null, or a topologyVersion document.
 
 In monitoring tests, an "outcome" contains a list of SDAM events that should
 have been published by the client as a result of processing ismaster responses
@@ -125,10 +126,10 @@ For monitoring tests, once all responses are processed, assert that the
 events collected so far by the SDAM event listener are equivalent to the
 events specified in the phase.
 
-Some fields such as "logicalSessionTimeoutMinutes" or "compatible" were added
-later and haven't been added to all test files. If these fields are present,
-test that they are equivalent to the fields of the driver's current
-TopologyDescription.
+Some fields such as "logicalSessionTimeoutMinutes", "compatible", and
+"topologyVersion" were added later and haven't been added to all test files.
+If these fields are present, test that they are equivalent to the fields of
+the driver's current TopologyDescription or ServerDescription.
 
 For monitoring tests, clear the list of events collected so far.
 

--- a/test/spec/server-discovery-and-monitoring/rs/topology_version_equal.json
+++ b/test/spec/server-discovery-and-monitoring/rs/topology_version_equal.json
@@ -1,0 +1,99 @@
+{
+  "description": "Primary with equal topologyVersion",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "topologyVersion": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/topology_version_equal.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/topology_version_equal.yml
@@ -1,0 +1,66 @@
+description: "Primary with equal topologyVersion"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    # Primary A is discovered
+    {
+        responses: [
+            ["a:27017", {
+                ok: 1,
+                ismaster: true,
+                hosts: ["a:27017"],
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 9,
+                topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "1"}}
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs",
+                    topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "1"}}
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    },
+
+    # A responds with an equal topologyVersion, we should process the response.
+    {
+        responses: [
+            ["a:27017", {
+                ok: 1,
+                ismaster: true,
+                hosts: ["a:27017", "b:27017"],
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 9,
+                topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "1"}}
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs",
+                    topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "1"}}
+                },
+                "b:27017": {
+                    type: "Unknown",
+                    topologyVersion: null
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/topology_version_greater.json
+++ b/test/spec/server-discovery-and-monitoring/rs/topology_version_greater.json
@@ -1,0 +1,255 @@
+{
+  "description": "Primary with newer topologyVersion",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "2"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "2"
+              }
+            }
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "topologyVersion": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000002"
+              },
+              "counter": {
+                "$numberLong": "0"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000002"
+              },
+              "counter": {
+                "$numberLong": "0"
+              }
+            }
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "topologyVersion": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "d:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": null
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": null
+          },
+          "d:27017": {
+            "type": "Unknown",
+            "topologyVersion": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "e:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000003"
+              },
+              "counter": {
+                "$numberLong": "0"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000003"
+              },
+              "counter": {
+                "$numberLong": "0"
+              }
+            }
+          },
+          "e:27017": {
+            "type": "Unknown",
+            "topologyVersion": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {}
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "topologyVersion": null
+          },
+          "e:27017": {
+            "type": "Unknown",
+            "topologyVersion": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/topology_version_greater.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/topology_version_greater.yml
@@ -1,0 +1,190 @@
+description: "Primary with newer topologyVersion"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    # Primary A is discovered
+    {
+        responses: [
+            ["a:27017", {
+                ok: 1,
+                ismaster: true,
+                hosts: ["a:27017"],
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 9,
+                topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "1"}}
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs",
+                    topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "1"}}
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    },
+
+    # A responds with a greater topologyVersion counter, we should process the response.
+    {
+        responses: [
+            ["a:27017", {
+                ok: 1,
+                ismaster: true,
+                hosts: ["a:27017", "b:27017"],
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 9,
+                topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "2"}}
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs",
+                    topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "2"}}
+                },
+                "b:27017": {
+
+                    type: "Unknown",
+                    topologyVersion: null
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    },
+
+    # A responds with a different topologyVersion processId, we should process the response.
+    {
+        responses: [
+            ["a:27017", {
+                ok: 1,
+                ismaster: true,
+                hosts: ["a:27017", "c:27017"],
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 9,
+                topologyVersion: {'processId': {"$oid": "000000000000000000000002"}, "counter": {"$numberLong": "0"}}
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs",
+                    topologyVersion: {'processId': {"$oid": "000000000000000000000002"}, "counter": {"$numberLong": "0"}}
+                },
+                "c:27017": {
+
+                    type: "Unknown",
+                    topologyVersion: null
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    },
+
+    # A responds without a topologyVersion, we should process the response.
+    {
+        responses: [
+            ["a:27017", {
+                ok: 1,
+                ismaster: true,
+                hosts: ["a:27017", "d:27017"],
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 9,
+                topologyVersion: null
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs",
+                    topologyVersion: null
+                },
+                "d:27017": {
+
+                    type: "Unknown",
+                    topologyVersion: null
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    },
+
+    # A responds with a topologyVersion again, we should process the response.
+    {
+        responses: [
+            ["a:27017", {
+                ok: 1,
+                ismaster: true,
+                hosts: ["a:27017", "e:27017"],
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 9,
+                topologyVersion: {'processId': {"$oid": "000000000000000000000003"}, "counter": {"$numberLong": "0"}}
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs",
+                    topologyVersion: {'processId': {"$oid": "000000000000000000000003"}, "counter": {"$numberLong": "0"}}
+                },
+                "e:27017": {
+
+                    type: "Unknown",
+                    topologyVersion: null
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    },
+
+    # A responds with a network error, we should process the response.
+    {
+        responses: [
+            ["a:27017", {}]
+        ],
+
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Unknown",
+                    topologyVersion: null
+                },
+                "e:27017": {
+
+                    type: "Unknown",
+                    topologyVersion: null
+                }
+            },
+            topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    }
+]

--- a/test/spec/server-discovery-and-monitoring/rs/topology_version_less.json
+++ b/test/spec/server-discovery-and-monitoring/rs/topology_version_less.json
@@ -1,0 +1,95 @@
+{
+  "description": "Primary with older topologyVersion",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "0"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/topology_version_less.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/topology_version_less.yml
@@ -1,0 +1,62 @@
+description: "Primary with older topologyVersion"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    # Primary A is discovered
+    {
+        responses: [
+            ["a:27017", {
+                ok: 1,
+                ismaster: true,
+                hosts: ["a:27017"],
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 9,
+                topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "1"}}
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs",
+                    topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "1"}}
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    },
+
+    # A responds with an older topologyVersion, we should ignore the response.
+    {
+        responses: [
+            ["a:27017", {
+                ok: 1,
+                ismaster: true,
+                hosts: ["a:27017", "b:27017"],
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 9,
+                topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "0"}}
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs",
+                    topologyVersion: {'processId': {"$oid": "000000000000000000000001"}, "counter": {"$numberLong": "1"}}
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    }
+]


### PR DESCRIPTION
This change introduces support for a `topologyVersion` field on monitoring responses. If this field is present, it will be used to determine if incoming monitoring responses are out of date, in which case the driver will not use the response to update the local topology information.

NODE-2559