### PR TITLE
test: add writeConcernError propagate

### DIFF
--- a/test/unit/core/write_concern_error.test.js
+++ b/test/unit/core/write_concern_error.test.js
@@ -29,6 +29,25 @@ describe('WriteConcernError', function() {
     }
   };
 
+  const RAW_USER_WRITE_CONCERN_ERROR_INFO = {
+    ok: 0,
+    errmsg: 'waiting for replication timed out',
+    code: 64,
+    codeName: 'WriteConcernFailed',
+    writeConcernError: {
+      code: 64,
+      codeName: 'WriteConcernFailed',
+      errmsg: 'waiting for replication timed out',
+      errInfo: {
+        writeConcern: {
+          w: 2,
+          wtimeout: 0,
+          provenance: 'clientSupplied'
+        }
+      }
+    }
+  };
+
   before(() => (test = new ReplSetFixture()));
   afterEach(() => mock.cleanup());
   beforeEach(() => test.setup());
@@ -92,6 +111,41 @@ describe('WriteConcernError', function() {
           expect(err.result).to.not.have.property('code');
           expect(err.result).to.not.have.property('codeName');
           expect(err.result).to.have.property('writeConcernError');
+        } catch (e) {
+          _err = e;
+        } finally {
+          cleanup(_err);
+        }
+      });
+    });
+  });
+
+  it('should propagate writeConcernError.errInfo ', function(done) {
+    test.primaryServer.setMessageHandler(request => {
+      const doc = request.document;
+      if (doc.ismaster) {
+        setTimeout(() => request.reply(test.primaryStates[0]));
+      } else if (doc.createUser) {
+        setTimeout(() => request.reply(RAW_USER_WRITE_CONCERN_ERROR_INFO));
+      }
+    });
+
+    makeAndConnectReplSet((err, replSet) => {
+      // cleanup the server before calling done
+      const cleanup = err => replSet.destroy(err2 => done(err || err2));
+
+      if (err) {
+        return cleanup(err);
+      }
+
+      replSet.command('db1', Object.assign({}, RAW_USER_WRITE_CONCERN_CMD), err => {
+        let _err;
+        try {
+          expect(err).to.be.an.instanceOf(MongoWriteConcernError);
+          expect(err.result).to.exist;
+          expect(err.result.writeConcernError).to.deep.equal(
+            RAW_USER_WRITE_CONCERN_ERROR_INFO.writeConcernError
+          );
         } catch (e) {
           _err = e;
         } finally {


### PR DESCRIPTION
Adds test to check if "errInfo" writeConcernError values are being propagated values like w, wtimeout, and provenance.

NODE-2506