### PR TITLE
[NODE-2564] fix: clarify handle wrong set name single topology (master)

### DIFF
--- a/lib/sdam/server_description.js
+++ b/lib/sdam/server_description.js
@@ -136,6 +136,29 @@ class ServerDescription {
       this.logicalSessionTimeoutMinutes === other.logicalSessionTimeoutMinutes
     );
   }
+
+  /**
+   * Creates a new ServerDescription from this
+   * serverDescription with no ismaster response.
+   *
+   * @returns ServerDescription
+   */
+  reset() {
+    return new ServerDescription(this.address, null);
+  }
+
+  /**
+   * Resets the ServerDescription if the string setName
+   * passed in doesn't match the ismaster.setName.
+   *
+   * @param {string} setName
+   * @returns ServerDescription
+   */
+  resetIfWrongSetName(setName) {
+    if (!this.setName || !setName) return this;
+    if (this.setName !== setName) return this.reset();
+    return this;
+  }
 }
 
 /**

--- a/lib/sdam/server_description.js
+++ b/lib/sdam/server_description.js
@@ -51,6 +51,8 @@ class ServerDescription {
    * @param {object} [ismaster] An optional ismaster response for this server
    * @param {object} [options] Optional settings
    * @param {number} [options.roundTripTime] The round trip time to ping this server (in ms)
+   * @param {Error} [options.error] An Error used for better reporting debugging
+   * @param {any} [options.topologyVersion] The topologyVersion
    */
   constructor(address, ismaster, options) {
     options = options || {};

--- a/lib/sdam/server_description.js
+++ b/lib/sdam/server_description.js
@@ -136,29 +136,6 @@ class ServerDescription {
       this.logicalSessionTimeoutMinutes === other.logicalSessionTimeoutMinutes
     );
   }
