### PR TITLE
chore: change prepublishOnly package.json script to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "check:ts": "tsc --noEmit",
     "check:atlas": "mocha --config \"test/manual/mocharc.json\" test/manual/atlas_connectivity.test.js",
     "check:ocsp": "mocha --config \"test/manual/mocharc.json\" test/manual/ocsp_support.test.js",
-    "prepublishOnly": "npm run build:ts",
+    "prepare": "npm run build:ts",
     "release": "standard-version -i HISTORY.md",
     "test": "npm run check:lint && npm run check:test"
   },


### PR DESCRIPTION
## Description

This is required for the `drivers-atlas-testing` integration , and should prove useful generally (e.g. when users are attempting to `npm link` the module).

**What changed?**

**Are there any files to ignore?**
