### PR TITLE
NODE-2671: IPv6 is not supported when using dns service discovering

### DIFF
--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -16,6 +16,7 @@ import {
   ServerHeartbeatSucceededEvent,
   ServerHeartbeatFailedEvent
 } from './events';
+import { Server } from './server';
 
 const kServer = Symbol('server');
 const kMonitorId = Symbol('monitorId');
@@ -48,7 +49,7 @@ class Monitor extends EventEmitter {
   [kCancellationToken]: any;
   [kMonitorId]: any;
 
-  constructor(server: any, options: any) {
+  constructor(server: Server, options: any) {
     super(options);
     this[kServer] = server;
     this[kConnection] = undefined;
@@ -74,12 +75,11 @@ class Monitor extends EventEmitter {
     });
 
     // TODO: refactor this to pull it directly from the pool, requires new ConnectionPool integration
-    const addressParts = server.description.address.split(':');
     const connectOptions = Object.assign(
       {
         id: '<monitor>',
-        host: addressParts[0],
-        port: parseInt(addressParts[1], 10),
+        host: server.description.host,
+        port: server.description.port,
         connectionType: Connection
       },
       server.s.options,

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -102,11 +102,7 @@ class Server extends EventEmitter {
 
     // create the connection pool
     // NOTE: this used to happen in `connect`, we supported overriding pool options there
-    const addressParts = this.description.address.split(':');
-    const poolOptions = Object.assign(
-      { host: addressParts[0], port: parseInt(addressParts[1], 10) },
-      options
-    );
+    const poolOptions = Object.assign({ host: description.host, port: description.port }, options);
 
     this.s.pool = new ConnectionPool(poolOptions);
     relayEvents(
@@ -150,7 +146,7 @@ class Server extends EventEmitter {
     });
   }
 
-  get description() {
+  get description(): ServerDescription {
     return this.s.description;
   }
 

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -43,7 +43,7 @@ const ISMASTER_FIELDS = [
  * Internal type, not meant to be directly instantiated
  */
 class ServerDescription {
-  address: any;
+  address: string;
   error: any;
   roundTripTime: any;
   lastUpdateTime: any;
@@ -133,6 +133,16 @@ class ServerDescription {
    */
   get isWritable() {
     return WRITABLE_SERVER_TYPES.has(this.type);
+  }
+
+  get host() {
+    const chopLength = `:${this.port}`.length;
+    return this.address.slice(0, -chopLength);
+  }
+
+  get port() {
+    const addressParts = this.address.split(':');
+    return Number.parseInt(addressParts[addressParts.length - 1], 10);
   }
 
   /**

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -141,8 +141,8 @@ class ServerDescription {
   }
 
   get port() {
-    const addressParts = this.address.split(':');
-    return Number.parseInt(addressParts[addressParts.length - 1], 10);
+    const port = this.address.split(':').pop();
+    return port ? Number.parseInt(port, 10) : port;
   }
 
   /**

--- a/test/unit/sdam/monitoring.test.js
+++ b/test/unit/sdam/monitoring.test.js
@@ -96,7 +96,7 @@ describe('monitoring', function() {
     });
   });
 
-  describe('Monitor class', function() {
+  describe('Monitor', function() {
     it('should connect and issue an initial server check', function(done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;

--- a/test/unit/sdam/monitoring.test.js
+++ b/test/unit/sdam/monitoring.test.js
@@ -9,10 +9,8 @@ const { ServerDescription } = require('../../../src/sdam/server_description');
 class MockServer {
   constructor(options) {
     this.s = {};
-    this.description = {
-      type: ServerType.Unknown,
-      address: `${options.host}:${options.port}`
-    };
+    this.description = new ServerDescription(`${options.host}:${options.port}`);
+    this.description.type = ServerType.Unknown;
   }
 }
 
@@ -193,8 +191,8 @@ describe('monitoring', function() {
       });
 
       const server = new MockServer(mockServer.address());
-      const serverDescription = new ServerDescription(server.description.address);
-      const monitor = new Monitor(serverDescription, {
+      server.description = new ServerDescription(server.description.address);
+      const monitor = new Monitor(server, {
         heartbeatFrequencyMS: 250,
         minHeartbeatFrequencyMS: 50
       });

--- a/test/unit/sdam/monitoring.test.js
+++ b/test/unit/sdam/monitoring.test.js
@@ -4,6 +4,7 @@ const { ServerType } = require('../../../src/sdam/common');
 const { Topology } = require('../../../src/sdam/topology');
 const { Monitor } = require('../../../src/sdam/monitor');
 const { expect } = require('chai');
+const { ServerDescription } = require('../../../src/sdam/server_description');
 
 class MockServer {
   constructor(options) {
@@ -97,7 +98,7 @@ describe('monitoring', function() {
     });
   });
 
-  describe('Monitor', function() {
+  describe('Monitor class', function() {
     it('should connect and issue an initial server check', function(done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
@@ -192,7 +193,8 @@ describe('monitoring', function() {
       });
 
       const server = new MockServer(mockServer.address());
-      const monitor = new Monitor(server, {
+      const serverDescription = new ServerDescription(server.description.address);
+      const monitor = new Monitor(serverDescription, {
         heartbeatFrequencyMS: 250,
         minHeartbeatFrequencyMS: 50
       });

--- a/test/unit/sdam/server_description.test.js
+++ b/test/unit/sdam/server_description.test.js
@@ -41,4 +41,10 @@ describe('ServerDescription', function() {
       });
     });
   });
+
+  it('should sensibly parse an ipv6 address', function() {
+    const description = new ServerDescription('abcd:f::abcd:abcd:abcd:abcd:27017');
+    expect(description.host).to.equal('abcd:f::abcd:abcd:abcd:abcd');
+    expect(description.port).to.equal(27017);
+  });
 });


### PR DESCRIPTION
https://jira.mongodb.org/browse/NODE-2671

Both server class and monitoring class split the address string on `:` and assumed it would return address and port tuple. To handle IPv6 addresses we need to use the number at the end of the address and keep the ipv6 address from being split. I consolidated the logic into ServerDescription getters.