### PR TITLE
fix: unordered bulk write should attempt to execute all batches

### DIFF
--- a/lib/bulk/unordered.js
+++ b/lib/bulk/unordered.js
@@ -108,6 +108,14 @@ class UnorderedBulkOperation extends BulkOperationBase {
 
     super(topology, collection, options, false);
   }
+
+  handleWriteError(callback, writeResult) {
+    if (this.s.batches.length) {
+      return false;
+    }
+
+    return super.handleWriteError(callback, writeResult);
+  }
 }
 
 /**


### PR DESCRIPTION
When an unordered bulk operation is executed, it should attempt to
execute all batches and only return errors after all batches have
been attempted

NODE-2619