-
-  /**
-   * Creates a new ServerDescription from this
-   * serverDescription with no ismaster response.
-   *
-   * @returns ServerDescription
-   */
-  reset() {
-    return new ServerDescription(this.address, null);
-  }
-
-  /**
-   * Resets the ServerDescription if the string setName
-   * passed in doesn't match the ismaster.setName.
-   *
-   * @param {string} setName
-   * @returns ServerDescription
-   */
-  resetIfWrongSetName(setName) {
-    if (!this.setName || !setName) return this;
-    if (this.setName !== setName) return this.reset();
-    return this;
-  }
 }
 
 /**

--- a/lib/sdam/topology_description.js
+++ b/lib/sdam/topology_description.js
@@ -134,6 +134,8 @@ class TopologyDescription {
     let maxElectionId = this.maxElectionId;
     let commonWireVersion = this.commonWireVersion;
 
+    serverDescription = serverDescription.resetIfWrongSetName(setName);
+
     const serverType = serverDescription.type;
     let serverDescriptions = new Map(this.servers);
 

--- a/lib/sdam/topology_description.js
+++ b/lib/sdam/topology_description.js
@@ -134,7 +134,7 @@ class TopologyDescription {
     let maxElectionId = this.maxElectionId;
     let commonWireVersion = this.commonWireVersion;
 
-    if (serverDescription.setName !== setName) {
+    if (serverDescription.setName && setName && serverDescription.setName !== setName) {
       serverDescription = new ServerDescription(address, null);
     }
 

--- a/lib/sdam/topology_description.js
+++ b/lib/sdam/topology_description.js
@@ -134,7 +134,9 @@ class TopologyDescription {
     let maxElectionId = this.maxElectionId;
     let commonWireVersion = this.commonWireVersion;
 
-    serverDescription = serverDescription.resetIfWrongSetName(setName);
+    if (serverDescription.setName !== setName) {
+      serverDescription = new ServerDescription(address, null);
+    }
 
     const serverType = serverDescription.type;
     let serverDescriptions = new Map(this.servers);

--- a/test/spec/server-discovery-and-monitoring/README.rst
+++ b/test/spec/server-discovery-and-monitoring/README.rst
@@ -63,6 +63,7 @@ current TopologyDescription. It has the following keys:
 - logicalSessionTimeoutMinutes: absent, null, or an integer.
 - minWireVersion: absent or an integer.
 - maxWireVersion: absent or an integer.
+- topologyVersion: absent, null, or a topologyVersion document.
 
 In monitoring tests, an "outcome" contains a list of SDAM events that should
 have been published by the client as a result of processing ismaster responses
@@ -125,10 +126,10 @@ For monitoring tests, once all responses are processed, assert that the
 events collected so far by the SDAM event listener are equivalent to the
 events specified in the phase.
 
-Some fields such as "logicalSessionTimeoutMinutes" or "compatible" were added
-later and haven't been added to all test files. If these fields are present,
-test that they are equivalent to the fields of the driver's current
-TopologyDescription.
+Some fields such as "logicalSessionTimeoutMinutes", "compatible", and
+"topologyVersion" were added later and haven't been added to all test files.
+If these fields are present, test that they are equivalent to the fields of
+the driver's current TopologyDescription or ServerDescription.
 
 For monitoring tests, clear the list of events collected so far.
 

--- a/test/spec/server-discovery-and-monitoring/README.rst
+++ b/test/spec/server-discovery-and-monitoring/README.rst
@@ -63,7 +63,6 @@ current TopologyDescription. It has the following keys:
 - logicalSessionTimeoutMinutes: absent, null, or an integer.
 - minWireVersion: absent or an integer.
 - maxWireVersion: absent or an integer.
-- topologyVersion: absent, null, or a topologyVersion document.
 
 In monitoring tests, an "outcome" contains a list of SDAM events that should
 have been published by the client as a result of processing ismaster responses
@@ -126,10 +125,10 @@ For monitoring tests, once all responses are processed, assert that the
 events collected so far by the SDAM event listener are equivalent to the
 events specified in the phase.
 
-Some fields such as "logicalSessionTimeoutMinutes", "compatible", and
-"topologyVersion" were added later and haven't been added to all test files.
-If these fields are present, test that they are equivalent to the fields of
-the driver's current TopologyDescription or ServerDescription.
+Some fields such as "logicalSessionTimeoutMinutes" or "compatible" were added
+later and haven't been added to all test files. If these fields are present,
+test that they are equivalent to the fields of the driver's current
+TopologyDescription.
 
 For monitoring tests, clear the list of events collected so far.
 

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_wrong_set_name.json
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_wrong_set_name.json
@@ -1,7 +1,35 @@
 {
   "description": "Direct connection to RSPrimary with wrong set name",
-  "uri": "mongodb://a/?directConnection=true&replicaSet=wrong",
+  "uri": "mongodb://a/?directConnection=true&replicaSet=rs",
   "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "wrong",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
     {
       "responses": [
         [
@@ -28,7 +56,7 @@
         },
         "topologyType": "Single",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "wrong"
+        "setName": "rs"
       }
     }
   ]

--- a/test/spec/server-discovery-and-monitoring/single/direct_connection_wrong_set_name.yml
+++ b/test/spec/server-discovery-and-monitoring/single/direct_connection_wrong_set_name.yml
@@ -1,36 +1,38 @@
-description: "Direct connection to RSPrimary with wrong set name"
-
-uri: "mongodb://a/?directConnection=true&replicaSet=wrong"
-
-phases: [
-
-    {
-        responses: [
-
-                ["a:27017", {
-
-                   ok: 1,
-                   ismaster: true,
-                   hosts: ["a:27017", "b:27017"],
-                   setName: "rs",
-                   minWireVersion: 0,
-                   maxWireVersion: 6
-                }]
-        ],
-
-        outcome: {
-
-            servers: {
-
-                "a:27017": {
-
-                    type: "RSPrimary",
-                    setName: "rs"
-                }
-            },
-            topologyType: "Single",
-            logicalSessionTimeoutMinutes: null,
-            setName: wrong
-        }
-    }
-]
+description: Direct connection to RSPrimary with wrong set name
+uri: mongodb://a/?directConnection=true&replicaSet=rs
+phases:
+- responses:
+  - - a:27017
+    - ok: 1
+      ismaster: true
+      hosts:
+      - a:27017
+      - b:27017
+      setName: wrong
+      minWireVersion: 0
+      maxWireVersion: 6
+  outcome:
+    servers:
+      a:27017:
+        type: Unknown
+    topologyType: Single
+    logicalSessionTimeoutMinutes: 
+    setName: rs
+- responses:
+  - - a:27017
+    - ok: 1
+      ismaster: true
+      hosts:
+      - a:27017
+      - b:27017
+      setName: rs
+      minWireVersion: 0
+      maxWireVersion: 6
+  outcome:
+    servers:
+      a:27017:
+        type: RSPrimary
+        setName: rs
+    topologyType: Single
+    logicalSessionTimeoutMinutes: 
+    setName: rs


### PR DESCRIPTION
[NODE-2564](https://jira.mongodb.org/browse/NODE-2564)

```
fix: clarify handle wrong set name single topology

Adds check to see if topologyDescription setName matches the serverDescription setName. In instances where they don't match, sets serverDescription type to Unknown. Incorporates spec tests from SPEC-1656 (bc864e6f9ccbdd162658cfbc08bfb1cb713143c5).

NODE-2564
```