### PR TITLE
[NODE-2566] refactor: consolidate read-preference creation (master)

### DIFF
--- a/lib/cmap/wire_protocol/command.js
+++ b/lib/cmap/wire_protocol/command.js
@@ -60,12 +60,7 @@ function _command(server, ns, cmd, options, callback) {
     finalCmd.$clusterTime = clusterTime;
   }
 
-  if (
-    isSharded(server) &&
-    !shouldUseOpMsg &&
-    readPreference &&
-    readPreference.preference !== 'primary'
-  ) {
+  if (isSharded(server) && !shouldUseOpMsg && readPreference && readPreference.mode !== 'primary') {
     finalCmd = {
       $query: finalCmd,
       $readPreference: readPreference.toJSON()

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -14,7 +14,6 @@ const {
   checkCollectionName,
   deprecateOptions,
   executeLegacyOperation,
-  resolveReadPreference,
   MongoDBNamespace
 } = require('./utils');
 const {
@@ -408,7 +407,7 @@ Collection.prototype.find = deprecateOptions(
     newOptions.slaveOk = options.slaveOk != null ? options.slaveOk : this.s.db.slaveOk;
 
     // Add read preference if needed
-    newOptions.readPreference = resolveReadPreference(this, newOptions);
+    newOptions.readPreference = ReadPreference.resolve(this, newOptions);
 
     // Set slave ok to true if read preference different from primary
     if (
@@ -1995,7 +1994,7 @@ Collection.prototype.parallelCollectionScan = deprecate(function(options, callba
 
   options = Object.assign({}, options);
   // Ensure we have the right read preference inheritance
-  options.readPreference = resolveReadPreference(this, options);
+  options.readPreference = ReadPreference.resolve(this, options);
 
   if (options.session) {
     options.session = undefined;

--- a/lib/db.js
+++ b/lib/db.js
@@ -21,7 +21,6 @@ const {
   toError,
   mergeOptionsAndWriteConcern,
   executeLegacyOperation,
-  resolveReadPreference,
   deprecateOptions,
   MongoDBNamespace
 } = require('./utils');
@@ -671,7 +670,7 @@ Db.prototype.collections = function(options, callback) {
 Db.prototype.executeDbAdminCommand = function(selector, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
-  options.readPreference = resolveReadPreference(this, options);
+  options.readPreference = ReadPreference.resolve(this, options);
 
   const executeDbAdminCommandOperation = new ExecuteDbAdminCommandOperation(
     this,

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -10,7 +10,6 @@ const {
   applyWriteConcern,
   decorateWithCollation,
   decorateWithReadConcern,
-  resolveReadPreference,
   handleCallback,
   toError
 } = require('../utils');
@@ -191,7 +190,7 @@ function group(coll, keys, condition, initial, reduce, finalize, command, option
 
     options = Object.assign({}, options);
     // Ensure we have the right read preference inheritance
-    options.readPreference = resolveReadPreference(coll, options);
+    options.readPreference = ReadPreference.resolve(coll, options);
 
     // Do we have a readConcern specified
     decorateWithReadConcern(selector, coll, options);

--- a/lib/operations/command.js
+++ b/lib/operations/command.js
@@ -3,13 +3,7 @@
 const ReadPreference = require('../read_preference');
 const { Aspect, OperationBase } = require('./operation');
 const { MongoError } = require('../error');
-const {
-  applyWriteConcern,
-  debugOptions,
-  handleCallback,
-  resolveReadPreference,
-  MongoDBNamespace
-} = require('../utils');
+const { applyWriteConcern, debugOptions, handleCallback, MongoDBNamespace } = require('../utils');
 
 const debugFields = [
   'authSource',
@@ -38,9 +32,9 @@ class CommandOperation extends OperationBase {
 
     if (!this.hasAspect(Aspect.WRITE_OPERATION)) {
       if (collection != null) {
-        this.options.readPreference = resolveReadPreference(collection, options);
+        this.options.readPreference = ReadPreference.resolve(collection, options);
       } else {
-        this.options.readPreference = resolveReadPreference(db, options);
+        this.options.readPreference = ReadPreference.resolve(db, options);
       }
     } else {
       if (collection != null) {

--- a/lib/operations/command_v2.js
+++ b/lib/operations/command_v2.js
@@ -3,7 +3,8 @@
 const { Aspect, OperationBase } = require('./operation');
 const ReadConcern = require('../read_concern');
 const WriteConcern = require('../write_concern');
-const { maxWireVersion, resolveReadPreference } = require('../utils');
+const { maxWireVersion } = require('../utils');
+const ReadPreference = require('../read_preference');
 const { commandSupportsReadConcern } = require('../sessions');
 const { MongoError } = require('../error');
 
@@ -14,7 +15,7 @@ class CommandOperationV2 extends OperationBase {
     super(options);
 
     this.ns = parent.s.namespace.withCollection('$cmd');
-    this.readPreference = resolveReadPreference(parent, this.options);
+    this.readPreference = ReadPreference.resolve(parent, this.options);
     this.readConcern = resolveReadConcern(parent, this.options);
     this.writeConcern = resolveWriteConcern(parent, this.options);
     this.explain = false;

--- a/lib/operations/db_ops.js
+++ b/lib/operations/db_ops.js
@@ -10,7 +10,6 @@ const CONSTANTS = require('../constants');
 const { count, findOne, remove, updateOne } = require('./collection_ops');
 const {
   applyWriteConcern,
-  resolveReadPreference,
   debugOptions,
   handleCallback,
   parseIndexOptions,
@@ -392,7 +391,7 @@ function executeCommand(db, command, options, callback) {
   const dbName = options.dbName || options.authdb || db.databaseName;
 
   // Convert the readPreference if its not a write
-  options.readPreference = resolveReadPreference(db, options);
+  options.readPreference = ReadPreference.resolve(db, options);
 
   // Debug information
   if (db.s.logger.isDebug())

--- a/lib/operations/find.js
+++ b/lib/operations/find.js
@@ -3,7 +3,7 @@
 const OperationBase = require('./operation').OperationBase;
 const Aspect = require('./operation').Aspect;
 const defineAspects = require('./operation').defineAspects;
-const resolveReadPreference = require('../utils').resolveReadPreference;
+const ReadPreference = require('../read_preference');
 
 class FindOperation extends OperationBase {
   constructor(collection, ns, command, options) {
@@ -11,7 +11,7 @@ class FindOperation extends OperationBase {
 
     this.ns = ns;
     this.cmd = command;
-    this.readPreference = resolveReadPreference(collection, this.options);
+    this.readPreference = ReadPreference.resolve(collection, this.options);
   }
 
   execute(server, callback) {

--- a/lib/operations/map_reduce.js
+++ b/lib/operations/map_reduce.js
@@ -12,9 +12,9 @@ const {
   decorateWithReadConcern,
   handleCallback,
   isObject,
-  resolveReadPreference,
   toError
 } = require('../utils');
+const ReadPreference = require('../read_preference');
 
 const exclusionList = [
   'readPreference',
@@ -85,7 +85,7 @@ class MapReduceOperation extends OperationBase {
     options = Object.assign({}, options);
 
     // Ensure we have the right read preference inheritance
-    options.readPreference = resolveReadPreference(coll, options);
+    options.readPreference = ReadPreference.resolve(coll, options);
 
     // If we have a read preference and inline is not set as output fail hard
     if (

--- a/lib/read_preference.js
+++ b/lib/read_preference.js
@@ -113,6 +113,50 @@ ReadPreference.fromOptions = function(options) {
 };
 
 /**
+ * Resolves a read preference based on well-defined inheritance rules. This method will not only
+ * determine the read preference (if there is one), but will also ensure the returned value is a
+ * properly constructed instance of `ReadPreference`.
+ *
+ * @param {Collection|Db|MongoClient} parent The parent of the operation on which to determine the read
+ * preference, used for determining the inherited read preference.
+ * @param {object} options The options passed into the method, potentially containing a read preference
+ * @returns {(ReadPreference|null)} The resolved read preference
+ */
+ReadPreference.resolve = function(parent, options) {
+  options = options || {};
+  const session = options.session;
+
+  const inheritedReadPreference = parent.readPreference;
+
+  let readPreference;
+  if (options.readPreference) {
+    readPreference = ReadPreference.fromOptions(options);
+  } else if (session && session.inTransaction() && session.transaction.options.readPreference) {
+    // The transaction’s read preference MUST override all other user configurable read preferences.
+    readPreference = session.transaction.options.readPreference;
+  } else if (inheritedReadPreference != null) {
+    readPreference = inheritedReadPreference;
+  } else {
+    throw new Error('No readPreference was provided or inherited.');
+  }
+
+  return typeof readPreference === 'string' ? new ReadPreference(readPreference) : readPreference;
+};
+
+/**
+ * Replaces options.readPreference with a ReadPreference instance
+ */
+ReadPreference.translate = function(options) {
+  if (options.readPreference == null) return undefined;
+  const r = options.readPreference;
+  options.readPreference = ReadPreference.fromOptions(options);
+  if (!(options.readPreference instanceof ReadPreference)) {
+    throw new TypeError('Invalid read preference: ' + r);
+  }
+  return options;
+};
+
+/**
  * Validate if a mode is legal
  *
  * @function

--- a/lib/sdam/topology.js
+++ b/lib/sdam/topology.js
@@ -259,7 +259,7 @@ class Topology extends EventEmitter {
     // connect all known servers, then attempt server selection to connect
     connectServers(this, Array.from(this.s.description.servers.values()));
 
-    translateReadPreference(options);
+    ReadPreference.translate(options);
     const readPreference = options.readPreference || ReadPreference.primary;
     const connectHandler = err => {
       if (err) {
@@ -374,7 +374,7 @@ class Topology extends EventEmitter {
         if (selector instanceof ReadPreference) {
           readPreference = selector;
         } else {
-          translateReadPreference(options);
+          ReadPreference.translate(options);
           readPreference = options.readPreference || ReadPreference.primary;
         }
 
@@ -647,7 +647,7 @@ class Topology extends EventEmitter {
       (callback = options), (options = {}), (options = options || {});
     }
 
-    translateReadPreference(options);
+    ReadPreference.translate(options);
     const readPreference = options.readPreference || ReadPreference.primary;
 
     this.selectServer(readPreferenceServerSelector(readPreference), options, (err, server) => {
@@ -708,7 +708,7 @@ class Topology extends EventEmitter {
     options = options || {};
     const topology = options.topology || this;
     const CursorClass = options.cursorFactory || this.s.Cursor;
-    translateReadPreference(options);
+    ReadPreference.translate(options);
 
     return new CursorClass(topology, ns, cmd, options);
   }
@@ -961,29 +961,6 @@ function executeWriteOperation(args, options, callback) {
 
 function shouldRetryOperation(err) {
   return err instanceof MongoError && err.hasErrorLabel('RetryableWriteError');
-}
-
-function translateReadPreference(options) {
-  if (options.readPreference == null) {
-    return;
-  }
-
-  let r = options.readPreference;
-  if (typeof r === 'string') {
-    options.readPreference = new ReadPreference(r);
-  } else if (r && !(r instanceof ReadPreference) && typeof r === 'object') {
-    const mode = r.mode || r.preference;
-    if (mode && typeof mode === 'string') {
-      options.readPreference = new ReadPreference(mode, r.tags, {
-        maxStalenessSeconds: r.maxStalenessSeconds,
-        hedge: r.hedge
-      });
-    }
-  } else if (!(r instanceof ReadPreference)) {
-    throw new TypeError('Invalid read preference: ' + r);
-  }
-
-  return options;
 }
 
 function srvPollingHandler(topology) {

--- a/lib/topologies/topology_base.js
+++ b/lib/topologies/topology_base.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events');
 const { MongoError } = require('../error');
 const { format: f } = require('util');
-const { translateReadPreference } = require('../utils');
+const ReadPreference = require('../read_preference');
 const { ClientSession } = require('../sessions');
 
 // The store of ops
@@ -293,7 +293,7 @@ class TopologyBase extends EventEmitter {
 
   // Command
   command(ns, cmd, options, callback) {
-    this.s.coreTopology.command(ns.toString(), cmd, translateReadPreference(options), callback);
+    this.s.coreTopology.command(ns.toString(), cmd, ReadPreference.translate(options), callback);
   }
 
   // Insert
@@ -314,7 +314,7 @@ class TopologyBase extends EventEmitter {
   // IsConnected
   isConnected(options) {
     options = options || {};
-    options = translateReadPreference(options);
+    options = ReadPreference.translate(options);
 
     return this.s.coreTopology.isConnected(options);
   }
@@ -327,7 +327,7 @@ class TopologyBase extends EventEmitter {
   // Cursor
   cursor(ns, cmd, options) {
     options = options || {};
-    options = translateReadPreference(options);
+    options = ReadPreference.translate(options);
     options.disconnectHandler = this.s.store;
     options.topology = this;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,34 +4,7 @@ const PromiseProvider = require('./promise_provider');
 const os = require('os');
 const crypto = require('crypto');
 const { MongoError } = require('./error');
-const ReadPreference = require('./read_preference');
 const WriteConcern = require('./write_concern');
-
-// Figure out the read preference
-var translateReadPreference = function(options) {
-  var r = null;
-  if (options.readPreference) {
-    r = options.readPreference;
-  } else {
-    return options;
-  }
-
-  if (typeof r === 'string') {
-    options.readPreference = new ReadPreference(r);
-  } else if (r && !(r instanceof ReadPreference) && typeof r === 'object') {
-    const mode = r.mode || r.preference;
-    if (mode && typeof mode === 'string') {
-      options.readPreference = new ReadPreference(mode, r.tags, {
-        maxStalenessSeconds: r.maxStalenessSeconds,
-        hedge: r.hedge
-      });
-    }
-  } else if (!(r instanceof ReadPreference)) {
-    throw new TypeError('Invalid read preference: ' + r);
-  }
-
-  return options;
-};
 
 // Set simple property
 var getSingleProperty = function(obj, name, value) {
@@ -491,37 +464,6 @@ function applyWriteConcern(target, sources, options) {
 }
 
 /**
- * Resolves a read preference based on well-defined inheritance rules. This method will not only
- * determine the read preference (if there is one), but will also ensure the returned value is a
- * properly constructed instance of `ReadPreference`.
- *
- * @param {Collection|Db|MongoClient} parent The parent of the operation on which to determine the read
- * preference, used for determining the inherited read preference.
- * @param {object} options The options passed into the method, potentially containing a read preference
- * @returns {(ReadPreference|null)} The resolved read preference
- */
-function resolveReadPreference(parent, options) {
-  options = options || {};
-  const session = options.session;
-
-  const inheritedReadPreference = parent.readPreference;
-
-  let readPreference;
-  if (options.readPreference) {
-    readPreference = ReadPreference.fromOptions(options);
-  } else if (session && session.inTransaction() && session.transaction.options.readPreference) {
-    // The transaction’s read preference MUST override all other user configurable read preferences.
-    readPreference = session.transaction.options.readPreference;
-  } else if (inheritedReadPreference != null) {
-    readPreference = inheritedReadPreference;
-  } else {
-    throw new Error('No readPreference was provided or inherited.');
-  }
-
-  return typeof readPreference === 'string' ? new ReadPreference(readPreference) : readPreference;
-}
-
-/**
  * Checks if a given value is a Promise
  *
  * @param {any} maybePromise
@@ -960,7 +902,6 @@ module.exports = {
   debugOptions,
   MAX_JS_INT: Number.MAX_SAFE_INTEGER + 1,
   mergeOptionsAndWriteConcern,
-  translateReadPreference,
   executeLegacyOperation,
   applyRetryableWrites,
   applyWriteConcern,
@@ -969,7 +910,6 @@ module.exports = {
   decorateWithReadConcern,
   deprecateOptions,
   MongoDBNamespace,
-  resolveReadPreference,
   emitDeprecationWarning,
   emitDeprecatedOptionWarning,
   makeCounter,


### PR DESCRIPTION
Wondering what people's thoughts are about being more DRY and centralizing the readPreference creation to the ReadPreference class.

```
refactor: consolidate read-preference creation

Centralizes `ReadPreference` "translation" and "resolution" to `ReadPreference` class. Removes duplicate code from `utils` and `topology`.

NODE-2566
```

[Reasoning in ticket here.](https://jira.mongodb.org/browse/NODE-2566?focusedCommentId=3092955&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-3092955)