### PR TITLE
refactor: translate modern tls options from connect options object to ssl

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -46,5 +46,6 @@ module.exports = {
   ScramSHA1: require('./auth/scram').ScramSHA1,
   ScramSHA256: require('./auth/scram').ScramSHA256,
   // Utilities
-  parseConnectionString: require('./uri_parser')
+  parseConnectionString: require('./uri_parser').parseConnectionString,
+  translateTLSOptions: require('./uri_parser').translateTLSOptions
 };

--- a/lib/core/uri_parser.js
+++ b/lib/core/uri_parser.js
@@ -685,4 +685,7 @@ function parseConnectionString(uri, options, callback) {
   callback(null, result);
 }
 
-module.exports = parseConnectionString;
+module.exports = {
+  parseConnectionString: parseConnectionString,
+  translateTLSOptions: translateTLSOptions
+};

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -7,6 +7,7 @@ const MongoError = require('../core').MongoError;
 const Mongos = require('../topologies/mongos');
 const NativeTopology = require('../topologies/native_topology');
 const parse = require('../core').parseConnectionString;
+const translateTLSOptions = require('../core').translateTLSOptions;
 const ReadConcern = require('../read_concern');
 const ReadPreference = require('../core').ReadPreference;
 const ReplSet = require('../topologies/replset');
@@ -297,6 +298,7 @@ function connect(mongoClient, url, options, callback) {
     }
 
     // resolve tls options if needed
+    translateTLSOptions(_finalOptions);
     resolveTLSOptions(_finalOptions);
 
     // Store the merged options object


### PR DESCRIPTION
refactor: translate modern tls options from connect options object to ssl

Translation of `tls` variants into ssl options is now applied to the options
object in the connect operation in the same manner as the url query string.

