### PR TITLE
chore: remove safe-buffer dependency

### DIFF
--- a/docs/guide/installation-guide.txt
+++ b/docs/guide/installation-guide.txt
@@ -21,9 +21,8 @@ Troubleshooting
 The MongoDB driver depends on several other packages, including:
 
 * `bson <https://www.npmjs.com/package/bson>`_
-* `require_optional <https://www.npmjs.com/package/require_optional>`_
-* `safe-buffer <https://www.npmjs.com/package/safe-buffer>`_
-* `saslprep <https://www.npmjs.com/package/saslprep>`_
+* `denque <https://github.com/invertase/denque>`_
+* `bl <https://github.com/rvagg/bl>`_
 
 Additionally, there are multiple optional dependencies that can be installed alongside the driver:
 

--- a/lib/cmap/auth/scram.js
+++ b/lib/cmap/auth/scram.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const crypto = require('crypto');
-const { Buffer } = require('safe-buffer');
 const {
   BSON: { Binary }
 } = require('../../deps');

--- a/lib/cmap/commands.js
+++ b/lib/cmap/commands.js
@@ -2,7 +2,6 @@
 
 const ReadPreference = require('../read_preference');
 const { BSON } = require('../deps');
-const { Buffer } = require('safe-buffer');
 const { databaseNamespace } = require('../utils');
 const { OP_QUERY, OP_GETMORE, OP_KILL_CURSORS, OP_MSG } = require('./wire_protocol/constants');
 

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -3,7 +3,6 @@
 var crypto = require('crypto');
 var stream = require('stream');
 var util = require('util');
-var Buffer = require('safe-buffer').Buffer;
 const {
   BSON: { ObjectId }
 } = require('../deps');

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "dependencies": {
     "bl": "^2.2.0",
     "bson": "^4.0.4",
-    "denque": "^1.4.1",
-    "safe-buffer": "^5.1.2"
+    "denque": "^1.4.1"
   },
   "devDependencies": {
     "@types/node": "^13.9.8",

--- a/test/disabled/server.test.js
+++ b/test/disabled/server.test.js
@@ -5,7 +5,6 @@ const locateAuthMethod = require('./shared').locateAuthMethod;
 const executeCommand = require('./shared').executeCommand;
 const BSON = require('bson');
 const mock = require('mongodb-mock-server');
-const Buffer = require('safe-buffer').Buffer;
 
 const core = require('../../../lib/core');
 const ReadPreference = core.ReadPreference;

--- a/test/functional/cursorstream.test.js
+++ b/test/functional/cursorstream.test.js
@@ -1,6 +1,5 @@
 'use strict';
 var expect = require('chai').expect;
-var Buffer = require('safe-buffer').Buffer;
 const setupDatabase = require('./shared').setupDatabase;
 const { Binary } = require('../..');
 

--- a/test/functional/find.test.js
+++ b/test/functional/find.test.js
@@ -2,7 +2,6 @@
 const test = require('./shared').assert;
 const setupDatabase = require('./shared').setupDatabase;
 const expect = require('chai').expect;
-const Buffer = require('safe-buffer').Buffer;
 const sinon = require('sinon');
 const { Code, ObjectID, Long, Binary } = require('../..');
 

--- a/test/functional/gridfs_stream.test.js
+++ b/test/functional/gridfs_stream.test.js
@@ -7,7 +7,6 @@ const fs = require('fs');
 const { assert: test } = require('./shared');
 const { setupDatabase } = require('./shared');
 const { expect } = require('chai');
-const { Buffer } = require('safe-buffer');
 const { GridFSBucket, ObjectId } = require('../..');
 
 describe('GridFS Stream', function() {

--- a/test/functional/insert.test.js
+++ b/test/functional/insert.test.js
@@ -4,7 +4,6 @@ const { setupDatabase } = require('./shared');
 const Script = require('vm');
 const { expect } = require('chai');
 const { normalizedFunctionString } = require('bson/lib/parser/utils');
-const { Buffer } = require('safe-buffer');
 
 const {
   Long,

--- a/test/functional/promote_buffers.test.js
+++ b/test/functional/promote_buffers.test.js
@@ -1,7 +1,6 @@
 'use strict';
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
-var Buffer = require('safe-buffer').Buffer;
 
 describe('Promote Buffers', function() {
   before(function() {

--- a/test/unit/core/common.js
+++ b/test/unit/core/common.js
@@ -2,7 +2,6 @@
 
 const mock = require('mongodb-mock-server');
 const { ObjectId, Timestamp, Binary } = require('bson');
-const { Buffer } = require('safe-buffer');
 
 class ReplSetFixture {
   constructor() {

--- a/test/unit/core/scram_iterations.test.js
+++ b/test/unit/core/scram_iterations.test.js
@@ -3,7 +3,6 @@
 const { expect } = require('chai');
 const mock = require('mongodb-mock-server');
 const { Topology } = require('../../../lib/sdam/topology');
-const { Buffer } = require('safe-buffer');
 const { MongoCredentials } = require('../../../lib/cmap/auth/mongo_credentials');
 
 describe('SCRAM Iterations Tests', function() {


### PR DESCRIPTION
## Description

`safe-buffer` [does nothing](https://github.com/feross/safe-buffer/blob/7d544741d5a360613abb0d47926e107722fae723/index.js#L11) when native `Buffer.from` API is available and it's available since Nodes.JS 5.10 (https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_array), so, there is no sense to bring it as production dependency (one of four) when your declared minimum supported Node.JS version is 10.x (in `master`).
