### PR TITLE
fix(bulk): make `insertMany()` error always contain `writeErrors` property

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -1200,14 +1200,19 @@ class BulkOperationBase {
    * @ignore
    * @param {function} callback
    * @param {BulkWriteResult} writeResult
-   * @param {class} self either OrderedBulkOperation or UnorderdBulkOperation
+   * @param {class} self either OrderedBulkOperation or UnorderedBulkOperation
    */
   handleWriteError(callback, writeResult) {
     if (this.s.bulkResult.writeErrors.length > 0) {
       if (this.s.bulkResult.writeErrors.length === 1) {
+        const err = toError({
+          message: this.s.bulkResult.writeErrors[0].message,
+          code: this.s.bulkResult.writeErrors[0].code,
+          writeErrors: this.s.bulkResult.writeErrors
+        });
         handleCallback(
           callback,
-          new BulkWriteError(toError(this.s.bulkResult.writeErrors[0]), writeResult),
+          new BulkWriteError(err, writeResult),
           null
         );
         return true;


### PR DESCRIPTION
## Description

This popped up in https://github.com/Automattic/mongoose/issues/8938 . TLDR; currently, if you run `insertMany()` with `ordered: false` and there are multiple errors, the error will have a top-level `writeErrors` property. But there will **not** be a `writeErrors` property if there is exactly one error.

Quick demo with Mongoose:

```javascript
'use strict';
  
const mongoose = require('mongoose');

mongoose.set('useFindAndModify', false);

const { Schema } = mongoose;

run().catch(err => console.log(err));

async function run() {
  await mongoose.connect('mongodb://localhost:27017/test', {
    useNewUrlParser: true,
    useUnifiedTopology: true
  });
  
  await mongoose.connection.dropDatabase();

  const QuestionType = new mongoose.Schema({ 
    code: { name: 'Type code', type: String, required: true, unique: true },
    text: { name: 'Description of type', type: String, required: true },
    questions: [{ type: mongoose.Types.ObjectId, ref: 'Question' }],
  }, { timestamps: true });
  const Question = mongoose.model('Question', QuestionType);
  await Question.init();

  await Question.create({ code: 'MEDIUM', text: '123' });
  //await Question.create({ code: 'HARD', text: '123' });
  
  const data = [
    {"code":"MEDIUM","text":"1111"},
    {"code":"test","text":"222"},
    {"code":"HARD","text":"2222"}
  ];
  
  const err = await Question.insertMany(data, { ordered: false, rawResult: true }).catch(err => err);
  console.log(err);
  console.log(err.writeErrors); // undefined
}
```

Uncomment out `await Question.create({ code: 'HARD', text: '123' });` and all of a sudden `err.writeErrors` is an array.

**What changed?**

Add a `writeErrors` property to `insertMany` errors if there's 1 error. Otherwise no change.

**Are there any files to ignore?**
