### PR TITLE
NODE-2487: introduce speculative authentication

### DIFF
--- a/lib/core/auth/auth_provider.js
+++ b/lib/core/auth/auth_provider.js
@@ -1,5 +1,14 @@
 'use strict';
 
+/**
+ * Context used during authentication
+ *
+ * @property {Connection} connection The connection to authenticate
+ * @property {MongoCredentials} credentials The credentials to use for authentication
+ * @property {object} options The options passed to the `connect` method
+ * @property {object?} response The response of the initial handshake
+ * @property {Buffer?} nonce A random nonce generated for use in an authentication conversation
+ */
 class AuthContext {
   constructor(connection, credentials, options) {
     this.connection = connection;
@@ -14,13 +23,24 @@ class AuthProvider {
   }
 
   /**
+   * Prepare the handshake document before the initial handshake.
+   *
+   * @param {object} handshakeDoc The document used for the initial handshake on a connection
+   * @param {AuthContext} authContext Context for authentication flow
+   * @param {function} callback
+   */
+  prepare(handshakeDoc, context, callback) {
+    callback(undefined, handshakeDoc);
+  }
+
+  /**
    * Authenticate
    *
    * @param {AuthContext} context A shared context for authentication flow
    * @param {authResultCallback} callback The callback to return the result from the authentication
    */
   auth(context, callback) {
-    callback(new Error('`auth` method must be overridden by subclass'));
+    callback(new TypeError('`auth` method must be overridden by subclass'));
   }
 }
 

--- a/lib/core/auth/auth_provider.js
+++ b/lib/core/auth/auth_provider.js
@@ -1,10 +1,13 @@
 'use strict';
 
-/**
- * Creates a new AuthProvider, which dictates how to authenticate for a given
- * mechanism.
- * @class
- */
+class AuthContext {
+  constructor(connection, credentials, options) {
+    this.connection = connection;
+    this.credentials = credentials;
+    this.options = options;
+  }
+}
+
 class AuthProvider {
   constructor(bson) {
     this.bson = bson;
@@ -12,29 +15,21 @@ class AuthProvider {
 
   /**
    * Authenticate
-   * @method
-   * @param {Connection} connection The connection to authenticate
-   * @param {MongoCredentials} credentials Authentication credentials
+   *
+   * @param {AuthContext} context A shared context for authentication flow
    * @param {authResultCallback} callback The callback to return the result from the authentication
    */
-  auth(/* connection, credentials, callback */) {
-    throw new Error('`auth` method must be overridden by subclass');
+  auth(context, callback) {
+    callback(new Error('`auth` method must be overridden by subclass'));
   }
 }
 
 /**
- * A callback for a specific auth command
- * @callback AuthWriteCallback
- * @param {Error} err If command failed, an error from the server
- * @param {object} r The response from the server
- */
-
-/**
- * This is a result from an authentication strategy
+ * This is a result from an authentication provider
  *
  * @callback authResultCallback
  * @param {error} error An error object. Set to null if no error present
  * @param {boolean} result The result of the authentication process
  */
 
-module.exports = { AuthProvider };
+module.exports = { AuthContext, AuthProvider };

--- a/lib/core/auth/gssapi.js
+++ b/lib/core/auth/gssapi.js
@@ -1,20 +1,13 @@
 'use strict';
-
 const AuthProvider = require('./auth_provider').AuthProvider;
 const retrieveKerberos = require('../utils').retrieveKerberos;
 let kerberos;
 
-/**
- * Creates a new GSSAPI authentication mechanism
- * @class
- * @extends AuthProvider
- */
 class GSSAPI extends AuthProvider {
-  /**
-   * Implementation of authentication for a single connection
-   * @override
-   */
-  auth(connection, credentials, callback) {
+  auth(authContext, callback) {
+    const connection = authContext.connection;
+    const credentials = authContext.credentials;
+
     if (kerberos == null) {
       try {
         kerberos = retrieveKerberos();

--- a/lib/core/auth/mongocr.js
+++ b/lib/core/auth/mongocr.js
@@ -3,17 +3,10 @@
 const crypto = require('crypto');
 const AuthProvider = require('./auth_provider').AuthProvider;
 
-/**
- * Creates a new MongoCR authentication mechanism
- *
- * @extends AuthProvider
- */
 class MongoCR extends AuthProvider {
-  /**
-   * Implementation of authentication for a single connection
-   * @override
-   */
-  auth(connection, credentials, callback) {
+  auth(authContext, callback) {
+    const connection = authContext.connection;
+    const credentials = authContext.credentials;
     const username = credentials.username;
     const password = credentials.password;
     const source = credentials.source;

--- a/lib/core/auth/mongodb_aws.js
+++ b/lib/core/auth/mongodb_aws.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const AuthProvider = require('./auth_provider').AuthProvider;
 const MongoCredentials = require('./mongo_credentials').MongoCredentials;
 const MongoError = require('../error').MongoError;
@@ -21,7 +20,10 @@ const AWS_EC2_URI = 'http://169.254.169.254';
 const AWS_EC2_PATH = '/latest/meta-data/iam/security-credentials';
 
 class MongoDBAWS extends AuthProvider {
-  auth(connection, credentials, callback) {
+  auth(authContext, callback) {
+    const connection = authContext.connection;
+    const credentials = authContext.credentials;
+
     if (maxWireVersion(connection) < 9) {
       callback(new MongoError('MONGODB-AWS authentication requires MongoDB version 4.4 or later'));
       return;

--- a/lib/core/auth/plain.js
+++ b/lib/core/auth/plain.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const retrieveBSON = require('../connection/utils').retrieveBSON;
 const AuthProvider = require('./auth_provider').AuthProvider;
 
@@ -7,19 +6,13 @@ const AuthProvider = require('./auth_provider').AuthProvider;
 const BSON = retrieveBSON();
 const Binary = BSON.Binary;
 
-/**
- * Creates a new Plain authentication mechanism
- *
- * @extends AuthProvider
- */
 class Plain extends AuthProvider {
-  /**
-   * Implementation of authentication for a single connection
-   * @override
-   */
-  auth(connection, credentials, callback) {
+  auth(authContext, callback) {
+    const connection = authContext.connection;
+    const credentials = authContext.credentials;
     const username = credentials.username;
     const password = credentials.password;
+
     const payload = new Binary(`\x00${username}\x00${password}`);
     const command = {
       saslStart: 1,

--- a/lib/core/auth/scram.js
+++ b/lib/core/auth/scram.js
@@ -15,32 +15,236 @@ try {
   // don't do anything;
 }
 
-var parsePayload = function(payload) {
-  var dict = {};
-  var parts = payload.split(',');
-  for (var i = 0; i < parts.length; i++) {
-    var valueParts = parts[i].split('=');
+class ScramSHA extends AuthProvider {
+  constructor(bson, cryptoMethod) {
+    super(bson);
+    this.cryptoMethod = cryptoMethod || 'sha1';
+  }
+
+  prepare(handshakeDoc, authContext, callback) {
+    const cryptoMethod = this.cryptoMethod;
+    if (cryptoMethod === 'sha256' && saslprep == null) {
+      console.warn('Warning: no saslprep library specified. Passwords will not be sanitized');
+    }
+
+    crypto.randomBytes(24, (err, nonce) => {
+      if (err) {
+        return callback(err);
+      }
+
+      // store the nonce for later use
+      Object.assign(authContext, { nonce });
+
+      const credentials = authContext.credentials;
+      const request = Object.assign({}, handshakeDoc, {
+        speculativeAuthenticate: Object.assign(makeFirstMessage(cryptoMethod, credentials, nonce), {
+          db: credentials.source
+        })
+      });
+
+      callback(undefined, request);
+    });
+  }
+
+  auth(authContext, callback) {
+    const response = authContext.response;
+    if (response && response.speculativeAuthenticate) {
+      continueScramConversation(
+        this.cryptoMethod,
+        response.speculativeAuthenticate,
+        authContext,
+        callback
+      );
+
+      return;
+    }
+
+    executeScram(this.cryptoMethod, authContext, callback);
+  }
+}
+
+function cleanUsername(username) {
+  return username.replace('=', '=3D').replace(',', '=2C');
+}
+
+function clientFirstMessageBare(username, nonce) {
+  // NOTE: This is done b/c Javascript uses UTF-16, but the server is hashing in UTF-8.
+  // Since the username is not sasl-prep-d, we need to do this here.
+  return Buffer.concat([
+    Buffer.from('n=', 'utf8'),
+    Buffer.from(username, 'utf8'),
+    Buffer.from(',r=', 'utf8'),
+    Buffer.from(nonce.toString('base64'), 'utf8')
+  ]);
+}
+
+function makeFirstMessage(cryptoMethod, credentials, nonce) {
+  const username = cleanUsername(credentials.username);
+  const mechanism = cryptoMethod === 'sha1' ? 'SCRAM-SHA-1' : 'SCRAM-SHA-256';
+
+  // NOTE: This is done b/c Javascript uses UTF-16, but the server is hashing in UTF-8.
+  // Since the username is not sasl-prep-d, we need to do this here.
+  return {
+    saslStart: 1,
+    mechanism,
+    payload: new Binary(
+      Buffer.concat([Buffer.from('n,,', 'utf8'), clientFirstMessageBare(username, nonce)])
+    ),
+    autoAuthorize: 1,
+    options: { skipEmptyExchange: true }
+  };
+}
+
+function executeScram(cryptoMethod, authContext, callback) {
+  const connection = authContext.connection;
+  const credentials = authContext.credentials;
+  const nonce = authContext.nonce;
+  const db = credentials.source;
+
+  const saslStartCmd = makeFirstMessage(cryptoMethod, credentials, nonce);
+  connection.command(`${db}.$cmd`, saslStartCmd, (_err, result) => {
+    const err = resolveError(_err, result);
+    if (err) {
+      return callback(err);
+    }
+
+    continueScramConversation(cryptoMethod, result.result, authContext, callback);
+  });
+}
+
+function continueScramConversation(cryptoMethod, response, authContext, callback) {
+  const connection = authContext.connection;
+  const credentials = authContext.credentials;
+  const nonce = authContext.nonce;
+
+  const db = credentials.source;
+  const username = cleanUsername(credentials.username);
+  const password = credentials.password;
+
+  let processedPassword;
+  if (cryptoMethod === 'sha256') {
+    processedPassword = saslprep ? saslprep(password) : password;
+  } else {
+    try {
+      processedPassword = passwordDigest(username, password);
+    } catch (e) {
+      return callback(e);
+    }
+  }
+
+  const payload = Buffer.isBuffer(response.payload)
+    ? new Binary(response.payload)
+    : response.payload;
+  const dict = parsePayload(payload.value());
+
+  const iterations = parseInt(dict.i, 10);
+  if (iterations && iterations < 4096) {
+    callback(new MongoError(`Server returned an invalid iteration count ${iterations}`), false);
+    return;
+  }
+
+  const salt = dict.s;
+  const rnonce = dict.r;
+  if (rnonce.startsWith('nonce')) {
+    callback(new MongoError(`Server returned an invalid nonce: ${rnonce}`), false);
+    return;
+  }
+
+  // Set up start of proof
+  const withoutProof = `c=biws,r=${rnonce}`;
+  const saltedPassword = HI(
+    processedPassword,
+    Buffer.from(salt, 'base64'),
+    iterations,
+    cryptoMethod
+  );
+
+  const clientKey = HMAC(cryptoMethod, saltedPassword, 'Client Key');
+  const serverKey = HMAC(cryptoMethod, saltedPassword, 'Server Key');
+  const storedKey = H(cryptoMethod, clientKey);
+  const authMessage = [
+    clientFirstMessageBare(username, nonce),
+    payload.value().toString('base64'),
+    withoutProof
+  ].join(',');
+
+  const clientSignature = HMAC(cryptoMethod, storedKey, authMessage);
+  const clientProof = `p=${xor(clientKey, clientSignature)}`;
+  const clientFinal = [withoutProof, clientProof].join(',');
+
+  const serverSignature = HMAC(cryptoMethod, serverKey, authMessage);
+  const saslContinueCmd = {
+    saslContinue: 1,
+    conversationId: response.conversationId,
+    payload: new Binary(Buffer.from(clientFinal))
+  };
+
+  connection.command(`${db}.$cmd`, saslContinueCmd, (_err, result) => {
+    const err = resolveError(_err, result);
+    if (err) {
+      return callback(err);
+    }
+
+    const r = result.result;
+    const parsedResponse = parsePayload(r.payload.value());
+    if (!compareDigest(Buffer.from(parsedResponse.v, 'base64'), serverSignature)) {
+      callback(new MongoError('Server returned an invalid signature'));
+      return;
+    }
+
+    if (!r || r.done !== false) {
+      return callback(err, r);
+    }
+
+    const retrySaslContinueCmd = {
+      saslContinue: 1,
+      conversationId: r.conversationId,
+      payload: Buffer.alloc(0)
+    };
+
+    connection.command(`${db}.$cmd`, retrySaslContinueCmd, callback);
+  });
+}
+
+function parsePayload(payload) {
+  const dict = {};
+  const parts = payload.split(',');
+  for (let i = 0; i < parts.length; i++) {
+    const valueParts = parts[i].split('=');
     dict[valueParts[0]] = valueParts[1];
   }
 
   return dict;
-};
+}
 
-var passwordDigest = function(username, password) {
-  if (typeof username !== 'string') throw new MongoError('username must be a string');
-  if (typeof password !== 'string') throw new MongoError('password must be a string');
-  if (password.length === 0) throw new MongoError('password cannot be empty');
-  // Use node md5 generator
-  var md5 = crypto.createHash('md5');
-  // Generate keys used for authentication
-  md5.update(username + ':mongo:' + password, 'utf8');
+function passwordDigest(username, password) {
+  if (typeof username !== 'string') {
+    throw new MongoError('username must be a string');
+  }
+
+  if (typeof password !== 'string') {
+    throw new MongoError('password must be a string');
+  }
+
+  if (password.length === 0) {
+    throw new MongoError('password cannot be empty');
+  }
+
+  const md5 = crypto.createHash('md5');
+  md5.update(`${username}:mongo:${password}`, 'utf8');
   return md5.digest('hex');
-};
+}
 
 // XOR two buffers
 function xor(a, b) {
-  if (!Buffer.isBuffer(a)) a = Buffer.from(a);
-  if (!Buffer.isBuffer(b)) b = Buffer.from(b);
+  if (!Buffer.isBuffer(a)) {
+    a = Buffer.from(a);
+  }
+
+  if (!Buffer.isBuffer(b)) {
+    b = Buffer.from(b);
+  }
+
   const length = Math.max(a.length, b.length);
   const res = [];
 
@@ -65,12 +269,12 @@ function HMAC(method, key, text) {
     .digest();
 }
 
-var _hiCache = {};
-var _hiCacheCount = 0;
-var _hiCachePurge = function() {
+let _hiCache = {};
+let _hiCacheCount = 0;
+function _hiCachePurge() {
   _hiCache = {};
   _hiCacheCount = 0;
-};
+}
 
 const hiLengthMap = {
   sha256: 32,
@@ -120,149 +324,6 @@ function compareDigest(lhs, rhs) {
   return result === 0;
 }
 
-class ScramSHA extends AuthProvider {
-  constructor(bson, cryptoMethod) {
-    super(bson);
-    this.cryptoMethod = cryptoMethod || 'sha1';
-  }
-
-  auth(authContext, callback) {
-    const connection = authContext.connection;
-    const credentials = authContext.credentials;
-
-    const cryptoMethod = this.cryptoMethod;
-    if (cryptoMethod === 'sha256' && saslprep == null) {
-      console.warn('Warning: no saslprep library specified. Passwords will not be sanitized');
-    }
-
-    // Create a random nonce
-    crypto.randomBytes(24, (err, buff) => {
-      if (err) {
-        return callback(err, null);
-      }
-
-      return executeScram(cryptoMethod, connection, credentials, buff.toString('base64'), callback);
-    });
-  }
-}
-
-function executeScram(cryptoMethod, connection, credentials, nonce, callback) {
-  let username = credentials.username;
-  const password = credentials.password;
-  const db = credentials.source;
-
-  let mechanism = 'SCRAM-SHA-1';
-  let processedPassword;
-  if (cryptoMethod === 'sha256') {
-    mechanism = 'SCRAM-SHA-256';
-
-    processedPassword = saslprep ? saslprep(password) : password;
-  } else {
-    try {
-      processedPassword = passwordDigest(username, password);
-    } catch (e) {
-      return callback(e);
-    }
-  }
-
-  // Clean up the user
-  username = username.replace('=', '=3D').replace(',', '=2C');
-
-  // NOTE: This is done b/c Javascript uses UTF-16, but the server is hashing in UTF-8.
-  // Since the username is not sasl-prep-d, we need to do this here.
-  const firstBare = Buffer.concat([
-    Buffer.from('n=', 'utf8'),
-    Buffer.from(username, 'utf8'),
-    Buffer.from(',r=', 'utf8'),
-    Buffer.from(nonce, 'utf8')
-  ]);
-
-  // Build command structure
-  const saslStartCmd = {
-    saslStart: 1,
-    mechanism,
-    payload: new Binary(Buffer.concat([Buffer.from('n,,', 'utf8'), firstBare])),
-    autoAuthorize: 1,
-    options: { skipEmptyExchange: true }
-  };
-
-  // Write the commmand on the connection
-  connection.command(`${db}.$cmd`, saslStartCmd, (_err, result) => {
-    const err = resolveError(_err, result);
-    if (err) {
-      return callback(err);
-    }
-
-    const r = result.result;
-    const payload = Buffer.isBuffer(r.payload) ? new Binary(r.payload) : r.payload;
-    const dict = parsePayload(payload.value());
-
-    const iterations = parseInt(dict.i, 10);
-    if (iterations && iterations < 4096) {
-      callback(new MongoError(`Server returned an invalid iteration count ${iterations}`), false);
-      return;
-    }
-
-    const salt = dict.s;
-    const rnonce = dict.r;
-    if (rnonce.startsWith('nonce')) {
-      callback(new MongoError(`Server returned an invalid nonce: ${rnonce}`), false);
-      return;
-    }
-
-    // Set up start of proof
-    const withoutProof = `c=biws,r=${rnonce}`;
-    const saltedPassword = HI(
-      processedPassword,
-      Buffer.from(salt, 'base64'),
-      iterations,
-      cryptoMethod
-    );
-
-    const clientKey = HMAC(cryptoMethod, saltedPassword, 'Client Key');
-    const serverKey = HMAC(cryptoMethod, saltedPassword, 'Server Key');
-    const storedKey = H(cryptoMethod, clientKey);
-    const authMessage = [firstBare, payload.value().toString('base64'), withoutProof].join(',');
-
-    const clientSignature = HMAC(cryptoMethod, storedKey, authMessage);
-    const clientProof = `p=${xor(clientKey, clientSignature)}`;
-    const clientFinal = [withoutProof, clientProof].join(',');
-
-    const serverSignature = HMAC(cryptoMethod, serverKey, authMessage);
-    const saslContinueCmd = {
-      saslContinue: 1,
-      conversationId: r.conversationId,
-      payload: new Binary(Buffer.from(clientFinal))
-    };
-
-    connection.command(`${db}.$cmd`, saslContinueCmd, (_err, result) => {
-      const err = resolveError(_err, result);
-      if (err) {
-        return callback(err);
-      }
-
-      const r = result.result;
-      const parsedResponse = parsePayload(r.payload.value());
-      if (!compareDigest(Buffer.from(parsedResponse.v, 'base64'), serverSignature)) {
-        callback(new MongoError('Server returned an invalid signature'));
-        return;
-      }
-
-      if (!r || r.done !== false) {
-        return callback(err, r);
-      }
-
-      const retrySaslContinueCmd = {
-        saslContinue: 1,
-        conversationId: r.conversationId,
-        payload: Buffer.alloc(0)
-      };
-
-      connection.command(`${db}.$cmd`, retrySaslContinueCmd, callback);
-    });
-  });
-}
-
 function resolveError(err, result) {
   if (err) return err;
 
@@ -270,22 +331,12 @@ function resolveError(err, result) {
   if (r.$err || r.errmsg) return new MongoError(r);
 }
 
-/**
- * Creates a new ScramSHA1 authentication mechanism
- * @class
- * @extends ScramSHA
- */
 class ScramSHA1 extends ScramSHA {
   constructor(bson) {
     super(bson, 'sha1');
   }
 }
 
-/**
- * Creates a new ScramSHA256 authentication mechanism
- * @class
- * @extends ScramSHA
- */
 class ScramSHA256 extends ScramSHA {
   constructor(bson) {
     super(bson, 'sha256');

--- a/lib/core/auth/scram.js
+++ b/lib/core/auth/scram.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const crypto = require('crypto');
 const Buffer = require('safe-buffer').Buffer;
 const retrieveBSON = require('../connection/utils').retrieveBSON;
@@ -121,22 +120,16 @@ function compareDigest(lhs, rhs) {
   return result === 0;
 }
 
-/**
- * Creates a new ScramSHA authentication mechanism
- * @class
- * @extends AuthProvider
- */
 class ScramSHA extends AuthProvider {
   constructor(bson, cryptoMethod) {
     super(bson);
     this.cryptoMethod = cryptoMethod || 'sha1';
   }
 
-  /**
-   * Implementation of authentication for a single connection
-   * @override
-   */
-  auth(connection, credentials, callback) {
+  auth(authContext, callback) {
+    const connection = authContext.connection;
+    const credentials = authContext.credentials;
+
     const cryptoMethod = this.cryptoMethod;
     if (cryptoMethod === 'sha256' && saslprep == null) {
       console.warn('Warning: no saslprep library specified. Passwords will not be sanitized');

--- a/lib/core/auth/x509.js
+++ b/lib/core/auth/x509.js
@@ -2,18 +2,34 @@
 const AuthProvider = require('./auth_provider').AuthProvider;
 
 class X509 extends AuthProvider {
+  prepare(handshakeDoc, authContext, callback) {
+    const credentials = authContext.credentials;
+    Object.assign(handshakeDoc, {
+      speculativeAuthenticate: x509AuthenticateCommand(credentials)
+    });
+
+    callback(undefined, handshakeDoc);
+  }
+
   auth(authContext, callback) {
     const connection = authContext.connection;
     const credentials = authContext.credentials;
-
-    const username = credentials.username;
-    const command = { authenticate: 1, mechanism: 'MONGODB-X509' };
-    if (username) {
-      command.user = username;
+    const response = authContext.response;
+    if (response.speculativeAuthenticate) {
+      return callback();
     }
 
-    connection.command('$external.$cmd', command, callback);
+    connection.command('$external.$cmd', x509AuthenticateCommand(credentials), callback);
   }
+}
+
+function x509AuthenticateCommand(credentials) {
+  const command = { authenticate: 1, mechanism: 'MONGODB-X509' };
+  if (credentials.username) {
+    Object.apply(command, { user: credentials.username });
+  }
+
+  return command;
 }
 
 module.exports = X509;

--- a/lib/core/auth/x509.js
+++ b/lib/core/auth/x509.js
@@ -1,18 +1,11 @@
 'use strict';
-
 const AuthProvider = require('./auth_provider').AuthProvider;
 
-/**
- * Creates a new X509 authentication mechanism
- * @class
- * @extends AuthProvider
- */
 class X509 extends AuthProvider {
-  /**
-   * Implementation of authentication for a single connection
-   * @override
-   */
-  auth(connection, credentials, callback) {
+  auth(authContext, callback) {
+    const connection = authContext.connection;
+    const credentials = authContext.credentials;
+
     const username = credentials.username;
     const command = { authenticate: 1, mechanism: 'MONGODB-X509' };
     if (username) {

--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -5,6 +5,7 @@ const Connection = require('./connection');
 const MongoError = require('../error').MongoError;
 const MongoNetworkError = require('../error').MongoNetworkError;
 const defaultAuthProviders = require('../auth/defaultAuthProviders').defaultAuthProviders;
+const AuthContext = require('../auth/auth_provider').AuthContext;
 const WIRE_CONSTANTS = require('../wireprotocol/constants');
 const makeClientMetadata = require('../utils').makeClientMetadata;
 const MAX_SUPPORTED_WIRE_VERSION = WIRE_CONSTANTS.MAX_SUPPORTED_WIRE_VERSION;
@@ -81,7 +82,8 @@ function performInitialHandshake(conn, options, _callback) {
     }
   }
 
-  prepareHandshakeDocument(options, (err, handshakeDoc) => {
+  const authContext = new AuthContext(conn, credentials, options);
+  prepareHandshakeDocument(authContext, (err, handshakeDoc) => {
     if (err) {
       return callback(err);
     }
@@ -137,7 +139,7 @@ function performInitialHandshake(conn, options, _callback) {
       if (!response.arbiterOnly && credentials) {
         const resolvedCredentials = credentials.resolveAuthMechanism(response);
         const authProvider = AUTH_PROVIDERS[resolvedCredentials.mechanism];
-        authProvider.auth(conn, credentials, err => {
+        authProvider.auth(authContext, err => {
           if (err) return callback(err);
           callback(undefined, conn);
         });
@@ -150,9 +152,11 @@ function performInitialHandshake(conn, options, _callback) {
   });
 }
 
-function prepareHandshakeDocument(options, callback) {
+function prepareHandshakeDocument(authContext, callback) {
+  const options = authContext.options;
   const compressors =
     options.compression && options.compression.compressors ? options.compression.compressors : [];
+
   const handshakeDoc = {
     ismaster: true,
     client: options.metadata || makeClientMetadata(options),

--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -137,6 +137,9 @@ function performInitialHandshake(conn, options, _callback) {
       conn.lastIsMasterMS = new Date().getTime() - start;
 
       if (!response.arbiterOnly && credentials) {
+        // store the response on auth context
+        Object.assign(authContext, { response });
+
         const resolvedCredentials = credentials.resolveAuthMechanism(response);
         const authProvider = AUTH_PROVIDERS[resolvedCredentials.mechanism];
         authProvider.auth(authContext, err => {
@@ -163,13 +166,20 @@ function prepareHandshakeDocument(authContext, callback) {
     compression: compressors
   };
 
-  const credentials = options.credentials;
+  const credentials = authContext.credentials;
   if (credentials) {
     if (credentials.mechanism.match(/DEFAULT/i) && credentials.username) {
       Object.assign(handshakeDoc, {
         saslSupportedMechs: `${credentials.source}.${credentials.username}`
       });
+
+      AUTH_PROVIDERS['scram-sha-256'].prepare(handshakeDoc, authContext, callback);
+      return;
     }
+
+    const authProvider = AUTH_PROVIDERS[credentials.mechanism];
+    authProvider.prepare(handshakeDoc, authContext, callback);
+    return;
   }
 
   callback(undefined, handshakeDoc);

--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -39,29 +39,6 @@ function isModernConnectionType(conn) {
   return !(conn instanceof Connection);
 }
 
-function getSaslSupportedMechs(options) {
-  if (!(options && options.credentials)) {
-    return {};
-  }
-
-  const credentials = options.credentials;
-
-  // TODO: revisit whether or not items like `options.user` and `options.dbName` should be checked here
-  const authMechanism = credentials.mechanism;
-  const authSource = credentials.source || options.dbName || 'admin';
-  const user = credentials.username || options.user;
-
-  if (typeof authMechanism === 'string' && authMechanism.toUpperCase() !== 'DEFAULT') {
-    return {};
-  }
-
-  if (!user) {
-    return {};
-  }
-
-  return { saslSupportedMechs: `${authSource}.${user}` };
-}
-
 function checkSupportedServer(ismaster, options) {
   const serverVersionHighEnough =
     ismaster &&
@@ -96,77 +73,102 @@ function performInitialHandshake(conn, options, _callback) {
     _callback(err, ret);
   };
 
-  let compressors = [];
-  if (options.compression && options.compression.compressors) {
-    compressors = options.compression.compressors;
+  const credentials = options.credentials;
+  if (credentials) {
+    if (!credentials.mechanism.match(/DEFAULT/i) && !AUTH_PROVIDERS[credentials.mechanism]) {
+      callback(new MongoError(`authMechanism '${credentials.mechanism}' not supported`));
+      return;
+    }
   }
 
-  const handshakeDoc = Object.assign(
-    {
-      ismaster: true,
-      client: options.metadata || makeClientMetadata(options),
-      compression: compressors
-    },
-    getSaslSupportedMechs(options)
-  );
-
-  const handshakeOptions = Object.assign({}, options);
-
-  // The handshake technically is a monitoring check, so its socket timeout should be connectTimeoutMS
-  if (options.connectTimeoutMS || options.connectionTimeout) {
-    handshakeOptions.socketTimeout = options.connectTimeoutMS || options.connectionTimeout;
-  }
-
-  const start = new Date().getTime();
-  conn.command('admin.$cmd', handshakeDoc, handshakeOptions, (err, result) => {
+  prepareHandshakeDocument(options, (err, handshakeDoc) => {
     if (err) {
-      callback(err);
-      return;
+      return callback(err);
     }
 
-    const ismaster = result.result;
-    if (ismaster.ok === 0) {
-      callback(new MongoError(ismaster));
-      return;
+    const handshakeOptions = Object.assign({}, options);
+    if (options.connectTimeoutMS || options.connectionTimeout) {
+      // The handshake technically is a monitoring check, so its socket timeout should be connectTimeoutMS
+      handshakeOptions.socketTimeout = options.connectTimeoutMS || options.connectionTimeout;
     }
 
-    const supportedServerErr = checkSupportedServer(ismaster, options);
-    if (supportedServerErr) {
-      callback(supportedServerErr);
-      return;
-    }
+    const start = new Date().getTime();
+    conn.command('admin.$cmd', handshakeDoc, handshakeOptions, (err, result) => {
+      if (err) {
+        callback(err);
+        return;
+      }
 
-    if (!isModernConnectionType(conn)) {
-      // resolve compression
-      if (ismaster.compression) {
-        const agreedCompressors = compressors.filter(
-          compressor => ismaster.compression.indexOf(compressor) !== -1
-        );
+      const response = result.result;
+      if (response.ok === 0) {
+        callback(new MongoError(response));
+        return;
+      }
 
-        if (agreedCompressors.length) {
-          conn.agreedCompressor = agreedCompressors[0];
-        }
+      const supportedServerErr = checkSupportedServer(response, options);
+      if (supportedServerErr) {
+        callback(supportedServerErr);
+        return;
+      }
 
-        if (options.compression && options.compression.zlibCompressionLevel) {
-          conn.zlibCompressionLevel = options.compression.zlibCompressionLevel;
+      if (!isModernConnectionType(conn)) {
+        // resolve compression
+        if (response.compression) {
+          const agreedCompressors = handshakeDoc.compression.filter(
+            compressor => response.compression.indexOf(compressor) !== -1
+          );
+
+          if (agreedCompressors.length) {
+            conn.agreedCompressor = agreedCompressors[0];
+          }
+
+          if (options.compression && options.compression.zlibCompressionLevel) {
+            conn.zlibCompressionLevel = options.compression.zlibCompressionLevel;
+          }
         }
       }
-    }
 
-    // NOTE: This is metadata attached to the connection while porting away from
-    //       handshake being done in the `Server` class. Likely, it should be
-    //       relocated, or at very least restructured.
-    conn.ismaster = ismaster;
-    conn.lastIsMasterMS = new Date().getTime() - start;
+      // NOTE: This is metadata attached to the connection while porting away from
+      //       handshake being done in the `Server` class. Likely, it should be
+      //       relocated, or at very least restructured.
+      conn.ismaster = response;
+      conn.lastIsMasterMS = new Date().getTime() - start;
 
-    const credentials = options.credentials;
-    if (!ismaster.arbiterOnly && credentials) {
-      authenticate(conn, credentials.resolveAuthMechanism(ismaster), callback);
-      return;
-    }
+      if (!response.arbiterOnly && credentials) {
+        const resolvedCredentials = credentials.resolveAuthMechanism(response);
+        const authProvider = AUTH_PROVIDERS[resolvedCredentials.mechanism];
+        authProvider.auth(conn, credentials, err => {
+          if (err) return callback(err);
+          callback(undefined, conn);
+        });
 
-    callback(undefined, conn);
+        return;
+      }
+
+      callback(undefined, conn);
+    });
   });
+}
+
+function prepareHandshakeDocument(options, callback) {
+  const compressors =
+    options.compression && options.compression.compressors ? options.compression.compressors : [];
+  const handshakeDoc = {
+    ismaster: true,
+    client: options.metadata || makeClientMetadata(options),
+    compression: compressors
+  };
+
+  const credentials = options.credentials;
+  if (credentials) {
+    if (credentials.mechanism.match(/DEFAULT/i) && credentials.username) {
+      Object.assign(handshakeDoc, {
+        saslSupportedMechs: `${credentials.source}.${credentials.username}`
+      });
+    }
+  }
+
+  callback(undefined, handshakeDoc);
 }
 
 const LEGAL_SSL_SOCKET_OPTIONS = [
@@ -315,20 +317,6 @@ function makeConnection(family, options, cancellationToken, _callback) {
   }
 
   socket.once(connectEvent, connectHandler);
-}
-
-function authenticate(conn, credentials, callback) {
-  const mechanism = credentials.mechanism;
-  if (!AUTH_PROVIDERS[mechanism]) {
-    callback(new MongoError(`authMechanism '${mechanism}' not supported`));
-    return;
-  }
-
-  const provider = AUTH_PROVIDERS[mechanism];
-  provider.auth(conn, credentials, err => {
-    if (err) return callback(err);
-    callback(undefined, conn);
-  });
 }
 
 function connectionFailureError(type, err) {


### PR DESCRIPTION
## Description
MongoDB 4.4+ supports speculative authentication for the SCRAM-SHA and X509 auth mechanisms, which means that these mechanisms can include the first part of their auth 
conversation in the initial ismaster, potentially reducing one round trip.

**What changed?**
The majority of the work here can be summed up in the following points:
- A `prepare` step was added to `AuthProvider` which allows a provider to manipulate the handshake document before the initial handshake

- An `AuthContext` was introduced to carry methods like `connection`, `credentials` and optionally information a mechanism might need to share between steps of an auth conversation. Currently the only piece of context tracked is the `nonce` generated for SCRAM-SHA. 

**Are there any files to ignore?**
None