### PR TITLE
More informative operation traces

### DIFF
--- a/lib/cmap/connection.js
+++ b/lib/cmap/connection.js
@@ -263,7 +263,15 @@ function messageHandler(conn) {
         }
 
         if (document.ok === 0 || document.$err || document.errmsg || document.code) {
-          callback(new MongoError(document));
+          const error = new MongoError(document);
+          if (operationDescription.stack) {
+            const x = error.stack.split('\n');
+            const y = operationDescription.stack.split('\n');
+            y[0] = x[0];
+            error.stack = y.join('\n');
+          }
+
+          callback(error);
           return;
         }
       }
@@ -311,8 +319,11 @@ function write(command, options, callback) {
     promoteLongs: typeof options.promoteLongs === 'boolean' ? options.promoteLongs : true,
     promoteValues: typeof options.promoteValues === 'boolean' ? options.promoteValues : true,
     promoteBuffers: typeof options.promoteBuffers === 'boolean' ? options.promoteBuffers : false,
-    raw: typeof options.raw === 'boolean' ? options.raw : false
+    raw: typeof options.raw === 'boolean' ? options.raw : false,
   };
+
+  // save a stack trace for later
+  Error.captureStackTrace(operationDescription);
 
   if (this[kDescription] && this[kDescription].compressor) {
     operationDescription.agreedCompressor = this[kDescription].compressor;


### PR DESCRIPTION
Have you ever run into stack traces like this: 
```
[mbroadst@chomp node-mongodb-native (more-informative-operation-traces ✗)]$ node repro.js
Connecting to mongodb://localhost:27017/
running command...
Connection failure MongoError: Failing command due to 'failCommand' failpoint
    at MessageStream.messageHandler (/home/mbroadst/Development/mongo/node-mongodb-native/lib/cmap/connection.js:266:25)
    at MessageStream.emit (events.js:209:13)
    at processIncomingData (/home/mbroadst/Development/mongo/node-mongodb-native/lib/cmap/message_stream.js:144:12)
    at MessageStream._write (/home/mbroadst/Development/mongo/node-mongodb-native/lib/cmap/message_stream.js:42:5)
    at doWrite (_stream_writable.js:428:12)
    at writeOrBuffer (_stream_writable.js:412:5)
    at MessageStream.Writable.write (_stream_writable.js:302:11)
    at Socket.ondata (_stream_readable.js:722:22)
    at Socket.emit (events.js:209:13)
    at addChunk (_stream_readable.js:305:12) {
  ok: 0,
  errmsg: "Failing command due to 'failCommand' failpoint",
  code: 10107,
  codeName: 'NotMaster',
  name: 'MongoError'
}
```

What if they could actually tell you where they started:
```
[mbroadst@chomp node-mongodb-native (more-informative-operation-traces ✗)]$ node repro.js
Connecting to mongodb://localhost:27017/
running command...
Connection failure MongoError: Failing command due to 'failCommand' failpoint
    at Connection.write (/home/mbroadst/Development/mongo/node-mongodb-native/lib/cmap/connection.js:326:9)
    at _command (/home/mbroadst/Development/mongo/node-mongodb-native/lib/core/wireprotocol/command.js:125:10)
    at command (/home/mbroadst/Development/mongo/node-mongodb-native/lib/core/wireprotocol/command.js:28:5)
    at writeCommand (/home/mbroadst/Development/mongo/node-mongodb-native/lib/core/wireprotocol/write_command.js:47:3)
    at Object.insert (/home/mbroadst/Development/mongo/node-mongodb-native/lib/core/wireprotocol/index.js:6:5)
    at Connection.insert (/home/mbroadst/Development/mongo/node-mongodb-native/lib/cmap/connection.js:183:8)
    at /home/mbroadst/Development/mongo/node-mongodb-native/lib/core/sdam/server.js:479:13
    at Object.callback (/home/mbroadst/Development/mongo/node-mongodb-native/lib/cmap/connection_pool.js:347:7)
    at processWaitQueue (/home/mbroadst/Development/mongo/node-mongodb-native/lib/cmap/connection_pool.js:466:23)
    at ConnectionPool.checkOut (/home/mbroadst/Development/mongo/node-mongodb-native/lib/cmap/connection_pool.js:236:5) {
  ok: 0,
  errmsg: "Failing command due to 'failCommand' failpoint",
  code: 10107,
  codeName: 'NotMaster',
  name: 'MongoError'
}
```

:thinking: 
