### PR TITLE
[NODE-2516] docs: update comment in transactions (3.6)

### DIFF
--- a/test/examples/transactions.js
+++ b/test/examples/transactions.js
@@ -232,7 +232,7 @@ describe('examples(transactions):', function() {
       const client = new MongoClient(uri);
       await client.connect();
 
-      // Prereq: Create collections. CRUD operations in transactions must be on existing collections.
+      // Prereq: Create collections.
 
       await client
         .db('mydb1')


### PR DESCRIPTION
[NODE-2516](https://jira.mongodb.org/browse/NODE-2516)

```
docs: update comment in transactions 

Removes "CRUD operations in transactions must be on existing collections." part of comment.

NODE-2516
```