### PR TITLE
fix: don't immediately schedule monitoring after streaming failure

### DIFF
--- a/lib/core/sdam/monitor.js
+++ b/lib/core/sdam/monitor.js
@@ -134,8 +134,7 @@ class Monitor extends EventEmitter {
     const minHeartbeatFrequencyMS = this.options.minHeartbeatFrequencyMS;
     this[kMonitorId] = makeInterruptableAsyncInterval(monitorServer(this), {
       interval: heartbeatFrequencyMS,
-      minInterval: minHeartbeatFrequencyMS,
-      immediate: true
+      minInterval: minHeartbeatFrequencyMS
     });
   }
 


### PR DESCRIPTION
When a failure occurs while streaming topology updates, we need to wait some time before restarting the monitoring protocol. It's
likely that if some error closed the connection, an immediate attempt to reconnect will also fail, leading to tight failure loops.

NODE-2711