### PR TITLE
test: improve shared helpers

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -9,6 +9,7 @@ NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
 
 # this needs to be explicitly exported for the nvm install below
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+export XDG_CONFIG_HOME=${NODE_ARTIFACTS_PATH}
 
 # create node artifacts path if needed
 mkdir -p ${NODE_ARTIFACTS_PATH}
@@ -16,9 +17,9 @@ mkdir -p ${NPM_CACHE_DIR}
 mkdir -p "${NPM_TMP_DIR}"
 
 # install Node.js
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
 [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
-nvm install --lts=${NODE_LTS_NAME}
+nvm install --no-progress --lts=${NODE_LTS_NAME}
 
 # setup npm cache in a local directory
 cat <<EOT > .npmrc

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "check:atlas": "node test/tools/atlas_connectivity_tests.js",
     "check:bench": "node test/benchmarks/driverBench",
     "check:coverage": "nyc mocha --timeout 60000 --recursive test/functional test/unit",
-    "check:lint": "eslint index.js lib test",
+    "check:lint": "eslint -v && eslint index.js lib test",
     "check:test": "mocha --recursive test/functional test/unit",
     "check:types": "tsc -p tsconfig.check.json",
     "release": "standard-version -i HISTORY.md",

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2601,45 +2601,46 @@ describe('Change Streams', function() {
   describe('tryNext', function() {
     it('should return null on single iteration of empty cursor', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: function() {
-        return withClient.bind(this)(
-          withDb(
-            'testTryNext',
-            { w: 'majority' },
-            (db, done) => {
-              const changeStream = db.collection('test').watch();
-              tryNext(changeStream, (err, doc) => {
-                expect(err).to.not.exist;
-                expect(doc).to.not.exist;
+      test: withClient(
+        withDb(
+          'testTryNext',
+          { w: 'majority' },
+          (db, done) => {
+            const changeStream = db.collection('test').watch();
+            tryNext(changeStream, (err, doc) => {
+              expect(err).to.not.exist;
+              expect(doc).to.not.exist;
 
-                changeStream.close(done);
-              });
-            },
-            true
-          )
-        );
-      }
+              changeStream.close(done);
+            });
+          },
+          true
+        )
+      )
     });
 
     it('should iterate a change stream until first empty batch', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: function() {
-        return withClient.bind(this)(
-          withDb(
-            'testTryNext',
-            { w: 'majority' },
-            (db, done) => {
-              const collection = db.collection('test');
-              const changeStream = collection.watch();
-              waitForStarted(changeStream, () => {
-                collection.insertOne({ a: 42 }, err => {
-                  expect(err).to.not.exist;
+      test: withClient(
+        withDb(
+          'testTryNext',
+          { w: 'majority' },
+          (db, done) => {
+            const collection = db.collection('test');
+            const changeStream = collection.watch();
+            waitForStarted(changeStream, () => {
+              collection.insertOne({ a: 42 }, err => {
+                expect(err).to.not.exist;
 
-                  collection.insertOne({ b: 24 }, err => {
-                    expect(err).to.not.exist;
-                  });
+                collection.insertOne({ b: 24 }, err => {
+                  expect(err).to.not.exist;
                 });
               });
+            });
+
+            tryNext(changeStream, (err, doc) => {
+              expect(err).to.not.exist;
+              expect(doc).to.exist;
 
               tryNext(changeStream, (err, doc) => {
                 expect(err).to.not.exist;
@@ -2647,21 +2648,16 @@ describe('Change Streams', function() {
 
                 tryNext(changeStream, (err, doc) => {
                   expect(err).to.not.exist;
-                  expect(doc).to.exist;
+                  expect(doc).to.not.exist;
 
-                  tryNext(changeStream, (err, doc) => {
-                    expect(err).to.not.exist;
-                    expect(doc).to.not.exist;
-
-                    changeStream.close(done);
-                  });
+                  changeStream.close(done);
                 });
               });
-            },
-            true
-          )
-        );
-      }
+            });
+          },
+          true
+        )
+      )
     });
   });
 

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2616,37 +2616,34 @@ describe('Change Streams', function() {
     }
     it('should return null on single iteration of empty cursor', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: withTemporaryCollectionOnDb(
-        'testTryNext',
-        { helper: { drop: true } },
-        (collection, done) => {
-          const changeStream = collection.watch();
-          tryNext(changeStream, (err, doc) => {
-            expect(err).to.not.exist;
-            expect(doc).to.not.exist;
+      test: withTemporaryCollectionOnDb('testTryNext', (collection, done) => {
+        const changeStream = collection.watch();
+        tryNext(changeStream, (err, doc) => {
+          expect(err).to.not.exist;
+          expect(doc).to.not.exist;
 
-            changeStream.close(done);
-          });
-        }
-      )
+          changeStream.close(done);
+        });
+      })
     });
 
     it('should iterate a change stream until first empty batch', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: withTemporaryCollectionOnDb(
-        'testTryNext',
-        { helper: { drop: true } },
-        (collection, done) => {
-          const changeStream = collection.watch();
-          waitForStarted(changeStream, () => {
-            collection.insertOne({ a: 42 }, err => {
-              expect(err).to.not.exist;
+      test: withTemporaryCollectionOnDb('testTryNext', (collection, done) => {
+        const changeStream = collection.watch();
+        waitForStarted(changeStream, () => {
+          collection.insertOne({ a: 42 }, err => {
+            expect(err).to.not.exist;
 
-              collection.insertOne({ b: 24 }, err => {
-                expect(err).to.not.exist;
-              });
+            collection.insertOne({ b: 24 }, err => {
+              expect(err).to.not.exist;
             });
           });
+        });
+
+        tryNext(changeStream, (err, doc) => {
+          expect(err).to.not.exist;
+          expect(doc).to.exist;
 
           tryNext(changeStream, (err, doc) => {
             expect(err).to.not.exist;
@@ -2654,18 +2651,13 @@ describe('Change Streams', function() {
 
             tryNext(changeStream, (err, doc) => {
               expect(err).to.not.exist;
-              expect(doc).to.exist;
+              expect(doc).to.not.exist;
 
-              tryNext(changeStream, (err, doc) => {
-                expect(err).to.not.exist;
-                expect(doc).to.not.exist;
-
-                changeStream.close(done);
-              });
+              changeStream.close(done);
             });
           });
-        }
-      )
+        });
+      })
     });
   });
 

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2,8 +2,7 @@
 const assert = require('assert');
 const { Transform } = require('stream');
 const { MongoError, MongoNetworkError } = require('../../lib/error');
-const shared = require('./shared');
-const { setupDatabase, delay } = shared;
+const { delay, setupDatabase, withClient, withDb } = require('./shared');
 const co = require('co');
 const mock = require('mongodb-mock-server');
 const chai = require('chai');
@@ -2603,13 +2602,11 @@ describe('Change Streams', function() {
     it('should return null on single iteration of empty cursor', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
       test: function() {
-        const withClient = shared.withClient.bind(this);
-        const withDb = shared.withDb.bind(this);
-        return withClient(
+        return withClient.bind(this)(
           withDb(
             'testTryNext',
             { w: 'majority' },
-            function(db, done) {
+            (db, done) => {
               const changeStream = db.collection('test').watch();
               tryNext(changeStream, (err, doc) => {
                 expect(err).to.not.exist;
@@ -2627,13 +2624,11 @@ describe('Change Streams', function() {
     it('should iterate a change stream until first empty batch', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
       test: function() {
-        const withClient = shared.withClient.bind(this);
-        const withDb = shared.withDb.bind(this);
-        return withClient(
+        return withClient.bind(this)(
           withDb(
             'testTryNext',
             { w: 'majority' },
-            function(db, done) {
+            (db, done) => {
               const collection = db.collection('test');
               const changeStream = collection.watch();
               waitForStarted(changeStream, () => {

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -2,7 +2,7 @@
 const assert = require('assert');
 const { Transform } = require('stream');
 const { MongoError, MongoNetworkError } = require('../../lib/error');
-const { delay, setupDatabase, withClient, withDb } = require('./shared');
+const { delay, setupDatabase, withClient, withDb, withCollection } = require('./shared');
 const co = require('co');
 const mock = require('mongodb-mock-server');
 const chai = require('chai');
@@ -2599,44 +2599,58 @@ describe('Change Streams', function() {
   });
 
   describe('tryNext', function() {
+    function withTemporaryCollectionOnDb(database, testFn) {
+      return withClient(
+        withDb(
+          database,
+          { helper: { drop: true } },
+          withCollection(
+            {
+              collection: { w: 'majority' },
+              helper: { create: true }
+            },
+            testFn
+          )
+        )
+      );
+    }
     it('should return null on single iteration of empty cursor', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: withClient(
-        withDb(
-          'testTryNext',
-          { w: 'majority' },
-          (db, done) => {
-            const changeStream = db.collection('test').watch();
-            tryNext(changeStream, (err, doc) => {
-              expect(err).to.not.exist;
-              expect(doc).to.not.exist;
+      test: withTemporaryCollectionOnDb(
+        'testTryNext',
+        { helper: { drop: true } },
+        (collection, done) => {
+          const changeStream = collection.watch();
+          tryNext(changeStream, (err, doc) => {
+            expect(err).to.not.exist;
+            expect(doc).to.not.exist;
 
-              changeStream.close(done);
-            });
-          },
-          true
-        )
+            changeStream.close(done);
+          });
+        }
       )
     });
 
     it('should iterate a change stream until first empty batch', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: withClient(
-        withDb(
-          'testTryNext',
-          { w: 'majority' },
-          (db, done) => {
-            const collection = db.collection('test');
-            const changeStream = collection.watch();
-            waitForStarted(changeStream, () => {
-              collection.insertOne({ a: 42 }, err => {
-                expect(err).to.not.exist;
+      test: withTemporaryCollectionOnDb(
+        'testTryNext',
+        { helper: { drop: true } },
+        (collection, done) => {
+          const changeStream = collection.watch();
+          waitForStarted(changeStream, () => {
+            collection.insertOne({ a: 42 }, err => {
+              expect(err).to.not.exist;
 
-                collection.insertOne({ b: 24 }, err => {
-                  expect(err).to.not.exist;
-                });
+              collection.insertOne({ b: 24 }, err => {
+                expect(err).to.not.exist;
               });
             });
+          });
+
+          tryNext(changeStream, (err, doc) => {
+            expect(err).to.not.exist;
+            expect(doc).to.exist;
 
             tryNext(changeStream, (err, doc) => {
               expect(err).to.not.exist;
@@ -2644,19 +2658,13 @@ describe('Change Streams', function() {
 
               tryNext(changeStream, (err, doc) => {
                 expect(err).to.not.exist;
-                expect(doc).to.exist;
+                expect(doc).to.not.exist;
 
-                tryNext(changeStream, (err, doc) => {
-                  expect(err).to.not.exist;
-                  expect(doc).to.not.exist;
-
-                  changeStream.close(done);
-                });
+                changeStream.close(done);
               });
             });
-          },
-          true
-        )
+          });
+        }
       )
     });
   });

--- a/test/functional/index.test.js
+++ b/test/functional/index.test.js
@@ -3,7 +3,7 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const expect = require('chai').expect;
 const shared = require('./shared');
-const { withClient, withDb, withMonitoredClient } = shared;
+const { withClient, withMonitoredClient } = shared;
 
 describe('Indexes', function() {
   before(function() {
@@ -1208,19 +1208,18 @@ describe('Indexes', function() {
     function throwErrorTest(testCommand) {
       return {
         metadata: { requires: { mongodb: '<4.4' } },
-        test: withClient(
-          withDb('test', (db, done) => {
-            const collection = db.collection('commitQuorum');
-            testCommand(db, collection, (err, result) => {
-              expect(err).to.exist;
-              expect(err.message).to.equal(
-                '`commitQuorum` option for `createIndexes` not supported on servers < 4.4'
-              );
-              expect(result).to.not.exist;
-              done();
-            });
-          })
-        )
+        test: withClient((client, done) => {
+          const db = client.db('test');
+          const collection = db.collection('commitQuorum');
+          testCommand(db, collection, (err, result) => {
+            expect(err).to.exist;
+            expect(err.message).to.equal(
+              '`commitQuorum` option for `createIndexes` not supported on servers < 4.4'
+            );
+            expect(result).to.not.exist;
+            done();
+          });
+        })
       };
     }
     it(

--- a/test/functional/index.test.js
+++ b/test/functional/index.test.js
@@ -1208,21 +1208,19 @@ describe('Indexes', function() {
     function throwErrorTest(testCommand) {
       return {
         metadata: { requires: { mongodb: '<4.4' } },
-        test: function() {
-          return withClient.bind(this)(
-            withDb('test', (db, done) => {
-              const collection = db.collection('commitQuorum');
-              testCommand(db, collection, (err, result) => {
-                expect(err).to.exist;
-                expect(err.message).to.equal(
-                  '`commitQuorum` option for `createIndexes` not supported on servers < 4.4'
-                );
-                expect(result).to.not.exist;
-                done();
-              });
-            })
-          );
-        }
+        test: withClient(
+          withDb('test', (db, done) => {
+            const collection = db.collection('commitQuorum');
+            testCommand(db, collection, (err, result) => {
+              expect(err).to.exist;
+              expect(err.message).to.equal(
+                '`commitQuorum` option for `createIndexes` not supported on servers < 4.4'
+              );
+              expect(result).to.not.exist;
+              done();
+            });
+          })
+        )
       };
     }
     it(

--- a/test/functional/index.test.js
+++ b/test/functional/index.test.js
@@ -3,6 +3,7 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const expect = require('chai').expect;
 const shared = require('./shared');
+const { withClient, withDb, withMonitoredClient } = shared;
 
 describe('Indexes', function() {
   before(function() {
@@ -1208,9 +1209,7 @@ describe('Indexes', function() {
       return {
         metadata: { requires: { mongodb: '<4.4' } },
         test: function() {
-          const withClient = shared.withClient.bind(this);
-          const withDb = shared.withDb.bind(this);
-          return withClient(
+          return withClient.bind(this)(
             withDb('test', (db, done) => {
               const collection = db.collection('commitQuorum');
               testCommand(db, collection, (err, result) => {
@@ -1252,7 +1251,7 @@ describe('Indexes', function() {
     function commitQuorumTest(testCommand) {
       return {
         metadata: { requires: { mongodb: '>=4.4', topology: ['replicaset', 'sharded'] } },
-        test: shared.withMonitoredClient('createIndexes', function(client, events, done) {
+        test: withMonitoredClient('createIndexes', function(client, events, done) {
           const db = client.db('test');
           const collection = db.collection('commitQuorum');
           collection.insertOne({ a: 1 }, function(err) {

--- a/test/functional/index.test.js
+++ b/test/functional/index.test.js
@@ -1,9 +1,6 @@
 'use strict';
-var test = require('./shared').assert;
-var setupDatabase = require('./shared').setupDatabase;
-const expect = require('chai').expect;
-const shared = require('./shared');
-const { withClient, withMonitoredClient } = shared;
+const { expect } = require('chai');
+const { assert: test, setupDatabase, withClient, withMonitoredClient } = require('./shared');
 
 describe('Indexes', function() {
   before(function() {

--- a/test/functional/logger.test.js
+++ b/test/functional/logger.test.js
@@ -59,7 +59,7 @@ describe('Logger', function() {
       Logger.setCurrentLogger(function() {});
       Logger.setLevel('debug');
 
-      return withClient.bind(this)(
+      return withClient(
         this.configuration.newClient('mongodb://localhost:27017/test'),
         withDb(this.configuration.db, (db, done) => {
           // perform any operation that gets logged
@@ -82,7 +82,7 @@ describe('Logger', function() {
     metadata: { requires: { topology: ['single'] } },
 
     test: function() {
-      return withClient.bind(this)(
+      return withClient(
         this.configuration.newClient('mongodb://localhost:27017/test'),
         withDb(this.configuration.db, (db, done) => {
           // Status
@@ -126,7 +126,7 @@ describe('Logger', function() {
       Logger.filter('class', ['Cursor']);
       var logged = false;
 
-      return withClient.bind(this)(
+      return withClient(
         this.configuration.newClient('mongodb://localhost:27017/test'),
         withDb(
           this.configuration.db,

--- a/test/functional/logger.test.js
+++ b/test/functional/logger.test.js
@@ -1,6 +1,6 @@
 'use strict';
 const expect = require('chai').expect;
-const shared = require('./shared');
+const { withClient, withDb } = require('./shared');
 const Logger = require('../../lib/logger');
 
 describe('Logger', function() {
@@ -59,11 +59,9 @@ describe('Logger', function() {
       Logger.setCurrentLogger(function() {});
       Logger.setLevel('debug');
 
-      const withClient = shared.withClient.bind(this);
-      const withDb = shared.withDb.bind(this);
-      return withClient(
+      return withClient.bind(this)(
         this.configuration.newClient('mongodb://localhost:27017/test'),
-        withDb(this.configuration.db, function(db, done) {
+        withDb(this.configuration.db, (db, done) => {
           // perform any operation that gets logged
           db.collection('foo').findOne({}, function(err) {
             expect(err).to.not.exist;
@@ -84,11 +82,9 @@ describe('Logger', function() {
     metadata: { requires: { topology: ['single'] } },
 
     test: function() {
-      const withClient = shared.withClient.bind(this);
-      const withDb = shared.withDb.bind(this);
-      return withClient(
+      return withClient.bind(this)(
         this.configuration.newClient('mongodb://localhost:27017/test'),
-        withDb(this.configuration.db, function(db, done) {
+        withDb(this.configuration.db, (db, done) => {
           // Status
           var logged = false;
 
@@ -130,9 +126,7 @@ describe('Logger', function() {
       Logger.filter('class', ['Cursor']);
       var logged = false;
 
-      const withClient = shared.withClient.bind(this);
-      const withDb = shared.withDb.bind(this);
-      return withClient(
+      return withClient.bind(this)(
         this.configuration.newClient('mongodb://localhost:27017/test'),
         withDb(
           this.configuration.db,

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -178,7 +178,9 @@ function withMonitoredClient(commands, options, callback) {
     );
     const events = [];
     monitoredClient.on('commandStarted', filterForCommands(commands, events));
-    return withClient(monitoredClient, (client, done) => callback(client, events, done));
+    return withClient(monitoredClient, (client, done) =>
+      callback.bind(this)(client, events, done)
+    )();
   };
 }
 

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -144,7 +144,12 @@ function withClient(client, callback) {
     return client
       .connect()
       .then(callback)
-      .then(() => cleanup(), cleanup);
+      .then(err => {
+        cleanup();
+        if (err) {
+          throw err;
+        }
+      }, cleanup);
   }
 
   if (this && this.configuration) {

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const MongoClient = require('../../').MongoClient;
 const expect = require('chai').expect;
 
 // helpers for using chai.expect in the assert style

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -150,23 +150,75 @@ function withClient(client, operation, errorHandler) {
 }
 
 /**
+ * use as the `testFn` of `withDb`
+ *
+ * @param {string} [name='test'] database name
+ * @param {object} [options] options
+ * @param {object} [options.collection={}] collection options
+ * @param {object} [options.helper={}] helper options
+ * @param {boolean} [options.helper.create] create collection before test
+ * @param {boolean} [options.helper.drop] drop collection after test
+ * @param {Function} testFn test function to execute
+ */
+function withCollection(name, options, testFn) {
+  if (arguments.length === 1) {
+    testFn = name;
+    name = 'test';
+    options = { collection: {}, helper: {} };
+  } else if (arguments.length === 2) {
+    testFn = options;
+    if (typeof name === 'string') {
+      options = { collection: {}, helper: {} };
+    } else {
+      options = name;
+      name = 'test';
+    }
+  }
+  function runTest(collection, done) {
+    testFn(collection, options.helper.drop ? () => collection.drop(done) : done);
+  }
+  if (options.helper.create) {
+    return (db, done) =>
+      db.createCollection(name, options, (err, collection) => {
+        if (err) return done(err);
+        runTest(collection, done);
+      });
+  }
+  return (db, done) => {
+    const collection = db.collection(name, options.collection);
+    runTest(collection, done);
+  };
+}
+
+/**
  * use as the `operation` of `withClient`
  *
- * @param {string} name database name
- * @param {object} [options] database options
+ * @param {string} [name='test'] database name
+ * @param {object} [options] options
+ * @param {object} [options.db={}] database options
+ * @param {object} [options.helper={}] helper options
+ * @param {boolean} [options.helper.drop] drop database after test
  * @param {Function} testFn test function to execute
- * @param {boolean} [drop] drop database after test
+ 
  */
-function withDb(name, options, testFn, drop) {
-  if (typeof options === 'function') {
-    drop = testFn;
+function withDb(name, options, testFn) {
+  if (arguments.length === 1) {
+    testFn = name;
+    name = 'test';
+    options = { db: {}, helper: {} };
+  } else if (arguments.length === 2) {
     testFn = options;
-    options = {};
+    if (typeof name === 'string') {
+      options = { db: {}, helper: {} };
+    } else {
+      options = name;
+      name = 'test';
+    }
   }
   return client =>
     new Promise(resolve => {
-      const db = client.db(name, options);
-      testFn(db, drop ? () => db.dropDatabase(resolve) : resolve);
+      const db = client.db(name, options.db);
+      testFn(db, options.helper.drop ? () => db.dropDatabase(resolve) : resolve);
     });
 }
 
@@ -289,5 +341,6 @@ module.exports = {
   withClient,
   withMonitoredClient,
   withDb,
+  withCollection,
   EventCollector
 };

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -141,7 +141,7 @@ function withDb(name, options, testFn, drop) {
   return client =>
     new Promise(resolve => {
       const db = client.db(name, options);
-      testFn.call(this, db, drop ? () => db.dropDatabase(resolve) : resolve);
+      testFn(db, drop ? () => db.dropDatabase(resolve) : resolve);
     });
 }
 

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -43,6 +43,11 @@ function dropCollection(dbObj, collectionName) {
 }
 
 function filterForCommands(commands, bag) {
+  if (typeof commands === 'function') {
+    return function(event) {
+      if (commands(event.commandName)) bag.push(event);
+    };
+  }
   commands = Array.isArray(commands) ? commands : [commands];
   return function(event) {
     if (commands.indexOf(event.commandName) !== -1) bag.push(event);
@@ -50,6 +55,11 @@ function filterForCommands(commands, bag) {
 }
 
 function filterOutCommands(commands, bag) {
+  if (typeof commands === 'function') {
+    return function(event) {
+      if (!commands(event.commandName)) bag.push(event);
+    };
+  }
   commands = Array.isArray(commands) ? commands : [commands];
   return function(event) {
     if (commands.indexOf(event.commandName) === -1) bag.push(event);
@@ -163,7 +173,7 @@ function withDb(name, options, testFn, drop) {
 /**
  * Perform a test with a monitored MongoClient that will filter for certain commands.
  *
- * @param {string|Array} commands commands to filter for
+ * @param {string|Array|Function} commands commands to filter for
  * @param {object} [options] options to pass on to configuration.newClient
  * @param {object} [options.queryOptions] connection string options
  * @param {object} [options.clientOptions] MongoClient options

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -97,11 +97,12 @@ function setupDatabase(configuration, dbsToClean) {
     );
 }
 
+/** @typedef {(client: MongoClient) => Promise | (client: MongoClient, done: Function) => void} withClientCallback */
 /**
  * Safely perform a test with provided MongoClient, ensuring client won't leak.
  *
- * @param {string|MongoClient} [client] if not provided, withClient must be bound to test function `this`
- * @param {Function} operation (client):Promise or (client, done):void
+ * @param {string|MongoClient} [client] if not provided, `withClient` must be bound to test function `this`
+ * @param {withClientCallback} operation test operation to perform
  */
 function withClient(client, operation) {
   let connectionString;
@@ -152,6 +153,7 @@ function withClient(client, operation) {
   return lambda;
 }
 
+/** @typedef {(client: MongoClient, events: Array, done: Function) => void} withMonitoredClientCallback */
 /**
  * Perform a test with a monitored MongoClient that will filter for certain commands.
  *
@@ -187,12 +189,7 @@ function withMonitoredClient(commands, options, callback) {
   };
 }
 
-/**
- * @callback withMonitoredClientCallback
- * @param {MongoClient} client monitored client
- * @param {Array} events record of monitored commands
- * @param {Function} done trigger end of test and cleanup
- */
+
 
 /**
  * A class for listening on specific events

--- a/test/functional/shared.test.js
+++ b/test/functional/shared.test.js
@@ -36,7 +36,7 @@ describe('shared test utilities', function() {
             return innerDone();
           });
       }).bind(this);
-      encapsulatedTest(fakeDone);
+      encapsulatedTest().then(fakeDone);
     });
 
     it('should propagate passed error to done', function(done) {
@@ -59,7 +59,7 @@ describe('shared test utilities', function() {
             return innerDone(new Error('hello world'));
           });
       }).bind(this);
-      encapsulatedTest(fakeDone);
+      encapsulatedTest().catch(fakeDone);
     });
 
     it('should call done and close connection with promise', function(done) {
@@ -82,7 +82,7 @@ describe('shared test utilities', function() {
             return innerDone();
           });
       }).bind(this);
-      encapsulatedTest(fakeDone);
+      encapsulatedTest().then(fakeDone);
     });
 
     it('should propagate passed error to done from promise', function(done) {
@@ -106,7 +106,7 @@ describe('shared test utilities', function() {
             return innerDone(new Error('hello world'));
           });
       }).bind(this);
-      encapsulatedTest(fakeDone);
+      encapsulatedTest().catch(fakeDone);
     });
   });
 });


### PR DESCRIPTION
## Description

[NODE-2605](https://jira.mongodb.org/browse/NODE-2605)

**What changed?**

- remove `withTempDb`
- make `client` argument of `withClient` optional
- move unexported top-level function `makeCleanupFn` into `withClient`
- remove `connectToDb` helper
-  add filter function to `filterForCommands`/`filterOutCommands`/`withMonitoredClient`
- alphabetize helpers in `shared.js`

Also introduced some CI-related cleanup:
- output `eslint` version before linting
- upgrade `nvm` and use `--no-progress` option to clean up log output

**Are there any files to ignore?**
