### PR TITLE
fix(GridFS): emit error on bad options

### DIFF
--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -268,6 +268,7 @@ function init(self) {
     if (error) {
       return __handleError(self, error);
     }
+
     if (!doc) {
       var identifier = self.s.filter._id ? self.s.filter._id.toString() : self.s.filter.filename;
       var errmsg = 'FileNotFound: file ' + identifier + ' was not found';
@@ -291,7 +292,11 @@ function init(self) {
       return;
     }
 
-    self.s.bytesToSkip = handleStartOption(self, doc, self.s.options);
+    try {
+      self.s.bytesToSkip = handleStartOption(self, doc, self.s.options);
+    } catch (error) {
+      return __handleError(self, error);
+    }
 
     var filter = { files_id: doc._id };
 
@@ -312,7 +317,13 @@ function init(self) {
 
     self.s.expectedEnd = Math.ceil(doc.length / doc.chunkSize);
     self.s.file = doc;
-    self.s.bytesToTrim = handleEndOption(self, doc, self.s.cursor, self.s.options);
+
+    try {
+      self.s.bytesToTrim = handleEndOption(self, doc, self.s.cursor, self.s.options);
+    } catch (error) {
+      return __handleError(self, error);
+    }
+
     self.emit('file', doc);
   });
 }


### PR DESCRIPTION
**Description**

Errors related to handling the start/end options for `createDownloadStream`
did not propagate correctly.

[NODE-2623](https://jira.mongodb.org/browse/NODE-2623)

merge into master

**What changed?**

**Are there any files to ignore?**
