### PR TITLE
fix: throw an error if `allowDiskUse` is used on MongoDB < 3.2

### DIFF
--- a/lib/operations/find.js
+++ b/lib/operations/find.js
@@ -4,6 +4,8 @@ const OperationBase = require('./operation').OperationBase;
 const Aspect = require('./operation').Aspect;
 const defineAspects = require('./operation').defineAspects;
 const resolveReadPreference = require('../utils').resolveReadPreference;
+const maxWireVersion = require('../core/utils').maxWireVersion;
+const MongoError = require('../core/error').MongoError;
 
 class FindOperation extends OperationBase {
   constructor(collection, ns, command, options) {
@@ -18,9 +20,13 @@ class FindOperation extends OperationBase {
     // copied from `CommandOperationV2`, to be subclassed in the future
     this.server = server;
 
-    const cursorState = this.cursorState || {};
+    if (typeof this.cmd.allowDiskUse !== 'undefined' && maxWireVersion(server) < 4) {
+      callback(new MongoError('The `allowDiskUse` option is not supported on MongoDB < 3.2'));
+      return;
+    }
 
     // TOOD: use `MongoDBNamespace` through and through
+    const cursorState = this.cursorState || {};
     server.query(this.ns.toString(), this.cmd, cursorState, this.options, callback);
   }
 }

--- a/test/spec/crud/README.rst
+++ b/test/spec/crud/README.rst
@@ -128,7 +128,7 @@ Each YAML file has the following keys:
         present then use the collection under test.
 
       - ``data``: The data that should exist in the collection after the
-        operation has been run.
+        operation has been run, sorted by "_id".
 
 Legacy Test Format for Single Operations
 ----------------------------------------
@@ -246,6 +246,8 @@ For each test file:
 
   - If the ``outcome`` field is present, assert the contents of the specified
     collection using ``globalMongoClient``.
+    Note the server does not guarantee that documents returned by a find
+    command will be in inserted order. This find MUST sort by ``{_id:1}``.
 
 Evaluating Matches
 ------------------

--- a/test/spec/crud/v2/find-allowdiskuse-clientError.json
+++ b/test/spec/crud/v2/find-allowdiskuse-clientError.json
@@ -1,0 +1,40 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "3.0.99"
+    }
+  ],
+  "collection_name": "test_find_allowdiskuse_clienterror",
+  "tests": [
+    {
+      "description": "Find fails when allowDiskUse true is specified against pre 3.2 server",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {},
+            "allowDiskUse": true
+          },
+          "error": true
+        }
+      ],
+      "expectations": []
+    },
+    {
+      "description": "Find fails when allowDiskUse false is specified against pre 3.2 server",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {},
+            "allowDiskUse": false
+          },
+          "error": true
+        }
+      ],
+      "expectations": []
+    }
+  ]
+}

--- a/test/spec/crud/v2/find-allowdiskuse-clientError.yml
+++ b/test/spec/crud/v2/find-allowdiskuse-clientError.yml
@@ -1,0 +1,28 @@
+runOn:
+  - { maxServerVersion: "3.0.99" }
+
+collection_name: &collection_name 'test_find_allowdiskuse_clienterror'
+
+tests:
+  -
+    description: "Find fails when allowDiskUse true is specified against pre 3.2 server"
+    operations:
+      -
+        object: collection
+        name: find
+        arguments:
+          filter: { }
+          allowDiskUse: true
+        error: true
+    expectations: []
+  -
+    description: "Find fails when allowDiskUse false is specified against pre 3.2 server"
+    operations:
+      -
+        object: collection
+        name: find
+        arguments:
+          filter: { }
+          allowDiskUse: false
+        error: true
+    expectations: []

--- a/test/spec/crud/v2/find-allowdiskuse-serverError.json
+++ b/test/spec/crud/v2/find-allowdiskuse-serverError.json
@@ -1,0 +1,61 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.2",
+      "maxServerVersion": "4.3.0"
+    }
+  ],
+  "collection_name": "test_find_allowdiskuse_servererror",
+  "tests": [
+    {
+      "description": "Find fails when allowDiskUse true is specified against pre 4.4 server (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {},
+            "allowDiskUse": true
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test_find_allowdiskuse_servererror",
+              "filter": {},
+              "allowDiskUse": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Find fails when allowDiskUse false is specified against pre 4.4 server (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {},
+            "allowDiskUse": false
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test_find_allowdiskuse_servererror",
+              "filter": {},
+              "allowDiskUse": false
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/v2/find-allowdiskuse-serverError.yml
+++ b/test/spec/crud/v2/find-allowdiskuse-serverError.yml
@@ -1,0 +1,44 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 3.2.0
+  # raise errors for unknown find options, and server versions >= 4.3.1
+  # support the allowDiskUse option in find.
+  - { minServerVersion: "3.2", maxServerVersion: "4.3.0" }
+
+collection_name: &collection_name 'test_find_allowdiskuse_servererror'
+
+tests:
+  -
+    description: "Find fails when allowDiskUse true is specified against pre 4.4 server (server-side error)"
+    operations:
+      -
+        object: collection
+        name: find
+        arguments:
+          filter: &filter { }
+          allowDiskUse: true
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            find: *collection_name
+            filter: *filter
+            allowDiskUse: true
+  -
+    description: "Find fails when allowDiskUse false is specified against pre 4.4 server (server-side error)"
+    operations:
+      -
+        object: collection
+        name: find
+        arguments:
+          filter: *filter
+          allowDiskUse: false
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            find: *collection_name
+            filter: *filter
+            allowDiskUse: false


### PR DESCRIPTION
NODE-2622
