### PR TITLE
Handle null value of change in ChangeStream.processNewChange

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -493,22 +493,24 @@ function processNewChange(changeStream, change, callback) {
     return;
   }
 
-  if (change && !change._id) {
-    const noResumeTokenError = new Error(
-      'A change stream document has been received that lacks a resume token (_id).'
-    );
+  if (change) {
+    if (!change._id) {
+      const noResumeTokenError = new Error(
+        'A change stream document has been received that lacks a resume token (_id).'
+      );
 
-    if (!callback) return changeStream.emit('error', noResumeTokenError);
-    return callback(noResumeTokenError);
+      if (!callback) return changeStream.emit('error', noResumeTokenError);
+      return callback(noResumeTokenError);
+    }
+
+    // cache the resume token
+    cursor.cacheResumeToken(change._id);
+
+    // wipe the startAtOperationTime if there was one so that there won't be a conflict
+    // between resumeToken and startAtOperationTime if we need to reconnect the cursor
+    changeStream.options.startAtOperationTime = undefined;
   }
-
-  // cache the resume token
-  cursor.cacheResumeToken(change._id);
-
-  // wipe the startAtOperationTime if there was one so that there won't be a conflict
-  // between resumeToken and startAtOperationTime if we need to reconnect the cursor
-  changeStream.options.startAtOperationTime = undefined;
-
+  
   // Return the change
   if (!callback) return changeStream.emit('change', change);
   return callback(undefined, change);


### PR DESCRIPTION
The `change` can be `null` in `processNewChange` when the server connection is closed but the call to `cacheResumeToken` did not allow for that.
