### PR TITLE
fix(ChangeStream): handle null changes

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -326,8 +326,8 @@ class ChangeStreamCursor extends Cursor {
 
   _initializeCursor(callback) {
     super._initializeCursor((err, result) => {
-      if (err) {
-        callback(err);
+      if (err || result == null) {
+        callback(err, result);
         return;
       }
 
@@ -482,6 +482,11 @@ function waitForTopologyConnected(topology, options, callback) {
 
 function processNewChange(changeStream, change, callback) {
   const cursor = changeStream.cursor;
+
+  // a null change means the cursor has been notified, implicitly closing the change stream
+  if (change == null) {
+    changeStream.closed = true;
+  }
 
   if (changeStream.closed) {
     if (callback) callback(new MongoError('ChangeStream is closed'));

--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -464,50 +464,41 @@ class CoreCursor extends Readable {
       }
 
       const result = r.message;
-      if (result.queryFailure) {
-        return done(new MongoError(result.documents[0]), null);
-      }
 
-      // Check if we have a command cursor
-      if (
-        Array.isArray(result.documents) &&
-        result.documents.length === 1 &&
-        (!cursor.cmd.find || (cursor.cmd.find && cursor.cmd.virtual === false)) &&
-        (typeof result.documents[0].cursor !== 'string' ||
-          result.documents[0]['$err'] ||
-          result.documents[0]['errmsg'] ||
-          Array.isArray(result.documents[0].result))
-      ) {
-        // We have an error document, return the error
-        if (result.documents[0]['$err'] || result.documents[0]['errmsg']) {
-          return done(new MongoError(result.documents[0]), null);
+      if (Array.isArray(result.documents) && result.documents.length === 1) {
+        const document = result.documents[0];
+
+        if (result.queryFailure) {
+          return done(new MongoError(document), null);
         }
 
-        // We have a cursor document
-        if (result.documents[0].cursor != null && typeof result.documents[0].cursor !== 'string') {
-          const id = result.documents[0].cursor.id;
-          // If we have a namespace change set the new namespace for getmores
-          if (result.documents[0].cursor.ns) {
-            cursor.ns = result.documents[0].cursor.ns;
-          }
-          // Promote id to long if needed
-          cursor.cursorState.cursorId = typeof id === 'number' ? Long.fromNumber(id) : id;
-          cursor.cursorState.lastCursorId = cursor.cursorState.cursorId;
-          cursor.cursorState.operationTime = result.documents[0].operationTime;
-
-          // If we have a firstBatch set it
-          if (Array.isArray(result.documents[0].cursor.firstBatch)) {
-            cursor.cursorState.documents = result.documents[0].cursor.firstBatch; //.reverse();
+        // Check if we have a command cursor
+        if (!cursor.cmd.find || (cursor.cmd.find && cursor.cmd.virtual === false)) {
+          // We have an error document, return the error
+          if (document.$err || document.errmsg) {
+            return done(new MongoError(document), null);
           }
 
-          // Return after processing command cursor
-          return done(null, result);
-        }
+          // We have a cursor document
+          if (document.cursor != null && typeof document.cursor !== 'string') {
+            const id = document.cursor.id;
+            // If we have a namespace change set the new namespace for getmores
+            if (document.cursor.ns) {
+              cursor.ns = document.cursor.ns;
+            }
+            // Promote id to long if needed
+            cursor.cursorState.cursorId = typeof id === 'number' ? Long.fromNumber(id) : id;
+            cursor.cursorState.lastCursorId = cursor.cursorState.cursorId;
+            cursor.cursorState.operationTime = document.operationTime;
 
-        if (Array.isArray(result.documents[0].result)) {
-          cursor.cursorState.documents = result.documents[0].result;
-          cursor.cursorState.cursorId = Long.ZERO;
-          return done(null, result);
+            // If we have a firstBatch set it
+            if (Array.isArray(document.cursor.firstBatch)) {
+              cursor.cursorState.documents = document.cursor.firstBatch; //.reverse();
+            }
+
+            // Return after processing command cursor
+            return done(null, result);
+          }
         }
       }
 


### PR DESCRIPTION
## Description

A notified cursor triggers a `null` change, which caused an exception
to be thrown. This PR implements graceful handling of such `null`
changes.

[NODE-2626](https://jira.mongodb.org/browse/NODE-2626)

**What changed?**

**Are there any files to ignore?**
