### PR TITLE
[NODE-2616] test: sdam spec test typo property "compatible" (master) 

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -569,8 +569,7 @@ function processError(changeStream, error, callback) {
  * Safely provides a cursor across resume attempts
  *
  * @param {ChangeStream} changeStream the parent ChangeStream
- * @param {function} callback gets the cursor or error
- * @param {ChangeStreamCursor} [oldCursor] when resuming from an error, carry over options from previous cursor
+ * @param {Function} callback gets the cursor or error
  */
 function getCursor(changeStream, callback) {
   if (changeStream.isClosed()) {

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -193,7 +193,7 @@ function withMonitoredClient(commands, options, callback) {
  * Safely perform a test with an arbitrary cursor.
  *
  * @param {Function} cursor any cursor that needs to be closed
- * @param {(cursor: Object, done: Function) => void} body test body
+ * @param {(cursor: object, done: Function) => void} body test body
  * @param {Function} done called after cleanup
  */
 function withCursor(cursor, body, done) {

--- a/test/unit/sdam/spec.test.js
+++ b/test/unit/sdam/spec.test.js
@@ -273,7 +273,7 @@ function executeSDAMTest(testData, testDone) {
         });
 
         // remove error handler
-        topology.removeListener('error', incompatabilityHandler);
+        topology.removeListener('error', incompatibilityHandler);
 
         // reset the captured events for each phase
         events = [];

--- a/test/unit/sdam/spec.test.js
+++ b/test/unit/sdam/spec.test.js
@@ -204,7 +204,7 @@ function executeSDAMTest(testData, testDone) {
       topology.close(e => testDone(e || err));
     }
 
-    const incompatabilityHandler = err => {
+    const incompatibilityHandler = err => {
       if (err.message.match(/but this version of the driver/)) return;
       throw err;
     };
@@ -214,9 +214,9 @@ function executeSDAMTest(testData, testDone) {
       expect(err).to.not.exist;
 
       testData.phases.forEach(phase => {
-        const incompatibilityExpected = phase.outcome ? !phase.outcome.comptabile : false;
+        const incompatibilityExpected = phase.outcome ? !phase.outcome.compatible : false;
         if (incompatibilityExpected) {
-          topology.on('error', incompatabilityHandler);
+          topology.on('error', incompatibilityHandler);
         }
 
         // simulate each ismaster response


### PR DESCRIPTION
Commit Message:

```
test: sdam spec test typo property "compatible"

Fixes sdam spec test typo property "compatible"

NODE-2616
```

[NODE-2616](https://jira.mongodb.org/browse/NODE-2616)