### PR TITLE
fix: writes within transactions are not retryable

### DIFF
--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -22,6 +22,7 @@ const maxWireVersion = require('../utils').maxWireVersion;
 const makeStateMachine = require('../utils').makeStateMachine;
 const common = require('./common');
 const ServerType = common.ServerType;
+const isTransactionCommand = require('../transactions').isTransactionCommand;
 
 // Used for filtering out fields for logging
 const DEBUG_FIELDS = [
@@ -282,7 +283,7 @@ class Server extends EventEmitter {
         return cb(err);
       }
 
-      conn.command(ns, cmd, options, makeOperationHandler(this, conn, options, cb));
+      conn.command(ns, cmd, options, makeOperationHandler(this, conn, cmd, options, cb));
     }, callback);
   }
 
@@ -306,7 +307,7 @@ class Server extends EventEmitter {
         return cb(err);
       }
 
-      conn.query(ns, cmd, cursorState, options, makeOperationHandler(this, conn, options, cb));
+      conn.query(ns, cmd, cursorState, options, makeOperationHandler(this, conn, cmd, options, cb));
     }, callback);
   }
 
@@ -335,7 +336,7 @@ class Server extends EventEmitter {
         cursorState,
         batchSize,
         options,
-        makeOperationHandler(this, conn, options, cb)
+        makeOperationHandler(this, conn, null, options, cb)
       );
     }, callback);
   }
@@ -362,7 +363,7 @@ class Server extends EventEmitter {
         return cb(err);
       }
 
-      conn.killCursors(ns, cursorState, makeOperationHandler(this, conn, undefined, cb));
+      conn.killCursors(ns, cursorState, makeOperationHandler(this, conn, null, undefined, cb));
     }, callback);
   }
 
@@ -476,7 +477,7 @@ function executeWriteOperation(args, options, callback) {
       return cb(err);
     }
 
-    conn[op](ns, ops, options, makeOperationHandler(server, conn, options, cb));
+    conn[op](ns, ops, options, makeOperationHandler(server, conn, ops, options, cb));
   }, callback);
 }
 
@@ -506,7 +507,11 @@ function shouldHandleStateChangeError(server, err) {
   return compareTopologyVersion(stv, etv) < 0;
 }
 
