### PR TITLE
Fixed data path

### DIFF
--- a/docs/reference/content/quick-start/quick-start.md
+++ b/docs/reference/content/quick-start/quick-start.md
@@ -43,7 +43,7 @@ For complete MongoDB installation instructions, see [the manual](https://docs.mo
 3. Install and start a ``mongod`` process.
 
 ```
-mongod --dbpath=/data
+mongod --dbpath=./data
 ```
 
 You should see the **mongod** process start up and print some status information.


### PR DESCRIPTION
Without this, mongo will look for /data path i.e. starting from the root of the System. `./data` will fix it.

## Description

**What changed?** `data` directory path in the documentation.

**Are there any files to ignore?** No.
