### PR TITLE
refactor(ChangeStream): use maybePromise for close, improve tests

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -143,7 +143,7 @@ class ChangeStream extends EventEmitter {
   next(callback) {
     return maybePromise(this.parent, callback, cb => {
       if (this.isClosed()) {
-        return cb(new Error('Change Stream is not open.'));
+        return cb(new MongoError('ChangeStream is closed.'));
       }
       this.cursor.next((error, change) => {
         processNewChange({ changeStream: this, error, change, callback: cb });
@@ -475,11 +475,8 @@ function processNewChange(args) {
     if (eventEmitter) {
       return;
     }
-
-    const error = new MongoError('ChangeStream is closed');
-    return typeof callback === 'function'
-      ? callback(error, null)
-      : changeStream.promiseLibrary.reject(error);
+    callback(new MongoError('ChangeStream is closed.'));
+    return;
   }
 
   const topology = changeStream.topology;
@@ -536,8 +533,7 @@ function processNewChange(args) {
     }
 
     if (eventEmitter) return changeStream.emit('error', error);
-    if (typeof callback === 'function') return callback(error, null);
-    return changeStream.promiseLibrary.reject(error);
+    return callback(error, null);
   }
 
   changeStream.attemptingResume = false;
@@ -548,8 +544,7 @@ function processNewChange(args) {
     );
 
     if (eventEmitter) return changeStream.emit('error', noResumeTokenError);
-    if (typeof callback === 'function') return callback(noResumeTokenError, null);
-    return changeStream.promiseLibrary.reject(noResumeTokenError);
+    return callback(noResumeTokenError, null);
   }
 
   // cache the resume token

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -157,7 +157,7 @@ class ChangeStream extends EventEmitter {
    * @return {boolean}
    */
   isClosed() {
-    return (this.cursor && this.cursor.isClosed()) || this.closed;
+    return this.closed || (this.cursor && this.cursor.isClosed());
   }
 
   /**
@@ -169,6 +169,8 @@ class ChangeStream extends EventEmitter {
   close(callback) {
     return maybePromise(this.parent, callback, cb => {
       if (this.closed) return cb();
+
+      // flag the change stream as explicitly closed
       this.closed = true;
 
       // Tidy up the existing cursor
@@ -463,7 +465,7 @@ function processNewChange(args) {
   const eventEmitter = args.eventEmitter || false;
   const cursor = changeStream.cursor;
 
-  // If the cursor is null, then it should not process a change.
+  // If the cursor is null or the change stream has been closed explictly, do not process a change.
   if (cursor == null || changeStream.closed) {
     // We do not error in the eventEmitter case.
     changeStream.closed = true;
@@ -492,6 +494,7 @@ function processNewChange(args) {
 
       waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
         if (err) {
+          // if there's an error reconnecting, close the change stream
           changeStream.closed = true;
           if (eventEmitter) {
             changeStream.emit('error', err);

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -443,7 +443,7 @@ function applyKnownOptions(target, source, optionNames) {
 // ChangeStream resumability until the new SDAM layer can be used.
 const SELECTION_TIMEOUT = 30000;
 function waitForTopologyConnected(topology, options, callback) {
-  if (isUnifiedTopology(topology)) return callback();
+  // if (isUnifiedTopology(topology)) return callback();
   setTimeout(() => {
     if (options && options.start == null) options.start = process.hrtime();
     const start = options.start || process.hrtime();

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -6,7 +6,7 @@ const MongoError = require('./core').MongoError;
 const Cursor = require('./cursor');
 const relayEvents = require('./core/utils').relayEvents;
 const maxWireVersion = require('./core/utils').maxWireVersion;
-const isUnifiedTopology = require('./core/utils').isUnifiedTopology;
+// const isUnifiedTopology = require('./core/utils').isUnifiedTopology;
 const maybePromise = require('./utils').maybePromise;
 const AggregateOperation = require('./operations/aggregate');
 

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -6,7 +6,6 @@ const MongoError = require('./core').MongoError;
 const Cursor = require('./cursor');
 const relayEvents = require('./core/utils').relayEvents;
 const maxWireVersion = require('./core/utils').maxWireVersion;
-// const isUnifiedTopology = require('./core/utils').isUnifiedTopology;
 const maybePromise = require('./utils').maybePromise;
 const AggregateOperation = require('./operations/aggregate');
 
@@ -443,7 +442,6 @@ function applyKnownOptions(target, source, optionNames) {
 // ChangeStream resumability until the new SDAM layer can be used.
 const SELECTION_TIMEOUT = 30000;
 function waitForTopologyConnected(topology, options, callback) {
-  // if (isUnifiedTopology(topology)) return callback();
   setTimeout(() => {
     if (options && options.start == null) options.start = process.hrtime();
     const start = options.start || process.hrtime();

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -6,6 +6,7 @@ const MongoError = require('./core').MongoError;
 const Cursor = require('./cursor');
 const relayEvents = require('./core/utils').relayEvents;
 const maxWireVersion = require('./core/utils').maxWireVersion;
+const isUnifiedTopology = require('./core/utils').isUnifiedTopology;
 const maybePromise = require('./utils').maybePromise;
 const AggregateOperation = require('./operations/aggregate');
 
@@ -442,6 +443,7 @@ function applyKnownOptions(target, source, optionNames) {
 // ChangeStream resumability until the new SDAM layer can be used.
 const SELECTION_TIMEOUT = 30000;
 function waitForTopologyConnected(topology, options, callback) {
+  if (isUnifiedTopology(topology)) return callback();
   setTimeout(() => {
     if (options && options.start == null) options.start = process.hrtime();
     const start = options.start || process.hrtime();
@@ -453,7 +455,7 @@ function waitForTopologyConnected(topology, options, callback) {
     const elapsed = (hrElapsed[0] * 1e9 + hrElapsed[1]) / 1e6;
     if (elapsed > timeout) return callback(new MongoError('Timed out waiting for connection'));
     waitForTopologyConnected(topology, options, callback);
-  }, 3000); // this is an arbitrary wait time to allow SDAM to transition
+  }, 500); // this is an arbitrary wait time to allow SDAM to transition
 }
 
 // Handle new change events. This method brings together the routes from the callback, event emitter, and promise ways of using ChangeStream.

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -495,41 +495,22 @@ function processNewChange(args) {
       // close internal cursor, ignore errors
       changeStream.cursor.close();
 
-      // attempt recreating the cursor
-      if (eventEmitter) {
-        waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-          if (err) {
+      waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
+        if (err) {
+          changeStream.closed = true;
+          if (eventEmitter) {
             changeStream.emit('error', err);
             changeStream.emit('close');
             return;
           }
-          changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
-        });
+          return callback(err, null);
+        }
 
-        return;
-      }
-
-      if (callback) {
-        waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-          if (err) return callback(err, null);
-
-          changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
-          changeStream.next(callback);
-        });
-
-        return;
-      }
-
-      return new Promise((resolve, reject) => {
-        waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-          if (err) return reject(err);
-          resolve();
-        });
-      })
-        .then(
-          () => (changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions))
-        )
-        .then(() => changeStream.next());
+        changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
+        if (eventEmitter) return;
+        changeStream.next(callback);
+      });
+      return;
     }
 
     if (eventEmitter) return changeStream.emit('error', error);

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -94,6 +94,8 @@ class ChangeStream extends EventEmitter {
     // Create contained Change Stream cursor
     this.cursor = createChangeStreamCursor(this, options);
 
+    this.closed = false;
+
     // Listen for any `change` listeners being added to ChangeStream
     this.on('newListener', eventName => {
       if (eventName === 'change' && this.cursor && this.listenerCount('change') === 0) {
@@ -158,7 +160,7 @@ class ChangeStream extends EventEmitter {
     if (this.cursor) {
       return this.cursor.isClosed();
     }
-    return true;
+    return this.closed;
   }
 
   /**
@@ -168,31 +170,21 @@ class ChangeStream extends EventEmitter {
    * @return {Promise} returns Promise if no callback passed
    */
   close(callback) {
-    if (!this.cursor) {
-      if (callback) return callback();
-      return this.promiseLibrary.resolve();
-    }
+    return maybePromise(this.parent, callback, cb => {
+      this.closed = true;
 
-    // Tidy up the existing cursor
-    const cursor = this.cursor;
+      if (!this.cursor) {
+        return cb();
+      }
 
-    if (callback) {
+      // Tidy up the existing cursor
+      const cursor = this.cursor;
+
       return cursor.close(err => {
         ['data', 'close', 'end', 'error'].forEach(event => cursor.removeAllListeners(event));
         delete this.cursor;
 
-        return callback(err);
-      });
-    }
-
-    const PromiseCtor = this.promiseLibrary || Promise;
-    return new PromiseCtor((resolve, reject) => {
-      cursor.close(err => {
-        ['data', 'close', 'end', 'error'].forEach(event => cursor.removeAllListeners(event));
-        delete this.cursor;
-
-        if (err) return reject(err);
-        resolve();
+        return cb(err);
       });
     });
   }
@@ -569,8 +561,7 @@ function processNewChange(args) {
 
   // Return the change
   if (eventEmitter) return changeStream.emit('change', change);
-  if (typeof callback === 'function') return callback(error, change);
-  return changeStream.promiseLibrary.resolve(change);
+  return callback(error, change);
 }
 
 /**

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -464,7 +464,7 @@ function processNewChange(args) {
   const cursor = changeStream.cursor;
 
   // If the cursor is null, then it should not process a change.
-  if (cursor == null) {
+  if (cursor == null || changeStream.closed) {
     // We do not error in the eventEmitter case.
     changeStream.closed = true;
     if (eventEmitter) {

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -143,7 +143,7 @@ class ChangeStream extends EventEmitter {
   next(callback) {
     return maybePromise(this.parent, callback, cb => {
       if (this.isClosed()) {
-        return cb(new MongoError('ChangeStream is closed.'));
+        return cb(new MongoError('ChangeStream is closed'));
       }
       this.cursor.next((error, change) => {
         processNewChange({ changeStream: this, error, change, callback: cb });
@@ -157,10 +157,7 @@ class ChangeStream extends EventEmitter {
    * @return {boolean}
    */
   isClosed() {
-    if (this.cursor) {
-      return this.cursor.isClosed();
-    }
-    return this.closed;
+    return (this.cursor && this.cursor.isClosed()) || this.closed;
   }
 
   /**
@@ -171,18 +168,15 @@ class ChangeStream extends EventEmitter {
    */
   close(callback) {
     return maybePromise(this.parent, callback, cb => {
+      if (this.closed) return cb();
       this.closed = true;
-
-      if (!this.cursor) {
-        return cb();
-      }
 
       // Tidy up the existing cursor
       const cursor = this.cursor;
 
       return cursor.close(err => {
         ['data', 'close', 'end', 'error'].forEach(event => cursor.removeAllListeners(event));
-        delete this.cursor;
+        this.cursor = undefined;
 
         return cb(err);
       });
@@ -313,7 +307,7 @@ class ChangeStreamCursor extends Cursor {
   _initializeCursor(callback) {
     super._initializeCursor((err, result) => {
       if (err) {
-        callback(err, null);
+        callback(err);
         return;
       }
 
@@ -339,7 +333,7 @@ class ChangeStreamCursor extends Cursor {
   _getMore(callback) {
     super._getMore((err, response) => {
       if (err) {
-        callback(err, null);
+        callback(err);
         return;
       }
 
@@ -452,7 +446,7 @@ function waitForTopologyConnected(topology, options, callback) {
     const timeout = options.timeout || SELECTION_TIMEOUT;
     const readPreference = options.readPreference;
 
-    if (topology.isConnected({ readPreference })) return callback(null, null);
+    if (topology.isConnected({ readPreference })) return callback();
     const hrElapsed = process.hrtime(start);
     const elapsed = (hrElapsed[0] * 1e9 + hrElapsed[1]) / 1e6;
     if (elapsed > timeout) return callback(new MongoError('Timed out waiting for connection'));
@@ -472,10 +466,11 @@ function processNewChange(args) {
   // If the cursor is null, then it should not process a change.
   if (cursor == null) {
     // We do not error in the eventEmitter case.
+    changeStream.closed = true;
     if (eventEmitter) {
       return;
     }
-    callback(new MongoError('ChangeStream is closed.'));
+    callback(new MongoError('ChangeStream is closed'));
     return;
   }
 
@@ -503,7 +498,7 @@ function processNewChange(args) {
             changeStream.emit('close');
             return;
           }
-          return callback(err, null);
+          return callback(err);
         }
 
         changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
@@ -514,7 +509,7 @@ function processNewChange(args) {
     }
 
     if (eventEmitter) return changeStream.emit('error', error);
-    return callback(error, null);
+    return callback(error);
   }
 
   changeStream.attemptingResume = false;
@@ -525,7 +520,7 @@ function processNewChange(args) {
     );
 
     if (eventEmitter) return changeStream.emit('error', noResumeTokenError);
-    return callback(noResumeTokenError, null);
+    return callback(noResumeTokenError);
   }
 
   // cache the resume token

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -38,7 +38,11 @@ function triggerResumableError(changeStream, onCursorClosed) {
  * @param {function} callback
  */
 function waitForStarted(changeStream, callback) {
+  const timeout = setTimeout(() => {
+    throw new Error('Change stream never started');
+  }, 2000);
   changeStream.cursor.once('init', () => {
+    clearTimeout(timeout);
     callback();
   });
 }

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -61,10 +61,6 @@ function tryNext(changeStream, callback) {
     if (complete) return;
     // if the arity is 1 then this a callback for `more`
     if (arguments.length === 1) {
-      if (err instanceof Error) {
-        callback(err);
-        return;
-      }
       result = err;
       const batch = result.cursor.firstBatch || result.cursor.nextBatch;
       if (batch.length === 0) {

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2020,14 +2020,18 @@ describe('Change Streams', function() {
         });
     });
 
-    it('when invoked with promises', {
+    it.skip('when invoked with promises', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
       test: function() {
         function read() {
           return Promise.resolve()
             .then(() => changeStream.next())
             .then(() => changeStream.next())
-            .then(() => Promise.all([changeStream.close(), changeStream.next()]));
+            .then(() => {
+              const nextP = changeStream.next();
+
+              return changeStream.close().then(() => nextP);
+            });
         }
 
         return Promise.all([read(), write()]).then(
@@ -2037,12 +2041,11 @@ describe('Change Streams', function() {
       }
     });
 
-    it('when invoked with callbacks', {
+    it.skip('when invoked with callbacks', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
       test: function(done) {
         changeStream.next(() => {
           changeStream.next(() => {
-            changeStream.close();
             changeStream.next(err => {
               let _err = null;
               try {
@@ -2053,6 +2056,7 @@ describe('Change Streams', function() {
                 done(_err);
               }
             });
+            changeStream.close();
           });
         });
 

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -421,15 +421,19 @@ describe('Change Streams', function() {
         client.connect(function(err, client) {
           assert.ifError(err);
 
+          const forbiddenStage = {};
+          const forbiddenStageName = '$alksdjfhlaskdfjh';
+          forbiddenStage[forbiddenStageName] = 2;
+
           var theDatabase = client.db('integration_tests');
-          var changeStream = theDatabase
-            .collection('forbiddenStageTest')
-            .watch([{ $alksdjfhlaskdfjh: 2 }]);
+          var changeStream = theDatabase.collection('forbiddenStageTest').watch([forbiddenStage]);
 
           changeStream.next(function(err) {
             assert.ok(err);
             assert.ok(err.message);
-            // assert.ok(err.message.indexOf('SOME ERROR MESSAGE HERE ONCE SERVER-29137 IS DONE') > -1);
+            assert.ok(
+              err.message.indexOf(`Unrecognized pipeline stage name: '${forbiddenStageName}'`) > -1
+            );
             changeStream.close(err => client.close(cerr => done(err || cerr)));
           });
         });

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -1945,7 +1945,7 @@ describe('Change Streams', function() {
     test: function(done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
-      const closeSpy = sinon.spy();
+      const errorSpy = sinon.spy();
 
       client.connect(function(err, client) {
         expect(err).to.not.exist;
@@ -1961,15 +1961,12 @@ describe('Change Streams', function() {
           expect(changeDoc).to.be.null;
         });
 
-        changeStream.on('error', err => {
-          expect(err).to.exist;
-          changeStream.close(() => {
-            expect(closeSpy.calledOnce).to.be.true;
-            client.close(done);
-          });
-        });
+        changeStream.on('error', errorSpy);
 
-        changeStream.on('close', closeSpy);
+        changeStream.on('close', () => {
+          expect(errorSpy.calledOnce).to.be.true;
+          client.close(done);
+        });
 
         // Trigger the first database event
         waitForStarted(changeStream, () => {

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -707,6 +707,7 @@ describe('Change Streams', function() {
 
             function completeStream() {
               changeStream.hasNext(function(err, hasNext) {
+                expect(err).to.not.exist;
                 assert.equal(hasNext, false);
                 assert.equal(changeStream.isClosed(), true);
                 client.close(done);
@@ -2024,7 +2025,7 @@ describe('Change Streams', function() {
 
         return Promise.all([read(), write()]).then(
           () => Promise.reject(new Error('Expected operation to fail with error')),
-          err => expect(err.message).to.equal('ChangeStream is closed.')
+          err => expect(err.message).to.equal('ChangeStream is closed')
         );
       }
     });
@@ -2041,7 +2042,7 @@ describe('Change Streams', function() {
               changeStream.next(err => {
                 let _err = null;
                 try {
-                  expect(err.message).to.equal('ChangeStream is closed.');
+                  expect(err.message).to.equal('ChangeStream is closed');
                 } catch (e) {
                   _err = e;
                 } finally {

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2107,7 +2107,11 @@ describe('Change Streams', function() {
         });
         changeStream.on('error', err => close(err));
 
-        waitForStarted(changeStream, () => write().catch(() => {}));
+        waitForStarted(changeStream, () =>
+          write()
+            .then(() => lastWrite())
+            .catch(() => {})
+        );
       }
     });
   });

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -1981,7 +1981,6 @@ describe('Change Streams', function() {
     }
   });
 
-  // TODO: re-enable/fix these tests in NODE-2548
   describe('should properly handle a changeStream event being processed mid-close', function() {
     let client, coll;
 

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -1944,7 +1944,7 @@ describe('Change Streams', function() {
       .then(() => teardown(), teardown);
   });
 
-  it.only('should emit close event after error event', {
+  it('should emit close event after error event', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
     test: function(done) {
       const configuration = this.configuration;

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -576,7 +576,7 @@ describe('Change Streams', function() {
             expect(err).to.exist;
 
             // Close the change stream
-            thisChangeStream.close(client.close(done));
+            thisChangeStream.close(() => client.close(done));
           });
         });
       }

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -576,7 +576,7 @@ describe('Change Streams', function() {
             expect(err).to.exist;
 
             // Close the change stream
-            thisChangeStream.close().then(() => client.close(done));
+            thisChangeStream.close(client.close(done));
           });
         });
       }

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -448,7 +448,7 @@ describe('Change Streams', function() {
         var thisChangeStream = theDatabase.collection('cacheResumeTokenCallback').watch(pipeline);
 
         // Trigger the first database event
-        setTimeout(() => {
+        waitForStarted(thisChangeStream, () => {
           theDatabase
             .collection('cacheResumeTokenCallback')
             .insert({ b: 2 }, function(err, result) {
@@ -484,7 +484,7 @@ describe('Change Streams', function() {
         var theDatabase = client.db('integration_tests');
         var thisChangeStream = theDatabase.collection('cacheResumeTokenPromise').watch(pipeline);
 
-        setTimeout(() => {
+        waitForStarted(thisChangeStream, () => {
           // Trigger the first database event
           theDatabase.collection('cacheResumeTokenPromise').insert({ b: 2 }, function(err, result) {
             assert.ifError(err);
@@ -530,7 +530,7 @@ describe('Change Streams', function() {
           thisChangeStream.close().then(() => client.close(done));
         });
 
-        setTimeout(() => {
+        waitForStarted(thisChangeStream, () => {
           // Trigger the first database event
           theDatabase
             .collection('cacheResumeTokenListener')

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -562,14 +562,14 @@ describe('Change Streams', function() {
             .watch([{ $project: { _id: false } }]);
 
           // Trigger the first database event
-          setTimeout(() => {
+          waitForStarted(thisChangeStream, () => {
             theDatabase
               .collection('resumetokenProjectedOutCallback')
               .insert({ b: 2 }, function(err, result) {
                 expect(err).to.not.exist;
                 expect(result.insertedCount).to.equal(1);
               });
-          }, 250);
+          });
 
           // Fetch the change notification
           thisChangeStream.next(function(err) {
@@ -610,7 +610,7 @@ describe('Change Streams', function() {
         });
 
         // Trigger the first database event
-        setTimeout(() => {
+        waitForStarted(thisChangeStream, () => {
           theDatabase
             .collection('resumetokenProjectedOutListener')
             .insert({ b: 2 }, function(err, result) {
@@ -669,7 +669,7 @@ describe('Change Streams', function() {
         });
 
         // Trigger the first database event
-        setTimeout(() => {
+        waitForStarted(changeStream, () => {
           database.collection('invalidateListeners').insert({ a: 1 }, function(err) {
             assert.ifError(err);
           });
@@ -693,7 +693,7 @@ describe('Change Streams', function() {
         var changeStream = database.collection('invalidateCallback').watch(pipeline);
 
         // Trigger the first database event
-        setTimeout(() => {
+        waitForStarted(changeStream, () => {
           database.collection('invalidateCallback').insert({ a: 1 }, function(err) {
             assert.ifError(err);
           });
@@ -758,14 +758,14 @@ describe('Change Streams', function() {
         var changeStream = database.collection('invalidateCollectionDropPromises').watch(pipeline);
 
         // Trigger the first database event
-        setTimeout(() => {
+        waitForStarted(changeStream, () => {
           return database
             .collection('invalidateCollectionDropPromises')
             .insert({ a: 1 })
             .then(function() {
               return delay(200);
             });
-        }, 200);
+        });
 
         return changeStream
           .next()
@@ -1139,7 +1139,7 @@ describe('Change Streams', function() {
         // Trigger the first database event
 
         firstChangeStream = collection.watch(pipeline);
-        setTimeout(() => {
+        waitForStarted(firstChangeStream, () => {
           return collection
             .insert(docs[0])
             .then(function(result) {
@@ -1224,7 +1224,7 @@ describe('Change Streams', function() {
           fullDocument: 'updateLookup'
         });
 
-        setTimeout(() => {
+        waitForStarted(changeStream, () => {
           return collection.insert({ f: 128 }).then(function(result) {
             assert.equal(result.insertedCount, 1);
           });
@@ -1280,7 +1280,7 @@ describe('Change Streams', function() {
         });
 
         // Trigger the first database event
-        setTimeout(() => {
+        waitForStarted(changeStream, () => {
           return collection
             .insert({ i: 128 })
             .then(function(result) {
@@ -1417,7 +1417,7 @@ describe('Change Streams', function() {
           })
           .on('error', close);
 
-        setTimeout(() => {
+        waitForStarted(thisChangeStream, () => {
           theCollection.insert({ a: 1 }, function(err) {
             assert.ifError(err);
           });
@@ -1632,7 +1632,7 @@ describe('Change Streams', function() {
           done(err);
         });
 
-        setTimeout(() => {
+        waitForStarted(thisChangeStream, () => {
           theCollection.insert({ a: 1407 }, function(err) {
             if (err) done(err);
           });
@@ -1972,7 +1972,7 @@ describe('Change Streams', function() {
         changeStream.on('close', closeSpy);
 
         // Trigger the first database event
-        setTimeout(() => {
+        waitForStarted(changeStream, () => {
           coll.insertOne({ a: 1 }, (err, result) => {
             expect(err).to.not.exist;
             expect(result.insertedCount).to.equal(1);
@@ -2078,7 +2078,7 @@ describe('Change Streams', function() {
         });
         changeStream.on('error', err => close(err));
 
-        setTimeout(() => write().catch(() => {}));
+        waitForStarted(changeStream, () => write().catch(() => {}));
       }
     });
   });

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2017,10 +2017,7 @@ describe('Change Streams', function() {
           return Promise.resolve()
             .then(() => changeStream.next())
             .then(() => changeStream.next())
-            .then(() => {
-              const nextP = () => changeStream.next();
-              return changeStream.close().then(() => nextP());
-            });
+            .then(() => Promise.all([changeStream.close(), changeStream.next()]));
         }
 
         return Promise.all([read(), write()]).then(
@@ -2037,18 +2034,16 @@ describe('Change Streams', function() {
 
         changeStream.next(() => {
           changeStream.next(() => {
-            changeStream.close(err => {
-              expect(err).to.not.exist;
-              changeStream.next(err => {
-                let _err = null;
-                try {
-                  expect(err.message).to.equal('ChangeStream is closed');
-                } catch (e) {
-                  _err = e;
-                } finally {
-                  done(_err);
-                }
-              });
+            changeStream.close();
+            changeStream.next(err => {
+              let _err = null;
+              try {
+                expect(err.message).to.equal('ChangeStream is closed');
+              } catch (e) {
+                _err = e;
+              } finally {
+                done(_err);
+              }
             });
           });
         });

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -158,7 +158,7 @@ describe('Change Streams', function() {
             close(err);
           });
         });
-        setTimeout(() => coll.insertOne({ x: 1 }));
+        waitForStarted(changeStream, () => coll.insertOne({ x: 1 }));
         changeStream.on('error', err => close(err));
       });
     }
@@ -176,17 +176,6 @@ describe('Change Streams', function() {
         expect(err).to.not.exist;
         const collection = client.db('integration_tests').collection('docsDataEvent');
         const changeStream = collection.watch(pipeline);
-
-        changeStream.cursor.once('response', () => {
-          // Trigger the first database event
-          collection.insertOne({ d: 4 }, function(err) {
-            assert.ifError(err);
-            // Trigger the second database event
-            collection.updateOne({ d: 4 }, { $inc: { d: 2 } }, function(err) {
-              assert.ifError(err);
-            });
-          });
-        });
 
         let count = 0;
 
@@ -223,6 +212,17 @@ describe('Change Streams', function() {
           } catch (e) {
             cleanup(e);
           }
+        });
+
+        waitForStarted(changeStream, () => {
+          // Trigger the first database event
+          collection.insertOne({ d: 4 }, function(err) {
+            assert.ifError(err);
+            // Trigger the second database event
+            collection.updateOne({ d: 4 }, { $inc: { d: 2 } }, function(err) {
+              assert.ifError(err);
+            });
+          });
         });
       });
     }

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -75,11 +75,11 @@ function makeCleanupFn(client) {
   };
 }
 
-function withTempDb(dbName, client, operation, errorHandler) {
+function withTempDb(name, options, client, operation, errorHandler) {
   return withClient(
     client,
     client => done => {
-      const db = client.db(dbName);
+      const db = client.db(name, options);
       operation.call(this, db)(() => db.dropDatabase(done));
     },
     errorHandler

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -80,7 +80,7 @@ function withTempDb(dbName, client, operation, errorHandler) {
     client,
     client => done => {
       const db = client.db(dbName);
-      operation(db)(() => db.dropDatabase(done));
+      operation.call(this, db)(() => db.dropDatabase(done));
     },
     errorHandler
   );

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -75,6 +75,17 @@ function makeCleanupFn(client) {
   };
 }
 
+function withTempDb(dbName, client, operation, errorHandler) {
+  return withClient(
+    client,
+    client => done => {
+      const db = client.db(dbName);
+      operation(db)(() => db.dropDatabase(done));
+    },
+    errorHandler
+  );
+}
+
 function withClient(client, operation, errorHandler) {
   const cleanup = makeCleanupFn(client);
 
@@ -198,6 +209,7 @@ module.exports = {
   assert,
   delay,
   withClient,
+  withTempDb,
   filterForCommands,
   filterOutCommands,
   ignoreNsNotFound,


### PR DESCRIPTION
## Description

[NODE-2598](https://jira.mongodb.org/browse/NODE-2598)

**What changed?**

 - Refactor `close` to use `maybePromise` helper
 - Ensure explicitly closed change streams don't process further changes
 - Fix broken `mid-close` tests by delaying the final write
 - Add `waitForStarted` helper to tests where appropriate to reduce flakiness


**Are there any files to ignore?**
