### PR TITLE
test: add Dockerfile for running tests

### DIFF
--- a/test/tools/docker-tests/Dockerfile
+++ b/test/tools/docker-tests/Dockerfile
@@ -1,0 +1,21 @@
+# Example usage
+#
+# $ cd test/tools/docker-tests
+# $ docker build --tag test-node-mongodb-native .
+# $ docker run -it --net=host -v /tmp:/tmp test-node-mongodb-native 3.5 argon
+
+FROM centos:7 AS base
+RUN yum update -y && yum install -y git make gcc gcc-c++
+
+FROM base
+
+WORKDIR /root
+COPY entrypoint.sh entrypoint.sh
+
+ENV MONGODB_UNIFIED_TOPOLOGY 1
+ENV MONGODB_HOST "host.docker.internal"
+ENV GITHUB_REPO_URL "https://github.com/mongodb/node-mongodb-native.git"
+ENV GITHUB_REPO_NAME "node-mongodb-native"
+
+ENTRYPOINT ["/bin/bash", "/root/entrypoint.sh"]
+CMD ["master", "dubnium"]

--- a/test/tools/docker-tests/entrypoint.sh
+++ b/test/tools/docker-tests/entrypoint.sh
@@ -1,0 +1,24 @@
+NVM_DIR=/root/.nvm
+DRIVER_REF=${1:-"master"}
+NODE_LTS_NAME=${2:-"carbon"}
+
+# Clone repo and check out appropriate ref
+# Note - could add an option to allow a volume containing the src to be mounted, to allow testing of uncommitted code
+git clone $GITHUB_REPO_URL
+cd $GITHUB_REPO_NAME
+git checkout $DRIVER_REF
+
+# Install desired LTS version of Node
+# Note - can extend this logic to support non-LTS versions of node, if desired
+curl https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash \
+    && . $NVM_DIR/nvm.sh \
+    && nvm install --lts=$NODE_LTS_NAME \
+    && npm install
+
+# Run tests on each topology type
+# single
+MONGODB_URI="mongodb://${MONGODB_HOST}:27017" npm test
+# replicaset
+MONGODB_URI="mongodb://${MONGODB_HOST}:31000/?replicaSet=rs" npm test
+# sharded
+MONGODB_URI="mongodb://${MONGODB_HOST}:51000,${MONGODB_HOST}:51001/" npm test


### PR DESCRIPTION
**Description**

This adds a Dockerfile to `test/tools/docker-tests` that can be used as follows:

`docker run -it --net=host -v /tmp:/tmp test-node-mongodb-native 3.5 argon`

`3.5` can be any branch or commit SHA of `node-mongodb-native`.

`argon` can be any LTS name of Node supported by `nvm`.

If a different repo needs to be used for some reason, it can be altered via environment variables `GITHUB_REPO_URL`/`GITHUB_REPO_NAME`. So to use my fork I might do:

`docker run -it --net=host -v /tmp:/tmp -e GITHUB_REPO_URL="https://github.com/emadum/node-mongodb-native.git" test-node-mongodb-native 3.5 argon`

The tests also run with the unified topology by default, `-e MONGODB_UNIFIED_TOPOLOGY=0` can be set to use the legacy topology.

**What changed?**

**Are there any files to ignore?**
