### PR TITLE
fix(GridFS): emit error on bad end options

### DIFF
--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -322,8 +322,12 @@ function init(self) {
 
     self.s.expectedEnd = Math.ceil(doc.length / doc.chunkSize);
     self.s.file = doc;
-    self.s.bytesToTrim = handleEndOption(self, doc, self.s.cursor, self.s.options);
-    self.emit('file', doc);
+    try {
+      self.s.bytesToTrim = handleEndOption(self, doc, self.s.cursor, self.s.options);
+      self.emit('file', doc);
+    } catch (error) {
+      __handleError(self, error);
+    }
   });
 }
 

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -278,51 +278,51 @@ function init(self) {
     if (error) {
       return __handleError(self, error);
     }
-    if (!doc) {
-      var identifier = self.s.filter._id ? self.s.filter._id.toString() : self.s.filter.filename;
-      var errmsg = 'FileNotFound: file ' + identifier + ' was not found';
-      var err = new Error(errmsg);
-      err.code = 'ENOENT';
-      return __handleError(self, err);
-    }
-
-    // If document is empty, kill the stream immediately and don't
-    // execute any reads
-    if (doc.length <= 0) {
-      self.push(null);
-      return;
-    }
-
-    if (self.destroyed) {
-      // If user destroys the stream before we have a cursor, wait
-      // until the query is done to say we're 'closed' because we can't
-      // cancel a query.
-      self.emit('close');
-      return;
-    }
-
-    self.s.bytesToSkip = handleStartOption(self, doc, self.s.options);
-
-    var filter = { files_id: doc._id };
-
-    // Currently (MongoDB 3.4.4) skip function does not support the index,
-    // it needs to retrieve all the documents first and then skip them. (CS-25811)
-    // As work around we use $gte on the "n" field.
-    if (self.s.options && self.s.options.start != null) {
-      var skip = Math.floor(self.s.options.start / doc.chunkSize);
-      if (skip > 0) {
-        filter['n'] = { $gte: skip };
-      }
-    }
-    self.s.cursor = self.s.chunks.find(filter).sort({ n: 1 });
-
-    if (self.s.readPreference) {
-      self.s.cursor.setReadPreference(self.s.readPreference);
-    }
-
-    self.s.expectedEnd = Math.ceil(doc.length / doc.chunkSize);
-    self.s.file = doc;
     try {
+      if (!doc) {
+        var identifier = self.s.filter._id ? self.s.filter._id.toString() : self.s.filter.filename;
+        var errmsg = 'FileNotFound: file ' + identifier + ' was not found';
+        var err = new Error(errmsg);
+        err.code = 'ENOENT';
+        return __handleError(self, err);
+      }
+
+      // If document is empty, kill the stream immediately and don't
+      // execute any reads
+      if (doc.length <= 0) {
+        self.push(null);
+        return;
+      }
+
+      if (self.destroyed) {
+        // If user destroys the stream before we have a cursor, wait
+        // until the query is done to say we're 'closed' because we can't
+        // cancel a query.
+        self.emit('close');
+        return;
+      }
+
+      self.s.bytesToSkip = handleStartOption(self, doc, self.s.options);
+
+      var filter = { files_id: doc._id };
+
+      // Currently (MongoDB 3.4.4) skip function does not support the index,
+      // it needs to retrieve all the documents first and then skip them. (CS-25811)
+      // As work around we use $gte on the "n" field.
+      if (self.s.options && self.s.options.start != null) {
+        var skip = Math.floor(self.s.options.start / doc.chunkSize);
+        if (skip > 0) {
+          filter['n'] = { $gte: skip };
+        }
+      }
+      self.s.cursor = self.s.chunks.find(filter).sort({ n: 1 });
+
+      if (self.s.readPreference) {
+        self.s.cursor.setReadPreference(self.s.readPreference);
+      }
+
+      self.s.expectedEnd = Math.ceil(doc.length / doc.chunkSize);
+      self.s.file = doc;
       self.s.bytesToTrim = handleEndOption(self, doc, self.s.cursor, self.s.options);
       self.emit('file', doc);
     } catch (error) {

--- a/test/functional/gridfs_stream.test.js
+++ b/test/functional/gridfs_stream.test.js
@@ -1470,7 +1470,7 @@ describe('GridFS Stream', function() {
     }
   });
 
-  it('NODE-2623 uncaught error on end > size', function() {
+  it('NODE-2623 downloadStream should emit error on end > size', function() {
     const configuration = this.configuration;
     return withClient.bind(this)((client, done) => {
       const GridFSBucket = configuration.require.GridFSBucket;
@@ -1493,7 +1493,7 @@ describe('GridFS Stream', function() {
           expect(err.message).to.equal(
             `Stream end (${wrongExpectedSize}) must not be more than the length of the file (${actualSize})`
           );
-          client.close(done);
+          done();
         });
       });
 


### PR DESCRIPTION
## Description

Errors related to handling the start/end options for `createDownloadStream`
did not propagate correctly.

[NODE-2623](https://jira.mongodb.org/browse/NODE-2623)

**What changed?**

**Are there any files to ignore?**