-function makeOperationHandler(server, connection, options, callback) {
+function inActiveTransaction(session, cmd) {
+  return session && session.inTransaction() && !isTransactionCommand(cmd);
+}
+
+function makeOperationHandler(server, connection, cmd, options, callback) {
   const session = options && options.session;
 
   return function handleOperationResult(err, result) {
@@ -516,7 +521,7 @@ function makeOperationHandler(server, connection, options, callback) {
           session.serverSession.isDirty = true;
         }
 
-        if (supportsRetryableWrites(server)) {
+        if (supportsRetryableWrites(server) && !inActiveTransaction(session, cmd)) {
           err.addErrorLabel('RetryableWriteError');
         }
 
@@ -526,7 +531,11 @@ function makeOperationHandler(server, connection, options, callback) {
         }
       } else {
         // if pre-4.4 server, then add error label if its a retryable write error
-        if (maxWireVersion(server) < 9 && isRetryableWriteError(err)) {
+        if (
+          maxWireVersion(server) < 9 &&
+          isRetryableWriteError(err) &&
+          !inActiveTransaction(session, cmd)
+        ) {
           err.addErrorLabel('RetryableWriteError');
         }
 

--- a/test/functional/core/operations.test.js
+++ b/test/functional/core/operations.test.js
@@ -311,7 +311,9 @@ describe('Operation tests', function() {
           },
           function(insertErr, insertResults) {
             expect(insertErr).to.be.null;
-            expect(insertResults.result.n).to.equal(3);
+            expect(insertResults)
+              .nested.property('result.n')
+              .to.equal(3);
 
             // Execute find
             var cursor = _server.cursor(f('%s.inserts10', self.configuration.db), {
@@ -323,16 +325,22 @@ describe('Operation tests', function() {
             // Execute next
             cursor._next(function(cursorErr, cursorD) {
               expect(cursorErr).to.be.null;
-              expect(cursorD.a).to.equal(1);
+              expect(cursorD)
+                .property('a')
+                .to.equal(1);
 
               // Execute next
               cursor._next(function(secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
-                expect(secondCursorD.a).to.equal(2);
+                expect(secondCursorD)
+                  .property('a')
+                  .to.equal(2);
 
                 cursor._next(function(thirdCursorErr, thirdCursorD) {
                   expect(thirdCursorErr).to.be.null;
-                  expect(thirdCursorD.a).to.equal(3);
+                  expect(thirdCursorD)
+                    .property('a')
+                    .to.equal(3);
 
                   // Destroy the server connection
                   _server.destroy(done);

--- a/test/spec/transactions/README.rst
+++ b/test/spec/transactions/README.rst
@@ -41,7 +41,10 @@ The ``failCommand`` fail point may be configured like so::
           failCommands: ["commandName", "commandName2"],
           closeConnection: <true|false>,
           errorCode: <Number>,
-          writeConcernError: <document>
+          writeConcernError: <document>,
+          appName: <string>,
+          blockConnection: <true|false>,
+          blockTimeMS: <Number>,
         }
     });
 
@@ -66,10 +69,13 @@ control the fail point's behavior. ``failCommand`` supports the following
 - ``errorCode``: Integer option, which is unset by default. If set, the command
   will not be executed and the specified command error code will be returned as
   a command error.
-- ``writeConcernError``: A document, which is unset by default. If set, the
-  server will return this document in the "writeConcernError" field. This
-  failure response only applies to commands that support write concern and
-  happens *after* the command finishes (regardless of success or failure).
+- ``appName``: A string to filter which MongoClient should be affected by
+  the failpoint. `New in mongod 4.4.0-rc2 <https://jira.mongodb.org/browse/SERVER-47195>`_.
+- ``blockConnection``: Whether the server should block the affected commands.
+  Default false.
+- ``blockTimeMS``: The number of milliseconds the affect commands should be
+  blocked for. Required when blockConnection is true.
+  `New in mongod 4.3.4 <https://jira.mongodb.org/browse/SERVER-41070>`_.
 
 Test Format
 ===========
@@ -175,7 +181,7 @@ Each YAML file has the following keys:
     - ``collection``:
 
       - ``data``: The data that should exist in the collection after the
-        operations have run.
+        operations have run, sorted by "_id".
 
 Use as Integration Tests
 ========================
@@ -299,6 +305,8 @@ Then for each element in ``tests``:
      latest data by using **primary read preference** with
      **local read concern** even when the MongoClient is configured with
      another read preference or read concern.
+     Note the server does not guarantee that documents returned by a find
+     command will be in inserted order. This find MUST sort by ``{_id:1}``.
 
 .. _SERVER-38335: https://jira.mongodb.org/browse/SERVER-38335
 

--- a/test/spec/transactions/error-labels.json
+++ b/test/spec/transactions/error-labels.json
@@ -134,6 +134,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -223,6 +224,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -312,6 +314,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -462,7 +465,7 @@
       }
     },
     {
-      "description": "add TransientTransactionError label to connection errors",
+      "description": "add TransientTransactionError label to connection errors, but do not add RetryableWriteError label",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -497,6 +500,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -512,6 +516,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -534,6 +539,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -550,6 +556,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -1095,6 +1102,103 @@
               "_id": 1
             }
           ]
+        }
+      }
+    },
+    {
+      "description": "do not add RetryableWriteError label to writeConcernError ShutdownInProgress that occurs within transaction",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "writeConcernError": {
+            "code": 91,
+            "errmsg": "Replication is being shut down"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "writeConcern": {
+                "w": "majority"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [],
+            "errorLabelsOmit": [
+              "RetryableWriteError",
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
         }
       }
     },

--- a/test/spec/transactions/error-labels.yml
+++ b/test/spec/transactions/error-labels.yml
@@ -86,7 +86,7 @@ tests:
         result:
           # Note, the server will return the errorLabel in this case.
           errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
       - name: abortTransaction
         object: session0
 
@@ -143,7 +143,7 @@ tests:
         result:
           # Note, the server will return the errorLabel in this case.
           errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
       - name: abortTransaction
         object: session0
 
@@ -200,7 +200,7 @@ tests:
         result:
           # Note, the server will return the errorLabel in this case.
           errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
       - name: abortTransaction
         object: session0
 
@@ -295,7 +295,7 @@ tests:
       collection:
         data: []
 
-  - description: add TransientTransactionError label to connection errors
+  - description: add TransientTransactionError label to connection errors, but do not add RetryableWriteError label
 
     failPoint:
       configureFailPoint: failCommand
@@ -315,7 +315,10 @@ tests:
             _id: 1
         result: &transient_label_only
           errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["UnknownTransactionCommitResult"]
+          # While a connection error would normally be retryable, these are not because
+          # they occur within a transaction; ensure the driver does not add the
+          # RetryableWriteError label to these errors.
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
       - name: find
         object: collection
         arguments:
@@ -669,6 +672,66 @@ tests:
       collection:
         data:
           - _id: 1
+
+  - description: do not add RetryableWriteError label to writeConcernError ShutdownInProgress that occurs within transaction
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["insert"]
+          writeConcernError:
+            code: 91
+            errmsg: Replication is being shut down
+
+    operations:
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            writeConcern:
+              w: majority
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          errorLabelsContain: []
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError", "UnknownTransactionCommitResult"]
+      - name: abortTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+          command_name: abortTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data: []
 
   - description: add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed
 


### PR DESCRIPTION
Unless a write command is `commitTransaction` or `abortTransaction` it should not receive a `RetryableWriteError` label on command failure.

NODE-2594