### PR TITLE
fix(create_indexes): add missing `bucketSize` option to list of valid options

### DIFF
--- a/lib/operations/create_indexes.js
+++ b/lib/operations/create_indexes.js
@@ -14,7 +14,8 @@ const validIndexOptions = new Set([
   'background',
   'expireAfterSeconds',
   'storageEngine',
-  'collation'
+  'collation',
+  'bucketSize'
 ]);
 
 class CreateIndexesOperation extends CommandOperationV2 {


### PR DESCRIPTION
## Description

**What changed?**

Added `bucketSize` to the list of valid options for indexes, because geoHaystack indexes require `bucketSize`: https://docs.mongodb.com/manual/tutorial/build-a-geohaystack-index/#geospatial-indexes-haystack-index

**Are there any files to ignore?**

Nope