### PR TITLE
feat(reIndex): deprecate and make standalone-only command

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1380,7 +1380,7 @@ Collection.prototype.reIndex = deprecate(function(options, callback) {
   const reIndexOperation = new ReIndexOperation(this, options);
 
   return executeOperation(this.s.topology, reIndexOperation, callback);
-}, 'collection.reIndex is deprecated. Use db.runCommand instead.');
+}, 'collection.reIndex is deprecated. Use db.command instead.');
 
 /**
  * Get the list of all indexes information for the collection.

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1367,19 +1367,20 @@ Collection.prototype.dropAllIndexes = deprecate(
  * Reindex all indexes on the collection
  * Warning: reIndex is a blocking operation (indexes are rebuilt in the foreground) and will be slow for large collections.
  * @method
+ * @deprecated use db.runCommand instead
  * @param {Object} [options] Optional settings
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
  */
-Collection.prototype.reIndex = function(options, callback) {
+Collection.prototype.reIndex = deprecate(function(options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
   const reIndexOperation = new ReIndexOperation(this, options);
 
   return executeOperation(this.s.topology, reIndexOperation, callback);
-};
+}, 'collection.reIndex is deprecated. Use db.runCommand instead.');
 
 /**
  * Get the list of all indexes information for the collection.

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1367,7 +1367,7 @@ Collection.prototype.dropAllIndexes = deprecate(
  * Reindex all indexes on the collection
  * Warning: reIndex is a blocking operation (indexes are rebuilt in the foreground) and will be slow for large collections.
  * @method
- * @deprecated use db.runCommand instead
+ * @deprecated use db.command instead
  * @param {Object} [options] Optional settings
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The command result callback

--- a/lib/core/sdam/common.js
+++ b/lib/core/sdam/common.js
@@ -28,6 +28,13 @@ const ServerType = {
   Unknown: 'Unknown'
 };
 
+// helper to get a server's type that works for both legacy and unified topologies
+function serverType(server) {
+  let description = server.s.description || server.s.serverDescription;
+  if (description.topologyType === TopologyType.Single) return description.servers[0].type;
+  return description.type;
+}
+
 const TOPOLOGY_DEFAULTS = {
   useUnifiedTopology: true,
   localThresholdMS: 15,
@@ -54,6 +61,7 @@ module.exports = {
   TOPOLOGY_DEFAULTS,
   TopologyType,
   ServerType,
+  serverType,
   drainTimerQueue,
   clearAndRemoveTimerFrom
 };

--- a/lib/operations/re_index.js
+++ b/lib/operations/re_index.js
@@ -9,9 +9,8 @@ const MongoError = require('../core').MongoError;
 
 class ReIndexOperation extends CommandOperationV2 {
   constructor(collection, options) {
-    super(collection.s.db, options);
-    this.collection = collection;
-    this.command = { reIndex: collection.collectionName };
+    super(collection, options);
+    this.reIndex = collection.collectionName;
   }
 
   execute(server, callback) {
@@ -19,7 +18,7 @@ class ReIndexOperation extends CommandOperationV2 {
       callback(new MongoError(`reIndex can only be executed on standalone servers.`));
       return;
     }
-    super.executeCommand(server, this.command, (err, result) => {
+    super.executeCommand(server, { reIndex: this.reIndex }, (err, result) => {
       if (err) {
         callback(err);
         return;

--- a/lib/operations/re_index.js
+++ b/lib/operations/re_index.js
@@ -3,10 +3,15 @@
 const Aspect = require('./operation').Aspect;
 const defineAspects = require('./operation').defineAspects;
 const CommandOperationV2 = require('./command_v2');
-const topologyType = require('../core/topologies/shared').topologyType;
 const TopologyType = require('../core/sdam/common').TopologyType;
 const ServerType = require('../core/sdam/common').ServerType;
 const MongoError = require('../core').MongoError;
+
+function serverDescription(server) {
+  let description = server.s.description || server.s.serverDescription;
+  if (description.topologyType === TopologyType.Single) return description.servers[0];
+  return description;
+}
 
 class ReIndexOperation extends CommandOperationV2 {
   constructor(collection, options) {
@@ -16,8 +21,7 @@ class ReIndexOperation extends CommandOperationV2 {
   }
 
   execute(server, callback) {
-    const type = topologyType(server);
-    if (!(type === TopologyType.Single || type === ServerType.Standalone)) {
+    if (serverDescription(server).type !== ServerType.Standalone) {
       callback(new MongoError(`reIndex can only be executed on standalone servers.`));
       return;
     }

--- a/lib/operations/re_index.js
+++ b/lib/operations/re_index.js
@@ -10,7 +10,7 @@ const MongoError = require('../core').MongoError;
 class ReIndexOperation extends CommandOperationV2 {
   constructor(collection, options) {
     super(collection, options);
-    this.reIndex = collection.collectionName;
+    this.collectionName = collection.collectionName;
   }
 
   execute(server, callback) {
@@ -18,7 +18,7 @@ class ReIndexOperation extends CommandOperationV2 {
       callback(new MongoError(`reIndex can only be executed on standalone servers.`));
       return;
     }
-    super.executeCommand(server, { reIndex: this.reIndex }, (err, result) => {
+    super.executeCommand(server, { reIndex: this.collectionName }, (err, result) => {
       if (err) {
         callback(err);
         return;

--- a/lib/operations/re_index.js
+++ b/lib/operations/re_index.js
@@ -3,9 +3,10 @@
 const Aspect = require('./operation').Aspect;
 const defineAspects = require('./operation').defineAspects;
 const CommandOperationV2 = require('./command_v2');
-const getTopologyType = require('../core/topologies/shared').getTopologyType;
-const MongoError = require('../core').MongoError;
+const topologyType = require('../core/topologies/shared').topologyType;
+const TopologyType = require('../core/sdam/common').TopologyType;
 const ServerType = require('../core/sdam/common').ServerType;
+const MongoError = require('../core').MongoError;
 
 class ReIndexOperation extends CommandOperationV2 {
   constructor(collection, options) {
@@ -15,7 +16,8 @@ class ReIndexOperation extends CommandOperationV2 {
   }
 
   execute(server, callback) {
-    if (getTopologyType(server) !== ServerType.Standalone) {
+    const type = topologyType(server);
+    if (!(type === TopologyType.Single || type === ServerType.Standalone)) {
       callback(new MongoError(`reIndex can only be executed on standalone servers.`));
       return;
     }

--- a/lib/operations/re_index.js
+++ b/lib/operations/re_index.js
@@ -3,15 +3,9 @@
 const Aspect = require('./operation').Aspect;
 const defineAspects = require('./operation').defineAspects;
 const CommandOperationV2 = require('./command_v2');
-const TopologyType = require('../core/sdam/common').TopologyType;
+const serverType = require('../core/sdam/common').serverType;
 const ServerType = require('../core/sdam/common').ServerType;
 const MongoError = require('../core').MongoError;
-
-function serverDescription(server) {
-  let description = server.s.description || server.s.serverDescription;
-  if (description.topologyType === TopologyType.Single) return description.servers[0];
-  return description;
-}
 
 class ReIndexOperation extends CommandOperationV2 {
   constructor(collection, options) {
@@ -21,7 +15,7 @@ class ReIndexOperation extends CommandOperationV2 {
   }
 
   execute(server, callback) {
-    if (serverDescription(server).type !== ServerType.Standalone) {
+    if (serverType(server) !== ServerType.Standalone) {
       callback(new MongoError(`reIndex can only be executed on standalone servers.`));
       return;
     }

--- a/lib/operations/re_index.js
+++ b/lib/operations/re_index.js
@@ -1,28 +1,34 @@
 'use strict';
 
-const CommandOperation = require('./command');
-const handleCallback = require('../utils').handleCallback;
+const Aspect = require('./operation').Aspect;
+const defineAspects = require('./operation').defineAspects;
+const CommandOperationV2 = require('./command_v2');
+const getTopologyType = require('../core/topologies/shared').getTopologyType;
+const MongoError = require('../core').MongoError;
+const ServerType = require('../core/sdam/common').ServerType;
 
-class ReIndexOperation extends CommandOperation {
+class ReIndexOperation extends CommandOperationV2 {
   constructor(collection, options) {
-    super(collection.s.db, options, collection);
+    super(collection.s.db, options);
+    this.collection = collection;
+    this.command = { reIndex: collection.collectionName };
   }
 
-  _buildCommand() {
-    const collection = this.collection;
-
-    const cmd = { reIndex: collection.collectionName };
-
-    return cmd;
-  }
-
-  execute(callback) {
-    super.execute((err, result) => {
-      if (callback == null) return;
-      if (err) return handleCallback(callback, err, null);
-      handleCallback(callback, null, result.ok ? true : false);
+  execute(server, callback) {
+    if (getTopologyType(server) !== ServerType.Standalone) {
+      callback(new MongoError(`reIndex can only be executed on standalone servers.`));
+      return;
+    }
+    super.executeCommand(server, this.command, (err, result) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+      callback(null, !!result.ok);
     });
   }
 }
+
+defineAspects(ReIndexOperation, [Aspect.EXECUTE_WITH_SELECTION]);
 
 module.exports = ReIndexOperation;


### PR DESCRIPTION
## Description

The `collection.reIndex` helper has been deprecated, and will be removed
in the next major version. It is also now only supported on standalone 
servers.

[NODE-2560](https://jira.mongodb.org/browse/NODE-2560)

**What changed?**

**Are there any files to ignore?**
