### PR TITLE
fix: always clear cancelled wait queue members during processing

### DIFF
--- a/lib/cmap/connection_pool.js
+++ b/lib/cmap/connection_pool.js
@@ -198,6 +198,10 @@ class ConnectionPool extends EventEmitter {
     return this[kConnections].length;
   }
 
+  get waitQueueSize() {
+    return this[kWaitQueue].length;
+  }
+
   /**
    * Check a connection out of this pool. The connection will continue to be tracked, but no reference to it
    * will be held by the pool. This means that if a connection is checked out it MUST be checked back in or
@@ -295,7 +299,7 @@ class ConnectionPool extends EventEmitter {
     this[kCancellationToken].emit('cancel');
 
     // drain the wait queue
-    while (this[kWaitQueue].length) {
+    while (this.waitQueueSize) {
       const waitQueueMember = this[kWaitQueue].pop();
       clearTimeout(waitQueueMember.timer);
       if (!waitQueueMember[kCancelled]) {
@@ -449,11 +453,15 @@ function processWaitQueue(pool) {
     return;
   }
 
-  while (pool[kWaitQueue].length && pool.availableConnectionCount) {
+  while (pool.waitQueueSize) {
     const waitQueueMember = pool[kWaitQueue].peekFront();
     if (waitQueueMember[kCancelled]) {
       pool[kWaitQueue].shift();
       continue;
+    }
+
+    if (!pool.availableConnectionCount) {
+      break;
     }
 
     const connection = pool[kConnections].shift();
@@ -472,7 +480,7 @@ function processWaitQueue(pool) {
   }
 
   const maxPoolSize = pool.options.maxPoolSize;
-  if (pool[kWaitQueue].length && (maxPoolSize <= 0 || pool.totalConnectionCount < maxPoolSize)) {
+  if (pool.waitQueueSize && (maxPoolSize <= 0 || pool.totalConnectionCount < maxPoolSize)) {
     createConnection(pool, (err, connection) => {
       const waitQueueMember = pool[kWaitQueue].shift();
       if (waitQueueMember == null) {


### PR DESCRIPTION
Each time the wait queue in the connection pool is processed it is currently gated by having available connections. This can result in a memory leak where many wait queue members are cancelled, but the pool is unable to clear them out before all connections are used for new operations.

NODE-2413