### PR TITLE
fix: allow connect again after close

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -9,6 +9,7 @@ NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
 
 # this needs to be explicitly exported for the nvm install below
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+export XDG_CONFIG_HOME=${NODE_ARTIFACTS_PATH}
 
 # create node artifacts path if needed
 mkdir -p ${NODE_ARTIFACTS_PATH}

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -18,7 +18,7 @@ mkdir -p "${NPM_TMP_DIR}"
 # install Node.js
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
 [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
-nvm install --lts=${NODE_LTS_NAME}
+nvm install --no-progress --lts=${NODE_LTS_NAME}
 
 # setup npm cache in a local directory
 cat <<EOT > .npmrc

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -16,7 +16,7 @@ mkdir -p ${NPM_CACHE_DIR}
 mkdir -p "${NPM_TMP_DIR}"
 
 # install Node.js
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
 [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
 nvm install --no-progress --lts=${NODE_LTS_NAME}
 

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -241,11 +241,13 @@ MongoClient.prototype.close = function(force, callback) {
     force = false;
   }
 
+  const topology = this.topology;
+
   return maybePromise(this, callback, cb => {
     const completeClose = err => {
       this.emit('close', this);
 
-      if (!(this.topology instanceof NativeTopology)) {
+      if (!(topology instanceof NativeTopology)) {
         for (const item of this.s.dbCache) {
           item[1].emit('close', this);
         }
@@ -261,13 +263,13 @@ MongoClient.prototype.close = function(force, callback) {
       cb(err);
     };
 
-    if (this.topology == null) {
+    if (topology == null) {
       completeClose();
       return;
     }
 
-    this.topology.close(force, err => {
-      const autoEncrypter = this.topology.s.options.autoEncrypter;
+    topology.close(force, err => {
+      const autoEncrypter = topology.s.options.autoEncrypter;
       if (!autoEncrypter) {
         completeClose(err);
         return;

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -167,6 +167,8 @@ function MongoClient(url, options) {
     writeConcern: WriteConcern.fromOptions(options),
     namespace: new MongoDBNamespace('admin')
   };
+
+  this.originalOptions = Object.assign({}, this.s.options);
 }
 
 /**
@@ -241,28 +243,35 @@ MongoClient.prototype.close = function(force, callback) {
     force = false;
   }
 
-  const client = this;
   return maybePromise(this, callback, cb => {
     const completeClose = err => {
-      client.emit('close', client);
+      this.emit('close', this);
 
-      if (!(client.topology instanceof NativeTopology)) {
-        for (const item of client.s.dbCache) {
-          item[1].emit('close', client);
+      if (!(this.topology instanceof NativeTopology)) {
+        for (const item of this.s.dbCache) {
+          item[1].emit('close', this);
         }
       }
 
-      client.removeAllListeners('close');
+      this.removeAllListeners('close');
+
+      // clear out references to old topology
+      this.topology = undefined;
+      this.s.dbCache = new Map();
+
+      // restore options
+      this.s.options = Object.assign({}, this.originalOptions);
+
       cb(err);
     };
 
-    if (client.topology == null) {
+    if (this.topology == null) {
       completeClose();
       return;
     }
 
-    client.topology.close(force, err => {
-      const autoEncrypter = client.topology.s.options.autoEncrypter;
+    this.topology.close(force, err => {
+      const autoEncrypter = this.topology.s.options.autoEncrypter;
       if (!autoEncrypter) {
         completeClose(err);
         return;

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -167,8 +167,6 @@ function MongoClient(url, options) {
     writeConcern: WriteConcern.fromOptions(options),
     namespace: new MongoDBNamespace('admin')
   };
-
-  this.originalOptions = Object.assign({}, this.s.options);
 }
 
 /**
@@ -258,9 +256,6 @@ MongoClient.prototype.close = function(force, callback) {
       // clear out references to old topology
       this.topology = undefined;
       this.s.dbCache = new Map();
-
-      // restore options
-      this.s.options = Object.assign({}, this.originalOptions);
 
       cb(err);
     };

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -256,6 +256,7 @@ MongoClient.prototype.close = function(force, callback) {
       // clear out references to old topology
       this.topology = undefined;
       this.s.dbCache = new Map();
+      this.s.sessions = new Set();
 
       cb(err);
     };

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -260,6 +260,18 @@ function connect(mongoClient, url, options, callback) {
     throw new Error('no callback function provided');
   }
 
+  // Has a connection already been established?
+  if (mongoClient.topology) {
+    if (mongoClient.topology.isConnected()) {
+      throw new Error('already connected');
+    }
+    // this is a reconnect, clear out old state
+    mongoClient.topology = undefined;
+    mongoClient.s.options = {};
+    mongoClient.s.dbCache = new Map();
+    mongoClient.s.sessions = new Set();
+  }
+
   let didRequestAuthentication = false;
   const logger = Logger('MongoClient', options);
 

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -261,15 +261,8 @@ function connect(mongoClient, url, options, callback) {
   }
 
   // Has a connection already been established?
-  if (mongoClient.topology) {
-    if (mongoClient.topology.isConnected()) {
-      throw new Error('already connected');
-    }
-    // this is a reconnect, clear out old state
-    mongoClient.topology = undefined;
-    mongoClient.s.options = {};
-    mongoClient.s.dbCache = new Map();
-    mongoClient.s.sessions = new Set();
+  if (mongoClient.topology && mongoClient.topology.isConnected()) {
+    throw new Error(`'connect' cannot be called when already connected`);
   }
 
   let didRequestAuthentication = false;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "test": "npm run lint && mocha --recursive test/functional test/unit test/core",
     "test-nolint": "mocha --recursive test/functional test/unit test/core",
     "coverage": "istanbul cover mongodb-test-runner -- -t 60000 test/core test/unit test/functional",
-    "lint": "eslint lib test",
+    "lint": "eslint -v && eslint lib test",
     "format": "prettier --print-width 100 --tab-width 2 --single-quote --write 'test/**/*.js' 'lib/**/*.js'",
     "bench": "node test/benchmarks/driverBench/",
     "generate-evergreen": "node .evergreen/generate_evergreen_tasks.js",

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -517,7 +517,7 @@ describe('Connection', function() {
   });
 
   it('should be able to connect again after close', function() {
-    return withClient(this.configuration.newClient(), client => done => {
+    return withClient.call(this, (client, done) => {
       expect(client.isConnected()).to.be.true;
       const collection = () => client.db('testReconnect').collection('test');
       collection().insertOne({ a: 1 }, (err, result) => {

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -125,7 +125,7 @@ describe('Sessions', function() {
               // verify that the `endSessions` command was sent
               const lastCommand = test.commands.started[test.commands.started.length - 1];
               expect(lastCommand.commandName).to.equal('endSessions');
-              expect(client.topology.s.sessionPool.sessions).to.have.length(0);
+              expect(client.topology).to.not.exist;
             });
         });
       });
@@ -149,7 +149,7 @@ describe('Sessions', function() {
             // verify that the `endSessions` command was sent
             const lastCommand = test.commands.started[test.commands.started.length - 1];
             expect(lastCommand.commandName).to.equal('endSessions');
-            expect(client.topology.s.sessionPool.sessions).to.have.length(0);
+            expect(client.topology).to.not.exist;
           });
       });
     }

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -78,9 +78,20 @@ function makeCleanupFn(client) {
 function withClient(client, operation, errorHandler) {
   const cleanup = makeCleanupFn(client);
 
+  function operationHandler(client) {
+    // run the operation
+    const result = operation(client);
+    // if it returns a callback, wrap it in a Promise
+    if (typeof result === 'function') {
+      return new Promise(done => result(done));
+    }
+    // otherwise assume it returned a Promise
+    return result;
+  }
+
   return client
     .connect()
-    .then(operation, errorHandler)
+    .then(operationHandler, errorHandler)
     .then(() => cleanup(), cleanup);
 }
 


### PR DESCRIPTION
## Description

`connect` doesn't work again after `close` has been called once on a `MongoClient`.

Cleaning up some state beforehand fixes the issue.

[NODE-2544](https://jira.mongodb.org/browse/NODE-2544)

**What changed?**

Also introduced some CI-related cleanup:
- output `eslint` version before linting
- upgrade `nvm` and use `--no-progress` option to clean up log output

I can split this out into a separate PR if desired.

**Are there any files to ignore?**
