### PR TITLE
fix: honor journal=true in connection string

### DIFF
--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -290,6 +290,12 @@ function connect(mongoClient, url, options, callback) {
       delete _finalOptions.db_options.auth;
     }
 
+    // `journal` should be translated to `j` for the driver
+    if (_finalOptions.journal != null) {
+      _finalOptions.j = _finalOptions.journal;
+      _finalOptions.journal = undefined;
+    }
+
     // resolve tls options if needed
     resolveTLSOptions(_finalOptions);
 

--- a/test/functional/write_concern.test.js
+++ b/test/functional/write_concern.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('chai-subset'));
+const withMonitoredClient = require('./shared').withMonitoredClient;
+
+describe('Write Concern', function() {
+  describe('test journal connection string option', function() {
+    function journalOptionTest(client, events, done) {
+      expect(client).to.have.nested.property('s.options');
+      const clientOptions = client.s.options;
+      expect(clientOptions).property('j').to.be.true;
+      client
+        .db('test')
+        .collection('test')
+        .insertOne({ a: 1 }, (err, result) => {
+          expect(err).to.not.exist;
+          expect(result).to.exist;
+          expect(events)
+            .to.be.an('array')
+            .with.lengthOf(1);
+          expect(events[0]).to.containSubset({
+            commandName: 'insert',
+            command: {
+              writeConcern: { j: true }
+            }
+          });
+          done();
+        });
+    }
+
+    // baseline to confirm client option is working
+    it(
+      'should set write concern with j: true client option',
+      withMonitoredClient('insert', { clientOptions: { j: true } }, journalOptionTest)
+    );
+
+    // ensure query option in connection string passes through
+    it(
+      'should set write concern with journal=true connection string option',
+      withMonitoredClient('insert', { queryOptions: { journal: true } }, journalOptionTest)
+    );
+  });
+});


### PR DESCRIPTION
Ensure the journal option returned by parseQueryString is converted
into j during the connect operation. This fixes the issue of the
write concern not being set on commands where journal is only
specified in the connection string.

NODE-2422

## Description

**What changed?**

**Are there any files to ignore?**
