### PR TITLE
fix: honor journal=true in connection string

### DIFF
--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -294,6 +294,12 @@ function connect(mongoClient, url, options, callback) {
       delete _finalOptions.db_options.auth;
     }
 
+    // `journal` should be translated to `j` for the driver
+    if (_finalOptions.journal != null) {
+      _finalOptions.j = _finalOptions.journal;
+      _finalOptions.journal = undefined;
+    }
+
     // resolve tls options if needed
     resolveTLSOptions(_finalOptions);
 

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -86,6 +86,13 @@ function withTempDb(name, options, client, operation, errorHandler) {
   );
 }
 
+/**
+ * Safely perform a test with provided MongoClient, ensuring client won't leak.
+ *
+ * @param {MongoClient} client
+ * @param {Function|Promise} operation
+ * @param {Function|Promise} [errorHandler]
+ */
 function withClient(client, operation, errorHandler) {
   const cleanup = makeCleanupFn(client);
 
@@ -203,13 +210,29 @@ class EventCollector {
   }
 }
 
-function withMonitoredClient(commands, callback) {
-  if (!Object.hasOwnProperty.call(callback, 'prototype')) {
+/**
+ * Perform a test with a monitored MongoClient that will filter for certain commands.
+ *
+ * @param {string|Array} commands commands to filter for
+ * @param {object} [options] options to pass on to configuration.newClient
+ * @param {object} [options.queryOptions] connection string options
+ * @param {object} [options.clientOptions] MongoClient options
+ * @param {withMonitoredClientCallback} callback the test function
+ */
+function withMonitoredClient(commands, options, callback) {
+  if (arguments.length === 2) {
+    callback = options;
+    options = {};
+  }
+  if (!Object.prototype.hasOwnProperty.call(callback, 'prototype')) {
     throw new Error('withMonitoredClient callback can not be arrow function');
   }
   return function(done) {
     const configuration = this.configuration;
-    const client = configuration.newClient({ monitorCommands: true });
+    const client = configuration.newClient(
+      Object.assign({}, options.queryOptions),
+      Object.assign({ monitorCommands: true }, options.clientOptions)
+    );
     const events = [];
     client.on('commandStarted', filterForCommands(commands, events));
     client.connect((err, client) => {
@@ -221,6 +244,13 @@ function withMonitoredClient(commands, callback) {
     });
   };
 }
+
+/**
+ * @callback withMonitoredClientCallback
+ * @param {MongoClient} client monitored client
+ * @param {Array} events record of monitored commands
+ * @param {Function} done trigger end of test and cleanup
+ */
 
 module.exports = {
   connectToDb,

--- a/test/functional/write_concern.test.js
+++ b/test/functional/write_concern.test.js
@@ -2,10 +2,11 @@
 
 const chai = require('chai');
 const expect = chai.expect;
+chai.use(require('chai-subset'));
 const TestRunnerContext = require('./spec-runner').TestRunnerContext;
 const generateTopologyTests = require('./spec-runner').generateTopologyTests;
 const loadSpecTests = require('../spec').loadSpecTests;
-const { withMonitoredClient } = require('./shared');
+const withMonitoredClient = require('./shared').withMonitoredClient;
 
 describe('Write Concern', function() {
   describe('spec tests', function() {

--- a/test/functional/write_concern.test.js
+++ b/test/functional/write_concern.test.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const chai = require('chai');
+const expect = chai.expect;
 const TestRunnerContext = require('./spec-runner').TestRunnerContext;
 const generateTopologyTests = require('./spec-runner').generateTopologyTests;
 const loadSpecTests = require('../spec').loadSpecTests;
+const { withMonitoredClient } = require('./shared');
 
 describe('Write Concern', function() {
   describe('spec tests', function() {
@@ -15,5 +18,43 @@ describe('Write Concern', function() {
     });
 
     generateTopologyTests(testSuites, testContext);
+  });
+
+  // TODO: once `read-write-concern/connection-string` spec tests are implemented these can likely be removed
+  describe('test journal connection string option', function() {
+    function journalOptionTest(client, events, done) {
+      expect(client).to.have.nested.property('s.options');
+      const clientOptions = client.s.options;
+      expect(clientOptions).to.containSubset({ j: true });
+      client
+        .db('test')
+        .collection('test')
+        .insertOne({ a: 1 }, (err, result) => {
+          expect(err).to.not.exist;
+          expect(result).to.exist;
+          expect(events)
+            .to.be.an('array')
+            .with.lengthOf(1);
+          expect(events[0]).to.containSubset({
+            commandName: 'insert',
+            command: {
+              writeConcern: { j: true }
+            }
+          });
+          done();
+        });
+    }
+
+    // baseline to confirm client option is working
+    it(
+      'should set write concern with j: true client option',
+      withMonitoredClient('insert', { clientOptions: { j: true } }, journalOptionTest)
+    );
+
+    // ensure query option in connection string passes through
+    it(
+      'should set write concern with journal=true connection string option',
+      withMonitoredClient('insert', { queryOptions: { journal: true } }, journalOptionTest)
+    );
   });
 });


### PR DESCRIPTION
Ensure the journal option returned by parseQueryString is converted
into j during the connect operation. This fixes the issue of the
write concern not being set on commands where journal is only
specified in the connection string.

NODE-2422

## Description

**What changed?**

**Are there any files to ignore?**
