### PR TITLE
add return value to bulk replaceOne

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -660,7 +660,7 @@ class FindOperators {
    * @returns {void} A reference to the parent BulkOperation
    */
   replaceOne(updateDocument) {
-    this.updateOne(updateDocument);
+    return this.updateOne(updateDocument);
   }
 
   /**


### PR DESCRIPTION
## Description

Without a return value we can't use fluid bulk syntax with replaceOne statements. Example:

```
ops
  .find({ _id: 1}).upsert().replaceOne({ _id: 1, value: 2 })
  .find({ _id: 2}).upsert().replaceOne({ _id: 2, value: 1 })
```

**What changed?**

Added return statement to replaceOne()

**Are there any files to ignore?**

No