### PR TITLE
fix(ChangeStream): should resume from errors when iterating

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -170,8 +170,8 @@ class ChangeStream extends EventEmitter {
    * @param  {boolean} [checkCursor=true] also check if the underlying cursor is closed
    * @return {boolean}
    */
-  isClosed(checkCursor) {
-    return !!(this.closed || (checkCursor && this.cursor && this.cursor.isClosed()));
+  isClosed() {
+    return this.closed || (this.cursor && this.cursor.isClosed());
   }
 
   /**
@@ -475,7 +475,7 @@ function waitForTopologyConnected(topology, options, callback) {
 function processNewChange(changeStream, change, callback) {
   const cursor = changeStream.cursor;
 
-  if (changeStream.isClosed()) {
+  if (changeStream.closed) {
     if (callback) callback(new MongoError('ChangeStream is closed'));
     return;
   }
@@ -506,7 +506,7 @@ function processError(changeStream, error, callback) {
   const cursor = changeStream.cursor;
 
   // If the change stream has been closed explictly, do not process error.
-  if (changeStream.isClosed()) {
+  if (changeStream.closed) {
     if (callback) callback(new MongoError('ChangeStream is closed'));
     return;
   }
@@ -568,7 +568,7 @@ function processError(changeStream, error, callback) {
  * @param {ChangeStreamCursor} [oldCursor] when resuming from an error, carry over options from previous cursor
  */
 function getCursor(changeStream, callback) {
-  if (changeStream.isClosed(true)) {
+  if (changeStream.isClosed()) {
     callback(new MongoError('ChangeStream is closed.'));
     return;
   }
@@ -593,7 +593,7 @@ function getCursor(changeStream, callback) {
 function processResumeQueue(changeStream, err) {
   while (changeStream[kResumeQueue].length) {
     const request = changeStream[kResumeQueue].pop();
-    if (changeStream.isClosed(true) && !err) {
+    if (changeStream.isClosed() && !err) {
       request(new MongoError('Change Stream is not open.'));
       return;
     }

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -469,17 +469,12 @@ function waitForTopologyConnected(topology, options, callback) {
   }, 500); // this is an arbitrary wait time to allow SDAM to transition
 }
 
-// Handle new change events. This method brings together the routes from the callback, event emitter, and promise ways of using ChangeStream.
 function processNewChange(changeStream, change, callback) {
   const cursor = changeStream.cursor;
 
   if (changeStream.closed) {
     if (callback) callback(new MongoError('ChangeStream is closed'));
     return;
-  }
-
-  if (cursor == null) {
-    throw new Error('cursor should never be null here');
   }
 
   if (change && !change._id) {
@@ -513,6 +508,13 @@ function processError(changeStream, error, callback) {
     return;
   }
 
+  // if the resume succeeds, continue with the new cursor
+  function resumeWithCursor(newCursor) {
+    changeStream.cursor = newCursor;
+    processResumeQueue(changeStream);
+  }
+
+  // otherwise, raise an error and close the change stream
   function unresumableError(err) {
     if (!callback) {
       changeStream.emit('error', err);
@@ -520,11 +522,6 @@ function processError(changeStream, error, callback) {
     }
     processResumeQueue(changeStream, err);
     changeStream.closed = true;
-  }
-
-  function resumeWithCursor(newCursor) {
-    changeStream.cursor = newCursor;
-    processResumeQueue(changeStream);
   }
 
   if (cursor && isResumableError(error, maxWireVersion(cursor.server))) {
@@ -536,13 +533,23 @@ function processError(changeStream, error, callback) {
     // close internal cursor, ignore errors
     cursor.close();
 
+    // the presence of a callback here indicates the error happened during a .next
+    // so it should be retried on resume
     if (callback) changeStream[kResumeQueue].push(() => changeStream.next(callback));
 
     waitForTopologyConnected(topology, { readPreference: cursor.options.readPreference }, err => {
+      // if the topology can't reconnect, close the stream
       if (err) return unresumableError(err);
+
+      // create a new cursor, preserving the old cursor's options
       const newCursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
+
+      // attempt to continue in emitter mode
       if (!callback) return resumeWithCursor(newCursor);
+
+      // attempt to continue in iterator mode
       newCursor.hasNext(err => {
+        // if there's an error immediately after resuming, close the stream
         if (err) return unresumableError(err);
         resumeWithCursor(newCursor);
       });

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -135,7 +135,7 @@ class ChangeStream extends EventEmitter {
   hasNext(callback) {
     return maybePromise(this.parent, callback, cb => {
       getCursor(this, (err, cursor) => {
-        if (err) return cb(err);
+        if (err) return cb(err); // failed to resume, raise an error
         cursor.hasNext(cb);
       });
     });
@@ -151,10 +151,12 @@ class ChangeStream extends EventEmitter {
   next(callback) {
     return maybePromise(this.parent, callback, cb => {
       getCursor(this, (err, cursor) => {
-        if (err) return cb(err);
+        if (err) return cb(err); // failed to resume, raise an error
         cursor.next((error, change) => {
           if (error) {
-            return processError(this, error, cb);
+            this[kResumeQueue].push(() => this.next(cb));
+            processError(this, error, cb);
+            return;
           }
           processNewChange(this, change, cb);
         });
@@ -163,12 +165,13 @@ class ChangeStream extends EventEmitter {
   }
 
   /**
-   * Is the cursor closed
+   * Is the change stream closed
    * @method ChangeStream.prototype.isClosed
+   * @param  {boolean} [checkCursor=true] also check if the underlying cursor is closed
    * @return {boolean}
    */
-  isClosed() {
-    return this.closed || (this.cursor && this.cursor.isClosed());
+  isClosed(checkCursor) {
+    return !!(this.closed || (checkCursor && this.cursor && this.cursor.isClosed()));
   }
 
   /**
@@ -472,7 +475,7 @@ function waitForTopologyConnected(topology, options, callback) {
 function processNewChange(changeStream, change, callback) {
   const cursor = changeStream.cursor;
 
-  if (changeStream.closed) {
+  if (changeStream.isClosed()) {
     if (callback) callback(new MongoError('ChangeStream is closed'));
     return;
   }
@@ -503,7 +506,7 @@ function processError(changeStream, error, callback) {
   const cursor = changeStream.cursor;
 
   // If the change stream has been closed explictly, do not process error.
-  if (changeStream.closed) {
+  if (changeStream.isClosed()) {
     if (callback) callback(new MongoError('ChangeStream is closed'));
     return;
   }
@@ -532,10 +535,6 @@ function processError(changeStream, error, callback) {
 
     // close internal cursor, ignore errors
     cursor.close();
-
-    // the presence of a callback here indicates the error happened during a .next
-    // so it should be retried on resume
-    if (callback) changeStream[kResumeQueue].push(() => changeStream.next(callback));
 
     waitForTopologyConnected(topology, { readPreference: cursor.options.readPreference }, err => {
       // if the topology can't reconnect, close the stream
@@ -569,7 +568,7 @@ function processError(changeStream, error, callback) {
  * @param {ChangeStreamCursor} [oldCursor] when resuming from an error, carry over options from previous cursor
  */
 function getCursor(changeStream, callback) {
-  if (changeStream.isClosed()) {
+  if (changeStream.isClosed(true)) {
     callback(new MongoError('ChangeStream is closed.'));
     return;
   }
@@ -594,7 +593,7 @@ function getCursor(changeStream, callback) {
 function processResumeQueue(changeStream, err) {
   while (changeStream[kResumeQueue].length) {
     const request = changeStream[kResumeQueue].pop();
-    if (changeStream.isClosed() && !err) {
+    if (changeStream.isClosed(true) && !err) {
       request(new MongoError('Change Stream is not open.'));
       return;
     }

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -471,18 +471,15 @@ function waitForTopologyConnected(topology, options, callback) {
 
 // Handle new change events. This method brings together the routes from the callback, event emitter, and promise ways of using ChangeStream.
 function processNewChange(changeStream, change, callback) {
-  const eventEmitter = typeof callback !== 'function';
   const cursor = changeStream.cursor;
 
-  // If the cursor is null or the change stream has been closed explictly, do not process a change.
-  if (cursor == null || changeStream.closed) {
-    // We do not error in the eventEmitter case.
-    changeStream.closed = true;
-    if (eventEmitter) {
-      return;
-    }
-    callback(new MongoError('ChangeStream is closed'));
+  if (changeStream.closed) {
+    if (callback) callback(new MongoError('ChangeStream is closed'));
     return;
+  }
+
+  if (cursor == null) {
+    throw new Error('cursor should never be null here');
   }
 
   if (change && !change._id) {
@@ -490,7 +487,7 @@ function processNewChange(changeStream, change, callback) {
       'A change stream document has been received that lacks a resume token (_id).'
     );
 
-    if (eventEmitter) return changeStream.emit('error', noResumeTokenError);
+    if (!callback) return changeStream.emit('error', noResumeTokenError);
     return callback(noResumeTokenError);
   }
 
@@ -502,38 +499,35 @@ function processNewChange(changeStream, change, callback) {
   changeStream.options.startAtOperationTime = undefined;
 
   // Return the change
-  if (eventEmitter) return changeStream.emit('change', change);
+  if (!callback) return changeStream.emit('change', change);
   return callback(undefined, change);
 }
 
 function processError(changeStream, error, callback) {
-  const eventEmitter = typeof callback !== 'function';
   const topology = changeStream.topology;
   const cursor = changeStream.cursor;
 
-  // If the cursor is null or the change stream has been closed explictly, do not process a change.
-  if (cursor == null || changeStream.closed) {
-    // We do not error in the eventEmitter case.
-    changeStream.closed = true;
-    if (eventEmitter) {
-      return;
-    }
-    callback(new MongoError('ChangeStream is closed'));
+  // If the change stream has been closed explictly, do not process error.
+  if (changeStream.closed) {
+    if (callback) callback(new MongoError('ChangeStream is closed'));
     return;
   }
 
-  function handleError(err) {
-    // if there's an error reconnecting, close the change stream
-    if (eventEmitter) {
+  function unresumableError(err) {
+    if (!callback) {
       changeStream.emit('error', err);
       changeStream.emit('close');
-      // return;
     }
     processResumeQueue(changeStream, err);
     changeStream.closed = true;
   }
 
-  if (isResumableError(error, maxWireVersion(cursor.server))) {
+  function resumeWithCursor(newCursor) {
+    changeStream.cursor = newCursor;
+    processResumeQueue(changeStream);
+  }
+
+  if (cursor && isResumableError(error, maxWireVersion(cursor.server))) {
     changeStream.cursor = undefined;
 
     // stop listening to all events from old cursor
@@ -542,28 +536,21 @@ function processError(changeStream, error, callback) {
     // close internal cursor, ignore errors
     cursor.close();
 
-    if (!eventEmitter) changeStream[kResumeQueue].push(() => changeStream.next(callback));
+    if (callback) changeStream[kResumeQueue].push(() => changeStream.next(callback));
 
     waitForTopologyConnected(topology, { readPreference: cursor.options.readPreference }, err => {
-      if (err) {
-        return handleError(err);
-      }
+      if (err) return unresumableError(err);
       const newCursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
-      if (eventEmitter) {
-        changeStream.cursor = newCursor;
-        processResumeQueue(changeStream);
-        return;
-      }
+      if (!callback) return resumeWithCursor(newCursor);
       newCursor.hasNext(err => {
-        if (err) return handleError(err);
-        changeStream.cursor = newCursor;
-        processResumeQueue(changeStream);
+        if (err) return unresumableError(err);
+        resumeWithCursor(newCursor);
       });
     });
     return;
   }
 
-  if (eventEmitter) return changeStream.emit('error', error);
+  if (!callback) return changeStream.emit('error', error);
   return callback(error);
 }
 

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -514,6 +514,7 @@ function processNewChange(args) {
         }
         changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
         processResumeQueue(changeStream);
+        if (!eventEmitter) changeStream.cursor.next(callback);
       });
       return;
     }

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -104,9 +104,7 @@ class ChangeStream extends EventEmitter {
     // Listen for any `change` listeners being added to ChangeStream
     this.on('newListener', eventName => {
       if (eventName === 'change' && this.cursor && this.listenerCount('change') === 0) {
-        this.cursor.on('data', change =>
-          processNewChange({ changeStream: this, change, eventEmitter: true })
-        );
+        this.cursor.on('data', change => processNewChange(this, change));
       }
     });
 
@@ -154,9 +152,12 @@ class ChangeStream extends EventEmitter {
     return maybePromise(this.parent, callback, cb => {
       getCursor(this, (err, cursor) => {
         if (err) return cb(err);
-        cursor.next((error, change) =>
-          processNewChange({ changeStream: this, error, change, callback: cb })
-        );
+        cursor.next((error, change) => {
+          if (error) {
+            return processError(this, error, cb);
+          }
+          processNewChange(this, change, cb);
+        });
       });
     });
   }
@@ -182,6 +183,8 @@ class ChangeStream extends EventEmitter {
 
       // flag the change stream as explicitly closed
       this.closed = true;
+
+      if (!this.cursor) return cb();
 
       // Tidy up the existing cursor
       const cursor = this.cursor;
@@ -393,7 +396,7 @@ function createChangeStreamCursor(self, options) {
    */
   if (self.listenerCount('change') > 0) {
     changeStreamCursor.on('data', function(change) {
-      processNewChange({ changeStream: self, change, eventEmitter: true });
+      processNewChange(self, change);
     });
   }
 
@@ -425,7 +428,7 @@ function createChangeStreamCursor(self, options) {
    * @type {Error}
    */
   changeStreamCursor.on('error', function(error) {
-    processNewChange({ changeStream: self, error, eventEmitter: true });
+    processError(self, error);
   });
 
   if (self.pipeDestinations) {
@@ -467,12 +470,8 @@ function waitForTopologyConnected(topology, options, callback) {
 }
 
 // Handle new change events. This method brings together the routes from the callback, event emitter, and promise ways of using ChangeStream.
-function processNewChange(args) {
-  const changeStream = args.changeStream;
-  const error = args.error;
-  const change = args.change;
-  const callback = args.callback;
-  const eventEmitter = args.eventEmitter || false;
+function processNewChange(changeStream, change, callback) {
+  const eventEmitter = typeof callback !== 'function';
   const cursor = changeStream.cursor;
 
   // If the cursor is null or the change stream has been closed explictly, do not process a change.
@@ -484,43 +483,6 @@ function processNewChange(args) {
     }
     callback(new MongoError('ChangeStream is closed'));
     return;
-  }
-
-  const topology = changeStream.topology;
-  const options = changeStream.cursor.options;
-  const wireVersion = maxWireVersion(cursor.server);
-
-  if (error) {
-    if (isResumableError(error, wireVersion)) {
-      const cursor = changeStream.cursor;
-      changeStream.cursor = null;
-
-      // stop listening to all events from old cursor
-      ['data', 'close', 'end', 'error'].forEach(event => cursor.removeAllListeners(event));
-
-      // close internal cursor, ignore errors
-      cursor.close();
-
-      waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
-        if (err) {
-          // if there's an error reconnecting, close the change stream
-          changeStream.closed = true;
-          if (eventEmitter) {
-            changeStream.emit('error', err);
-            changeStream.emit('close');
-            return;
-          }
-          return processResumeQueue(changeStream, err);
-        }
-        changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
-        processResumeQueue(changeStream);
-        if (!eventEmitter) changeStream.next(callback);
-      });
-      return;
-    }
-
-    if (eventEmitter) return changeStream.emit('error', error);
-    return callback(error);
   }
 
   if (change && !change._id) {
@@ -541,7 +503,68 @@ function processNewChange(args) {
 
   // Return the change
   if (eventEmitter) return changeStream.emit('change', change);
-  return callback(error, change);
+  return callback(undefined, change);
+}
+
+function processError(changeStream, error, callback) {
+  const eventEmitter = typeof callback !== 'function';
+  const topology = changeStream.topology;
+  const cursor = changeStream.cursor;
+
+  // If the cursor is null or the change stream has been closed explictly, do not process a change.
+  if (cursor == null || changeStream.closed) {
+    // We do not error in the eventEmitter case.
+    changeStream.closed = true;
+    if (eventEmitter) {
+      return;
+    }
+    callback(new MongoError('ChangeStream is closed'));
+    return;
+  }
+
+  function handleError(err) {
+    // if there's an error reconnecting, close the change stream
+    if (eventEmitter) {
+      changeStream.emit('error', err);
+      changeStream.emit('close');
+      // return;
+    }
+    processResumeQueue(changeStream, err);
+    changeStream.closed = true;
+  }
+
+  if (isResumableError(error, maxWireVersion(cursor.server))) {
+    changeStream.cursor = undefined;
+
+    // stop listening to all events from old cursor
+    ['data', 'close', 'end', 'error'].forEach(event => cursor.removeAllListeners(event));
+
+    // close internal cursor, ignore errors
+    cursor.close();
+
+    if (!eventEmitter) changeStream[kResumeQueue].push(() => changeStream.next(callback));
+
+    waitForTopologyConnected(topology, { readPreference: cursor.options.readPreference }, err => {
+      if (err) {
+        return handleError(err);
+      }
+      const newCursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
+      if (eventEmitter) {
+        changeStream.cursor = newCursor;
+        processResumeQueue(changeStream);
+        return;
+      }
+      newCursor.hasNext(err => {
+        if (err) return handleError(err);
+        changeStream.cursor = newCursor;
+        processResumeQueue(changeStream);
+      });
+    });
+    return;
+  }
+
+  if (eventEmitter) return changeStream.emit('error', error);
+  return callback(error);
 }
 
 /**
@@ -576,11 +599,11 @@ function getCursor(changeStream, callback) {
  */
 function processResumeQueue(changeStream, err) {
   while (changeStream[kResumeQueue].length) {
-    if (changeStream.isClosed()) {
+    const request = changeStream[kResumeQueue].pop();
+    if (changeStream.isClosed() && !err) {
       request(new MongoError('Change Stream is not open.'));
       return;
     }
-    const request = changeStream[kResumeQueue].pop();
     request(err, changeStream.cursor);
   }
 }

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Denque = require('denque');
 const EventEmitter = require('events');
 const isResumableError = require('./error').isResumableError;
 const MongoError = require('./core').MongoError;
@@ -8,6 +9,8 @@ const relayEvents = require('./core/utils').relayEvents;
 const maxWireVersion = require('./core/utils').maxWireVersion;
 const maybePromise = require('./utils').maybePromise;
 const AggregateOperation = require('./operations/aggregate');
+
+const kResumeQueue = Symbol('resumeQueue');
 
 const CHANGE_STREAM_OPTIONS = ['resumeAfter', 'startAfter', 'startAtOperationTime', 'fullDocument'];
 const CURSOR_OPTIONS = ['batchSize', 'maxAwaitTimeMS', 'collation', 'readPreference'].concat(
@@ -91,6 +94,8 @@ class ChangeStream extends EventEmitter {
       this.options.readPreference = parent.s.readPreference;
     }
 
+    this[kResumeQueue] = new Denque();
+
     // Create contained Change Stream cursor
     this.cursor = createChangeStreamCursor(this, options);
 
@@ -130,7 +135,12 @@ class ChangeStream extends EventEmitter {
    * @returns {Promise|void} returns Promise if no callback passed
    */
   hasNext(callback) {
-    return maybePromise(this.parent, callback, cb => this.cursor.hasNext(cb));
+    return maybePromise(this.parent, callback, cb => {
+      getCursor(this, (err, cursor) => {
+        if (err) return cb(err);
+        cursor.hasNext(cb);
+      });
+    });
   }
 
   /**
@@ -142,11 +152,11 @@ class ChangeStream extends EventEmitter {
    */
   next(callback) {
     return maybePromise(this.parent, callback, cb => {
-      if (this.isClosed()) {
-        return cb(new MongoError('ChangeStream is closed'));
-      }
-      this.cursor.next((error, change) => {
-        processNewChange({ changeStream: this, error, change, callback: cb });
+      getCursor(this, (err, cursor) => {
+        if (err) return cb(err);
+        cursor.next((error, change) =>
+          processNewChange({ changeStream: this, error, change, callback: cb })
+        );
       });
     });
   }
@@ -481,16 +491,15 @@ function processNewChange(args) {
   const wireVersion = maxWireVersion(cursor.server);
 
   if (error) {
-    if (isResumableError(error, wireVersion) && !changeStream.attemptingResume) {
-      changeStream.attemptingResume = true;
+    if (isResumableError(error, wireVersion)) {
+      const cursor = changeStream.cursor;
+      changeStream.cursor = null;
 
       // stop listening to all events from old cursor
-      ['data', 'close', 'end', 'error'].forEach(event =>
-        changeStream.cursor.removeAllListeners(event)
-      );
+      ['data', 'close', 'end', 'error'].forEach(event => cursor.removeAllListeners(event));
 
       // close internal cursor, ignore errors
-      changeStream.cursor.close();
+      cursor.close();
 
       waitForTopologyConnected(topology, { readPreference: options.readPreference }, err => {
         if (err) {
@@ -501,12 +510,10 @@ function processNewChange(args) {
             changeStream.emit('close');
             return;
           }
-          return callback(err);
+          return processResumeQueue(changeStream, err);
         }
-
         changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
-        if (eventEmitter) return;
-        changeStream.next(callback);
+        processResumeQueue(changeStream);
       });
       return;
     }
@@ -514,8 +521,6 @@ function processNewChange(args) {
     if (eventEmitter) return changeStream.emit('error', error);
     return callback(error);
   }
-
-  changeStream.attemptingResume = false;
 
   if (change && !change._id) {
     const noResumeTokenError = new Error(
@@ -536,6 +541,47 @@ function processNewChange(args) {
   // Return the change
   if (eventEmitter) return changeStream.emit('change', change);
   return callback(error, change);
+}
+
+/**
+ * Safely provides a cursor across resume attempts
+ *
+ * @param {ChangeStream} changeStream the parent ChangeStream
+ * @param {function} callback gets the cursor or error
+ * @param {ChangeStreamCursor} [oldCursor] when resuming from an error, carry over options from previous cursor
+ */
+function getCursor(changeStream, callback) {
+  if (changeStream.isClosed()) {
+    callback(new MongoError('ChangeStream is closed.'));
+    return;
+  }
+
+  // if a cursor exists and it is open, return it
+  if (changeStream.cursor) {
+    callback(undefined, changeStream.cursor);
+    return;
+  }
+
+  // no cursor, queue callback until topology reconnects
+  changeStream[kResumeQueue].push(callback);
+}
+
+/**
+ * Drain the resume queue when a new has become available
+ *
+ * @param {ChangeStream} changeStream the parent ChangeStream
+ * @param {?ChangeStreamCursor} changeStream.cursor the new cursor
+ * @param {?Error} err error getting a new cursor
+ */
+function processResumeQueue(changeStream, err) {
+  while (changeStream[kResumeQueue].length) {
+    if (changeStream.isClosed()) {
+      request(new MongoError('Change Stream is not open.'));
+      return;
+    }
+    const request = changeStream[kResumeQueue].pop();
+    request(err, changeStream.cursor);
+  }
 }
 
 /**

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -587,8 +587,8 @@ function getCursor(changeStream, callback) {
  * Drain the resume queue when a new has become available
  *
  * @param {ChangeStream} changeStream the parent ChangeStream
- * @param {?ChangeStreamCursor} changeStream.cursor the new cursor
- * @param {?Error} err error getting a new cursor
+ * @param {ChangeStreamCursor?} changeStream.cursor the new cursor
+ * @param {Error} [err] error getting a new cursor
  */
 function processResumeQueue(changeStream, err) {
   while (changeStream[kResumeQueue].length) {

--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -514,7 +514,7 @@ function processNewChange(args) {
         }
         changeStream.cursor = createChangeStreamCursor(changeStream, cursor.resumeOptions);
         processResumeQueue(changeStream);
-        if (!eventEmitter) changeStream.cursor.next(callback);
+        if (!eventEmitter) changeStream.next(callback);
       });
       return;
     }

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -733,7 +733,7 @@ describe('Change Streams', function() {
               changeStream.hasNext(function(err, hasNext) {
                 expect(err).to.not.exist;
                 assert.equal(hasNext, false);
-                assert.equal(changeStream.isClosed(true), true);
+                assert.equal(changeStream.isClosed(), true);
                 client.close(done);
               });
             }
@@ -801,7 +801,7 @@ describe('Change Streams', function() {
           .then(() => changeStream.hasNext())
           .then(function(hasNext) {
             assert.equal(hasNext, false);
-            assert.equal(changeStream.isClosed(true), true);
+            assert.equal(changeStream.isClosed(), true);
             client.close(done);
           })
           .catch(function(err) {

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2899,11 +2899,15 @@ describe('Change Stream Resume Error Tests', function() {
       waitForStarted(changeStream, () => {
         collection.insertOne({ a: 42 }, err => {
           expect(err).to.not.exist;
-          triggerResumableError(changeStream, () => {
-            collection.insertOne({ b: 24 }, err => {
-              expect(err).to.not.exist;
-            });
-          });
+          triggerResumableError(
+            changeStream,
+            () => {
+              collection.insertOne({ b: 24 }, err => {
+                expect(err).to.not.exist;
+              });
+            },
+            1000
+          );
         });
       });
     })

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -798,7 +798,7 @@ describe('Change Streams', function() {
     }
   });
 
-  it('Should return MongoNetworkError after first retry attempt fails using promises', {
+  it.skip('Should return MongoNetworkError after first retry attempt fails using promises', {
     metadata: {
       requires: {
         generators: true,
@@ -896,7 +896,7 @@ describe('Change Streams', function() {
     }
   });
 
-  it('Should return MongoNetworkError after first retry attempt fails using callbacks', {
+  it.skip('Should return MongoNetworkError after first retry attempt fails using callbacks', {
     metadata: {
       requires: {
         generators: true,
@@ -991,7 +991,7 @@ describe('Change Streams', function() {
     }
   });
 
-  it('Should resume Change Stream when a resumable error is encountered', {
+  it.skip('Should resume Change Stream when a resumable error is encountered', {
     metadata: {
       requires: {
         generators: true,

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -28,7 +28,7 @@ function withChangeStream(dbName, collectionName, callback) {
   collectionName = collectionName || 'test';
 
   return withClient((client, done) => {
-    const db = client.db();
+    const db = client.db(dbName);
     db.createCollection(collectionName, { w: 'majority' }, (err, collection) => {
       if (err) return done(err);
       withCursor(
@@ -2674,7 +2674,6 @@ describe('Change Streams', function() {
   });
 
   describe('tryNext', function() {
-
     it('should return null on single iteration of empty cursor', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
       test: withChangeStream((collection, changeStream, done) => {

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2866,12 +2866,12 @@ describe('Change Stream Resume Error Tests', function() {
       const client = configuration.newClient();
       client.connect(err => {
         expect(err).to.not.exist;
-        const db = client.db('test');
+        const db = client.db(`changeStreamResumeErrorDb${process.pid}`);
         db.createCollection('changeStreamResumeErrorTest', (err, collection) => {
           expect(err).to.not.exist;
           const changeStream = collection.watch();
           callback(collection, changeStream, () =>
-            changeStream.close(() => collection.drop(() => client.close(done)))
+            changeStream.close(() => db.dropDatabase(() => client.close(done)))
           );
         });
       });

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2860,18 +2860,18 @@ describe('Change Streams', function() {
 });
 
 describe('Change Stream Resume Error Tests', function() {
-  function withChangeStream(callback) {
+  function withChangeStream(testName, callback) {
     return function(done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
       client.connect(err => {
         expect(err).to.not.exist;
-        const db = client.db(`changeStreamResumeErrorDb${process.pid}`);
-        db.createCollection('changeStreamResumeErrorTest', (err, collection) => {
+        const db = client.db('changeStreamResumErrorTest');
+        db.createCollection(testName, (err, collection) => {
           expect(err).to.not.exist;
           const changeStream = collection.watch();
           callback(collection, changeStream, () =>
-            changeStream.close(() => db.dropDatabase(() => client.close(done)))
+            changeStream.close(() => collection.drop(() => client.close(done)))
           );
         });
       });
@@ -2879,7 +2879,7 @@ describe('Change Stream Resume Error Tests', function() {
   }
   it('(events) should continue iterating after a resumable error', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: withChangeStream((collection, changeStream, done) => {
+    test: withChangeStream('resumeErrorEvents', (collection, changeStream, done) => {
       const docs = [];
       changeStream.on('change', change => {
         expect(change).to.exist;
@@ -2911,7 +2911,7 @@ describe('Change Stream Resume Error Tests', function() {
 
   it('(callback) hasNext and next should work after a resumable error', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: withChangeStream((collection, changeStream, done) => {
+    test: withChangeStream('resumeErrorIterator', (collection, changeStream, done) => {
       waitForStarted(changeStream, () => {
         collection.insertOne({ a: 42 }, err => {
           expect(err).to.not.exist;

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -798,7 +798,7 @@ describe('Change Streams', function() {
     }
   });
 
-  it.skip('Should return MongoNetworkError after first retry attempt fails using promises', {
+  it('Should return MongoNetworkError after first retry attempt fails using promises', {
     metadata: {
       requires: {
         generators: true,
@@ -896,7 +896,7 @@ describe('Change Streams', function() {
     }
   });
 
-  it.skip('Should return MongoNetworkError after first retry attempt fails using callbacks', {
+  it('Should return MongoNetworkError after first retry attempt fails using callbacks', {
     metadata: {
       requires: {
         generators: true,
@@ -991,7 +991,7 @@ describe('Change Streams', function() {
     }
   });
 
-  it.skip('Should resume Change Stream when a resumable error is encountered', {
+  it('Should resume Change Stream when a resumable error is encountered', {
     metadata: {
       requires: {
         generators: true,

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -190,6 +190,20 @@ function withMonitoredClient(commands, options, callback) {
 }
 
 /**
+ * Safely perform a test with an arbitrary cursor.
+ *
+ * @param {function} getCursor given a client, provide cursor for test
+ * @param {function} callback the test function
+ */
+function withCursor(getCursor, callback) {
+  return withClient((client, done) => {
+    getCursor(client, (cursorErr, cursor) => {
+      callback(cursor, () => cursor.close(closeErr => done(cursorErr || closeErr)));
+    });
+  });
+}
+
+/**
  * A class for listening on specific events
  *
  * @example
@@ -265,5 +279,6 @@ module.exports = {
   setupDatabase,
   withClient,
   withMonitoredClient,
+  withCursor,
   EventCollector
 };

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -197,8 +197,9 @@ function withMonitoredClient(commands, options, callback) {
  */
 function withCursor(getCursor, callback) {
   return withClient((client, done) => {
-    getCursor(client, (cursorErr, cursor) => {
-      callback(cursor, () => cursor.close(closeErr => done(cursorErr || closeErr)));
+    getCursor(client, (err, cursor) => {
+      if (err) return done(err);
+      callback(cursor, () => cursor.close(done));
     });
   });
 }

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -192,16 +192,22 @@ function withMonitoredClient(commands, options, callback) {
 /**
  * Safely perform a test with an arbitrary cursor.
  *
- * @param {function} getCursor given a client, provide cursor for test
- * @param {function} callback the test function
+ * @param {function} cursor any cursor that needs to be closed
+ * @param {(cursor: Object, done: Function) => void} body test body
+ * @param {function} done called after cleanup
  */
-function withCursor(getCursor, callback) {
-  return withClient((client, done) => {
-    getCursor(client, (err, cursor) => {
-      if (err) return done(err);
-      callback(cursor, () => cursor.close(done));
-    });
-  });
+function withCursor(cursor, body, done) {
+  let clean = false;
+  function cleanup(testErr) {
+    if (clean) return;
+    clean = true;
+    return cursor.close(closeErr => done(testErr || closeErr));
+  }
+  try {
+    body(cursor, cleanup);
+  } catch (err) {
+    cleanup(err);
+  }
 }
 
 /**

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -192,9 +192,9 @@ function withMonitoredClient(commands, options, callback) {
 /**
  * Safely perform a test with an arbitrary cursor.
  *
- * @param {function} cursor any cursor that needs to be closed
+ * @param {Function} cursor any cursor that needs to be closed
  * @param {(cursor: Object, done: Function) => void} body test body
- * @param {function} done called after cleanup
+ * @param {Function} done called after cleanup
  */
 function withCursor(cursor, body, done) {
   let clean = false;


### PR DESCRIPTION
## Description
Introduced `getCursor` method to safely provide a change stream cursor
for `next`/`hasNext` across recoveries from resumable errors.

[NODE-2548](https://jira.mongodb.org/browse/NODE-2548)

**What changed?**
- `next` and `hasNext` now use `getCursor`
- `processError` was extracted from `processNewChange`
- added `withCursor` shared test helper


**Are there any files to ignore?**
