### PR TITLE
fix event names in gridFS tutorial

### DIFF
--- a/docs/reference/content/tutorials/gridfs/streaming.md
+++ b/docs/reference/content/tutorials/gridfs/streaming.md
@@ -166,7 +166,7 @@ bucket.openDownloadStreamByName('meistersinger.mp3').
   on('error', function(error) {
     assert.ifError(error);
   }).
-  on('end', function() {
+  on('finish', function() {
     console.log('done!');
     process.exit(0);
   });
@@ -185,7 +185,7 @@ bucket.openDownloadStreamByName('meistersinger.mp3').
   on('error', function(error) {
     assert.ifError(error);
   }).
-  on('end', function() {
+  on('finish', function() {
     console.log('done!');
     process.exit(0);
   });


### PR DESCRIPTION
## Description

**What changed?**
event names for the pipe().on() listeners

**Are there any files to ignore?**
