### PR TITLE
fix: always include `writeErrors` on a `BulkWriteError` instance

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -1200,19 +1200,10 @@ class BulkOperationBase {
    * @ignore
    * @param {function} callback
    * @param {BulkWriteResult} writeResult
-   * @param {class} self either OrderedBulkOperation or UnorderdBulkOperation
+   * @param {class} self either OrderedBulkOperation or UnorderedBulkOperation
    */
   handleWriteError(callback, writeResult) {
     if (this.s.bulkResult.writeErrors.length > 0) {
-      if (this.s.bulkResult.writeErrors.length === 1) {
-        handleCallback(
-          callback,
-          new BulkWriteError(toError(this.s.bulkResult.writeErrors[0]), writeResult),
-          null
-        );
-        return true;
-      }
-
       const msg = this.s.bulkResult.writeErrors[0].errmsg
         ? this.s.bulkResult.writeErrors[0].errmsg
         : 'write operation failed';
@@ -1230,7 +1221,9 @@ class BulkOperationBase {
         null
       );
       return true;
-    } else if (writeResult.getWriteConcernError()) {
+    }
+
+    if (writeResult.getWriteConcernError()) {
       handleCallback(
         callback,
         new BulkWriteError(toError(writeResult.getWriteConcernError()), writeResult),

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -19,6 +19,10 @@ class MongoError extends Error {
       } else {
         super(message.message || message.errmsg || message.$err || 'n/a');
         for (var name in message) {
+          if (name === 'errmsg') {
+            continue;
+          }
+
           this[name] = message[name];
         }
       }
@@ -27,6 +31,13 @@ class MongoError extends Error {
     }
 
     this.name = 'MongoError';
+  }
+
+  /**
+   * Legacy name for server error responses
+   */
+  get errmsg() {
+    return this.message;
   }
 
   /**


### PR DESCRIPTION
We special case situations where there is only one error returned from a bulk operation, but that can be quite confusing for users of the bulk API. Promoting the single error to the top-level error message is reasonable, but in all cases we should use a consistent shape, and return `writeErrors` as a field on the object

NODE-2625