### PR TITLE
NODE-2680: Bump prettier version and modify config to reduce reformatting

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "tabWidth": 2,
   "printWidth": 100,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "trailingComma": "none"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6871,9 +6871,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mocha-sinon": "^2.1.0",
     "mongodb-mock-server": "^2.0.1",
     "nyc": "^15.0.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "semver": "^5.5.0",
     "sinon": "^4.3.0",
     "sinon-chai": "^3.2.0",

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -1,4 +1,4 @@
-import * as _BSON from 'bson';
+import type * as _BSON from 'bson';
 let BSON: typeof _BSON = require('bson');
 try {
   BSON = require('bson-ext');

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1261,7 +1261,7 @@ class BulkOperationBase {
 
 Object.defineProperty(BulkOperationBase.prototype, 'length', {
   enumerable: true,
-  get: function() {
+  get() {
     return this.s.currentIndex;
   }
 });

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -50,15 +50,14 @@ function checkSupportedServer(ismaster: any, options: any) {
     return new MongoError(message);
   }
 
-  const message = `Server at ${options.host}:${
-    options.port
-  } reports maximum wire version ${ismaster.maxWireVersion ||
-    0}, but this version of the Node.js Driver requires at least ${MIN_SUPPORTED_WIRE_VERSION} (MongoDB ${MIN_SUPPORTED_SERVER_VERSION})`;
+  const message = `Server at ${options.host}:${options.port} reports maximum wire version ${
+    ismaster.maxWireVersion || 0
+  }, but this version of the Node.js Driver requires at least ${MIN_SUPPORTED_WIRE_VERSION} (MongoDB ${MIN_SUPPORTED_SERVER_VERSION})`;
   return new MongoError(message);
 }
 
 function performInitialHandshake(conn: any, options: any, _callback: any) {
-  const callback = function(err?: any, ret?: any) {
+  const callback = function (err?: any, ret?: any) {
     if (err && conn) {
       conn.destroy();
     }
@@ -205,11 +204,9 @@ function parseSslOptions(family: any, options: any) {
 
   // Override checkServerIdentity behavior
   if (options.checkServerIdentity === false) {
-    // Skip the identiy check by retuning undefined as per node documents
+    // Skip the identity check by retuning undefined as per node documents
     // https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
-    result.checkServerIdentity = function() {
-      return undefined;
-    };
+    result.checkServerIdentity = () => undefined;
   } else if (typeof options.checkServerIdentity === 'function') {
     result.checkServerIdentity = options.checkServerIdentity;
   }
@@ -244,7 +241,7 @@ function makeConnection(family: any, options: any, cancellationToken: any, _call
   }
 
   let socket: any;
-  const callback = function(err?: any, ret?: any) {
+  const callback = function (err?: any, ret?: any) {
     if (err && socket) {
       socket.destroy();
     }

--- a/src/cursor/core_cursor.ts
+++ b/src/cursor/core_cursor.ts
@@ -790,7 +790,7 @@ function nextFunction(self: any, callback: Function) {
     if (isConnectionDead(self, callback)) return;
 
     // Execute the next get more
-    self._getMore(function(err: any, doc: any, connection: any) {
+    self._getMore(function (err: any, doc: any, connection: any) {
       if (err) {
         return handleCallback(callback, err);
       }
@@ -866,9 +866,9 @@ function nextFunction(self: any, callback: Function) {
       // Ensure we kill the cursor on the server
       self.kill();
       // Set cursor in dead and notified state
-      return setCursorDeadAndNotified(self, function() {
-        handleCallback(callback, new MongoError(doc ? doc.$err : undefined));
-      });
+      return setCursorDeadAndNotified(self, () =>
+        handleCallback(callback, new MongoError(doc ? doc.$err : undefined))
+      );
     }
 
     // Transform the doc with passed in transformation method if provided

--- a/src/cursor/cursor.ts
+++ b/src/cursor/cursor.ts
@@ -1017,7 +1017,7 @@ class Cursor extends CoreCursor {
     if (typeof streamOptions.transform === 'function') {
       const stream = new Transform({
         objectMode: true,
-        transform: function(chunk: any, encoding: any, callback: Function) {
+        transform(chunk: any, encoding: any, callback: Function) {
           this.push(streamOptions.transform(chunk));
           callback();
         }

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -39,7 +39,9 @@ class CommandOperation extends OperationBase {
     //       something we'd want to reconsider. Perhaps those commands can use `Admin`
     //       as a parent?
     const dbNameOverride = options?.dbName || options?.authdb;
-    this.ns = dbNameOverride ? new MongoDBNamespace(dbNameOverride, '$cmd') : parent.s.namespace.withCollection('$cmd');
+    this.ns = dbNameOverride
+      ? new MongoDBNamespace(dbNameOverride, '$cmd')
+      : parent.s.namespace.withCollection('$cmd');
 
     const propertyProvider = this.hasAspect(Aspect.NO_INHERIT_OPTIONS) ? undefined : parent;
     this.readPreference = ReadPreference.resolve(propertyProvider, this.options);

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -7,9 +7,7 @@ import { commandSupportsReadConcern } from '../sessions';
 import { MongoError } from '../error';
 import Logger = require('../logger');
 
-/* eslint-disable */
 import type { Server } from '../sdam/server';
-/* eslint-enable */
 
 const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
 

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -8,7 +8,7 @@ import {
   handleCallback
 } from '../utils';
 import { MongoError } from '../error';
-import { defineAspects, Aspect, OperationBase } from './operation';
+import { OperationBase } from './operation';
 
 class FindAndModifyOperation extends OperationBase {
   collection: any;

--- a/src/operations/find_one.ts
+++ b/src/operations/find_one.ts
@@ -18,10 +18,7 @@ class FindOneOperation extends OperationBase {
     const options = this.options;
 
     try {
-      const cursor = coll
-        .find(query, options)
-        .limit(-1)
-        .batchSize(1);
+      const cursor = coll.find(query, options).limit(-1).batchSize(1);
 
       // Return the item
       cursor.next((err?: any, item?: any) => {

--- a/src/operations/run_command.ts
+++ b/src/operations/run_command.ts
@@ -3,8 +3,8 @@ import { defineAspects, Aspect } from './operation';
 import Db = require('../db');
 import Collection = require('../collection');
 import MongoClient = require('../mongo_client');
-import { Server } from '../sdam/server';
 import { MongoDBNamespace } from '../utils';
+import type { Server } from '../sdam/server';
 
 class RunCommandOperation extends CommandOperation {
   command: any;

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -15,7 +15,8 @@ import {
   ServerHeartbeatSucceededEvent,
   ServerHeartbeatFailedEvent
 } from './events';
-import { Server } from './server';
+
+import type { Server } from './server';
 
 const kServer = Symbol('server');
 const kMonitorId = Symbol('monitorId');

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -407,10 +407,10 @@ class Server extends EventEmitter {
 }
 
 Object.defineProperty(Server.prototype, 'clusterTime', {
-  get: function() {
+  get() {
     return this.s.topology.clusterTime;
   },
-  set: function(clusterTime: any) {
+  set(clusterTime: any) {
     this.s.topology.clusterTime = clusterTime;
   }
 });

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -10,12 +10,11 @@ const SMALLEST_MAX_STALENESS_SECONDS = 90;
  * Returns a server selector that selects for writable servers
  */
 function writableServerSelector() {
-  return function(topologyDescription: any, servers: any) {
-    return latencyWindowReducer(
+  return (topologyDescription: any, servers: any) =>
+    latencyWindowReducer(
       topologyDescription,
       servers.filter((s: any) => s.isWritable)
     );
-  };
 }
 
 /**
@@ -181,7 +180,7 @@ function readPreferenceServerSelector(readPreference: any) {
     throw new TypeError('Invalid read preference specified');
   }
 
-  return function(topologyDescription: any, servers: any) {
+  return function (topologyDescription: any, servers: any) {
     const commonWireVersion = topologyDescription.commonWireVersion;
     if (
       commonWireVersion &&

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -757,10 +757,10 @@ class Topology extends EventEmitter {
 
 Object.defineProperty(Topology.prototype, 'clusterTime', {
   enumerable: true,
-  get: function() {
+  get() {
     return this.s.clusterTime;
   },
-  set: function(clusterTime: any) {
+  set(clusterTime: any) {
     this.s.clusterTime = clusterTime;
   }
 });
@@ -1079,7 +1079,7 @@ function makeCompressionInfo(options: any) {
   }
 
   // Check that all supplied compressors are valid
-  options.compression.compressors.forEach(function(compressor: any) {
+  options.compression.compressors.forEach((compressor: any) => {
     if (compressor !== 'snappy' && compressor !== 'zlib') {
       throw new Error('compressors must be at least one of snappy or zlib');
     }
@@ -1095,7 +1095,7 @@ const RETRYABLE_WIRE_VERSION = 6;
  *
  * @param {Mongos|Replset} topology
  */
-const isRetryableWritesSupported = function(topology: any) {
+function isRetryableWritesSupported(topology: any) {
   const maxWireVersion = topology.lastIsMaster().maxWireVersion;
   if (maxWireVersion < RETRYABLE_WIRE_VERSION) {
     return false;
@@ -1110,6 +1110,6 @@ const isRetryableWritesSupported = function(topology: any) {
   }
 
   return true;
-};
+}
 
 export { Topology };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,16 +7,16 @@ import WriteConcern = require('./write_concern');
 const MAX_JS_INT = Number.MAX_SAFE_INTEGER + 1;
 
 // Set simple property
-var getSingleProperty = function(obj: any, name: any, value: any) {
+function getSingleProperty(obj: any, name: any, value: any) {
   Object.defineProperty(obj, name, {
     enumerable: true,
-    get: function() {
+    get() {
       return value;
     }
   });
-};
+}
 
-var formatSortValue = (exports.formatSortValue = function(sortDirection: any) {
+function formatSortValue(sortDirection: any) {
   var value = ('' + sortDirection).toLowerCase();
 
   switch (value) {
@@ -35,9 +35,9 @@ var formatSortValue = (exports.formatSortValue = function(sortDirection: any) {
           "['field2', '(ascending|descending)']]"
       );
   }
-});
+}
 
-var formattedOrderClause = (exports.formattedOrderClause = function(sortValue: any) {
+function formattedOrderClause(sortValue: any) {
   var orderBy: any = {};
   if (sortValue == null) return null;
   if (Array.isArray(sortValue)) {
@@ -64,9 +64,9 @@ var formattedOrderClause = (exports.formattedOrderClause = function(sortValue: a
   }
 
   return orderBy;
-});
+}
 
-var checkCollectionName = function checkCollectionName(collectionName: any) {
+function checkCollectionName(collectionName: any) {
   if ('string' !== typeof collectionName) {
     throw new MongoError('collection name must be a String');
   }
@@ -90,7 +90,7 @@ var checkCollectionName = function checkCollectionName(collectionName: any) {
   if (collectionName.indexOf('\x00') !== -1) {
     throw new MongoError('collection names cannot contain a null character');
   }
-};
+}
 
 /**
  * Tries to call a provided callback with an error or some result with logic to
@@ -109,7 +109,7 @@ function handleCallback(callback: Function, err: any, value1?: any, value2?: any
       return value2 ? callback(err, value1, value2) : callback(err, value1);
     }
   } catch (err) {
-    process.nextTick(function() {
+    process.nextTick(function () {
       throw err;
     });
     return false;
@@ -123,7 +123,7 @@ function handleCallback(callback: Function, err: any, value1?: any, value2?: any
  *
  * @param {any} error
  */
-var toError = function(error: any) {
+function toError(error: any) {
   if (error instanceof Error) return error;
 
   var msg = error.err || error.errmsg || error.errMessage || error;
@@ -141,12 +141,12 @@ var toError = function(error: any) {
   }
 
   return e;
-};
+}
 
 /**
  * @param {any} hint
  */
-var normalizeHintField = function normalizeHintField(hint: any) {
+function normalizeHintField(hint: any) {
   var finalHint: any = null;
 
   if (typeof hint === 'string') {
@@ -154,7 +154,7 @@ var normalizeHintField = function normalizeHintField(hint: any) {
   } else if (Array.isArray(hint)) {
     finalHint = {};
 
-    hint.forEach(function(param: any) {
+    hint.forEach(function (param: any) {
       finalHint[param] = 1;
     });
   } else if (hint != null && typeof hint === 'object') {
@@ -165,14 +165,14 @@ var normalizeHintField = function normalizeHintField(hint: any) {
   }
 
   return finalHint;
-};
+}
 
 /**
  * Create index name based on field spec
  *
  * @param {any} fieldOrSpec
  */
-var parseIndexOptions = function(fieldOrSpec: any) {
+function parseIndexOptions(fieldOrSpec: any) {
   var fieldHash: any = {};
   var indexes = [];
   var keys;
@@ -183,7 +183,7 @@ var parseIndexOptions = function(fieldOrSpec: any) {
     indexes.push(fieldOrSpec + '_' + 1);
     fieldHash[fieldOrSpec] = 1;
   } else if (Array.isArray(fieldOrSpec)) {
-    fieldOrSpec.forEach(function(f: any) {
+    fieldOrSpec.forEach(function (f: any) {
       if ('string' === typeof f) {
         // [{location:'2d'}, 'type']
         indexes.push(f + '_' + 1);
@@ -195,7 +195,7 @@ var parseIndexOptions = function(fieldOrSpec: any) {
       } else if (isObject(f)) {
         // [{location:'2d'}, {type:1}]
         keys = Object.keys(f);
-        keys.forEach(function(k: any) {
+        keys.forEach(function (k: any) {
           indexes.push(k + '_' + f[k]);
           fieldHash[k] = f[k];
         });
@@ -206,7 +206,7 @@ var parseIndexOptions = function(fieldOrSpec: any) {
   } else if (isObject(fieldOrSpec)) {
     // {location:'2d', type:1}
     keys = Object.keys(fieldOrSpec);
-    keys.forEach(function(key: any) {
+    keys.forEach(function (key: any) {
       indexes.push(key + '_' + fieldOrSpec[key]);
       fieldHash[key] = fieldOrSpec[key];
     });
@@ -217,39 +217,39 @@ var parseIndexOptions = function(fieldOrSpec: any) {
     keys: keys,
     fieldHash: fieldHash
   };
-};
+}
 
-var isObject = (exports.isObject = function(arg: any) {
+function isObject(arg: any) {
   return '[object Object]' === Object.prototype.toString.call(arg);
-});
+}
 
-var debugOptions = function(debugFields: any, options: any) {
+function debugOptions(debugFields: any, options: any) {
   var finaloptions: any = {};
-  debugFields.forEach(function(n: any) {
+  debugFields.forEach(function (n: any) {
     finaloptions[n] = options[n];
   });
 
   return finaloptions;
-};
+}
 
-var decorateCommand = function(command: any, options: any, exclude: any) {
+function decorateCommand(command: any, options: any, exclude: any) {
   for (var name in options) {
     if (exclude.indexOf(name) === -1) command[name] = options[name];
   }
 
   return command;
-};
+}
 
-var mergeOptions = function(target: any, source: any) {
+function mergeOptions(target: any, source: any) {
   for (var name in source) {
     target[name] = source[name];
   }
 
   return target;
-};
+}
 
 // Merge options with translation
-var translateOptions = function(target: any, source: any) {
+function translateOptions(target: any, source: any) {
   var translations: any = {
     // SSL translation options
     sslCA: 'ca',
@@ -279,9 +279,9 @@ var translateOptions = function(target: any, source: any) {
   }
 
   return target;
-};
+}
 
-var filterOptions = function(options: any, names: any) {
+function filterOptions(options: any, names: any) {
   var filterOptions: any = {};
 
   for (var name in options) {
@@ -290,13 +290,13 @@ var filterOptions = function(options: any, names: any) {
 
   // Filtered options
   return filterOptions;
-};
+}
 
 // Write concern keys
 var writeConcernKeys = ['w', 'j', 'wtimeout', 'fsync'];
 
 // Merge the write concern options
-var mergeOptionsAndWriteConcern = function(
+function mergeOptionsAndWriteConcern(
   targetOptions: any,
   sourceOptions: any,
   keys: any,
@@ -330,7 +330,7 @@ var mergeOptionsAndWriteConcern = function(
   }
 
   return targetOptions;
-};
+}
 
 /**
  * Executes the given operation with provided arguments.
@@ -412,7 +412,7 @@ const executeLegacyOperation = (topology: any, operation: Function, args: any, o
     throw new TypeError('final argument to `executeLegacyOperation` must be a callback');
   }
 
-  return new Promise(function(resolve: any, reject: any) {
+  return new Promise(function (resolve: any, reject: any) {
     const handler = makeExecuteCallback(resolve, reject);
     args[args.length - 1] = handler;
 
@@ -571,7 +571,7 @@ function deprecateOptions(config: any, fn: Function): any {
     }
 
     const self = this;
-    config.deprecatedOptions.forEach(function(deprecatedOption: any) {
+    config.deprecatedOptions.forEach(function (deprecatedOption: any) {
       if (
         Object.prototype.hasOwnProperty.call(options, deprecatedOption) &&
         !optionsWarned.has(deprecatedOption)
@@ -665,7 +665,7 @@ function maybePromise(callback: Function | undefined, wrapper: Function): any | 
     });
   }
 
-  wrapper(function(err?: any, res?: any) {
+  wrapper(function (err?: any, res?: any) {
     if (err != null) {
       try {
         callback!(err);
@@ -688,10 +688,7 @@ function databaseNamespace(ns: any) {
 }
 
 function collectionNamespace(ns: any) {
-  return ns
-    .split('.')
-    .slice(1)
-    .join('.');
+  return ns.split('.').slice(1).join('.');
 }
 
 /**
@@ -1036,6 +1033,7 @@ export {
   getSingleProperty,
   checkCollectionName,
   toError,
+  formatSortValue,
   formattedOrderClause,
   parseIndexOptions,
   normalizeHintField,

--- a/test/benchmarks/driverBench/common.js
+++ b/test/benchmarks/driverBench/common.js
@@ -62,7 +62,7 @@ function dropBucket() {
 }
 
 function makeLoadJSON(name) {
-  return function() {
+  return function () {
     this.doc = JSON.parse(loadSpecString(['single_and_multi_document', name]));
   };
 }

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -39,7 +39,7 @@ function decodeBSON() {
 }
 
 function makeBSONLoader(fileName) {
-  return function() {
+  return function () {
     this.dataString = EJSON.parse(loadSpecString(['extended_bson', `${fileName}.json`]));
     this.data = BSON.serialize(this.dataString);
   };
@@ -50,7 +50,7 @@ function loadGridFs() {
 }
 
 function makeTestInsertOne(numberOfOps) {
-  return function(done) {
+  return function (done) {
     const loop = _id => {
       if (_id > numberOfOps) {
         return done();
@@ -66,7 +66,7 @@ function makeTestInsertOne(numberOfOps) {
 }
 
 function makeLoadTweets(makeId) {
-  return function() {
+  return function () {
     const doc = this.doc;
     const tweets = [];
     for (let _id = 1; _id <= 10000; _id += 1) {
@@ -78,7 +78,7 @@ function makeLoadTweets(makeId) {
 }
 
 function makeLoadInsertDocs(numberOfOperations) {
-  return function() {
+  return function () {
     this.docs = [];
     for (let i = 0; i < numberOfOperations; i += 1) {
       this.docs.push(Object.assign({}, this.doc));
@@ -131,40 +131,22 @@ const benchmarkRunner = new Runner()
   .suite('bsonBench', suite =>
     suite
       .benchmark('flatBsonEncoding', benchmark =>
-        benchmark
-          .taskSize(75.31)
-          .setup(makeBSONLoader('flat_bson'))
-          .task(encodeBSON)
+        benchmark.taskSize(75.31).setup(makeBSONLoader('flat_bson')).task(encodeBSON)
       )
       .benchmark('flatBsonDecoding', benchmark =>
-        benchmark
-          .taskSize(75.31)
-          .setup(makeBSONLoader('flat_bson'))
-          .task(decodeBSON)
+        benchmark.taskSize(75.31).setup(makeBSONLoader('flat_bson')).task(decodeBSON)
       )
       .benchmark('deepBsonEncoding', benchmark =>
-        benchmark
-          .taskSize(19.64)
-          .setup(makeBSONLoader('deep_bson'))
-          .task(encodeBSON)
+        benchmark.taskSize(19.64).setup(makeBSONLoader('deep_bson')).task(encodeBSON)
       )
       .benchmark('deepBsonDecoding', benchmark =>
-        benchmark
-          .taskSize(19.64)
-          .setup(makeBSONLoader('deep_bson'))
-          .task(decodeBSON)
+        benchmark.taskSize(19.64).setup(makeBSONLoader('deep_bson')).task(decodeBSON)
       )
       .benchmark('fullBsonEncoding', benchmark =>
-        benchmark
-          .taskSize(57.34)
-          .setup(makeBSONLoader('full_bson'))
-          .task(encodeBSON)
+        benchmark.taskSize(57.34).setup(makeBSONLoader('full_bson')).task(encodeBSON)
       )
       .benchmark('fullBsonDecoding', benchmark =>
-        benchmark
-          .taskSize(57.34)
-          .setup(makeBSONLoader('full_bson'))
-          .task(decodeBSON)
+        benchmark.taskSize(57.34).setup(makeBSONLoader('full_bson')).task(decodeBSON)
       )
   )
   .suite('singleBench', suite =>
@@ -297,7 +279,7 @@ const benchmarkRunner = new Runner()
           .beforeTask(initBucket)
           .beforeTask(gridFsInitUploadStream)
           .beforeTask(writeSingleByteToUploadStream)
-          .task(function(done) {
+          .task(function (done) {
             this.stream.on('error', done).end(this.bin, null, () => done());
           })
           .teardown(dropDb)
@@ -316,7 +298,7 @@ const benchmarkRunner = new Runner()
           .setup(dropBucket)
           .setup(initBucket)
           .setup(gridFsInitUploadStream)
-          .setup(function() {
+          .setup(function () {
             return new Promise((resolve, reject) => {
               this.stream.end(this.bin, null, err => {
                 if (err) {
@@ -329,11 +311,8 @@ const benchmarkRunner = new Runner()
               });
             });
           })
-          .task(function(done) {
-            this.bucket
-              .openDownloadStream(this.id)
-              .resume()
-              .on('end', done);
+          .task(function (done) {
+            this.bucket.openDownloadStream(this.id).resume().on('end', done);
           })
           .teardown(dropDb)
           .teardown(disconnectClient)

--- a/test/benchmarks/mongoBench/runner.js
+++ b/test/benchmarks/mongoBench/runner.js
@@ -74,7 +74,7 @@ class Runner {
     this.minExecutionCount = options.minExecutionCount || CONSTANTS.DEFAULT_MIN_EXECUTION_COUNT;
     this.reporter =
       options.reporter ||
-      function() {
+      function () {
         console.log.apply(console, arguments);
       };
     this.children = {};

--- a/test/benchmarks/mongoBench/util.js
+++ b/test/benchmarks/mongoBench/util.js
@@ -8,7 +8,7 @@ function asyncChain(_chain) {
       throw new TypeError(`${fn} is not a function`);
     }
   });
-  return function() {
+  return function () {
     const context = this;
 
     // Takes an array of async and/or sync functions, and executes them in order.

--- a/test/disabled/basic_single_server_auth.test.js
+++ b/test/disabled/basic_single_server_auth.test.js
@@ -7,10 +7,10 @@ const Connection = require('../../../src/cmap/connection');
 
 const { MongoCredentials } = require('../../../src/core/auth/mongo_credentials');
 
-describe('Basic single server auth tests', function() {
+describe('Basic single server auth tests', function () {
   it('should correctly authenticate server using scram-sha-256 using connect auth', {
     metadata: { requires: { topology: 'auth', mongodb: '>=3.7.3' } },
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       const mechanism = 'scram-sha-256';
       const source = 'admin';
@@ -64,15 +64,15 @@ describe('Basic single server auth tests', function() {
   it('should fail to authenticate server using scram-sha-1 using connect auth', {
     metadata: { requires: { topology: 'auth' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
 
       // Enable connections accounting
       Connection.enableConnectionAccounting();
 
       // Restart instance
-      self.configuration.manager.restart(true).then(function() {
-        locateAuthMethod(self.configuration, function(err, method) {
+      self.configuration.manager.restart(true).then(function () {
+        locateAuthMethod(self.configuration, function (err, method) {
           expect(err).to.be.null;
 
           const credentials = new MongoCredentials({
@@ -91,7 +91,7 @@ describe('Basic single server auth tests', function() {
               roles: [{ role: 'root', db: 'admin' }],
               digestPassword: true
             },
-            function(cmdErr, r) {
+            function (cmdErr, r) {
               expect(r).to.exist;
               expect(cmdErr).to.be.null;
 
@@ -100,7 +100,7 @@ describe('Basic single server auth tests', function() {
                 this.configuration.port
               );
 
-              server.on('error', function() {
+              server.on('error', function () {
                 // console.log('=================== ' + Object.keys(Connection.connections()).length)
                 expect(Object.keys(Connection.connections()).length).to.equal(0);
                 Connection.disableConnectionAccounting();
@@ -119,7 +119,7 @@ describe('Basic single server auth tests', function() {
   it('should correctly authenticate server using scram-sha-1 using connect auth', {
     metadata: { requires: { topology: 'auth' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
 
@@ -127,8 +127,8 @@ describe('Basic single server auth tests', function() {
       Connection.enableConnectionAccounting();
 
       // Restart instance
-      self.configuration.manager.restart(true).then(function() {
-        locateAuthMethod(self.configuration, function(err, method) {
+      self.configuration.manager.restart(true).then(function () {
+        locateAuthMethod(self.configuration, function (err, method) {
           expect(err).to.be.null;
 
           executeCommand(
@@ -140,7 +140,7 @@ describe('Basic single server auth tests', function() {
               roles: [{ role: 'root', db: 'admin' }],
               digestPassword: true
             },
-            function(cmdErr, r) {
+            function (cmdErr, r) {
               expect(r).to.exist;
               expect(cmdErr).to.be.null;
 
@@ -153,13 +153,13 @@ describe('Basic single server auth tests', function() {
                 password: 'root'
               });
 
-              server.on('connect', function(_server) {
+              server.on('connect', function (_server) {
                 executeCommand(
                   self.configuration,
                   'admin',
                   { dropUser: 'root' },
                   { credentials },
-                  function(dropUserErr, dropUserRes) {
+                  function (dropUserErr, dropUserRes) {
                     expect(dropUserRes).to.exist;
                     expect(dropUserErr).to.be.null;
 
@@ -185,7 +185,7 @@ describe('Basic single server auth tests', function() {
     {
       metadata: { requires: { topology: 'auth' } },
 
-      test: function(done) {
+      test: function (done) {
         var self = this;
         const config = this.configuration;
 
@@ -193,8 +193,8 @@ describe('Basic single server auth tests', function() {
         Connection.enableConnectionAccounting();
 
         // Restart instance
-        self.configuration.manager.restart(true).then(function() {
-          locateAuthMethod(self.configuration, function(err, method) {
+        self.configuration.manager.restart(true).then(function () {
+          locateAuthMethod(self.configuration, function (err, method) {
             expect(err).to.be.null;
 
             executeCommand(
@@ -206,7 +206,7 @@ describe('Basic single server auth tests', function() {
                 roles: [{ role: 'root', db: 'admin' }],
                 digestPassword: true
               },
-              function(cmdErr, r) {
+              function (cmdErr, r) {
                 expect(r).to.exist;
                 expect(cmdErr).to.be.null;
 
@@ -227,7 +227,7 @@ describe('Basic single server auth tests', function() {
                     digestPassword: true
                   },
                   { credentials },
-                  function(createUserErr, createUserRes) {
+                  function (createUserErr, createUserRes) {
                     expect(createUserRes).to.exist;
                     expect(createUserErr).to.be.null;
 
@@ -239,7 +239,7 @@ describe('Basic single server auth tests', function() {
 
                     var index = 0;
 
-                    var messageHandler = function(messageHandlerErr, result) {
+                    var messageHandler = function (messageHandlerErr, result) {
                       index = index + 1;
 
                       // Tests
@@ -257,9 +257,9 @@ describe('Basic single server auth tests', function() {
                     };
 
                     // Add event listeners
-                    server.on('connect', function() {
+                    server.on('connect', function () {
                       for (var i = 0; i < 10; i++) {
-                        process.nextTick(function() {
+                        process.nextTick(function () {
                           server.insert('test.test', [{ a: 1 }], messageHandler);
                           server.insert('test.test', [{ a: 1 }], messageHandler);
                           server.insert('test.test', [{ a: 1 }], messageHandler);
@@ -289,7 +289,7 @@ describe('Basic single server auth tests', function() {
   it('should correctly authenticate server using scram-sha-1 using auth method', {
     metadata: { requires: { topology: 'auth' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
 
@@ -297,8 +297,8 @@ describe('Basic single server auth tests', function() {
       Connection.enableConnectionAccounting();
 
       // Restart instance
-      self.configuration.manager.restart(true).then(function() {
-        locateAuthMethod(self.configuration, function(err, method) {
+      self.configuration.manager.restart(true).then(function () {
+        locateAuthMethod(self.configuration, function (err, method) {
           expect(err).to.be.null;
 
           executeCommand(
@@ -310,7 +310,7 @@ describe('Basic single server auth tests', function() {
               roles: [{ role: 'root', db: 'admin' }],
               digestPassword: true
             },
-            function(cmdErr, r) {
+            function (cmdErr, r) {
               expect(r).to.exist;
               expect(cmdErr).to.be.null;
 
@@ -331,7 +331,7 @@ describe('Basic single server auth tests', function() {
                   digestPassword: true
                 },
                 { credentials },
-                function(createUserErr, createUserRes) {
+                function (createUserErr, createUserRes) {
                   expect(createUserRes).to.exist;
                   expect(createUserErr).to.be.null;
 
@@ -341,7 +341,7 @@ describe('Basic single server auth tests', function() {
                   var index = 0;
                   var error = false;
 
-                  var messageHandler = function(messageHandlerErr, result) {
+                  var messageHandler = function (messageHandlerErr, result) {
                     index = index + 1;
 
                     // Tests
@@ -361,20 +361,20 @@ describe('Basic single server auth tests', function() {
                   };
 
                   // Add event listeners
-                  server.on('connect', function(_server) {
-                    _server.auth(credentials, function(authErr, authRes) {
+                  server.on('connect', function (_server) {
+                    _server.auth(credentials, function (authErr, authRes) {
                       expect(authRes).to.exist;
                       expect(authErr).to.not.exist;
 
                       for (var i = 0; i < 100; i++) {
-                        process.nextTick(function() {
+                        process.nextTick(function () {
                           server.insert('test.test', [{ a: 1 }], messageHandler);
                         });
                       }
                     });
 
-                    var executeIsMaster = function() {
-                      _server.command('admin.$cmd', { ismaster: true }, function(
+                    var executeIsMaster = function () {
+                      _server.command('admin.$cmd', { ismaster: true }, function (
                         adminErr,
                         adminRes
                       ) {
@@ -404,7 +404,7 @@ describe('Basic single server auth tests', function() {
   it.skip('should correctly authenticate server using scram-sha-1 using connect auth then logout', {
     metadata: { requires: { topology: 'auth' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
 
@@ -412,8 +412,8 @@ describe('Basic single server auth tests', function() {
       Connection.enableConnectionAccounting();
 
       // Restart instance
-      self.configuration.manager.restart(true).then(function() {
-        locateAuthMethod(self.configuration, function(err, method) {
+      self.configuration.manager.restart(true).then(function () {
+        locateAuthMethod(self.configuration, function (err, method) {
           expect(err).to.be.null;
 
           executeCommand(
@@ -425,7 +425,7 @@ describe('Basic single server auth tests', function() {
               roles: [{ role: 'root', db: 'admin' }],
               digestPassword: true
             },
-            function(cmdErr, r) {
+            function (cmdErr, r) {
               expect(r).to.exist;
               expect(cmdErr).to.be.null;
 
@@ -446,7 +446,7 @@ describe('Basic single server auth tests', function() {
                   digestPassword: true
                 },
                 { credentials },
-                function(createUserErr, createUserRes) {
+                function (createUserErr, createUserRes) {
                   expect(createUserRes).to.exist;
                   expect(createUserErr).to.be.null;
 
@@ -454,16 +454,16 @@ describe('Basic single server auth tests', function() {
                   var server = config.newTopology(this.configuration.host, this.configuration.port);
 
                   // Add event listeners
-                  server.on('connect', function(_server) {
-                    _server.insert('test.test', [{ a: 1 }], function(insertErr, insertRes) {
+                  server.on('connect', function (_server) {
+                    _server.insert('test.test', [{ a: 1 }], function (insertErr, insertRes) {
                       expect(insertRes).to.exist;
                       expect(insertErr).to.be.null;
 
                       // Logout pool
-                      _server.logout('test', function(logoutErr) {
+                      _server.logout('test', function (logoutErr) {
                         expect(logoutErr).to.be.null;
 
-                        _server.insert('test.test', [{ a: 1 }], function(
+                        _server.insert('test.test', [{ a: 1 }], function (
                           secondInsertErr,
                           secondInsertRes
                         ) {
@@ -495,7 +495,7 @@ describe('Basic single server auth tests', function() {
   it('should correctly have server auth wait for logout to finish', {
     metadata: { requires: { topology: 'auth' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
 
@@ -503,8 +503,8 @@ describe('Basic single server auth tests', function() {
       Connection.enableConnectionAccounting();
 
       // Restart instance
-      self.configuration.manager.restart(true).then(function() {
-        locateAuthMethod(self.configuration, function(err, method) {
+      self.configuration.manager.restart(true).then(function () {
+        locateAuthMethod(self.configuration, function (err, method) {
           expect(err).to.be.null;
 
           executeCommand(
@@ -516,7 +516,7 @@ describe('Basic single server auth tests', function() {
               roles: [{ role: 'root', db: 'admin' }],
               digestPassword: true
             },
-            function(ercmdErrr, r) {
+            function (ercmdErrr, r) {
               expect(r).to.exist;
               expect(err).to.be.null;
 
@@ -537,28 +537,28 @@ describe('Basic single server auth tests', function() {
                   digestPassword: true
                 },
                 { credentials },
-                function(createUserErr, createUserRes) {
+                function (createUserErr, createUserRes) {
                   expect(createUserRes).to.exist;
                   expect(createUserErr).to.be.null;
                   // Attempt to connect
                   var server = config.newTopology(this.configuration.host, this.configuration.port);
 
                   // Add event listeners
-                  server.on('connect', function(_server) {
-                    _server.insert('test.test', [{ a: 1 }], function(insertErr, insertRes) {
+                  server.on('connect', function (_server) {
+                    _server.insert('test.test', [{ a: 1 }], function (insertErr, insertRes) {
                       expect(insertRes).to.exist;
                       expect(insertErr).to.be.null;
 
                       // Logout pool
-                      _server.logout('test', function(logoutErr) {
+                      _server.logout('test', function (logoutErr) {
                         expect(logoutErr).to.be.null;
                       });
 
-                      _server.auth(credentials, function(authErr, authRes) {
+                      _server.auth(credentials, function (authErr, authRes) {
                         expect(authRes).to.exist;
                         expect(authErr).to.be.null;
 
-                        _server.insert('test.test', [{ a: 1 }], function(
+                        _server.insert('test.test', [{ a: 1 }], function (
                           secondInsertErr,
                           secondInsertRes
                         ) {

--- a/test/disabled/connection.test.js
+++ b/test/disabled/connection.test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
 const Connection = require('../../../src/core/connection/connection');
 
-describe('Connection', function() {
+describe('Connection', function () {
   const noop = () => {};
   let server;
   afterEach(() => mock.cleanup());
@@ -13,7 +13,7 @@ describe('Connection', function() {
     const config = options.config;
     const args = {
       metadata: { requires: { topology: ['single'] } },
-      test: function(done) {
+      test: function (done) {
         const connection = new Connection(noop, Object.assign({ port: server.port }, config));
 
         const cleanup = err => {
@@ -60,7 +60,7 @@ describe('Connection', function() {
     }
   }
 
-  describe.skip('IPv4', function() {
+  describe.skip('IPv4', function () {
     beforeEach(() => mock.createServer(0, '127.0.0.1').then(_server => (server = _server)));
 
     testCase('should connect with no family', {
@@ -85,7 +85,7 @@ describe('Connection', function() {
     });
   });
 
-  describe.skip('IPv6', function() {
+  describe.skip('IPv6', function () {
     beforeEach(() => mock.createServer(0, '::').then(_server => (server = _server)));
 
     testCase('should connect with no family', {

--- a/test/disabled/disconnect_handler.test.js
+++ b/test/disabled/disconnect_handler.test.js
@@ -1,21 +1,21 @@
 'use strict';
 var test = require('./shared').assert;
 
-describe('Disconnect Handler', function() {
+describe('Disconnect Handler', function () {
   // NOTE: skipped for use of topology manager
   it.skip('Should correctly recover when bufferMaxEntries: -1 and restart', {
     metadata: { requires: { topology: ['single', 'replicaset'] }, ignore: { travis: true } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       const client = configuration.newCLient();
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
-        configuration.manager.stop(9).then(function() {
-          db.collection('disconnect_handler_tests').update({ a: 1 }, { $set: { b: 1 } }, function(
+        configuration.manager.stop(9).then(function () {
+          db.collection('disconnect_handler_tests').update({ a: 1 }, { $set: { b: 1 } }, function (
             err,
             r
           ) {
@@ -25,8 +25,8 @@ describe('Disconnect Handler', function() {
             client.close();
           });
 
-          setTimeout(function() {
-            configuration.manager.restart(9, { waitMS: 5000 }).then(function() {
+          setTimeout(function () {
+            configuration.manager.restart(9, { waitMS: 5000 }).then(function () {
               done();
             });
           }, 5000);

--- a/test/disabled/jira_bug.test.js
+++ b/test/disabled/jira_bug.test.js
@@ -18,7 +18,7 @@ var setupDatabase = require('./shared').setupDatabase;
 //   etRep   tRep  etReplsetRep setRep       lsetReplset  plsetRepl   ReplsetRepls    plsetRe
 // **********************************************************************************************/
 
-var setUp = function(configuration, options, callback) {
+var setUp = function (configuration, options, callback) {
   var ReplSetManager = require('mongodb-topology-manager').ReplSet;
 
   // Check if we have any options
@@ -76,36 +76,36 @@ var setUp = function(configuration, options, callback) {
   // Create a manager
   var replicasetManager = new ReplSetManager('mongod', nodes, rsOptions.client);
   // Purge the set
-  replicasetManager.purge().then(function() {
+  replicasetManager.purge().then(function () {
     // Start the server
     replicasetManager
       .start()
-      .then(function() {
-        setTimeout(function() {
+      .then(function () {
+        setTimeout(function () {
           callback(null, replicasetManager);
         }, 10000);
       })
-      .catch(function(e) {
+      .catch(function (e) {
         callback(e, null);
       });
   });
 };
 
-describe('JIRA bugs', function() {
-  before(function() {
+describe('JIRA bugs', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it('NODE-746 should correctly connect to single primary/secondary with both hosts in uri', {
     metadata: { requires: { topology: ['auth'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Db = configuration.require.Db,
         Server = configuration.require.Server,
         ReplSet = configuration.require.ReplSet;
 
-      setUp(configuration, function(err, replicasetManager) {
+      setUp(configuration, function (err, replicasetManager) {
         var replSet = new ReplSet(
           [new Server('localhost', 31000), new Server('localhost', 31001)],
           {
@@ -115,14 +115,14 @@ describe('JIRA bugs', function() {
         );
 
         // Connect
-        new Db('replicaset_test_auth', replSet, { w: 1 }).open(function(err, db) {
+        new Db('replicaset_test_auth', replSet, { w: 1 }).open(function (err, db) {
           // Add a user
-          db.admin().addUser('root', 'root', { w: 3, wtimeout: 25000 }, function(err) {
+          db.admin().addUser('root', 'root', { w: 3, wtimeout: 25000 }, function (err) {
             test.equal(null, err);
             db.close();
 
             // shut down one of the secondaries
-            replicasetManager.secondaries().then(function(managers) {
+            replicasetManager.secondaries().then(function (managers) {
               // Remove the secondary server
               replicasetManager
                 .removeMember(
@@ -139,16 +139,16 @@ describe('JIRA bugs', function() {
                     password: 'root'
                   }
                 )
-                .then(function() {
+                .then(function () {
                   // Attempt to connect
                   const client = configuration.newClient(
                     'mongodb://root:root@localhost:31000,localhost:31001/admin?replicaSet=rs'
                   );
-                  client.connect(function(err, db) {
+                  client.connect(function (err, db) {
                     test.equal(null, err);
                     db.close();
 
-                    replicasetManager.stop().then(function() {
+                    replicasetManager.stop().then(function () {
                       done();
                     });
                   });

--- a/test/disabled/kerberos.test.js
+++ b/test/disabled/kerberos.test.js
@@ -9,15 +9,15 @@ var setupDatabase = require('./shared').setupDatabase;
 // kinit -p drivers@LDAPTEST.10GEN.CC
 // password: (not shown)
 
-describe('Kerberos', function() {
-  before(function() {
+describe('Kerberos', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it('Should Correctly Authenticate using kerberos with MongoClient', {
     metadata: { requires: { topology: 'kerberos', os: '!win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // KDC Server
@@ -31,13 +31,13 @@ describe('Kerberos', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db('kerberos');
 
         db.collection('test')
           .find()
-          .toArray(function(err, docs) {
+          .toArray(function (err, docs) {
             test.equal(null, err);
             test.ok(true, docs[0].kerberos);
 
@@ -50,7 +50,7 @@ describe('Kerberos', function() {
   it('Validate that SERVICE_REALM and CANONICALIZE_HOST_NAME is passed in', {
     metadata: { requires: { topology: 'kerberos', os: '!win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // KDC Server
@@ -64,13 +64,13 @@ describe('Kerberos', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db('kerberos');
 
         db.collection('test')
           .find()
-          .toArray(function(err, docs) {
+          .toArray(function (err, docs) {
             test.equal(null, err);
             test.ok(true, docs[0].kerberos);
 
@@ -85,7 +85,7 @@ describe('Kerberos', function() {
     {
       metadata: { requires: { topology: 'kerberos', os: '!win32' } },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
 
         // KDC Server
@@ -99,13 +99,13 @@ describe('Kerberos', function() {
         );
 
         const client = configuration.newClient(url);
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db('kerberos');
 
           db.collection('test')
             .find()
-            .toArray(function(err, docs) {
+            .toArray(function (err, docs) {
               test.equal(null, err);
               test.ok(true, docs[0].kerberos);
 
@@ -119,7 +119,7 @@ describe('Kerberos', function() {
   it('Should Correctly Authenticate using kerberos with MongoClient and then reconnect', {
     metadata: { requires: { topology: 'kerberos', os: '!win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // KDC Server
@@ -133,22 +133,22 @@ describe('Kerberos', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         client
           .db('kerberos')
           .collection('test')
-          .findOne(function(err, doc) {
+          .findOne(function (err, doc) {
             test.equal(null, err);
             test.equal(true, doc.kerberos);
 
-            client.topology.once('reconnect', function() {
+            client.topology.once('reconnect', function () {
               // Await reconnect and re-authentication
               client
                 .db('kerberos')
                 .collection('test')
-                .findOne(function(err, doc) {
+                .findOne(function (err, doc) {
                   test.equal(null, err);
                   test.equal(true, doc.kerberos);
 
@@ -159,7 +159,7 @@ describe('Kerberos', function() {
                   client
                     .db('kerberos')
                     .collection('test')
-                    .findOne(function(err, doc) {
+                    .findOne(function (err, doc) {
                       test.equal(null, err);
                       test.equal(true, doc.kerberos);
 
@@ -178,7 +178,7 @@ describe('Kerberos', function() {
   it('Should Correctly Authenticate authenticate method manually', {
     metadata: { requires: { topology: 'kerberos', os: '!win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var MongoClient = configuration.require.MongoClient,
         Server = configuration.require.Server;
@@ -192,14 +192,14 @@ describe('Kerberos', function() {
         user: principal,
         authMechanism: 'GSSAPI'
       });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         // Await reconnect and re-authentication
         client
           .db('kerberos')
           .collection('test')
-          .findOne(function(err, doc) {
+          .findOne(function (err, doc) {
             test.equal(null, err);
             test.equal(true, doc.kerberos);
 
@@ -212,7 +212,7 @@ describe('Kerberos', function() {
   it('Should Fail to Authenticate due to illegal service name', {
     metadata: { requires: { topology: 'kerberos', os: '!win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // KDC Server
@@ -226,7 +226,7 @@ describe('Kerberos', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.ok(err != null);
         done();
       });
@@ -236,7 +236,7 @@ describe('Kerberos', function() {
   it('Should Correctly Authenticate on Win32 using kerberos with MongoClient', {
     metadata: { requires: { topology: 'kerberos', os: 'win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // KDC Server
@@ -254,13 +254,13 @@ describe('Kerberos', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db('kerberos');
 
         db.collection('test')
           .find()
-          .toArray(function(err, docs) {
+          .toArray(function (err, docs) {
             test.equal(null, err);
             test.ok(true, docs[0].kerberos);
 
@@ -273,7 +273,7 @@ describe('Kerberos', function() {
   it('Should Correctly Authenticate using kerberos on Win32 with MongoClient and then reconnect', {
     metadata: { requires: { topology: 'kerberos', os: 'win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // KDC Server
@@ -290,22 +290,22 @@ describe('Kerberos', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         client
           .db('kerberos')
           .collection('test')
-          .findOne(function(err, doc) {
+          .findOne(function (err, doc) {
             test.equal(null, err);
             test.equal(true, doc.kerberos);
 
-            client.topology.once('reconnect', function() {
+            client.topology.once('reconnect', function () {
               // Await reconnect and re-authentication
               client
                 .db('kerberos')
                 .collection('test')
-                .findOne(function(err, doc) {
+                .findOne(function (err, doc) {
                   test.equal(null, err);
                   test.equal(true, doc.kerberos);
 
@@ -316,7 +316,7 @@ describe('Kerberos', function() {
                   client
                     .db('kerberos')
                     .collection('test')
-                    .findOne(function(err, doc) {
+                    .findOne(function (err, doc) {
                       test.equal(null, err);
                       test.equal(true, doc.kerberos);
 
@@ -335,7 +335,7 @@ describe('Kerberos', function() {
   it('Should Correctly Authenticate on Win32 authenticate method manually', {
     metadata: { requires: { topology: 'kerberos', os: 'win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var MongoClient = configuration.require.MongoClient,
         Server = configuration.require.Server;
@@ -352,13 +352,13 @@ describe('Kerberos', function() {
         authMechanism: 'GSSAPI'
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db('kerberos');
 
         db.collection('test')
           .find()
-          .toArray(function(err, docs) {
+          .toArray(function (err, docs) {
             test.equal(null, err);
             test.ok(true, docs[0].kerberos);
 
@@ -371,7 +371,7 @@ describe('Kerberos', function() {
   it('Should Fail to Authenticate due to illegal service name on win32', {
     metadata: { requires: { topology: 'kerberos', os: 'win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // KDC Server
@@ -389,7 +389,7 @@ describe('Kerberos', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.ok(err != null);
         done();
       });

--- a/test/disabled/mongos/events.test.js
+++ b/test/disabled/mongos/events.test.js
@@ -7,7 +7,7 @@ const MongosFixture = require('../common').MongosFixture;
 
 const test = new MongosFixture();
 
-describe('EventEmitters (Mongos)', function() {
+describe('EventEmitters (Mongos)', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => {
     return mock.createServer().then(mockServer => {
@@ -17,7 +17,7 @@ describe('EventEmitters (Mongos)', function() {
 
   it('should remove `serverDescriptionChanged` listeners when server is closed', {
     metadata: { requires: { topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       test.server.setMessageHandler(req => {
         const doc = req.document;
         if (doc.ismaster) {

--- a/test/disabled/mongos/reconnect.test.js
+++ b/test/disabled/mongos/reconnect.test.js
@@ -8,7 +8,7 @@ const genClusterTime = require('../common').genClusterTime;
 const Connection = require('../../../../src/core/connection/connection');
 const ConnectionSpy = require('../../../functional/shared').ConnectionSpy;
 
-describe.skip('Reconnect (Mongos)', function() {
+describe.skip('Reconnect (Mongos)', function () {
   const fixture = {};
 
   function startServer() {
@@ -38,7 +38,7 @@ describe.skip('Reconnect (Mongos)', function() {
   afterEach(() => stopServer());
 
   // NOTE: skipped due to flakiness and extremely long test runs
-  it.skip('should not connection swarm when reconnecting', function(done) {
+  it.skip('should not connection swarm when reconnecting', function (done) {
     const reconnectInterval = 500;
     const socketTimeout = reconnectInterval * 5;
     const haInterval = reconnectInterval * 10;

--- a/test/disabled/mongos/retryable_writes.test.js
+++ b/test/disabled/mongos/retryable_writes.test.js
@@ -10,13 +10,13 @@ const ServerSessionPool = core.Sessions.ServerSessionPool;
 const Mongos = core.Mongos;
 
 const test = new MongosFixture();
-describe('Retryable Writes (Mongos)', function() {
+describe('Retryable Writes (Mongos)', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => test.setup({ ismaster: mock.DEFAULT_ISMASTER_36 }));
 
   it('should add `txnNumber` to write commands where `retryWrites` is true', {
     metadata: { requires: { topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       const topology = new Mongos(
         test.servers.map(server => server.address()),
         {
@@ -48,8 +48,8 @@ describe('Retryable Writes (Mongos)', function() {
       test.servers[0].setMessageHandler(messageHandler('MONGOS1'));
       test.servers[1].setMessageHandler(messageHandler('MONGOS2'));
 
-      topology.once('fullsetup', function() {
-        topology.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+      topology.once('fullsetup', function () {
+        topology.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function (
           err
         ) {
           expect(err).to.not.exist;
@@ -68,7 +68,7 @@ describe('Retryable Writes (Mongos)', function() {
 
   it('should retry write commands where `retryWrites` is true, and not increment `txnNumber`', {
     metadata: { requires: { topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       const mongos = new Mongos(
         test.servers.map(server => server.address()),
         {
@@ -106,8 +106,8 @@ describe('Retryable Writes (Mongos)', function() {
 
       test.servers[0].setMessageHandler(messageHandler('MONGOS1'));
       test.servers[1].setMessageHandler(messageHandler('MONGOS2'));
-      mongos.once('fullsetup', function() {
-        mongos.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+      mongos.once('fullsetup', function () {
+        mongos.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function (
           err
         ) {
           if (err) console.dir(err);
@@ -125,7 +125,7 @@ describe('Retryable Writes (Mongos)', function() {
 
   it('should retry write commands where `retryWrites` is true, and there is a "not master" error', {
     metadata: { requires: { topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       const mongos = new Mongos(
         test.servers.map(server => server.address()),
         {
@@ -163,8 +163,8 @@ describe('Retryable Writes (Mongos)', function() {
 
       test.servers[0].setMessageHandler(messageHandler('MONGOS1'));
       test.servers[1].setMessageHandler(messageHandler('MONGOS2'));
-      mongos.once('fullsetup', function() {
-        mongos.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+      mongos.once('fullsetup', function () {
+        mongos.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function (
           err
         ) {
           expect(err).to.not.exist;

--- a/test/disabled/mongos/sessions.test.js
+++ b/test/disabled/mongos/sessions.test.js
@@ -11,7 +11,7 @@ const ReadPreference = core.ReadPreference;
 const Mongos = core.Mongos;
 
 const test = {};
-describe('Sessions (Mongos)', function() {
+describe('Sessions (Mongos)', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => {
     return mock.createServer().then(mockServer => {
@@ -21,7 +21,7 @@ describe('Sessions (Mongos)', function() {
 
   it('should recognize and set `clusterTime` on the topology', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       const clusterTime = genClusterTime(Date.now());
       test.server.setMessageHandler(request => {
         request.reply(
@@ -52,7 +52,7 @@ describe('Sessions (Mongos)', function() {
 
   it('should report the deployment `clusterTime` for all servers in the topology', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       const clusterTime = genClusterTime(Date.now());
       test.server.setMessageHandler(request => {
         request.reply(
@@ -86,7 +86,7 @@ describe('Sessions (Mongos)', function() {
 
   it('should track the highest `$clusterTime` seen', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       const clusterTime = genClusterTime(Date.now()),
         futureClusterTime = genClusterTime(Date.now() + 10 * 60 * 1000);
 
@@ -115,7 +115,7 @@ describe('Sessions (Mongos)', function() {
         expect(mongos.clusterTime).to.exist;
         expect(mongos.clusterTime).to.eql(clusterTime);
 
-        mongos.insert('test.test', [{ created: new Date() }], function(err) {
+        mongos.insert('test.test', [{ created: new Date() }], function (err) {
           expect(err).to.not.exist;
           expect(mongos.clusterTime).to.exist;
           expect(mongos.clusterTime).to.not.eql(clusterTime);
@@ -132,7 +132,7 @@ describe('Sessions (Mongos)', function() {
 
   it('should default `logicalSessionTimeoutMinutes` to `null`', {
     metadata: { requires: { topology: 'single' } },
-    test: function() {
+    test: function () {
       const mongos = new Mongos([test.server.address()]);
       expect(mongos.logicalSessionTimeoutMinutes).to.equal(null);
     }
@@ -140,7 +140,7 @@ describe('Sessions (Mongos)', function() {
 
   it('should track `logicalSessionTimeoutMinutes`', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       test.server.setMessageHandler(request => {
         request.reply(
           Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -172,7 +172,7 @@ describe('Sessions (Mongos)', function() {
     'should ensure that lsid is received within the query object of a find request when read preference is not primary',
     {
       metadata: { requires: { topology: 'single' } },
-      test: function(done) {
+      test: function (done) {
         const clusterTime = genClusterTime(Date.now());
         test.server.setMessageHandler(request => {
           const doc = request.document;

--- a/test/disabled/mongos_mocks/mixed_seed_list.test.js
+++ b/test/disabled/mongos_mocks/mixed_seed_list.test.js
@@ -8,7 +8,7 @@ const Logger = core.Logger;
 const Mongos = core.Mongos;
 const ObjectId = core.BSON.ObjectId;
 
-describe('Mongos Mixed Seed List (mocks)', function() {
+describe('Mongos Mixed Seed List (mocks)', function () {
   afterEach(() => mock.cleanup());
 
   it.skip('Should correctly print warning when non mongos proxy passed in seed list', {
@@ -19,7 +19,7 @@ describe('Mongos Mixed Seed List (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Contain mock server
       var mongos1 = null;
       var mongos2 = null;
@@ -42,7 +42,7 @@ describe('Mongos Mixed Seed List (mocks)', function() {
       var serverIsMaster = [Object.assign({}, defaultFields), Object.assign({}, defaultRSFields)];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         mongos1 = yield mock.createServer();
         mongos2 = yield mock.createServer();
 
@@ -74,7 +74,7 @@ describe('Mongos Mixed Seed List (mocks)', function() {
         });
 
         const logger = Logger.currentLogger();
-        Logger.setCurrentLogger(function(msg, state) {
+        Logger.setCurrentLogger(function (msg, state) {
           expect(state.type).to.equal('warn');
           expect(state.message).to.equal(
             `expected mongos proxy, but found replicaset member mongod for server ${mongos2.uri()}`
@@ -100,7 +100,7 @@ describe('Mongos Mixed Seed List (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Contain mock server
       var mongos1 = null;
       var mongos2 = null;
@@ -118,7 +118,7 @@ describe('Mongos Mixed Seed List (mocks)', function() {
       var serverIsMaster = [Object.assign({}, defaultRSFields), Object.assign({}, defaultRSFields)];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         mongos1 = yield mock.createServer();
         mongos2 = yield mock.createServer();
 
@@ -151,13 +151,13 @@ describe('Mongos Mixed Seed List (mocks)', function() {
 
         var warnings = [];
         var logger = Logger.currentLogger();
-        Logger.setCurrentLogger(function(msg, state) {
+        Logger.setCurrentLogger(function (msg, state) {
           console.log('pushed: ', state);
           expect(state.type).to.equal('warn');
           warnings.push(state);
         });
 
-        server.on('error', function() {
+        server.on('error', function () {
           Logger.setCurrentLogger(logger);
           var errors = [
             'expected mongos proxy, but found replicaset member mongod for server localhost:52002',

--- a/test/disabled/mongos_mocks/multiple_proxies.test.js
+++ b/test/disabled/mongos_mocks/multiple_proxies.test.js
@@ -6,7 +6,7 @@ const mock = require('mongodb-mock-server');
 const core = require('../../../../src/core');
 const Mongos = core.Mongos;
 
-describe('Mongos Multiple Proxies (mocks)', function() {
+describe('Mongos Multiple Proxies (mocks)', function () {
   afterEach(() => mock.cleanup());
 
   it('Should correctly load-balance the operations', {
@@ -17,7 +17,7 @@ describe('Mongos Multiple Proxies (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Contain mock server
       var mongos1 = null;
       var mongos2 = null;
@@ -30,7 +30,7 @@ describe('Mongos Multiple Proxies (mocks)', function() {
       // Primary server states
       var serverIsMaster = [Object.assign({}, defaultFields)];
       // Boot the mock
-      co(function*() {
+      co(function* () {
         mongos1 = yield mock.createServer();
         mongos2 = yield mock.createServer();
 
@@ -64,8 +64,8 @@ describe('Mongos Multiple Proxies (mocks)', function() {
         var lastPort;
 
         // Add event listeners
-        server.once('connect', function(_server) {
-          _server.insert('test.test', [{ created: new Date() }], function(err, r) {
+        server.once('connect', function (_server) {
+          _server.insert('test.test', [{ created: new Date() }], function (err, r) {
             expect(err).to.be.null;
             expect(r.connection.port).to.be.oneOf([mongos1.address().port, mongos2.address().port]);
             lastPort =
@@ -73,7 +73,7 @@ describe('Mongos Multiple Proxies (mocks)', function() {
                 ? mongos2.address().port
                 : mongos1.address().port;
 
-            _server.insert('test.test', [{ created: new Date() }], function(_err, _r) {
+            _server.insert('test.test', [{ created: new Date() }], function (_err, _r) {
               expect(_err).to.be.null;
               expect(_r.connection.port).to.equal(lastPort);
               lastPort =
@@ -81,7 +81,7 @@ describe('Mongos Multiple Proxies (mocks)', function() {
                   ? mongos2.address().port
                   : mongos1.address().port;
 
-              _server.insert('test.test', [{ created: new Date() }], function(__err, __r) {
+              _server.insert('test.test', [{ created: new Date() }], function (__err, __r) {
                 expect(__err).to.be.null;
                 expect(__r.connection.port).to.equal(lastPort);
 
@@ -106,7 +106,7 @@ describe('Mongos Multiple Proxies (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Default message fields
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         msg: 'isdbgrid'
@@ -115,7 +115,7 @@ describe('Mongos Multiple Proxies (mocks)', function() {
       // Primary server states
       var serverIsMaster = [Object.assign({}, defaultFields)];
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const mongos1 = yield mock.createServer();
         const mongos2 = yield mock.createServer();
 
@@ -149,12 +149,12 @@ describe('Mongos Multiple Proxies (mocks)', function() {
         });
 
         // Add event listeners
-        server.once('fullsetup', function() {
-          server.insert('test.test', [{ created: new Date() }], function(err, r) {
+        server.once('fullsetup', function () {
+          server.insert('test.test', [{ created: new Date() }], function (err, r) {
             expect(err).to.be.null;
             expect(r.connection.port).to.equal(mongos1.address().port);
 
-            server.insert('test.test', [{ created: new Date() }], function(_err, _r) {
+            server.insert('test.test', [{ created: new Date() }], function (_err, _r) {
               expect(_err).to.be.null;
               expect(_r.connection.port).to.equal(mongos1.address().port);
               server.destroy();
@@ -169,12 +169,12 @@ describe('Mongos Multiple Proxies (mocks)', function() {
               });
 
               // Add event listeners
-              server2.once('fullsetup', function() {
-                server2.insert('test.test', [{ created: new Date() }], function(__err, __r) {
+              server2.once('fullsetup', function () {
+                server2.insert('test.test', [{ created: new Date() }], function (__err, __r) {
                   expect(__err).to.be.null;
                   expect(__r.connection.port).to.equal(mongos1.address().port);
 
-                  server2.insert('test.test', [{ created: new Date() }], function(___err, ___r) {
+                  server2.insert('test.test', [{ created: new Date() }], function (___err, ___r) {
                     expect(___err).to.be.null;
                     expect(___r.connection.port).to.equal(mongos2.address().port);
 
@@ -185,7 +185,7 @@ describe('Mongos Multiple Proxies (mocks)', function() {
                 });
               });
 
-              setTimeout(function() {
+              setTimeout(function () {
                 server2.connect();
               }, 100);
             });

--- a/test/disabled/mongos_mocks/proxy_failover.test.js
+++ b/test/disabled/mongos_mocks/proxy_failover.test.js
@@ -6,7 +6,7 @@ const mock = require('mongodb-mock-server');
 const core = require('../../../../src/core');
 const Mongos = core.Mongos;
 
-describe('Mongos Proxy Failover (mocks)', function() {
+describe('Mongos Proxy Failover (mocks)', function () {
   afterEach(() => mock.cleanup());
 
   it('Should correctly failover due to proxy going away causing timeout', {
@@ -17,7 +17,7 @@ describe('Mongos Proxy Failover (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Default message fields
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         msg: 'isdbgrid'
@@ -26,7 +26,7 @@ describe('Mongos Proxy Failover (mocks)', function() {
       // Primary server states
       var serverIsMaster = [Object.assign({}, defaultFields)];
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const mongos1 = yield mock.createServer();
         const mongos2 = yield mock.createServer();
 
@@ -58,9 +58,9 @@ describe('Mongos Proxy Failover (mocks)', function() {
         });
 
         // Add event listeners
-        server.once('fullsetup', function() {
-          var intervalId = setInterval(function() {
-            server.insert('test.test', [{ created: new Date() }], function(err, r) {
+        server.once('fullsetup', function () {
+          var intervalId = setInterval(function () {
+            server.insert('test.test', [{ created: new Date() }], function (err, r) {
               // If we have a successful insert
               // validate that it's the expected proxy
               if (r) {
@@ -88,7 +88,7 @@ describe('Mongos Proxy Failover (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Current index for the ismaster
       var currentStep = 0;
 
@@ -100,7 +100,7 @@ describe('Mongos Proxy Failover (mocks)', function() {
       // Primary server states
       var serverIsMaster = [Object.assign({}, defaultFields)];
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const mongos1 = yield mock.createServer();
         const mongos2 = yield mock.createServer();
 
@@ -133,9 +133,9 @@ describe('Mongos Proxy Failover (mocks)', function() {
         });
 
         // Add event listeners
-        server.once('fullsetup', function() {
-          var intervalId = setInterval(function() {
-            server.insert('test.test', [{ created: new Date() }], function(err, r) {
+        server.once('fullsetup', function () {
+          var intervalId = setInterval(function () {
+            server.insert('test.test', [{ created: new Date() }], function (err, r) {
               // If we have a successful insert
               // validate that it's the expected proxy
               if (r) {
@@ -146,11 +146,11 @@ describe('Mongos Proxy Failover (mocks)', function() {
                 var proxies = {};
 
                 // Perform interval inserts waiting for both proxies to come back
-                var intervalId2 = setInterval(function() {
+                var intervalId2 = setInterval(function () {
                   // Bring back the missing proxy
                   if (currentStep === 0) currentStep = currentStep + 1;
                   // Perform inserts
-                  server.insert('test.test', [{ created: new Date() }], function(_err, _r) {
+                  server.insert('test.test', [{ created: new Date() }], function (_err, _r) {
                     if (_r) {
                       proxies[_r.connection.port] = true;
                     }
@@ -183,7 +183,7 @@ describe('Mongos Proxy Failover (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Current index for the ismaster
       var currentStep = 0;
 
@@ -195,7 +195,7 @@ describe('Mongos Proxy Failover (mocks)', function() {
       // Primary server states
       var serverIsMaster = [Object.assign({}, defaultFields)];
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const mongos1 = yield mock.createServer();
         const mongos2 = yield mock.createServer();
 
@@ -230,9 +230,9 @@ describe('Mongos Proxy Failover (mocks)', function() {
         });
 
         // Add event listeners
-        server.once('fullsetup', function() {
-          var intervalId = setInterval(function() {
-            server.insert('test.test', [{ created: new Date() }], function() {
+        server.once('fullsetup', function () {
+          var intervalId = setInterval(function () {
+            server.insert('test.test', [{ created: new Date() }], function () {
               if (intervalId === null) return;
               // Clear out the interval
               clearInterval(intervalId);
@@ -244,9 +244,9 @@ describe('Mongos Proxy Failover (mocks)', function() {
               var proxies = {};
 
               // Perform interval inserts waiting for both proxies to come back
-              var intervalId2 = setInterval(function() {
+              var intervalId2 = setInterval(function () {
                 // Perform inserts
-                server.insert('test.test', [{ created: new Date() }], function(_err, _r) {
+                server.insert('test.test', [{ created: new Date() }], function (_err, _r) {
                   if (intervalId2 === null) return;
                   if (_r) {
                     proxies[_r.connection.port] = true;

--- a/test/disabled/mongos_mocks/proxy_read_preference.test.js
+++ b/test/disabled/mongos_mocks/proxy_read_preference.test.js
@@ -8,7 +8,7 @@ const Mongos = core.Mongos;
 const ReadPreference = core.ReadPreference;
 const Long = core.BSON.Long;
 
-describe('Mongos Proxy Read Preference (mocks)', function() {
+describe('Mongos Proxy Read Preference (mocks)', function () {
   afterEach(() => mock.cleanup());
 
   it('Should correctly set query and readpreference field on wire protocol for 3.2', {
@@ -19,7 +19,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Default message fields
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         msg: 'isdbgrid'
@@ -30,7 +30,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
       // Received command on server
       var command = null;
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const mongos1 = yield mock.createServer();
 
         mongos1.setMessageHandler(request => {
@@ -61,7 +61,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
         });
 
         // Add event listeners
-        server.once('fullsetup', function() {
+        server.once('fullsetup', function () {
           // Execute find
           var cursor = server.cursor(
             'test.test',
@@ -74,7 +74,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
           );
 
           // Execute next
-          cursor._next(function(err, d) {
+          cursor._next(function (err, d) {
             expect(err).to.not.exist;
             expect(d).to.be.null;
             expect(command).to.have.keys(['$query', '$readPreference']);
@@ -99,7 +99,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Default message fields
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         msg: 'isdbgrid'
@@ -110,7 +110,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
       // Received command on server
       var command = null;
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const mongos1 = yield mock.createServer();
 
         mongos1.setMessageHandler(request => {
@@ -140,7 +140,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
         });
 
         // Add event listeners
-        server.once('fullsetup', function() {
+        server.once('fullsetup', function () {
           // Execute find
           var cursor = server.cursor(
             'test.test',
@@ -153,7 +153,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
           );
 
           // Execute next
-          cursor._next(function(err, d) {
+          cursor._next(function (err, d) {
             expect(err).to.be.null;
             expect(d).to.be.null;
             expect(command).to.have.keys(['$query', '$readPreference']);
@@ -179,7 +179,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Default message fields
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         msg: 'isdbgrid'
@@ -190,7 +190,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
       // Received command on server
       var command = null;
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const mongos1 = yield mock.createServer();
 
         mongos1.setMessageHandler(request => {
@@ -212,7 +212,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
         });
 
         // Add event listeners
-        server.once('connect', function() {
+        server.once('connect', function () {
           // Execute find
           var cursor = server.cursor(
             'test.test',
@@ -225,7 +225,7 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
           );
 
           // Execute next
-          cursor._next(function(err, d) {
+          cursor._next(function (err, d) {
             expect(err).to.be.null;
             expect(d).to.be.null;
             expect(command).to.have.keys(['$query', '$readPreference']);

--- a/test/disabled/mongos_mocks/single_proxy_connection.test.js
+++ b/test/disabled/mongos_mocks/single_proxy_connection.test.js
@@ -9,7 +9,7 @@ const Mongos = core.Mongos;
 const ObjectId = core.BSON.ObjectId;
 const Long = core.BSON.Long;
 
-describe('Mongos Single Proxy Connection (mocks)', function() {
+describe('Mongos Single Proxy Connection (mocks)', function () {
   afterEach(() => mock.cleanup());
 
   it('Should correctly timeout mongos socket operation and then correctly re-execute', {
@@ -20,7 +20,7 @@ describe('Mongos Single Proxy Connection (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Current index for the ismaster
       var currentStep = 0;
       // Primary stop responding
@@ -35,7 +35,7 @@ describe('Mongos Single Proxy Connection (mocks)', function() {
       var serverIsMaster = [Object.assign({}, defaultFields)];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const server = yield mock.createServer();
 
         server.setMessageHandler(request => {
@@ -59,7 +59,7 @@ describe('Mongos Single Proxy Connection (mocks)', function() {
         });
 
         // Start dropping the packets
-        setTimeout(function() {
+        setTimeout(function () {
           stopRespondingPrimary = true;
         }, 500);
 
@@ -75,10 +75,10 @@ describe('Mongos Single Proxy Connection (mocks)', function() {
         var finished = false;
 
         // Add event listeners
-        mongos.once('connect', function() {
+        mongos.once('connect', function () {
           // Run an interval
-          var intervalId = setInterval(function() {
-            mongos.insert('test.test', [{ created: new Date() }], function(err, r) {
+          var intervalId = setInterval(function () {
+            mongos.insert('test.test', [{ created: new Date() }], function (err, r) {
               if (r && !finished) {
                 finished = true;
                 clearInterval(intervalId);
@@ -104,7 +104,7 @@ describe('Mongos Single Proxy Connection (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Default message fields
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         msg: 'isdbgrid'
@@ -114,7 +114,7 @@ describe('Mongos Single Proxy Connection (mocks)', function() {
       var serverIsMaster = [Object.assign({}, defaultFields)];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const server = yield mock.createServer();
 
         server.setMessageHandler(request => {
@@ -156,7 +156,7 @@ describe('Mongos Single Proxy Connection (mocks)', function() {
         });
 
         // Add event listeners
-        mongos.once('connect', function() {
+        mongos.once('connect', function () {
           // Execute find
           var cursor = mongos.cursor('test.test', {
             find: 'test',
@@ -165,11 +165,11 @@ describe('Mongos Single Proxy Connection (mocks)', function() {
           });
 
           // Execute next
-          cursor._next(function(err, d) {
+          cursor._next(function (err, d) {
             expect(err).to.not.exist;
             expect(d).to.exist;
 
-            cursor._next(function(_err, _d) {
+            cursor._next(function (_err, _d) {
               expect(_err).to.not.exist;
               expect(_d).to.exist;
 

--- a/test/disabled/pool.test.js
+++ b/test/disabled/pool.test.js
@@ -7,7 +7,7 @@ const { MongoWriteConcernError } = require('../../../src/error');
 const sinon = require('sinon');
 
 const test = {};
-describe('Pool (unit)', function() {
+describe('Pool (unit)', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => {
     return mock.createServer().then(mockServer => {
@@ -15,7 +15,7 @@ describe('Pool (unit)', function() {
     });
   });
 
-  it('should throw a MongoWriteConcernError when a writeConcernError is present', function(done) {
+  it('should throw a MongoWriteConcernError when a writeConcernError is present', function (done) {
     test.server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
@@ -50,7 +50,7 @@ describe('Pool (unit)', function() {
     client.connect();
   });
 
-  it('should not allow overriding `slaveOk` when connected to a mongos', function(done) {
+  it('should not allow overriding `slaveOk` when connected to a mongos', function (done) {
     test.server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {

--- a/test/disabled/reconnect.test.js
+++ b/test/disabled/reconnect.test.js
@@ -2,8 +2,8 @@
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-describe('Reconnect', function() {
-  before(function() {
+describe('Reconnect', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -11,7 +11,7 @@ describe('Reconnect', function() {
   it.skip('Should correctly stop reconnection attempts after limit reached', {
     metadata: { requires: { topology: ['single'] }, ignore: { travis: true } },
 
-    test: function(done) {
+    test: function (done) {
       // Create a new db instance
       var configuration = this.configuration;
       var client = configuration.newClient(
@@ -24,15 +24,15 @@ describe('Reconnect', function() {
         }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Now let's stop the server
-        configuration.manager.stop().then(function() {
-          db.collection('waiting_for_reconnect').insert({ a: 1 }, function(err) {
+        configuration.manager.stop().then(function () {
+          db.collection('waiting_for_reconnect').insert({ a: 1 }, function (err) {
             test.ok(err != null);
             client.close();
 
-            configuration.manager.start().then(function() {
+            configuration.manager.start().then(function () {
               done();
             });
           });
@@ -45,7 +45,7 @@ describe('Reconnect', function() {
   it.skip('Should correctly recover when bufferMaxEntries: -1 and multiple restarts', {
     metadata: { requires: { topology: ['single'] }, ignore: { travis: true } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient('mongodb://localhost:27017/test', {
         db: { native_parser: true, bufferMaxEntries: -1 },
@@ -57,27 +57,27 @@ describe('Reconnect', function() {
         }
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var col = db.collection('t');
         var count = 1;
 
-        var execute = function() {
+        var execute = function () {
           if (!done) {
-            col.insertOne({ a: 1, count: count }, function(err) {
+            col.insertOne({ a: 1, count: count }, function (err) {
               test.equal(null, err);
               count = count + 1;
 
-              col.findOne({}, function(err) {
+              col.findOne({}, function (err) {
                 test.equal(null, err);
                 setTimeout(execute, 500);
               });
             });
           } else {
-            col.insertOne({ a: 1, count: count }, function(err) {
+            col.insertOne({ a: 1, count: count }, function (err) {
               test.equal(null, err);
 
-              col.findOne({}, function(err) {
+              col.findOne({}, function (err) {
                 test.equal(null, err);
                 client.close(done);
               });
@@ -90,7 +90,7 @@ describe('Reconnect', function() {
 
       var count = 2;
 
-      var restartServer = function() {
+      var restartServer = function () {
         if (count === 0) {
           done = true;
           return;
@@ -98,9 +98,9 @@ describe('Reconnect', function() {
 
         count = count - 1;
 
-        configuration.manager.stop().then(function() {
-          setTimeout(function() {
-            configuration.manager.start().then(function() {
+        configuration.manager.stop().then(function () {
+          setTimeout(function () {
+            configuration.manager.start().then(function () {
               setTimeout(restartServer, 1000);
             });
           }, 2000);

--- a/test/disabled/replset.test.js
+++ b/test/disabled/replset.test.js
@@ -9,25 +9,25 @@ const Server = core.Server;
 const ReplSet = core.ReplSet;
 const ReadPreference = core.ReadPreference;
 
-var restartAndDone = function(configuration, done) {
-  configuration.manager.restart(9, { waitMS: 2000 }).then(function() {
+var restartAndDone = function (configuration, done) {
+  configuration.manager.restart(9, { waitMS: 2000 }).then(function () {
     done();
   });
 };
 
-describe.skip('A replica set', function() {
+describe.skip('A replica set', function () {
   this.timeout(0);
 
   it('Discover arbiters', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       this.timeout(0);
       var self = this;
       var manager = this.configuration.manager;
 
       // Get the primary server
-      manager.primary().then(function(_manager) {
+      manager.primary().then(function (_manager) {
         // Enable connections accounting
         Connection.enableConnectionAccounting();
         // Attempt to connect
@@ -48,11 +48,11 @@ describe.skip('A replica set', function() {
           done();
         }
 
-        server.on('joined', function(_type) {
+        server.on('joined', function (_type) {
           if (_type === 'arbiter') {
             server.destroy();
 
-            setTimeout(function() {
+            setTimeout(function () {
               expect(Object.keys(Connection.connections()).length).to.equal(0);
               Connection.disableConnectionAccounting();
               done();
@@ -69,12 +69,12 @@ describe.skip('A replica set', function() {
   it('Discover passives', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var manager = this.configuration.manager;
 
       // Get the primary server
-      manager.primary().then(function(_manager) {
+      manager.primary().then(function (_manager) {
         // Enable connections accounting
         Connection.enableConnectionAccounting();
         // Attempt to connect
@@ -90,11 +90,11 @@ describe.skip('A replica set', function() {
           }
         );
 
-        server.on('joined', function(_type, _server) {
+        server.on('joined', function (_type, _server) {
           if (_type === 'secondary' && _server.lastIsMaster().passive) {
             server.destroy();
 
-            setTimeout(function() {
+            setTimeout(function () {
               expect(Object.keys(Connection.connections()).length).to.equal(0);
               Connection.disableConnectionAccounting();
               done();
@@ -111,12 +111,12 @@ describe.skip('A replica set', function() {
   it('Discover primary', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var manager = this.configuration.manager;
 
       // Get the primary server
-      manager.primary().then(function(_manager) {
+      manager.primary().then(function (_manager) {
         // Enable connections accounting
         Connection.enableConnectionAccounting();
         // Attempt to connect
@@ -132,11 +132,11 @@ describe.skip('A replica set', function() {
           }
         );
 
-        server.on('joined', function(_type) {
+        server.on('joined', function (_type) {
           if (_type === 'primary') {
             server.destroy();
 
-            setTimeout(function() {
+            setTimeout(function () {
               expect(Object.keys(Connection.connections()).length).to.equal(0);
               Connection.disableConnectionAccounting();
               done();
@@ -153,12 +153,12 @@ describe.skip('A replica set', function() {
   it('Discover secondaries', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var manager = this.configuration.manager;
 
       // Get the primary server
-      manager.primary().then(function(_manager) {
+      manager.primary().then(function (_manager) {
         // Enable connections accounting
         Connection.enableConnectionAccounting();
         // Attempt to connect
@@ -175,12 +175,12 @@ describe.skip('A replica set', function() {
         );
 
         var count = 0;
-        server.on('joined', function(_type) {
+        server.on('joined', function (_type) {
           if (_type === 'secondary') count = count + 1;
           if (count === 2) {
             server.destroy();
 
-            setTimeout(function() {
+            setTimeout(function () {
               expect(Object.keys(Connection.connections()).length).to.equal(0);
               Connection.disableConnectionAccounting();
               done();
@@ -197,14 +197,14 @@ describe.skip('A replica set', function() {
   it('Replica set discovery', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var manager = this.configuration.manager;
 
       // State
       var state = { primary: 1, secondary: 2, arbiter: 1, passive: 1 };
       // Get the primary server
-      manager.primary().then(function(_manager) {
+      manager.primary().then(function (_manager) {
         // Enable connections accounting
         Connection.enableConnectionAccounting();
         // Attempt to connect
@@ -220,7 +220,7 @@ describe.skip('A replica set', function() {
           }
         );
 
-        server.on('joined', function(_type, _server) {
+        server.on('joined', function (_type, _server) {
           if (_type === 'secondary' && _server.lastIsMaster().passive) {
             state.passive = state.passive - 1;
           } else {
@@ -235,7 +235,7 @@ describe.skip('A replica set', function() {
           ) {
             server.destroy();
 
-            setTimeout(function() {
+            setTimeout(function () {
               expect(Object.keys(Connection.connections()).length).to.equal(0);
               Connection.disableConnectionAccounting();
               done();
@@ -256,14 +256,14 @@ describe.skip('A replica set', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var manager = this.configuration.manager;
 
       // State
       var state = { primary: 1, secondary: 2, arbiter: 1, passive: 1 };
       // Get the primary server
-      manager.primary().then(function(_manager) {
+      manager.primary().then(function (_manager) {
         Connection.enableConnectionAccounting();
         // Attempt to connect
         var server = new ReplSet(
@@ -282,7 +282,7 @@ describe.skip('A replica set', function() {
           }
         );
 
-        server.on('joined', function(_type, _server) {
+        server.on('joined', function (_type, _server) {
           // console.log('======= joined :: ' + _type + ' :: ' + _server.name)
           if (_type === 'secondary' && _server.lastIsMaster().passive) {
             state.passive = state.passive - 1;
@@ -300,7 +300,7 @@ describe.skip('A replica set', function() {
           ) {
             server.destroy();
 
-            setTimeout(function() {
+            setTimeout(function () {
               expect(Object.keys(Connection.connections()).length).to.equal(0);
               Connection.disableConnectionAccounting();
               done();
@@ -321,7 +321,7 @@ describe.skip('A replica set', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var ServerManager = require('mongodb-topology-manager').Server,
         manager = this.configuration.manager;
@@ -329,13 +329,13 @@ describe.skip('A replica set', function() {
       // State
       var state = { primary: 1, secondary: 1, arbiter: 1, passive: 1 };
       // Get the primary server
-      manager.primary().then(function(primaryManager) {
+      manager.primary().then(function (primaryManager) {
         // Get the secondary server
-        manager.secondaries().then(function(managers) {
+        manager.secondaries().then(function (managers) {
           var serverManager = managers[0];
 
           // Stop the secondary
-          serverManager.stop().then(function() {
+          serverManager.stop().then(function () {
             // Start a new server manager
             var nonReplSetMember = new ServerManager('mongod', {
               bind_ip: serverManager.host,
@@ -344,7 +344,7 @@ describe.skip('A replica set', function() {
             });
 
             // Start a non replset member
-            nonReplSetMember.start().then(function() {
+            nonReplSetMember.start().then(function () {
               // console.log('------------------------ 4')
               var config = [
                 {
@@ -358,12 +358,12 @@ describe.skip('A replica set', function() {
               };
 
               // Wait for primary
-              manager.waitForPrimary().then(function() {
+              manager.waitForPrimary().then(function () {
                 // Enable connections accounting
                 Connection.enableConnectionAccounting();
                 // Attempt to connect
                 var replset = new ReplSet(config, options);
-                replset.on('joined', function(_type, _server) {
+                replset.on('joined', function (_type, _server) {
                   if (_type === 'secondary' && _server.lastIsMaster().passive) {
                     state.passive = state.passive - 1;
                   } else {
@@ -378,14 +378,14 @@ describe.skip('A replica set', function() {
                     state.passive === 0
                   ) {
                     replset.destroy();
-                    setTimeout(function() {
+                    setTimeout(function () {
                       expect(Object.keys(Connection.connections()).length).to.equal(0);
                       Connection.disableConnectionAccounting();
 
                       // Stop the normal server
-                      nonReplSetMember.stop().then(function() {
+                      nonReplSetMember.stop().then(function () {
                         // Restart the secondary server
-                        serverManager.start().then(function() {
+                        serverManager.start().then(function () {
                           restartAndDone(self.configuration, done);
                         });
                       });
@@ -411,14 +411,14 @@ describe.skip('A replica set', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var manager = this.configuration.manager;
 
       // Get the primary server
-      manager.primary().then(function(primaryServerManager) {
+      manager.primary().then(function (primaryServerManager) {
         // Get the secondary server
-        manager.secondaries().then(function(managers) {
+        manager.secondaries().then(function (managers) {
           var secondaryServerManager = managers[0];
 
           var config = [
@@ -438,13 +438,13 @@ describe.skip('A replica set', function() {
           // console.log('============================= 4')
           // Attempt to connect
           var server = new ReplSet(config, options);
-          server.on('fullsetup', function() {
+          server.on('fullsetup', function () {
             // console.log('------------------------------------------ 0')
             // Save number of secondaries
             var numberOfSecondaries = server.s.replicaSetState.secondaries.length;
 
             // Let's listen to changes
-            server.on('left', function(_t, _server) {
+            server.on('left', function (_t, _server) {
               if (_server.s.options.port === secondaryServerManager.options.port) {
                 expect(server.s.replicaSetState.primary).to.not.be.null;
                 expect(server.s.replicaSetState.secondaries.length).to.be.below(
@@ -453,7 +453,7 @@ describe.skip('A replica set', function() {
                 expect(server.s.replicaSetState.arbiters.length).to.equal(1);
                 server.destroy();
 
-                setTimeout(function() {
+                setTimeout(function () {
                   // console.log('=================== 0')
                   // console.dir(Object.keys(Connection.connections()))
                   expect(Object.keys(Connection.connections()).length).to.equal(0);
@@ -483,12 +483,12 @@ describe.skip('A replica set', function() {
   it('Should not leak any connections after hammering the replicaset with a mix of operations', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const manager = this.configuration.manager;
 
       // Get the primary server
-      manager.primary().then(function(_manager) {
+      manager.primary().then(function (_manager) {
         // Enable connections accounting
         Connection.enableConnectionAccounting();
         Server.enableServerAccounting();
@@ -516,7 +516,7 @@ describe.skip('A replica set', function() {
             Connection.disableConnectionAccounting();
             Server.disableServerAccounting();
 
-            setTimeout(function() {
+            setTimeout(function () {
               expect(Object.keys(Connection.connections()).length).to.equal(0);
               expect(Object.keys(Server.servers()).length).to.equal(0);
               done();
@@ -524,11 +524,11 @@ describe.skip('A replica set', function() {
           }
         }
 
-        server.on('connect', function(_server) {
+        server.on('connect', function (_server) {
           var insertcount = 10000;
           var querycount = 10000;
 
-          var insertCountDecrement = function() {
+          var insertCountDecrement = function () {
             insertcount = insertcount - 1;
 
             if (insertcount === 0) {
@@ -536,7 +536,7 @@ describe.skip('A replica set', function() {
             }
           };
 
-          var queryCountDecrement = function() {
+          var queryCountDecrement = function () {
             querycount = querycount - 1;
 
             if (querycount === 0) {

--- a/test/disabled/replset/auth.test.js
+++ b/test/disabled/replset/auth.test.js
@@ -6,7 +6,7 @@ const ReplSetFixture = require('../common').ReplSetFixture;
 const ReadPreference = require('../../../../src/core/topologies/read_preference');
 const MongoCredentials = require('../../../../src/core/auth/mongo_credentials').MongoCredentials;
 
-describe('Auth (ReplSet)', function() {
+describe('Auth (ReplSet)', function () {
   let test;
   before(() => (test = new ReplSetFixture()));
   afterEach(() => mock.cleanup());
@@ -19,7 +19,7 @@ describe('Auth (ReplSet)', function() {
     flush: () => {}
   };
 
-  it('should not stall on authentication when you are connected', function(done) {
+  it('should not stall on authentication when you are connected', function (done) {
     const credentials = new MongoCredentials({
       mechanism: 'default',
       source: 'db',

--- a/test/disabled/replset/compression.test.js
+++ b/test/disabled/replset/compression.test.js
@@ -5,13 +5,13 @@ const mock = require('mongodb-mock-server');
 const ReplSetFixture = require('../common').ReplSetFixture;
 const expect = require('chai').expect;
 
-describe('Compression (ReplSet)', function() {
+describe('Compression (ReplSet)', function () {
   let test;
   before(() => (test = new ReplSetFixture()));
   afterEach(() => mock.cleanup());
   beforeEach(() => test.setup());
 
-  it('should pass compression information to child server instances on connect', function(done) {
+  it('should pass compression information to child server instances on connect', function (done) {
     const compressionData = [];
     test.primaryServer.setMessageHandler(request => {
       const doc = request.document;

--- a/test/disabled/replset/read_preference.test.js
+++ b/test/disabled/replset/read_preference.test.js
@@ -8,7 +8,7 @@ const ReplSetFixture = require('../common').ReplSetFixture;
 const ReplSetState = require('../../../../src/core/topologies/replset_state');
 const MongoError = require('../../../../src').MongoError;
 
-describe('ReadPreference (ReplSet)', function() {
+describe('ReadPreference (ReplSet)', function () {
   let test;
   before(() => (test = new ReplSetFixture()));
   afterEach(() => mock.cleanup());
@@ -21,7 +21,7 @@ describe('ReadPreference (ReplSet)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const replSet = new ReplSet(
         [test.primaryServer.address(), test.firstSecondaryServer.address()],
         {
@@ -51,7 +51,7 @@ describe('ReadPreference (ReplSet)', function() {
     }
   });
 
-  it('should correctly sort servers by `lastIsMasterMS` during nearest selection', function() {
+  it('should correctly sort servers by `lastIsMasterMS` during nearest selection', function () {
     const state = new ReplSetState();
     const sampleData = [
       { type: 'RSPrimary', lastIsMasterMS: 5 },

--- a/test/disabled/replset/retryable_writes.test.js
+++ b/test/disabled/replset/retryable_writes.test.js
@@ -10,13 +10,13 @@ const ServerSessionPool = core.Sessions.ServerSessionPool;
 const ReplSet = core.ReplSet;
 
 const test = new ReplSetFixture();
-describe('Retryable Writes (ReplSet)', function() {
+describe('Retryable Writes (ReplSet)', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => test.setup({ ismaster: mock.DEFAULT_ISMASTER_36 }));
 
   it('should add `txnNumber` to write commands where `retryWrites` is true', {
     metadata: { requires: { topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       var replset = new ReplSet(
         [test.primaryServer.address(), test.firstSecondaryServer.address()],
         {
@@ -44,7 +44,7 @@ describe('Retryable Writes (ReplSet)', function() {
       });
 
       replset.on('all', () => {
-        replset.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+        replset.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function (
           err
         ) {
           expect(err).to.not.exist;
@@ -63,7 +63,7 @@ describe('Retryable Writes (ReplSet)', function() {
 
   it('should retry write commands where `retryWrites` is true, and not increment `txnNumber`', {
     metadata: { requires: { topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       var replset = new ReplSet(
         [test.primaryServer.address(), test.firstSecondaryServer.address()],
         {
@@ -99,7 +99,7 @@ describe('Retryable Writes (ReplSet)', function() {
       });
 
       replset.on('all', () => {
-        replset.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+        replset.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function (
           err
         ) {
           if (err) console.dir(err);
@@ -119,7 +119,7 @@ describe('Retryable Writes (ReplSet)', function() {
 
   it('should retry write commands where `retryWrites` is true, and there is a "not master" error', {
     metadata: { requires: { topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       var replset = new ReplSet(
         [test.primaryServer.address(), test.firstSecondaryServer.address()],
         {
@@ -155,7 +155,7 @@ describe('Retryable Writes (ReplSet)', function() {
       });
 
       replset.on('all', () => {
-        replset.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+        replset.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function (
           err
         ) {
           expect(err).to.not.exist;

--- a/test/disabled/replset/sessions.test.js
+++ b/test/disabled/replset/sessions.test.js
@@ -6,13 +6,13 @@ var expect = require('chai').expect,
   ReplSetFixture = require('../common').ReplSetFixture;
 
 const test = new ReplSetFixture();
-describe('Sessions (ReplSet)', function() {
+describe('Sessions (ReplSet)', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => test.setup({ ismaster: mock.DEFAULT_ISMASTER_36 }));
 
   it('should track the highest `clusterTime` seen in a replica set', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       const clusterTime = genClusterTime(Date.now()),
         futureClusterTime = genClusterTime(Date.now() + 10 * 60 * 1000);
 
@@ -44,7 +44,7 @@ describe('Sessions (ReplSet)', function() {
 
   it('should report the deployment clusterTime for Server topologies in a ReplSet topology', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       const clusterTime = genClusterTime(Date.now()),
         futureClusterTime = genClusterTime(Date.now() + 10 * 60 * 1000);
 
@@ -81,7 +81,7 @@ describe('Sessions (ReplSet)', function() {
 
   it('should set `logicalSessionTimeoutMinutes` to `null` if any incoming server is `null`', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       test.firstSecondaryStates[0].logicalSessionTimeoutMinutes = null;
 
       const replset = new ReplSet(
@@ -110,7 +110,7 @@ describe('Sessions (ReplSet)', function() {
     'should track `logicalSessionTimeoutMinutes` for replset topology, choosing the lowest value',
     {
       metadata: { requires: { topology: 'single' } },
-      test: function(done) {
+      test: function (done) {
         test.primaryStates[0].logicalSessionTimeoutMinutes = 426;
         test.firstSecondaryStates[0].logicalSessionTimeoutMinutes = 1;
         test.arbiterStates[0].logicalSessionTimeoutMinutes = 32;
@@ -140,7 +140,7 @@ describe('Sessions (ReplSet)', function() {
 
   it('should exclude arbiters when tracking `logicalSessionTimeoutMinutes`', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       test.arbiterServer.setMessageHandler(req => {
         const doc = req.document;
         if (doc.ismaster) {

--- a/test/disabled/replset/step_down.test.js
+++ b/test/disabled/replset/step_down.test.js
@@ -5,7 +5,7 @@ const ReplSet = require('../../../../src/core/topologies/replset');
 const mock = require('mongodb-mock-server');
 const ReplSetFixture = require('../common').ReplSetFixture;
 
-describe('Step Down (ReplSet)', function() {
+describe('Step Down (ReplSet)', function () {
   class MyFixture extends ReplSetFixture {
     constructor() {
       super();
@@ -102,7 +102,7 @@ describe('Step Down (ReplSet)', function() {
         topology: 'single'
       }
     },
-    test: function(done) {
+    test: function (done) {
       const replSet = makeReplicaSet();
 
       replSet.on('error', done);
@@ -113,7 +113,7 @@ describe('Step Down (ReplSet)', function() {
         };
 
         // Should successfully insert since we have a primary
-        replSet.insert('foo.bar', [{ a: 1 }], function(err, result) {
+        replSet.insert('foo.bar', [{ a: 1 }], function (err, result) {
           try {
             expect(err).to.not.exist;
             expect(result).to.exist;
@@ -124,7 +124,7 @@ describe('Step Down (ReplSet)', function() {
           test.nextState();
 
           // Should issue a "not master", since primary has stepped down
-          replSet.insert('foo.bar', [{ b: 2 }], function(err, result) {
+          replSet.insert('foo.bar', [{ b: 2 }], function (err, result) {
             try {
               expect(err).to.exist;
               expect(err.message).to.match(/not master/);
@@ -135,7 +135,7 @@ describe('Step Down (ReplSet)', function() {
 
             // Should issue a "no primary server found", as monitoring has not
             // found a new primary
-            replSet.insert('foo.bar', [{ b: 2 }], function(err, result) {
+            replSet.insert('foo.bar', [{ b: 2 }], function (err, result) {
               try {
                 expect(err).to.exist;
                 expect(err.message).to.match(/no primary server found/);
@@ -148,7 +148,7 @@ describe('Step Down (ReplSet)', function() {
 
               setTimeout(() => {
                 // Now that we have given time for SDAM, insert should succeed
-                replSet.insert('foo.bar', [{ c: 3 }], function(err, result) {
+                replSet.insert('foo.bar', [{ c: 3 }], function (err, result) {
                   try {
                     expect(err).to.not.exist;
                     expect(result).to.exist;
@@ -173,7 +173,7 @@ describe('Step Down (ReplSet)', function() {
         topology: 'single'
       }
     },
-    test: function(done) {
+    test: function (done) {
       const replSet = makeReplicaSet();
 
       replSet.on('error', done);

--- a/test/disabled/replset/transactions_feature_decoration.test.js
+++ b/test/disabled/replset/transactions_feature_decoration.test.js
@@ -9,7 +9,7 @@ const ReplSet = core.ReplSet;
 const ClientSession = core.Sessions.ClientSession;
 const ServerSessionPool = core.Sessions.ServerSessionPool;
 
-describe('Transaction Feature Decoration', function() {
+describe('Transaction Feature Decoration', function () {
   let test;
   const ns = 'db.foo';
   const noop = () => {};
@@ -74,7 +74,7 @@ describe('Transaction Feature Decoration', function() {
     .forEach(config => {
       it(config.description, {
         metadata: { requires: { topology: 'single', mongodb: '>=3.7.3' } },
-        test: function(done) {
+        test: function (done) {
           const replSet = new ReplSet(
             [test.primaryServer.address(), test.firstSecondaryServer.address()],
             {

--- a/test/disabled/replset/utils.test.js
+++ b/test/disabled/replset/utils.test.js
@@ -2,8 +2,8 @@
 const Timeout = require('../../../../src/core/topologies/shared').Timeout;
 const expect = require('chai').expect;
 
-describe('', function() {
-  it('should detect when a timer is finished running', function(done) {
+describe('', function () {
+  it('should detect when a timer is finished running', function (done) {
     let timeout;
     function timeoutHandler() {
       expect(timeout.isRunning()).to.be.false;

--- a/test/disabled/replset_connection.test.js
+++ b/test/disabled/replset_connection.test.js
@@ -3,16 +3,16 @@ var f = require('util').format;
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-var restartAndDone = function(configuration, done) {
+var restartAndDone = function (configuration, done) {
   var CoreServer = configuration.require.CoreServer,
     CoreConnection = configuration.require.CoreConnection;
 
-  setTimeout(function() {
+  setTimeout(function () {
     // Connection account tests
     CoreServer.disableServerAccounting();
     CoreConnection.disableConnectionAccounting();
 
-    configuration.manager.restart().then(function() {
+    configuration.manager.restart().then(function () {
       done();
     });
   }, 200);
@@ -20,10 +20,10 @@ var restartAndDone = function(configuration, done) {
 
 // NOTE: skipped for dubious benefit over SDAM unit tests, as well as the disruptive nature
 //       of starting and stopping the topology. Look into coverage benefits in the future.
-describe.skip('ReplSet (Connection)', function() {
-  before(function() {
+describe.skip('ReplSet (Connection)', function () {
+  before(function () {
     var configuration = this.configuration;
-    return setupDatabase(configuration).then(function() {
+    return setupDatabase(configuration).then(function () {
       return configuration.manager.restart();
     });
   });
@@ -31,7 +31,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should throw error due to mongos connection usage', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSet = configuration.require.ReplSet,
         Server = configuration.require.Server,
@@ -55,7 +55,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly handle error when no server up in replicaset', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -68,10 +68,10 @@ describe.skip('ReplSet (Connection)', function() {
         'mongodb://localhost:28390,localhost:28391,localhost:28392/test?replicaSet=rs',
         { w: 0 }
       );
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.ok(err != null);
 
-        setTimeout(function() {
+        setTimeout(function () {
           // Connection account tests
           test.equal(0, Object.keys(CoreConnection.connections()).length);
           test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -87,24 +87,24 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly connect with default replicaset', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Replset start port
-      configuration.manager.secondaries().then(function(managers) {
-        managers[0].stop().then(function() {
+      configuration.manager.secondaries().then(function (managers) {
+        managers[0].stop().then(function () {
           // Accounting tests
           CoreServer.enableServerAccounting();
           CoreConnection.enableConnectionAccounting();
 
           const client = configuration.newClient({}, { w: 0 });
-          client.connect(function(err, client) {
+          client.connect(function (err, client) {
             test.equal(null, err);
             client.close();
 
-            setTimeout(function() {
+            setTimeout(function () {
               restartAndDone(configuration, done);
             }, 1000);
           });
@@ -116,20 +116,20 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly connect with default replicaset and no setName specified', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Replset start port
-      configuration.manager.secondaries().then(function(managers) {
-        managers[0].stop().then(function() {
+      configuration.manager.secondaries().then(function (managers) {
+        managers[0].stop().then(function () {
           // Accounting tests
           CoreServer.enableServerAccounting();
           CoreConnection.enableConnectionAccounting();
 
           const client = configuration.newClient({}, { w: 0 });
-          client.connect(function(err, client) {
+          client.connect(function (err, client) {
             test.equal(null, err);
             client.close();
 
@@ -143,7 +143,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly connect with default replicaset and socket options set', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -156,7 +156,7 @@ describe.skip('ReplSet (Connection)', function() {
         { w: 0, keepAlive: true, keepAliveInitialDelay: 100 }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         // Get a connection
         var connection = client.topology.connections()[0];
@@ -171,7 +171,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should emit close no callback', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -181,17 +181,17 @@ describe.skip('ReplSet (Connection)', function() {
       CoreConnection.enableConnectionAccounting();
 
       const client = configuration.newClient({}, { w: 0 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var dbCloseCount = 0;
-        client.on('close', function() {
+        client.on('close', function () {
           ++dbCloseCount;
         });
 
         // Force a close on a socket
         client.close();
 
-        setTimeout(function() {
+        setTimeout(function () {
           // Connection account tests
           test.equal(0, Object.keys(CoreConnection.connections()).length);
           test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -208,7 +208,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should emit close with callback', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -218,16 +218,16 @@ describe.skip('ReplSet (Connection)', function() {
       CoreConnection.enableConnectionAccounting();
 
       const client = configuration.newClient({}, { w: 0 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var dbCloseCount = 0;
-        client.on('close', function() {
+        client.on('close', function () {
           ++dbCloseCount;
         });
 
-        client.close(function() {
+        client.close(function () {
           // Let all events fire.
-          setTimeout(function() {
+          setTimeout(function () {
             // Connection account tests
             test.equal(0, Object.keys(CoreConnection.connections()).length);
             test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -245,10 +245,10 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly pass error when wrong replicaSet', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient({}, { rs_name: 'wrong' });
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.notEqual(null, err);
         done();
       });
@@ -256,17 +256,17 @@ describe.skip('ReplSet (Connection)', function() {
   });
 
   var retries = 120;
-  var ensureConnection = function(configuration, numberOfTries, callback) {
+  var ensureConnection = function (configuration, numberOfTries, callback) {
     if (numberOfTries <= 0) {
       return callback(new Error('could not connect correctly'), null);
     }
 
     // Open the db
     const client = configuration.newClient({}, { w: 0, connectTimeoutMS: 1000 });
-    client.connect(function(err, client) {
+    client.connect(function (err, client) {
       if (err != null) {
         // Wait for a sec and retry
-        setTimeout(function() {
+        setTimeout(function () {
           numberOfTries = numberOfTries - 1;
           ensureConnection(configuration, numberOfTries, callback);
         }, 3000);
@@ -280,7 +280,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should connect with primary stepped down', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -292,13 +292,13 @@ describe.skip('ReplSet (Connection)', function() {
       // // Step down primary server
       configuration.manager
         .stepDownPrimary(false, { stepDownSecs: 1, force: true })
-        .then(function() {
+        .then(function () {
           // Wait for new primary to pop up
-          ensureConnection(configuration, retries, function(err) {
+          ensureConnection(configuration, retries, function (err) {
             test.equal(null, err);
 
             const client = configuration.newClient({}, { w: 0 });
-            client.connect(function(err, client) {
+            client.connect(function (err, client) {
               test.ok(err == null);
               // Get a connection
               var connection = client.topology.connections()[0];
@@ -316,24 +316,24 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should connect with third node killed', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Replset start port
-      configuration.manager.secondaries().then(function(managers) {
-        managers[0].stop().then(function() {
+      configuration.manager.secondaries().then(function (managers) {
+        managers[0].stop().then(function () {
           // Accounting tests
           CoreServer.enableServerAccounting();
           CoreConnection.enableConnectionAccounting();
 
           // Wait for new primary to pop up
-          ensureConnection(configuration, retries, function(err) {
+          ensureConnection(configuration, retries, function (err) {
             test.equal(null, err);
 
             const client = configuration.newClient({}, { w: 0 });
-            client.connect(function(err, client) {
+            client.connect(function (err, client) {
               test.ok(err == null);
               // Get a connection
               var connection = client.topology.connections()[0];
@@ -352,24 +352,24 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should connect with primary node killed', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Replset start port
-      configuration.manager.primary().then(function(primary) {
-        primary.stop().then(function() {
+      configuration.manager.primary().then(function (primary) {
+        primary.stop().then(function () {
           // Accounting tests
           CoreServer.enableServerAccounting();
           CoreConnection.enableConnectionAccounting();
 
           // Wait for new primary to pop up
-          ensureConnection(configuration, retries, function(err) {
+          ensureConnection(configuration, retries, function (err) {
             test.equal(null, err);
 
             const client = configuration.newClient({}, { w: 0 });
-            client.connect(function(err, client) {
+            client.connect(function (err, client) {
               test.ok(err == null);
               // Get a connection
               var connection = client.topology.connections()[0];
@@ -388,7 +388,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly emit open signal and full set signal', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -399,18 +399,18 @@ describe.skip('ReplSet (Connection)', function() {
       CoreConnection.enableConnectionAccounting();
 
       const client = configuration.newClient({}, { w: 0 });
-      client.once('open', function(_err) {
+      client.once('open', function (_err) {
         test.equal(null, _err);
         openCalled = true;
       });
 
-      client.once('fullsetup', function(client) {
+      client.once('fullsetup', function (client) {
         test.equal(true, openCalled);
 
         // Close and cleanup
         client.close();
 
-        setTimeout(function() {
+        setTimeout(function () {
           // Connection account tests
           test.equal(0, Object.keys(CoreConnection.connections()).length);
           test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -421,7 +421,7 @@ describe.skip('ReplSet (Connection)', function() {
         }, 200);
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -430,7 +430,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('ReplSet honors socketOptions options', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -449,7 +449,7 @@ describe.skip('ReplSet (Connection)', function() {
         }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         // Get a connection
         var connection = client.topology.connections()[0];
@@ -458,7 +458,7 @@ describe.skip('ReplSet (Connection)', function() {
         test.equal(false, connection.noDelay);
         client.close();
 
-        setTimeout(function() {
+        setTimeout(function () {
           // Connection account tests
           test.equal(0, Object.keys(CoreConnection.connections()).length);
           test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -474,7 +474,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should receive all events for primary and secondary leaving', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -485,11 +485,11 @@ describe.skip('ReplSet (Connection)', function() {
 
       // Connect to the replicaset
       const client = configuration.newClient({}, { w: 0 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // Kill the secondary
         // Replset start port
-        configuration.manager.secondaries().then(function(managers) {
-          managers[0].stop().then(function() {
+        configuration.manager.secondaries().then(function (managers) {
+          managers[0].stop().then(function () {
             test.equal(null, err);
             client.close();
 
@@ -503,7 +503,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should Fail due to bufferMaxEntries = 0 not causing any buffering', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -514,14 +514,16 @@ describe.skip('ReplSet (Connection)', function() {
 
       // Connect to the replicaset
       const client = configuration.newClient({}, { w: 1, bufferMaxEntries: 0 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         // Setup
-        client.topology.on('left', function(t) {
+        client.topology.on('left', function (t) {
           if (t === 'primary') {
             // Attempt an insert
-            db.collection('_should_fail_due_to_bufferMaxEntries_0').insert({ a: 1 }, function(err) {
+            db.collection('_should_fail_due_to_bufferMaxEntries_0').insert({ a: 1 }, function (
+              err
+            ) {
               test.ok(err != null);
               test.ok(err.message.indexOf('0') !== -1);
               client.close();
@@ -533,8 +535,8 @@ describe.skip('ReplSet (Connection)', function() {
 
         // Kill the secondary
         // Replset start port
-        configuration.manager.primary().then(function(primary) {
-          primary.stop().then(function() {
+        configuration.manager.primary().then(function (primary) {
+          primary.stop().then(function () {
             test.equal(null, err);
           });
         });
@@ -545,7 +547,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly connect to a replicaset with additional options', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const CoreServer = configuration.require.CoreServer;
       const CoreConnection = configuration.require.CoreConnection;
@@ -571,7 +573,7 @@ describe.skip('ReplSet (Connection)', function() {
         }
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
@@ -582,13 +584,13 @@ describe.skip('ReplSet (Connection)', function() {
           { a: 1 },
           { b: 1 },
           { upsert: true },
-          function(err, result) {
+          function (err, result) {
             test.equal(null, err);
             test.equal(1, result.result.n);
 
             client.close();
 
-            setTimeout(function() {
+            setTimeout(function () {
               // Connection account tests
               test.equal(0, Object.keys(CoreConnection.connections()).length);
               test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -606,7 +608,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly connect to a replicaset with readPreference set', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const CoreServer = configuration.require.CoreServer;
       const CoreConnection = configuration.require.CoreConnection;
@@ -626,15 +628,15 @@ describe.skip('ReplSet (Connection)', function() {
       CoreConnection.enableConnectionAccounting();
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
-        db.collection('test_collection').insert({ a: 1 }, function(err) {
+        db.collection('test_collection').insert({ a: 1 }, function (err) {
           test.equal(null, err);
 
           client.close();
 
-          setTimeout(function() {
+          setTimeout(function () {
             // Connection account tests
             test.equal(0, Object.keys(CoreConnection.connections()).length);
             test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -651,7 +653,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should give an error for non-existing servers', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = f(
         'mongodb://%s,%s/%s?replicaSet=%s&readPreference=%s',
@@ -663,7 +665,7 @@ describe.skip('ReplSet (Connection)', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.ok(err != null);
         done();
       });
@@ -675,7 +677,7 @@ describe.skip('ReplSet (Connection)', function() {
     {
       metadata: { requires: { topology: 'replicaset' } },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
         var mongo = configuration.require,
           GridStore = mongo.GridStore,
@@ -698,14 +700,14 @@ describe.skip('ReplSet (Connection)', function() {
         CoreConnection.enableConnectionAccounting();
 
         const client = configuration.newClient(url);
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(configuration.db);
           var gs = new GridStore(db, new ObjectId());
           test.equal('majority', gs.writeConcern.w);
           test.equal(5000, gs.writeConcern.wtimeout);
           client.close();
 
-          setTimeout(function() {
+          setTimeout(function () {
             // Connection account tests
             test.equal(0, Object.keys(CoreConnection.connections()).length);
             test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -722,7 +724,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should Correctly remove server going into recovery mode', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
@@ -733,12 +735,12 @@ describe.skip('ReplSet (Connection)', function() {
 
       // Open the db connection
       const client = configuration.newClient({}, { w: 1, socketTimeoutMS: 5000 });
-      client.on('fullsetup', function(client) {
+      client.on('fullsetup', function (client) {
         var db = client.db(configuration.db);
-        db.command({ ismaster: true }, function(err, result) {
+        db.command({ ismaster: true }, function (err, result) {
           // Filter out the secondaries
           var secondaries = [];
-          result.hosts.forEach(function(s) {
+          result.hosts.forEach(function (s) {
             if (result.primary !== s && result.arbiters.indexOf(s) === -1) secondaries.push(s);
           });
 
@@ -748,17 +750,17 @@ describe.skip('ReplSet (Connection)', function() {
           var client1 = configuration.newClient({}, { host, port, w: 1 });
           var finished = false;
 
-          client.topology.on('left', function(t) {
+          client.topology.on('left', function (t) {
             if (t === 'primary' && !finished) {
               finished = true;
               // Return to working state
-              client1.db('admin').command({ replSetMaintenance: 0 }, function(err) {
+              client1.db('admin').command({ replSetMaintenance: 0 }, function (err) {
                 test.equal(null, err);
                 client.close();
                 client1.close();
 
-                setTimeout(function() {
-                  setTimeout(function() {
+                setTimeout(function () {
+                  setTimeout(function () {
                     // Connection account tests
                     test.equal(0, Object.keys(CoreConnection.connections()).length);
                     test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -772,19 +774,19 @@ describe.skip('ReplSet (Connection)', function() {
             }
           });
 
-          client1.connect(function(err, client1) {
+          client1.connect(function (err, client1) {
             var db1 = client1.db(configuration.db);
             test.equal(null, err);
             global.debug = true;
 
-            db1.admin().command({ replSetMaintenance: 1 }, function(err) {
+            db1.admin().command({ replSetMaintenance: 1 }, function (err) {
               test.equal(null, err);
             });
           });
         });
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -793,7 +795,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should return single server direct connection when replicaSet not provided', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         Server = mongo.Server,
@@ -807,12 +809,12 @@ describe.skip('ReplSet (Connection)', function() {
       CoreConnection.enableConnectionAccounting();
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         test.ok(client.topology instanceof Server);
         client.close();
 
-        setTimeout(function() {
+        setTimeout(function () {
           // Connection account tests
           test.equal(0, Object.keys(CoreConnection.connections()).length);
           test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -826,21 +828,21 @@ describe.skip('ReplSet (Connection)', function() {
   });
 
   var waitForPrimary;
-  waitForPrimary = function(count, config, options, callback) {
+  waitForPrimary = function (count, config, options, callback) {
     var ReplSet = require('../../src/core').ReplSet;
     if (count === 0) return callback(new Error('could not connect'));
     // Attempt to connect
     var server = new ReplSet(config, options);
-    server.on('error', function(err) {
+    server.on('error', function (err) {
       test.equal(null, err);
       server.destroy();
 
-      setTimeout(function() {
+      setTimeout(function () {
         waitForPrimary(count - 1, config, options, callback);
       }, 1000);
     });
 
-    server.on('fullsetup', function() {
+    server.on('fullsetup', function () {
       server.destroy();
       callback();
     });
@@ -852,13 +854,13 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly connect to arbiter with single connection', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
       // Replset start port
-      configuration.manager.arbiters().then(function(managers) {
+      configuration.manager.arbiters().then(function (managers) {
         // Accounting tests
         CoreServer.enableServerAccounting();
         CoreConnection.enableConnectionAccounting();
@@ -868,15 +870,15 @@ describe.skip('ReplSet (Connection)', function() {
         var port = managers[0].port;
 
         var client = configuration.newClient({}, { host, port, w: 1 });
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(configuration.db);
           test.equal(null, err);
 
-          db.command({ ismaster: true }, function(err) {
+          db.command({ ismaster: true }, function (err) {
             test.equal(null, err);
 
             // Should fail
-            db.collection('t').insert({ a: 1 }, function(err) {
+            db.collection('t').insert({ a: 1 }, function (err) {
               test.ok(err != null);
               client.close();
               restartAndDone(configuration, done);
@@ -890,12 +892,12 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly connect to secondary with single connection', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var CoreServer = configuration.require.CoreServer,
         CoreConnection = configuration.require.CoreConnection;
 
-      configuration.manager.secondaries().then(function(managers) {
+      configuration.manager.secondaries().then(function (managers) {
         // Accounting tests
         CoreServer.enableServerAccounting();
         CoreConnection.enableConnectionAccounting();
@@ -905,11 +907,11 @@ describe.skip('ReplSet (Connection)', function() {
         var port = managers[0].port;
 
         var client = configuration.newClient({}, { host, port, w: 1 });
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(configuration.db);
           test.equal(null, err);
 
-          db.command({ ismaster: true }, function(err) {
+          db.command({ ismaster: true }, function (err) {
             test.equal(null, err);
             client.close();
             restartAndDone(configuration, done);
@@ -926,7 +928,7 @@ describe.skip('ReplSet (Connection)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSet = configuration.require.ReplSet,
         ServerManager = require('mongodb-topology-manager').Server,
@@ -934,7 +936,7 @@ describe.skip('ReplSet (Connection)', function() {
         CoreConnection = configuration.require.CoreConnection;
 
       // Get the primary server
-      configuration.manager.primary().then(function(primaryServerManager) {
+      configuration.manager.primary().then(function (primaryServerManager) {
         var nonReplSetMember = new ServerManager('mongod', {
           bind_ip: primaryServerManager.host,
           port: primaryServerManager.port,
@@ -942,13 +944,13 @@ describe.skip('ReplSet (Connection)', function() {
         });
 
         // Stop the primary
-        primaryServerManager.stop().then(function(err) {
+        primaryServerManager.stop().then(function (err) {
           test.equal(null, err);
 
-          nonReplSetMember.purge().then(function() {
+          nonReplSetMember.purge().then(function () {
             // Start a non replset member
-            nonReplSetMember.start().then(function() {
-              configuration.manager.waitForPrimary().then(function() {
+            nonReplSetMember.start().then(function () {
+              configuration.manager.waitForPrimary().then(function () {
                 var url = f(
                   'mongodb://localhost:%s,localhost:%s,localhost:%s/integration_test_?replicaSet=%s',
                   configuration.port,
@@ -963,13 +965,13 @@ describe.skip('ReplSet (Connection)', function() {
 
                 // Attempt to connect using MongoClient uri
                 const client = configuration.newClient(url);
-                client.connect(function(err, client) {
+                client.connect(function (err, client) {
                   test.equal(null, err);
                   test.ok(client.topology instanceof ReplSet);
                   client.close();
 
                   // Stop the normal server
-                  nonReplSetMember.stop().then(function() {
+                  nonReplSetMember.stop().then(function () {
                     restartAndDone(configuration, done);
                   });
                 });
@@ -984,7 +986,7 @@ describe.skip('ReplSet (Connection)', function() {
   it('Should correctly modify the server reconnectTries for all replset instances', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const CoreServer = configuration.require.CoreServer;
       const CoreConnection = configuration.require.CoreConnection;
@@ -1001,7 +1003,7 @@ describe.skip('ReplSet (Connection)', function() {
       CoreConnection.enableConnectionAccounting();
 
       const client = configuration.newClient(url, { reconnectTries: 10 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var servers = client.topology.s.coreTopology.s.replicaSetState.allServers();
@@ -1012,7 +1014,7 @@ describe.skip('ReplSet (Connection)', function() {
         // Destroy the pool
         client.close();
 
-        setTimeout(function() {
+        setTimeout(function () {
           // Connection account tests
           test.equal(0, Object.keys(CoreConnection.connections()).length);
           test.equal(0, Object.keys(CoreServer.servers()).length);
@@ -1030,7 +1032,7 @@ describe.skip('ReplSet (Connection)', function() {
     {
       metadata: { requires: { topology: 'replicaset' } },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
         var url = f(
           'mongodb://me:secret@localhost:%s,localhost:%s/integration_test_?replicaSet=%s',
@@ -1044,7 +1046,7 @@ describe.skip('ReplSet (Connection)', function() {
           bufferMaxEntries: 0
         });
 
-        client.connect(function(err) {
+        client.connect(function (err) {
           test.ok(err);
           test.ok(
             err.message.indexOf(

--- a/test/disabled/replset_failover.test.js
+++ b/test/disabled/replset_failover.test.js
@@ -5,18 +5,18 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const expect = require('chai').expect;
 
-var restartAndDone = function(configuration, done) {
-  configuration.manager.restart(9, { waitMS: 5000 }).then(function() {
+var restartAndDone = function (configuration, done) {
+  configuration.manager.restart(9, { waitMS: 5000 }).then(function () {
     done();
   });
 };
 
 // NOTE: skipped for dubious benefit over SDAM unit tests, as well as the disruptive nature
 //       of starting and stopping the topology. Look into coverage benefits in the future.
-describe.skip('ReplSet (Failover)', function() {
-  before(function() {
+describe.skip('ReplSet (Failover)', function () {
+  before(function () {
     var configuration = this.configuration;
-    return setupDatabase(configuration).then(function() {
+    return setupDatabase(configuration).then(function () {
       return configuration.manager.restart();
     });
   });
@@ -26,7 +26,7 @@ describe.skip('ReplSet (Failover)', function() {
     {
       metadata: { requires: { topology: 'replicaset' } },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
 
         // The state
@@ -35,10 +35,10 @@ describe.skip('ReplSet (Failover)', function() {
 
         // Get a new instance
         var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
 
-          client.topology.on('joined', function(t, d, s) {
+          client.topology.on('joined', function (t, d, s) {
             if (
               t === 'secondary' &&
               secondaryServerManager &&
@@ -49,9 +49,9 @@ describe.skip('ReplSet (Failover)', function() {
             }
           });
 
-          client.once('fullsetup', function() {
+          client.once('fullsetup', function () {
             // Get the secondary server
-            manager.secondaries().then(function(managers) {
+            manager.secondaries().then(function (managers) {
               secondaryServerManager = managers[0];
 
               // Remove the secondary server
@@ -61,8 +61,8 @@ describe.skip('ReplSet (Failover)', function() {
                   force: false,
                   skipWait: true
                 })
-                .then(function() {
-                  setTimeout(function() {
+                .then(function () {
+                  setTimeout(function () {
                     // Add a new member to the set
                     manager.addMember(secondaryServerManager, {
                       returnImmediately: false,
@@ -80,24 +80,24 @@ describe.skip('ReplSet (Failover)', function() {
   it('Should correctly handle primary stepDown', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       // The state
       var state = 0;
 
       var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // Wait for close event due to primary stepdown
-        client.topology.on('joined', function(t) {
+        client.topology.on('joined', function (t) {
           if (t === 'primary') state++;
         });
 
-        client.topology.on('left', function(t) {
+        client.topology.on('left', function (t) {
           if (t === 'primary') state++;
         });
 
         // Wait fo rthe test to be done
-        var interval = setInterval(function() {
+        var interval = setInterval(function () {
           if (state === 2) {
             clearInterval(interval);
             client.close();
@@ -105,10 +105,10 @@ describe.skip('ReplSet (Failover)', function() {
           }
         }, 500);
 
-        client.once('fullsetup', function() {
+        client.once('fullsetup', function () {
           configuration.manager
             .stepDownPrimary(false, { stepDownSecs: 1, force: true })
-            .then(function() {});
+            .then(function () {});
         });
       });
     }
@@ -117,7 +117,7 @@ describe.skip('ReplSet (Failover)', function() {
   it('Should correctly recover from secondary shutdowns', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReadPreference = configuration.require.ReadPreference;
 
@@ -127,27 +127,27 @@ describe.skip('ReplSet (Failover)', function() {
       var managers = null;
 
       // Wait for a second and shutdown secondaries
-      client.once('fullsetup', function() {
-        configuration.manager.secondaries().then(function(m) {
+      client.once('fullsetup', function () {
+        configuration.manager.secondaries().then(function (m) {
           managers = m;
 
           // Stop bot secondaries
           managers[0]
             .stop()
-            .then(function() {
+            .then(function () {
               return managers[1].stop();
             })
-            .then(function() {
+            .then(function () {
               // Start bot secondaries
               return managers[0].start();
             })
-            .then(function() {
+            .then(function () {
               managers[1].start();
             });
         });
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
         // The state
@@ -155,26 +155,26 @@ describe.skip('ReplSet (Failover)', function() {
         var joined = 0;
 
         // Wait for left events
-        client.topology.on('left', function(t, s) {
+        client.topology.on('left', function (t, s) {
           left[s.name] = { type: t, server: s };
 
           // Restart the servers
           if (Object.keys(left).length === 2) {
             client.topology.removeAllListeners('left');
             // Wait for close event due to primary stepdown
-            client.topology.on('joined', function(t, d, s) {
+            client.topology.on('joined', function (t, d, s) {
               if ('secondary' === t && left[s.name]) {
                 joined++;
               }
 
               if (joined >= Object.keys(left).length) {
-                db.collection('replset_insert0').insert({ a: 1 }, function(err) {
+                db.collection('replset_insert0').insert({ a: 1 }, function (err) {
                   test.equal(null, err);
 
                   db.command(
                     { ismaster: true },
                     { readPreference: new ReadPreference('secondary') },
-                    function(err) {
+                    function (err) {
                       test.equal(null, err);
                       client.close();
                       restartAndDone(configuration, done);
@@ -194,17 +194,17 @@ describe.skip('ReplSet (Failover)', function() {
     {
       metadata: { requires: { topology: 'replicaset' } },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
         var leftServer = null;
 
         // Get a new instance
         var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
 
           // Add event listeners
-          client.topology.on('joined', function(t, d, s) {
+          client.topology.on('joined', function (t, d, s) {
             if (
               t === 'primary' &&
               leftServer &&
@@ -215,8 +215,8 @@ describe.skip('ReplSet (Failover)', function() {
             }
           });
 
-          client.once('fullsetup', function() {
-            configuration.manager.secondaries().then(function(managers) {
+          client.once('fullsetup', function () {
+            configuration.manager.secondaries().then(function (managers) {
               leftServer = managers[0];
 
               // Remove the first secondary
@@ -226,7 +226,7 @@ describe.skip('ReplSet (Failover)', function() {
                   force: false,
                   skipWait: true
                 })
-                .then(function() {
+                .then(function () {
                   var config = JSON.parse(JSON.stringify(configuration.manager.configurations[0]));
                   var members = config.members;
                   // Update the right configuration
@@ -246,8 +246,8 @@ describe.skip('ReplSet (Failover)', function() {
                       returnImmediately: false,
                       force: false
                     })
-                    .then(function() {
-                      setTimeout(function() {
+                    .then(function () {
+                      setTimeout(function () {
                         managers[0].start();
                       }, 10000);
                     });
@@ -262,35 +262,35 @@ describe.skip('ReplSet (Failover)', function() {
   it('Should work correctly with inserts after bringing master back', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var manager = configuration.manager;
       const client = configuration.newClient({}, { w: 1, tag: 'Application', poolSize: 1 });
 
-      client.on('fullsetup', function(client) {
+      client.on('fullsetup', function (client) {
         var db = client.db(configuration.db);
         // Drop collection on replicaset
-        db.dropCollection('shouldWorkCorrectlyWithInserts', function(err) {
+        db.dropCollection('shouldWorkCorrectlyWithInserts', function (err) {
           test.equal(null, err);
           var collection = db.collection('shouldWorkCorrectlyWithInserts');
           // Insert a dummy document
-          collection.insert({ a: 20 }, { w: 'majority', wtimeout: 30000 }, function(err) {
+          collection.insert({ a: 20 }, { w: 'majority', wtimeout: 30000 }, function (err) {
             test.equal(null, err);
 
             // Execute a count
-            collection.count(function(err, c) {
+            collection.count(function (err, c) {
               test.equal(null, err);
               test.equal(1, c);
 
-              manager.primary().then(function(primary) {
-                primary.stop().then(function() {
+              manager.primary().then(function (primary) {
+                primary.stop().then(function () {
                   // Execute a set of inserts
                   function inserts(callback) {
                     var a = 30;
                     var totalCount = 5;
 
                     for (var i = 0; i < 5; i++) {
-                      collection.insert({ a: a }, { w: 2, wtimeout: 10000 }, function(err) {
+                      collection.insert({ a: a }, { w: 2, wtimeout: 10000 }, function (err) {
                         test.equal(null, err);
                         totalCount = totalCount - 1;
 
@@ -302,38 +302,38 @@ describe.skip('ReplSet (Failover)', function() {
                     }
                   }
 
-                  inserts(function(err) {
+                  inserts(function (err) {
                     test.equal(null, err);
                     // Restart the old master and wait for the sync to happen
-                    primary.start().then(function() {
+                    primary.start().then(function () {
                       // Contains the results
                       var results = [];
 
-                      collection.find().each(function(err, item) {
+                      collection.find().each(function (err, item) {
                         if (item == null) {
                           // Ensure we have the correct values
                           test.equal(6, results.length);
-                          [20, 30, 40, 50, 60, 70].forEach(function(a) {
+                          [20, 30, 40, 50, 60, 70].forEach(function (a) {
                             test.equal(
                               1,
-                              results.filter(function(element) {
+                              results.filter(function (element) {
                                 return element.a === a;
                               }).length
                             );
                           });
 
                           // Run second check
-                          collection.save({ a: 80 }, { w: 1 }, function(err) {
+                          collection.save({ a: 80 }, { w: 1 }, function (err) {
                             expect(err).to.not.exist;
 
-                            collection.find().toArray(function(err, items) {
+                            collection.find().toArray(function (err, items) {
                               expect(err).to.not.exist;
 
                               // Ensure we have the correct values
                               test.equal(7, items.length);
 
                               // Sort items by a
-                              items = items.sort(function(a, b) {
+                              items = items.sort(function (a, b) {
                                 return a.a > b.a;
                               });
                               // Test all items
@@ -361,7 +361,7 @@ describe.skip('ReplSet (Failover)', function() {
         });
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -370,7 +370,7 @@ describe.skip('ReplSet (Failover)', function() {
   it('Should correctly read from secondary even if primary is down', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -385,25 +385,25 @@ describe.skip('ReplSet (Failover)', function() {
         }
       );
 
-      client.on('fullsetup', function(client) {
+      client.on('fullsetup', function (client) {
         var p_db = client.db(configuration.db);
         var collection = p_db.collection('notempty');
 
         // Insert a document
-        collection.insert({ a: 1 }, { w: 2, wtimeout: 10000 }, function(err) {
+        collection.insert({ a: 1 }, { w: 2, wtimeout: 10000 }, function (err) {
           test.equal(null, err);
 
           // Run a simple query
-          collection.findOne(function(err, doc) {
+          collection.findOne(function (err, doc) {
             test.ok(err == null);
             test.ok(1, doc.a);
 
             // Shut down primary server
-            manager.primary().then(function(primary) {
+            manager.primary().then(function (primary) {
               // Stop the primary
-              primary.stop().then(function() {
+              primary.stop().then(function () {
                 // Run a simple query
-                collection.findOne(function(err, doc) {
+                collection.findOne(function (err, doc) {
                   // test.ok(Object.keys(replSet._state.secondaries).length > 0);
                   test.equal(null, err);
                   test.ok(doc != null);
@@ -417,7 +417,7 @@ describe.skip('ReplSet (Failover)', function() {
         });
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -426,7 +426,7 @@ describe.skip('ReplSet (Failover)', function() {
   it('shouldStillQuerySecondaryWhenNoPrimaryAvailable', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -451,25 +451,25 @@ describe.skip('ReplSet (Failover)', function() {
         }
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
-        db.collection('replicaset_readpref_test').insert({ testfield: 123 }, function(err) {
+        db.collection('replicaset_readpref_test').insert({ testfield: 123 }, function (err) {
           test.equal(null, err);
 
-          db.collection('replicaset_readpref_test').findOne({}, function(err, result) {
+          db.collection('replicaset_readpref_test').findOne({}, function (err, result) {
             test.equal(null, err);
             test.equal(result.testfield, 123);
 
             // wait five seconds, then kill 2 of the 3 nodes that are up.
-            setTimeout(function() {
-              manager.secondaries().then(function(secondaries) {
-                secondaries[0].stop().then(function() {
+            setTimeout(function () {
+              manager.secondaries().then(function (secondaries) {
+                secondaries[0].stop().then(function () {
                   // Shut down primary server
-                  manager.primary().then(function(primary) {
+                  manager.primary().then(function (primary) {
                     // Stop the primary
-                    primary.stop().then(function() {});
+                    primary.stop().then(function () {});
                   });
                 });
               });
@@ -477,7 +477,7 @@ describe.skip('ReplSet (Failover)', function() {
 
             // we should be able to continue querying for a full minute
             var counter = 0;
-            var intervalid = setInterval(function() {
+            var intervalid = setInterval(function () {
               if (counter++ >= 30) {
                 clearInterval(intervalid);
                 client.close();
@@ -487,7 +487,7 @@ describe.skip('ReplSet (Failover)', function() {
               db.collection('replicaset_readpref_test').findOne(
                 {},
                 { readPreference: ReadPreference.SECONDARY_PREFERRED },
-                function(err) {
+                function (err) {
                   test.equal(null, err);
                 }
               );
@@ -503,7 +503,7 @@ describe.skip('ReplSet (Failover)', function() {
     {
       metadata: { requires: { topology: 'replicaset' } },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
         var mongo = configuration.require,
           ReadPreference = mongo.ReadPreference;
@@ -519,15 +519,15 @@ describe.skip('ReplSet (Failover)', function() {
         );
 
         const client = configuration.newClient(url, { readPreference: ReadPreference.NEAREST });
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
           // Shut down primary server
-          manager.primary().then(function(primary) {
+          manager.primary().then(function (primary) {
             // Stop the primary
-            primary.stop().then(function() {
-              db.collection('notempty_does_not_exist', { strict: true }, function(err) {
+            primary.stop().then(function () {
+              db.collection('notempty_does_not_exist', { strict: true }, function (err) {
                 test.ok(err != null);
                 test.ok(err.message.indexOf('Currently in strict mode') !== -1);
 

--- a/test/disabled/replset_operations.test.js
+++ b/test/disabled/replset_operations.test.js
@@ -4,15 +4,15 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const expect = require('chai').expect;
 
-var restartAndDone = function(configuration, done) {
-  configuration.manager.restart().then(function() {
+var restartAndDone = function (configuration, done) {
+  configuration.manager.restart().then(function () {
     done();
   });
 };
 
 // TODO: Remove skips when NODE-1527 is resolved
-describe('ReplSet (Operations)', function() {
-  before(function() {
+describe('ReplSet (Operations)', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -30,7 +30,7 @@ describe('ReplSet (Operations)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
 
       // Create url
@@ -110,7 +110,7 @@ describe('ReplSet (Operations)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
 
         // Create url
@@ -139,10 +139,7 @@ describe('ReplSet (Operations)', function() {
               // Initialize the Ordered Batch
               const batch = col.initializeOrderedBulkOp();
               batch.insert({ a: 1 });
-              batch
-                .find({ a: 3 })
-                .upsert()
-                .updateOne({ a: 3, b: 1 });
+              batch.find({ a: 3 }).upsert().updateOne({ a: 3, b: 1 });
               batch.insert({ a: 1 });
               batch.insert({ a: 2 });
 
@@ -208,7 +205,7 @@ describe('ReplSet (Operations)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
 
       // Create url
@@ -237,10 +234,7 @@ describe('ReplSet (Operations)', function() {
             // Initialize the Ordered Batch
             const batch = col.initializeUnorderedBulkOp();
             batch.insert({ a: 1 });
-            batch
-              .find({ a: 3 })
-              .upsert()
-              .updateOne({ a: 3, b: 1 });
+            batch.find({ a: 3 }).upsert().updateOne({ a: 3, b: 1 });
             batch.insert({ a: 2 });
 
             // Execute the operations
@@ -293,7 +287,7 @@ describe('ReplSet (Operations)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
 
         // Create url
@@ -316,16 +310,13 @@ describe('ReplSet (Operations)', function() {
             expect(err).to.not.exist;
 
             // ensure index
-            col.ensureIndex({ a: 1 }, { unique: true }, function(err) {
+            col.ensureIndex({ a: 1 }, { unique: true }, function (err) {
               expect(err).to.not.exist;
 
               // Initialize the Ordered Batch
               var batch = col.initializeOrderedBulkOp();
               batch.insert({ a: 1 });
-              batch
-                .find({ a: 3 })
-                .upsert()
-                .updateOne({ a: 3, b: 1 });
+              batch.find({ a: 3 }).upsert().updateOne({ a: 3, b: 1 });
               batch.insert({ a: 1 });
               batch.insert({ a: 2 });
 
@@ -388,7 +379,7 @@ describe('ReplSet (Operations)', function() {
   it.skip('Should fail to do map reduce to out collection', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>1.7.6' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -404,7 +395,7 @@ describe('ReplSet (Operations)', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
@@ -415,15 +406,15 @@ describe('ReplSet (Operations)', function() {
         });
 
         // Parse version of server if available
-        db.admin().serverInfo(function(err) {
+        db.admin().serverInfo(function (err) {
           test.equal(null, err);
 
           // Map function
-          var map = function() {
+          var map = function () {
             emit(this.user_id, 1); // eslint-disable-line
           };
           // Reduce function
-          var reduce = function(/* k, vals */) {
+          var reduce = function (/* k, vals */) {
             return 1;
           };
 
@@ -432,7 +423,7 @@ describe('ReplSet (Operations)', function() {
             map,
             reduce,
             { out: { replace: 'replacethiscollection' }, readPreference: ReadPreference.SECONDARY },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               client.close(done);
             }
@@ -446,7 +437,7 @@ describe('ReplSet (Operations)', function() {
   it.skip('Should Correctly group using replicaset', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -464,7 +455,7 @@ describe('ReplSet (Operations)', function() {
       var manager = configuration.manager;
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
@@ -482,13 +473,13 @@ describe('ReplSet (Operations)', function() {
             { key: 3, x: 20 }
           ],
           configuration.writeConcernMax(),
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
             // Kill the primary
-            manager.primary().then(function(m) {
+            manager.primary().then(function (m) {
               // Stop the primary
-              m.stop().then(function() {
+              m.stop().then(function () {
                 // Do a collection find
                 collection.group(
                   ['key'],
@@ -498,7 +489,7 @@ describe('ReplSet (Operations)', function() {
                     memo.sum += record.x;
                   },
                   true,
-                  function(err, items) {
+                  function (err, items) {
                     test.equal(null, err);
                     test.equal(3, items.length);
                     client.close();
@@ -517,7 +508,7 @@ describe('ReplSet (Operations)', function() {
   it.skip('Should Correctly execute createIndex with secondary readPreference', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -533,7 +524,7 @@ describe('ReplSet (Operations)', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
@@ -543,7 +534,7 @@ describe('ReplSet (Operations)', function() {
           wtimeout: 10000
         });
 
-        collection.createIndexes([{ name: 'a_1', key: { a: 1 } }], function(err) {
+        collection.createIndexes([{ name: 'a_1', key: { a: 1 } }], function (err) {
           test.equal(null, err);
 
           client.close();

--- a/test/disabled/replset_read_preference.test.js
+++ b/test/disabled/replset_read_preference.test.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-var restartAndDone = function(done) {
+var restartAndDone = function (done) {
   done();
 };
 
@@ -18,15 +18,15 @@ function filterSecondaries(hosts, isMaster) {
 }
 
 // NOTE: skipped because they haven't worked in some time, need refactoring
-describe.skip('ReplSet (ReadPreference)', function() {
-  before(function() {
+describe.skip('ReplSet (ReadPreference)', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it('Should Correctly Pick lowest ping time', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -38,10 +38,10 @@ describe.skip('ReplSet (ReadPreference)', function() {
       );
 
       // Trigger test once whole set is up
-      client.on('fullsetup', function(client) {
+      client.on('fullsetup', function (client) {
         var db = client.db(configuration.db);
 
-        db.command({ ismaster: true }, function(err, result) {
+        db.command({ ismaster: true }, function (err, result) {
           test.equal(null, err);
 
           var time = 10;
@@ -52,7 +52,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
           // Sorted by time
           var byTime = [];
           byTime = client.topology.replset.getServers({ ignoreArbiters: true });
-          byTime.forEach(function(s) {
+          byTime.forEach(function (s) {
             s.lastIsMasterMS = time;
             time = time + 10;
           });
@@ -78,7 +78,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
           // var lastServer = null;
 
           // Pick the server
-          client.topology.replset.once('pickedServer', function(readPreference, server) {
+          client.topology.replset.once('pickedServer', function (readPreference, server) {
             test.equal(byTime[0].name, server.name);
           });
 
@@ -86,11 +86,11 @@ describe.skip('ReplSet (ReadPreference)', function() {
           db.collection('somecollection').findOne(
             {},
             { readPreference: new ReadPreference(ReadPreference.NEAREST) },
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Pick the server
-              client.topology.replset.once('pickedServer', function(readPreference, server) {
+              client.topology.replset.once('pickedServer', function (readPreference, server) {
                 test.ok(secondaries.indexOf(server.name) !== -1);
               });
 
@@ -98,11 +98,11 @@ describe.skip('ReplSet (ReadPreference)', function() {
               db.collection('somecollection').findOne(
                 {},
                 { readPreference: new ReadPreference(ReadPreference.SECONDARY) },
-                function(err) {
+                function (err) {
                   test.equal(null, err);
 
                   // Pick the server
-                  client.topology.replset.once('pickedServer', function(readPreference, server) {
+                  client.topology.replset.once('pickedServer', function (readPreference, server) {
                     test.ok(secondaries.indexOf(server.name) !== -1);
                   });
 
@@ -110,11 +110,11 @@ describe.skip('ReplSet (ReadPreference)', function() {
                   db.collection('somecollection').findOne(
                     {},
                     { readPreference: new ReadPreference(ReadPreference.SECONDARY_PREFERRED) },
-                    function(err) {
+                    function (err) {
                       test.equal(null, err);
 
                       // Pick the server
-                      client.topology.replset.once('pickedServer', function(
+                      client.topology.replset.once('pickedServer', function (
                         readPreference,
                         server
                       ) {
@@ -125,7 +125,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
                       db.collection('somecollection').findOne(
                         {},
                         { readPreference: new ReadPreference(ReadPreference.PRIMARY) },
-                        function(err) {
+                        function (err) {
                           test.equal(null, err);
 
                           // Close db
@@ -142,7 +142,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
         });
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -151,7 +151,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Should Correctly vary read server when using readpreference NEAREST', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -162,33 +162,33 @@ describe.skip('ReplSet (ReadPreference)', function() {
         { w: 1, readPreference: ReadPreference.NEAREST, debug: true }
       );
 
-      client.on('fullsetup', function() {
+      client.on('fullsetup', function () {
         var db = client.db(configuration.db);
         // Servers viewed
         var viewedServers = {};
 
         // Pick the server
-        client.topology.replset.once('pickedServer', function(readPreference, server) {
+        client.topology.replset.once('pickedServer', function (readPreference, server) {
           viewedServers[server.name] = server.name;
         });
 
-        db.collection('nearest_collection_test').findOne({ a: 1 }, function(err) {
+        db.collection('nearest_collection_test').findOne({ a: 1 }, function (err) {
           test.equal(null, err);
 
           // Pick the server
-          client.topology.replset.once('pickedServer', function(readPreference, server) {
+          client.topology.replset.once('pickedServer', function (readPreference, server) {
             viewedServers[server.name] = server.name;
           });
 
-          db.collection('nearest_collection_test').findOne({ a: 1 }, function(err) {
+          db.collection('nearest_collection_test').findOne({ a: 1 }, function (err) {
             test.equal(null, err);
 
             // Pick the server
-            client.topology.replset.once('pickedServer', function(readPreference, server) {
+            client.topology.replset.once('pickedServer', function (readPreference, server) {
               viewedServers[server.name] = server.name;
             });
 
-            db.collection('nearest_collection_test').findOne({ a: 1 }, function(err) {
+            db.collection('nearest_collection_test').findOne({ a: 1 }, function (err) {
               test.equal(null, err);
               test.ok(Object.keys(viewedServers).length > 1);
 
@@ -199,7 +199,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
         });
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -210,7 +210,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
     {
       metadata: { requires: { topology: 'replicaset' } },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
         var mongo = configuration.require,
           ReadPreference = mongo.ReadPreference;
@@ -221,39 +221,39 @@ describe.skip('ReplSet (ReadPreference)', function() {
           { w: 1, readPreference: ReadPreference.NEAREST, debug: true }
         );
 
-        client.on('fullsetup', function() {
+        client.on('fullsetup', function () {
           var db = client.db(configuration.db);
           // Servers viewed
           var viewedServers = {};
 
           // Pick the server
-          client.topology.replset.once('pickedServer', function(readPreference, server) {
+          client.topology.replset.once('pickedServer', function (readPreference, server) {
             viewedServers[server.name] = server.name;
           });
 
           db.collection('nearest_collection_test', {
             readPreference: 'nearest'
-          }).findOne({ a: 1 }, function(err) {
+          }).findOne({ a: 1 }, function (err) {
             test.equal(null, err);
 
             // Pick the server
-            client.topology.replset.once('pickedServer', function(readPreference, server) {
+            client.topology.replset.once('pickedServer', function (readPreference, server) {
               viewedServers[server.name] = server.name;
             });
 
             db.collection('nearest_collection_test', {
               readPreference: 'nearest'
-            }).findOne({ a: 1 }, function(err) {
+            }).findOne({ a: 1 }, function (err) {
               test.equal(null, err);
 
               // Pick the server
-              client.topology.replset.once('pickedServer', function(readPreference, server) {
+              client.topology.replset.once('pickedServer', function (readPreference, server) {
                 viewedServers[server.name] = server.name;
               });
 
               db.collection('nearest_collection_test', {
                 readPreference: 'nearest'
-              }).findOne({ a: 1 }, function(err) {
+              }).findOne({ a: 1 }, function (err) {
                 test.equal(null, err);
                 test.ok(Object.keys(viewedServers).length > 1);
 
@@ -264,7 +264,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
           });
         });
 
-        client.connect(function(err) {
+        client.connect(function (err) {
           test.equal(null, err);
         });
       }
@@ -274,7 +274,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('shouldCorrectlyReadFromGridstoreWithSecondaryReadPreference', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var GridStore = configuration.require.GridStore,
         ObjectId = configuration.require.ObjectId,
@@ -292,10 +292,10 @@ describe.skip('ReplSet (ReadPreference)', function() {
         }
       );
 
-      client.on('fullsetup', function() {
+      client.on('fullsetup', function () {
         var db = client.db(configuration.db);
 
-        db.command({ ismaster: true }, function(err, result) {
+        db.command({ ismaster: true }, function (err, result) {
           test.equal(null, err);
 
           var gridStore = new GridStore(db, id, 'w', { w: 4 });
@@ -305,28 +305,28 @@ describe.skip('ReplSet (ReadPreference)', function() {
           gridStore.chunkSize = 5000;
           var data = fs.readFileSync('./test/functional/data/test_gs_weird_bug.png');
 
-          gridStore.open(function(err, gridStore) {
+          gridStore.open(function (err, gridStore) {
             test.equal(null, err);
 
             // Write the file using write
-            gridStore.write(data, function(err) {
+            gridStore.write(data, function (err) {
               test.equal(null, err);
 
-              gridStore.close(function(err, doc) {
+              gridStore.close(function (err, doc) {
                 test.equal(null, err);
 
                 // Pick the server
-                client.topology.replset.once('pickedServer', function(readPreference, server) {
+                client.topology.replset.once('pickedServer', function (readPreference, server) {
                   test.ok(secondaries[server.name] != null);
                 });
 
                 // Read the file using readBuffer
                 new GridStore(db, doc._id, 'r', {
                   readPreference: ReadPreference.SECONDARY
-                }).open(function(err, gridStore) {
+                }).open(function (err, gridStore) {
                   test.equal(null, err);
 
-                  gridStore.read(function(err, data2) {
+                  gridStore.read(function (err, data2) {
                     test.equal(null, err);
                     test.equal(data.toString('base64'), data2.toString('base64'));
                     client.close();
@@ -339,7 +339,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
         });
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -348,7 +348,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Connection to replicaset with primary read preference', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -361,21 +361,21 @@ describe.skip('ReplSet (ReadPreference)', function() {
 
       // Logger.setLevel('info');
       // Trigger test once whole set is up
-      client.on('fullsetup', function(client) {
+      client.on('fullsetup', function (client) {
         var db = client.db(configuration.db);
 
-        db.command({ ismaster: true }, function(err, result) {
+        db.command({ ismaster: true }, function (err, result) {
           test.equal(null, err);
 
           // Pick the server
-          client.topology.replset.once('pickedServer', function(readPreference, server) {
+          client.topology.replset.once('pickedServer', function (readPreference, server) {
             test.equal(result.primary, server.name);
           });
 
           // Grab the collection
           var collection = db.collection('read_preference_replicaset_test_0');
           // Attempt to read (should fail due to the server not being a primary);
-          collection.find().toArray(function(err) {
+          collection.find().toArray(function (err) {
             test.equal(null, err);
             client.close();
             restartAndDone(done);
@@ -384,7 +384,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
       });
 
       // Connect to the db
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -393,7 +393,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Should Set read preference at collection level using collection method', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -401,16 +401,16 @@ describe.skip('ReplSet (ReadPreference)', function() {
       // Create db instance
       var client = configuration.newClient({}, { w: 0, debug: true });
       // Connect to the db
-      client.on('fullsetup', function(client) {
+      client.on('fullsetup', function (client) {
         var db = client.db(configuration.db);
-        db.command({ ismaster: true }, function(err, result) {
+        db.command({ ismaster: true }, function (err, result) {
           test.equal(null, err);
 
           // Filter out the secondaries
           var secondaries = filterSecondaries(result.hosts, result);
 
           // Pick the server
-          client.topology.replset.once('pickedServer', function(readPreference, server) {
+          client.topology.replset.once('pickedServer', function (readPreference, server) {
             test.ok(secondaries[server.name] != null);
           });
 
@@ -420,7 +420,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
           });
           // Attempt to read (should fail due to the server not being a primary);
           var cursor = collection.find();
-          cursor.toArray(function(err) {
+          cursor.toArray(function (err) {
             test.equal(null, err);
             test.equal(ReadPreference.SECONDARY, cursor.readPreference.preference);
             client.close();
@@ -430,7 +430,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
       });
 
       // Connect to the db
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -439,7 +439,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Should Set read preference at collection level using createCollection method', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -447,9 +447,9 @@ describe.skip('ReplSet (ReadPreference)', function() {
       // Create db instance
       var client = configuration.newClient({}, { w: 0, debug: true });
       // Connect to the db
-      client.on('fullsetup', function() {
+      client.on('fullsetup', function () {
         var db = client.db(configuration.db);
-        db.command({ ismaster: true }, function(err, result) {
+        db.command({ ismaster: true }, function (err, result) {
           // Filter out the secondaries
           var secondaries = filterSecondaries(result.hosts, result);
 
@@ -457,17 +457,17 @@ describe.skip('ReplSet (ReadPreference)', function() {
           db.createCollection(
             'read_preferences_all_levels_1',
             { readPreference: ReadPreference.SECONDARY },
-            function(err, collection) {
+            function (err, collection) {
               test.equal(null, err);
 
               // Pick the server
-              client.topology.replset.once('pickedServer', function(readPreference, server) {
+              client.topology.replset.once('pickedServer', function (readPreference, server) {
                 test.ok(secondaries[server.name] != null);
               });
 
               var cursor = collection.find();
               // Attempt to read (should fail due to the server not being a primary);
-              cursor.toArray(function(err) {
+              cursor.toArray(function (err) {
                 test.equal(null, err);
                 // Does not get called or we don't care
                 test.equal(ReadPreference.SECONDARY, cursor.readPreference.preference);
@@ -480,7 +480,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
       });
 
       // Connect to the db
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -489,7 +489,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Should Set read preference at cursor level', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -497,9 +497,9 @@ describe.skip('ReplSet (ReadPreference)', function() {
       // Create db instance
       var client = configuration.newClient({}, { w: 0, debug: true });
       // Connect to the db
-      client.on('fullsetup', function() {
+      client.on('fullsetup', function () {
         var db = client.db(configuration.db);
-        db.command({ ismaster: true }, function(err, result) {
+        db.command({ ismaster: true }, function (err, result) {
           // Filter out the secondaries
           var secondaries = filterSecondaries(result.hosts, result);
 
@@ -507,8 +507,8 @@ describe.skip('ReplSet (ReadPreference)', function() {
           var collection = db.collection('read_preferences_all_levels_1');
 
           // Pick the server
-          client.topology.replset.once('pickedServer', function() {
-            client.topology.replset.once('pickedServer', function(readPreference, server) {
+          client.topology.replset.once('pickedServer', function () {
+            client.topology.replset.once('pickedServer', function (readPreference, server) {
               test.ok(secondaries[server.name] != null);
             });
           });
@@ -517,7 +517,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
           collection
             .find()
             .setReadPreference(ReadPreference.SECONDARY)
-            .toArray(function(err) {
+            .toArray(function (err) {
               test.equal(null, err);
               client.close();
               restartAndDone(done);
@@ -526,7 +526,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
       });
 
       // Connect to the db
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -535,24 +535,24 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Attempt to change read preference at cursor level after object read legacy', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
 
       const client = configuration.newClient({}, { w: 0, debug: true });
       // Connect to the db
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Grab the collection
         var collection = db.collection('read_preferences_all_levels_2');
         // Insert a bunch of documents
-        collection.insert([{ a: 1 }, { b: 1 }, { c: 1 }], { w: 1 }, function(err) {
+        collection.insert([{ a: 1 }, { b: 1 }, { c: 1 }], { w: 1 }, function (err) {
           test.equal(null, err);
 
           // Set up cursor
           var cursor = collection.find().setReadPreference(ReadPreference.SECONDARY);
-          cursor.each(function(err, result) {
+          cursor.each(function (err, result) {
             if (result == null) {
               client.close();
               restartAndDone(done);
@@ -576,7 +576,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Set read preference at db level', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -587,14 +587,14 @@ describe.skip('ReplSet (ReadPreference)', function() {
       );
 
       // Connect to the db
-      client.on('fullsetup', function() {
+      client.on('fullsetup', function () {
         var db = client.db(configuration.db);
-        db.command({ ismaster: true }, function(err, result) {
+        db.command({ ismaster: true }, function (err, result) {
           // Filter out the secondaries
           var hosts = result.hosts.concat(result.passives || []);
           var secondaries = filterSecondaries(hosts, result);
 
-          client.topology.replset.once('pickedServer', function(readPreference, server) {
+          client.topology.replset.once('pickedServer', function (readPreference, server) {
             test.ok(secondaries[server.name] != null);
           });
 
@@ -602,7 +602,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
           var collection = db.collection('read_preferences_all_levels_2');
           // Attempt to read (should fail due to the server not being a primary);
           var cursor = collection.find();
-          cursor.toArray(function(err) {
+          cursor.toArray(function (err) {
             test.equal(null, err);
             // Does not get called or we don't care
             test.equal(ReadPreference.SECONDARY, cursor.readPreference.preference);
@@ -613,7 +613,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
       });
 
       // Connect to the db
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -622,7 +622,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Set read preference at collection level using collection method', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -630,13 +630,13 @@ describe.skip('ReplSet (ReadPreference)', function() {
       const client = configuration.newClient({}, { w: 0, debug: true, haInterval: 100 });
 
       // Connect to the db
-      client.on('fullsetup', function(client) {
+      client.on('fullsetup', function (client) {
         var db = client.db(configuration.db);
-        db.command({ ismaster: true }, function(err, result) {
+        db.command({ ismaster: true }, function (err, result) {
           // Filter out the secondaries
           var secondaries = filterSecondaries(result.hosts, result);
 
-          client.topology.replset.once('pickedServer', function(readPreference, server) {
+          client.topology.replset.once('pickedServer', function (readPreference, server) {
             test.ok(secondaries[server.name] != null);
           });
 
@@ -647,7 +647,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
 
           // Attempt to read (should fail due to the server not being a primary);
           var cursor = collection.find();
-          cursor.toArray(function(err) {
+          cursor.toArray(function (err) {
             test.equal(null, err);
             // Does not get called or we don't care
             test.equal(ReadPreference.SECONDARY, cursor.readPreference.preference);
@@ -658,7 +658,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
       });
 
       // Connect to the db
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -667,7 +667,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Ensure tag read goes only to the correct server', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -683,8 +683,8 @@ describe.skip('ReplSet (ReadPreference)', function() {
       );
 
       // Trigger test once whole set is up
-      client.on('fullsetup', function() {
-        client.topology.replset.once('pickedServer', function(readPreference) {
+      client.on('fullsetup', function () {
+        client.topology.replset.once('pickedServer', function (readPreference) {
           test.equal('secondary', readPreference.preference);
           test.equal('ny', readPreference.tags['loc']);
         });
@@ -693,14 +693,14 @@ describe.skip('ReplSet (ReadPreference)', function() {
           .db('local')
           .collection('system.replset')
           .find()
-          .toArray(function(err) {
+          .toArray(function (err) {
             test.equal(null, err);
             client.close();
             restartAndDone(done);
           });
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -709,7 +709,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Ensure tag read goes only to the correct servers using nearest', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -726,8 +726,8 @@ describe.skip('ReplSet (ReadPreference)', function() {
 
       var success = false;
       // Trigger test once whole set is up
-      client.on('fullsetup', function(client) {
-        client.topology.replset.once('pickedServer', function(readPreference, server) {
+      client.on('fullsetup', function (client) {
+        client.topology.replset.once('pickedServer', function (readPreference, server) {
           test.equal('ny', server.lastIsMaster().tags.loc);
           // Mark success
           success = true;
@@ -737,7 +737,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
           .db('local')
           .collection('system.replset')
           .find()
-          .toArray(function(err) {
+          .toArray(function (err) {
             test.equal(null, err);
             test.ok(success);
             client.close();
@@ -745,7 +745,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
           });
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -754,7 +754,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('Always uses primary readPreference for findAndModify', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         ReadPreference = mongo.ReadPreference;
@@ -770,16 +770,16 @@ describe.skip('ReplSet (ReadPreference)', function() {
       );
 
       // Trigger test once whole set is up
-      client.on('fullsetup', function(client) {
+      client.on('fullsetup', function (client) {
         var db = client.db(configuration.db);
-        db.collection('test').findAndModify({}, {}, { upsert: false }, function(err) {
+        db.collection('test').findAndModify({}, {}, { upsert: false }, function (err) {
           test.equal(null, err);
           client.close();
           restartAndDone(done);
         });
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -788,7 +788,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
   it('should correctly apply read preference for direct secondary connection', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var mongo = configuration.require,
         Server = mongo.Server,
@@ -802,17 +802,17 @@ describe.skip('ReplSet (ReadPreference)', function() {
         readPreference: ReadPreference.NEAREST
       });
 
-      client.on('fullsetup', function(client) {
+      client.on('fullsetup', function (client) {
         var db = client.db(configuration.db);
 
         db.collection('direct_secondary_read_test').insertMany(
           [{ a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }],
           configuration.writeConcernMax(),
-          function(err) {
+          function (err) {
             test.equal(null, err);
             client.close();
 
-            setTimeout(function() {
+            setTimeout(function () {
               var url = format(
                 'mongodb://localhost:%s/integration_test_?readPreference=nearest',
                 configuration.port + 1
@@ -820,12 +820,12 @@ describe.skip('ReplSet (ReadPreference)', function() {
 
               // Connect using the MongoClient
               const client2 = configuration.newClient(url);
-              client2.connect(url, function(err, client2) {
+              client2.connect(url, function (err, client2) {
                 test.equal(null, err);
                 var db = client2.db(configuration.db);
                 test.ok(client2.topology instanceof Server);
 
-                db.collection('direct_secondary_read_test').count(function(err, n) {
+                db.collection('direct_secondary_read_test').count(function (err, n) {
                   test.equal(null, err);
                   test.ok(n > 0);
 
@@ -838,7 +838,7 @@ describe.skip('ReplSet (ReadPreference)', function() {
         );
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }

--- a/test/disabled/rs_mocks/add_remove.test.js
+++ b/test/disabled/rs_mocks/add_remove.test.js
@@ -11,7 +11,7 @@ const ReplSet = core.ReplSet;
 const ObjectId = core.BSON.ObjectId;
 
 let test = {};
-describe('ReplSet Add Remove (mocks)', function() {
+describe('ReplSet Add Remove (mocks)', function () {
   beforeEach(() => {
     test.spy = new ConnectionSpy();
     Connection.enableConnectionAccounting(test.spy);
@@ -32,7 +32,7 @@ describe('ReplSet Add Remove (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var currentIsMasterIndex = 0;
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -116,7 +116,7 @@ describe('ReplSet Add Remove (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32003, 'localhost');
@@ -169,7 +169,7 @@ describe('ReplSet Add Remove (mocks)', function() {
         var secondaries = {};
         var arbiters = {};
 
-        server.on('joined', function(_type, _server) {
+        server.on('joined', function (_type, _server) {
           if (_type === 'arbiter') {
             arbiters[_server.name] = _server;
             // Flip the ismaster message
@@ -200,7 +200,7 @@ describe('ReplSet Add Remove (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var currentIsMasterIndex = 0;
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -292,34 +292,34 @@ describe('ReplSet Add Remove (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32003, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
 
-        primaryServer.setMessageHandler(function(request) {
+        primaryServer.setMessageHandler(function (request) {
           var doc = request.document;
           if (doc.ismaster) {
             request.reply(primary[currentIsMasterIndex]);
           }
         });
 
-        firstSecondaryServer.setMessageHandler(function(request) {
+        firstSecondaryServer.setMessageHandler(function (request) {
           var doc = request.document;
           if (doc.ismaster) {
             request.reply(firstSecondary[currentIsMasterIndex]);
           }
         });
 
-        secondSecondaryServer.setMessageHandler(function(request) {
+        secondSecondaryServer.setMessageHandler(function (request) {
           var doc = request.document;
           if (doc.ismaster) {
             request.reply(secondSecondary[currentIsMasterIndex]);
           }
         });
 
-        arbiterServer.setMessageHandler(function(request) {
+        arbiterServer.setMessageHandler(function (request) {
           var doc = request.document;
           if (doc.ismaster) {
             request.reply(arbiter[currentIsMasterIndex]);
@@ -345,7 +345,7 @@ describe('ReplSet Add Remove (mocks)', function() {
         // Joined
         var joined = 0;
 
-        server.on('joined', function() {
+        server.on('joined', function () {
           joined = joined + 1;
 
           // primary, secondary and arbiter have joined
@@ -363,7 +363,7 @@ describe('ReplSet Add Remove (mocks)', function() {
           }
         });
 
-        server.on('left', function(_type, _server) {
+        server.on('left', function (_type, _server) {
           if (_type === 'secondary' && _server.name === 'localhost:32003') {
             expect(server.s.replicaSetState.secondaries).to.have.length(1);
             expect(server.s.replicaSetState.secondaries[0].name).to.equal('localhost:32001');
@@ -392,7 +392,7 @@ describe('ReplSet Add Remove (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var currentIsMasterIndex = 0;
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -512,7 +512,7 @@ describe('ReplSet Add Remove (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32003, 'localhost');
@@ -562,7 +562,7 @@ describe('ReplSet Add Remove (mocks)', function() {
           }
         );
 
-        setTimeout(function() {
+        setTimeout(function () {
           expect(server.s.replicaSetState.set['localhost:32000'].type).to.equal('RSPrimary');
           expect(server.s.replicaSetState.set['localhost:32001'].type).to.equal('RSSecondary');
           expect(server.s.replicaSetState.set['localhost:32002'].type).to.equal('RSArbiter');
@@ -570,7 +570,7 @@ describe('ReplSet Add Remove (mocks)', function() {
           currentIsMasterIndex = currentIsMasterIndex + 1;
 
           // Wait for another sweep
-          setTimeout(function() {
+          setTimeout(function () {
             expect(server.s.replicaSetState.set['localhost:32000'].type).to.equal('RSPrimary');
             expect(server.s.replicaSetState.set['localhost:32001'].type).to.equal('RSSecondary');
             expect(server.s.replicaSetState.set['localhost:32002'].type).to.equal('RSArbiter');
@@ -580,12 +580,12 @@ describe('ReplSet Add Remove (mocks)', function() {
             expect(server.s.replicaSetState.primary).to.exist;
 
             // Ensure we have 4 interval ids and
-            var intervalIds = server.intervalIds.filter(function(x) {
+            var intervalIds = server.intervalIds.filter(function (x) {
               return x.__host !== undefined;
             });
 
             expect(intervalIds).to.have.length(4);
-            var hosts = intervalIds.map(function(x) {
+            var hosts = intervalIds.map(function (x) {
               return x.__host;
             });
 
@@ -599,7 +599,7 @@ describe('ReplSet Add Remove (mocks)', function() {
           }, 1000);
         }, 500);
 
-        server.on('left', function(_type, _server) {
+        server.on('left', function (_type, _server) {
           if (_type === 'secondary' && _server.name === 'localhost:32003') {
             expect(server.s.replicaSetState.secondaries).to.have.length(1);
             expect(server.s.replicaSetState.secondaries[0].name).to.equal('localhost:32001');
@@ -628,7 +628,7 @@ describe('ReplSet Add Remove (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var currentIsMasterIndex = 0;
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -712,7 +712,7 @@ describe('ReplSet Add Remove (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32003, 'localhost');
@@ -766,7 +766,7 @@ describe('ReplSet Add Remove (mocks)', function() {
         var arbiters = {};
         var allservers = {};
 
-        server.on('serverHeartbeatStarted', function(description) {
+        server.on('serverHeartbeatStarted', function (description) {
           allservers[description.connectionId] = true;
           if (allservers['localhost:32003']) {
             server.destroy();
@@ -774,7 +774,7 @@ describe('ReplSet Add Remove (mocks)', function() {
           }
         });
 
-        server.on('joined', function(_type, _server) {
+        server.on('joined', function (_type, _server) {
           if (_type === 'arbiter') {
             arbiters[_server.name] = _server;
             // Flip the ismaster message
@@ -790,8 +790,8 @@ describe('ReplSet Add Remove (mocks)', function() {
           }
         });
 
-        server.on('error', function() {});
-        server.on('connect', function() {
+        server.on('error', function () {});
+        server.on('connect', function () {
           server.__connected = true;
         });
 

--- a/test/disabled/rs_mocks/all_servers_close.test.js
+++ b/test/disabled/rs_mocks/all_servers_close.test.js
@@ -11,7 +11,7 @@ const ReplSet = core.ReplSet;
 const ObjectId = core.BSON.ObjectId;
 
 let test = {};
-describe('ReplSet All Servers Close (mocks)', function() {
+describe('ReplSet All Servers Close (mocks)', function () {
   beforeEach(() => {
     test.spy = new ConnectionSpy();
     Connection.enableConnectionAccounting(test.spy);
@@ -32,7 +32,7 @@ describe('ReplSet All Servers Close (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var die = false;
 
@@ -79,7 +79,7 @@ describe('ReplSet All Servers Close (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -137,15 +137,15 @@ describe('ReplSet All Servers Close (mocks)', function() {
           }
         );
 
-        server.on('connect', function(_server) {
-          setTimeout(function() {
+        server.on('connect', function (_server) {
+          setTimeout(function () {
             die = true;
 
-            setTimeout(function() {
+            setTimeout(function () {
               die = false;
 
-              setTimeout(function() {
-                _server.command('admin.$cmd', { ismaster: true }, function(err, r) {
+              setTimeout(function () {
+                _server.command('admin.$cmd', { ismaster: true }, function (err, r) {
                   expect(r).to.exist;
                   expect(err).to.be.null;
                   expect(_server.s.replicaSetState.primary).to.not.be.null;
@@ -176,7 +176,7 @@ describe('ReplSet All Servers Close (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var electionIds = [new ObjectId(), new ObjectId()];
         var die = false;
 
@@ -223,7 +223,7 @@ describe('ReplSet All Servers Close (mocks)', function() {
         ];
 
         // Boot the mock
-        co(function*() {
+        co(function* () {
           const primaryServer = yield mock.createServer(34000, 'localhost');
           const firstSecondaryServer = yield mock.createServer(34001, 'localhost');
           const arbiterServer = yield mock.createServer(34002, 'localhost');
@@ -277,20 +277,20 @@ describe('ReplSet All Servers Close (mocks)', function() {
             }
           );
 
-          server.on('connect', function() {
-            setTimeout(function() {
+          server.on('connect', function () {
+            setTimeout(function () {
               die = true;
 
-              var intervalId = setInterval(function() {
-                server.command('admin.$cmd', { ismaster: true }, function() {});
+              var intervalId = setInterval(function () {
+                server.command('admin.$cmd', { ismaster: true }, function () {});
               }, 500);
 
-              setTimeout(function() {
+              setTimeout(function () {
                 die = false;
-                setTimeout(function() {
+                setTimeout(function () {
                   clearInterval(intervalId);
 
-                  server.command('admin.$cmd', { ismaster: true }, function(err, r) {
+                  server.command('admin.$cmd', { ismaster: true }, function (err, r) {
                     expect(r).to.exist;
                     expect(err).to.be.null;
                     expect(server.s.replicaSetState.primary).to.not.be.null;

--- a/test/disabled/rs_mocks/connection.test.js
+++ b/test/disabled/rs_mocks/connection.test.js
@@ -10,7 +10,7 @@ const ReplSet = core.ReplSet;
 const ObjectId = core.BSON.ObjectId;
 
 let test = {};
-describe('ReplSet Connection Tests (mocks)', function() {
+describe('ReplSet Connection Tests (mocks)', function () {
   beforeEach(() => {
     test.spy = new ConnectionSpy();
     Connection.enableConnectionAccounting(test.spy);
@@ -31,7 +31,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
 
       // Default message fields
@@ -77,7 +77,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -119,7 +119,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
           }
         );
 
-        server.on('joined', function(_type) {
+        server.on('joined', function (_type) {
           if (_type === 'arbiter' || _type === 'secondary' || _type === 'primary') {
             if (
               server.s.replicaSetState.secondaries.length === 1 &&
@@ -156,7 +156,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var electionIds = [new ObjectId(), new ObjectId()];
         var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
           setName: 'rs',
@@ -200,7 +200,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         ];
 
         // Boot the mock
-        co(function*() {
+        co(function* () {
           const primaryServer = yield mock.createServer(32000, 'localhost');
           const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
           const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -235,7 +235,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
             size: 1
           });
 
-          server.on('joined', function(_type) {
+          server.on('joined', function (_type) {
             if (_type === 'arbiter' || _type === 'secondary' || _type === 'primary') {
               if (
                 server.s.replicaSetState.secondaries.length === 1 &&
@@ -271,7 +271,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -304,7 +304,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
 
@@ -356,12 +356,12 @@ describe('ReplSet Connection Tests (mocks)', function() {
         }
 
         // Joined
-        server.on('joined', function() {
+        server.on('joined', function () {
           numberOfEvents = numberOfEvents + 1;
           if (numberOfEvents === 3) validations();
         });
 
-        server.on('failed', function() {
+        server.on('failed', function () {
           numberOfEvents = numberOfEvents + 1;
           if (numberOfEvents === 3) validations();
         });
@@ -379,7 +379,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -401,7 +401,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
 
         firstSecondaryServer.setMessageHandler(request => {
@@ -427,7 +427,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
           }
         );
 
-        server.on('error', function() {
+        server.on('error', function () {
           server.destroy();
           done();
         });
@@ -447,7 +447,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var electionIds = [new ObjectId(), new ObjectId()];
         var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
           setName: 'rs',
@@ -480,7 +480,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         ];
 
         // Boot the mock
-        co(function*() {
+        co(function* () {
           const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
           const arbiterServer = yield mock.createServer(32002, 'localhost');
 
@@ -515,7 +515,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
             }
           );
 
-          server.on('joined', function() {
+          server.on('joined', function () {
             if (
               server.s.replicaSetState.secondaries.length === 1 &&
               server.s.replicaSetState.arbiters.length === 1
@@ -549,7 +549,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var electionIds = [new ObjectId(), new ObjectId()];
         var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
           setName: 'rs',
@@ -593,7 +593,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         ];
 
         // Boot the mock
-        co(function*() {
+        co(function* () {
           const primaryServer = yield mock.createServer(32000, 'localhost');
           const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
           const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -636,7 +636,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
             }
           );
 
-          server.on('joined', function(_type) {
+          server.on('joined', function (_type) {
             if (_type === 'arbiter' || _type === 'secondary' || _type === 'primary') {
               if (
                 server.s.replicaSetState.secondaries.length === 1 &&
@@ -672,7 +672,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -716,7 +716,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -758,13 +758,13 @@ describe('ReplSet Connection Tests (mocks)', function() {
           }
         );
 
-        server.on('error', function() {
+        server.on('error', function () {
           server.destroy();
           done();
         });
 
         // Gives proxies a chance to boot up
-        setTimeout(function() {
+        setTimeout(function () {
           server.connect();
         }, 100);
       });
@@ -779,7 +779,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -812,7 +812,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
 
@@ -845,7 +845,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
           }
         );
 
-        server.on('joined', function(_type) {
+        server.on('joined', function (_type) {
           if (_type === 'secondary' || _type === 'primary') {
             if (
               server.s.replicaSetState.secondaries.length === 1 &&
@@ -878,7 +878,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var electionIds = [new ObjectId(), new ObjectId()];
         var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
           setName: 'rs',
@@ -922,7 +922,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         ];
 
         // Boot the mock
-        co(function*() {
+        co(function* () {
           const primaryServer = yield mock.createServer(32000, 'localhost');
           const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
           const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -963,7 +963,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
             }
           );
 
-          server.on('joined', function(_type) {
+          server.on('joined', function (_type) {
             if (_type === 'arbiter' || _type === 'secondary' || _type === 'primary') {
               if (
                 server.s.replicaSetState.secondaries.length === 1 &&
@@ -999,7 +999,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -1030,7 +1030,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
 
@@ -1058,7 +1058,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         });
 
         server.on('error', done);
-        server.on('joined', function(_type) {
+        server.on('joined', function (_type) {
           if (_type === 'arbiter' || _type === 'secondary' || _type === 'primary') {
             if (
               server.s.replicaSetState.arbiters.length === 1 &&
@@ -1091,7 +1091,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var electionIds = [new ObjectId(), new ObjectId()];
         var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
           setName: 'rs',
@@ -1135,7 +1135,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         ];
 
         // Boot the mock
-        co(function*() {
+        co(function* () {
           const primaryServer = yield mock.createServer(32000, 'localhost');
           const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
           const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -1170,15 +1170,15 @@ describe('ReplSet Connection Tests (mocks)', function() {
             size: 1
           });
 
-          server.on('fullsetup', function() {
+          server.on('fullsetup', function () {
             server.__fullsetup = true;
           });
 
-          server.on('connect', function() {
+          server.on('connect', function () {
             server.__connected = true;
           });
 
-          server.on('all', function() {
+          server.on('all', function () {
             expect(server.__connected).to.be.true;
             expect(server.__fullsetup).to.be.true;
 
@@ -1202,7 +1202,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var electionIds = [new ObjectId(), new ObjectId()];
         var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
           setName: 'rs',
@@ -1235,7 +1235,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
         ];
 
         // Boot the mock
-        co(function*() {
+        co(function* () {
           const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
           const arbiterServer = yield mock.createServer(32002, 'localhost');
 
@@ -1270,7 +1270,7 @@ describe('ReplSet Connection Tests (mocks)', function() {
             }
           );
 
-          server.on('connect', function() {
+          server.on('connect', function () {
             var result = server.lastIsMaster();
             expect(result).to.exist;
 

--- a/test/disabled/rs_mocks/failover.test.js
+++ b/test/disabled/rs_mocks/failover.test.js
@@ -11,7 +11,7 @@ const ReplSet = core.ReplSet;
 const ObjectId = core.BSON.ObjectId;
 
 let test = {};
-describe('ReplSet Failover (mocks)', function() {
+describe('ReplSet Failover (mocks)', function () {
   beforeEach(() => {
     test.spy = new ConnectionSpy();
     Connection.enableConnectionAccounting(test.spy);
@@ -32,7 +32,7 @@ describe('ReplSet Failover (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var currentIsMasterIndex = 0;
       var electionIds = [new ObjectId(0), new ObjectId(1)];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -125,7 +125,7 @@ describe('ReplSet Failover (mocks)', function() {
       var die = false;
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -181,11 +181,11 @@ describe('ReplSet Failover (mocks)', function() {
 
         Server.enableServerAccounting();
 
-        server.on('connect', function() {
+        server.on('connect', function () {
           server.__connected = true;
 
           // Perform the two steps
-          setTimeout(function() {
+          setTimeout(function () {
             die = true;
             currentIsMasterIndex = currentIsMasterIndex + 1;
 
@@ -193,7 +193,7 @@ describe('ReplSet Failover (mocks)', function() {
             var joinedEvents = 0;
 
             // Add listener
-            server.on('joined', function(_type, _server) {
+            server.on('joined', function (_type, _server) {
               if (_type === 'secondary' && _server.name === 'localhost:32000') {
                 joinedEvents = joinedEvents + 1;
               } else if (_type === 'primary' && _server.name === 'localhost:32001') {
@@ -218,7 +218,7 @@ describe('ReplSet Failover (mocks)', function() {
               }
             });
 
-            setTimeout(function() {
+            setTimeout(function () {
               die = false;
               currentIsMasterIndex = currentIsMasterIndex + 1;
             }, 500);
@@ -239,7 +239,7 @@ describe('ReplSet Failover (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var currentIsMasterIndex = 0;
       var electionIds = [new ObjectId(0), new ObjectId(1)];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -332,7 +332,7 @@ describe('ReplSet Failover (mocks)', function() {
       var die = false;
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -388,21 +388,21 @@ describe('ReplSet Failover (mocks)', function() {
 
         Server.enableServerAccounting();
 
-        server.on('connect', function() {
+        server.on('connect', function () {
           server.__connected = true;
 
           // Perform the two steps
-          setTimeout(function() {
+          setTimeout(function () {
             die = true;
             currentIsMasterIndex = currentIsMasterIndex + 1;
 
-            server.on('reconnect', function() {
+            server.on('reconnect', function () {
               server.destroy();
               Server.disableServerAccounting();
               done();
             });
 
-            setTimeout(function() {
+            setTimeout(function () {
               die = false;
               currentIsMasterIndex = currentIsMasterIndex + 1;
             }, 500);

--- a/test/disabled/rs_mocks/maintanance_mode.test.js
+++ b/test/disabled/rs_mocks/maintanance_mode.test.js
@@ -10,7 +10,7 @@ const ReplSet = core.ReplSet;
 const ObjectId = core.BSON.ObjectId;
 
 let test = {};
-describe('ReplSet Maintenance Mode (mocks)', function() {
+describe('ReplSet Maintenance Mode (mocks)', function () {
   beforeEach(() => {
     test.spy = new ConnectionSpy();
     Connection.enableConnectionAccounting(test.spy);
@@ -31,7 +31,7 @@ describe('ReplSet Maintenance Mode (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var currentIsMasterIndex = 0;
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -115,7 +115,7 @@ describe('ReplSet Maintenance Mode (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32003, 'localhost');
@@ -168,7 +168,7 @@ describe('ReplSet Maintenance Mode (mocks)', function() {
         // Joined
         var joined = 0;
 
-        server.on('joined', function() {
+        server.on('joined', function () {
           joined = joined + 1;
 
           // primary, secondary and arbiter have joined
@@ -188,7 +188,7 @@ describe('ReplSet Maintenance Mode (mocks)', function() {
           }
         });
 
-        server.on('left', function(_type, _server) {
+        server.on('left', function (_type, _server) {
           if (_type === 'secondary' && _server.name === 'localhost:32003') {
             server.destroy();
             done();

--- a/test/disabled/rs_mocks/monitoring.test.js
+++ b/test/disabled/rs_mocks/monitoring.test.js
@@ -9,12 +9,12 @@ const Connection = core.Connection;
 const ReplSet = core.ReplSet;
 const ObjectId = core.BSON.ObjectId;
 
-var delay = function(timeout) {
+var delay = function (timeout) {
   return new Promise(resolve => setTimeout(() => resolve(), timeout));
 };
 
 let test = {};
-describe('ReplSet Monitoring (mocks)', function() {
+describe('ReplSet Monitoring (mocks)', function () {
   beforeEach(() => {
     test.spy = new ConnectionSpy();
     Connection.enableConnectionAccounting(test.spy);
@@ -37,7 +37,7 @@ describe('ReplSet Monitoring (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         // NOTE: skipped because we now force close connections in these situations
         var electionIds = [new ObjectId(), new ObjectId()];
         var currentIsMasterState = 0;
@@ -103,7 +103,7 @@ describe('ReplSet Monitoring (mocks)', function() {
         var leftPrimaries = {};
 
         // Boot the mock
-        co(function*() {
+        co(function* () {
           const primaryServer = yield mock.createServer(32000, 'localhost');
           const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
           const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -160,7 +160,7 @@ describe('ReplSet Monitoring (mocks)', function() {
           });
 
           // Start dropping the packets
-          setTimeout(function() {
+          setTimeout(function () {
             stopRespondingPrimary = true;
             currentIsMasterState = 1;
           }, 500);
@@ -182,11 +182,11 @@ describe('ReplSet Monitoring (mocks)', function() {
           );
 
           // Add event listeners
-          server.on('connect', function(_server) {
+          server.on('connect', function (_server) {
             // Set up a write
             function schedule() {
-              setTimeout(function() {
-                _server.insert('test.test', [{ created: new Date() }], function(err, r) {
+              setTimeout(function () {
+                _server.insert('test.test', [{ created: new Date() }], function (err, r) {
                   // Did we switch servers
                   if (r && r.connection.port === 32001) {
                     expect(stopRespondingPrimary).to.be.true;
@@ -214,12 +214,12 @@ describe('ReplSet Monitoring (mocks)', function() {
           });
 
           server.on('error', done);
-          server.on('joined', function(type, _server) {
+          server.on('joined', function (type, _server) {
             if (type === 'primary') joinedPrimaries[_server.name] = 1;
             if (type === 'secondary') joinedSecondaries[_server.name] = 1;
           });
 
-          server.on('left', function(type, _server) {
+          server.on('left', function (type, _server) {
             if (type === 'primary') leftPrimaries[_server.name] = 1;
           });
 
@@ -237,7 +237,7 @@ describe('ReplSet Monitoring (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var currentIsMasterState = 0;
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -296,7 +296,7 @@ describe('ReplSet Monitoring (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -339,8 +339,8 @@ describe('ReplSet Monitoring (mocks)', function() {
         );
 
         // Add event listeners
-        server.on('connect', function(_server) {
-          setTimeout(function() {
+        server.on('connect', function (_server) {
+          setTimeout(function () {
             expect(_server.intervalIds.length).to.be.greaterThan(1);
 
             server.destroy();

--- a/test/disabled/rs_mocks/no_primary_found.test.js
+++ b/test/disabled/rs_mocks/no_primary_found.test.js
@@ -9,7 +9,7 @@ const ReplSet = core.ReplSet;
 const ObjectId = core.BSON.ObjectId;
 
 let test = {};
-describe('ReplSet No Primary Found (mocks)', function() {
+describe('ReplSet No Primary Found (mocks)', function () {
   beforeEach(() => {
     test.spy = new ConnectionSpy();
     Connection.enableConnectionAccounting(test.spy);
@@ -30,7 +30,7 @@ describe('ReplSet No Primary Found (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
         setVersion: 1,
@@ -81,7 +81,7 @@ describe('ReplSet No Primary Found (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -129,7 +129,7 @@ describe('ReplSet No Primary Found (mocks)', function() {
         });
 
         // Add event listeners
-        server.on('connect', function() {
+        server.on('connect', function () {
           server.destroy();
           done();
         });

--- a/test/disabled/rs_mocks/operation.test.js
+++ b/test/disabled/rs_mocks/operation.test.js
@@ -10,7 +10,7 @@ const ObjectId = core.BSON.ObjectId;
 const ReadPreference = core.ReadPreference;
 
 let test = {};
-describe('ReplSet Operations (mocks)', function() {
+describe('ReplSet Operations (mocks)', function () {
   beforeEach(() => {
     test.spy = new ConnectionSpy();
     Connection.enableConnectionAccounting(test.spy);
@@ -31,7 +31,7 @@ describe('ReplSet Operations (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var currentIsMasterIndex = 0;
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -52,7 +52,7 @@ describe('ReplSet Operations (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
 
         primaryServer.setMessageHandler(request => {
@@ -72,13 +72,13 @@ describe('ReplSet Operations (mocks)', function() {
           haInterval: 2000,
           size: 1,
           disconnectHandler: {
-            add: function() {},
-            execute: function() {}
+            add: function () {},
+            execute: function () {}
           }
         });
 
-        server.on('connect', function(_server) {
-          _server.command('test.test', { count: 'test' }, function() {
+        server.on('connect', function (_server) {
+          _server.command('test.test', { count: 'test' }, function () {
             server.destroy();
             done();
           });
@@ -99,7 +99,7 @@ describe('ReplSet Operations (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var currentIsMasterIndex = 0;
         var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
           setName: 'rs',
@@ -120,7 +120,7 @@ describe('ReplSet Operations (mocks)', function() {
         ];
 
         // Boot the mock
-        co(function*() {
+        co(function* () {
           const primaryServer = yield mock.createServer(32000, 'localhost');
 
           primaryServer.setMessageHandler(request => {
@@ -140,17 +140,17 @@ describe('ReplSet Operations (mocks)', function() {
             haInterval: 2000,
             size: 1,
             disconnectHandler: {
-              add: function() {},
-              execute: function() {}
+              add: function () {},
+              execute: function () {}
             }
           });
 
-          server.on('connect', function() {
+          server.on('connect', function () {
             server.command(
               'test.test',
               { count: 'test' },
               { readPreference: ReadPreference.secondaryPreferred },
-              function() {
+              function () {
                 server.destroy();
                 done();
               }

--- a/test/disabled/rs_mocks/primary_loses_network.test.js
+++ b/test/disabled/rs_mocks/primary_loses_network.test.js
@@ -9,7 +9,7 @@ const ReplSet = core.ReplSet;
 const ObjectId = core.BSON.ObjectId;
 
 let test = {};
-describe('ReplSet Primary Loses Network (mocks)', function() {
+describe('ReplSet Primary Loses Network (mocks)', function () {
   beforeEach(() => {
     test.spy = new ConnectionSpy();
     Connection.enableConnectionAccounting(test.spy);
@@ -30,7 +30,7 @@ describe('ReplSet Primary Loses Network (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var currentIsMasterIndex = 0;
       var step = 0;
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -95,7 +95,7 @@ describe('ReplSet Primary Loses Network (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -143,9 +143,9 @@ describe('ReplSet Primary Loses Network (mocks)', function() {
         let intervalId;
         let cleaningUp = false;
         server.on('error', done);
-        server.on('left', function(_type) {
+        server.on('left', function (_type) {
           if (_type === 'primary') {
-            server.on('joined', function(__type, __server) {
+            server.on('joined', function (__type, __server) {
               if (__type === 'primary' && __server.name === 'localhost:32002') {
                 if (cleaningUp) {
                   return;
@@ -159,11 +159,11 @@ describe('ReplSet Primary Loses Network (mocks)', function() {
           }
         });
 
-        server.on('connect', function(_server) {
+        server.on('connect', function (_server) {
           server.__connected = true;
 
-          intervalId = setInterval(function() {
-            _server.command('system.$cmd', { ismaster: 1 }, function(err) {
+          intervalId = setInterval(function () {
+            _server.command('system.$cmd', { ismaster: 1 }, function (err) {
               if (err) {
                 // console.error(err);
               } else {
@@ -173,11 +173,11 @@ describe('ReplSet Primary Loses Network (mocks)', function() {
           }, 1000);
 
           // Primary dies
-          setTimeout(function() {
+          setTimeout(function () {
             step = step + 1;
 
             // Election happened
-            setTimeout(function() {
+            setTimeout(function () {
               step = step + 1;
               currentIsMasterIndex = currentIsMasterIndex + 1;
             }, 1000);

--- a/test/disabled/rs_mocks/read_preferences.test.js
+++ b/test/disabled/rs_mocks/read_preferences.test.js
@@ -13,7 +13,7 @@ const ReadPreference = core.ReadPreference;
 const Long = core.BSON.Long;
 
 let test = {};
-describe('ReplSet Read Preferences (mocks)', function() {
+describe('ReplSet Read Preferences (mocks)', function () {
   beforeEach(() => {
     test.spy = new ConnectionSpy();
     Connection.enableConnectionAccounting(test.spy);
@@ -34,7 +34,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -77,7 +77,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -127,7 +127,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
         );
 
         // Add event listeners
-        server.on('connect', function(_server) {
+        server.on('connect', function (_server) {
           // Set up a write
           function schedule() {
             // Perform a find
@@ -140,7 +140,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
               {
                 readPreference: new ReadPreference('secondary', { loc: 'dc' })
               },
-              function(err, r) {
+              function (err, r) {
                 expect(err).to.be.null;
                 expect(r.connection.port).to.equal(32002);
 
@@ -151,7 +151,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
           }
 
           // Schedule an insert
-          setTimeout(function() {
+          setTimeout(function () {
             schedule();
           }, 2000);
         });
@@ -169,7 +169,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -212,7 +212,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -261,10 +261,10 @@ describe('ReplSet Read Preferences (mocks)', function() {
         );
 
         // Add event listeners
-        server.on('connect', function(_server) {
+        server.on('connect', function (_server) {
           // Set up a write
           function schedule() {
-            setTimeout(function() {
+            setTimeout(function () {
               // Perform a find
               _server.command(
                 'test.test',
@@ -275,7 +275,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
                 {
                   readPreference: new ReadPreference('primaryPreferred')
                 },
-                function(err, r) {
+                function (err, r) {
                   expect(err).to.be.null;
                   expect(r.connection.port).to.equal(32000);
 
@@ -303,7 +303,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -346,7 +346,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -396,10 +396,10 @@ describe('ReplSet Read Preferences (mocks)', function() {
 
         // Add event listeners
         var port = 0;
-        server.on('connect', function(_server) {
+        server.on('connect', function (_server) {
           // Set up a write
           function schedule() {
-            setTimeout(function() {
+            setTimeout(function () {
               // Perform a find
               _server.command(
                 'test.test',
@@ -410,7 +410,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
                 {
                   readPreference: new ReadPreference('secondary')
                 },
-                function(err, r) {
+                function (err, r) {
                   expect(err).to.be.null;
                   port = r.connection.port;
 
@@ -424,7 +424,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
                     {
                       readPreference: new ReadPreference('secondary')
                     },
-                    function(_err, _r) {
+                    function (_err, _r) {
                       expect(_err).to.be.null;
                       expect(_r.connection.port).to.not.equal(port);
                       port = _r.connection.port;
@@ -439,7 +439,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
                         {
                           readPreference: new ReadPreference('secondary')
                         },
-                        function(__err, __r) {
+                        function (__err, __r) {
                           expect(__err).to.be.null;
                           expect(__r.connection.port).to.not.equal(port);
 
@@ -471,7 +471,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -501,7 +501,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
 
@@ -525,15 +525,15 @@ describe('ReplSet Read Preferences (mocks)', function() {
 
         // mock ops store from node-mongodb-native for handling repl set disconnects
         var mockDisconnectHandler = {
-          add: function(opType, ns, ops, options, callback) {
+          add: function (opType, ns, ops, options, callback) {
             // Command issued to replSet will fail immediately if !server.isConnected()
             return callback(new MongoError({ message: 'no connection available', driver: true }));
           },
-          execute: function() {
+          execute: function () {
             // method needs to be called, so provide a dummy version
             return;
           },
-          flush: function() {
+          flush: function () {
             // method needs to be called, so provide a dummy version
             return;
           }
@@ -559,9 +559,9 @@ describe('ReplSet Read Preferences (mocks)', function() {
         );
 
         // Add event listeners
-        server.on('connect', function(_server) {
+        server.on('connect', function (_server) {
           function schedule() {
-            setTimeout(function() {
+            setTimeout(function () {
               // Perform a find
               _server.command(
                 'test.test',
@@ -572,14 +572,14 @@ describe('ReplSet Read Preferences (mocks)', function() {
                 {
                   readPreference: new ReadPreference('primaryPreferred')
                 },
-                function(err, r) {
+                function (err, r) {
                   expect(err).to.be.null;
                   expect(r.connection.port).to.equal(32000);
                   primaryServer;
 
                   _server.on(
                     'left',
-                    function() {
+                    function () {
                       // Perform another find, after primary is gone
                       _server.command(
                         'test.test',
@@ -590,7 +590,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
                         {
                           readPreference: new ReadPreference('primaryPreferred')
                         },
-                        function(_err, _r) {
+                        function (_err, _r) {
                           expect(_err).to.be.null;
                           expect(_r.connection.port).to.equal(32001); // reads from secondary while primary down
 
@@ -623,7 +623,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -666,7 +666,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -716,7 +716,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
 
         // Add event listeners
         let joinCount = 0;
-        server.on('joined', function() {
+        server.on('joined', function () {
           joinCount++;
           if (joinCount !== 3) return;
 
@@ -732,11 +732,11 @@ describe('ReplSet Read Preferences (mocks)', function() {
               {
                 readPreference: new ReadPreference('primaryPreferred')
               },
-              function(err) {
+              function (err) {
                 expect(err).to.exist;
 
                 // Let all sockets properly close
-                process.nextTick(function() {
+                process.nextTick(function () {
                   // Test primaryPreferred
                   server.command(
                     'test.test',
@@ -747,7 +747,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
                     {
                       readPreference: new ReadPreference('primaryPreferred')
                     },
-                    function(_err, _r) {
+                    function (_err, _r) {
                       expect(_err).to.be.null;
                       expect(_r.connection.port).to.not.equal(32000);
 
@@ -761,7 +761,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
                         {
                           readPreference: new ReadPreference('secondaryPreferred')
                         },
-                        function(__err, __r) {
+                        function (__err, __r) {
                           expect(__err).to.be.null;
                           expect(__r.connection.port).to.not.equal(32000);
 
@@ -793,7 +793,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -836,7 +836,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -888,7 +888,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
         function runTest(_server) {
           _server.s.replicaSetState.secondaries = _server.s.replicaSetState.secondaries
             .sort((a, b) => Number(a.name.split(':')[1]) > Number(b.name.split(':')[1]))
-            .map(function(x, i) {
+            .map(function (x, i) {
               x.lastIsMasterMS = i * 50;
               return x;
             });
@@ -903,7 +903,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
             {
               readPreference: new ReadPreference('nearest')
             },
-            function(err, r) {
+            function (err, r) {
               expect(err).to.be.null;
               expect(r.connection.port).to.be.oneOf([32000, 32001]);
 
@@ -914,7 +914,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
         }
 
         let joinCount = 0;
-        server.on('joined', function() {
+        server.on('joined', function () {
           joinCount++;
           if (joinCount !== 3) return;
           runTest(server);
@@ -933,7 +933,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -976,7 +976,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -1028,7 +1028,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
         function runTest(_server) {
           _server.s.replicaSetState.secondaries = _server.s.replicaSetState.secondaries
             .sort((a, b) => Number(a.name.split(':')[1]) > Number(b.name.split(':')[1]))
-            .map(function(x, i) {
+            .map(function (x, i) {
               x.lastIsMasterMS = i * 50;
               return x;
             });
@@ -1043,7 +1043,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
             {
               readPreference: new ReadPreference('nearest', { loc: 'dc' })
             },
-            function(err, r) {
+            function (err, r) {
               expect(err).to.be.null;
               expect(r.connection.port).to.be.oneOf([32001, 32002]);
 
@@ -1055,7 +1055,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
 
         // Add event listeners
         let joinCount = 0;
-        server.on('joined', function() {
+        server.on('joined', function () {
           joinCount++;
           if (joinCount !== 3) return;
           runTest(server);
@@ -1076,7 +1076,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var electionIds = [new ObjectId(), new ObjectId()];
         var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
           setName: 'rs',
@@ -1097,7 +1097,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
         ];
 
         // Boot the mock
-        co(function*() {
+        co(function* () {
           const primaryServer = yield mock.createServer(32000, 'localhost');
 
           primaryServer.setMessageHandler(request => {
@@ -1119,10 +1119,10 @@ describe('ReplSet Read Preferences (mocks)', function() {
           });
 
           // Add event listeners
-          server.on('connect', function(_server) {
+          server.on('connect', function (_server) {
             // Set up a write
             function schedule() {
-              setTimeout(function() {
+              setTimeout(function () {
                 // Perform a find
                 _server.command(
                   'test.test',
@@ -1133,7 +1133,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
                   {
                     readPreference: new ReadPreference('secondaryPreferred')
                   },
-                  function(err, r) {
+                  function (err, r) {
                     expect(err).to.be.null;
                     expect(r.connection.port).to.equal(32000);
 
@@ -1162,7 +1162,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
         setName: 'rs',
@@ -1205,7 +1205,7 @@ describe('ReplSet Read Preferences (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -1254,13 +1254,13 @@ describe('ReplSet Read Preferences (mocks)', function() {
         );
 
         // Add event listeners
-        server.on('all', function(_server) {
+        server.on('all', function (_server) {
           // Execute more operations than there is servers connected
-          setTimeout(function() {
+          setTimeout(function () {
             var count = 50;
             var portsSeen = {};
 
-            var checkHandler = function(err, r) {
+            var checkHandler = function (err, r) {
               count = count - 1;
               expect(err).to.be.null;
 

--- a/test/disabled/sdam.test.js
+++ b/test/disabled/sdam.test.js
@@ -2,15 +2,15 @@
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-describe.skip('SDAM', function() {
-  before(function() {
+describe.skip('SDAM', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it('Should correctly emit all Replicaset SDAM operations', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var operations = {
         serverDescriptionChanged: [],
@@ -34,16 +34,16 @@ describe.skip('SDAM', function() {
         'topologyDescriptionChanged',
         'topologyClosed'
       ];
-      events.forEach(function(e) {
-        client.on(e, function(result) {
+      events.forEach(function (e) {
+        client.on(e, function (result) {
           operations[e].push(result);
         });
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
 
-        client.close(true, function() {
+        client.close(true, function () {
           setTimeout(() => {
             for (var name in operations) {
               test.ok(operations[name].length > 0);
@@ -59,7 +59,7 @@ describe.skip('SDAM', function() {
   it('Should correctly emit all Mongos SDAM operations', {
     metadata: { requires: { topology: 'sharded' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var operations = {
         serverDescriptionChanged: [],
@@ -83,14 +83,14 @@ describe.skip('SDAM', function() {
         'topologyDescriptionChanged',
         'topologyClosed'
       ];
-      events.forEach(function(e) {
-        client.on(e, function(result) {
+      events.forEach(function (e) {
+        client.on(e, function (result) {
           operations[e].push(result);
         });
       });
 
-      client.on('fullsetup', function(topology) {
-        setTimeout(function() {
+      client.on('fullsetup', function (topology) {
+        setTimeout(function () {
           topology.close();
 
           for (var name in operations) {
@@ -101,7 +101,7 @@ describe.skip('SDAM', function() {
         }, 1000);
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
       });
     }
@@ -110,7 +110,7 @@ describe.skip('SDAM', function() {
   it('Should correctly emit all Server SDAM operations', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var operations = {
         serverDescriptionChanged: [],
@@ -130,13 +130,13 @@ describe.skip('SDAM', function() {
         'topologyDescriptionChanged',
         'topologyClosed'
       ];
-      events.forEach(function(e) {
-        client.on(e, function(result) {
+      events.forEach(function (e) {
+        client.on(e, function (result) {
           operations[e].push(result);
         });
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         client.close(true);
 

--- a/test/disabled/sdam_monitoring_mocks/mongos_topology.test.js
+++ b/test/disabled/sdam_monitoring_mocks/mongos_topology.test.js
@@ -6,7 +6,7 @@ const mock = require('mongodb-mock-server');
 const core = require('../../../../src/core');
 const Mongos = core.Mongos;
 
-describe.skip('Mongos SDAM Monitoring (mocks)', function() {
+describe.skip('Mongos SDAM Monitoring (mocks)', function () {
   it('SDAM Monitoring Should correctly connect to two proxies', {
     metadata: {
       requires: {
@@ -15,7 +15,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Contain mock server
       var mongos1 = null;
       var mongos2 = null;
@@ -30,7 +30,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       // Primary server states
       var serverIsMaster = [Object.assign({}, defaultFields)];
       // Boot the mock
-      co(function*() {
+      co(function* () {
         mongos1 = yield mock.createServer();
         mongos2 = yield mock.createServer();
 
@@ -62,9 +62,9 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       });
 
       // Add event listeners
-      server.once('fullsetup', function(_server) {
-        var intervalId = setInterval(function() {
-          server.insert('test.test', [{ created: new Date() }], function(err, r) {
+      server.once('fullsetup', function (_server) {
+        var intervalId = setInterval(function () {
+          server.insert('test.test', [{ created: new Date() }], function (err, r) {
             // If we have a successful insert
             // validate that it's the expected proxy
             if (r) {
@@ -75,11 +75,11 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
               var proxies = {};
 
               // Perform interval inserts waiting for both proxies to come back
-              var intervalId2 = setInterval(function() {
+              var intervalId2 = setInterval(function () {
                 // Bring back the missing proxy
                 if (currentStep === 0) currentStep = currentStep + 1;
                 // Perform inserts
-                server.insert('test.test', [{ created: new Date() }], function(_err, _r) {
+                server.insert('test.test', [{ created: new Date() }], function (_err, _r) {
                   expect(_err).to.be.null;
                   if (_r) {
                     proxies[_r.connection.port] = true;
@@ -91,7 +91,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
                     server.destroy();
 
                     mock.cleanup().then(() => {
-                      setTimeout(function() {
+                      setTimeout(function () {
                         var results = [
                           {
                             topologyId: _server.s.id,
@@ -160,49 +160,49 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       });
 
       var responses = {};
-      var add = function(a) {
+      var add = function (a) {
         if (!responses[a.type]) responses[a.type] = [];
         responses[a.type].push(a.event);
       };
 
-      server.on('serverOpening', function(event) {
+      server.on('serverOpening', function (event) {
         add({ type: 'serverOpening', event: event });
       });
 
-      server.on('serverClosed', function(event) {
+      server.on('serverClosed', function (event) {
         add({ type: 'serverClosed', event: event });
       });
 
-      server.on('serverDescriptionChanged', function(event) {
+      server.on('serverDescriptionChanged', function (event) {
         add({ type: 'serverDescriptionChanged', event: event });
       });
 
-      server.on('topologyOpening', function(event) {
+      server.on('topologyOpening', function (event) {
         add({ type: 'topologyOpening', event: event });
       });
 
-      server.on('topologyClosed', function(event) {
+      server.on('topologyClosed', function (event) {
         add({ type: 'topologyClosed', event: event });
       });
 
-      server.on('topologyDescriptionChanged', function(event) {
+      server.on('topologyDescriptionChanged', function (event) {
         add({ type: 'topologyDescriptionChanged', event: event });
       });
 
-      server.on('serverHeartbeatStarted', function(event) {
+      server.on('serverHeartbeatStarted', function (event) {
         add({ type: 'serverHeartbeatStarted', event: event });
       });
 
-      server.on('serverHeartbeatSucceeded', function(event) {
+      server.on('serverHeartbeatSucceeded', function (event) {
         add({ type: 'serverHeartbeatSucceeded', event: event });
       });
 
-      server.on('serverHeartbeatFailed', function(event) {
+      server.on('serverHeartbeatFailed', function (event) {
         add({ type: 'serverHeartbeatFailed', event: event });
       });
 
       server.on('error', done);
-      setTimeout(function() {
+      setTimeout(function () {
         server.connect();
       }, 100);
     }
@@ -216,7 +216,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Contain mock server
       var mongos1 = null;
       var mongos2 = null;
@@ -229,7 +229,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       // Primary server states
       var serverIsMaster = [Object.assign({}, defaultFields)];
       // Boot the mock
-      co(function*() {
+      co(function* () {
         mongos1 = yield mock.createServer();
         mongos2 = yield mock.createServer();
 
@@ -263,21 +263,21 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       });
 
       // Add event listeners
-      server.once('fullsetup', function(_server) {
-        var intervalId = setInterval(function() {
-          server.insert('test.test', [{ created: new Date() }], function(err, r) {
+      server.once('fullsetup', function (_server) {
+        var intervalId = setInterval(function () {
+          server.insert('test.test', [{ created: new Date() }], function (err, r) {
             // If we have a successful insert
             // validate that it's the expected proxy
             if (r) {
               clearInterval(intervalId);
               // Wait to allow at least one heartbeat to pass
-              setTimeout(function() {
+              setTimeout(function () {
                 expect(r.connection.port).to.equal(62003);
                 server.destroy();
 
                 mock.cleanup().then(() => {
                   // Wait for a little bit to let all events fire
-                  setTimeout(function() {
+                  setTimeout(function () {
                     expect(responses.serverOpening.length).to.be.at.least(2);
                     expect(responses.serverClosed.length).to.be.at.least(2);
                     expect(responses.topologyOpening).to.have.length(1);
@@ -350,44 +350,44 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       });
 
       var responses = {};
-      var add = function(a) {
+      var add = function (a) {
         if (!responses[a.type]) responses[a.type] = [];
         responses[a.type].push(a.event);
       };
 
-      server.on('serverOpening', function(event) {
+      server.on('serverOpening', function (event) {
         add({ type: 'serverOpening', event: event });
       });
 
-      server.on('serverClosed', function(event) {
+      server.on('serverClosed', function (event) {
         add({ type: 'serverClosed', event: event });
       });
 
-      server.on('serverDescriptionChanged', function(event) {
+      server.on('serverDescriptionChanged', function (event) {
         add({ type: 'serverDescriptionChanged', event: event });
       });
 
-      server.on('topologyOpening', function(event) {
+      server.on('topologyOpening', function (event) {
         add({ type: 'topologyOpening', event: event });
       });
 
-      server.on('topologyClosed', function(event) {
+      server.on('topologyClosed', function (event) {
         add({ type: 'topologyClosed', event: event });
       });
 
-      server.on('topologyDescriptionChanged', function(event) {
+      server.on('topologyDescriptionChanged', function (event) {
         add({ type: 'topologyDescriptionChanged', event: event });
       });
 
-      server.on('serverHeartbeatStarted', function(event) {
+      server.on('serverHeartbeatStarted', function (event) {
         add({ type: 'serverHeartbeatStarted', event: event });
       });
 
-      server.on('serverHeartbeatSucceeded', function(event) {
+      server.on('serverHeartbeatSucceeded', function (event) {
         add({ type: 'serverHeartbeatSucceeded', event: event });
       });
 
-      server.on('serverHeartbeatFailed', function(event) {
+      server.on('serverHeartbeatFailed', function (event) {
         add({ type: 'serverHeartbeatFailed', event: event });
       });
 
@@ -404,7 +404,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Contain mock server
       var mongos1 = null;
       var mongos2 = null;
@@ -419,7 +419,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       // Primary server states
       var serverIsMaster = [Object.assign({}, defaultFields)];
       // Boot the mock
-      co(function*() {
+      co(function* () {
         mongos1 = yield mock.createServer();
         mongos2 = yield mock.createServer();
 
@@ -440,13 +440,13 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
         });
 
         // Start dropping the packets
-        setTimeout(function() {
+        setTimeout(function () {
           currentStep = 1;
 
-          setTimeout(function() {
+          setTimeout(function () {
             currentStep = 0;
 
-            setTimeout(function() {
+            setTimeout(function () {
               expect(responses.topologyDescriptionChanged.length).to.be.greaterThan(0);
               server.destroy();
               mock.cleanup().then(() => done());
@@ -464,44 +464,44 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function() {
       });
 
       var responses = {};
-      var add = function(a) {
+      var add = function (a) {
         if (!responses[a.type]) responses[a.type] = [];
         responses[a.type].push(a.event);
       };
 
-      server.on('serverOpening', function(event) {
+      server.on('serverOpening', function (event) {
         add({ type: 'serverOpening', event: event });
       });
 
-      server.on('serverClosed', function(event) {
+      server.on('serverClosed', function (event) {
         add({ type: 'serverClosed', event: event });
       });
 
-      server.on('serverDescriptionChanged', function(event) {
+      server.on('serverDescriptionChanged', function (event) {
         add({ type: 'serverDescriptionChanged', event: event });
       });
 
-      server.on('topologyOpening', function(event) {
+      server.on('topologyOpening', function (event) {
         add({ type: 'topologyOpening', event: event });
       });
 
-      server.on('topologyClosed', function(event) {
+      server.on('topologyClosed', function (event) {
         add({ type: 'topologyClosed', event: event });
       });
 
-      server.on('topologyDescriptionChanged', function(event) {
+      server.on('topologyDescriptionChanged', function (event) {
         add({ type: 'topologyDescriptionChanged', event: event });
       });
 
-      server.on('serverHeartbeatStarted', function(event) {
+      server.on('serverHeartbeatStarted', function (event) {
         add({ type: 'serverHeartbeatStarted', event: event });
       });
 
-      server.on('serverHeartbeatSucceeded', function(event) {
+      server.on('serverHeartbeatSucceeded', function (event) {
         add({ type: 'serverHeartbeatSucceeded', event: event });
       });
 
-      server.on('serverHeartbeatFailed', function(event) {
+      server.on('serverHeartbeatFailed', function (event) {
         add({ type: 'serverHeartbeatFailed', event: event });
       });
 

--- a/test/disabled/sdam_monitoring_mocks/replset_topology.test.js
+++ b/test/disabled/sdam_monitoring_mocks/replset_topology.test.js
@@ -7,7 +7,7 @@ const core = require('../../../../src/core');
 const ReplSet = core.ReplSet;
 const ObjectId = core.BSON.ObjectId;
 
-describe.skip('ReplSet SDAM Monitoring (mocks)', function() {
+describe.skip('ReplSet SDAM Monitoring (mocks)', function () {
   afterEach(() => mock.cleanup());
 
   it('Successful emit SDAM monitoring events for replicaset', {
@@ -18,7 +18,7 @@ describe.skip('ReplSet SDAM Monitoring (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Contain mock server
       var primaryServer = null;
       var firstSecondaryServer = null;
@@ -110,7 +110,7 @@ describe.skip('ReplSet SDAM Monitoring (mocks)', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         primaryServer = yield mock.createServer(32000, 'localhost');
         firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -155,61 +155,61 @@ describe.skip('ReplSet SDAM Monitoring (mocks)', function() {
 
       var responses = {};
       var step = 0;
-      var add = function(a) {
+      var add = function (a) {
         if (!responses[a.type]) responses[a.type] = [];
         responses[a.type].push(a.event);
       };
 
-      server.on('serverOpening', function(event) {
+      server.on('serverOpening', function (event) {
         add({ type: 'serverOpening', event: event });
       });
 
-      server.on('serverClosed', function(event) {
+      server.on('serverClosed', function (event) {
         add({ type: 'serverClosed', event: event });
       });
 
-      server.on('serverDescriptionChanged', function(event) {
+      server.on('serverDescriptionChanged', function (event) {
         add({ type: 'serverDescriptionChanged', event: event });
       });
 
-      server.on('topologyOpening', function(event) {
+      server.on('topologyOpening', function (event) {
         add({ type: 'topologyOpening', event: event });
       });
 
-      server.on('topologyClosed', function(event) {
+      server.on('topologyClosed', function (event) {
         add({ type: 'topologyClosed', event: event });
       });
 
-      server.on('topologyDescriptionChanged', function(event) {
+      server.on('topologyDescriptionChanged', function (event) {
         add({ type: 'topologyDescriptionChanged', event: event });
       });
 
-      server.on('serverHeartbeatStarted', function(event) {
+      server.on('serverHeartbeatStarted', function (event) {
         add({ type: 'serverHeartbeatStarted', event: event });
       });
 
-      server.on('serverHeartbeatSucceeded', function(event) {
+      server.on('serverHeartbeatSucceeded', function (event) {
         add({ type: 'serverHeartbeatSucceeded', event: event });
       });
 
-      server.on('serverHeartbeatFailed', function(event) {
+      server.on('serverHeartbeatFailed', function (event) {
         add({ type: 'serverHeartbeatFailed', event: event });
       });
 
       // Add event listeners
-      server.on('fullsetup', function(_server) {
-        setTimeout(function() {
+      server.on('fullsetup', function (_server) {
+        setTimeout(function () {
           step = step + 1;
 
-          setTimeout(function() {
+          setTimeout(function () {
             step = step + 1;
 
-            setTimeout(function() {
+            setTimeout(function () {
               expect(responses.serverOpening.length).to.be.at.least(3);
               _server.destroy();
 
               // Wait to ensure all events fired
-              setTimeout(function() {
+              setTimeout(function () {
                 expect(responses.serverOpening.length).to.be.at.least(3);
                 expect(responses.serverClosed.length).to.be.at.least(3);
                 expect(responses.topologyOpening.length).to.equal(1);
@@ -241,7 +241,7 @@ describe.skip('ReplSet SDAM Monitoring (mocks)', function() {
       });
 
       // Gives proxies a chance to boot up
-      setTimeout(function() {
+      setTimeout(function () {
         server.connect();
       }, 100);
 

--- a/test/disabled/sdam_monitoring_mocks/single_topology.test.js
+++ b/test/disabled/sdam_monitoring_mocks/single_topology.test.js
@@ -3,7 +3,7 @@ var expect = require('chai').expect,
   co = require('co'),
   mock = require('mongodb-mock-server');
 
-describe.skip('Single SDAM Monitoring (mocks)', function() {
+describe.skip('Single SDAM Monitoring (mocks)', function () {
   afterEach(() => mock.cleanup());
 
   it('Should correctly emit sdam monitoring events for single server', {
@@ -14,7 +14,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
 
       // Contain mock server
@@ -28,7 +28,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
 
       // Boot the mock
       var mockServer;
-      co(function*() {
+      co(function* () {
         mockServer = yield mock.createServer();
 
         mockServer.setMessageHandler(request => {
@@ -51,38 +51,38 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
       var id = null;
 
       // Add event listeners
-      server.once('connect', function(_server) {
+      server.once('connect', function (_server) {
         id = _server.id;
         _server.destroy({ emitClose: true });
       });
 
-      server.on('serverOpening', function(event) {
+      server.on('serverOpening', function (event) {
         flags[0] = event;
       });
 
-      server.on('serverClosed', function(event) {
+      server.on('serverClosed', function (event) {
         flags[1] = event;
       });
 
-      server.on('serverDescriptionChanged', function(event) {
+      server.on('serverDescriptionChanged', function (event) {
         flags[2] = event;
       });
 
-      server.on('topologyOpening', function(event) {
+      server.on('topologyOpening', function (event) {
         flags[3] = event;
       });
 
-      server.on('topologyClosed', function(event) {
+      server.on('topologyClosed', function (event) {
         flags[4] = event;
       });
 
-      server.on('topologyDescriptionChanged', function(event) {
+      server.on('topologyDescriptionChanged', function (event) {
         flags[5] = event;
       });
 
       server.on('error', done);
-      server.on('close', function() {
-        setTimeout(function() {
+      server.on('close', function () {
+        setTimeout(function () {
           expect({ topologyId: id, address: 'localhost:37018' }).to.eql(flags[0]);
           expect({ topologyId: id, address: 'localhost:37018' }).to.eql(flags[1]);
           expect({
@@ -140,7 +140,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
         }, 100);
       });
 
-      setTimeout(function() {
+      setTimeout(function () {
         server.connect();
       }, 100);
     }
@@ -149,7 +149,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
   it('Should correctly emit sdam monitoring events for single server, with correct server type', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
 
       // Contain mock server
@@ -165,7 +165,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
 
       // Boot the mock
       var mockServer;
-      co(function*() {
+      co(function* () {
         mockServer = yield mock.createServer();
 
         mockServer.setMessageHandler(request => {
@@ -188,38 +188,38 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
       var id = null;
 
       // Add event listeners
-      server.once('connect', function(_server) {
+      server.once('connect', function (_server) {
         id = _server.id;
         _server.destroy({ emitClose: true });
       });
 
-      server.on('serverOpening', function(event) {
+      server.on('serverOpening', function (event) {
         flags[0] = event;
       });
 
-      server.on('serverClosed', function(event) {
+      server.on('serverClosed', function (event) {
         flags[1] = event;
       });
 
-      server.on('serverDescriptionChanged', function(event) {
+      server.on('serverDescriptionChanged', function (event) {
         flags[2] = event;
       });
 
-      server.on('topologyOpening', function(event) {
+      server.on('topologyOpening', function (event) {
         flags[3] = event;
       });
 
-      server.on('topologyClosed', function(event) {
+      server.on('topologyClosed', function (event) {
         flags[4] = event;
       });
 
-      server.on('topologyDescriptionChanged', function(event) {
+      server.on('topologyDescriptionChanged', function (event) {
         flags[5] = event;
       });
 
       server.on('error', done);
-      server.on('close', function() {
-        setTimeout(function() {
+      server.on('close', function () {
+        setTimeout(function () {
           expect({ topologyId: id, address: 'localhost:37008' }, flags[0]);
           expect({ topologyId: id, address: 'localhost:37008' }, flags[1]);
           expect({
@@ -276,7 +276,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
         }, 100);
       });
 
-      setTimeout(function() {
+      setTimeout(function () {
         server.connect();
       }, 100);
     }

--- a/test/disabled/server.test.js
+++ b/test/disabled/server.test.js
@@ -11,16 +11,16 @@ const ReadPreference = core.ReadPreference;
 const MongoCredentials = core.MongoCredentials;
 const Connection = core.Connection;
 
-describe('Server tests', function() {
+describe('Server tests', function () {
   it('should correctly connect server to single instance', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var server = config.newTopology(this.configuration.host, this.configuration.port);
 
       // Add event listeners
-      server.on('connect', function() {
+      server.on('connect', function () {
         server.destroy();
         done();
       });
@@ -33,13 +33,13 @@ describe('Server tests', function() {
   it('should correctly connect server to single instance and execute ismaster', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var server = config.newTopology(this.configuration.host, this.configuration.port);
 
       // Add event listeners
-      server.on('connect', function() {
-        server.command('admin.$cmd', { ismaster: true }, function(err, r) {
+      server.on('connect', function () {
+        server.command('admin.$cmd', { ismaster: true }, function (err, r) {
           expect(err).to.be.null;
           expect(r.result.ismaster).to.be.true;
           expect(r.connection).to.not.be.null;
@@ -57,19 +57,19 @@ describe('Server tests', function() {
   it('should correctly connect server to single instance and execute ismaster returning raw', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var server = config.newTopology(this.configuration.host, this.configuration.port);
 
       // Add event listeners
-      server.on('connect', function() {
+      server.on('connect', function () {
         server.command(
           'admin.$cmd',
           { ismaster: true },
           {
             raw: true
           },
-          function(err, r) {
+          function (err, r) {
             expect(err).to.be.null;
             expect(r.result).to.be.an.instanceof(Buffer);
             expect(r.connection).to.not.be.null;
@@ -88,17 +88,17 @@ describe('Server tests', function() {
   it('should correctly connect server to single instance and execute insert', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var server = config.newTopology(this.configuration.host, this.configuration.port);
 
       // Add event listeners
-      server.on('connect', function() {
-        server.insert('integration_tests.inserts', { a: 1 }, function(insertOneErr, insertOneR) {
+      server.on('connect', function () {
+        server.insert('integration_tests.inserts', { a: 1 }, function (insertOneErr, insertOneR) {
           expect(insertOneErr).to.be.null;
           expect(insertOneR.result.n).to.equal(1);
 
-          server.insert('integration_tests.inserts', { a: 1 }, { ordered: false }, function(
+          server.insert('integration_tests.inserts', { a: 1 }, { ordered: false }, function (
             insertTwoErr,
             insertTwoR
           ) {
@@ -121,19 +121,19 @@ describe('Server tests', function() {
     {
       metadata: { requires: { topology: 'single' } },
 
-      test: function(done) {
+      test: function (done) {
         const config = this.configuration;
         var server = config.newTopology(this.configuration.host, this.configuration.port, {
           compression: { compressors: ['snappy', 'zlib'] }
         });
 
         // Add event listeners
-        server.on('connect', function() {
+        server.on('connect', function () {
           server.command(
             'system.$cmd',
             { ismaster: true },
             { readPreference: new ReadPreference('primary') },
-            function(err, result) {
+            function (err, result) {
               if (err) {
                 console.log(err);
               }
@@ -155,13 +155,13 @@ describe('Server tests', function() {
   it('should correctly connect server to single instance and execute bulk insert', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var server = config.newTopology(this.configuration.host, this.configuration.port);
 
       // Add event listeners
-      server.on('connect', function() {
-        server.insert('integration_tests.inserts', [{ a: 1 }, { b: 1 }], function(
+      server.on('connect', function () {
+        server.insert('integration_tests.inserts', [{ a: 1 }, { b: 1 }], function (
           insertOneErr,
           insertOneR
         ) {
@@ -172,7 +172,7 @@ describe('Server tests', function() {
             'integration_tests.inserts',
             [{ a: 1 }, { b: 1 }],
             { ordered: false },
-            function(insertTwoErr, insertTwoR) {
+            function (insertTwoErr, insertTwoR) {
               expect(insertTwoErr).to.be.null;
               expect(insertTwoR.result.n).to.equal(2);
 
@@ -191,13 +191,13 @@ describe('Server tests', function() {
   it('should correctly connect server to single instance and execute insert with w:0', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var server = config.newTopology(this.configuration.host, this.configuration.port);
 
       // Add event listeners
-      server.on('connect', function() {
-        server.insert('integration_tests.inserts', { a: 1 }, { writeConcern: { w: 0 } }, function(
+      server.on('connect', function () {
+        server.insert('integration_tests.inserts', { a: 1 }, { writeConcern: { w: 0 } }, function (
           insertOneErr,
           insertOneR
         ) {
@@ -208,7 +208,7 @@ describe('Server tests', function() {
             'integration_tests.inserts',
             { a: 1 },
             { ordered: false, writeConcern: { w: 0 } },
-            function(insertTwoErr, insertTwoR) {
+            function (insertTwoErr, insertTwoR) {
               expect(insertTwoErr).to.be.null;
               expect(insertTwoR.result.ok).to.equal(1);
 
@@ -227,12 +227,12 @@ describe('Server tests', function() {
   it('should correctly connect server to single instance and execute update', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var server = config.newTopology(this.configuration.host, this.configuration.port);
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         _server.update(
           'integration_tests.inserts_example2',
           [
@@ -246,7 +246,7 @@ describe('Server tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -264,13 +264,13 @@ describe('Server tests', function() {
   it('should correctly connect server to single instance and execute remove', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var server = config.newTopology(this.configuration.host, this.configuration.port);
 
       // Add event listeners
-      server.on('connect', function(_server) {
-        server.insert('integration_tests.remove_example', { a: 1 }, function(err, r) {
+      server.on('connect', function (_server) {
+        server.insert('integration_tests.remove_example', { a: 1 }, function (err, r) {
           expect(err).to.be.null;
           expect(r.result.ok).to.equal(1);
 
@@ -281,7 +281,7 @@ describe('Server tests', function() {
               writeConcern: { w: 1 },
               ordered: true
             },
-            function(removeErr, results) {
+            function (removeErr, results) {
               expect(removeErr).to.be.null;
               expect(results.result.n).to.equal(1);
 
@@ -303,7 +303,7 @@ describe('Server tests', function() {
       requires: { topology: ['single'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var testDone = false;
 
@@ -311,13 +311,13 @@ describe('Server tests', function() {
       var server = config.newTopology(this.configuration.host, this.configuration.port);
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         var count = 1;
         var ns = 'integration_tests.t';
 
-        var execute = function() {
+        var execute = function () {
           if (!testDone) {
-            server.insert(ns, { a: 1, count: count }, function() {
+            server.insert(ns, { a: 1, count: count }, function () {
               count = count + 1;
 
               // Execute find
@@ -328,12 +328,12 @@ describe('Server tests', function() {
               });
 
               // Execute next
-              cursor._next(function() {
+              cursor._next(function () {
                 setTimeout(execute, 500);
               });
             });
           } else {
-            server.insert(ns, { a: 1, count: count }, function(err, r) {
+            server.insert(ns, { a: 1, count: count }, function (err, r) {
               expect(err).to.be.null;
               expect(r).to.exist;
 
@@ -345,7 +345,7 @@ describe('Server tests', function() {
               });
 
               // Execute next
-              cursor._next(function(cursorErr, d) {
+              cursor._next(function (cursorErr, d) {
                 expect(err).to.be.null;
                 expect(d).to.exist;
                 server.destroy();
@@ -360,7 +360,7 @@ describe('Server tests', function() {
 
       var count = 2;
 
-      var restartServer = function() {
+      var restartServer = function () {
         if (count === 0) {
           testDone = true;
           return;
@@ -368,9 +368,9 @@ describe('Server tests', function() {
 
         count = count - 1;
 
-        self.configuration.manager.stop().then(function() {
-          setTimeout(function() {
-            self.configuration.manager.start().then(function() {
+        self.configuration.manager.stop().then(function () {
+          setTimeout(function () {
+            self.configuration.manager.start().then(function () {
               setTimeout(restartServer, 1000);
             });
           }, 2000);
@@ -390,11 +390,11 @@ describe('Server tests', function() {
       ignore: { travis: true }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       const manager = this.configuration.manager;
 
-      manager.stop('SIGINT').then(function() {
+      manager.stop('SIGINT').then(function () {
         // Attempt to connect while server is down
         var server = config.newTopology(this.configuration.host, this.configuration.port, {
           reconnect: true,
@@ -403,20 +403,20 @@ describe('Server tests', function() {
           emitError: true
         });
 
-        server.on('connect', function() {
+        server.on('connect', function () {
           server.destroy();
           done();
         });
 
-        server.on('reconnect', function() {
+        server.on('reconnect', function () {
           server.destroy();
           done();
         });
 
-        server.on('error', function(err) {
+        server.on('error', function (err) {
           expect(err).to.exist;
           expect(err.message.indexOf('failed to')).to.not.equal(-1);
-          manager.start().then(function() {});
+          manager.start().then(function () {});
         });
 
         server.connect();
@@ -432,7 +432,7 @@ describe('Server tests', function() {
       ignore: { travis: true }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       var server = config.newTopology(this.configuration.host, this.configuration.port, {
@@ -442,10 +442,10 @@ describe('Server tests', function() {
         emitError: true
       });
 
-      server.on('connect', function() {
+      server.on('connect', function () {
         var left = 5000;
 
-        var leftDecrement = function(err, results) {
+        var leftDecrement = function (err, results) {
           expect(err).to.not.exist;
           expect(results).to.exist;
 
@@ -484,7 +484,7 @@ describe('Server tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var server = config.newTopology(this.configuration.host, this.configuration.port, {
         size: 10
@@ -493,8 +493,8 @@ describe('Server tests', function() {
       var ns = 'integration_tests.remove_example';
 
       // Add event listeners
-      server.on('connect', function() {
-        var docs = new Array(150).fill(0).map(function(_, i) {
+      server.on('connect', function () {
+        var docs = new Array(150).fill(0).map(function (_, i) {
           return {
             _id: 'needle_' + i,
             is_even: i % 2,
@@ -504,7 +504,7 @@ describe('Server tests', function() {
           };
         });
 
-        server.insert(ns, docs, function(err, r) {
+        server.insert(ns, docs, function (err, r) {
           expect(err).to.be.null;
           expect(r.result.ok).to.equal(1);
 
@@ -522,7 +522,7 @@ describe('Server tests', function() {
           );
 
           function callNext(_cursor) {
-            _cursor._next(function(cursorErr, doc) {
+            _cursor._next(function (cursorErr, doc) {
               expect(cursorErr).to.not.exist;
               if (!doc) {
                 server.destroy(done);
@@ -552,7 +552,7 @@ describe('Server tests', function() {
   it('should error when invalid compressors are specified', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
 
       try {
@@ -572,14 +572,14 @@ describe('Server tests', function() {
     {
       metadata: { requires: { topology: ['auth', 'snappyCompression'] } },
 
-      test: function(done) {
+      test: function (done) {
         var self = this;
         const config = this.configuration;
 
         Connection.enableConnectionAccounting();
 
-        self.configuration.manager.restart(true).then(function() {
-          locateAuthMethod(self.configuration, function(err, method) {
+        self.configuration.manager.restart(true).then(function () {
+          locateAuthMethod(self.configuration, function (err, method) {
             expect(err).to.be.null;
 
             const credentials = new MongoCredentials({
@@ -599,7 +599,7 @@ describe('Server tests', function() {
                 roles: [{ role: 'root', db: 'admin' }],
                 digestPassword: true
               },
-              function(cmdErr, r) {
+              function (cmdErr, r) {
                 expect(cmdErr).to.not.exist;
                 expect(r).to.exist;
 
@@ -608,8 +608,8 @@ describe('Server tests', function() {
                 });
 
                 // Add event listeners
-                server.on('connect', function() {
-                  server.insert('integration_tests.inserts', { a: 1 }, function(
+                server.on('connect', function () {
+                  server.insert('integration_tests.inserts', { a: 1 }, function (
                     insertOneErr,
                     insertOneRes
                   ) {
@@ -620,7 +620,7 @@ describe('Server tests', function() {
                       'integration_tests.inserts',
                       { a: 1 },
                       { ordered: false },
-                      function(insertTwoErr, insertTwoR) {
+                      function (insertTwoErr, insertTwoR) {
                         expect(insertTwoErr).to.be.null;
                         expect(insertTwoR.result.n).to.equal(1);
 
@@ -647,14 +647,14 @@ describe('Server tests', function() {
     {
       metadata: { requires: { topology: ['auth', 'snappyCompression'] } },
 
-      test: function(done) {
+      test: function (done) {
         var self = this;
         const config = this.configuration;
 
         Connection.enableConnectionAccounting();
 
-        this.configuration.manager.restart(true).then(function() {
-          locateAuthMethod(self.configuration, function(err, method) {
+        this.configuration.manager.restart(true).then(function () {
+          locateAuthMethod(self.configuration, function (err, method) {
             expect(err).to.be.null;
 
             const credentials = new MongoCredentials({
@@ -674,7 +674,7 @@ describe('Server tests', function() {
                 roles: [{ role: 'root', db: 'admin' }],
                 digestPassword: true
               },
-              function(cmdErr, r) {
+              function (cmdErr, r) {
                 expect(cmdErr).to.not.exist;
                 expect(r).to.exist;
 
@@ -683,7 +683,7 @@ describe('Server tests', function() {
                 });
 
                 // Add event listeners
-                server.on('error', function() {
+                server.on('error', function () {
                   expect(Object.keys(Connection.connections()).length).to.equal(0);
                   Connection.disableConnectionAccounting();
                   done();
@@ -698,7 +698,7 @@ describe('Server tests', function() {
     }
   );
 
-  describe('Unsupported wire protocols', function() {
+  describe('Unsupported wire protocols', function () {
     let server;
     beforeEach(() => mock.createServer().then(_server => (server = _server)));
     afterEach(() => mock.cleanup());
@@ -706,7 +706,7 @@ describe('Server tests', function() {
     it('errors when unsupported wire protocol is returned from isMaster', {
       metadata: { requires: { topology: ['single'] } },
 
-      test: function(done) {
+      test: function (done) {
         server.setMessageHandler(request => {
           request.reply(Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 1 }));
         });
@@ -741,19 +741,19 @@ describe('Server tests', function() {
   it.skip('Should not try to reconnect forever if reconnectTries = 0', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var server = config.newTopology('doesntexist', 12345, {
         reconnectTries: 0
       });
 
       // Add event listeners
-      server.on('error', function() {});
+      server.on('error', function () {});
 
       // Start connection
       server.connect();
 
-      server.s.pool.on('reconnectFailed', function() {
+      server.s.pool.on('reconnectFailed', function () {
         done();
       });
     }

--- a/test/disabled/sharding_read_preference.test.js
+++ b/test/disabled/sharding_read_preference.test.js
@@ -3,15 +3,15 @@ const setupDatabase = require('./shared').setupDatabase;
 const expect = require('chai').expect;
 const { MongoClient, ReadPreference, Logger } = require('../../src');
 
-describe('Sharding (Read Preference)', function() {
-  before(function() {
+describe('Sharding (Read Preference)', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it.skip('Should correctly perform a Mongos secondary read using the read preferences', {
     metadata: { requires: { topology: 'sharded' } },
 
-    test: function(done) {
+    test: function (done) {
       // NOTE: this test is skipped because it directly mucks with the connection string, which isn't
       // guaranteed to be present with mongo-orchestration. This behavior should be unit tested.
 
@@ -22,14 +22,14 @@ describe('Sharding (Read Preference)', function() {
       const url = `mongodb://${host}:${port}/sharded_test_db?w=1`;
       // Connect using the mongos connections
       var client = new MongoClient(url, { w: 0, monitorCommands: true });
-      client.connect(function(err) {
+      client.connect(function (err) {
         expect(err).to.not.exist;
         const db = client.db(configuration.db);
 
         // Perform a simple insert into a collection
         const collection = db.collection('shard_test1');
         // Insert a simple doc
-        collection.insertOne({ test: 1 }, { w: 'majority', wtimeout: 10000 }, function(err) {
+        collection.insertOne({ test: 1 }, { w: 'majority', wtimeout: 10000 }, function (err) {
           expect(err).to.not.exist;
 
           // Set debug level for the driver
@@ -38,7 +38,7 @@ describe('Sharding (Read Preference)', function() {
           let gotMessage = false;
 
           // Get the current logger
-          Logger.setCurrentLogger(function(message, options) {
+          Logger.setCurrentLogger(function (message, options) {
             if (
               options.type === 'debug' &&
               options.className === 'Cursor' &&
@@ -51,7 +51,7 @@ describe('Sharding (Read Preference)', function() {
           collection.findOne(
             { test: 1 },
             { readPreference: new ReadPreference(ReadPreference.SECONDARY) },
-            function(err, item) {
+            function (err, item) {
               expect(err).to.not.exist;
               expect(item).to.exist.and.to.have.property('test', 1);
               expect(gotMessage).to.equal(true);
@@ -70,7 +70,7 @@ describe('Sharding (Read Preference)', function() {
   it('Should fail a Mongos secondary read using the read preference and tags that dont exist', {
     metadata: { requires: { topology: 'sharded' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const host = configuration.host;
       const port = configuration.port;
@@ -78,14 +78,14 @@ describe('Sharding (Read Preference)', function() {
       const url = `mongodb://${host}:${port}/sharded_test_db?w=1`;
       // Connect using the mongos connections
       const client = new MongoClient(url, { w: 0 });
-      client.connect(function(err) {
+      client.connect(function (err) {
         expect(err).to.not.exist;
         const db = client.db(configuration.db);
 
         // Perform a simple insert into a collection
         const collection = db.collection('shard_test3');
         // Insert a simple doc
-        collection.insertOne({ test: 1 }, { w: 'majority', wtimeout: 10000 }, function(err) {
+        collection.insertOne({ test: 1 }, { w: 'majority', wtimeout: 10000 }, function (err) {
           expect(err).to.not.exist;
 
           // Set debug level for the driver
@@ -93,7 +93,7 @@ describe('Sharding (Read Preference)', function() {
 
           let gotMessage = false;
           // Get the current logger
-          Logger.setCurrentLogger(function(message, options) {
+          Logger.setCurrentLogger(function (message, options) {
             if (
               options.type === 'debug' &&
               options.className === 'Cursor' &&
@@ -113,7 +113,7 @@ describe('Sharding (Read Preference)', function() {
                 { dc: 'ma', s: '2' }
               ])
             },
-            function(err) {
+            function (err) {
               expect(err).to.exist;
               expect(gotMessage).to.equal(true);
               // Set error level for the driver
@@ -131,20 +131,20 @@ describe('Sharding (Read Preference)', function() {
     // NOTE: skipped because mongo-orchestration will not set up these tags
     metadata: { requires: { topology: 'sharded' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       // Set up mongos connection
 
       // Connect using the mongos connections
       const client = new MongoClient(configuration.url(), { w: 0 });
-      client.connect(function(err) {
+      client.connect(function (err) {
         expect(err).to.not.exist;
         const db = client.db(configuration.db);
 
         // Perform a simple insert into a collection
         const collection = db.collection('shard_test4');
         // Insert a simple doc
-        collection.insertOne({ test: 1 }, { w: 'majority', wtimeout: 10000 }, function(err) {
+        collection.insertOne({ test: 1 }, { w: 'majority', wtimeout: 10000 }, function (err) {
           expect(err).to.not.exist;
 
           // Set debug level for the driver
@@ -152,7 +152,7 @@ describe('Sharding (Read Preference)', function() {
 
           let gotMessage = false;
           // Get the current logger
-          Logger.setCurrentLogger(function(message, options) {
+          Logger.setCurrentLogger(function (message, options) {
             if (
               options.type === 'debug' &&
               options.className === 'Cursor' &&
@@ -171,7 +171,7 @@ describe('Sharding (Read Preference)', function() {
                 { loc: 'sf' }
               ])
             },
-            function(err, item) {
+            function (err, item) {
               expect(err).to.not.exist;
               expect(item).to.exist.and.to.have.a.property('test', 1);
               expect(gotMessage).to.equal(true);
@@ -189,7 +189,7 @@ describe('Sharding (Read Preference)', function() {
   it('shouldCorrectlyEmitOpenEvent', {
     metadata: { requires: { topology: 'sharded' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
 
       let openCalled = false;
@@ -197,7 +197,7 @@ describe('Sharding (Read Preference)', function() {
       const client = new MongoClient(configuration.url(), { w: 0 });
       client.once('open', () => (openCalled = true));
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         expect(client).to.exist;
         expect(openCalled).to.equal(true);
@@ -210,25 +210,25 @@ describe('Sharding (Read Preference)', function() {
   it('Should correctly apply readPreference when performing inline mapReduce', {
     metadata: { requires: { topology: 'sharded' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
 
       // Connect using the mongos connections
       const client = new MongoClient(configuration.url());
-      client.connect(function(err) {
+      client.connect(function (err) {
         expect(err).to.not.exist;
         const db = client.db(configuration.db);
 
         // Get the collection
         const col = db.collection('items');
         // Insert some items
-        col.insertMany([{ a: 1 }, { a: 2 }, { a: 3 }], function(err) {
+        col.insertMany([{ a: 1 }, { a: 2 }, { a: 3 }], function (err) {
           expect(err).to.not.exist;
 
-          client.db('admin').command({ enableSharding: 'integration_test_2' }, function(err) {
+          client.db('admin').command({ enableSharding: 'integration_test_2' }, function (err) {
             expect(err).to.not.exist;
 
-            col.createIndex({ _id: 'hashed' }, function(err) {
+            col.createIndex({ _id: 'hashed' }, function (err) {
               expect(err).to.not.exist;
 
               client.db('admin').command(
@@ -236,14 +236,14 @@ describe('Sharding (Read Preference)', function() {
                   shardCollection: 'integration_test_2.items',
                   key: { _id: 'hashed' }
                 },
-                function(err) {
+                function (err) {
                   expect(err).to.not.exist;
 
-                  var map = function() {
+                  var map = function () {
                     emit(this._id, this._id); // eslint-disable-line
                   };
 
-                  var reduce = function() {
+                  var reduce = function () {
                     return 123;
                   };
 
@@ -256,7 +256,7 @@ describe('Sharding (Read Preference)', function() {
                       },
                       readPreference: ReadPreference.SECONDARY_PREFERRED
                     },
-                    function(err, r) {
+                    function (err, r) {
                       expect(err).to.not.exist;
                       expect(r).to.have.a.lengthOf(3);
                       client.close(done);

--- a/test/disabled/single/sessions.test.js
+++ b/test/disabled/single/sessions.test.js
@@ -13,7 +13,7 @@ const ClientSession = core.Sessions.ClientSession;
 const ServerSessionPool = core.Sessions.ServerSessionPool;
 
 const test = {};
-describe('Sessions (Single)', function() {
+describe('Sessions (Single)', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => {
     return mock.createServer().then(mockServer => {
@@ -23,7 +23,7 @@ describe('Sessions (Single)', function() {
 
   it('should recognize and set `clusterTime` on the topology', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       const clusterTime = genClusterTime(Date.now());
       test.server.setMessageHandler(request => {
         request.reply(
@@ -47,7 +47,7 @@ describe('Sessions (Single)', function() {
 
   it('should track the highest `$clusterTime` seen', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       const clusterTime = genClusterTime(Date.now()),
         futureClusterTime = genClusterTime(Date.now() + 10 * 60 * 1000);
 
@@ -75,7 +75,7 @@ describe('Sessions (Single)', function() {
         expect(client.clusterTime).to.exist;
         expect(client.clusterTime).to.eql(clusterTime);
 
-        client.insert('test.test', [{ created: new Date() }], function(err) {
+        client.insert('test.test', [{ created: new Date() }], function (err) {
           expect(err).to.not.exist;
           expect(client.clusterTime).to.exist;
           expect(client.clusterTime).to.not.eql(clusterTime);
@@ -92,7 +92,7 @@ describe('Sessions (Single)', function() {
 
   it('should track the highest `$clusterTime` seen, and store it on a session if available', {
     metadata: { requires: { topology: 'single' } },
-    test: function(_done) {
+    test: function (_done) {
       const clusterTime = genClusterTime(Date.now()),
         futureClusterTime = genClusterTime(Date.now() + 10 * 60 * 1000);
 
@@ -124,7 +124,7 @@ describe('Sessions (Single)', function() {
         expect(client.clusterTime).to.exist;
         expect(client.clusterTime).to.eql(clusterTime);
 
-        client.insert('test.test', [{ created: new Date() }], { session: session }, function(err) {
+        client.insert('test.test', [{ created: new Date() }], { session: session }, function (err) {
           expect(err).to.not.exist;
           expect(client.clusterTime).to.exist;
           expect(client.clusterTime).to.not.eql(clusterTime);
@@ -142,7 +142,7 @@ describe('Sessions (Single)', function() {
 
   it('should send `clusterTime` on outgoing messages', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       const clusterTime = genClusterTime(Date.now());
       let sentIsMaster = false,
         command = null;
@@ -181,7 +181,7 @@ describe('Sessions (Single)', function() {
 
   it('should send the highest `clusterTime` between topology and session if it exists', {
     metadata: { requires: { topology: 'single' } },
-    test: function(_done) {
+    test: function (_done) {
       const clusterTime = genClusterTime(Date.now()),
         futureClusterTime = genClusterTime(Date.now() + 10 * 60 * 1000);
 
@@ -227,7 +227,7 @@ describe('Sessions (Single)', function() {
 
   it('should return server sessions to the pool on `endSession`', {
     metadata: { requires: { topology: 'single' } },
-    test: function(_done) {
+    test: function (_done) {
       let sentIsMaster = false;
       test.server.setMessageHandler(request => {
         if (sentIsMaster) {
@@ -273,7 +273,7 @@ describe('Sessions (Single)', function() {
 
   it('should default `logicalSessionTimeoutMinutes` to `null`', {
     metadata: { requires: { topology: 'single' } },
-    test: function() {
+    test: function () {
       const single = new Server();
       expect(single.logicalSessionTimeoutMinutes).to.equal(null);
     }
@@ -281,7 +281,7 @@ describe('Sessions (Single)', function() {
 
   it('should track `logicalSessionTimeoutMinutes`', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       test.server.setMessageHandler(request => {
         request.reply(
           Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -306,7 +306,7 @@ describe('Sessions (Single)', function() {
     'should add `lsid` to commands sent to the server, and update the session `lastUse` when a session is provided',
     {
       metadata: { requires: { topology: 'single' } },
-      test: function(_done) {
+      test: function (_done) {
         const client = new Server(test.server.address());
         const sessionPool = new ServerSessionPool(client);
         const session = new ClientSession(client, sessionPool);
@@ -353,7 +353,7 @@ describe('Sessions (Single)', function() {
 
   it('should use the same session for all getMore issued by a cursor', {
     metadata: { requires: { topology: 'single' } },
-    test: function(_done) {
+    test: function (_done) {
       const client = new Server(test.server.address());
       const sessionPool = new ServerSessionPool(client);
       const session = new ClientSession(client, sessionPool);
@@ -406,11 +406,11 @@ describe('Sessions (Single)', function() {
         );
 
         // Execute next
-        cursor._next(function(err) {
+        cursor._next(function (err) {
           expect(err).to.not.exist;
           expect(commands[0].lsid).to.eql(session.id);
 
-          cursor._next(function(err) {
+          cursor._next(function (err) {
             expect(err).to.not.exist;
             expect(commands[1].lsid).to.eql(session.id);
 
@@ -426,7 +426,7 @@ describe('Sessions (Single)', function() {
 
   it('should use the same session for any killCursor issued by a cursor', {
     metadata: { requires: { topology: 'single' } },
-    test: function(_done) {
+    test: function (_done) {
       const client = new Server(test.server.address());
       const sessionPool = new ServerSessionPool(client);
       const session = new ClientSession(client, sessionPool);
@@ -482,7 +482,7 @@ describe('Sessions (Single)', function() {
         );
 
         // Execute next
-        cursor._next(function(err) {
+        cursor._next(function (err) {
           expect(err).to.not.exist;
 
           cursor.kill(err => {
@@ -501,7 +501,7 @@ describe('Sessions (Single)', function() {
 
   it('should not hang on endSession when topology is closed', {
     metadata: { requires: { topology: 'single' } },
-    test: function(_done) {
+    test: function (_done) {
       const client = new Server(test.server.address());
       const sessionPool = new ServerSessionPool(client);
       const session = new ClientSession(client, sessionPool);
@@ -530,7 +530,7 @@ describe('Sessions (Single)', function() {
 
   it('should not allow use of an expired session', {
     metadata: { requires: { topology: 'single' } },
-    test: function(_done) {
+    test: function (_done) {
       const client = new Server(test.server.address());
       const sessionPool = new ServerSessionPool(client);
       const session = new ClientSession(client, sessionPool);
@@ -567,7 +567,7 @@ describe('Sessions (Single)', function() {
 
   it.skip('should not allow use of session object across clients', {
     metadata: { requires: { topology: 'single' } },
-    test: function(_done) {
+    test: function (_done) {
       const client = new Server(test.server.address());
       const client2 = new Server(test.server.address());
       const sessionPool = new ServerSessionPool(client);
@@ -603,7 +603,7 @@ describe('Sessions (Single)', function() {
 
   it('should track the highest `operationTime` seen, if causal consistency is enabled', {
     metadata: { requires: { topology: 'single' } },
-    test: function(_done) {
+    test: function (_done) {
       const client = new Server(test.server.address()),
         sessionPool = new ServerSessionPool(client),
         session = new ClientSession(client, sessionPool, { causalConsistency: true }),
@@ -650,7 +650,7 @@ describe('Sessions (Single)', function() {
 
   it('should emit an `ended` signal when the session is ended', {
     metadata: { requires: { topology: 'single' } },
-    test: function(_done) {
+    test: function (_done) {
       const client = new Server(test.server.address());
       const sessionPool = new ServerSessionPool(client);
       const session = new ClientSession(client, sessionPool);

--- a/test/disabled/single_mocks/compression.test.js
+++ b/test/disabled/single_mocks/compression.test.js
@@ -2,7 +2,7 @@
 const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
 
-describe('Single Compression (mocks)', function() {
+describe('Single Compression (mocks)', function () {
   let server;
   afterEach(() => mock.cleanup());
   beforeEach(() => mock.createServer().then(s => (server = s)));
@@ -15,7 +15,7 @@ describe('Single Compression (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Prepare the server's response
       var serverResponse = Object.assign({}, mock.DEFAULT_ISMASTER);
       const config = this.configuration;
@@ -32,7 +32,7 @@ describe('Single Compression (mocks)', function() {
         compression: { compressors: ['snappy', 'zlib'], zlibCompressionLevel: -1 }
       });
 
-      client.on('connect', function() {
+      client.on('connect', function () {
         client.destroy(done);
       });
 
@@ -50,7 +50,7 @@ describe('Single Compression (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         const config = this.configuration;
         var currentStep = 0;
 
@@ -109,20 +109,23 @@ describe('Single Compression (mocks)', function() {
         // Connect and try inserting, updating, and removing
         // All outbound messages from the driver will be uncompressed
         // Inbound messages from the server should be OP_COMPRESSED with no compression
-        client.on('connect', function(_server) {
-          _server.insert('test.test', [{ a: 1, created: new Date() }], function(err, r) {
+        client.on('connect', function (_server) {
+          _server.insert('test.test', [{ a: 1, created: new Date() }], function (err, r) {
             expect(err).to.be.null;
             expect(r.result.n).to.equal(1);
 
-            _server.update('test.test', { q: { a: 1 }, u: { $set: { b: 1 } } }, function(_err, _r) {
+            _server.update('test.test', { q: { a: 1 }, u: { $set: { b: 1 } } }, function (
+              _err,
+              _r
+            ) {
               expect(_err).to.be.null;
               expect(_r.result.n).to.equal(1);
 
-              _server.remove('test.test', { q: { a: 1 } }, function(__err, __r) {
+              _server.remove('test.test', { q: { a: 1 } }, function (__err, __r) {
                 expect(__err).to.be.null;
                 expect(__r.result.n).to.equal(1);
 
-                _server.command('system.$cmd', { ping: 1 }, function(___err, ___r) {
+                _server.command('system.$cmd', { ping: 1 }, function (___err, ___r) {
                   expect(___err).to.be.null;
                   expect(___r.result.ok).to.equal(1);
 
@@ -148,7 +151,7 @@ describe('Single Compression (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         const config = this.configuration;
         var currentStep = 0;
 
@@ -203,20 +206,23 @@ describe('Single Compression (mocks)', function() {
         // Connect and try inserting, updating, and removing
         // All outbound messages from the driver (after initial connection) will be OP_COMPRESSED using snappy
         // Inbound messages from the server should be OP_COMPRESSED with snappy
-        client.on('connect', function(_server) {
-          _server.insert('test.test', [{ a: 1, created: new Date() }], function(err, r) {
+        client.on('connect', function (_server) {
+          _server.insert('test.test', [{ a: 1, created: new Date() }], function (err, r) {
             expect(err).to.be.null;
             expect(r.result.n).to.equal(1);
 
-            _server.update('test.test', { q: { a: 1 }, u: { $set: { b: 1 } } }, function(_err, _r) {
+            _server.update('test.test', { q: { a: 1 }, u: { $set: { b: 1 } } }, function (
+              _err,
+              _r
+            ) {
               expect(_err).to.be.null;
               expect(_r.result.n).to.equal(1);
 
-              _server.remove('test.test', { q: { a: 1 } }, function(__err, __r) {
+              _server.remove('test.test', { q: { a: 1 } }, function (__err, __r) {
                 expect(__err).to.be.null;
                 expect(__r.result.n).to.equal(1);
 
-                _server.command('system.$cmd', { ping: 1 }, function(___err, ___r) {
+                _server.command('system.$cmd', { ping: 1 }, function (___err, ___r) {
                   expect(___err).to.be.null;
                   expect(___r.result.ok).to.equal(1);
 
@@ -242,7 +248,7 @@ describe('Single Compression (mocks)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         const config = this.configuration;
         var currentStep = 0;
 
@@ -299,20 +305,23 @@ describe('Single Compression (mocks)', function() {
         // Connect and try inserting, updating, and removing
         // All outbound messages from the driver (after initial connection) will be OP_COMPRESSED using zlib
         // Inbound messages from the server should be OP_COMPRESSED with zlib
-        client.on('connect', function(_server) {
-          _server.insert('test.test', [{ a: 1, created: new Date() }], function(err, r) {
+        client.on('connect', function (_server) {
+          _server.insert('test.test', [{ a: 1, created: new Date() }], function (err, r) {
             expect(err).to.be.null;
             expect(r.result.n).to.equal(1);
 
-            _server.update('test.test', { q: { a: 1 }, u: { $set: { b: 1 } } }, function(_err, _r) {
+            _server.update('test.test', { q: { a: 1 }, u: { $set: { b: 1 } } }, function (
+              _err,
+              _r
+            ) {
               expect(_err).to.be.null;
               expect(_r.result.n).to.equal(1);
 
-              _server.remove('test.test', { q: { a: 1 } }, function(__err, __r) {
+              _server.remove('test.test', { q: { a: 1 } }, function (__err, __r) {
                 expect(__err).to.be.null;
                 expect(__r.result.n).to.equal(1);
 
-                _server.command('system.$cmd', { ping: 1 }, function(___err, ___r) {
+                _server.command('system.$cmd', { ping: 1 }, function (___err, ___r) {
                   expect(___err).to.be.null;
                   expect(___r.result.ok).to.equal(1);
 
@@ -336,7 +345,7 @@ describe('Single Compression (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       var currentStep = 0;
 
@@ -389,20 +398,20 @@ describe('Single Compression (mocks)', function() {
       });
 
       // Connect and try some commands, checking that uncompressible commands are indeed not compressed
-      client.on('connect', function(_server) {
-        _server.command('system.$cmd', { ping: 1 }, function(err, r) {
+      client.on('connect', function (_server) {
+        _server.command('system.$cmd', { ping: 1 }, function (err, r) {
           expect(err).to.be.null;
           expect(r.result.ok).to.equal(1);
 
-          _server.command('system.$cmd', { ismaster: 1 }, function(_err, _r) {
+          _server.command('system.$cmd', { ismaster: 1 }, function (_err, _r) {
             expect(_err).to.be.null;
             expect(_r.result.ok).to.equal(1);
 
-            _server.command('system.$cmd', { getnonce: 1 }, function(__err, __r) {
+            _server.command('system.$cmd', { getnonce: 1 }, function (__err, __r) {
               expect(__err).to.be.null;
               expect(__r.result.ok).to.equal(1);
 
-              _server.command('system.$cmd', { ismaster: 1 }, function(___err, ___r) {
+              _server.command('system.$cmd', { ismaster: 1 }, function (___err, ___r) {
                 expect(___err).to.be.null;
                 expect(___r.result.ok).to.equal(1);
 

--- a/test/disabled/sni.test.js
+++ b/test/disabled/sni.test.js
@@ -1,11 +1,11 @@
 'use strict';
 var test = require('./shared').assert;
 
-describe('SNI', function() {
+describe('SNI', function () {
   it('Should correct connect to snitest1.10gen.cc', {
     metadata: { requires: { topology: 'sni', os: '!win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var MongoClient = configuration.require.MongoClient;
 
@@ -15,7 +15,7 @@ describe('SNI', function() {
         {
           // servername: 'snitest1.10gen.cc',
         },
-        function(err, client) {
+        function (err, client) {
           test.equal(null, err);
           client.close(done);
         }
@@ -26,7 +26,7 @@ describe('SNI', function() {
   it('Should correct connect to snitest2.mongodb.com', {
     metadata: { requires: { topology: 'sni', os: '!win32' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var MongoClient = configuration.require.MongoClient;
 
@@ -36,7 +36,7 @@ describe('SNI', function() {
         {
           // servername: 'snitest2.mongodb.com',
         },
-        function(err, client) {
+        function (err, client) {
           test.equal(null, err);
           client.close(done);
         }

--- a/test/disabled/ssl_mongoclient.test.js
+++ b/test/disabled/ssl_mongoclient.test.js
@@ -7,11 +7,11 @@ var f = require('util').format;
 // NOTE: This suite seems to require a special host file configuration on the test
 //       server. Disabling the suite until we can sort this out for everyone.
 
-describe.skip('SSL (MongoClient)', function() {
+describe.skip('SSL (MongoClient)', function () {
   it('shouldCorrectlyCommunicateUsingSSLSocket', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server,
         MongoClient = configuration.require.MongoClient;
@@ -33,20 +33,20 @@ describe.skip('SSL (MongoClient)', function() {
 
       serverManager
         .purge()
-        .then(function() {
+        .then(function () {
           return serverManager.start();
         })
-        .then(function() {
+        .then(function () {
           MongoClient.connect(
             'mongodb://localhost:27019/test?ssl=true',
             {
               sslValidate: false
             },
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
               client.close();
 
-              serverManager.stop().then(function() {
+              serverManager.stop().then(function () {
                 done();
               });
             }
@@ -58,7 +58,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('should fail due to CRL list passed in', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server,
         MongoClient = configuration.require.MongoClient;
@@ -84,10 +84,10 @@ describe.skip('SSL (MongoClient)', function() {
 
       serverManager
         .purge()
-        .then(function() {
+        .then(function () {
           return serverManager.start();
         })
-        .then(function() {
+        .then(function () {
           MongoClient.connect(
             'mongodb://localhost:27019/test?ssl=true',
             {
@@ -95,11 +95,11 @@ describe.skip('SSL (MongoClient)', function() {
               sslCA: ca,
               sslCRL: crl
             },
-            function(err) {
+            function (err) {
               test.ok(err);
               test.ok(err.message.indexOf('CRL has expired') !== -1);
 
-              serverManager.stop().then(function() {
+              serverManager.stop().then(function () {
                 done();
               });
             }
@@ -111,7 +111,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('shouldCorrectlyValidateServerCertificate', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server,
         MongoClient = configuration.require.MongoClient;
@@ -132,10 +132,10 @@ describe.skip('SSL (MongoClient)', function() {
 
       serverManager
         .purge()
-        .then(function() {
+        .then(function () {
           return serverManager.start();
         })
-        .then(function() {
+        .then(function () {
           // Connect and validate the server certificate
           MongoClient.connect(
             'mongodb://server:27019/test?ssl=true&maxPoolSize=1',
@@ -143,11 +143,11 @@ describe.skip('SSL (MongoClient)', function() {
               sslValidate: true,
               sslCA: ca
             },
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
               client.close();
 
-              serverManager.stop().then(function() {
+              serverManager.stop().then(function () {
                 done();
               });
             }
@@ -159,7 +159,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('Should correctly pass down servername to connection for TLS SNI support', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server,
         MongoClient = configuration.require.MongoClient;
@@ -180,10 +180,10 @@ describe.skip('SSL (MongoClient)', function() {
 
       serverManager
         .purge()
-        .then(function() {
+        .then(function () {
           return serverManager.start();
         })
-        .then(function() {
+        .then(function () {
           MongoClient.connect(
             'mongodb://server:27019/test?ssl=true&maxPoolSize=1',
             {
@@ -191,12 +191,12 @@ describe.skip('SSL (MongoClient)', function() {
               servername: 'server',
               sslCA: ca
             },
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
 
               client.close();
 
-              serverManager.stop().then(function() {
+              serverManager.stop().then(function () {
                 done();
               });
             }
@@ -210,7 +210,7 @@ describe.skip('SSL (MongoClient)', function() {
     {
       metadata: { requires: { topology: 'ssl' } },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
         var ServerManager = require('mongodb-topology-manager').Server,
           MongoClient = configuration.require.MongoClient;
@@ -234,28 +234,28 @@ describe.skip('SSL (MongoClient)', function() {
 
         serverManager
           .purge()
-          .then(function() {
+          .then(function () {
             return serverManager.start();
           })
-          .then(function() {
+          .then(function () {
             // Connect and validate the server certificate
             MongoClient.connect(
               'mongodb://server:27019/test?ssl=true&maxPoolSize=1',
               {
                 sslValidate: true,
-                checkServerIdentity: function() {
+                checkServerIdentity: function () {
                   checkServerIdentityCalled = true;
                   return undefined;
                 },
                 sslCA: ca
               },
-              function(err, client) {
+              function (err, client) {
                 test.equal(null, err);
                 test.ok(checkServerIdentityCalled);
 
                 client.close();
 
-                serverManager.stop().then(function() {
+                serverManager.stop().then(function () {
                   done();
                 });
               }
@@ -268,7 +268,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('should fail to validate certificate due to illegal host name', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server,
         MongoClient = configuration.require.MongoClient;
@@ -289,20 +289,20 @@ describe.skip('SSL (MongoClient)', function() {
 
       serverManager
         .purge()
-        .then(function() {
+        .then(function () {
           return serverManager.start();
         })
-        .then(function() {
+        .then(function () {
           MongoClient.connect(
             'mongodb://localhost:27017/test?ssl=true&maxPoolSize=1',
             {
               sslValidate: true,
               sslCA: ca
             },
-            function(err) {
+            function (err) {
               test.ok(err != null);
 
-              serverManager.stop().then(function() {
+              serverManager.stop().then(function () {
                 done();
               });
             }
@@ -314,7 +314,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('shouldCorrectlyValidatePresentedServerCertificateAndPresentValidCertificate', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server,
         MongoClient = configuration.require.MongoClient;
@@ -339,10 +339,10 @@ describe.skip('SSL (MongoClient)', function() {
 
       serverManager
         .purge()
-        .then(function() {
+        .then(function () {
           return serverManager.start();
         })
-        .then(function() {
+        .then(function () {
           // Connect and validate the server certificate
           MongoClient.connect(
             'mongodb://server:27019/test?ssl=true&maxPoolSize=1',
@@ -353,12 +353,12 @@ describe.skip('SSL (MongoClient)', function() {
               sslCert: cert,
               sslPass: '10gen'
             },
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
 
               client.close();
 
-              serverManager.stop().then(function() {
+              serverManager.stop().then(function () {
                 done();
               });
             }
@@ -370,7 +370,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('shouldValidatePresentedServerCertificateButPresentInvalidCertificate', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server,
         MongoClient = configuration.require.MongoClient;
@@ -391,10 +391,10 @@ describe.skip('SSL (MongoClient)', function() {
 
       serverManager
         .purge()
-        .then(function() {
+        .then(function () {
           return serverManager.start();
         })
-        .then(function() {
+        .then(function () {
           // Read the ca
           var cert = fs.readFileSync(__dirname + '/ssl/mycert.pem');
           var key = fs.readFileSync(__dirname + '/ssl/mycert.pem');
@@ -410,10 +410,10 @@ describe.skip('SSL (MongoClient)', function() {
               sslCert: cert,
               sslPass: '10gen'
             },
-            function(err) {
+            function (err) {
               test.ok(err != null);
 
-              serverManager.stop().then(function() {
+              serverManager.stop().then(function () {
                 done();
               });
             }
@@ -425,7 +425,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('shouldCorrectlyValidatePresentedServerCertificateAndInvalidKey', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server,
         MongoClient = configuration.require.MongoClient;
@@ -450,10 +450,10 @@ describe.skip('SSL (MongoClient)', function() {
 
       serverManager
         .purge()
-        .then(function() {
+        .then(function () {
           return serverManager.start();
         })
-        .then(function() {
+        .then(function () {
           // Connect and validate the server certificate
           MongoClient.connect(
             'mongodb://server:27019/test?ssl=true&maxPoolSize=1',
@@ -464,10 +464,10 @@ describe.skip('SSL (MongoClient)', function() {
               sslCert: cert,
               sslPass: '10gen'
             },
-            function(err) {
+            function (err) {
               test.ok(err != null);
 
-              serverManager.stop().then(function() {
+              serverManager.stop().then(function () {
                 done();
               });
             }
@@ -479,7 +479,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('Should correctly shut down if attempting to connect to ssl server with wrong parameters', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server,
         MongoClient = configuration.require.MongoClient;
@@ -498,14 +498,14 @@ describe.skip('SSL (MongoClient)', function() {
       // Start server
       serverManager
         .purge()
-        .then(function() {
+        .then(function () {
           return serverManager.start();
         })
-        .then(function() {
-          MongoClient.connect('mongodb://localhost:27019/test?ssl=false', function(err) {
+        .then(function () {
+          MongoClient.connect('mongodb://localhost:27019/test?ssl=false', function (err) {
             test.ok(err != null);
 
-            serverManager.stop().then(function() {
+            serverManager.stop().then(function () {
               done();
             });
           });
@@ -516,7 +516,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('should correctly connect using SSL to ReplSetManager', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSetManager = require('mongodb-topology-manager').ReplSet,
         MongoClient = configuration.require.MongoClient;
@@ -564,10 +564,10 @@ describe.skip('SSL (MongoClient)', function() {
 
       replicasetManager
         .purge()
-        .then(function() {
+        .then(function () {
           return replicasetManager.start();
         })
-        .then(function() {
+        .then(function () {
           // Connect and validate the server certificate
           MongoClient.connect(
             'mongodb://server:31000,server:31001,server:31002/test?ssl=true&replicaSet=rs&maxPoolSize=1',
@@ -576,11 +576,11 @@ describe.skip('SSL (MongoClient)', function() {
               sslValidate: false,
               sslCA: ca
             },
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
               client.close();
 
-              replicasetManager.stop().then(function() {
+              replicasetManager.stop().then(function () {
                 done();
               });
             }
@@ -592,7 +592,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('shouldCorrectlySendCertificateToReplSetAndValidateServerCertificate', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSetManager = require('mongodb-topology-manager').ReplSet,
         MongoClient = configuration.require.MongoClient;
@@ -649,10 +649,10 @@ describe.skip('SSL (MongoClient)', function() {
         }
       );
 
-      replicasetManager.purge().then(function() {
+      replicasetManager.purge().then(function () {
         return replicasetManager
           .start()
-          .then(function() {
+          .then(function () {
             // Connect and validate the server certificate
             MongoClient.connect(
               'mongodb://server:31000,server:31001/test?ssl=true&replicaSet=rs&maxPoolSize=1',
@@ -662,17 +662,17 @@ describe.skip('SSL (MongoClient)', function() {
                 sslKey: key,
                 sslCert: cert
               },
-              function(err, client) {
+              function (err, client) {
                 test.equal(null, err);
                 client.close();
 
-                replicasetManager.stop().then(function() {
+                replicasetManager.stop().then(function () {
                   done();
                 });
               }
             );
           })
-          .catch(function(e) {
+          .catch(function (e) {
             done(e);
           });
       });
@@ -682,7 +682,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('should correctly send SNI TLS servername to replicaset members', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSetManager = require('mongodb-topology-manager').ReplSet,
         MongoClient = configuration.require.MongoClient;
@@ -739,12 +739,12 @@ describe.skip('SSL (MongoClient)', function() {
         }
       );
 
-      replicasetManager.purge().then(function() {
+      replicasetManager.purge().then(function () {
         // Start the server
         replicasetManager
           .start()
-          .then(function() {
-            setTimeout(function() {
+          .then(function () {
+            setTimeout(function () {
               // Connect and validate the server certificate
               MongoClient.connect(
                 'mongodb://server:31000/test?ssl=true&replicaSet=rs&maxPoolSize=1',
@@ -755,19 +755,19 @@ describe.skip('SSL (MongoClient)', function() {
                   sslKey: key,
                   sslCert: cert
                 },
-                function(err, client) {
+                function (err, client) {
                   test.equal(null, err);
 
                   client.close();
 
-                  replicasetManager.stop().then(function() {
+                  replicasetManager.stop().then(function () {
                     done();
                   });
                 }
               );
             }, 10000);
           })
-          .catch(function(e) {
+          .catch(function (e) {
             done(e);
           });
       });
@@ -777,7 +777,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('should correctly send SNI TLS servername to replicaset members with restart', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSetManager = require('mongodb-topology-manager').ReplSet,
         MongoClient = configuration.require.MongoClient;
@@ -834,12 +834,12 @@ describe.skip('SSL (MongoClient)', function() {
         }
       );
 
-      replicasetManager.purge().then(function() {
+      replicasetManager.purge().then(function () {
         // Start the server
         replicasetManager
           .start()
-          .then(function() {
-            setTimeout(function() {
+          .then(function () {
+            setTimeout(function () {
               // Connect and validate the server certificate
               MongoClient.connect(
                 'mongodb://server:31000/test?ssl=true&replicaSet=rs&maxPoolSize=1',
@@ -851,15 +851,15 @@ describe.skip('SSL (MongoClient)', function() {
                   sslCert: cert,
                   haInterval: 2000
                 },
-                function(err, client) {
+                function (err, client) {
                   test.equal(null, err);
 
-                  replicasetManager.primary().then(function(primary) {
-                    primary.stop().then(function() {
+                  replicasetManager.primary().then(function (primary) {
+                    primary.stop().then(function () {
                       // Restart the old master and wait for the sync to happen
-                      primary.start().then(function() {
+                      primary.start().then(function () {
                         // Wait to allow haInterval to happen
-                        setTimeout(function() {
+                        setTimeout(function () {
                           client.close();
                           var connections = client.topology.connections();
 
@@ -867,7 +867,7 @@ describe.skip('SSL (MongoClient)', function() {
                             test.equal('server', connections[i].options.servername);
                           }
 
-                          replicasetManager.stop().then(function() {
+                          replicasetManager.stop().then(function () {
                             done();
                           });
                         }, 3000);
@@ -878,7 +878,7 @@ describe.skip('SSL (MongoClient)', function() {
               );
             }, 10000);
           })
-          .catch(function(e) {
+          .catch(function (e) {
             done(e);
           });
       });
@@ -888,7 +888,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('shouldSendWrongCertificateToReplSetAndValidateServerCertificate', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSetManager = require('mongodb-topology-manager').ReplSet,
         MongoClient = configuration.require.MongoClient;
@@ -943,12 +943,12 @@ describe.skip('SSL (MongoClient)', function() {
         }
       );
 
-      replicasetManager.purge().then(function() {
+      replicasetManager.purge().then(function () {
         // Start the server
         replicasetManager
           .start()
-          .then(function() {
-            setTimeout(function() {
+          .then(function () {
+            setTimeout(function () {
               // Present wrong certificate
               var cert = fs.readFileSync(__dirname + '/ssl/mycert.pem');
               var key = fs.readFileSync(__dirname + '/ssl/mycert.pem');
@@ -963,17 +963,17 @@ describe.skip('SSL (MongoClient)', function() {
                   sslCert: cert,
                   sslPass: '10gen'
                 },
-                function(err) {
+                function (err) {
                   test.ok(err != null);
 
-                  replicasetManager.stop().then(function() {
+                  replicasetManager.stop().then(function () {
                     done();
                   });
                 }
               );
             }, 10000);
           })
-          .catch(function(e) {
+          .catch(function (e) {
             done(e);
           });
       });
@@ -983,7 +983,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('should correctly to replicaset using ssl connect with password', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSetManager = require('mongodb-topology-manager').ReplSet,
         MongoClient = configuration.require.MongoClient;
@@ -1040,10 +1040,10 @@ describe.skip('SSL (MongoClient)', function() {
         }
       );
 
-      replicasetManager.purge().then(function() {
+      replicasetManager.purge().then(function () {
         // Start the server
-        replicasetManager.start().then(function() {
-          setTimeout(function() {
+        replicasetManager.start().then(function () {
+          setTimeout(function () {
             // Connect and validate the server certificate
             MongoClient.connect(
               'mongodb://server:31000,server:31001/test?ssl=true&replicaSet=rs&maxPoolSize=1',
@@ -1054,11 +1054,11 @@ describe.skip('SSL (MongoClient)', function() {
                 sslCert: cert,
                 sslPass: '10gen'
               },
-              function(err, client) {
+              function (err, client) {
                 test.equal(null, err);
                 client.close();
 
-                replicasetManager.stop().then(function() {
+                replicasetManager.stop().then(function () {
                   done();
                 });
               }
@@ -1072,7 +1072,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('should correctly connect using ssl with sslValidation turned off', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSetManager = require('mongodb-topology-manager').ReplSet,
         MongoClient = configuration.require.MongoClient;
@@ -1119,10 +1119,10 @@ describe.skip('SSL (MongoClient)', function() {
         }
       );
 
-      replicasetManager.purge().then(function() {
+      replicasetManager.purge().then(function () {
         // Start the server
-        replicasetManager.start().then(function() {
-          setTimeout(function() {
+        replicasetManager.start().then(function () {
+          setTimeout(function () {
             // Connect and validate the server certificate
             MongoClient.connect(
               'mongodb://server:31000,server:31001/test?ssl=true&replicaSet=rs&maxPoolSize=1',
@@ -1130,12 +1130,12 @@ describe.skip('SSL (MongoClient)', function() {
                 ssl: true,
                 sslValidate: false
               },
-              function(err, client) {
+              function (err, client) {
                 test.equal(null, err);
 
                 client.close();
 
-                replicasetManager.stop().then(function() {
+                replicasetManager.stop().then(function () {
                   done();
                 });
               }
@@ -1149,7 +1149,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('should correctly connect using SSL to replicaset with requireSSL', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSetManager = require('mongodb-topology-manager').ReplSet,
         MongoClient = configuration.require.MongoClient;
@@ -1198,12 +1198,12 @@ describe.skip('SSL (MongoClient)', function() {
         }
       );
 
-      replicasetManager.purge().then(function() {
+      replicasetManager.purge().then(function () {
         // Start the server
         replicasetManager
           .start()
-          .then(function() {
-            setTimeout(function() {
+          .then(function () {
+            setTimeout(function () {
               // Connect and validate the server certificate
               MongoClient.connect(
                 'mongodb://server:31000,server:31001,server:31002/test?replicaSet=rs',
@@ -1213,16 +1213,16 @@ describe.skip('SSL (MongoClient)', function() {
                   sslCert: cert,
                   sslCA: ca
                 },
-                function(err, client) {
+                function (err, client) {
                   test.equal(null, err);
                   var sets = [{}];
                   var db = client.db(configuration.db);
 
-                  var interval = setInterval(function() {
+                  var interval = setInterval(function () {
                     db.command(
                       { ismaster: true },
                       { readPreference: 'nearest', full: true },
-                      function(e, r) {
+                      function (e, r) {
                         // Add seen servers to list
                         if (r) {
                           sets[sets.length - 1][r.connection.port] = true;
@@ -1231,14 +1231,14 @@ describe.skip('SSL (MongoClient)', function() {
                     );
                   }, 500);
 
-                  setTimeout(function() {
+                  setTimeout(function () {
                     // Force a reconnect of a server
                     var secondary = client.topology.s.coreTopology.s.replicaSetState.secondaries[0];
                     secondary.destroy({ emitClose: true });
                     sets.push({});
 
-                    client.topology.once('joined', function() {
-                      setTimeout(function() {
+                    client.topology.once('joined', function () {
+                      setTimeout(function () {
                         clearInterval(interval);
 
                         test.ok(sets[0][31000]);
@@ -1251,7 +1251,7 @@ describe.skip('SSL (MongoClient)', function() {
 
                         client.close();
 
-                        replicasetManager.stop().then(function() {
+                        replicasetManager.stop().then(function () {
                           done();
                         });
                       }, 5000);
@@ -1261,7 +1261,7 @@ describe.skip('SSL (MongoClient)', function() {
               );
             });
           }, 10000)
-          .catch(function(err) {
+          .catch(function (err) {
             done(err);
           });
       });
@@ -1271,7 +1271,7 @@ describe.skip('SSL (MongoClient)', function() {
   it('should correctly connect to Replicaset using SSL when secondary down', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ReplSetManager = require('mongodb-topology-manager').ReplSet,
         MongoClient = configuration.require.MongoClient;
@@ -1317,14 +1317,14 @@ describe.skip('SSL (MongoClient)', function() {
         }
       );
 
-      replicasetManager.purge().then(function() {
+      replicasetManager.purge().then(function () {
         // Start the server
-        replicasetManager.start().then(function() {
-          replicasetManager.secondaries().then(function(managers) {
+        replicasetManager.start().then(function () {
+          replicasetManager.secondaries().then(function (managers) {
             var secondaryServerManager = managers[0];
 
-            secondaryServerManager.stop().then(function() {
-              setTimeout(function() {
+            secondaryServerManager.stop().then(function () {
+              setTimeout(function () {
                 // Connect and validate the server certificate
                 MongoClient.connect(
                   'mongodb://server:31000,server:31001,server:31002/test?ssl=true&replicaSet=rs&maxPoolSize=1',
@@ -1333,11 +1333,11 @@ describe.skip('SSL (MongoClient)', function() {
                     sslValidate: false,
                     sslCA: ca
                   },
-                  function(err, client) {
+                  function (err, client) {
                     test.equal(null, err);
                     client.close();
 
-                    replicasetManager.stop().then(function() {
+                    replicasetManager.stop().then(function () {
                       done();
                     });
                   }

--- a/test/disabled/ssl_validation.test.js
+++ b/test/disabled/ssl_validation.test.js
@@ -5,7 +5,7 @@ var f = require('util').format;
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-var setUp = function(configuration, options, callback) {
+var setUp = function (configuration, options, callback) {
   var ReplSetManager = require('mongodb-topology-manager').ReplSet;
 
   // Check if we have any options
@@ -73,36 +73,36 @@ var setUp = function(configuration, options, callback) {
   var replicasetManager = new ReplSetManager('mongod', nodes, rsOptions.client);
 
   // Purge the set
-  replicasetManager.purge().then(function() {
+  replicasetManager.purge().then(function () {
     // Start the server
     replicasetManager
       .start()
-      .then(function() {
-        setTimeout(function() {
+      .then(function () {
+        setTimeout(function () {
           callback(null, replicasetManager);
         }, 10000);
       })
-      .catch(function(e) {
+      .catch(function (e) {
         test.ok(e != null);
       });
   });
 };
 
-describe('SSL Validation', function() {
-  before(function() {
+describe('SSL Validation', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it('shouldFailDuePresentingWrongCredentialsToServer', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Server = configuration.require.Server,
         ReplSet = configuration.require.ReplSet,
         MongoClient = configuration.require.MongoClient;
 
-      setUp(configuration, function(e, replicasetManager) {
+      setUp(configuration, function (e, replicasetManager) {
         // Read the ca
         var ca = [fs.readFileSync(__dirname + '/ssl/ca.pem')];
         var cert = fs.readFileSync(__dirname + '/ssl/mycert.pem');
@@ -128,10 +128,10 @@ describe('SSL Validation', function() {
 
         // Connect to the replicaset
         var client = new MongoClient(replSet, configuration.writeConcernMax());
-        client.connect(function(err) {
+        client.connect(function (err) {
           test.ok(err != null);
 
-          replicasetManager.stop().then(function() {
+          replicasetManager.stop().then(function () {
             done();
           });
         });
@@ -142,13 +142,13 @@ describe('SSL Validation', function() {
   it('Should correctly receive ping and ha events using ssl', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Server = configuration.require.Server,
         ReplSet = configuration.require.ReplSet,
         MongoClient = configuration.require.MongoClient;
 
-      setUp(configuration, function(e, replicasetManager) {
+      setUp(configuration, function (e, replicasetManager) {
         // Read the ca
         var ca = [fs.readFileSync(__dirname + '/ssl/ca.pem')];
         var cert = fs.readFileSync(__dirname + '/ssl/client.pem');
@@ -172,20 +172,20 @@ describe('SSL Validation', function() {
 
         // Connect to the replicaset
         var client = new MongoClient(replSet, configuration.writeConcernMax());
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var ha = false;
-          client.topology.once('serverHeartbeatSucceeded', function(e) {
+          client.topology.once('serverHeartbeatSucceeded', function (e) {
             test.equal(null, e);
             ha = true;
           });
 
-          var interval = setInterval(function() {
+          var interval = setInterval(function () {
             if (ha) {
               clearInterval(interval);
               client.close();
 
-              replicasetManager.stop().then(function() {
+              replicasetManager.stop().then(function () {
                 done();
               });
             }
@@ -198,7 +198,7 @@ describe('SSL Validation', function() {
   it('shouldFailToValidateServerSSLCertificate', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Server = configuration.require.Server,
         ReplSet = configuration.require.ReplSet,
@@ -207,7 +207,7 @@ describe('SSL Validation', function() {
       var ca = [fs.readFileSync(__dirname + '/ssl/mycert.pem')];
 
       // Startup replicaset
-      setUp(configuration, function(e, replicasetManager) {
+      setUp(configuration, function (e, replicasetManager) {
         // Create new
         var replSet = new ReplSet(
           [
@@ -225,10 +225,10 @@ describe('SSL Validation', function() {
 
         // Connect to the replicaset
         var client = new MongoClient(replSet, configuration.writeConcernMax());
-        client.connect(function(err) {
+        client.connect(function (err) {
           test.ok(err != null);
 
-          replicasetManager.stop().then(function() {
+          replicasetManager.stop().then(function () {
             done();
           });
         });
@@ -239,13 +239,13 @@ describe('SSL Validation', function() {
   it('shouldCorrectlyValidateAndPresentCertificateReplSet', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Server = configuration.require.Server,
         ReplSet = configuration.require.ReplSet,
         MongoClient = configuration.require.MongoClient;
 
-      setUp(configuration, function(e, replicasetManager) {
+      setUp(configuration, function (e, replicasetManager) {
         // Read the ca
         var ca = [fs.readFileSync(__dirname + '/ssl/ca.pem')];
         var cert = fs.readFileSync(__dirname + '/ssl/client.pem');
@@ -269,30 +269,30 @@ describe('SSL Validation', function() {
 
         // Connect to the replicaset
         var client = new MongoClient(replSet, configuration.writeConcernMax());
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
-          setInterval(function() {
-            db.collection('test').count(function() {});
+          setInterval(function () {
+            db.collection('test').count(function () {});
           }, 1000);
 
           // Create a collection
-          db.createCollection('shouldCorrectlyValidateAndPresentCertificateReplSet1', function(
+          db.createCollection('shouldCorrectlyValidateAndPresentCertificateReplSet1', function (
             err,
             collection
           ) {
-            collection.remove({}, configuration.writeConcernMax(), function() {
+            collection.remove({}, configuration.writeConcernMax(), function () {
               collection.insert(
                 [{ a: 1 }, { b: 2 }, { c: 'hello world' }],
                 configuration.writeConcernMax(),
-                function(err) {
+                function (err) {
                   test.equal(null, err);
-                  collection.find({}).toArray(function(err, items) {
+                  collection.find({}).toArray(function (err, items) {
                     test.equal(3, items.length);
                     client.close();
 
-                    replicasetManager.stop().then(function() {
+                    replicasetManager.stop().then(function () {
                       done();
                     });
                   });
@@ -308,7 +308,7 @@ describe('SSL Validation', function() {
   it('shouldCorrectlyConnectToSSLBasedReplicaset', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Server = configuration.require.Server,
         ReplSet = configuration.require.ReplSet,
@@ -336,7 +336,7 @@ describe('SSL Validation', function() {
             rejectUnauthorized: false
           }
         },
-        function(e, replicasetManager) {
+        function (e, replicasetManager) {
           // Read the ca
           var ca = [fs.readFileSync(__dirname + '/ssl/ca.pem')];
           // Create new
@@ -355,15 +355,15 @@ describe('SSL Validation', function() {
 
           // Connect to the replicaset
           var client = new MongoClient(replSet, configuration.writeConcernMax());
-          client.connect(function(err, client) {
+          client.connect(function (err, client) {
             test.equal(null, err);
             var db = client.db(configuration.db);
 
-            db.collection('test').find({}, function(error) {
+            db.collection('test').find({}, function (error) {
               test.equal(null, error);
               client.close();
 
-              replicasetManager.stop().then(function() {
+              replicasetManager.stop().then(function () {
                 done();
               });
             });
@@ -376,13 +376,13 @@ describe('SSL Validation', function() {
   it('shouldFailToValidateServerSSLCertificate', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Server = configuration.require.Server,
         ReplSet = configuration.require.ReplSet,
         MongoClient = configuration.require.MongoClient;
 
-      setUp(configuration, function(e, replicasetManager) {
+      setUp(configuration, function (e, replicasetManager) {
         // Read the ca
         var ca = [fs.readFileSync(__dirname + '/ssl/mycert.pem')];
         // Create new
@@ -402,11 +402,11 @@ describe('SSL Validation', function() {
 
         // Connect to the replicaset
         var client = new MongoClient(replSet, configuration.writeConcernMax());
-        client.connect(function(err) {
+        client.connect(function (err) {
           test.ok(err != null);
           test.ok(err instanceof Error);
 
-          replicasetManager.stop().then(function() {
+          replicasetManager.stop().then(function () {
             done();
           });
         });
@@ -417,13 +417,13 @@ describe('SSL Validation', function() {
   it('shouldFailDueToNotPresentingCertificateToServer', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Server = configuration.require.Server,
         ReplSet = configuration.require.ReplSet,
         MongoClient = configuration.require.MongoClient;
 
-      setUp(configuration, function(e, replicasetManager) {
+      setUp(configuration, function (e, replicasetManager) {
         // Read the ca
         var ca = [fs.readFileSync(__dirname + '/ssl/mycert.pem')];
         var cert = fs.readFileSync(__dirname + '/ssl/client.pem');
@@ -445,10 +445,10 @@ describe('SSL Validation', function() {
 
         // Connect to the replicaset
         var client = new MongoClient(replSet, configuration.writeConcernMax());
-        client.connect(function(err) {
+        client.connect(function (err) {
           test.ok(err != null);
 
-          replicasetManager.stop().then(function() {
+          replicasetManager.stop().then(function () {
             done();
           });
         });
@@ -459,7 +459,7 @@ describe('SSL Validation', function() {
   it('shouldCorrectlyPresentPasswordProtectedCertificate', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Server = configuration.require.Server,
         ReplSet = configuration.require.ReplSet,
@@ -492,7 +492,7 @@ describe('SSL Validation', function() {
             replSet: 'rs'
           }
         },
-        function(e, replicasetManager) {
+        function (e, replicasetManager) {
           // Create new
           var replSet = new ReplSet(
             [
@@ -513,26 +513,26 @@ describe('SSL Validation', function() {
 
           // Connect to the replicaset
           var client = new MongoClient(replSet, configuration.writeConcernMax());
-          client.connect(function(err, client) {
+          client.connect(function (err, client) {
             test.equal(null, err);
             var db = client.db(configuration.db);
 
             // Create a collection
-            db.createCollection('shouldCorrectlyValidateAndPresentCertificate2', function(
+            db.createCollection('shouldCorrectlyValidateAndPresentCertificate2', function (
               err,
               collection
             ) {
-              collection.remove({}, configuration.writeConcernMax(), function() {
+              collection.remove({}, configuration.writeConcernMax(), function () {
                 collection.insert(
                   [{ a: 1 }, { b: 2 }, { c: 'hello world' }],
                   configuration.writeConcernMax(),
-                  function(err) {
+                  function (err) {
                     test.equal(null, err);
-                    collection.find({}).toArray(function(err, items) {
+                    collection.find({}).toArray(function (err, items) {
                       test.equal(3, items.length);
                       client.close();
 
-                      replicasetManager.stop().then(function() {
+                      replicasetManager.stop().then(function () {
                         done();
                       });
                     });
@@ -549,7 +549,7 @@ describe('SSL Validation', function() {
   it('shouldCorrectlyValidateServerSSLCertificate', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Server = configuration.require.Server,
         ReplSet = configuration.require.ReplSet,
@@ -573,7 +573,7 @@ describe('SSL Validation', function() {
             replSet: 'rs'
           }
         },
-        function(e, replicasetManager) {
+        function (e, replicasetManager) {
           // Create new
           var replSet = new ReplSet(
             [
@@ -591,26 +591,26 @@ describe('SSL Validation', function() {
 
           // Connect to the replicaset
           var client = new MongoClient(replSet, configuration.writeConcernMax());
-          client.connect(function(err, client) {
+          client.connect(function (err, client) {
             test.equal(null, err);
             var db = client.db(configuration.db);
 
             // Create a collection
-            db.createCollection('shouldCorrectlyCommunicateUsingSSLSocket', function(
+            db.createCollection('shouldCorrectlyCommunicateUsingSSLSocket', function (
               err,
               collection
             ) {
-              collection.remove({}, configuration.writeConcernMax(), function() {
+              collection.remove({}, configuration.writeConcernMax(), function () {
                 collection.insert(
                   [{ a: 1 }, { b: 2 }, { c: 'hello world' }],
                   configuration.writeConcernMax(),
-                  function(err) {
+                  function (err) {
                     test.equal(null, err);
-                    collection.find({}).toArray(function(err, items) {
+                    collection.find({}).toArray(function (err, items) {
                       test.equal(3, items.length);
                       client.close();
 
-                      replicasetManager.stop().then(function() {
+                      replicasetManager.stop().then(function () {
                         done();
                       });
                     });

--- a/test/disabled/wire_protocol.test.js
+++ b/test/disabled/wire_protocol.test.js
@@ -6,12 +6,12 @@ const sinon = require('sinon');
 const { ConnectionPool } = require('../../../src/cmap/connection_pool.js');
 const wireProtocol = require('../../../src/cmap/wire_protocol');
 
-describe('WireProtocol', function() {
-  it('should only set bypassDocumentValidation to true if explicitly set by user to true', function() {
+describe('WireProtocol', function () {
+  it('should only set bypassDocumentValidation to true if explicitly set by user to true', function () {
     testPoolWrite(true, true);
   });
 
-  it('should not set bypassDocumentValidation to anything if not explicitly set by user to true', function() {
+  it('should not set bypassDocumentValidation to anything if not explicitly set by user to true', function () {
     testPoolWrite(false, undefined);
   });
 

--- a/test/examples/aggregate.js
+++ b/test/examples/aggregate.js
@@ -3,20 +3,20 @@
 
 const setupDatabase = require('../functional/shared').setupDatabase;
 
-describe('examples.aggregaton:', function() {
+describe('examples.aggregaton:', function () {
   let client;
   let collection;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     collection = client.db(this.configuration.db).collection('aggregateExample');
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     collection = undefined;
@@ -24,7 +24,7 @@ describe('examples.aggregaton:', function() {
 
   it('supports simple aggregation', {
     metadata: { requires: { mongodb: '>=2.8.0', topology: ['single'] } },
-    test: async function() {
+    test: async function () {
       // Start aggregate example 1
       const cursor = collection.aggregate([
         { $match: { 'items.fruit': 'banana' } },
@@ -36,7 +36,7 @@ describe('examples.aggregaton:', function() {
 
   it('supports $match, $group, $project, $unwind, $sum, $sort, $dayOfWeek', {
     metadata: { requires: { mongodb: '>=2.8.0', topology: ['single'] } },
-    test: async function() {
+    test: async function () {
       // Start aggregate example 2
       const cursor = collection.aggregate([
         {
@@ -70,7 +70,7 @@ describe('examples.aggregaton:', function() {
 
   it('supports $unwind, $group, $sum, $dayOfWeek, $multiply, $project, $cond', {
     metadata: { requires: { mongodb: '>=2.8.0', topology: ['single'] } },
-    test: async function() {
+    test: async function () {
       // Start aggregate example 3
       const cursor = collection.aggregate([
         {
@@ -100,7 +100,7 @@ describe('examples.aggregaton:', function() {
 
   it('supports $lookup, $filter, $match', {
     metadata: { requires: { mongodb: '>=3.6.0', topology: ['single'] } },
-    test: async function() {
+    test: async function () {
       // Start aggregate example 4
       const cursor = collection.aggregate([
         {

--- a/test/examples/array_filters.js
+++ b/test/examples/array_filters.js
@@ -2,20 +2,20 @@
 
 const setupDatabase = require('../functional/shared').setupDatabase;
 
-describe('examples(project-fields-from-query):', function() {
+describe('examples(project-fields-from-query):', function () {
   let client;
   let collection;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     collection = client.db(this.configuration.db).collection('arrayFilterUpdateExample');
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     collection = undefined;
@@ -23,7 +23,7 @@ describe('examples(project-fields-from-query):', function() {
 
   it('supports array filters when updating', {
     metadata: { requires: { mongodb: '>=3.6.x', topology: ['single'] } },
-    test: async function() {
+    test: async function () {
       // 3. Exploiting the power of arrays
       await collection.updateOne(
         { _id: 1 },

--- a/test/examples/causal_consistency.js
+++ b/test/examples/causal_consistency.js
@@ -3,21 +3,21 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(causal-consistency):', function() {
+describe('examples(causal-consistency):', function () {
   let client;
   let collection;
   let session;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     collection = client.db(this.configuration.db).collection('arrayFilterUpdateExample');
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     if (session) {
       await session.endSession();
       session = undefined;
@@ -34,7 +34,7 @@ describe('examples(causal-consistency):', function() {
       sessions: { skipLeakTests: true }
     },
 
-    test: async function() {
+    test: async function () {
       const session = client.startSession({ causalConsistency: true });
 
       collection.insertOne({ darmok: 'jalad' }, { session });

--- a/test/examples/change_streams.js
+++ b/test/examples/change_streams.js
@@ -4,15 +4,15 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(change-stream):', function() {
+describe('examples(change-stream):', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
@@ -23,7 +23,7 @@ describe('examples(change-stream):', function() {
     await db.collection('inventory').deleteMany({});
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -56,7 +56,7 @@ describe('examples(change-stream):', function() {
 
   it('Open A Change Stream', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.6.0' } },
-    test: async function() {
+    test: async function () {
       const looper = new Looper(() => db.collection('inventory').insertOne({ a: 1 }));
       looper.run();
 
@@ -77,15 +77,13 @@ describe('examples(change-stream):', function() {
       await changeStreamIterator.close();
       await looper.stop();
 
-      expect(next)
-        .to.have.property('operationType')
-        .that.equals('insert');
+      expect(next).to.have.property('operationType').that.equals('insert');
     }
   });
 
   it('Lookup Full Document for Update Operations', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.6.0' } },
-    test: async function() {
+    test: async function () {
       await db.collection('inventory').insertOne({ a: 1, b: 2 });
       const looper = new Looper(() =>
         db.collection('inventory').updateOne({ a: 1 }, { $set: { a: 2 } })
@@ -109,18 +107,14 @@ describe('examples(change-stream):', function() {
       await changeStreamIterator.close();
       await looper.stop();
 
-      expect(next)
-        .to.have.property('operationType')
-        .that.equals('update');
-      expect(next)
-        .to.have.property('fullDocument')
-        .that.has.all.keys(['_id', 'a', 'b']);
+      expect(next).to.have.property('operationType').that.equals('update');
+      expect(next).to.have.property('fullDocument').that.has.all.keys(['_id', 'a', 'b']);
     }
   });
 
   it('Resume a Change Stream', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.6.0' } },
-    test: async function() {
+    test: async function () {
       const looper = new Looper(async () => {
         await db.collection('inventory').insertOne({ a: 1 });
         await db.collection('inventory').insertOne({ b: 2 });
@@ -172,7 +166,7 @@ describe('examples(change-stream):', function() {
 
   it('Modify Change Stream Output', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.6.0' } },
-    test: async function() {
+    test: async function () {
       const looper = new Looper(async () => {
         await db.collection('inventory').insertOne({ username: 'alice' });
       });

--- a/test/examples/create_index.js
+++ b/test/examples/create_index.js
@@ -2,20 +2,20 @@
 
 const setupDatabase = require('../functional/shared').setupDatabase;
 
-describe('examples.createIndex:', function() {
+describe('examples.createIndex:', function () {
   let client;
   let collection;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     collection = client.db(this.configuration.db).collection('createIndexExample');
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     collection = undefined;
@@ -23,7 +23,7 @@ describe('examples.createIndex:', function() {
 
   it('supports building simple ascending index', {
     metadata: { requires: { topology: ['single'] } },
-    test: async function() {
+    test: async function () {
       // Start createIndex example 1
       await collection.createIndex({ score: 1 });
       // End createIndex example 1
@@ -32,7 +32,7 @@ describe('examples.createIndex:', function() {
 
   it('supports building multikey index with partial filter expression', {
     metadata: { requires: { topology: ['single'], mongodb: '>=3.2.x' } },
-    test: async function() {
+    test: async function () {
       // Start createIndex example 2
       await collection.createIndex(
         { cuisine: 1, name: 1 },

--- a/test/examples/insert.js
+++ b/test/examples/insert.js
@@ -3,22 +3,22 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(insert):', function() {
+describe('examples(insert):', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
     await db.collection('inventory').deleteMany({});
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -26,7 +26,7 @@ describe('examples(insert):', function() {
 
   it('Insert a Single Document', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 1
       await db.collection('inventory').insertOne({
         item: 'canvas',
@@ -46,7 +46,7 @@ describe('examples(insert):', function() {
 
   it('Insert Multiple Documents', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 3
       await db.collection('inventory').insertMany([
         {

--- a/test/examples/project_fields_from_query_results.js
+++ b/test/examples/project_fields_from_query_results.js
@@ -3,15 +3,15 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(project-fields-from-query):', function() {
+describe('examples(project-fields-from-query):', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
@@ -55,7 +55,7 @@ describe('examples(project-fields-from-query):', function() {
     // End Example 42
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -63,7 +63,7 @@ describe('examples(project-fields-from-query):', function() {
 
   it('Return All Fields in Matching Documents', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 43
       const cursor = db.collection('inventory').find({
         status: 'A'
@@ -76,7 +76,7 @@ describe('examples(project-fields-from-query):', function() {
 
   it('Return the Specified Fields and the ``_id`` Field Only', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 44
       const cursor = db
         .collection('inventory')
@@ -87,7 +87,7 @@ describe('examples(project-fields-from-query):', function() {
       // End Example 44
 
       const docs = await cursor.toArray();
-      docs.forEach(function(doc) {
+      docs.forEach(function (doc) {
         expect(doc).to.have.all.keys(['_id', 'item', 'status']);
         expect(doc).to.not.have.all.keys(['size', 'instock']);
       });
@@ -96,7 +96,7 @@ describe('examples(project-fields-from-query):', function() {
 
   it('Suppress ``_id`` Field', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 45
       const cursor = db
         .collection('inventory')
@@ -106,7 +106,7 @@ describe('examples(project-fields-from-query):', function() {
         .project({ item: 1, status: 1, _id: 0 });
       // End Example 45
       const docs = await cursor.toArray();
-      docs.forEach(function(doc) {
+      docs.forEach(function (doc) {
         expect(doc).to.have.all.keys(['item', 'status']);
         expect(doc).to.not.have.all.keys(['_id', 'size', 'instock']);
       });
@@ -115,7 +115,7 @@ describe('examples(project-fields-from-query):', function() {
 
   it('Return All But the Excluded Fields', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 46
       const cursor = db
         .collection('inventory')
@@ -125,7 +125,7 @@ describe('examples(project-fields-from-query):', function() {
         .project({ status: 0, instock: 0 });
       // End Example 46
       const docs = await cursor.toArray();
-      docs.forEach(function(doc) {
+      docs.forEach(function (doc) {
         expect(doc).to.have.all.keys(['_id', 'item', 'size']);
         expect(doc).to.not.have.all.keys(['status', 'instock']);
       });
@@ -134,7 +134,7 @@ describe('examples(project-fields-from-query):', function() {
 
   it('Return Specific Fields in Embedded Documents', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 47
       const cursor = db
         .collection('inventory')
@@ -145,7 +145,7 @@ describe('examples(project-fields-from-query):', function() {
       // End Example 47
       const docs = await cursor.toArray();
 
-      docs.forEach(function(doc) {
+      docs.forEach(function (doc) {
         expect(doc).to.have.all.keys(['_id', 'item', 'status', 'size']);
         expect(doc).to.not.have.property('instock');
 
@@ -158,7 +158,7 @@ describe('examples(project-fields-from-query):', function() {
 
   it('Suppress Specific Fields in Embedded Documents', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 48
       const cursor = db
         .collection('inventory')
@@ -168,7 +168,7 @@ describe('examples(project-fields-from-query):', function() {
         .project({ 'size.uom': 0 });
       // End Example 48
       const docs = await cursor.toArray();
-      docs.forEach(function(doc) {
+      docs.forEach(function (doc) {
         expect(doc).to.have.all.keys(['_id', 'item', 'status', 'size', 'instock']);
         const size = doc.size;
         expect(size).to.have.all.keys(['h', 'w']);
@@ -179,7 +179,7 @@ describe('examples(project-fields-from-query):', function() {
 
   it('Projection on Embedded Documents in an Array', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 49
       const cursor = db
         .collection('inventory')
@@ -189,10 +189,10 @@ describe('examples(project-fields-from-query):', function() {
         .project({ item: 1, status: 1, 'instock.qty': 1 });
       // End Example 49
       const docs = await cursor.toArray();
-      docs.forEach(function(doc) {
+      docs.forEach(function (doc) {
         expect(doc).to.have.all.keys(['_id', 'item', 'status', 'instock']);
         expect(doc).to.not.have.property('size');
-        doc.instock.forEach(function(subdoc) {
+        doc.instock.forEach(function (subdoc) {
           expect(subdoc).to.have.property('qty');
           expect(subdoc).to.not.have.property('warehouse');
         });
@@ -202,7 +202,7 @@ describe('examples(project-fields-from-query):', function() {
 
   it('Project Specific Array Elements in the Returned Array', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 50
       const cursor = db
         .collection('inventory')
@@ -212,12 +212,10 @@ describe('examples(project-fields-from-query):', function() {
         .project({ item: 1, status: 1, instock: { $slice: -1 } });
       // End Example 50
       const docs = await cursor.toArray();
-      docs.forEach(function(doc) {
+      docs.forEach(function (doc) {
         expect(doc).to.have.all.keys(['_id', 'item', 'status', 'instock']);
         expect(doc).to.not.have.property('size');
-        expect(doc)
-          .to.have.property('instock')
-          .with.a.lengthOf(1);
+        expect(doc).to.have.property('instock').with.a.lengthOf(1);
       });
     }
   });

--- a/test/examples/query.js
+++ b/test/examples/query.js
@@ -3,15 +3,15 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(query):', function() {
+describe('examples(query):', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
@@ -52,7 +52,7 @@ describe('examples(query):', function() {
     // End Example 6
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -60,7 +60,7 @@ describe('examples(query):', function() {
 
   it('select all documents in a collection', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 7
       const cursor = db.collection('inventory').find({});
       // End Example 7
@@ -71,7 +71,7 @@ describe('examples(query):', function() {
 
   it('Specify Equality Condition', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 9
       const cursor = db.collection('inventory').find({ status: 'D' });
       // End Example 9
@@ -82,7 +82,7 @@ describe('examples(query):', function() {
 
   it('Specify Conditions Using Query Operators', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 10
       const cursor = db.collection('inventory').find({
         status: { $in: ['A', 'D'] }
@@ -94,7 +94,7 @@ describe('examples(query):', function() {
 
   it('Specify ``AND`` Condition', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 11
       const cursor = db.collection('inventory').find({
         status: 'A',
@@ -107,7 +107,7 @@ describe('examples(query):', function() {
 
   it('Specify ``OR`` Condition', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 12
       const cursor = db.collection('inventory').find({
         $or: [{ status: 'A' }, { qty: { $lt: 30 } }]
@@ -119,7 +119,7 @@ describe('examples(query):', function() {
 
   it('Specify ``AND`` as well as ``OR`` Conditions', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 13
       const cursor = db.collection('inventory').find({
         status: 'A',

--- a/test/examples/query_array_of_documents.js
+++ b/test/examples/query_array_of_documents.js
@@ -3,15 +3,15 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(query-array-of-documents):', function() {
+describe('examples(query-array-of-documents):', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
@@ -54,7 +54,7 @@ describe('examples(query-array-of-documents):', function() {
     // End Example 29
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -62,7 +62,7 @@ describe('examples(query-array-of-documents):', function() {
 
   it('Query for a Document Nested in an Array', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 30
       const cursor = db.collection('inventory').find({
         instock: { warehouse: 'A', qty: 5 }
@@ -75,7 +75,7 @@ describe('examples(query-array-of-documents):', function() {
 
   it('Query for a Document Nested in an Array - document order', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 31
       const cursor = db.collection('inventory').find({
         instock: { qty: 5, warehouse: 'A' }
@@ -88,7 +88,7 @@ describe('examples(query-array-of-documents):', function() {
 
   it('Use the Array Index to Query for a Field in the Embedded Document', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 32
       const cursor = db.collection('inventory').find({
         'instock.0.qty': { $lte: 20 }
@@ -101,7 +101,7 @@ describe('examples(query-array-of-documents):', function() {
 
   it('Specify a Query Condition on a Field Embedded in an Array of Documents', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 33
       const cursor = db.collection('inventory').find({
         'instock.qty': { $lte: 20 }
@@ -114,7 +114,7 @@ describe('examples(query-array-of-documents):', function() {
 
   it('A Single Nested Document Meets Multiple Query Conditions on Nested Fields', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 34
       const cursor = db.collection('inventory').find({
         instock: { $elemMatch: { qty: 5, warehouse: 'A' } }
@@ -127,7 +127,7 @@ describe('examples(query-array-of-documents):', function() {
 
   it('A Single Nested Document Meets Multiple Query Conditions on Nested Fields: operators', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 35
       const cursor = db.collection('inventory').find({
         instock: { $elemMatch: { qty: { $gt: 10, $lte: 20 } } }
@@ -140,7 +140,7 @@ describe('examples(query-array-of-documents):', function() {
 
   it('Combination of Elements Satisfies the Criteria', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 36
       const cursor = db.collection('inventory').find({
         'instock.qty': { $gt: 10, $lte: 20 }
@@ -153,7 +153,7 @@ describe('examples(query-array-of-documents):', function() {
 
   it('Combination of Elements Satisfies the Criteria 2', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 37
       const cursor = db.collection('inventory').find({
         'instock.qty': 5,

--- a/test/examples/query_arrays.js
+++ b/test/examples/query_arrays.js
@@ -3,15 +3,15 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(query-arrays):', function() {
+describe('examples(query-arrays):', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
@@ -52,7 +52,7 @@ describe('examples(query-arrays):', function() {
     // End Example 20
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -60,7 +60,7 @@ describe('examples(query-arrays):', function() {
 
   it('Match an Array', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 21
       const cursor = db.collection('inventory').find({
         tags: ['red', 'blank']
@@ -73,7 +73,7 @@ describe('examples(query-arrays):', function() {
 
   it('Match an Array: $all', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 22
       const cursor = db.collection('inventory').find({
         tags: { $all: ['red', 'blank'] }
@@ -86,7 +86,7 @@ describe('examples(query-arrays):', function() {
 
   it('Query an Array for an Element', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 23
       const cursor = db.collection('inventory').find({
         tags: 'red'
@@ -99,7 +99,7 @@ describe('examples(query-arrays):', function() {
 
   it('Query an Array for an Element w/ operators', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 24
       const cursor = db.collection('inventory').find({
         dim_cm: { $gt: 25 }
@@ -112,7 +112,7 @@ describe('examples(query-arrays):', function() {
 
   it('Query an Array with Compound Filter Conditions on the Array Elements', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 25
       const cursor = db.collection('inventory').find({
         dim_cm: { $gt: 15, $lt: 20 }
@@ -125,7 +125,7 @@ describe('examples(query-arrays):', function() {
 
   it('Query for an Array Element that Meets Multiple Criteria', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 26
       const cursor = db.collection('inventory').find({
         dim_cm: { $elemMatch: { $gt: 22, $lt: 30 } }
@@ -138,7 +138,7 @@ describe('examples(query-arrays):', function() {
 
   it('Query for an Element by the Array Index Position', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 27
       const cursor = db.collection('inventory').find({
         'dim_cm.1': { $gt: 25 }
@@ -151,7 +151,7 @@ describe('examples(query-arrays):', function() {
 
   it('Query an Array by Array Length', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 28
       const cursor = db.collection('inventory').find({
         tags: { $size: 3 }

--- a/test/examples/query_embedded_documents.js
+++ b/test/examples/query_embedded_documents.js
@@ -3,15 +3,15 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(query-embedded-documents):', function() {
+describe('examples(query-embedded-documents):', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
@@ -52,7 +52,7 @@ describe('examples(query-embedded-documents):', function() {
     // End Example 14
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -60,7 +60,7 @@ describe('examples(query-embedded-documents):', function() {
 
   it('Match an Embedded/Nested Document', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 15
       const cursor = db.collection('inventory').find({
         size: { h: 14, w: 21, uom: 'cm' }
@@ -73,7 +73,7 @@ describe('examples(query-embedded-documents):', function() {
 
   it('Match an Embedded/Nested Document - document order', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 16
       const cursor = db.collection('inventory').find({
         size: { w: 21, h: 14, uom: 'cm' }
@@ -86,7 +86,7 @@ describe('examples(query-embedded-documents):', function() {
 
   it('Specify Equality Match on a Nested Field', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 17
       const cursor = db.collection('inventory').find({
         'size.uom': 'in'
@@ -99,7 +99,7 @@ describe('examples(query-embedded-documents):', function() {
 
   it('Specify Match using Query Operator', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 18
       const cursor = db.collection('inventory').find({
         'size.h': { $lt: 15 }
@@ -112,7 +112,7 @@ describe('examples(query-embedded-documents):', function() {
 
   it('Specify ``AND`` Condition', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 19
       const cursor = db.collection('inventory').find({
         'size.h': { $lt: 15 },

--- a/test/examples/query_for_null_fields.js
+++ b/test/examples/query_for_null_fields.js
@@ -3,15 +3,15 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(query-for-null-fields):', function() {
+describe('examples(query-for-null-fields):', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
@@ -21,7 +21,7 @@ describe('examples(query-for-null-fields):', function() {
     // End Example 38
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -29,7 +29,7 @@ describe('examples(query-for-null-fields):', function() {
 
   it('Equality Filter', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 39
       const cursor = db.collection('inventory').find({
         item: null
@@ -42,7 +42,7 @@ describe('examples(query-for-null-fields):', function() {
 
   it('Type Check', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 40
       const cursor = db.collection('inventory').find({
         item: { $type: 10 }
@@ -55,7 +55,7 @@ describe('examples(query-for-null-fields):', function() {
 
   it('Existence Check', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 41
       const cursor = db.collection('inventory').find({
         item: { $exists: false }

--- a/test/examples/remove_documents.js
+++ b/test/examples/remove_documents.js
@@ -3,15 +3,15 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(remove-documents):', function() {
+describe('examples(remove-documents):', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
@@ -52,7 +52,7 @@ describe('examples(remove-documents):', function() {
     // End Example 55
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -60,7 +60,7 @@ describe('examples(remove-documents):', function() {
 
   it('Delete All Documents', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 56
       await db.collection('inventory').deleteMany({});
       // End Example 56
@@ -71,7 +71,7 @@ describe('examples(remove-documents):', function() {
 
   it('Delete All Documents that Match a Condition', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 57
       await db.collection('inventory').deleteMany({ status: 'A' });
       // End Example 57
@@ -82,7 +82,7 @@ describe('examples(remove-documents):', function() {
 
   it('Delete Only One Document that Matches a Condition', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 58
       await db.collection('inventory').deleteOne({ status: 'D' });
       // End Example 58

--- a/test/examples/run_command.js
+++ b/test/examples/run_command.js
@@ -2,15 +2,15 @@
 
 const setupDatabase = require('../functional/shared').setupDatabase;
 
-describe('examples.runCommand:', function() {
+describe('examples.runCommand:', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
@@ -18,7 +18,7 @@ describe('examples.runCommand:', function() {
     await db.collection('restaurants').insertOne({});
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -26,7 +26,7 @@ describe('examples.runCommand:', function() {
 
   it('supports runCommand 1', {
     metadata: { requires: { topology: ['single'] } },
-    test: async function() {
+    test: async function () {
       // Start runCommand example 1
       await db.command({ buildInfo: 1 });
       // End runCommand example 1
@@ -35,7 +35,7 @@ describe('examples.runCommand:', function() {
 
   it('supports runCommand 2', {
     metadata: { requires: { topology: ['single'] } },
-    test: async function() {
+    test: async function () {
       // Start runCommand example 2
       await db.command({ collStats: 'restaurants' });
       // End runCommand example 2

--- a/test/examples/transactions.js
+++ b/test/examples/transactions.js
@@ -3,22 +3,22 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const MongoClient = require('../../src').MongoClient;
 
-describe('examples(transactions):', function() {
+describe('examples(transactions):', function () {
   let client;
   let log;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
     log = console.log;
     console.log = () => {};
   });
 
-  after(function() {
+  after(function () {
     console.log = log;
     log = undefined;
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     await client.db('hr').dropDatabase();
     await client.db('hr').createCollection('employees');
@@ -26,14 +26,14 @@ describe('examples(transactions):', function() {
     await client.db('reporting').createCollection('events');
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
   });
 
   it('Transactions Retry Example 1', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Transactions Retry Example 1
       async function runTransactionWithRetry(txnFunc, client, session) {
         try {
@@ -91,7 +91,7 @@ describe('examples(transactions):', function() {
 
   it('Transactions Retry Example 2', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Transactions Retry Example 2
       async function commitWithRetry(session) {
         try {
@@ -146,7 +146,7 @@ describe('examples(transactions):', function() {
 
   it('Transaction Retry Example 3', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Transactions Retry Example 3
       async function commitWithRetry(session) {
         try {
@@ -219,7 +219,7 @@ describe('examples(transactions):', function() {
 
   it('Transactions withTransaction API Example 1', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.8.0' } },
-    test: async function() {
+    test: async function () {
       const uri = this.configuration.url();
 
       // Start Transactions withTxn API Example 1
@@ -234,15 +234,9 @@ describe('examples(transactions):', function() {
 
       // Prereq: Create collections.
 
-      await client
-        .db('mydb1')
-        .collection('foo')
-        .insertOne({ abc: 0 }, { w: 'majority' });
+      await client.db('mydb1').collection('foo').insertOne({ abc: 0 }, { w: 'majority' });
 
-      await client
-        .db('mydb2')
-        .collection('bar')
-        .insertOne({ xyz: 0 }, { w: 'majority' });
+      await client.db('mydb2').collection('bar').insertOne({ xyz: 0 }, { w: 'majority' });
 
       // Step 1: Start a Client Session
       const session = client.startSession();

--- a/test/examples/update_documents.js
+++ b/test/examples/update_documents.js
@@ -3,15 +3,15 @@
 const setupDatabase = require('../functional/shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('examples(update-documents):', function() {
+describe('examples(update-documents):', function () {
   let client;
   let db;
 
-  before(async function() {
+  before(async function () {
     await setupDatabase(this.configuration);
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = await this.configuration.newClient().connect();
     db = client.db(this.configuration.db);
 
@@ -82,7 +82,7 @@ describe('examples(update-documents):', function() {
     // End Example 51
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await client.close();
     client = undefined;
     db = undefined;
@@ -90,7 +90,7 @@ describe('examples(update-documents):', function() {
 
   it('Update a Single Document', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 52
       await db.collection('inventory').updateOne(
         { item: 'paper' },
@@ -105,13 +105,9 @@ describe('examples(update-documents):', function() {
       });
 
       const docs = await cursor.toArray();
-      docs.forEach(function(doc) {
-        expect(doc)
-          .to.have.nested.property('size.uom')
-          .that.equals('cm');
-        expect(doc)
-          .to.have.property('status')
-          .that.equals('P');
+      docs.forEach(function (doc) {
+        expect(doc).to.have.nested.property('size.uom').that.equals('cm');
+        expect(doc).to.have.property('status').that.equals('P');
         expect(doc).to.have.property('lastModified');
       });
     }
@@ -119,7 +115,7 @@ describe('examples(update-documents):', function() {
 
   it('Update Multiple Documents', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 53
       await db.collection('inventory').updateMany(
         { qty: { $lt: 50 } },
@@ -135,13 +131,9 @@ describe('examples(update-documents):', function() {
       });
 
       const docs = await cursor.toArray();
-      docs.forEach(function(doc) {
-        expect(doc)
-          .to.have.nested.property('size.uom')
-          .that.equals('in');
-        expect(doc)
-          .to.have.property('status')
-          .that.equals('P');
+      docs.forEach(function (doc) {
+        expect(doc).to.have.nested.property('size.uom').that.equals('in');
+        expect(doc).to.have.property('status').that.equals('P');
         expect(doc).to.have.property('lastModified');
       });
     }
@@ -149,7 +141,7 @@ describe('examples(update-documents):', function() {
 
   it('Replace a Document', {
     metadata: { requires: { topology: ['single'], mongodb: '>= 2.8.0' } },
-    test: async function() {
+    test: async function () {
       // Start Example 54
       await db.collection('inventory').replaceOne(
         { item: 'paper' },
@@ -163,18 +155,13 @@ describe('examples(update-documents):', function() {
       );
       // End Example 54
 
-      const cursor = db
-        .collection('inventory')
-        .find({ item: 'paper' })
-        .project({ _id: 0 });
+      const cursor = db.collection('inventory').find({ item: 'paper' }).project({ _id: 0 });
 
       const docs = await cursor.toArray();
-      docs.forEach(function(doc) {
+      docs.forEach(function (doc) {
         expect(Object.keys(doc)).to.have.a.lengthOf(2);
         expect(doc).to.have.property('item');
-        expect(doc)
-          .to.have.property('instock')
-          .that.has.a.lengthOf(2);
+        expect(doc).to.have.property('instock').that.has.a.lengthOf(2);
       });
     }
   });

--- a/test/functional/aggregation.test.js
+++ b/test/functional/aggregation.test.js
@@ -1,7 +1,7 @@
 'use strict';
 var expect = require('chai').expect;
 
-describe('Aggregation', function() {
+describe('Aggregation', function () {
   /**
    * Correctly call the aggregation framework using a pipeline in an Array.
    *
@@ -18,7 +18,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var client = this.configuration.newClient({ w: 1 }, { poolSize: 1 }),
         databaseName = this.configuration.db;
 
@@ -27,7 +27,7 @@ describe('Aggregation', function() {
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
@@ -50,7 +50,7 @@ describe('Aggregation', function() {
         // Create a collection
         var collection = db.collection('shouldCorrectlyExecuteSimpleAggregationPipelineUsingArray');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function(err, result) {
+        collection.insert(docs, { w: 1 }, function (err, result) {
           if (err) console.dir({ err });
           expect(result).to.exist;
           expect(err).to.be.null;
@@ -73,7 +73,7 @@ describe('Aggregation', function() {
             { $sort: { _id: -1 } }
           ]);
 
-          cursor.toArray(function(err, result) {
+          cursor.toArray(function (err, result) {
             expect(err).to.be.null;
             expect(result[0]._id.tags).to.equal('good');
             expect(result[0].authors).to.eql(['bob']);
@@ -96,10 +96,10 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const client = this.configuration.newClient({ w: 1 }, { poolSize: 1 });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
 
         const db = client.db('admin');
@@ -136,7 +136,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var client = this.configuration.newClient({ w: 1 }, { poolSize: 1 }),
         databaseName = this.configuration.db;
 
@@ -145,7 +145,7 @@ describe('Aggregation', function() {
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
@@ -170,7 +170,7 @@ describe('Aggregation', function() {
           'shouldCorrectlyExecuteSimpleAggregationPipelineUsingArguments'
         );
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function(err, result) {
+        collection.insert(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
 
@@ -193,7 +193,7 @@ describe('Aggregation', function() {
             { $sort: { _id: -1 } }
           ]);
 
-          cursor.toArray(function(err, result) {
+          cursor.toArray(function (err, result) {
             expect(err).to.be.null;
             expect(result[0]._id.tags).to.equal('good');
             expect(result[0].authors).to.eql(['bob']);
@@ -224,7 +224,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var client = this.configuration.newClient({ w: 1 }, { poolSize: 1 }),
         databaseName = this.configuration.db;
 
@@ -233,7 +233,7 @@ describe('Aggregation', function() {
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
@@ -258,7 +258,7 @@ describe('Aggregation', function() {
           'shouldCorrectlyExecuteSimpleAggregationPipelineUsingArguments'
         );
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function(err, result) {
+        collection.insert(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
 
@@ -281,7 +281,7 @@ describe('Aggregation', function() {
             { $sort: { _id: -1 } }
           ]);
 
-          cursor.toArray(function(err, result) {
+          cursor.toArray(function (err, result) {
             expect(err).to.be.null;
             expect(result[0]._id.tags).to.equal('good');
             expect(result[0].authors).to.eql(['bob']);
@@ -312,7 +312,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var client = this.configuration.newClient({ w: 1 }, { poolSize: 1 }),
         databaseName = this.configuration.db;
 
@@ -321,7 +321,7 @@ describe('Aggregation', function() {
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
@@ -344,7 +344,7 @@ describe('Aggregation', function() {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function(err, result) {
+        collection.insert(docs, { w: 1 }, function (err, result) {
           expect(err).to.be.null;
           expect(result).to.exist;
 
@@ -366,7 +366,7 @@ describe('Aggregation', function() {
           ]);
 
           // Iterate over all the items in the cursor
-          cursor.toArray(function(err, result) {
+          cursor.toArray(function (err, result) {
             expect(err).to.be.null;
             expect(result).to.exist;
 
@@ -394,7 +394,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var client = this.configuration.newClient({ w: 1 }, { poolSize: 1 }),
         databaseName = this.configuration.db;
 
@@ -403,7 +403,7 @@ describe('Aggregation', function() {
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
@@ -426,7 +426,7 @@ describe('Aggregation', function() {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function(err, result) {
+        collection.insert(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
 
@@ -453,7 +453,7 @@ describe('Aggregation', function() {
           );
 
           // Iterate over all the items in the cursor
-          cursor.explain(function(err, result) {
+          cursor.explain(function (err, result) {
             expect(err).to.be.null;
             expect(result.stages).to.have.lengthOf.at.least(1);
             expect(result.stages[0]).to.have.key('$cursor');
@@ -482,7 +482,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var client = this.configuration.newClient({ w: 1 }, { poolSize: 1 }),
         databaseName = this.configuration.db;
 
@@ -491,7 +491,7 @@ describe('Aggregation', function() {
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
@@ -514,7 +514,7 @@ describe('Aggregation', function() {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function(err, result) {
+        collection.insert(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
 
@@ -542,7 +542,7 @@ describe('Aggregation', function() {
           );
 
           // Iterate over all the items in the cursor
-          cursor.next(function(err, result) {
+          cursor.next(function (err, result) {
             expect(err).to.be.null;
             expect(result._id.tags).to.equal('good');
             expect(result.authors).to.eql(['bob']);
@@ -574,7 +574,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var client = this.configuration.newClient({ w: 1 }, { poolSize: 1 }),
         databaseName = this.configuration.db;
 
@@ -583,7 +583,7 @@ describe('Aggregation', function() {
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
@@ -606,7 +606,7 @@ describe('Aggregation', function() {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function(err, result) {
+        collection.insert(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
 
@@ -631,7 +631,7 @@ describe('Aggregation', function() {
               out: 'testingOutCollectionForAggregation'
             }
           );
-          cursor.toArray(function(err, results) {
+          cursor.toArray(function (err, results) {
             expect(err).to.be.null;
             expect(results).to.be.empty;
 
@@ -659,7 +659,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var client = this.configuration.newClient({ w: 1 }, { poolSize: 1 }),
         databaseName = this.configuration.db;
 
@@ -668,7 +668,7 @@ describe('Aggregation', function() {
       // REPLACE this.configuration.writeConcernMax() WITH {w:1}
       // REMOVE-LINE test.
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
@@ -691,7 +691,7 @@ describe('Aggregation', function() {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function(err, result) {
+        collection.insert(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
 
@@ -717,7 +717,7 @@ describe('Aggregation', function() {
               allowDiskUse: true
             }
           );
-          cursor.toArray(function(err, results) {
+          cursor.toArray(function (err, results) {
             expect(err).to.be.null;
             expect(results[0]._id.tags).to.equal('good');
             expect(results[0].authors).to.eql(['bob']);
@@ -745,23 +745,23 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var databaseName = this.configuration.db;
       var client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
         // Create a collection
         var col = db.collection('shouldPerformSimpleGroupAggregation');
-        col.remove({}, function(err) {
+        col.remove({}, function (err) {
           expect(err).to.be.null;
 
           // Insert a single document
-          col.insert([{ a: 1 }, { a: 1 }, { a: 1 }], function(err, r) {
+          col.insert([{ a: 1 }, { a: 1 }, { a: 1 }], function (err, r) {
             expect(err).to.be.null;
             expect(r.result.n).to.equal(3);
 
@@ -773,7 +773,7 @@ describe('Aggregation', function() {
                   $group: { _id: '$a', total: { $sum: '$a' } }
                 }
               ])
-              .toArray(function(err, docs) {
+              .toArray(function (err, docs) {
                 expect(err).to.be.null;
                 expect(docs[0].total).to.equal(3);
 
@@ -798,27 +798,27 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var databaseName = this.configuration.db;
       var client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
-        db.collection('te.st', function(err, col) {
+        db.collection('te.st', function (err, col) {
           expect(err).to.be.null;
           var count = 0;
 
-          col.insert([{ a: 1 }, { a: 1 }, { a: 1 }], function(err, r) {
+          col.insert([{ a: 1 }, { a: 1 }, { a: 1 }], function (err, r) {
             expect(err).to.be.null;
             expect(r.result.n).to.equal(3);
 
             const cursor = col.aggregate([{ $project: { a: 1 } }]);
 
-            cursor.toArray(function(err, docs) {
+            cursor.toArray(function (err, docs) {
               expect(err).to.be.null;
               expect(docs.length).to.be.greaterThan(0);
 
@@ -828,10 +828,10 @@ describe('Aggregation', function() {
                   cursor: { batchSize: 10000 }
                 })
                 .forEach(
-                  function() {
+                  function () {
                     count = count + 1;
                   },
-                  function(err) {
+                  function (err) {
                     expect(err).to.be.null;
                     expect(count).to.be.greaterThan(0);
 
@@ -858,13 +858,13 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var databaseName = this.configuration.db;
       var client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
@@ -887,7 +887,7 @@ describe('Aggregation', function() {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGetStream');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function(err, result) {
+        collection.insert(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
 
@@ -933,7 +933,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var databaseName = this.configuration.db;
       var client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
@@ -945,7 +945,7 @@ describe('Aggregation', function() {
         { readConcern: { level: 'local' }, writeConcern: { j: true } }
       ];
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         const wrapup = err => {
           client.close(err2 => done(err || err2));
         };
@@ -1001,13 +1001,13 @@ describe('Aggregation', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var client = this.configuration.newClient({ w: 1 }, { poolSize: 1 }),
           databaseName = this.configuration.db;
 
         // DOC_LINE var db = new Db('test', new Server('localhost', 27017));
         // DOC_START
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(databaseName);
 
           // Some docs for insertion
@@ -1029,7 +1029,7 @@ describe('Aggregation', function() {
           // Create a collection
           var collection = db.collection('shouldCorrectlyDoAggWithCursorMaxTimeMSSet');
           // Insert the docs
-          collection.insert(docs, { w: 1 }, function(err, result) {
+          collection.insert(docs, { w: 1 }, function (err, result) {
             expect(result).to.exist;
             expect(err).to.not.exist;
 
@@ -1061,7 +1061,7 @@ describe('Aggregation', function() {
             // is executed
             var cmd = db.command;
             // Validate the command
-            db.command = function(c) {
+            db.command = function (c) {
               expect(err).to.be.null;
               expect(c.maxTimeMS).to.equal(1000);
 
@@ -1070,13 +1070,13 @@ describe('Aggregation', function() {
             };
 
             // Iterate over all the items in the cursor
-            cursor.next(function(err, result) {
+            cursor.next(function (err, result) {
               expect(err).to.be.null;
               expect(result._id.tags).to.equal('good');
               expect(result.authors).to.eql(['bob']);
 
               // Validate the command
-              db.command = function(c) {
+              db.command = function (c) {
                 expect(err).to.be.null;
                 expect(c.maxTimeMS).to.equal(1000);
 
@@ -1128,13 +1128,13 @@ describe('Aggregation', function() {
         node: '>=4.8.5'
       }
     },
-    test: function(done) {
+    test: function (done) {
       const client = this.configuration.newClient({ w: 1 }, { poolSize: 1 });
       const databaseName = this.configuration.db;
 
       const comment = 'Darmok and Jalad at Tanagra';
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         const db = client.db(databaseName);
@@ -1142,11 +1142,9 @@ describe('Aggregation', function() {
 
         const command = db.command;
 
-        db.command = function(c) {
+        db.command = function (c) {
           expect(c).to.be.an('object');
-          expect(c.comment)
-            .to.be.a('string')
-            .and.to.equal('comment');
+          expect(c.comment).to.be.a('string').and.to.equal('comment');
           command.apply(db, Array.prototype.slice.call(arguments, 0));
         };
 
@@ -1171,7 +1169,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var databaseName = this.configuration.db;
       var client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
@@ -1179,7 +1177,7 @@ describe('Aggregation', function() {
 
       // DOC_LINE var client = new MongoClient(new Server('localhost', 27017));
       // DOC_START
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
@@ -1201,7 +1199,7 @@ describe('Aggregation', function() {
         // Create a collection
         var collection = db.collection('shouldCorrectlyQueryUsingISODate');
         // Insert the docs
-        collection.insertMany(docs, { w: 1 }, function(err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
 
@@ -1215,7 +1213,7 @@ describe('Aggregation', function() {
           ]);
 
           // Iterate over all the items in the cursor
-          cursor.next(function(err, result) {
+          cursor.next(function (err, result) {
             expect(err).to.be.null;
             expect(result.b).to.equal(1);
 
@@ -1238,7 +1236,7 @@ describe('Aggregation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var databaseName = this.configuration.db;
       var client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
@@ -1246,14 +1244,14 @@ describe('Aggregation', function() {
 
       // DOC_LINE var client = new MongoClient(new Server('localhost', 27017));
       // DOC_START
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.be.null;
 
         var db = client.db(databaseName);
         // Create a collection
         var collection = db.collection('shouldCorrectlyQueryUsingISODate3');
         // Insert the docs
-        collection.insertMany([{ a: 1 }, { b: 1 }], { w: 1 }, function(err, result) {
+        collection.insertMany([{ a: 1 }, { b: 1 }], { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
 
@@ -1265,7 +1263,7 @@ describe('Aggregation', function() {
           ]);
 
           // Iterate over all the items in the cursor
-          cursor.hasNext(function(err, result) {
+          cursor.hasNext(function (err, result) {
             expect(err).to.be.null;
             expect(result).to.equal(true);
 
@@ -1279,7 +1277,7 @@ describe('Aggregation', function() {
 
   it('should not send a batchSize for aggregations with an out stage', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
-    test: function(done) {
+    test: function (done) {
       const databaseName = this.configuration.db;
       const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1,
@@ -1325,9 +1323,7 @@ describe('Aggregation', function() {
           );
         })
         .then(() => {
-          expect(events)
-            .to.be.an('array')
-            .with.a.lengthOf(8);
+          expect(events).to.be.an('array').with.a.lengthOf(8);
           events.forEach(event => {
             expect(event).to.have.property('commandName', 'aggregate');
             expect(event)

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -11,8 +11,8 @@ const { loadSpecTests } = require('../spec');
 const { expect } = require('chai');
 const ReadPreference = require('../../src/read_preference');
 
-describe('APM', function() {
-  before(function() {
+describe('APM', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -21,7 +21,7 @@ describe('APM', function() {
     {
       metadata: { requires: { topology: ['single', 'replicaset', 'sharded'] } },
 
-      test: function() {
+      test: function () {
         let started = [];
         let succeeded = [];
 
@@ -37,10 +37,7 @@ describe('APM', function() {
         return client
           .connect()
           .then(client =>
-            client
-              .db(this.configuration.db)
-              .collection('apm_test')
-              .insertOne({ a: 1 })
+            client.db(this.configuration.db).collection('apm_test').insertOne({ a: 1 })
           )
           .then(r => {
             expect(r.insertedCount).to.equal(1);
@@ -61,12 +58,7 @@ describe('APM', function() {
 
             return client.connect();
           })
-          .then(() =>
-            client
-              .db(this.configuration.db)
-              .collection('apm_test')
-              .insertOne({ a: 1 })
-          )
+          .then(() => client.db(this.configuration.db).collection('apm_test').insertOne({ a: 1 }))
           .then(r => {
             expect(r.insertedCount).to.equal(1);
             expect(started.length).to.equal(0);
@@ -80,7 +72,7 @@ describe('APM', function() {
   it('should support legacy `instrument`/`uninstrument` methods with MongoClient `connect`', {
     metadata: { requires: { topology: ['single', 'replicaset', 'sharded'] } },
 
-    test: function() {
+    test: function () {
       let started = [];
       let succeeded = [];
 
@@ -128,7 +120,7 @@ describe('APM', function() {
   it('should correctly receive the APM events for an insert', {
     metadata: { requires: { topology: ['single', 'replicaset', 'sharded'] } },
 
-    test: function() {
+    test: function () {
       const started = [];
       const succeeded = [];
       const client = this.configuration.newClient(
@@ -141,12 +133,7 @@ describe('APM', function() {
 
       return client
         .connect()
-        .then(client =>
-          client
-            .db(this.configuration.db)
-            .collection('apm_test')
-            .insertOne({ a: 1 })
-        )
+        .then(client => client.db(this.configuration.db).collection('apm_test').insertOne({ a: 1 }))
         .then(r => {
           expect(r.insertedCount).to.equal(1);
           expect(started.length).to.equal(1);
@@ -161,7 +148,7 @@ describe('APM', function() {
   it('should correctly handle cursor.close when no cursor existed', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-    test: function() {
+    test: function () {
       const started = [];
       const succeeded = [];
       const self = this;
@@ -191,7 +178,7 @@ describe('APM', function() {
   it('should correctly receive the APM events for a listCollections command', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.0.0' } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -218,9 +205,7 @@ describe('APM', function() {
           )
           .then(() => {
             expect(started).to.have.lengthOf(2);
-            expect(started[0])
-              .property('address')
-              .to.not.equal(started[1].address);
+            expect(started[0]).property('address').to.not.equal(started[1].address);
 
             return client.close();
           });
@@ -231,7 +216,7 @@ describe('APM', function() {
   it('should correctly receive the APM events for a listIndexes command', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.0.0' } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -266,9 +251,7 @@ describe('APM', function() {
           )
           .then(() => {
             expect(started).to.have.lengthOf(2);
-            expect(started[0])
-              .property('address')
-              .to.not.equal(started[1].address);
+            expect(started[0]).property('address').to.not.equal(started[1].address);
 
             return client.close();
           });
@@ -281,7 +264,7 @@ describe('APM', function() {
     {
       metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-      test: function() {
+      test: function () {
         const self = this;
         const started = [];
         const succeeded = [];
@@ -348,7 +331,7 @@ describe('APM', function() {
   it('should correctly receive the APM events for a find with getmore and killcursor', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -421,7 +404,7 @@ describe('APM', function() {
   it('should correctly receive the APM failure event for find', {
     metadata: { requires: { topology: ['single', 'replicaset'], mongodb: '>=2.6.0' } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -480,7 +463,7 @@ describe('APM', function() {
   it('should correctly receive the APM events for a bulk operation', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -521,7 +504,7 @@ describe('APM', function() {
   it('should correctly receive the APM explain command', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -550,10 +533,7 @@ describe('APM', function() {
           )
           .then(r => {
             expect(r.insertedCount).to.equal(6);
-            return db
-              .collection('apm_test_2')
-              .find({ a: 1 })
-              .explain();
+            return db.collection('apm_test_2').find({ a: 1 }).explain();
           })
           .then(explain => {
             expect(explain).to.not.be.null;
@@ -572,7 +552,7 @@ describe('APM', function() {
   it('should correctly filter out sensitive commands', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -605,7 +585,7 @@ describe('APM', function() {
   it('should correctly receive the APM events for an updateOne', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -640,7 +620,7 @@ describe('APM', function() {
   it('should correctly receive the APM events for an updateMany', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -675,7 +655,7 @@ describe('APM', function() {
   it('should correctly receive the APM events for deleteOne', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -691,10 +671,7 @@ describe('APM', function() {
       return client
         .connect()
         .then(client =>
-          client
-            .db(self.configuration.db)
-            .collection('apm_test_u_3')
-            .deleteOne({ a: 1 })
+          client.db(self.configuration.db).collection('apm_test_u_3').deleteOne({ a: 1 })
         )
         .then(r => {
           expect(r).to.exist;
@@ -710,7 +687,7 @@ describe('APM', function() {
   it('should ensure killcursor commands are sent on 3.0 or earlier when APM is enabled', {
     metadata: { requires: { topology: ['single', 'replicaset'], mongodb: '<=3.0.x' } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const client = self.configuration.newClient(
         { w: 1 },
@@ -753,7 +730,7 @@ describe('APM', function() {
   it('should correctly decorate the apm result for aggregation with cursorId', {
     metadata: { requires: { topology: ['single', 'replicaset'], mongodb: '>=3.0.0' } },
 
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -804,7 +781,7 @@ describe('APM', function() {
 
   it('should correctly decorate the apm result for listCollections with cursorId', {
     metadata: { requires: { topology: ['single', 'replicaset'], mongodb: '>=3.0.0' } },
-    test: function() {
+    test: function () {
       const self = this;
       const started = [];
       const succeeded = [];
@@ -829,10 +806,7 @@ describe('APM', function() {
           .then(r => {
             expect(r).to.exist;
 
-            return db
-              .listCollections()
-              .batchSize(10)
-              .toArray();
+            return db.listCollections().batchSize(10).toArray();
           })
           .then(r => {
             expect(r).to.exist;
@@ -848,8 +822,8 @@ describe('APM', function() {
     }
   });
 
-  describe('spec tests', function() {
-    before(function() {
+  describe('spec tests', function () {
+    before(function () {
       return setupDatabase(this.configuration);
     });
 
@@ -1057,7 +1031,7 @@ describe('APM', function() {
     }
 
     loadSpecTests('apm').forEach(scenario => {
-      describe(scenario.name, function() {
+      describe(scenario.name, function () {
         scenario.tests.forEach(test => {
           const requirements = { topology: ['single', 'replicaset', 'sharded'] };
           if (test.ignore_if_server_version_greater_than) {
@@ -1074,7 +1048,7 @@ describe('APM', function() {
 
           it(test.description, {
             metadata: { requires: requirements },
-            test: function() {
+            test: function () {
               const client = this.configuration.newClient({}, { monitorCommands: true });
               return client.connect().then(client => {
                 expect(client).to.exist;

--- a/test/functional/buffering_proxy.test.js
+++ b/test/functional/buffering_proxy.test.js
@@ -4,7 +4,7 @@ var co = require('co');
 var mock = require('mongodb-mock-server');
 const { ReadPreference, ObjectId } = require('../../src');
 
-var extend = function(template, fields) {
+var extend = function (template, fields) {
   var object = {};
   for (var name in template) {
     object[name] = template[name];
@@ -17,7 +17,7 @@ var extend = function(template, fields) {
   return object;
 };
 
-describe.skip('Buffering Proxy', function() {
+describe.skip('Buffering Proxy', function () {
   afterEach(() => mock.cleanup());
 
   it('successfully handle buffering store execution for primary server', {
@@ -28,7 +28,7 @@ describe.skip('Buffering Proxy', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var currentIsMasterIndex = 0;
       var electionIds = [new ObjectId(0), new ObjectId(1)];
@@ -125,7 +125,7 @@ describe.skip('Buffering Proxy', function() {
       var dieSecondary = false;
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -184,17 +184,17 @@ describe.skip('Buffering Proxy', function() {
           }
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
           var results = [];
 
-          setTimeout(function() {
+          setTimeout(function () {
             die = true;
             dieSecondary = true;
 
-            setTimeout(function() {
-              db.collection('test').insertOne({ a: 1 }, function(err) {
+            setTimeout(function () {
+              db.collection('test').insertOne({ a: 1 }, function (err) {
                 test.equal(null, err);
                 results.push('insertOne');
               });
@@ -202,7 +202,7 @@ describe.skip('Buffering Proxy', function() {
               db.command(
                 { count: 'test', query: {} },
                 { readPreference: new ReadPreference(ReadPreference.SECONDARY) },
-                function(err) {
+                function (err) {
                   test.equal(null, err);
                   results.push('count');
                 }
@@ -210,7 +210,7 @@ describe.skip('Buffering Proxy', function() {
 
               db.collection('test')
                 .aggregate([{ $match: {} }])
-                .toArray(function(err) {
+                .toArray(function (err) {
                   test.equal(null, err);
                   results.push('aggregate');
                 });
@@ -218,15 +218,15 @@ describe.skip('Buffering Proxy', function() {
               db.collection('test')
                 .find({})
                 .setReadPreference(new ReadPreference(ReadPreference.SECONDARY))
-                .toArray(function(err) {
+                .toArray(function (err) {
                   test.equal(null, err);
                   results.push('find');
                 });
 
-              setTimeout(function() {
+              setTimeout(function () {
                 die = false;
 
-                setTimeout(function() {
+                setTimeout(function () {
                   test.deepEqual(['insertOne', 'aggregate'].sort(), results.sort());
                   client.close(done);
                 }, 1000);
@@ -246,7 +246,7 @@ describe.skip('Buffering Proxy', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var currentIsMasterIndex = 0;
       var electionIds = [new ObjectId(0), new ObjectId(1)];
@@ -343,7 +343,7 @@ describe.skip('Buffering Proxy', function() {
       var diePrimary = false;
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const secondSecondaryServer = yield mock.createServer(32002, 'localhost');
@@ -406,18 +406,18 @@ describe.skip('Buffering Proxy', function() {
           }
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
-          setTimeout(function() {
+          setTimeout(function () {
             die = true;
             diePrimary = true;
 
-            setTimeout(function() {
+            setTimeout(function () {
               var results = [];
 
-              db.collection('test').insertOne({ a: 1 }, function(err) {
+              db.collection('test').insertOne({ a: 1 }, function (err) {
                 test.equal(null, err);
                 results.push('insertOne');
               });
@@ -425,7 +425,7 @@ describe.skip('Buffering Proxy', function() {
               db.command(
                 { count: 'test', query: {} },
                 { readPreference: new ReadPreference(ReadPreference.SECONDARY) },
-                function(err) {
+                function (err) {
                   test.equal(null, err);
                   results.push('count');
                 }
@@ -433,7 +433,7 @@ describe.skip('Buffering Proxy', function() {
 
               db.collection('test')
                 .aggregate([{ $match: {} }])
-                .toArray(function(err) {
+                .toArray(function (err) {
                   test.equal(null, err);
                   results.push('aggregate');
                 });
@@ -441,15 +441,15 @@ describe.skip('Buffering Proxy', function() {
               db.collection('test')
                 .find({})
                 .setReadPreference(new ReadPreference(ReadPreference.SECONDARY))
-                .toArray(function(err) {
+                .toArray(function (err) {
                   test.equal(null, err);
                   results.push('find');
                 });
 
-              setTimeout(function() {
+              setTimeout(function () {
                 die = false;
 
-                setTimeout(function() {
+                setTimeout(function () {
                   test.deepEqual(['count', 'find'].sort(), results.sort());
                   client.close(done);
                 }, 1500);

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -6,8 +6,8 @@ const test = require('./shared').assert,
 const MongoError = require('../../src/error').MongoError;
 const ignoreNsNotFound = require('./shared').ignoreNsNotFound;
 
-describe('Bulk', function() {
-  before(function() {
+describe('Bulk', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -16,18 +16,18 @@ describe('Bulk', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_ordered_ops_10');
 
         // Add unique index on b field causing all updates to fail
-        col.ensureIndex({ a: 1 }, { unique: true, sparse: false }, function(err) {
+        col.ensureIndex({ a: 1 }, { unique: true, sparse: false }, function (err) {
           test.equal(err, null);
 
           var batch = col.initializeOrderedBulkOp();
@@ -38,7 +38,7 @@ describe('Bulk', function() {
             .updateOne({ $set: { a: 1 } });
           batch.insert({ b: 3, a: 2 });
 
-          batch.execute(function(err, result) {
+          batch.execute(function (err, result) {
             expect(err).to.exist;
             expect(result).to.not.exist;
 
@@ -75,7 +75,7 @@ describe('Bulk', function() {
 
   it('should use arrayFilters for updateMany', {
     metadata: { requires: { mongodb: '>=3.6.x' } },
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient({}, { w: 1 });
 
@@ -105,7 +105,7 @@ describe('Bulk', function() {
       requires: { topology: ['single'] }
     },
 
-    test: function() {
+    test: function () {
       const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
       });
@@ -135,7 +135,7 @@ describe('Bulk', function() {
       requires: { topology: ['single'] }
     },
 
-    test: function() {
+    test: function () {
       var client = this.configuration.newClient(this.configuration.writeConcernMax(), {
         poolSize: 1
       });
@@ -163,18 +163,18 @@ describe('Bulk', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_ordered_ops_2');
 
         // Add unique index on field `a` causing all updates to fail
-        col.ensureIndex({ a: 1 }, { unique: true, sparse: false }, function(err) {
+        col.ensureIndex({ a: 1 }, { unique: true, sparse: false }, function (err) {
           test.equal(err, null);
 
           var batch = col.initializeOrderedBulkOp();
@@ -194,7 +194,7 @@ describe('Bulk', function() {
           batch.insert({ b: 4, a: 3 });
           batch.insert({ b: 5, a: 1 });
 
-          batch.execute(function(err, result) {
+          batch.execute(function (err, result) {
             expect(err).to.exist;
             expect(result).to.not.exist;
 
@@ -228,13 +228,13 @@ describe('Bulk', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var coll = db.collection('batch_write_ordered_ops_3');
         // Set up a giant string to blow through the max message size
@@ -264,13 +264,13 @@ describe('Bulk', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var coll = db.collection('batch_write_ordered_ops_4');
 
@@ -291,7 +291,7 @@ describe('Bulk', function() {
         batch.insert({ a: 6, b: hugeString });
 
         // Execute the operations
-        batch.execute(function(err, result) {
+        batch.execute(function (err, result) {
           // Basic properties check
           test.equal(6, result.nInserted);
           test.equal(false, result.hasWriteErrors());
@@ -313,18 +313,18 @@ describe('Bulk', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var self = this;
         var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
           poolSize: 1
         });
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(self.configuration.db);
           var col = db.collection('batch_write_ordered_ops_5');
 
           // Add unique index on b field causing all updates to fail
-          col.ensureIndex({ b: 1 }, { unique: true, sparse: false }, function(err) {
+          col.ensureIndex({ b: 1 }, { unique: true, sparse: false }, function (err) {
             test.equal(err, null);
 
             var batch = col.initializeOrderedBulkOp();
@@ -333,21 +333,21 @@ describe('Bulk', function() {
             batch.insert({ $set: { a: 1 } });
 
             // Execute the operations
-            batch.execute(function(err) {
+            batch.execute(function (err) {
               test.ok(err != null);
 
               var batch = col.initializeOrderedBulkOp();
               // Add illegal remove
               batch.find({ $set: { a: 1 } }).removeOne();
               // Execute the operations
-              batch.execute(function(err) {
+              batch.execute(function (err) {
                 test.ok(err != null);
 
                 var batch = col.initializeOrderedBulkOp();
                 // Add illegal update
                 batch.find({ a: { $set2: 1 } }).updateOne({ c: { $set: { a: 1 } } });
                 // Execute the operations
-                batch.execute(function(err) {
+                batch.execute(function (err) {
                   test.ok(err != null);
 
                   client.close(done);
@@ -367,18 +367,18 @@ describe('Bulk', function() {
         requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
       },
 
-      test: function(done) {
+      test: function (done) {
         var self = this;
         var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
           poolSize: 1
         });
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(self.configuration.db);
           var col = db.collection('batch_write_ordered_ops_6');
 
           // Add unique index on b field causing all updates to fail
-          col.ensureIndex({ b: 1 }, { unique: true, sparse: false }, function(err) {
+          col.ensureIndex({ b: 1 }, { unique: true, sparse: false }, function (err) {
             test.equal(err, null);
 
             var batch = col.initializeOrderedBulkOp();
@@ -389,7 +389,7 @@ describe('Bulk', function() {
             batch.insert({ b: 1 });
 
             // Execute the operations
-            batch.execute(function(err, result) {
+            batch.execute(function (err, result) {
               expect(err).to.exist;
               expect(result).to.not.exist;
 
@@ -423,18 +423,18 @@ describe('Bulk', function() {
         requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
       },
 
-      test: function(done) {
+      test: function (done) {
         var self = this;
         var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
           poolSize: 1
         });
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(self.configuration.db);
           var col = db.collection('batch_write_ordered_ops_7');
 
           // Add unique index on b field causing all updates to fail
-          col.ensureIndex({ b: 1 }, { unique: true, sparse: false }, function(err) {
+          col.ensureIndex({ b: 1 }, { unique: true, sparse: false }, function (err) {
             test.equal(err, null);
 
             var batch = col.initializeOrderedBulkOp();
@@ -451,7 +451,7 @@ describe('Bulk', function() {
             batch.insert({ b: 1 });
 
             // Execute the operations
-            batch.execute(function(err, result) {
+            batch.execute(function (err, result) {
               expect(err).to.exist;
               expect(result).to.not.exist;
 
@@ -492,13 +492,13 @@ describe('Bulk', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_ordered_ops_8');
         var batch = col.initializeOrderedBulkOp();
@@ -510,7 +510,7 @@ describe('Bulk', function() {
           .updateOne({ $set: { b: 2 } });
 
         // Execute the operations
-        batch.execute(function(err, result) {
+        batch.execute(function (err, result) {
           // Check state of result
           test.equal(1, result.nUpserted);
           test.equal(0, result.nInserted);
@@ -535,15 +535,15 @@ describe('Bulk', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_ordered_ops_8');
 
-        col.initializeOrderedBulkOp().execute(function(err) {
+        col.initializeOrderedBulkOp().execute(function (err) {
           test.equal(err instanceof Error, true);
           test.equal(err.message, 'Invalid Operation, no operations specified');
 
@@ -558,13 +558,13 @@ describe('Bulk', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_ordered_ops_9');
 
@@ -573,13 +573,10 @@ describe('Bulk', function() {
           bulk.insert({ a: 1 });
         }
 
-        bulk
-          .find({ b: 1 })
-          .upsert()
-          .update({ b: 1 });
+        bulk.find({ b: 1 }).upsert().update({ b: 1 });
         bulk.find({ c: 1 }).remove();
 
-        bulk.execute({ w: 0 }, function(err, result) {
+        bulk.execute({ w: 0 }, function (err, result) {
           test.equal(null, err);
           test.equal(0, result.nUpserted);
           test.equal(0, result.nInserted);
@@ -597,18 +594,18 @@ describe('Bulk', function() {
   it('should correctly handle single unordered batch API', {
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_unordered_ops_legacy_1');
 
         // Add unique index on b field causing all updates to fail
-        col.ensureIndex({ a: 1 }, { unique: true, sparse: false }, function(err) {
+        col.ensureIndex({ a: 1 }, { unique: true, sparse: false }, function (err) {
           test.equal(err, null);
 
           // Initialize the unordered Batch
@@ -623,7 +620,7 @@ describe('Bulk', function() {
           batch.insert({ b: 3, a: 2 });
 
           // Execute the operations
-          batch.execute(function(err, result) {
+          batch.execute(function (err, result) {
             expect(err).to.exist;
             expect(result).to.not.exist;
 
@@ -661,7 +658,7 @@ describe('Bulk', function() {
     }
   });
 
-  it('should correctly handle multiple unordered batch API', function(done) {
+  it('should correctly handle multiple unordered batch API', function (done) {
     const configuration = this.configuration;
     const client = configuration.newClient(configuration.writeConcernMax(), {
       poolSize: 1
@@ -710,13 +707,13 @@ describe('Bulk', function() {
   it('should fail due to document being to big for unordered batch', {
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var coll = db.collection('batch_write_unordered_ops_legacy_3');
         // Set up a giant string to blow through the max message size
@@ -744,13 +741,13 @@ describe('Bulk', function() {
   it('should correctly split up messages into more batches for unordered batches', {
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var coll = db.collection('batch_write_unordered_ops_legacy_4');
 
@@ -771,7 +768,7 @@ describe('Bulk', function() {
         batch.insert({ a: 6, b: hugeString });
 
         // Execute the operations
-        batch.execute(function(err, result) {
+        batch.execute(function (err, result) {
           // Basic properties check
           test.equal(6, result.nInserted);
           test.equal(false, result.hasWriteErrors());
@@ -791,13 +788,13 @@ describe('Bulk', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_unordered_ops_legacy_5');
 
@@ -807,7 +804,7 @@ describe('Bulk', function() {
         writeConcern.sparse = false;
 
         // Add unique index on b field causing all updates to fail
-        col.ensureIndex({ b: 1 }, writeConcern, function(err) {
+        col.ensureIndex({ b: 1 }, writeConcern, function (err) {
           test.equal(err, null);
 
           // Initialize the unordered Batch
@@ -817,7 +814,7 @@ describe('Bulk', function() {
           batch.insert({ $set: { a: 1 } });
 
           // Execute the operations
-          batch.execute(function(err) {
+          batch.execute(function (err) {
             test.ok(err != null);
 
             // Initialize the unordered Batch
@@ -825,7 +822,7 @@ describe('Bulk', function() {
             // Add illegal remove
             batch.find({ $set: { a: 1 } }).removeOne();
             // Execute the operations
-            batch.execute(function(err) {
+            batch.execute(function (err) {
               test.ok(err != null);
 
               // Initialize the unordered Batch
@@ -833,7 +830,7 @@ describe('Bulk', function() {
               // Add illegal update
               batch.find({ $set: { a: 1 } }).updateOne({ c: { $set: { a: 1 } } });
               // Execute the operations
-              batch.execute(function(err) {
+              batch.execute(function (err) {
                 test.ok(err != null);
 
                 client.close(done);
@@ -848,13 +845,13 @@ describe('Bulk', function() {
   it('should Correctly Execute Unordered Batch with duplicate key errors on updates', {
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_unordered_ops_legacy_6');
 
@@ -864,7 +861,7 @@ describe('Bulk', function() {
         writeConcern.sparse = false;
 
         // Add unique index on b field causing all updates to fail
-        col.ensureIndex({ b: 1 }, writeConcern, function(err) {
+        col.ensureIndex({ b: 1 }, writeConcern, function (err) {
           test.equal(err, null);
 
           // Initialize the unordered Batch
@@ -879,7 +876,7 @@ describe('Bulk', function() {
           batch.insert({ b: 1 });
 
           // Execute the operations
-          batch.execute(self.configuration.writeConcernMax(), function(err, result) {
+          batch.execute(self.configuration.writeConcernMax(), function (err, result) {
             expect(err).to.exist;
             expect(result).to.not.exist;
 
@@ -901,7 +898,7 @@ describe('Bulk', function() {
     }
   });
 
-  it('should provide descriptive error message for unordered batch with duplicate key errors on inserts', function(done) {
+  it('should provide descriptive error message for unordered batch with duplicate key errors on inserts', function (done) {
     const configuration = this.configuration;
     const client = configuration.newClient(configuration.writeConcernMax(), {
       poolSize: 1
@@ -959,18 +956,18 @@ describe('Bulk', function() {
     {
       metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-      test: function(done) {
+      test: function (done) {
         var self = this;
         var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
           poolSize: 1
         });
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(self.configuration.db);
           var col = db.collection('batch_write_unordered_ops_legacy_7');
 
           // Add unique index on b field causing all updates to fail
-          col.ensureIndex({ b: 1 }, { unique: true, sparse: false }, function(err) {
+          col.ensureIndex({ b: 1 }, { unique: true, sparse: false }, function (err) {
             test.equal(err, null);
 
             // Initialize the unordered Batch
@@ -991,7 +988,7 @@ describe('Bulk', function() {
             batch.insert({ b: 1 });
 
             // Execute the operations
-            batch.execute(self.configuration.writeConcernMax(), function(err, result) {
+            batch.execute(self.configuration.writeConcernMax(), function (err, result) {
               expect(err).to.exist;
               expect(result).to.not.exist;
 
@@ -1029,13 +1026,13 @@ describe('Bulk', function() {
   it('should correctly perform unordered upsert with custom _id', {
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_unordered_ops_legacy_8');
         var batch = col.initializeUnorderedBulkOp();
@@ -1047,7 +1044,7 @@ describe('Bulk', function() {
           .updateOne({ $set: { b: 2 } });
 
         // Execute the operations
-        batch.execute(self.configuration.writeConcernMax(), function(err, result) {
+        batch.execute(self.configuration.writeConcernMax(), function (err, result) {
           // Check state of result
           test.equal(1, result.nUpserted);
           test.equal(0, result.nInserted);
@@ -1070,13 +1067,13 @@ describe('Bulk', function() {
   it('should prohibit batch finds with no selector', {
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_unordered_ops_legacy_9');
 
@@ -1105,17 +1102,17 @@ describe('Bulk', function() {
   it('should return an error when no operations in unordered batch', {
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_ordered_ops_8');
 
         col
           .initializeUnorderedBulkOp()
-          .execute(self.configuration.writeConcernMax(), function(err) {
+          .execute(self.configuration.writeConcernMax(), function (err) {
             test.equal(err instanceof Error, true);
             test.equal(err.message, 'Invalid Operation, no operations specified');
 
@@ -1128,13 +1125,13 @@ describe('Bulk', function() {
   it('should correctly execute unordered batch using w:0', {
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_ordered_ops_9');
         var bulk = col.initializeUnorderedBulkOp();
@@ -1142,13 +1139,10 @@ describe('Bulk', function() {
           bulk.insert({ a: 1 });
         }
 
-        bulk
-          .find({ b: 1 })
-          .upsert()
-          .update({ b: 1 });
+        bulk.find({ b: 1 }).upsert().update({ b: 1 });
         bulk.find({ c: 1 }).remove();
 
-        bulk.execute({ w: 0 }, function(err, result) {
+        bulk.execute({ w: 0 }, function (err, result) {
           test.equal(null, err);
           test.equal(0, result.nUpserted);
           test.equal(0, result.nInserted);
@@ -1171,20 +1165,20 @@ describe('Bulk', function() {
   it('should fail with w:2 and wtimeout write concern due single mongod instance ordered', {
     metadata: { requires: { topology: 'single', mongodb: '>2.5.4' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_concerns_ops_1');
         var batch = col.initializeOrderedBulkOp();
         batch.insert({ a: 1 });
         batch.insert({ a: 2 });
 
-        batch.execute({ w: 2, wtimeout: 1000 }, function(err) {
+        batch.execute({ w: 2, wtimeout: 1000 }, function (err) {
           test.ok(err != null);
           test.ok(err.code != null);
           test.ok(err.errmsg != null);
@@ -1205,13 +1199,13 @@ describe('Bulk', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var docs = [];
         for (var i = 0; i < 5; i++) {
@@ -1220,10 +1214,10 @@ describe('Bulk', function() {
           });
         }
 
-        db.collection('bigdocs_ordered').insertMany(docs, function(err) {
+        db.collection('bigdocs_ordered').insertMany(docs, function (err) {
           test.equal(null, err);
 
-          db.collection('bigdocs_ordered').count(function(err, c) {
+          db.collection('bigdocs_ordered').count(function (err, c) {
             test.equal(null, err);
             test.equal(5, c);
 
@@ -1242,20 +1236,20 @@ describe('Bulk', function() {
   it('should fail with w:2 and wtimeout write concern due single mongod instance unordered', {
     metadata: { requires: { topology: 'single', mongodb: '>2.5.4' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_concerns_ops_1');
         var batch = col.initializeUnorderedBulkOp();
         batch.insert({ a: 1 });
         batch.insert({ a: 2 });
 
-        batch.execute({ w: 2, wtimeout: 1000 }, function(err) {
+        batch.execute({ w: 2, wtimeout: 1000 }, function (err) {
           test.ok(err != null);
           test.ok(err.code != null);
           test.ok(err.errmsg != null);
@@ -1269,13 +1263,13 @@ describe('Bulk', function() {
   it('should correctly return the number of operations in the bulk', {
     metadata: { requires: { topology: 'single', mongodb: '>2.5.4' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var col = db.collection('batch_write_concerns_ops_1');
         var batch = col.initializeOrderedBulkOp();
@@ -1302,13 +1296,13 @@ describe('Bulk', function() {
   it('should correctly split unordered bulk batch', {
     metadata: { requires: { topology: 'single', mongodb: '>2.5.4' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var insertFirst = false;
         var batchSize = 1000;
@@ -1322,7 +1316,7 @@ describe('Bulk', function() {
           operation.insert(document);
         }
 
-        operation.execute(function(err) {
+        operation.execute(function (err) {
           test.equal(null, err);
 
           operation = collection.initializeUnorderedBulkOp();
@@ -1337,7 +1331,7 @@ describe('Bulk', function() {
             insertDocuments();
           }
 
-          operation.execute(function(err) {
+          operation.execute(function (err) {
             test.equal(null, err);
 
             client.close(done);
@@ -1362,13 +1356,13 @@ describe('Bulk', function() {
   it('should correctly split ordered bulk batch', {
     metadata: { requires: { topology: 'single', mongodb: '>2.5.4' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var insertFirst = false;
         var batchSize = 1000;
@@ -1382,7 +1376,7 @@ describe('Bulk', function() {
           operation.insert(document);
         }
 
-        operation.execute(function(err) {
+        operation.execute(function (err) {
           test.equal(null, err);
 
           operation = collection.initializeOrderedBulkOp();
@@ -1397,7 +1391,7 @@ describe('Bulk', function() {
             insertDocuments();
           }
 
-          operation.execute(function(err) {
+          operation.execute(function (err) {
             test.equal(null, err);
 
             client.close(done);
@@ -1429,13 +1423,13 @@ describe('Bulk', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var docs = [];
         for (var i = 0; i < 5; i++) {
@@ -1444,10 +1438,10 @@ describe('Bulk', function() {
           });
         }
 
-        db.collection('bigdocs_unordered').insertMany(docs, { ordered: false }, function(err) {
+        db.collection('bigdocs_unordered').insertMany(docs, { ordered: false }, function (err) {
           test.equal(null, err);
 
-          db.collection('bigdocs_unordered').count(function(err, c) {
+          db.collection('bigdocs_unordered').count(function (err, c) {
             test.equal(null, err);
             test.equal(5, c);
 
@@ -1462,12 +1456,12 @@ describe('Bulk', function() {
     'should return an error instead of throwing when no operations are provided for ordered bulk operation execute',
     {
       metadata: { requires: { mongodb: '>=2.6.0', topology: 'single' } },
-      test: function(done) {
+      test: function (done) {
         var self = this;
         var client = self.configuration.newClient({ w: 1 }, { poolSize: 1 });
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(self.configuration.db);
-          db.collection('doesnt_matter').insertMany([], function(err) {
+          db.collection('doesnt_matter').insertMany([], function (err) {
             test.equal(err instanceof Error, true);
             test.equal(err.message, 'Invalid Operation, no operations specified');
             client.close(done);
@@ -1481,13 +1475,13 @@ describe('Bulk', function() {
     'should return an error instead of throwing when no operations are provided for unordered bulk operation execute',
     {
       metadata: { requires: { mongodb: '>=2.6.0', topology: 'single' } },
-      test: function(done) {
+      test: function (done) {
         var self = this;
         var client = self.configuration.newClient({ w: 1 }, { poolSize: 1 });
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(self.configuration.db);
-          db.collection('doesnt_matter').insertMany([], { ordered: false }, function(err) {
+          db.collection('doesnt_matter').insertMany([], { ordered: false }, function (err) {
             test.equal(err instanceof Error, true);
             test.equal(err.message, 'Invalid Operation, no operations specified');
             client.close(done);
@@ -1497,29 +1491,29 @@ describe('Bulk', function() {
     }
   );
 
-  it('should return an error instead of throwing when an empty bulk operation is submitted (with promise)', function() {
+  it('should return an error instead of throwing when an empty bulk operation is submitted (with promise)', function () {
     var self = this;
     var client = self.configuration.newClient({ w: 1 }, { poolSize: 1 });
 
     return client
       .connect()
-      .then(function() {
+      .then(function () {
         var db = client.db(self.configuration.db);
         return db.collection('doesnt_matter').insertMany([]);
       })
-      .then(function() {
+      .then(function () {
         test.equal(false, true); // this should not happen!
       })
-      .catch(function(err) {
+      .catch(function (err) {
         test.equal(err instanceof Error, true);
         test.equal(err.message, 'Invalid Operation, no operations specified');
       })
-      .then(function() {
+      .then(function () {
         return client.close();
       });
   });
 
-  it('should properly account for array key size in bulk unordered inserts', function(done) {
+  it('should properly account for array key size in bulk unordered inserts', function (done) {
     const client = this.configuration.newClient();
     const documents = new Array(20000).fill('').map(() => ({
       arr: new Array(19).fill('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
@@ -1548,7 +1542,7 @@ describe('Bulk', function() {
       });
   });
 
-  it('should properly account for array key size in bulk ordered inserts', function(done) {
+  it('should properly account for array key size in bulk ordered inserts', function (done) {
     const client = this.configuration.newClient();
     const documents = new Array(20000).fill('').map(() => ({
       arr: new Array(19).fill('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
@@ -1591,7 +1585,7 @@ describe('Bulk', function() {
     );
   }
 
-  it('should propagate the proper error from executing an empty ordered batch', function() {
+  it('should propagate the proper error from executing an empty ordered batch', function () {
     const client = this.configuration.newClient();
 
     return client
@@ -1604,7 +1598,7 @@ describe('Bulk', function() {
       .then(() => client.close());
   });
 
-  it('should propagate the proper error from executing an empty unordered batch', function() {
+  it('should propagate the proper error from executing an empty unordered batch', function () {
     const client = this.configuration.newClient();
 
     return client
@@ -1617,7 +1611,7 @@ describe('Bulk', function() {
       .then(() => client.close());
   });
 
-  it('should promote a single error to the top-level message, and preserve writeErrors', function() {
+  it('should promote a single error to the top-level message, and preserve writeErrors', function () {
     const client = this.configuration.newClient();
     return client.connect().then(() => {
       this.defer(() => client.close());
@@ -1638,15 +1632,13 @@ describe('Bulk', function() {
             expect(err)
               .property('message')
               .to.match(/E11000/);
-            expect(err)
-              .to.have.property('writeErrors')
-              .with.length(1);
+            expect(err).to.have.property('writeErrors').with.length(1);
           }
         );
     });
   });
 
-  it('should preserve order of operation index in unordered bulkWrite', function() {
+  it('should preserve order of operation index in unordered bulkWrite', function () {
     const client = this.configuration.newClient();
     return client.connect().then(() => {
       this.defer(() => client.close());
@@ -1676,9 +1668,7 @@ describe('Bulk', function() {
             throw new Error('expected a bulk error');
           },
           err => {
-            expect(err)
-              .to.have.property('writeErrors')
-              .with.length(2);
+            expect(err).to.have.property('writeErrors').with.length(2);
 
             expect(err).to.have.nested.property('writeErrors[0].err.index', 0);
             expect(err).to.have.nested.property('writeErrors[1].err.index', 2);
@@ -1687,7 +1677,7 @@ describe('Bulk', function() {
     });
   });
 
-  it('should preserve order of operation index in unordered bulk operation', function() {
+  it('should preserve order of operation index in unordered bulk operation', function () {
     const client = this.configuration.newClient();
     return client.connect().then(() => {
       this.defer(() => client.close());
@@ -1709,9 +1699,7 @@ describe('Bulk', function() {
             throw new Error('expected a bulk error');
           },
           err => {
-            expect(err)
-              .to.have.property('writeErrors')
-              .with.length(2);
+            expect(err).to.have.property('writeErrors').with.length(2);
 
             expect(err).to.have.nested.property('writeErrors[0].err.index', 1);
             expect(err).to.have.nested.property('writeErrors[1].err.index', 3);
@@ -1720,7 +1708,7 @@ describe('Bulk', function() {
     });
   });
 
-  it('should not fail on the first error in an unorderd bulkWrite', function() {
+  it('should not fail on the first error in an unorderd bulkWrite', function () {
     const client = this.configuration.newClient();
     return client.connect().then(() => {
       this.defer(() => client.close());
@@ -1768,17 +1756,10 @@ describe('Bulk', function() {
           () => {
             throw new Error('expected a bulk error');
           },
-          err =>
-            expect(err)
-              .property('code')
-              .to.equal(11000)
+          err => expect(err).property('code').to.equal(11000)
         )
         .then(() => coll.findOne({ email: 'adam@gmail.com' }))
-        .then(updatedAdam =>
-          expect(updatedAdam)
-            .property('age')
-            .to.equal(39)
-        );
+        .then(updatedAdam => expect(updatedAdam).property('age').to.equal(39));
     });
   });
 });

--- a/test/functional/byo_promises.test.js
+++ b/test/functional/byo_promises.test.js
@@ -5,8 +5,8 @@ var expect = require('chai').expect;
 class CustomPromise extends Promise {}
 CustomPromise.prototype.isCustomMongo = true;
 
-describe('Optional PromiseLibrary / maybePromise', function() {
-  it('should correctly implement custom dependency-less promise', function(done) {
+describe('Optional PromiseLibrary / maybePromise', function () {
+  it('should correctly implement custom dependency-less promise', function (done) {
     const getCustomPromise = v => new CustomPromise(resolve => resolve(v));
     const getNativePromise = v => new Promise(resolve => resolve(v));
     expect(getNativePromise()).to.not.have.property('isCustomMongo');
@@ -16,7 +16,7 @@ describe('Optional PromiseLibrary / maybePromise', function() {
     done();
   });
 
-  it('should have cursor return native promise', function(done) {
+  it('should have cursor return native promise', function (done) {
     const configuration = this.configuration;
     const client = this.configuration.newClient({ w: 1 }, { poolSize: 1 });
     client.connect((err, client) => {
@@ -31,7 +31,7 @@ describe('Optional PromiseLibrary / maybePromise', function() {
     });
   });
 
-  it('should have cursor return custom promise from new client options', function(done) {
+  it('should have cursor return custom promise from new client options', function (done) {
     const configuration = this.configuration;
     const client = this.configuration.newClient(
       { w: 1 },

--- a/test/functional/causal_consistency.test.js
+++ b/test/functional/causal_consistency.test.js
@@ -5,12 +5,12 @@ const mongo = require('../../src'),
 
 const ignoredCommands = ['ismaster', 'endSessions'];
 const test = { commands: { started: [], succeeded: [] } };
-describe('Causal Consistency', function() {
-  before(function() {
+describe('Causal Consistency', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     test.commands = { started: [], succeeded: [] };
     test.listener = mongo.instrument(err => expect(err).to.be.null);
     test.listener.on('started', event => {
@@ -37,7 +37,7 @@ describe('Causal Consistency', function() {
       sessions: { skipLeakTests: true }
     },
 
-    test: function() {
+    test: function () {
       const session = test.client.startSession({ causalConsistency: true });
       const db = test.client.db(this.configuration.db);
 
@@ -61,7 +61,7 @@ describe('Causal Consistency', function() {
       sessions: { skipLeakTests: true }
     },
 
-    test: function() {
+    test: function () {
       const session = test.client.startSession({ causalConsistency: true });
       const db = test.client.db(this.configuration.db);
       expect(session.operationTime).to.be.null;
@@ -87,7 +87,7 @@ describe('Causal Consistency', function() {
       sessions: { skipLeakTests: true }
     },
 
-    test: function() {
+    test: function () {
       const session = test.client.startSession({ causalConsistency: true });
       const db = test.client.db(this.configuration.db);
       expect(session.operationTime).to.be.null;
@@ -121,7 +121,7 @@ describe('Causal Consistency', function() {
         sessions: { skipLeakTests: true }
       },
 
-      test: function() {
+      test: function () {
         const session = test.client.startSession({ causalConsistency: false });
         const db = test.client.db(this.configuration.db);
         const coll = db.collection('causal_test', { readConcern: { level: 'majority' } });
@@ -146,7 +146,7 @@ describe('Causal Consistency', function() {
       sessions: { skipLeakTests: true }
     },
 
-    test: function() {
+    test: function () {
       const session = test.client.startSession({ causalConsistency: true });
       const db = test.client.db(this.configuration.db);
       expect(session.operationTime).to.be.null;
@@ -173,7 +173,7 @@ describe('Causal Consistency', function() {
     {
       metadata: { requires: { topology: ['single'], mongodb: '>3.6.0-rc0' } },
 
-      test: function() {
+      test: function () {
         const db = test.client.db(this.configuration.db);
         const coll = db.collection('causal_test', { readConcern: { level: 'local' } });
 
@@ -195,7 +195,7 @@ describe('Causal Consistency', function() {
     'should not record `operationTime` for unacknowledged writes in a causally consistent session',
     {
       metadata: { requires: { topology: ['replicaset'], mongodb: '>3.6.0-rc0' } },
-      test: function() {
+      test: function () {
         const session = test.client.startSession({ causalConsistency: true });
         const db = test.client.db(this.configuration.db);
         expect(session.operationTime).to.be.null;

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -54,7 +54,7 @@ function triggerResumableError(changeStream, delay, onClose) {
   }
 
   const stub = sinon.stub(changeStream.cursor, 'close');
-  stub.callsFake(function() {
+  stub.callsFake(function () {
     stub.wrappedMethod.call(this);
     stub.restore();
     onClose();
@@ -155,12 +155,12 @@ const pipeline = [
   { $addFields: { comment: 'The documentKey field has been projected out of this document.' } }
 ];
 
-describe('Change Streams', function() {
-  before(function() {
+describe('Change Streams', function () {
+  before(function () {
     return setupDatabase(this.configuration, ['integration_tests']);
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     const configuration = this.configuration;
     const client = configuration.newClient();
 
@@ -180,7 +180,7 @@ describe('Change Streams', function() {
   it('should close the listeners after the cursor is closed', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function(done) {
+    test: function (done) {
       let closed = false;
       function close(err) {
         if (closed) return;
@@ -267,7 +267,7 @@ describe('Change Streams', function() {
   it('should create a ChangeStream on a collection and emit `change` events', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -323,7 +323,7 @@ describe('Change Streams', function() {
     {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
         const client = configuration.newClient();
 
@@ -381,7 +381,7 @@ describe('Change Streams', function() {
   it('should support creating multiple simultaneous ChangeStreams', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -408,7 +408,7 @@ describe('Change Streams', function() {
           .then(() =>
             Promise.all([changeStream1.hasNext(), changeStream2.hasNext(), changeStream3.hasNext()])
           )
-          .then(function(hasNexts) {
+          .then(function (hasNexts) {
             // Check all the Change Streams have a next item
             assert.ok(hasNexts[0]);
             assert.ok(hasNexts[1]);
@@ -416,7 +416,7 @@ describe('Change Streams', function() {
 
             return Promise.all([changeStream1.next(), changeStream2.next(), changeStream3.next()]);
           })
-          .then(function(changes) {
+          .then(function (changes) {
             // Check the values of the change documents are correct
             assert.equal(changes[0].operationType, 'insert');
             assert.equal(changes[1].operationType, 'insert');
@@ -449,7 +449,7 @@ describe('Change Streams', function() {
   it('should properly close ChangeStream cursor', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -481,7 +481,7 @@ describe('Change Streams', function() {
     {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
         const client = configuration.newClient();
 
@@ -514,7 +514,7 @@ describe('Change Streams', function() {
   it('should cache the change stream resume token using imperative callback form', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -532,10 +532,10 @@ describe('Change Streams', function() {
         });
 
         // Fetch the change notification
-        changeStream.hasNext(function(err, hasNext) {
+        changeStream.hasNext(function (err, hasNext) {
           expect(err).to.not.exist;
           assert.equal(true, hasNext);
-          changeStream.next(function(err, change) {
+          changeStream.next(function (err, change) {
             expect(err).to.not.exist;
             assert.deepEqual(changeStream.resumeToken, change._id);
             done();
@@ -547,7 +547,7 @@ describe('Change Streams', function() {
 
   it('should cache the change stream resume token using promises', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -579,7 +579,7 @@ describe('Change Streams', function() {
   it('should cache the change stream resume token using event listeners', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -596,15 +596,11 @@ describe('Change Streams', function() {
           // Trigger the first database event
           db.collection('cacheResumeTokenListener').insert({ b: 2 }, (err, result) => {
             expect(err).to.not.exist;
-            expect(result)
-              .property('insertedCount')
-              .to.equal(1);
+            expect(result).property('insertedCount').to.equal(1);
 
             collector.waitForEvent('change', (err, events) => {
               expect(err).to.not.exist;
-              expect(changeStream)
-                .property('resumeToken')
-                .to.eql(events[0]._id);
+              expect(changeStream).property('resumeToken').to.eql(events[0]._id);
 
               done();
             });
@@ -619,7 +615,7 @@ describe('Change Streams', function() {
     {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
         const client = configuration.newClient();
 
@@ -651,7 +647,7 @@ describe('Change Streams', function() {
   it('should error if resume token projected out of change stream document using event listeners', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -668,9 +664,7 @@ describe('Change Streams', function() {
         waitForStarted(changeStream, () => {
           collection.insert({ b: 2 }, (err, result) => {
             expect(err).to.not.exist;
-            expect(result)
-              .property('insertedCount')
-              .to.equal(1);
+            expect(result).property('insertedCount').to.equal(1);
 
             collector.waitForEvent('error', (err, events) => {
               expect(err).to.not.exist;
@@ -685,7 +679,7 @@ describe('Change Streams', function() {
 
   it('should invalidate change stream on collection rename using event listeners', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -738,7 +732,7 @@ describe('Change Streams', function() {
   it('should invalidate change stream on database drop using imperative callback form', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -763,7 +757,7 @@ describe('Change Streams', function() {
             expect(err).to.not.exist;
 
             function completeStream() {
-              changeStream.hasNext(function(err, hasNext) {
+              changeStream.hasNext(function (err, hasNext) {
                 expect(err).to.not.exist;
                 assert.equal(hasNext, false);
                 assert.equal(changeStream.isClosed(), true);
@@ -772,7 +766,7 @@ describe('Change Streams', function() {
             }
 
             function checkInvalidate() {
-              changeStream.next(function(err, change) {
+              changeStream.next(function (err, change) {
                 expect(err).to.not.exist;
 
                 // Check the cursor invalidation has occured
@@ -794,7 +788,7 @@ describe('Change Streams', function() {
   it('should invalidate change stream on collection drop using promises', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -825,13 +819,13 @@ describe('Change Streams', function() {
 
         return changeStream
           .next()
-          .then(function(change) {
+          .then(function (change) {
             assert.equal(change.operationType, 'insert');
             return database.dropCollection('invalidateCollectionDropPromises');
           })
           .then(() => checkInvalidate(changeStream))
           .then(() => changeStream.hasNext())
-          .then(function(hasNext) {
+          .then(function (hasNext) {
             assert.equal(hasNext, false);
             assert.equal(changeStream.isClosed(), true);
             done();
@@ -849,7 +843,7 @@ describe('Change Streams', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
 
       // Contain mock server
@@ -870,7 +864,7 @@ describe('Change Streams', function() {
         hosts: ['localhost:32000', 'localhost:32001', 'localhost:32002']
       };
 
-      co(function*() {
+      co(function* () {
         primaryServer = yield mock.createServer(32000, 'localhost');
 
         primaryServer.setMessageHandler(request => {
@@ -908,7 +902,7 @@ describe('Change Streams', function() {
 
         return changeStream
           .next()
-          .then(function() {
+          .then(function () {
             // We should never execute this line because calling changeStream.next() should throw an error
             throw new Error(
               'ChangeStream.next() returned a change document but it should have returned a MongoNetworkError'
@@ -945,7 +939,7 @@ describe('Change Streams', function() {
         mongodb: '>=3.6'
       }
     },
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
 
       // Contain mock server
@@ -969,7 +963,7 @@ describe('Change Streams', function() {
       // Die
       let die = false;
 
-      co(function*() {
+      co(function* () {
         primaryServer = yield mock.createServer(32000, 'localhost');
 
         primaryServer.setMessageHandler(request => {
@@ -1009,7 +1003,7 @@ describe('Change Streams', function() {
         const collection = database.collection('MongoNetworkErrorTestPromises');
         const changeStream = collection.watch(pipeline);
 
-        changeStream.next(function(err, change) {
+        changeStream.next(function (err, change) {
           assert.ok(err instanceof MongoNetworkError);
           assert.ok(err.message);
           assert.ok(err.message.indexOf('timed out') > -1);
@@ -1039,7 +1033,7 @@ describe('Change Streams', function() {
         mongodb: '>=3.6'
       }
     },
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
 
       // Contain mock server
@@ -1064,7 +1058,7 @@ describe('Change Streams', function() {
       let callsToGetMore = 0;
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         primaryServer = yield mock.createServer(32000, 'localhost');
 
         let counter = 0;
@@ -1134,7 +1128,7 @@ describe('Change Streams', function() {
 
           return changeStream
             .next()
-            .then(function(change) {
+            .then(function (change) {
               assert.ok(change);
               assert.equal(change.operationType, 'insert');
               assert.equal(change.fullDocument.counter, 0);
@@ -1144,7 +1138,7 @@ describe('Change Streams', function() {
 
               return changeStream.next();
             })
-            .then(function(change) {
+            .then(function (change) {
               assert.ok(change);
               assert.equal(change.operationType, 'insert');
               assert.equal(change.fullDocument.counter, 1);
@@ -1170,7 +1164,7 @@ describe('Change Streams', function() {
   it('should resume from point in time using user-provided resumeAfter', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -1254,7 +1248,7 @@ describe('Change Streams', function() {
   it('should support full document lookup', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -1274,11 +1268,11 @@ describe('Change Streams', function() {
 
         return changeStream
           .hasNext()
-          .then(function(hasNext) {
+          .then(function (hasNext) {
             assert.equal(true, hasNext);
             return changeStream.next();
           })
-          .then(function(change) {
+          .then(function (change) {
             assert.equal(change.operationType, 'insert');
             assert.equal(change.fullDocument.f, 128);
             assert.equal(change.ns.db, database.databaseName);
@@ -1290,10 +1284,10 @@ describe('Change Streams', function() {
             );
             return collection.update({ f: 128 }, { $set: { c: 2 } });
           })
-          .then(function() {
+          .then(function () {
             return changeStream.next();
           })
-          .then(function(change) {
+          .then(function (change) {
             assert.equal(change.operationType, 'update');
 
             // Check the correct fullDocument is present
@@ -1308,7 +1302,7 @@ describe('Change Streams', function() {
   it('should support full document lookup with deleted documents', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -1329,11 +1323,11 @@ describe('Change Streams', function() {
 
         return changeStream
           .hasNext()
-          .then(function(hasNext) {
+          .then(function (hasNext) {
             assert.equal(true, hasNext);
             return changeStream.next();
           })
-          .then(function(change) {
+          .then(function (change) {
             assert.equal(change.operationType, 'insert');
             assert.equal(change.fullDocument.i, 128);
             assert.equal(change.ns.db, database.databaseName);
@@ -1348,11 +1342,11 @@ describe('Change Streams', function() {
             return collection.update({ i: 128 }, { $set: { c: 2 } });
           })
           .then(() => changeStream.hasNext())
-          .then(function(hasNext) {
+          .then(function (hasNext) {
             assert.equal(true, hasNext);
             return changeStream.next();
           })
-          .then(function(change) {
+          .then(function (change) {
             assert.equal(change.operationType, 'delete');
             assert.equal(change.lookedUpDocument, null);
           });
@@ -1363,7 +1357,7 @@ describe('Change Streams', function() {
   it('should create Change Streams with correct read preferences', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -1409,7 +1403,7 @@ describe('Change Streams', function() {
   it('should support piping of Change Streams', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const stream = require('stream');
       const client = configuration.newClient();
@@ -1455,7 +1449,7 @@ describe('Change Streams', function() {
         mongodb: '>=3.6'
       }
     },
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
 
       // Contain mock server
@@ -1476,7 +1470,7 @@ describe('Change Streams', function() {
         hosts: ['localhost:32000', 'localhost:32001', 'localhost:32002']
       };
 
-      co(function*() {
+      co(function* () {
         primaryServer = yield mock.createServer();
 
         let counter = 0;
@@ -1575,7 +1569,7 @@ describe('Change Streams', function() {
           changeStream.stream({ transform: JSON.stringify }).pipe(outStream);
 
           // Listen for changes to the file
-          const watcher = fs.watch(filename, function(eventType) {
+          const watcher = fs.watch(filename, function (eventType) {
             assert.equal(eventType, 'change');
 
             const fileContents = fs.readFileSync(filename, 'utf8');
@@ -1597,7 +1591,7 @@ describe('Change Streams', function() {
 
   it('should support piping of Change Streams through multiple pipes', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient(configuration.url(), {
         poolSize: 1,
@@ -1626,14 +1620,14 @@ describe('Change Streams', function() {
         const pipedStream = basicStream.pipe(cipher).pipe(decipher);
 
         let dataEmitted = '';
-        pipedStream.on('data', function(data) {
+        pipedStream.on('data', function (data) {
           dataEmitted += data.toString();
 
           // Work around poor compatibility with crypto cipher
           changeStream.cursor.emit('end');
         });
 
-        pipedStream.on('end', function() {
+        pipedStream.on('end', function () {
           const parsedData = JSON.parse(dataEmitted.toString());
           assert.equal(parsedData.operationType, 'insert');
           assert.equal(parsedData.fullDocument.a, 1407);
@@ -1655,7 +1649,7 @@ describe('Change Streams', function() {
 
   it('should maintain change stream options on resume', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -1684,7 +1678,7 @@ describe('Change Streams', function() {
   // any results yet MUST include a startAtOperationTime option when resuming a change stream.
   it('should include a startAtOperationTime field when resuming if no changes have been received', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=4.0 <4.0.7' } },
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
 
       const OPERATION_TIME = new Timestamp(4, 1501511802);
@@ -1841,7 +1835,7 @@ describe('Change Streams', function() {
 
   it('should emit close event after error event', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
       const closeSpy = sinon.spy();
@@ -1878,7 +1872,7 @@ describe('Change Streams', function() {
     }
   });
 
-  describe('should properly handle a changeStream event being processed mid-close', function() {
+  describe('should properly handle a changeStream event being processed mid-close', function () {
     let client, coll, changeStream;
 
     function write() {
@@ -1891,7 +1885,7 @@ describe('Change Streams', function() {
       return coll.insertOne({ c: 3 });
     }
 
-    beforeEach(function() {
+    beforeEach(function () {
       client = this.configuration.newClient();
       return client.connect().then(_client => {
         client = _client;
@@ -1900,7 +1894,7 @@ describe('Change Streams', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       return Promise.resolve()
         .then(() => {
           if (changeStream && !changeStream.isClosed()) {
@@ -1921,7 +1915,7 @@ describe('Change Streams', function() {
 
     it('when invoked with promises', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: function() {
+      test: function () {
         const test = this;
 
         function read() {
@@ -1944,16 +1938,14 @@ describe('Change Streams', function() {
 
     it('when invoked with callbacks', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: function(done) {
+      test: function (done) {
         changeStream.next(() => {
           changeStream.next(() => {
             this.defer(lastWrite());
 
             changeStream.next(err => {
               try {
-                expect(err)
-                  .property('message')
-                  .to.equal('ChangeStream is closed');
+                expect(err).property('message').to.equal('ChangeStream is closed');
                 done();
               } catch (e) {
                 done(e);
@@ -1971,7 +1963,7 @@ describe('Change Streams', function() {
 
     it('when invoked using eventEmitter API', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: function(done) {
+      test: function (done) {
         let closed = false;
         const close = _err => {
           if (closed) {
@@ -2002,7 +1994,7 @@ describe('Change Streams', function() {
     });
   });
 
-  describe('resumeToken', function() {
+  describe('resumeToken', function () {
     class MockServerManager {
       constructor(config, commandIterators) {
         this.config = config;
@@ -2073,7 +2065,7 @@ describe('Change Streams', function() {
         if (this.client) {
           promise = promise.then(() => this.client.close()).catch();
         }
-        return promise.then(function() {
+        return promise.then(function () {
           if (e) {
             throw e;
           }
@@ -2197,13 +2189,13 @@ describe('Change Streams', function() {
     //   The batch is empty or has been iterated to the last document.
     // Expected result:
     //   getResumeToken must return the postBatchResumeToken from the current command response.
-    describe('for emptied batch on server >= 4.0.7', function() {
-      it('must return the postBatchResumeToken from the current command response', function() {
+    describe('for emptied batch on server >= 4.0.7', function () {
+      it('must return the postBatchResumeToken from the current command response', function () {
         const manager = new MockServerManager(this.configuration, {
-          aggregate: (function*() {
+          aggregate: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: true };
           })(),
-          getMore: (function*() {
+          getMore: (function* () {
             yield { numDocuments: 1, postBatchResumeToken: true };
           })()
         });
@@ -2248,13 +2240,13 @@ describe('Change Streams', function() {
     //   getResumeToken must return the _id of the last document returned if one exists.
     //   getResumeToken must return resumeAfter from the initial aggregate if the option was specified.
     //   If ``resumeAfter`` was not specified, the ``getResumeToken`` result must be empty.
-    describe('for emptied batch on server <= 4.0.7', function() {
-      it('must return the _id of the last document returned if one exists', function() {
+    describe('for emptied batch on server <= 4.0.7', function () {
+      it('must return the _id of the last document returned if one exists', function () {
         const manager = new MockServerManager(this.configuration, {
-          aggregate: (function*() {
+          aggregate: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })(),
-          getMore: (function*() {
+          getMore: (function* () {
             yield { numDocuments: 1, postBatchResumeToken: false };
           })()
         });
@@ -2283,12 +2275,12 @@ describe('Change Streams', function() {
             expect(tokens[0]).to.deep.equal(successes[1].nextBatch[0]._id);
           });
       });
-      it('must return resumeAfter from the initial aggregate if the option was specified', function() {
+      it('must return resumeAfter from the initial aggregate if the option was specified', function () {
         const manager = new MockServerManager(this.configuration, {
-          aggregate: (function*() {
+          aggregate: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })(),
-          getMore: (function*() {
+          getMore: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })()
         });
@@ -2321,12 +2313,12 @@ describe('Change Streams', function() {
             expect(token).to.deep.equal(resumeAfter);
           });
       });
-      it('must be empty if resumeAfter options was not specified', function() {
+      it('must be empty if resumeAfter options was not specified', function () {
         const manager = new MockServerManager(this.configuration, {
-          aggregate: (function*() {
+          aggregate: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })(),
-          getMore: (function*() {
+          getMore: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })()
         });
@@ -2365,13 +2357,13 @@ describe('Change Streams', function() {
     //   The batch has been iterated up to but not including the last element.
     // Expected result:
     //   getResumeToken must return the _id of the previous document returned.
-    describe('for non-empty batch iterated up to but not including the last element', function() {
-      it('must return the _id of the previous document returned', function() {
+    describe('for non-empty batch iterated up to but not including the last element', function () {
+      it('must return the _id of the previous document returned', function () {
         const manager = new MockServerManager(this.configuration, {
-          aggregate: (function*() {
+          aggregate: (function* () {
             yield { numDocuments: 2, postBatchResumeToken: true };
           })(),
-          getMore: (function*() {})()
+          getMore: (function* () {})()
         });
 
         return manager
@@ -2413,13 +2405,13 @@ describe('Change Streams', function() {
     //   getResumeToken must return startAfter from the initial aggregate if the option was specified.
     //   getResumeToken must return resumeAfter from the initial aggregate if the option was specified.
     //   If neither the startAfter nor resumeAfter options were specified, the getResumeToken result must be empty.
-    describe('for non-empty non-iterated batch where only the initial aggregate command has been executed', function() {
-      it('must return startAfter from the initial aggregate if the option was specified', function() {
+    describe('for non-empty non-iterated batch where only the initial aggregate command has been executed', function () {
+      it('must return startAfter from the initial aggregate if the option was specified', function () {
         const manager = new MockServerManager(this.configuration, {
-          aggregate: (function*() {
+          aggregate: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })(),
-          getMore: (function*() {
+          getMore: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })()
         });
@@ -2446,17 +2438,15 @@ describe('Change Streams', function() {
             err => manager.teardown(err)
           )
           .then(() => {
-            expect(token)
-              .to.deep.equal(startAfter)
-              .and.to.not.deep.equal(resumeAfter);
+            expect(token).to.deep.equal(startAfter).and.to.not.deep.equal(resumeAfter);
           });
       });
-      it('must return resumeAfter from the initial aggregate if the option was specified', function() {
+      it('must return resumeAfter from the initial aggregate if the option was specified', function () {
         const manager = new MockServerManager(this.configuration, {
-          aggregate: (function*() {
+          aggregate: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })(),
-          getMore: (function*() {
+          getMore: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })()
         });
@@ -2485,12 +2475,12 @@ describe('Change Streams', function() {
             expect(token).to.deep.equal(resumeAfter);
           });
       });
-      it('must be empty if neither the startAfter nor resumeAfter options were specified', function() {
+      it('must be empty if neither the startAfter nor resumeAfter options were specified', function () {
         const manager = new MockServerManager(this.configuration, {
-          aggregate: (function*() {
+          aggregate: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })(),
-          getMore: (function*() {
+          getMore: (function* () {
             yield { numDocuments: 0, postBatchResumeToken: false };
           })()
         });
@@ -2521,7 +2511,7 @@ describe('Change Streams', function() {
     });
   });
 
-  describe('tryNext', function() {
+  describe('tryNext', function () {
     it('should return null on single iteration of empty cursor', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
       test: withChangeStream((collection, changeStream, done) => {
@@ -2566,7 +2556,7 @@ describe('Change Streams', function() {
     });
   });
 
-  describe('startAfter', function() {
+  describe('startAfter', function () {
     let client;
     let coll;
     let startAfter;
@@ -2576,7 +2566,7 @@ describe('Change Streams', function() {
       events.push({ $changeStream: e.command.pipeline[0].$changeStream });
     }
 
-    beforeEach(function(done) {
+    beforeEach(function (done) {
       const configuration = this.configuration;
       client = configuration.newClient({ monitorCommands: true });
       client.connect(err => {
@@ -2602,13 +2592,13 @@ describe('Change Streams', function() {
       });
     });
 
-    afterEach(function(done) {
+    afterEach(function (done) {
       client.close(done);
     });
 
     it('should work with events', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=4.1.1' } },
-      test: function(done) {
+      test: function (done) {
         const changeStream = coll.watch([], { startAfter });
         this.defer(() => changeStream.close());
 
@@ -2628,7 +2618,7 @@ describe('Change Streams', function() {
 
     it('should work with callbacks', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=4.1.1' } },
-      test: function(done) {
+      test: function (done) {
         const changeStream = coll.watch([], { startAfter });
         this.defer(() => changeStream.close());
 
@@ -2655,7 +2645,7 @@ describe('Change Streams', function() {
     // when resuming a change stream.
     it('$changeStream without results must include startAfter and not resumeAfter', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=4.1.1' } },
-      test: function(done) {
+      test: function (done) {
         const events = [];
         client.on('commandStarted', e => recordEvent(events, e));
         const changeStream = coll.watch([], { startAfter });
@@ -2666,9 +2656,7 @@ describe('Change Streams', function() {
             operationType: 'insert',
             fullDocument: { x: 2 }
           });
-          expect(events)
-            .to.be.an('array')
-            .with.lengthOf(3);
+          expect(events).to.be.an('array').with.lengthOf(3);
           expect(events[0]).nested.property('$changeStream.startAfter').to.exist;
           expect(events[1]).to.equal('error');
           expect(events[2]).nested.property('$changeStream.startAfter').to.exist;
@@ -2689,7 +2677,7 @@ describe('Change Streams', function() {
     // when resuming a change stream.
     it('$changeStream with results must include resumeAfter and not startAfter', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=4.1.1' } },
-      test: function(done) {
+      test: function (done) {
         let events = [];
         client.on('commandStarted', e => recordEvent(events, e));
         const changeStream = coll.watch([], { startAfter });
@@ -2704,9 +2692,7 @@ describe('Change Streams', function() {
               triggerResumableError(changeStream, () => events.push('error'));
               break;
             case 3:
-              expect(events)
-                .to.be.an('array')
-                .with.lengthOf(3);
+              expect(events).to.be.an('array').with.lengthOf(3);
               expect(events[0]).to.equal('error');
               expect(events[1]).nested.property('$changeStream.resumeAfter').to.exist;
               expect(events[2]).to.eql({ change: { insert: { x: 3 } } });
@@ -2727,7 +2713,7 @@ describe('Change Streams', function() {
   });
 });
 
-describe('Change Stream Resume Error Tests', function() {
+describe('Change Stream Resume Error Tests', function () {
   it('should continue emitting change events after a resumable error', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
     test: withChangeStream((collection, changeStream, done) => {
@@ -2799,11 +2785,11 @@ describe('Change Stream Resume Error Tests', function() {
     })
   });
 });
-context('NODE-2626 - handle null changes without error', function() {
+context('NODE-2626 - handle null changes without error', function () {
   let mockServer;
   afterEach(() => mock.cleanup());
   beforeEach(() => mock.createServer().then(server => (mockServer = server)));
-  it('changeStream should close if cursor id for initial aggregate is Long.ZERO', function(done) {
+  it('changeStream should close if cursor id for initial aggregate is Long.ZERO', function (done) {
     mockServer.setMessageHandler(req => {
       const doc = req.document;
       if (doc.ismaster) {

--- a/test/functional/change_stream_spec.test.js
+++ b/test/functional/change_stream_spec.test.js
@@ -7,14 +7,14 @@ const setupDatabase = require('./shared').setupDatabase;
 const delay = require('./shared').delay;
 const expect = chai.expect;
 
-describe('Change Stream Spec', function() {
+describe('Change Stream Spec', function () {
   let globalClient;
   let ctx;
   let events;
 
   const TESTS_TO_SKIP = new Set([]);
 
-  before(function() {
+  before(function () {
     const configuration = this.configuration;
     return setupDatabase(configuration).then(() => {
       globalClient = configuration.newClient();
@@ -22,7 +22,7 @@ describe('Change Stream Spec', function() {
     });
   });
 
-  after(function() {
+  after(function () {
     const gc = globalClient;
     globalClient = undefined;
     return new Promise(r => gc.close(() => r()));
@@ -32,7 +32,7 @@ describe('Change Stream Spec', function() {
     const ALL_DBS = [suite.database_name, suite.database2_name];
 
     describe(suite.name, () => {
-      beforeEach(function() {
+      beforeEach(function () {
         const gc = globalClient;
         const sDB = suite.database_name;
         const sColl = suite.collection_name;
@@ -62,7 +62,7 @@ describe('Change Stream Spec', function() {
           });
       });
 
-      afterEach(function() {
+      afterEach(function () {
         const client = ctx.client;
         ctx = undefined;
         events = undefined;
@@ -126,7 +126,7 @@ describe('Change Stream Spec', function() {
       return () => Promise.resolve();
     }
 
-    return function(ctx) {
+    return function (ctx) {
       return ctx.gc.db('admin').command(test.failPoint);
     };
   }

--- a/test/functional/client_side_encryption/corpus.test.js
+++ b/test/functional/client_side_encryption/corpus.test.js
@@ -12,7 +12,7 @@ chai.config.includeStack = true;
 chai.config.showDiff = true;
 chai.config.truncateThreshold = 0;
 
-describe('Client Side Encryption Corpus', function() {
+describe('Client Side Encryption Corpus', function () {
   const metadata = {
     requires: {
       mongodb: '>=4.2.0',
@@ -127,7 +127,7 @@ describe('Client Side Encryption Corpus', function() {
     }
   }
 
-  before(function() {
+  before(function () {
     // 1. Create a MongoClient without encryption enabled (referred to as ``client``).
     client = this.configuration.newClient();
 
@@ -144,7 +144,7 @@ describe('Client Side Encryption Corpus', function() {
       });
   });
 
-  after(function() {
+  after(function () {
     if (client) {
       return client.close();
     }
@@ -152,7 +152,7 @@ describe('Client Side Encryption Corpus', function() {
 
   function defineCorpusTests(corpus, corpusEncryptedExpected, useClientSideSchema) {
     let clientEncrypted, clientEncryption;
-    beforeEach(function() {
+    beforeEach(function () {
       const mongodbClientEncryption = this.configuration.mongodbClientEncryption;
       return Promise.resolve()
         .then(() => {
@@ -213,7 +213,7 @@ describe('Client Side Encryption Corpus', function() {
     it(
       `should pass corpus ${useClientSideSchema ? 'with' : 'without'} client schema`,
       metadata,
-      function() {
+      function () {
         const corpusCopied = {};
         return Promise.resolve()
           .then(() => {
@@ -291,10 +291,7 @@ describe('Client Side Encryption Corpus', function() {
           })
           .then(() => {
             // 6. Using ``client_encrypted``, insert ``corpus_copied`` into ``db.coll``.
-            return clientEncrypted
-              .db(dataDbName)
-              .collection(dataCollName)
-              .insertOne(corpusCopied);
+            return clientEncrypted.db(dataDbName).collection(dataCollName).insertOne(corpusCopied);
           })
           .then(() => {
             // 7. Using ``client_encrypted``, find the inserted document from ``db.coll`` to a variable named ``corpus_decrypted``.

--- a/test/functional/client_side_encryption/driver.test.js
+++ b/test/functional/client_side_encryption/driver.test.js
@@ -9,7 +9,7 @@ chai.config.showDiff = true;
 chai.config.truncateThreshold = 0;
 chai.use(require('chai-subset'));
 
-describe('Client Side Encryption Functional', function() {
+describe('Client Side Encryption Functional', function () {
   const dataDbName = 'db';
   const dataCollName = 'coll';
   const keyVaultDbName = 'keyvault';
@@ -23,8 +23,8 @@ describe('Client Side Encryption Functional', function() {
     }
   };
 
-  describe('BSON Options', function() {
-    beforeEach(function() {
+  describe('BSON Options', function () {
+    beforeEach(function () {
       this.client = this.configuration.newClient();
 
       const noop = () => {};
@@ -87,7 +87,7 @@ describe('Client Side Encryption Functional', function() {
         });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       return Promise.resolve()
         .then(() => this.encryptedClient && this.encryptedClient.close())
         .then(() => this.client.close());
@@ -120,7 +120,7 @@ describe('Client Side Encryption Functional', function() {
     testCases.forEach(bsonOptions => {
       const name = `should respect bson options ${JSON.stringify(bsonOptions)}`;
 
-      it(name, metadata, function() {
+      it(name, metadata, function () {
         const data = {
           a: 12,
           b: new BSON.Int32(12),

--- a/test/functional/client_side_encryption/prose.test.js
+++ b/test/functional/client_side_encryption/prose.test.js
@@ -12,7 +12,7 @@ chai.use(require('chai-subset'));
 
 //   Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk
 
-describe('Client Side Encryption Prose Tests', function() {
+describe('Client Side Encryption Prose Tests', function () {
   const metadata = { requires: { clientSideEncryption: true, mongodb: '>=4.2.0' } };
   const dataDbName = 'db';
   const dataCollName = 'coll';
@@ -30,11 +30,11 @@ describe('Client Side Encryption Prose Tests', function() {
     'base64'
   );
 
-  describe('Data key and double encryption', function() {
+  describe('Data key and double encryption', function () {
     // Data key and double encryption
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // First, perform the setup.
-    beforeEach(function() {
+    beforeEach(function () {
       const mongodbClientEncryption = this.configuration.mongodbClientEncryption;
 
       // #. Create a MongoClient without encryption enabled (referred to as ``client``). Enable command monitoring to listen for command_started events.
@@ -115,7 +115,7 @@ describe('Client Side Encryption Prose Tests', function() {
       );
     });
 
-    afterEach(function() {
+    afterEach(function () {
       if (this.commandStartedEvents) {
         this.commandStartedEvents.teardown();
         this.commandStartedEvents = undefined;
@@ -125,7 +125,7 @@ describe('Client Side Encryption Prose Tests', function() {
         .then(() => this.client && this.client.close());
     });
 
-    it('should work for local KMS provider', metadata, function() {
+    it('should work for local KMS provider', metadata, function () {
       let localDatakeyId;
       let localEncrypted;
       return Promise.resolve()
@@ -193,7 +193,7 @@ describe('Client Side Encryption Prose Tests', function() {
         });
     });
 
-    it('should work for aws KMS provider', metadata, function() {
+    it('should work for aws KMS provider', metadata, function () {
       // Then, repeat the above tests with the ``aws`` KMS provider:
       let awsDatakeyId;
       let awsEncrypted;
@@ -271,7 +271,7 @@ describe('Client Side Encryption Prose Tests', function() {
         });
     });
 
-    it('should error on an attempt to double-encrypt a value', metadata, function() {
+    it('should error on an attempt to double-encrypt a value', metadata, function () {
       // Then, run the following final tests:
       // #. Test explicit encrypting an auto encrypted field.
       //    - Use ``client_encrypted`` to attempt to insert ``{ "encrypted_placeholder": (local_encrypted) }``
@@ -301,10 +301,10 @@ describe('Client Side Encryption Prose Tests', function() {
     });
   });
 
-  describe('Custom Endpoint', function() {
+  describe('Custom Endpoint', function () {
     // Data keys created with AWS KMS may specify a custom endpoint to contact (instead of the default endpoint derived from the AWS region).
 
-    beforeEach(function() {
+    beforeEach(function () {
       // 1. Create a ``ClientEncryption`` object (referred to as ``client_encryption``)
       //    Configure with ``aws`` KMS providers as follows:
       //    .. code:: javascript
@@ -324,7 +324,7 @@ describe('Client Side Encryption Prose Tests', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       return this.client && this.client.close();
     });
     const testCases = [
@@ -404,7 +404,7 @@ describe('Client Side Encryption Prose Tests', function() {
     ];
 
     testCases.forEach(testCase => {
-      it(testCase.description, metadata, function() {
+      it(testCase.description, metadata, function () {
         // 2. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
         // .. code:: javascript
         //    {
@@ -442,7 +442,7 @@ describe('Client Side Encryption Prose Tests', function() {
     });
   });
 
-  describe('BSON size limits and batch splitting', function() {
+  describe('BSON size limits and batch splitting', function () {
     const fs = require('fs');
     const path = require('path');
     const { EJSON } = BSON;
@@ -456,7 +456,7 @@ describe('Client Side Encryption Prose Tests', function() {
     const limitsKey = loadLimits('limits-key.json');
     const limitsDoc = loadLimits('limits-doc.json');
 
-    before(function() {
+    before(function () {
       // First, perform the setup.
 
       // #. Create a MongoClient without encryption enabled (referred to as ``client``).
@@ -483,7 +483,7 @@ describe('Client Side Encryption Prose Tests', function() {
       );
     });
 
-    beforeEach(function() {
+    beforeEach(function () {
       // #. Create a MongoClient configured with auto encryption (referred to as ``client_encrypted``)
       //    Configure with the ``local`` KMS provider as follows:
       //    .. code:: javascript
@@ -507,7 +507,7 @@ describe('Client Side Encryption Prose Tests', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       if (this.commandStartedEvents) {
         this.commandStartedEvents.teardown();
         this.commandStartedEvents = undefined;
@@ -517,7 +517,7 @@ describe('Client Side Encryption Prose Tests', function() {
       }
     });
 
-    after(function() {
+    after(function () {
       return this.client && this.client.close();
     });
 
@@ -603,7 +603,7 @@ describe('Client Side Encryption Prose Tests', function() {
     ];
 
     testCases.forEach(testCase => {
-      it(testCase.description, metadata, function() {
+      it(testCase.description, metadata, function () {
         return this.encryptedColl.insertMany(testCase.docs()).then(
           () => {
             if (testCase.error) {
@@ -643,8 +643,8 @@ describe('Client Side Encryption Prose Tests', function() {
     }
   });
 
-  describe('Views are prohibited', function() {
-    before(function() {
+  describe('Views are prohibited', function () {
+    before(function () {
       // First, perform the setup.
 
       // #. Create a MongoClient without encryption enabled (referred to as ``client``).
@@ -663,11 +663,11 @@ describe('Client Side Encryption Prose Tests', function() {
         });
     });
 
-    after(function() {
+    after(function () {
       return this.client && this.client.close();
     });
 
-    beforeEach(function() {
+    beforeEach(function () {
       this.clientEncrypted = this.configuration.newClient(
         {},
         {
@@ -681,11 +681,11 @@ describe('Client Side Encryption Prose Tests', function() {
       return this.clientEncrypted.connect();
     });
 
-    afterEach(function() {
+    afterEach(function () {
       return this.clientEncrypted && this.clientEncrypted.close();
     });
 
-    it('should error when inserting into a view with autoEncryption', metadata, function() {
+    it('should error when inserting into a view with autoEncryption', metadata, function () {
       return this.clientEncrypted
         .db(dataDbName)
         .collection('view')
@@ -707,7 +707,7 @@ describe('Client Side Encryption Prose Tests', function() {
   // connect-less client. So instead we are implementing the tests via APM,
   // and confirming that the externalClient is firing off keyVault requests during
   // encrypted operations
-  describe('External Key Vault', function() {
+  describe('External Key Vault', function () {
     const fs = require('fs');
     const path = require('path');
     const { EJSON } = BSON;
@@ -720,7 +720,7 @@ describe('Client Side Encryption Prose Tests', function() {
     const externalKey = loadExternal('external-key.json');
     const externalSchema = loadExternal('external-schema.json');
 
-    beforeEach(function() {
+    beforeEach(function () {
       this.client = this.configuration.newClient();
 
       // #. Create a MongoClient without encryption enabled (referred to as ``client``).
@@ -740,7 +740,7 @@ describe('Client Side Encryption Prose Tests', function() {
       );
     });
 
-    afterEach(function() {
+    afterEach(function () {
       if (this.commandStartedEvents) {
         this.commandStartedEvents.teardown();
         this.commandStartedEvents = undefined;
@@ -755,7 +755,7 @@ describe('Client Side Encryption Prose Tests', function() {
       it(
         `should work ${withExternalKeyVault ? 'with' : 'without'} external key vault`,
         metadata,
-        function() {
+        function () {
           const ClientEncryption = this.configuration.mongodbClientEncryption.ClientEncryption;
           return (
             Promise.resolve()

--- a/test/functional/client_side_encryption/spec.test.js
+++ b/test/functional/client_side_encryption/spec.test.js
@@ -5,7 +5,7 @@ const TestRunnerContext = require('../spec-runner').TestRunnerContext;
 const gatherTestSuites = require('../spec-runner').gatherTestSuites;
 const generateTopologyTests = require('../spec-runner').generateTopologyTests;
 
-describe('Client Side Encryption', function() {
+describe('Client Side Encryption', function () {
   // TODO: Replace this with using the filter once the filter works on describe blocks
   const skipTests =
     process.env.AWS_ACCESS_KEY_ID == null || process.env.AWS_SECRET_ACCESS_KEY == null;
@@ -26,7 +26,7 @@ describe('Client Side Encryption', function() {
   const testContext = new TestRunnerContext();
   const testSuites = gatherTestSuites(path.join(__dirname, '../../spec/client-side-encryption'));
   after(() => testContext.teardown());
-  before(function() {
+  before(function () {
     return testContext.setup(this.configuration);
   });
 

--- a/test/functional/cmap/connection.test.js
+++ b/test/functional/cmap/connection.test.js
@@ -5,12 +5,12 @@ const connect = require('../../../src/cmap/connect');
 const expect = require('chai').expect;
 const setupDatabase = require('../../functional/shared').setupDatabase;
 
-describe('Connection', function() {
-  before(function() {
+describe('Connection', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
-  it('should execute a command against a server', function(done) {
+  it('should execute a command against a server', function (done) {
     const connectOptions = Object.assign(
       { connectionType: Connection },
       this.configuration.options
@@ -32,7 +32,7 @@ describe('Connection', function() {
     });
   });
 
-  it('should emit command monitoring events', function(done) {
+  it('should emit command monitoring events', function (done) {
     const connectOptions = Object.assign(
       { connectionType: Connection, monitorCommands: true },
       this.configuration.options
@@ -60,7 +60,7 @@ describe('Connection', function() {
     });
   });
 
-  it('should support socket timeouts', function(done) {
+  it('should support socket timeouts', function (done) {
     const connectOptions = Object.assign({
       host: '240.0.0.1',
       connectionType: Connection,
@@ -76,7 +76,7 @@ describe('Connection', function() {
 
   it('should support calling back multiple times on exhaust commands', {
     metadata: { requires: { mongodb: '>=4.2.0', topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       const ns = `${this.configuration.db}.$cmd`;
       const connectOptions = Object.assign(
         { connectionType: Connection },
@@ -93,9 +93,7 @@ describe('Connection', function() {
 
         conn.command(ns, { insert: 'test', documents }, (err, res) => {
           expect(err).to.not.exist;
-          expect(res)
-            .nested.property('result.n')
-            .to.equal(documents.length);
+          expect(res).nested.property('result.n').to.equal(documents.length);
 
           let totalDocumentsRead = 0;
           conn.command(ns, { find: 'test', batchSize: 100 }, (err, result) => {

--- a/test/functional/collations.test.js
+++ b/test/functional/collations.test.js
@@ -5,8 +5,8 @@ const expect = require('chai').expect;
 const { Long, Code } = require('../../src');
 
 const testContext = {};
-describe('Collation', function() {
-  before(function() {
+describe('Collation', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -18,7 +18,7 @@ describe('Collation', function() {
   it('Successfully pass through collation to findAndModify command', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -59,7 +59,7 @@ describe('Collation', function() {
   it('Successfully pass through collation to count command', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -95,7 +95,7 @@ describe('Collation', function() {
   it('Successfully pass through collation to aggregation command', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -133,7 +133,7 @@ describe('Collation', function() {
   it('Successfully pass through collation to distinct command', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -169,7 +169,7 @@ describe('Collation', function() {
   it('Successfully pass through collation to group command', {
     metadata: { requires: { generators: true, topology: 'single', mongodb: '<=4.1.0' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -213,7 +213,7 @@ describe('Collation', function() {
   it('Successfully pass through collation to mapReduce command', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -254,7 +254,7 @@ describe('Collation', function() {
   it('Successfully pass through collation to remove command', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -290,7 +290,7 @@ describe('Collation', function() {
   it('Successfully pass through collation to update command', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -328,7 +328,7 @@ describe('Collation', function() {
   it('Successfully pass through collation to find command via options', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -364,7 +364,7 @@ describe('Collation', function() {
 
   it('Successfully pass through collation to find command via cursor', {
     metadata: { requires: { generators: true, topology: 'single' } },
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -402,7 +402,7 @@ describe('Collation', function() {
 
   it('Successfully pass through collation to findOne', {
     metadata: { requires: { generators: true, topology: 'single' } },
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -438,7 +438,7 @@ describe('Collation', function() {
 
   it('Successfully pass through collation to createCollection', {
     metadata: { requires: { generators: true, topology: 'single' } },
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -481,7 +481,7 @@ describe('Collation', function() {
   it('Fail due to no support for collation', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 4 })];
@@ -515,7 +515,7 @@ describe('Collation', function() {
 
   it('Fail command due to no support for collation', {
     metadata: { requires: { generators: true, topology: 'single' } },
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 4 })];
@@ -551,7 +551,7 @@ describe('Collation', function() {
 
   it('Successfully pass through collation to bulkWrite command', {
     metadata: { requires: { generators: true, topology: 'single' } },
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -605,7 +605,7 @@ describe('Collation', function() {
 
   it('Successfully fail bulkWrite due to unsupported collation', {
     metadata: { requires: { generators: true, topology: 'single' } },
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 4 })];
@@ -652,7 +652,7 @@ describe('Collation', function() {
 
   it('Successfully create index with collation', {
     metadata: { requires: { generators: true, topology: 'single' } },
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER)];
@@ -691,7 +691,7 @@ describe('Collation', function() {
   it('Fail to create index with collation due to no capabilities', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 4 })];
@@ -726,7 +726,7 @@ describe('Collation', function() {
   it('Fail to create indexs with collation due to no capabilities', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${testContext.server.uri()}/test`);
       const primary = [Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 4 })];
@@ -759,7 +759,7 @@ describe('Collation', function() {
 
   it('cursor count method should return the correct number when used with collation set', {
     metadata: { requires: { mongodb: '>=3.4.0' } },
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
 
@@ -798,7 +798,7 @@ describe('Collation', function() {
   it('Should correctly create index with collation', {
     metadata: { requires: { topology: 'single', mongodb: '>=3.3.12' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
@@ -829,7 +829,7 @@ describe('Collation', function() {
   it('Should correctly create collection with collation', {
     metadata: { requires: { topology: 'single', mongodb: '>=3.3.12' } },
 
-    test: function() {
+    test: function () {
       const configuration = this.configuration;
       const client = configuration.newClient();
 

--- a/test/functional/collection.test.js
+++ b/test/functional/collection.test.js
@@ -7,17 +7,17 @@ const mock = require('mongodb-mock-server');
 const { Long, ObjectId } = require('../../src');
 chai.use(sinonChai);
 
-describe('Collection', function() {
+describe('Collection', function () {
   let configuration;
-  before(function() {
+  before(function () {
     configuration = this.configuration;
     return setupDatabase(configuration, ['listCollectionsDb', 'listCollectionsDb2', 'test_db']);
   });
 
-  describe('standard collection tests', function() {
+  describe('standard collection tests', function () {
     let client;
     let db;
-    beforeEach(function() {
+    beforeEach(function () {
       client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1
       });
@@ -26,12 +26,12 @@ describe('Collection', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       db = undefined;
       return client.close();
     });
 
-    it('should correctly execute basic collection methods', function(done) {
+    it('should correctly execute basic collection methods', function (done) {
       db.createCollection('test_collection_methods', (err, collection) => {
         // Verify that all the result are correct coming back (should contain the value ok)
         expect(collection.collectionName).to.equal('test_collection_methods');
@@ -79,7 +79,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should correctly access collection names', function(done) {
+    it('should correctly access collection names', function (done) {
       // Create two collections
       db.createCollection('test.spiderman', () => {
         db.createCollection('test.mario', () => {
@@ -118,7 +118,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should correctly retrieve listCollections', function(done) {
+    it('should correctly retrieve listCollections', function (done) {
       db.createCollection('test_collection_names', err => {
         expect(err).to.not.exist;
 
@@ -165,7 +165,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should ensure strict access collection', function(done) {
+    it('should ensure strict access collection', function (done) {
       db.collection('does-not-exist', { strict: true }, err => {
         expect(err).to.be.an.instanceof(Error);
         expect(err.message).to.equal(
@@ -182,7 +182,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should perform strict create collection', function(done) {
+    it('should perform strict create collection', function (done) {
       db.createCollection('test_strict_create_collection', (err, collection) => {
         expect(err).to.not.exist;
         expect(collection.collectionName).to.equal('test_strict_create_collection');
@@ -199,7 +199,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should fail to insert due to illegal keys', function(done) {
+    it('should fail to insert due to illegal keys', function (done) {
       db.createCollection('test_invalid_key_names', (err, collection) => {
         // Legal inserts
         collection.insertMany(
@@ -285,7 +285,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should fail due to illegal listCollections', function(done) {
+    it('should fail due to illegal listCollections', function (done) {
       db.collection(5, err => {
         expect(err.message).to.equal('collection name must be a String');
       });
@@ -312,7 +312,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should return invalid collection name error by callback for createCollection', function(done) {
+    it('should return invalid collection name error by callback for createCollection', function (done) {
       db.dropDatabase(err => {
         expect(err).to.not.exist;
 
@@ -323,7 +323,7 @@ describe('Collection', function() {
         });
       });
     });
-    it('should correctly count on non-existent collection', function(done) {
+    it('should correctly count on non-existent collection', function (done) {
       db.collection('test_multiple_insert_2', (err, collection) => {
         collection.countDocuments((err, count) => {
           expect(count).to.equal(0);
@@ -333,7 +333,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should correctly execute save', function(done) {
+    it('should correctly execute save', function (done) {
       db.createCollection('test_save', (err, collection) => {
         const doc = { hello: 'world' };
         collection.save(doc, configuration.writeConcernMax(), (err, r) => {
@@ -384,7 +384,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should correctly save document with Long value', function(done) {
+    it('should correctly save document with Long value', function (done) {
       db.createCollection('test_save_long', (err, collection) => {
         collection.insertOne(
           { x: Long.fromNumber(9223372036854775807) },
@@ -402,7 +402,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should save object that has id but does not exist in collection', function(done) {
+    it('should save object that has id but does not exist in collection', function (done) {
       db.createCollection(
         'test_save_with_object_that_has_id_but_does_not_actually_exist_in_collection',
         (err, collection) => {
@@ -435,7 +435,7 @@ describe('Collection', function() {
       );
     });
 
-    it('should correctly execute insert update delete safe mode', function(done) {
+    it('should correctly execute insert update delete safe mode', function (done) {
       db.createCollection(
         'test_should_execute_insert_update_delete_safe_mode',
         (err, collection) => {
@@ -469,7 +469,7 @@ describe('Collection', function() {
       );
     });
 
-    it('should perform multiple saves', function(done) {
+    it('should perform multiple saves', function (done) {
       db.createCollection('multiple_save_test', (err, collection) => {
         const doc = {
           name: 'amit',
@@ -502,7 +502,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should correctly save document with nested array', function(done) {
+    it('should correctly save document with nested array', function (done) {
       db.createCollection('save_error_on_save_test', (err, collection) => {
         // Create unique index for username
         collection.createIndex([['username', 1]], configuration.writeConcernMax(), err => {
@@ -555,7 +555,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should perform collection remove with no callback', function(done) {
+    it('should perform collection remove with no callback', function (done) {
       db.collection('remove_with_no_callback_bug_test', (err, collection) => {
         expect(err).to.not.exist;
         collection.insertOne({ a: 1 }, configuration.writeConcernMax(), err => {
@@ -579,7 +579,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should correctly read back document with null', function(done) {
+    it('should correctly read back document with null', function (done) {
       db.createCollection('shouldCorrectlyReadBackDocumentWithNull', {}, (err, collection) => {
         // Insert a document with a date
         collection.insertOne({ test: null }, configuration.writeConcernMax(), err => {
@@ -594,7 +594,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should throw error due to illegal update', function(done) {
+    it('should throw error due to illegal update', function (done) {
       db.createCollection('shouldThrowErrorDueToIllegalUpdate', {}, (err, coll) => {
         coll.update({}, null, err => {
           expect(err.message).to.equal('document must be a valid JavaScript object');
@@ -607,7 +607,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should correctly handle 0 as id for save', function(done) {
+    it('should correctly handle 0 as id for save', function (done) {
       db.collection('shouldCorrectlyHandle0asIdForSave').save({ _id: 0 }, err => {
         expect(err).to.not.exist;
 
@@ -634,7 +634,7 @@ describe('Collection', function() {
     ];
 
     selectorTests.forEach(test => {
-      it(test.title, function(done) {
+      it(test.title, function (done) {
         db.collection(test.collectionName).updateOne(
           test.filterObject,
           test.updateObject,
@@ -663,7 +663,7 @@ describe('Collection', function() {
     ];
 
     updateTests.forEach(test => {
-      it(test.title, function(done) {
+      it(test.title, function (done) {
         db.createCollection(test.collectionName, (err, collection) => {
           collection.updateOne(
             test.filterObject,
@@ -680,7 +680,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should fail due to existing collection', function(done) {
+    it('should fail due to existing collection', function (done) {
       db.createCollection('shouldFailDueToExistingCollection', { strict: true }, (err, coll) => {
         expect(err).to.not.exist;
         expect(coll).to.exist;
@@ -707,7 +707,7 @@ describe('Collection', function() {
     ];
 
     listCollectionsTests.forEach(test => {
-      it(test.title, function(done) {
+      it(test.title, function (done) {
         db.createCollection(test.collectionName, (err, collection) => {
           expect(err).to.not.exist;
           expect(collection.collectionName).to.equal(test.collectionName);
@@ -725,7 +725,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should filter correctly with index during list', function(done) {
+    it('should filter correctly with index during list', function (done) {
       const testCollection = 'collection_124';
       // Create a collection
       db.createCollection(testCollection, err => {
@@ -752,7 +752,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should correctly list multipleCollections', function(done) {
+    it('should correctly list multipleCollections', function (done) {
       const emptyDb = client.db('listCollectionsDb');
       emptyDb.createCollection('test1', err => {
         expect(err).to.not.exist;
@@ -779,7 +779,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should correctly handle namespace when using collections method', function(done) {
+    it('should correctly handle namespace when using collections method', function (done) {
       const emptyDb = client.db('listCollectionsDb2');
       emptyDb.createCollection('test1', err => {
         expect(err).to.not.exist;
@@ -816,7 +816,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should provide access to the database name', function() {
+    it('should provide access to the database name', function () {
       return client
         .db('test_db')
         .createCollection('test1')
@@ -837,7 +837,7 @@ describe('Collection', function() {
     ];
 
     collectionTTLtests.forEach(test => {
-      it(test.title, function(done) {
+      it(test.title, function (done) {
         db.createCollection(test.collectionName, (err, collection) => {
           const errorCallBack = err => {
             expect(err).to.not.exist;
@@ -885,7 +885,7 @@ describe('Collection', function() {
       });
     });
 
-    it('should support createIndex with no options', function(done) {
+    it('should support createIndex with no options', function (done) {
       db.createCollection('create_index_without_options', {}, (err, collection) => {
         collection.createIndex({ createdAt: 1 }, err => {
           expect(err).to.not.exist;
@@ -902,11 +902,11 @@ describe('Collection', function() {
     });
   });
 
-  describe('(countDocuments)', function() {
+  describe('(countDocuments)', function () {
     let client;
     let db;
     let collection;
-    beforeEach(function() {
+    beforeEach(function () {
       client = configuration.newClient({}, { w: 1 });
 
       return client.connect().then(client => {
@@ -914,7 +914,7 @@ describe('Collection', function() {
         collection = db.collection('test_coll');
       });
     });
-    afterEach(function() {
+    afterEach(function () {
       return client.close();
     });
 
@@ -928,7 +928,7 @@ describe('Collection', function() {
     ];
 
     nonMatchQueryTests.forEach(test => {
-      it(test.title, function(done) {
+      it(test.title, function (done) {
         const close = e => client.close(() => done(e));
         let thenFunction;
         if (
@@ -946,7 +946,7 @@ describe('Collection', function() {
       });
     });
 
-    it('countDocuments should return Promise that resolves when no callback passed', function(done) {
+    it('countDocuments should return Promise that resolves when no callback passed', function (done) {
       const docsPromise = collection.countDocuments();
       const close = e => client.close(() => done(e));
 
@@ -958,7 +958,7 @@ describe('Collection', function() {
         .catch(e => close(e));
     });
 
-    it('countDocuments should not return a promise if callback given', function(done) {
+    it('countDocuments should not return a promise if callback given', function (done) {
       const close = e => client.close(() => done(e));
 
       const notPromise = collection.countDocuments({ a: 1 }, () => {
@@ -967,7 +967,7 @@ describe('Collection', function() {
       });
     });
 
-    it('countDocuments should correctly call the given callback', function(done) {
+    it('countDocuments should correctly call the given callback', function (done) {
       const docs = [{ a: 1 }, { a: 2 }];
       const close = e => client.close(() => done(e));
 
@@ -980,7 +980,7 @@ describe('Collection', function() {
     });
   });
 
-  describe('countDocuments with mock server', function() {
+  describe('countDocuments with mock server', function () {
     let server;
 
     beforeEach(() => {
@@ -1021,7 +1021,7 @@ describe('Collection', function() {
       });
     }
 
-    it('countDocuments should return appropriate error if aggregation fails with callback given', function(done) {
+    it('countDocuments should return appropriate error if aggregation fails with callback given', function (done) {
       const replyHandler = () => {};
       const executeCountDocuments = (collection, close) => {
         collection.countDocuments(err => {
@@ -1042,7 +1042,7 @@ describe('Collection', function() {
       );
     });
 
-    it('countDocuments should error if aggregation fails using Promises', function(done) {
+    it('countDocuments should error if aggregation fails using Promises', function (done) {
       const replyHandler = () => {};
       const executeCountDocuments = (collection, close) => {
         collection
@@ -1065,7 +1065,7 @@ describe('Collection', function() {
       );
     });
 
-    it('countDocuments pipeline should be correct with skip and limit applied', function(done) {
+    it('countDocuments pipeline should be correct with skip and limit applied', function (done) {
       const replyHandler = doc => {
         expect(doc.pipeline).to.deep.include({ $skip: 1 });
         expect(doc.pipeline).to.deep.include({ $limit: 1 });
@@ -1105,7 +1105,7 @@ describe('Collection', function() {
     });
   }
 
-  it('isCapped should return false for uncapped collections', function(done) {
+  it('isCapped should return false for uncapped collections', function (done) {
     testCapped(
       configuration,
       { config: configuration, collName: 'uncapped', opts: { capped: false } },
@@ -1113,18 +1113,18 @@ describe('Collection', function() {
     );
   });
 
-  it('isCapped should return false for collections instantiated without specifying capped', function(done) {
+  it('isCapped should return false for collections instantiated without specifying capped', function (done) {
     testCapped(configuration, { config: configuration, collName: 'uncapped2', opts: {} }, done);
   });
 
-  describe('Retryable Writes on bulk ops', function() {
+  describe('Retryable Writes on bulk ops', function () {
     let client;
     let db;
     let collection;
 
     const metadata = { requires: { topology: ['replicaset'], mongodb: '>=3.6.0' } };
 
-    beforeEach(function() {
+    beforeEach(function () {
       client = configuration.newClient({}, { retryWrites: true });
       return client.connect().then(() => {
         db = client.db('test_retry_writes');
@@ -1136,20 +1136,20 @@ describe('Collection', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       return client.close();
     });
 
     it('should succeed with retryWrite=true when using updateMany', {
       metadata,
-      test: function() {
+      test: function () {
         return collection.updateMany({ name: 'foobar' }, { $set: { name: 'fizzbuzz' } });
       }
     });
 
     it('should succeed with retryWrite=true when using update with multi=true', {
       metadata,
-      test: function() {
+      test: function () {
         return collection.updateOne(
           { name: 'foobar' },
           { $set: { name: 'fizzbuzz' } },
@@ -1160,14 +1160,14 @@ describe('Collection', function() {
 
     it('should succeed with retryWrite=true when using remove without option single', {
       metadata,
-      test: function() {
+      test: function () {
         return collection.deleteOne({ name: 'foobar' });
       }
     });
 
     it('should succeed with retryWrite=true when using deleteMany', {
       metadata,
-      test: function() {
+      test: function () {
         return collection.deleteMany({ name: 'foobar' });
       }
     });
@@ -1175,7 +1175,7 @@ describe('Collection', function() {
 
   it('should allow an empty replacement document for findOneAndReplace', {
     metadata: { requires: { mongodb: '>=3.0.0' } },
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient({}, { w: 1 });
 
@@ -1208,7 +1208,7 @@ describe('Collection', function() {
       requires: { mongodb: '>=4.2.0' }
     },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1

--- a/test/functional/command_write_concern.test.js
+++ b/test/functional/command_write_concern.test.js
@@ -5,7 +5,7 @@ var mock = require('mongodb-mock-server');
 const { ObjectId, Long, Code } = require('../../src');
 
 // Extend the object
-var extend = function(template, fields) {
+var extend = function (template, fields) {
   var object = {};
   for (var name in template) {
     object[name] = template[name];
@@ -18,7 +18,7 @@ var extend = function(template, fields) {
   return object;
 };
 
-describe('Command Write Concern', function() {
+describe('Command Write Concern', function () {
   afterEach(() => mock.cleanup());
 
   it('successfully pass through writeConcern to aggregate command', {
@@ -29,7 +29,7 @@ describe('Command Write Concern', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -74,7 +74,7 @@ describe('Command Write Concern', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         let primaryServer = yield mock.createServer(32000, 'localhost');
         let firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         let arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -114,7 +114,7 @@ describe('Command Write Concern', function() {
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -123,7 +123,7 @@ describe('Command Write Concern', function() {
               w: 2,
               wtimeout: 1000
             })
-            .toArray(function(err) {
+            .toArray(function (err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -142,7 +142,7 @@ describe('Command Write Concern', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -187,7 +187,7 @@ describe('Command Write Concern', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -239,11 +239,11 @@ describe('Command Write Concern', function() {
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
-          db.createCollection('test_collection_methods', { w: 2, wtimeout: 1000 }, function(err) {
+          db.createCollection('test_collection_methods', { w: 2, wtimeout: 1000 }, function (err) {
             test.equal(null, err);
             test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -262,7 +262,7 @@ describe('Command Write Concern', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -307,7 +307,7 @@ describe('Command Write Concern', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -350,7 +350,7 @@ describe('Command Write Concern', function() {
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -361,7 +361,7 @@ describe('Command Write Concern', function() {
               w: 2,
               wtimeout: 1000
             },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -381,7 +381,7 @@ describe('Command Write Concern', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -426,7 +426,7 @@ describe('Command Write Concern', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -468,7 +468,7 @@ describe('Command Write Concern', function() {
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -477,7 +477,7 @@ describe('Command Write Concern', function() {
               w: 2,
               wtimeout: 1000
             },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -497,7 +497,7 @@ describe('Command Write Concern', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -542,7 +542,7 @@ describe('Command Write Concern', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -584,7 +584,7 @@ describe('Command Write Concern', function() {
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -593,7 +593,7 @@ describe('Command Write Concern', function() {
               w: 2,
               wtimeout: 1000
             },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -613,7 +613,7 @@ describe('Command Write Concern', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -658,7 +658,7 @@ describe('Command Write Concern', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -700,7 +700,7 @@ describe('Command Write Concern', function() {
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -709,7 +709,7 @@ describe('Command Write Concern', function() {
               w: 2,
               wtimeout: 1000
             },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -729,7 +729,7 @@ describe('Command Write Concern', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -774,7 +774,7 @@ describe('Command Write Concern', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -816,7 +816,7 @@ describe('Command Write Concern', function() {
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -833,7 +833,7 @@ describe('Command Write Concern', function() {
               w: 2,
               wtimeout: 1000
             },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -853,7 +853,7 @@ describe('Command Write Concern', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -898,7 +898,7 @@ describe('Command Write Concern', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -940,11 +940,11 @@ describe('Command Write Concern', function() {
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
-          db.admin().addUser('kay:kay', 'abc123', { w: 2, wtimeout: 1000 }, function(err) {
+          db.admin().addUser('kay:kay', 'abc123', { w: 2, wtimeout: 1000 }, function (err) {
             test.equal(null, err);
             test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -963,7 +963,7 @@ describe('Command Write Concern', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -1008,7 +1008,7 @@ describe('Command Write Concern', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -1050,11 +1050,11 @@ describe('Command Write Concern', function() {
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
-          db.admin().removeUser('kay:kay', { w: 2, wtimeout: 1000 }, function(err) {
+          db.admin().removeUser('kay:kay', { w: 2, wtimeout: 1000 }, function (err) {
             test.equal(null, err);
             test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 
@@ -1073,7 +1073,7 @@ describe('Command Write Concern', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var electionIds = [new ObjectId(), new ObjectId()];
       var defaultFields = Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -1118,7 +1118,7 @@ describe('Command Write Concern', function() {
       ];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const primaryServer = yield mock.createServer(32000, 'localhost');
         const firstSecondaryServer = yield mock.createServer(32001, 'localhost');
         const arbiterServer = yield mock.createServer(32002, 'localhost');
@@ -1160,7 +1160,7 @@ describe('Command Write Concern', function() {
           'mongodb://localhost:32000,localhost:32001,localhost:32002/test?replicaSet=rs'
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
           var db = client.db(configuration.db);
 
@@ -1170,7 +1170,7 @@ describe('Command Write Concern', function() {
             [['a', 1]],
             { $set: { b1: 1 } },
             { new: true, w: 2, wtimeout: 1000 },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
 

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -3,25 +3,25 @@ const test = require('./shared').assert,
   setupDatabase = require('./shared').setupDatabase,
   expect = require('chai').expect;
 
-describe('Connection', function() {
-  before(function() {
+describe('Connection', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it('should correctly start monitoring for single server connection', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(
         { w: 1 },
         { poolSize: 1, host: '/tmp/mongodb-27017.sock', heartbeatFrequencyMS: 250 }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
-        client.topology.once('monitoring', function() {
+        client.topology.once('monitoring', function () {
           client.close(done);
         });
       });
@@ -31,23 +31,23 @@ describe('Connection', function() {
   it('should correctly connect to server using domain socket', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(
         { w: 1 },
         { poolSize: 1, host: '/tmp/mongodb-27017.sock' }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
-        db.collection('domainSocketCollection0').insert({ a: 1 }, { w: 1 }, function(err) {
+        db.collection('domainSocketCollection0').insert({ a: 1 }, { w: 1 }, function (err) {
           test.equal(null, err);
 
           db.collection('domainSocketCollection0')
             .find({ a: 1 })
-            .toArray(function(err, items) {
+            .toArray(function (err, items) {
               test.equal(null, err);
               test.equal(1, items.length);
 
@@ -63,11 +63,11 @@ describe('Connection', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: true });
 
-      client.on('open', function() {
+      client.on('open', function () {
         client.close(done);
       });
 
@@ -81,10 +81,10 @@ describe('Connection', function() {
       ignore: { travis: true }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 1 }, { poolSize: 2000, auto_reconnect: true });
-      client.on('open', function() {
+      client.on('open', function () {
         client.close(done);
       });
 
@@ -95,23 +95,23 @@ describe('Connection', function() {
   it('should connect to server using domain socket with undefined port', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(
         { w: 1 },
         { poolSize: 1, host: '/tmp/mongodb-27017.sock', port: undefined }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
-        db.collection('domainSocketCollection1').insert({ x: 1 }, { w: 1 }, function(err) {
+        db.collection('domainSocketCollection1').insert({ x: 1 }, { w: 1 }, function (err) {
           test.equal(null, err);
 
           db.collection('domainSocketCollection1')
             .find({ x: 1 })
-            .toArray(function(err, items) {
+            .toArray(function (err, items) {
               test.equal(null, err);
               test.equal(1, items.length);
 
@@ -128,17 +128,17 @@ describe('Connection', function() {
    * @param {any} callback
    */
   function connectionTester(configuration, testName, callback) {
-    return function(err, client) {
+    return function (err, client) {
       var db = client.db(configuration.db);
       test.equal(err, null);
 
-      db.collection(testName, function(err, collection) {
+      db.collection(testName, function (err, collection) {
         test.equal(err, null);
 
-        collection.insert({ foo: 123 }, { w: 1 }, function(err) {
+        collection.insert({ foo: 123 }, { w: 1 }, function (err) {
           test.equal(err, null);
 
-          db.dropDatabase(function(err, dropped) {
+          db.dropDatabase(function (err, dropped) {
             test.equal(err, null);
             test.ok(dropped);
             if (callback) return callback(client);
@@ -151,12 +151,12 @@ describe('Connection', function() {
   it('test connect no options', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
       client.connect(
-        connectionTester(configuration, 'testConnectNoOptions', function(client) {
+        connectionTester(configuration, 'testConnectNoOptions', function (client) {
           client.close(done);
         })
       );
@@ -166,7 +166,7 @@ describe('Connection', function() {
   it('test connect good auth', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var user = 'testConnectGoodAuth',
         password = 'password';
@@ -174,11 +174,11 @@ describe('Connection', function() {
       const setupClient = configuration.newClient();
 
       // First add a user.
-      setupClient.connect(function(err, client) {
+      setupClient.connect(function (err, client) {
         test.equal(err, null);
         var db = client.db(configuration.db);
 
-        db.addUser(user, password, function(err) {
+        db.addUser(user, password, function (err) {
           test.equal(err, null);
           client.close(restOfTest);
         });
@@ -187,7 +187,7 @@ describe('Connection', function() {
       function restOfTest() {
         const testClient = configuration.newClient(configuration.url(user, password));
         testClient.connect(
-          connectionTester(configuration, 'testConnectGoodAuth', function(client) {
+          connectionTester(configuration, 'testConnectGoodAuth', function (client) {
             client.close(done);
           })
         );
@@ -198,18 +198,18 @@ describe('Connection', function() {
   it('test connect good auth as option', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var user = 'testConnectGoodAuthAsOption',
         password = 'password';
 
       // First add a user.
       const setupClient = configuration.newClient();
-      setupClient.connect(function(err, client) {
+      setupClient.connect(function (err, client) {
         test.equal(err, null);
         var db = client.db(configuration.db);
 
-        db.addUser(user, password, function(err) {
+        db.addUser(user, password, function (err) {
           test.equal(err, null);
           client.close(restOfTest);
         });
@@ -224,7 +224,7 @@ describe('Connection', function() {
         );
 
         testClient.connect(
-          connectionTester(configuration, 'testConnectGoodAuthAsOption', function(client) {
+          connectionTester(configuration, 'testConnectGoodAuthAsOption', function (client) {
             client.close(done);
           })
         );
@@ -235,10 +235,10 @@ describe('Connection', function() {
   it('test connect bad auth', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient(configuration.url('slithy', 'toves'));
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.exist;
         expect(client).to.not.exist;
         done();
@@ -249,12 +249,12 @@ describe('Connection', function() {
   it('test connect bad url', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient('mangodb://localhost:27017/test?safe=false');
 
-      test.throws(function() {
-        client.connect(function() {
+      test.throws(function () {
+        client.connect(function () {
           test.ok(false, 'Bad URL!');
         });
       });
@@ -266,7 +266,7 @@ describe('Connection', function() {
   it('should correctly return false on `isConnected` before connection happened', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
       test.equal(false, client.isConnected());

--- a/test/functional/connections_stepdown.test.js
+++ b/test/functional/connections_stepdown.test.js
@@ -25,13 +25,13 @@ function expectPoolWasNotCleared(initialCount) {
   return count => expect(count).to.equal(initialCount);
 }
 
-describe('Connections survive primary step down', function() {
+describe('Connections survive primary step down', function () {
   let client;
   let checkClient;
   let db;
   let collection;
 
-  beforeEach(function() {
+  beforeEach(function () {
     const clientOptions = {
       poolSize: 1,
       retryWrites: false,
@@ -62,7 +62,7 @@ describe('Connections survive primary step down', function() {
   });
 
   let deferred = [];
-  afterEach(function() {
+  afterEach(function () {
     return Promise.all(deferred.map(d => d())).then(() => {
       deferred = [];
       return Promise.all([client.close(), checkClient.close()]);
@@ -72,7 +72,7 @@ describe('Connections survive primary step down', function() {
   it('getMore iteration', {
     metadata: { requires: { mongodb: '>=4.2.0', topology: 'replicaset' } },
 
-    test: function() {
+    test: function () {
       return collection
         .insertMany([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 }], {
           w: 'majority'
@@ -132,28 +132,28 @@ describe('Connections survive primary step down', function() {
 
   it('Not Master - Keep Connection Pool', {
     metadata: { requires: { mongodb: '>=4.2.0', topology: 'replicaset' } },
-    test: function() {
+    test: function () {
       return runStepownScenario(10107, expectPoolWasNotCleared);
     }
   });
 
   it('Not Master - Reset Connection Pool', {
     metadata: { requires: { mongodb: '4.0.x', topology: 'replicaset' } },
-    test: function() {
+    test: function () {
       return runStepownScenario(10107, expectPoolWasCleared);
     }
   });
 
   it('Shutdown in progress - Reset Connection Pool', {
     metadata: { requires: { mongodb: '>=4.0.0', topology: 'replicaset' } },
-    test: function() {
+    test: function () {
       return runStepownScenario(91, expectPoolWasCleared);
     }
   });
 
   it('Interrupted at shutdown - Reset Connection Pool', {
     metadata: { requires: { mongodb: '>=4.0.0', topology: 'replicaset' } },
-    test: function() {
+    test: function () {
       return runStepownScenario(11600, expectPoolWasCleared);
     }
   });

--- a/test/functional/core/cursor.test.js
+++ b/test/functional/core/cursor.test.js
@@ -4,8 +4,8 @@ const expect = require('chai').expect;
 const f = require('util').format;
 const setupDatabase = require('./shared').setupDatabase;
 
-describe('Cursor tests', function() {
-  before(function() {
+describe('Cursor tests', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -14,9 +14,9 @@ describe('Cursor tests', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       const server = this.configuration.newTopology();
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         var ns = f('integration_tests.cursor1');
         // Execute the write
         _server.insert(
@@ -26,7 +26,7 @@ describe('Cursor tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(3);
 
@@ -38,13 +38,13 @@ describe('Cursor tests', function() {
             });
 
             // Execute next
-            cursor._next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function (nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
               expect(cursor.bufferedCount()).to.equal(1);
 
               // Kill the cursor
-              cursor._next(function(killCursorErr, killCursorD) {
+              cursor._next(function (killCursorErr, killCursorD) {
                 expect(killCursorErr).to.be.null;
                 expect(killCursorD.a).to.equal(2);
                 expect(cursor.bufferedCount()).to.equal(0);
@@ -66,11 +66,11 @@ describe('Cursor tests', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       const server = this.configuration.newTopology();
       var ns = f('%s.cursor2', this.configuration.db);
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           ns,
@@ -79,7 +79,7 @@ describe('Cursor tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(5);
 
@@ -91,7 +91,7 @@ describe('Cursor tests', function() {
             });
 
             // Execute next
-            cursor._next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function (nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
               expect(cursor.bufferedCount()).to.equal(4);
@@ -100,7 +100,7 @@ describe('Cursor tests', function() {
               cursor.readBufferedDocuments(cursor.bufferedCount());
 
               // Get the next item
-              cursor._next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function (secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD).to.be.null;
 
@@ -122,11 +122,11 @@ describe('Cursor tests', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       const server = this.configuration.newTopology();
       var ns = f('%s.cursor3', this.configuration.db);
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           ns,
@@ -135,7 +135,7 @@ describe('Cursor tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -143,16 +143,16 @@ describe('Cursor tests', function() {
             var cursor = _server.cursor(ns, { find: ns, query: {}, batchSize: 5 });
 
             // Execute next
-            cursor._next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function (nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
 
               // Get the next item
-              cursor._next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function (secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD).to.be.null;
 
-                cursor._next(function(thirdCursorErr, thirdCursorD) {
+                cursor._next(function (thirdCursorErr, thirdCursorD) {
                   expect(thirdCursorErr).to.be.ok;
                   expect(thirdCursorD).to.be.undefined;
                   // Destroy the server connection
@@ -174,11 +174,11 @@ describe('Cursor tests', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       const server = this.configuration.newTopology();
       var ns = f('%s.cursor4', this.configuration.db);
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           ns,
@@ -187,7 +187,7 @@ describe('Cursor tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(3);
 
@@ -195,16 +195,16 @@ describe('Cursor tests', function() {
             var cursor = _server.cursor(ns, { find: ns, query: {}, batchSize: 2 });
 
             // Execute next
-            cursor._next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function (nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
 
               // Get the next item
-              cursor._next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function (secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD.a).to.equal(2);
 
-                cursor._next(function(thirdCursorErr, thirdCursorD) {
+                cursor._next(function (thirdCursorErr, thirdCursorD) {
                   expect(thirdCursorErr).to.be.null;
                   expect(thirdCursorD.a).to.equal(3);
                   // Destroy the server connection
@@ -226,11 +226,11 @@ describe('Cursor tests', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       const server = this.configuration.newTopology();
       var ns = f('%s.cursor4', this.configuration.db);
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           ns,
@@ -239,7 +239,7 @@ describe('Cursor tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(3);
 
@@ -247,19 +247,19 @@ describe('Cursor tests', function() {
             var cursor = _server.cursor(ns, { find: ns, query: {}, batchSize: 2 });
 
             // Execute next
-            cursor._next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function (nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
 
               // Get the next item
-              cursor._next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function (secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD.a).to.equal(2);
 
                 // Kill cursor
-                cursor.kill(function() {
+                cursor.kill(function () {
                   // Should error out
-                  cursor._next(function(thirdCursorErr, thirdCursorD) {
+                  cursor._next(function (thirdCursorErr, thirdCursorD) {
                     expect(thirdCursorErr).to.not.exist;
                     expect(thirdCursorD).to.not.exist;
 
@@ -284,12 +284,12 @@ describe('Cursor tests', function() {
       requires: { topology: ['single'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const server = this.configuration.newTopology();
       var ns = f('%s.cursor5', this.configuration.db);
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           ns,
@@ -298,7 +298,7 @@ describe('Cursor tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(3);
 
@@ -306,18 +306,18 @@ describe('Cursor tests', function() {
             var cursor = _server.cursor(ns, { find: ns, query: {}, batchSize: 2 });
 
             // Execute next
-            cursor._next(function(nextCursorErr, nextCursorD) {
+            cursor._next(function (nextCursorErr, nextCursorD) {
               expect(nextCursorErr).to.be.null;
               expect(nextCursorD.a).to.equal(1);
 
               // Get the next item
-              cursor._next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function (secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
                 expect(secondCursorD.a).to.equal(2);
 
-                self.configuration.manager.restart(false).then(function() {
+                self.configuration.manager.restart(false).then(function () {
                   // Should error out
-                  cursor._next(function(thirdCursorErr, thirdCursorD) {
+                  cursor._next(function (thirdCursorErr, thirdCursorD) {
                     expect(thirdCursorErr).to.be.ok;
                     expect(thirdCursorD).to.be.undefined;
 

--- a/test/functional/core/error.test.js
+++ b/test/functional/core/error.test.js
@@ -3,13 +3,13 @@
 const { expect } = require('chai');
 const { MongoError, MongoNetworkError } = require('../../../src/error');
 
-describe('Error tests', function() {
+describe('Error tests', function () {
   it('should create a MongoError from string', {
     metadata: {
       requires: { topology: ['single'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var errorMessage = 'A test error';
       var err = new MongoError(errorMessage);
       expect(err).to.be.an.instanceof(Error);
@@ -25,7 +25,7 @@ describe('Error tests', function() {
       requires: { topology: ['single'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var errorMessage = 'A test error';
       var err = new MongoError(new Error(errorMessage));
       expect(err).to.be.an.instanceof(Error);
@@ -41,7 +41,7 @@ describe('Error tests', function() {
       requires: { topology: ['single'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var errorMessage = 'A test error';
       var err = new MongoError({ message: errorMessage, someData: 12345 });
       expect(err).to.be.an.instanceof(Error);
@@ -58,7 +58,7 @@ describe('Error tests', function() {
       requires: { topology: ['single'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var errorMessage = 'A test error';
       var err = new MongoNetworkError(errorMessage);
       expect(err).to.be.an.instanceof(Error);

--- a/test/functional/core/extend_cursor.test.js
+++ b/test/functional/core/extend_cursor.test.js
@@ -4,13 +4,13 @@ const { expect } = require('chai');
 const { format: f } = require('util');
 const { CoreCursor } = require('../../../src/cursor');
 
-describe('Extend cursor tests', function() {
+describe('Extend cursor tests', function () {
   it('should correctly extend the cursor with custom implementation', {
     metadata: {
       requires: { topology: ['single'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
 
@@ -21,8 +21,8 @@ describe('Extend cursor tests', function() {
           var extendedCursorSelf = this;
 
           // Resolve all the next
-          var getAllNexts = function(items, callback) {
-            extendedCursorSelf._next(function(err, item) {
+          var getAllNexts = function (items, callback) {
+            extendedCursorSelf._next(function (err, item) {
               if (err) return callback(err);
               if (item === null) return callback(null, null);
               items.push(item);
@@ -31,10 +31,10 @@ describe('Extend cursor tests', function() {
           };
 
           // Adding a toArray function to the cursor
-          this.toArray = function(callback) {
+          this.toArray = function (callback) {
             var items = [];
 
-            getAllNexts(items, function(err) {
+            getAllNexts(items, function (err) {
               if (err) return callback(err, null);
               callback(null, items);
             });
@@ -48,7 +48,7 @@ describe('Extend cursor tests', function() {
       });
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           f('%s.inserts_extend_cursors', self.configuration.db),
@@ -57,7 +57,7 @@ describe('Extend cursor tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(3);
 
@@ -72,7 +72,7 @@ describe('Extend cursor tests', function() {
             // Set the batch size
             cursor.batchSize = 2;
             // Execute next
-            cursor.toArray(function(cursorErr, cursorItems) {
+            cursor.toArray(function (cursorErr, cursorItems) {
               expect(cursorErr).to.be.null;
               expect(cursorItems.length).to.equal(3);
               // Destroy the connection

--- a/test/functional/core/operation_example.test.js
+++ b/test/functional/core/operation_example.test.js
@@ -8,7 +8,7 @@ const { Topology } = require('../../../src/sdam/topology');
  * SERVER TESTS
  *
  *************************************************************************/
-describe('Server operation example tests', function() {
+describe('Server operation example tests', function () {
   /**
    * Correctly insert a document using the Server insert method
    *
@@ -22,7 +22,7 @@ describe('Server operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
 
       // Attempt to connect
@@ -37,7 +37,7 @@ describe('Server operation example tests', function() {
       // REMOVE-LINE done();
       // BEGIN
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example1',
@@ -46,7 +46,7 @@ describe('Server operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -75,7 +75,7 @@ describe('Server operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
 
       // Attempt to connect
@@ -90,7 +90,7 @@ describe('Server operation example tests', function() {
       // REMOVE-LINE done();
       // BEGIN
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example2',
@@ -99,7 +99,7 @@ describe('Server operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -116,7 +116,7 @@ describe('Server operation example tests', function() {
                 writeConcern: { w: 1 },
                 ordered: true
               },
-              function(updateErr, updateResults) {
+              function (updateErr, updateResults) {
                 expect(updateErr).to.be.null;
                 expect(updateResults.result.n).to.equal(1);
 
@@ -147,7 +147,7 @@ describe('Server operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
 
       // Attempt to connect
@@ -162,7 +162,7 @@ describe('Server operation example tests', function() {
       // REMOVE-LINE done();
       // BEGIN
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example3',
@@ -171,7 +171,7 @@ describe('Server operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -188,7 +188,7 @@ describe('Server operation example tests', function() {
                 writeConcern: { w: 1 },
                 ordered: true
               },
-              function(removeErr, removeResults) {
+              function (removeErr, removeResults) {
                 expect(removeErr).to.be.null;
                 expect(removeResults.result.n).to.equal(1);
 
@@ -219,7 +219,7 @@ describe('Server operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
 
       // Attempt to connect
@@ -234,7 +234,7 @@ describe('Server operation example tests', function() {
       // REMOVE-LINE done();
       // BEGIN
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example4',
@@ -243,7 +243,7 @@ describe('Server operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -254,7 +254,7 @@ describe('Server operation example tests', function() {
             });
 
             // Get the first document
-            cursor._next(function(cursorErr, doc) {
+            cursor._next(function (cursorErr, doc) {
               expect(cursorErr).to.be.null;
               expect(doc.a).to.equal(1);
 
@@ -284,7 +284,7 @@ describe('Server operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
 
       // Attempt to connect
@@ -299,9 +299,9 @@ describe('Server operation example tests', function() {
       // REMOVE-LINE done();
       // BEGIN
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the command
-        _server.command('system.$cmd', { ismaster: true }, function(err, result) {
+        _server.command('system.$cmd', { ismaster: true }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
           _server.destroy();
@@ -322,7 +322,7 @@ describe('Server operation example tests', function() {
  *
  *************************************************************************/
 
-describe('Topology operation example tests', function() {
+describe('Topology operation example tests', function () {
   /**
    * Correctly insert a document using the Topology insert method
    *
@@ -336,7 +336,7 @@ describe('Topology operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var config = [
         {
           host: this.configuration.host,
@@ -357,7 +357,7 @@ describe('Topology operation example tests', function() {
       // REMOVE-LINE done();
       // BEGIN
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example_replset_1',
@@ -366,7 +366,7 @@ describe('Topology operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -395,7 +395,7 @@ describe('Topology operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var config = [
         {
           host: this.configuration.host,
@@ -416,7 +416,7 @@ describe('Topology operation example tests', function() {
       // REMOVE-LINE done();
       // BEGIN
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example_replset_2',
@@ -425,7 +425,7 @@ describe('Topology operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -442,7 +442,7 @@ describe('Topology operation example tests', function() {
                 writeConcern: { w: 1 },
                 ordered: true
               },
-              function(updateErr, updateResults) {
+              function (updateErr, updateResults) {
                 expect(updateErr).to.be.null;
                 expect(updateResults.result.n).to.equal(1);
 
@@ -473,7 +473,7 @@ describe('Topology operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var config = [
         {
           host: this.configuration.host,
@@ -494,7 +494,7 @@ describe('Topology operation example tests', function() {
       // REMOVE-LINE done();
       // BEGIN
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example_replset_3',
@@ -503,7 +503,7 @@ describe('Topology operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -520,7 +520,7 @@ describe('Topology operation example tests', function() {
                 writeConcern: { w: 1 },
                 ordered: true
               },
-              function(removeErr, removeResults) {
+              function (removeErr, removeResults) {
                 expect(removeErr).to.be.null;
                 expect(removeResults.result.n).to.equal(1);
 
@@ -551,7 +551,7 @@ describe('Topology operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var config = [
         {
           host: this.configuration.host,
@@ -572,7 +572,7 @@ describe('Topology operation example tests', function() {
       // REMOVE-LINE done();
       // BEGIN
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example_replset_4',
@@ -581,7 +581,7 @@ describe('Topology operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -592,7 +592,7 @@ describe('Topology operation example tests', function() {
             });
 
             // Get the first document
-            cursor._next(function(cursorErr, doc) {
+            cursor._next(function (cursorErr, doc) {
               expect(cursorErr).to.be.null;
               expect(doc.a).to.equal(1);
 
@@ -622,7 +622,7 @@ describe('Topology operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var config = [
         {
           host: this.configuration.host,
@@ -643,9 +643,9 @@ describe('Topology operation example tests', function() {
       // REMOVE-LINE done();
       // BEGIN
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the command
-        _server.command('system.$cmd', { ismaster: true }, function(err, result) {
+        _server.command('system.$cmd', { ismaster: true }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
           server.destroy();
@@ -666,7 +666,7 @@ describe('Topology operation example tests', function() {
  *
  *************************************************************************/
 
-describe.skip('Mongos operation example tests', function() {
+describe.skip('Mongos operation example tests', function () {
   /**
    * Correctly insert a document using the Mongos insert method
    *
@@ -676,7 +676,7 @@ describe.skip('Mongos operation example tests', function() {
   it('simple insert into db using Mongos', {
     metadata: { requires: { topology: 'sharded' } },
 
-    test: function(done) {
+    test: function (done) {
       // Attempt to connect
       var server = new Topology([
         {
@@ -686,7 +686,7 @@ describe.skip('Mongos operation example tests', function() {
       ]);
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example_mongos_1',
@@ -695,7 +695,7 @@ describe.skip('Mongos operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(insertErr, insertResults) {
+          function (insertErr, insertResults) {
             expect(insertErr).to.be.null;
             expect(insertResults.result.n).to.equal(1);
 
@@ -723,7 +723,7 @@ describe.skip('Mongos operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Attempt to connect
       var server = new Topology([
         {
@@ -733,7 +733,7 @@ describe.skip('Mongos operation example tests', function() {
       ]);
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example_mongos_2',
@@ -742,7 +742,7 @@ describe.skip('Mongos operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -759,7 +759,7 @@ describe.skip('Mongos operation example tests', function() {
                 writeConcern: { w: 1 },
                 ordered: true
               },
-              function(updateErr, updateResults) {
+              function (updateErr, updateResults) {
                 expect(updateErr).to.be.null;
                 expect(updateResults.result.n).to.equal(1);
 
@@ -789,7 +789,7 @@ describe.skip('Mongos operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Attempt to connect
       var server = new Topology([
         {
@@ -799,7 +799,7 @@ describe.skip('Mongos operation example tests', function() {
       ]);
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example_mongos_3',
@@ -808,7 +808,7 @@ describe.skip('Mongos operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -825,7 +825,7 @@ describe.skip('Mongos operation example tests', function() {
                 writeConcern: { w: 1 },
                 ordered: true
               },
-              function(removeErr, removeResults) {
+              function (removeErr, removeResults) {
                 expect(removeErr).to.be.null;
                 expect(removeResults.result.n).to.equal(1);
 
@@ -855,7 +855,7 @@ describe.skip('Mongos operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Attempt to connect
       var server = new Topology([
         {
@@ -865,7 +865,7 @@ describe.skip('Mongos operation example tests', function() {
       ]);
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the insert
         _server.insert(
           'integration_tests.inserts_example_mongos_4',
@@ -874,7 +874,7 @@ describe.skip('Mongos operation example tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(err, results) {
+          function (err, results) {
             expect(err).to.be.null;
             expect(results.result.n).to.equal(1);
 
@@ -885,7 +885,7 @@ describe.skip('Mongos operation example tests', function() {
             });
 
             // Get the first document
-            cursor._next(function(cursorErr, doc) {
+            cursor._next(function (cursorErr, doc) {
               expect(cursorErr).to.be.null;
               expect(doc.a).to.equal(1);
 
@@ -914,7 +914,7 @@ describe.skip('Mongos operation example tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Attempt to connect
       var server = new Topology([
         {
@@ -924,9 +924,9 @@ describe.skip('Mongos operation example tests', function() {
       ]);
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the command
-        _server.command('system.$cmd', { ismaster: true }, function(err, result) {
+        _server.command('system.$cmd', { ismaster: true }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.be.null;
           _server.destroy();

--- a/test/functional/core/operations.test.js
+++ b/test/functional/core/operations.test.js
@@ -6,8 +6,8 @@ const mock = require('mongodb-mock-server');
 const { setupDatabase } = require('./shared');
 const ReadPreference = require('../../../src/read_preference');
 
-describe('Operation tests', function() {
-  beforeEach(function() {
+describe('Operation tests', function () {
+  beforeEach(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -20,10 +20,10 @@ describe('Operation tests', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       const server = config.newTopology();
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         _server.destroy(done);
       });
 
@@ -37,18 +37,18 @@ describe('Operation tests', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the command
         _server.command(
           'system.$cmd',
           { ismaster: true },
           { readPreference: new ReadPreference('primary') },
-          function(cmdErr, cmdRes) {
+          function (cmdErr, cmdRes) {
             expect(cmdErr).to.be.null;
             expect(cmdRes.result.ismaster).to.be.true;
             // Destroy the connection
@@ -67,11 +67,11 @@ describe('Operation tests', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           f('%s.inserts', self.configuration.db),
@@ -80,7 +80,7 @@ describe('Operation tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(insertErr, insertResults) {
+          function (insertErr, insertResults) {
             expect(insertErr).to.be.null;
             expect(insertResults.result.n).to.equal(1);
             // Destroy the connection
@@ -99,13 +99,13 @@ describe('Operation tests', function() {
       requires: { topology: ['single', 'replicaset'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           f('%s.inserts1', self.configuration.db),
@@ -114,13 +114,13 @@ describe('Operation tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(insertErr, insertResults) {
+          function (insertErr, insertResults) {
             expect(insertResults).to.exist;
             expect(insertErr).to.be.null;
 
             // Work around 2.4.x issue with mongos reporting write done but it has
             // not actually been written to the primary in the shard yet
-            setTimeout(function() {
+            setTimeout(function () {
               // Execute find
               var cursor = _server.cursor(
                 f('%s.inserts1', self.configuration.db),
@@ -132,12 +132,12 @@ describe('Operation tests', function() {
               );
 
               // Execute next
-              cursor._next(function(cursorErr, cursorD) {
+              cursor._next(function (cursorErr, cursorD) {
                 expect(cursorErr).to.be.null;
                 expect(cursorD.a).to.equal(1);
 
                 // Execute next
-                cursor._next(function(secondCursorErr, secondCursorD) {
+                cursor._next(function (secondCursorErr, secondCursorD) {
                   expect(secondCursorErr).to.be.null;
                   expect(secondCursorD).to.be.null;
                   // Destroy the server connection
@@ -159,13 +159,13 @@ describe('Operation tests', function() {
       requires: { topology: ['single', 'replicaset'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       const self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           f('%s.inserts12', self.configuration.db),
@@ -174,13 +174,13 @@ describe('Operation tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(insertErr, insertResults) {
+          function (insertErr, insertResults) {
             expect(insertResults).to.exist;
             expect(insertErr).to.be.null;
 
             // Work around 2.4.x issue with mongos reporting write done but it has
             // not actually been written to the primary in the shard yet
-            setTimeout(function() {
+            setTimeout(function () {
               // Execute find
               var cursor = _server.cursor(
                 f('%s.inserts12', self.configuration.db),
@@ -194,12 +194,12 @@ describe('Operation tests', function() {
               );
 
               // Execute next
-              cursor._next(function(cursorErr, cursorD) {
+              cursor._next(function (cursorErr, cursorD) {
                 expect(cursorErr).to.be.null;
                 expect(cursorD.a).to.equal(2);
 
                 // Execute next
-                cursor._next(function(secondCursorErr, secondCursorD) {
+                cursor._next(function (secondCursorErr, secondCursorD) {
                   expect(secondCursorErr).to.be.null;
                   expect(secondCursorD).to.be.null;
                   // Destroy the server connection
@@ -221,13 +221,13 @@ describe('Operation tests', function() {
       requires: { topology: ['single', 'replicaset'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           f('%s.inserts_result_1', self.configuration.db),
@@ -236,13 +236,13 @@ describe('Operation tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(insertErr, insertResults) {
+          function (insertErr, insertResults) {
             expect(insertResults).to.exist;
             expect(insertErr).to.be.null;
 
             // Work around 2.4.x issue with mongos reporting write done but it has
             // not actually been written to the primary in the shard yet
-            setTimeout(function() {
+            setTimeout(function () {
               // Execute find
               var cursor = _server.cursor(
                 f('%s.inserts_result_1', self.configuration.db),
@@ -254,17 +254,11 @@ describe('Operation tests', function() {
               );
 
               // Execute next
-              cursor._next(function(cursorErr, cursorD) {
+              cursor._next(function (cursorErr, cursorD) {
                 expect(cursorErr).to.not.exist;
-                expect(cursorD)
-                  .property('a')
-                  .to.equal(1);
-                expect(cursorD)
-                  .nested.property('result[0].c')
-                  .to.equal(1);
-                expect(cursorD)
-                  .nested.property('result[1].c')
-                  .to.equal(2);
+                expect(cursorD).property('a').to.equal(1);
+                expect(cursorD).nested.property('result[0].c').to.equal(1);
+                expect(cursorD).nested.property('result[1].c').to.equal(2);
 
                 // Destroy the server connection
                 _server.destroy(done);
@@ -287,13 +281,13 @@ describe('Operation tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           f('%s.inserts10', self.configuration.db),
@@ -302,11 +296,9 @@ describe('Operation tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(insertErr, insertResults) {
+          function (insertErr, insertResults) {
             expect(insertErr).to.not.exist;
-            expect(insertResults)
-              .nested.property('result.n')
-              .to.equal(3);
+            expect(insertResults).nested.property('result.n').to.equal(3);
 
             // Execute find
             var cursor = _server.cursor(f('%s.inserts10', self.configuration.db), {
@@ -316,24 +308,18 @@ describe('Operation tests', function() {
             });
 
             // Execute next
-            cursor._next(function(cursorErr, cursorD) {
+            cursor._next(function (cursorErr, cursorD) {
               expect(cursorErr).to.be.null;
-              expect(cursorD)
-                .property('a')
-                .to.equal(1);
+              expect(cursorD).property('a').to.equal(1);
 
               // Execute next
-              cursor._next(function(secondCursorErr, secondCursorD) {
+              cursor._next(function (secondCursorErr, secondCursorD) {
                 expect(secondCursorErr).to.be.null;
-                expect(secondCursorD)
-                  .property('a')
-                  .to.equal(2);
+                expect(secondCursorD).property('a').to.equal(2);
 
-                cursor._next(function(thirdCursorErr, thirdCursorD) {
+                cursor._next(function (thirdCursorErr, thirdCursorD) {
                   expect(thirdCursorErr).to.be.null;
-                  expect(thirdCursorD)
-                    .property('a')
-                    .to.equal(3);
+                  expect(thirdCursorD).property('a').to.equal(3);
 
                   // Destroy the server connection
                   _server.destroy(done);
@@ -357,13 +343,13 @@ describe('Operation tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           f('%s.inserts20', self.configuration.db),
@@ -372,7 +358,7 @@ describe('Operation tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(insertErr, insertResults) {
+          function (insertErr, insertResults) {
             expect(insertErr).to.be.null;
             expect(insertResults.result.n).to.equal(3);
 
@@ -384,16 +370,14 @@ describe('Operation tests', function() {
             });
 
             // Execute next
-            cursor._next(function(cursorErr, cursorD) {
+            cursor._next(function (cursorErr, cursorD) {
               expect(cursorErr).to.not.exist;
               expect(cursorD).to.exist;
-              expect(cursorD)
-                .property('a')
-                .to.equal(1);
+              expect(cursorD).property('a').to.equal(1);
 
               // Kill the cursor
-              cursor.kill(function() {
-                cursor._next(function(secondCursorErr, secondCursorD) {
+              cursor.kill(function () {
+                cursor._next(function (secondCursorErr, secondCursorD) {
                   expect(secondCursorErr).to.not.exist;
                   expect(secondCursorD).to.not.exist;
                   // Destroy the server connection
@@ -417,13 +401,13 @@ describe('Operation tests', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Execute the write
         _server.insert(
           f('%s.inserts21', self.configuration.db),
@@ -432,11 +416,9 @@ describe('Operation tests', function() {
             writeConcern: { w: 1 },
             ordered: true
           },
-          function(insertErr, insertResults) {
+          function (insertErr, insertResults) {
             expect(insertErr).to.be.null;
-            expect(insertResults)
-              .nested.property('result.n')
-              .to.equal(3);
+            expect(insertResults).nested.property('result.n').to.equal(3);
 
             // Execute find
             var cursor = _server.cursor(f('%s.inserts21', self.configuration.db), {
@@ -446,13 +428,13 @@ describe('Operation tests', function() {
             });
 
             // Execute next
-            cursor._next(function(cursorErr, cursorD) {
+            cursor._next(function (cursorErr, cursorD) {
               expect(cursorErr).to.be.null;
               expect(cursorD.a).to.equal(1);
 
               // Kill the cursor
-              cursor.kill(function() {
-                cursor._next(function(secondCursorErr, secondCursorD) {
+              cursor.kill(function () {
+                cursor._next(function (secondCursorErr, secondCursorD) {
                   expect(secondCursorErr).to.not.exist;
                   expect(secondCursorD).to.not.exist;
                   // Destroy the server connection
@@ -474,7 +456,7 @@ describe('Operation tests', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // NOTE: Skipped because the test is very flakey, sometimes the topology is
       // destroyed before the final insert is complete. This is an issue likely
       // introduced by logic to clear the pool when network errors occur.
@@ -484,10 +466,10 @@ describe('Operation tests', function() {
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         var left = 100;
 
-        var insertOps = function(insertErr, insertResults) {
+        var insertOps = function (insertErr, insertResults) {
           left = left - 1;
           expect(insertErr).to.be.null;
           expect(insertResults.result.n).to.equal(1);
@@ -495,11 +477,11 @@ describe('Operation tests', function() {
           // Number of operations left
           if (left === 0) {
             const innerServer = config.newTopology();
-            innerServer.on('connect', function(_innerServer) {
+            innerServer.on('connect', function (_innerServer) {
               _innerServer.command(
                 f('%s.$cmd', self.configuration.db),
                 { count: 'inserts_unref' },
-                function(e, result) {
+                function (e, result) {
                   expect(e).to.be.null;
                   expect(result.result.n).to.equal(100);
 

--- a/test/functional/core/shared.js
+++ b/test/functional/core/shared.js
@@ -22,7 +22,7 @@ function executeCommand(configuration, db, cmd, options, cb) {
   });
 
   // Add event listeners
-  pool.on('connect', function(_pool) {
+  pool.on('connect', function (_pool) {
     var query = new Query(f('%s.$cmd', db), cmd, {
       numberToSkip: 0,
       numberToReturn: 1
@@ -33,7 +33,7 @@ function executeCommand(configuration, db, cmd, options, cb) {
       {
         command: true
       },
-      function(err, result) {
+      function (err, result) {
         if (err) console.log(err.stack);
         // Close the pool
         _pool.destroy();
@@ -64,7 +64,7 @@ function locateAuthMethod(configuration, cb) {
   });
 
   // Add event listeners
-  pool.on('connect', function(_pool) {
+  pool.on('connect', function (_pool) {
     var query = new Query(f('%s.$cmd', db), cmd, {
       numberToSkip: 0,
       numberToReturn: 1
@@ -74,7 +74,7 @@ function locateAuthMethod(configuration, cb) {
       {
         command: true
       },
-      function(err, result) {
+      function (err, result) {
         if (err) console.log(err.stack);
         // Close the pool
         _pool.destroy();
@@ -94,9 +94,9 @@ function locateAuthMethod(configuration, cb) {
   pool.connect.apply(pool);
 }
 
-const delay = function(timeout) {
-  return new Promise(function(resolve) {
-    setTimeout(function() {
+const delay = function (timeout) {
+  return new Promise(function (resolve) {
+    setTimeout(function () {
       resolve();
     }, timeout);
   });
@@ -146,7 +146,7 @@ function setupDatabase(configuration, dbsToClean) {
 
     const topology = configuration.newTopology();
     dbsToClean.push(configDbName);
-    topology.on('connect', function() {
+    topology.on('connect', function () {
       let cleanedCount = 0;
       const dropHandler = err => {
         if (err) return reject(err);

--- a/test/functional/core/tailable_cursor.test.js
+++ b/test/functional/core/tailable_cursor.test.js
@@ -4,8 +4,8 @@ var expect = require('chai').expect,
   f = require('util').format;
 const setupDatabase = require('./shared').setupDatabase;
 
-describe('Tailable cursor tests', function() {
-  before(function() {
+describe('Tailable cursor tests', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -14,19 +14,19 @@ describe('Tailable cursor tests', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       var ns = f('%s.cursor_tailable', self.configuration.db);
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Create a capped collection
         _server.command(
           f('%s.$cmd', self.configuration.db),
           { create: 'cursor_tailable', capped: true, size: 10000 },
-          function(cmdErr, cmdRes) {
+          function (cmdErr, cmdRes) {
             expect(cmdErr).to.not.exist;
             expect(cmdRes).to.exist;
 
@@ -38,7 +38,7 @@ describe('Tailable cursor tests', function() {
                 writeConcern: { w: 1 },
                 ordered: true
               },
-              function(insertErr, results) {
+              function (insertErr, results) {
                 expect(insertErr).to.be.null;
                 expect(results.result.n).to.equal(1);
 
@@ -52,13 +52,13 @@ describe('Tailable cursor tests', function() {
                 });
 
                 // Execute next
-                cursor._next(function(cursorErr, cursorD) {
+                cursor._next(function (cursorErr, cursorD) {
                   expect(cursorErr).to.be.null;
                   expect(cursorD).to.exist;
 
                   var s = new Date();
 
-                  cursor._next(function() {
+                  cursor._next(function () {
                     var e = new Date();
                     expect(e.getTime() - s.getTime()).to.be.at.least(300);
 
@@ -66,7 +66,7 @@ describe('Tailable cursor tests', function() {
                     _server.destroy(done);
                   });
 
-                  setTimeout(function() {
+                  setTimeout(function () {
                     cursor.kill();
                   }, 300);
                 });

--- a/test/functional/core/topology.test.js
+++ b/test/functional/core/topology.test.js
@@ -1,8 +1,8 @@
 'use strict';
 const expect = require('chai').expect;
 
-describe('Topology', function() {
-  it('should correctly track states of a topology', function(done) {
+describe('Topology', function () {
+  it('should correctly track states of a topology', function (done) {
     const topology = this.configuration.newTopology();
 
     const states = [];

--- a/test/functional/core/undefined.test.js
+++ b/test/functional/core/undefined.test.js
@@ -4,21 +4,21 @@ const { expect } = require('chai');
 const { format: f } = require('util');
 const { ObjectId } = require('bson');
 
-describe('A server', function() {
+describe('A server', function () {
   it('should correctly execute insert culling undefined', {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Drop collection
-        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'insert1' }, function() {
+        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'insert1' }, function () {
           var ns = f('%s.insert1', self.configuration.db);
           var objectId = new ObjectId();
           // Execute the write
@@ -30,7 +30,7 @@ describe('A server', function() {
               ordered: true,
               ignoreUndefined: true
             },
-            function(insertErr, results) {
+            function (insertErr, results) {
               expect(insertErr).to.be.null;
               expect(results.result.n).to.eql(1);
 
@@ -42,7 +42,7 @@ describe('A server', function() {
               });
 
               // Execute next
-              cursor._next(function(nextErr, d) {
+              cursor._next(function (nextErr, d) {
                 expect(nextErr).to.be.null;
                 expect(d.b).to.be.undefined;
 
@@ -66,15 +66,15 @@ describe('A server', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         // Drop collection
-        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'update1' }, function() {
+        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'update1' }, function () {
           var ns = f('%s.update1', self.configuration.db);
           var objectId = new ObjectId();
           // Execute the write
@@ -90,7 +90,7 @@ describe('A server', function() {
               ordered: true,
               ignoreUndefined: true
             },
-            function(insertErr, results) {
+            function (insertErr, results) {
               expect(insertErr).to.be.null;
               expect(results.result.n).to.eql(1);
 
@@ -102,7 +102,7 @@ describe('A server', function() {
               });
 
               // Execute next
-              cursor._next(function(nextErr, d) {
+              cursor._next(function (nextErr, d) {
                 expect(nextErr).to.be.null;
                 expect(d.b).to.be.undefined;
 
@@ -126,17 +126,17 @@ describe('A server', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         var ns = f('%s.remove1', self.configuration.db);
         var objectId = new ObjectId();
 
-        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'remove1' }, function() {
+        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'remove1' }, function () {
           // Execute the write
           _server.insert(
             ns,
@@ -148,7 +148,7 @@ describe('A server', function() {
               writeConcern: { w: 1 },
               ordered: true
             },
-            function(insertErr, results) {
+            function (insertErr, results) {
               expect(insertErr).to.be.null;
               expect(results.result.n).to.eql(2);
 
@@ -166,7 +166,7 @@ describe('A server', function() {
                   ordered: true,
                   ignoreUndefined: true
                 },
-                function(removeErr, removeResults) {
+                function (removeErr, removeResults) {
                   expect(removeErr).to.be.null;
                   expect(removeResults.result.n).to.eql(2);
 
@@ -191,17 +191,17 @@ describe('A server', function() {
       requires: { topology: ['single', 'replicaset', 'sharded'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const config = this.configuration;
       const server = config.newTopology();
 
       // Add event listeners
-      server.on('connect', function(_server) {
+      server.on('connect', function (_server) {
         var ns = f('%s.remove2', self.configuration.db);
         var objectId = new ObjectId();
 
-        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'remove2' }, function() {
+        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'remove2' }, function () {
           // Execute the write
           _server.insert(
             ns,
@@ -213,7 +213,7 @@ describe('A server', function() {
               writeConcern: { w: 1 },
               ordered: true
             },
-            function(insertErr, results) {
+            function (insertErr, results) {
               expect(insertErr).to.be.null;
               expect(results.result.n).to.eql(2);
 
@@ -230,7 +230,7 @@ describe('A server', function() {
                   writeConcern: { w: 1 },
                   ordered: true
                 },
-                function(removeErr, removeResults) {
+                function (removeErr, removeResults) {
                   expect(removeErr).to.be.null;
                   expect(removeResults.result.n).to.eql(1);
 

--- a/test/functional/crud_api.test.js
+++ b/test/functional/crud_api.test.js
@@ -8,8 +8,8 @@ var test = require('./shared').assert,
 // backwards compatibility in a fundamental way
 //
 
-describe('CRUD API', function() {
-  before(function() {
+describe('CRUD API', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -20,13 +20,13 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
-        db.collection('t').insert([{ a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }], function(err) {
+        db.collection('t').insert([{ a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }], function (err) {
           test.equal(null, err);
 
           //
@@ -49,9 +49,9 @@ describe('CRUD API', function() {
           //
           // Exercise count method
           // -------------------------------------------------
-          var countMethod = function() {
+          var countMethod = function () {
             // Execute the different methods supported by the cursor
-            cursor.count(function(err, count) {
+            cursor.count(function (err, count) {
               test.equal(null, err);
               test.equal(2, count);
               eachMethod();
@@ -61,10 +61,10 @@ describe('CRUD API', function() {
           //
           // Exercise legacy method each
           // -------------------------------------------------
-          var eachMethod = function() {
+          var eachMethod = function () {
             var count = 0;
 
-            cursor.each(function(err, doc) {
+            cursor.each(function (err, doc) {
               test.equal(null, err);
               if (doc) count = count + 1;
               if (doc == null) {
@@ -77,8 +77,8 @@ describe('CRUD API', function() {
           //
           // Exercise toArray
           // -------------------------------------------------
-          var toArrayMethod = function() {
-            cursor.toArray(function(err, docs) {
+          var toArrayMethod = function () {
+            cursor.toArray(function (err, docs) {
               test.equal(null, err);
               test.equal(2, docs.length);
               nextMethod();
@@ -88,17 +88,17 @@ describe('CRUD API', function() {
           //
           // Exercise next method
           // -------------------------------------------------
-          var nextMethod = function() {
+          var nextMethod = function () {
             var clonedCursor = cursor.clone();
-            clonedCursor.next(function(err, doc) {
+            clonedCursor.next(function (err, doc) {
               test.equal(null, err);
               test.ok(doc != null);
 
-              clonedCursor.next(function(err, doc) {
+              clonedCursor.next(function (err, doc) {
                 test.equal(null, err);
                 test.ok(doc != null);
 
-                clonedCursor.next(function(err, doc) {
+                clonedCursor.next(function (err, doc) {
                   test.equal(null, err);
                   test.equal(null, doc);
                   streamMethod();
@@ -110,14 +110,14 @@ describe('CRUD API', function() {
           //
           // Exercise stream
           // -------------------------------------------------
-          var streamMethod = function() {
+          var streamMethod = function () {
             var count = 0;
             var clonedCursor = cursor.clone();
-            clonedCursor.on('data', function() {
+            clonedCursor.on('data', function () {
               count = count + 1;
             });
 
-            clonedCursor.once('end', function() {
+            clonedCursor.once('end', function () {
               test.equal(2, count);
               explainMethod();
             });
@@ -126,9 +126,9 @@ describe('CRUD API', function() {
           //
           // Explain method
           // -------------------------------------------------
-          var explainMethod = function() {
+          var explainMethod = function () {
             var clonedCursor = cursor.clone();
-            clonedCursor.explain(function(err, result) {
+            clonedCursor.explain(function (err, result) {
               test.equal(null, err);
               test.ok(result != null);
 
@@ -150,16 +150,16 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
-        db.collection('t1').insert([{ a: 1 }, { a: 1 }, { a: 2 }, { a: 1 }], function(err) {
+        db.collection('t1').insert([{ a: 1 }, { a: 1 }, { a: 2 }, { a: 1 }], function (err) {
           test.equal(null, err);
 
-          var testAllMethods = function() {
+          var testAllMethods = function () {
             // Get the cursor
             var cursor = db.collection('t1').aggregate({
               pipeline: [{ $match: {} }],
@@ -185,7 +185,7 @@ describe('CRUD API', function() {
 
             // Execute the command with all steps defined
             // will fail
-            cursor.toArray(function(err) {
+            cursor.toArray(function (err) {
               test.ok(err != null);
               testToArray();
             });
@@ -194,10 +194,10 @@ describe('CRUD API', function() {
           //
           // Exercise toArray
           // -------------------------------------------------
-          var testToArray = function() {
+          var testToArray = function () {
             var cursor = db.collection('t1').aggregate();
             cursor.match({ a: 1 });
-            cursor.toArray(function(err, docs) {
+            cursor.toArray(function (err, docs) {
               test.equal(null, err);
               test.equal(3, docs.length);
               testNext();
@@ -207,10 +207,10 @@ describe('CRUD API', function() {
           //
           // Exercise next
           // -------------------------------------------------
-          var testNext = function() {
+          var testNext = function () {
             var cursor = db.collection('t1').aggregate();
             cursor.match({ a: 1 });
-            cursor.next(function(err) {
+            cursor.next(function (err) {
               test.equal(null, err);
               testEach();
             });
@@ -219,11 +219,11 @@ describe('CRUD API', function() {
           //
           // Exercise each
           // -------------------------------------------------
-          var testEach = function() {
+          var testEach = function () {
             var count = 0;
             var cursor = db.collection('t1').aggregate();
             cursor.match({ a: 1 });
-            cursor.each(function(err, doc) {
+            cursor.each(function (err, doc) {
               test.equal(null, err);
               if (doc) count = count + 1;
               if (doc == null) {
@@ -236,15 +236,15 @@ describe('CRUD API', function() {
           //
           // Exercise stream
           // -------------------------------------------------
-          var testStream = function() {
+          var testStream = function () {
             var cursor = db.collection('t1').aggregate();
             var count = 0;
             cursor.match({ a: 1 });
-            cursor.on('data', function() {
+            cursor.on('data', function () {
               count = count + 1;
             });
 
-            cursor.once('end', function() {
+            cursor.once('end', function () {
               test.equal(3, count);
               testExplain();
             });
@@ -253,9 +253,9 @@ describe('CRUD API', function() {
           //
           // Explain method
           // -------------------------------------------------
-          var testExplain = function() {
+          var testExplain = function () {
             var cursor = db.collection('t1').aggregate();
-            cursor.explain(function(err, result) {
+            cursor.explain(function (err, result) {
               test.equal(null, err);
               test.ok(result != null);
 
@@ -276,17 +276,17 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         //
         // Legacy insert method
         // -------------------------------------------------
-        var legacyInsert = function() {
-          db.collection('t2_1').insert([{ a: 1 }, { a: 2 }], function(err, r) {
+        var legacyInsert = function () {
+          db.collection('t2_1').insert([{ a: 1 }, { a: 2 }], function (err, r) {
             test.equal(null, err);
             test.equal(2, r.result.n);
 
@@ -297,11 +297,11 @@ describe('CRUD API', function() {
         //
         // Bulk api insert method
         // -------------------------------------------------
-        var bulkAPIInsert = function() {
+        var bulkAPIInsert = function () {
           var bulk = db.collection('t2_2').initializeOrderedBulkOp();
           bulk.insert({ a: 1 });
           bulk.insert({ a: 1 });
-          bulk.execute(function(err) {
+          bulk.execute(function (err) {
             test.equal(null, err);
 
             insertOne();
@@ -311,8 +311,8 @@ describe('CRUD API', function() {
         //
         // Insert one method
         // -------------------------------------------------
-        var insertOne = function() {
-          db.collection('t2_3').insertOne({ a: 1 }, { w: 1 }, function(err, r) {
+        var insertOne = function () {
+          db.collection('t2_3').insertOne({ a: 1 }, { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.result.n);
             test.equal(1, r.insertedCount);
@@ -325,9 +325,9 @@ describe('CRUD API', function() {
         //
         // Insert many method
         // -------------------------------------------------
-        var insertMany = function() {
+        var insertMany = function () {
           var docs = [{ a: 1 }, { a: 1 }];
-          db.collection('t2_4').insertMany(docs, { w: 1 }, function(err, r) {
+          db.collection('t2_4').insertMany(docs, { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(2, r.result.n);
             test.equal(2, r.insertedCount);
@@ -341,8 +341,8 @@ describe('CRUD API', function() {
         //
         // Bulk write method unordered
         // -------------------------------------------------
-        var bulkWriteUnOrdered = function() {
-          db.collection('t2_5').insertMany([{ c: 1 }], { w: 1 }, function(err, r) {
+        var bulkWriteUnOrdered = function () {
+          db.collection('t2_5').insertMany([{ c: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
@@ -356,7 +356,7 @@ describe('CRUD API', function() {
                 { deleteMany: { q: { c: 1 } } }
               ],
               { ordered: false, w: 1 },
-              function(err, r) {
+              function (err, r) {
                 test.equal(null, err);
                 test.equal(3, r.nInserted);
                 test.equal(1, r.nUpserted);
@@ -380,8 +380,8 @@ describe('CRUD API', function() {
         //
         // Bulk write method unordered
         // -------------------------------------------------
-        var bulkWriteUnOrderedSpec = function() {
-          db.collection('t2_6').insertMany([{ c: 1 }, { c: 2 }, { c: 3 }], { w: 1 }, function(
+        var bulkWriteUnOrderedSpec = function () {
+          db.collection('t2_6').insertMany([{ c: 1 }, { c: 2 }, { c: 3 }], { w: 1 }, function (
             err,
             r
           ) {
@@ -398,7 +398,7 @@ describe('CRUD API', function() {
                 { replaceOne: { filter: { c: 3 }, replacement: { c: 4 }, upsert: true } }
               ],
               { ordered: false, w: 1 },
-              function(err, r) {
+              function (err, r) {
                 test.equal(null, err);
                 test.equal(1, r.nInserted);
                 test.equal(2, r.nUpserted);
@@ -422,8 +422,8 @@ describe('CRUD API', function() {
         //
         // Bulk write method ordered
         // -------------------------------------------------
-        var bulkWriteOrdered = function() {
-          db.collection('t2_7').insertMany([{ c: 1 }], { w: 1 }, function(err, r) {
+        var bulkWriteOrdered = function () {
+          db.collection('t2_7').insertMany([{ c: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
@@ -437,7 +437,7 @@ describe('CRUD API', function() {
                 { deleteMany: { q: { c: 1 } } }
               ],
               { ordered: true, w: 1 },
-              function(err, r) {
+              function (err, r) {
                 test.equal(null, err);
                 test.equal(3, r.nInserted);
                 test.equal(1, r.nUpserted);
@@ -460,8 +460,8 @@ describe('CRUD API', function() {
         //
         // Bulk write method ordered
         // -------------------------------------------------
-        var bulkWriteOrderedCrudSpec = function() {
-          db.collection('t2_8').insertMany([{ c: 1 }], { w: 1 }, function(err, r) {
+        var bulkWriteOrderedCrudSpec = function () {
+          db.collection('t2_8').insertMany([{ c: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
@@ -475,7 +475,7 @@ describe('CRUD API', function() {
                 { replaceOne: { filter: { c: 3 }, replacement: { c: 4 }, upsert: true } }
               ],
               { ordered: true, w: 1 },
-              function(err, r) {
+              function (err, r) {
                 // test.equal(null, err);
                 test.equal(1, r.nInserted);
                 test.equal(2, r.nUpserted);
@@ -507,17 +507,17 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         //
         // Legacy update method
         // -------------------------------------------------
-        var legacyUpdate = function() {
-          db.collection('t3_1').update({ a: 1 }, { $set: { a: 2 } }, { upsert: true }, function(
+        var legacyUpdate = function () {
+          db.collection('t3_1').update({ a: 1 }, { $set: { a: 2 } }, { upsert: true }, function (
             err,
             r
           ) {
@@ -531,8 +531,8 @@ describe('CRUD API', function() {
         //
         // Update one method
         // -------------------------------------------------
-        var updateOne = function() {
-          db.collection('t3_2').insertMany([{ c: 1 }], { w: 1 }, function(err, r) {
+        var updateOne = function () {
+          db.collection('t3_2').insertMany([{ c: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
@@ -540,13 +540,13 @@ describe('CRUD API', function() {
               { a: 1 },
               { $set: { a: 1 } },
               { upsert: true },
-              function(err, r) {
+              function (err, r) {
                 test.equal(null, err);
                 test.equal(1, r.result.n);
                 test.equal(0, r.matchedCount);
                 test.ok(r.upsertedId != null);
 
-                db.collection('t3_2').updateOne({ c: 1 }, { $set: { a: 1 } }, function(err, r) {
+                db.collection('t3_2').updateOne({ c: 1 }, { $set: { a: 1 } }, function (err, r) {
                   test.equal(null, err);
                   test.equal(1, r.result.n);
                   test.equal(1, r.matchedCount);
@@ -562,15 +562,15 @@ describe('CRUD API', function() {
         //
         // Replace one method
         // -------------------------------------------------
-        var replaceOne = function() {
-          db.collection('t3_3').replaceOne({ a: 1 }, { a: 2 }, { upsert: true }, function(err, r) {
+        var replaceOne = function () {
+          db.collection('t3_3').replaceOne({ a: 1 }, { a: 2 }, { upsert: true }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.result.n);
             test.equal(0, r.matchedCount);
             test.equal(1, r.ops.length);
             test.ok(r.upsertedId != null);
 
-            db.collection('t3_3').replaceOne({ a: 2 }, { a: 3 }, { upsert: true }, function(
+            db.collection('t3_3').replaceOne({ a: 2 }, { a: 3 }, { upsert: true }, function (
               err,
               r
             ) {
@@ -590,8 +590,8 @@ describe('CRUD API', function() {
         //
         // Update many method
         // -------------------------------------------------
-        var updateMany = function() {
-          db.collection('t3_4').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function(err, r) {
+        var updateMany = function () {
+          db.collection('t3_4').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(2, r.result.n);
 
@@ -599,7 +599,7 @@ describe('CRUD API', function() {
               { a: 1 },
               { $set: { a: 2 } },
               { upsert: true, w: 1 },
-              function(err, r) {
+              function (err, r) {
                 test.equal(null, err);
                 test.equal(2, r.result.n);
                 test.equal(2, r.matchedCount);
@@ -609,7 +609,7 @@ describe('CRUD API', function() {
                   { c: 1 },
                   { $set: { d: 2 } },
                   { upsert: true, w: 1 },
-                  function(err, r) {
+                  function (err, r) {
                     test.equal(null, err);
                     test.equal(0, r.matchedCount);
                     test.ok(r.upsertedId != null);
@@ -634,21 +634,21 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         //
         // Legacy update method
         // -------------------------------------------------
-        var legacyRemove = function() {
-          db.collection('t4_1').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function(err, r) {
+        var legacyRemove = function () {
+          db.collection('t4_1').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(2, r.result.n);
 
-            db.collection('t4_1').remove({ a: 1 }, { single: true }, function(err, r) {
+            db.collection('t4_1').remove({ a: 1 }, { single: true }, function (err, r) {
               test.equal(null, err);
               test.equal(1, r.result.n);
 
@@ -660,12 +660,12 @@ describe('CRUD API', function() {
         //
         // Update one method
         // -------------------------------------------------
-        var deleteOne = function() {
-          db.collection('t4_2').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function(err, r) {
+        var deleteOne = function () {
+          db.collection('t4_2').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(2, r.result.n);
 
-            db.collection('t4_2').deleteOne({ a: 1 }, function(err, r) {
+            db.collection('t4_2').deleteOne({ a: 1 }, function (err, r) {
               test.equal(null, err);
               test.equal(1, r.result.n);
               test.equal(1, r.deletedCount);
@@ -678,12 +678,12 @@ describe('CRUD API', function() {
         //
         // Update many method
         // -------------------------------------------------
-        var deleteMany = function() {
-          db.collection('t4_3').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function(err, r) {
+        var deleteMany = function () {
+          db.collection('t4_3').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(2, r.result.n);
 
-            db.collection('t4_3').deleteMany({ a: 1 }, function(err, r) {
+            db.collection('t4_3').deleteMany({ a: 1 }, function (err, r) {
               test.equal(null, err);
               test.equal(2, r.result.n);
               test.equal(2, r.deletedCount);
@@ -705,24 +705,24 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         //
         // findOneAndRemove method
         // -------------------------------------------------
-        var findOneAndRemove = function() {
-          db.collection('t5_1').insertMany([{ a: 1, b: 1 }], { w: 1 }, function(err, r) {
+        var findOneAndRemove = function () {
+          db.collection('t5_1').insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
             db.collection('t5_1').findOneAndDelete(
               { a: 1 },
               { projection: { b: 1 }, sort: { a: 1 } },
-              function(err, r) {
+              function (err, r) {
                 test.equal(null, err);
                 test.equal(1, r.lastErrorObject.n);
                 test.equal(1, r.value.b);
@@ -736,8 +736,8 @@ describe('CRUD API', function() {
         //
         // findOneAndRemove method
         // -------------------------------------------------
-        var findOneAndReplace = function() {
-          db.collection('t5_2').insertMany([{ a: 1, b: 1 }], { w: 1 }, function(err, r) {
+        var findOneAndReplace = function () {
+          db.collection('t5_2').insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
@@ -750,7 +750,7 @@ describe('CRUD API', function() {
                 returnOriginal: false,
                 upsert: true
               },
-              function(err, r) {
+              function (err, r) {
                 test.equal(null, err);
                 test.equal(1, r.lastErrorObject.n);
                 test.equal(1, r.value.b);
@@ -765,8 +765,8 @@ describe('CRUD API', function() {
         //
         // findOneAndRemove method
         // -------------------------------------------------
-        var findOneAndUpdate = function() {
-          db.collection('t5_3').insertMany([{ a: 1, b: 1 }], { w: 1 }, function(err, r) {
+        var findOneAndUpdate = function () {
+          db.collection('t5_3').insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.result.n);
 
@@ -779,7 +779,7 @@ describe('CRUD API', function() {
                 returnOriginal: false,
                 upsert: true
               },
-              function(err, r) {
+              function (err, r) {
                 test.equal(null, err);
                 test.equal(1, r.lastErrorObject.n);
                 test.equal(1, r.value.b);
@@ -803,15 +803,15 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         // Delete all items with no selector
-        db.collection('t6_1').deleteMany({}, function(err) {
+        db.collection('t6_1').deleteMany({}, function (err) {
           test.equal(null, err);
 
           client.close(done);
@@ -827,35 +827,35 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var col = db.collection('shouldCorrectlyExecuteInsertOneWithW0');
-        col.insertOne({ a: 1 }, { w: 0 }, function(err, result) {
+        col.insertOne({ a: 1 }, { w: 0 }, function (err, result) {
           test.equal(null, err);
           test.equal(1, result.result.ok);
 
-          col.insertMany([{ a: 1 }], { w: 0 }, function(err, result) {
+          col.insertMany([{ a: 1 }], { w: 0 }, function (err, result) {
             test.equal(null, err);
             test.equal(1, result.result.ok);
 
-            col.updateOne({ a: 1 }, { $set: { b: 1 } }, { w: 0 }, function(err, result) {
+            col.updateOne({ a: 1 }, { $set: { b: 1 } }, { w: 0 }, function (err, result) {
               test.equal(null, err);
               test.equal(1, result.result.ok);
 
-              col.updateMany({ a: 1 }, { $set: { b: 1 } }, { w: 0 }, function(err, result) {
+              col.updateMany({ a: 1 }, { $set: { b: 1 } }, { w: 0 }, function (err, result) {
                 test.equal(null, err);
                 test.equal(1, result.result.ok);
 
-                col.deleteOne({ a: 1 }, { w: 0 }, function(err, result) {
+                col.deleteOne({ a: 1 }, { w: 0 }, function (err, result) {
                   test.equal(null, err);
                   test.equal(1, result.result.ok);
 
-                  col.deleteMany({ a: 1 }, { w: 0 }, function(err, result) {
+                  col.deleteMany({ a: 1 }, { w: 0 }, function (err, result) {
                     test.equal(null, err);
                     test.equal(1, result.result.ok);
 
@@ -877,10 +877,10 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -888,7 +888,7 @@ describe('CRUD API', function() {
           { _id: 1 },
           { $set: { x: 1 } },
           { upsert: true, w: 0 },
-          function(err, r) {
+          function (err, r) {
             test.equal(null, err);
             test.ok(r != null);
 
@@ -906,15 +906,15 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var collection = db.collection('w0crudoperations');
-        collection.insertOne({}, function(err) {
+        collection.insertOne({}, function (err) {
           test.equal(null, err);
           client.close(done);
         });
@@ -941,7 +941,7 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
@@ -953,11 +953,11 @@ describe('CRUD API', function() {
 
       ops.push({ insertOne: { _id: 0, a: i } });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
-        db.collection('t20_1').bulkWrite(ops, { ordered: false, w: 1 }, function(err) {
+        db.collection('t20_1').bulkWrite(ops, { ordered: false, w: 1 }, function (err) {
           test.ok(err !== null);
           client.close(done);
         });
@@ -972,7 +972,7 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
@@ -984,11 +984,11 @@ describe('CRUD API', function() {
 
       ops.push({ insertOne: { _id: 0, a: i } });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
-        db.collection('t20_1').bulkWrite(ops, { ordered: true, w: 1 }, function(err) {
+        db.collection('t20_1').bulkWrite(ops, { ordered: true, w: 1 }, function (err) {
           test.ok(err !== null);
           client.close(done);
         });
@@ -996,24 +996,24 @@ describe('CRUD API', function() {
     }
   });
 
-  it('should correctly throw error if update doc for findOneAndUpdate lacks atomic operator', function(done) {
+  it('should correctly throw error if update doc for findOneAndUpdate lacks atomic operator', function (done) {
     let configuration = this.configuration;
     let client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-    client.connect(function(err, client) {
+    client.connect(function (err, client) {
       expect(err).to.not.exist;
       let db = client.db(configuration.db);
       let col = db.collection('t21_1');
-      col.insertOne({ a: 1, b: 2, c: 3 }, function(err, r) {
+      col.insertOne({ a: 1, b: 2, c: 3 }, function (err, r) {
         expect(err).to.not.exist;
         expect(r.insertedCount).to.equal(1);
 
         // empty update document
-        col.findOneAndUpdate({ a: 1 }, {}, function(err, r) {
+        col.findOneAndUpdate({ a: 1 }, {}, function (err, r) {
           expect(err).to.exist;
           expect(r).to.not.exist;
 
           // update document non empty but still lacks atomic operator
-          col.findOneAndUpdate({ a: 1 }, { b: 5 }, function(err, r) {
+          col.findOneAndUpdate({ a: 1 }, { b: 5 }, function (err, r) {
             expect(err).to.exist;
             expect(r).to.not.exist;
 
@@ -1031,24 +1031,24 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var col = db.collection('t21_1');
-        col.insertOne({ a: 1, b: 2, c: 3 }, function(err, r) {
+        col.insertOne({ a: 1, b: 2, c: 3 }, function (err, r) {
           expect(err).to.not.exist;
           expect(r.insertedCount).to.equal(1);
 
           // empty update document
-          col.updateOne({ a: 1 }, {}, function(err, r) {
+          col.updateOne({ a: 1 }, {}, function (err, r) {
             expect(err).to.exist;
             expect(r).to.not.exist;
 
             // update document non empty but still lacks atomic operator
-            col.updateOne({ a: 1 }, { b: 5 }, function(err, r) {
+            col.updateOne({ a: 1 }, { b: 5 }, function (err, r) {
               expect(err).to.exist;
               expect(r).to.not.exist;
 
@@ -1067,10 +1067,10 @@ describe('CRUD API', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         var db = client.db(configuration.db);
         var col = db.collection('t22_1');
@@ -1080,17 +1080,17 @@ describe('CRUD API', function() {
             { a: 1, b: 3 },
             { a: 1, b: 4 }
           ],
-          function(err, r) {
+          function (err, r) {
             expect(err).to.not.exist;
             expect(r.insertedCount).to.equal(3);
 
             // empty update document
-            col.updateMany({ a: 1 }, {}, function(err, r) {
+            col.updateMany({ a: 1 }, {}, function (err, r) {
               expect(err).to.exist;
               expect(r).to.not.exist;
 
               // update document non empty but still lacks atomic operator
-              col.updateMany({ a: 1 }, { b: 5 }, function(err, r) {
+              col.updateMany({ a: 1 }, { b: 5 }, function (err, r) {
                 expect(err).to.exist;
                 expect(r).to.not.exist;
 

--- a/test/functional/crud_spec.test.js
+++ b/test/functional/crud_spec.test.js
@@ -38,8 +38,8 @@ const readScenarios = findScenarios('v1', 'read');
 const writeScenarios = findScenarios('v1', 'write');
 
 const testContext = {};
-describe('CRUD spec', function() {
-  beforeEach(function() {
+describe('CRUD spec', function () {
+  beforeEach(function () {
     const configuration = this.configuration;
     const client = configuration.newClient();
     return client.connect().then(client => {
@@ -54,7 +54,7 @@ describe('CRUD spec', function() {
     }
   });
 
-  describe('read', function() {
+  describe('read', function () {
     readScenarios.forEach(scenarioData => {
       const scenarioName = scenarioData[0];
       const scenario = scenarioData[1];
@@ -68,12 +68,12 @@ describe('CRUD spec', function() {
 
       enforceServerVersionLimits(metadata.requires, scenario);
 
-      describe(scenarioName, function() {
+      describe(scenarioName, function () {
         scenario.tests.forEach(scenarioTest => {
           beforeEach(() => testContext.db.dropDatabase());
           it(scenarioTest.description, {
             metadata,
-            test: function() {
+            test: function () {
               return executeScenario(scenario, scenarioTest, this.configuration, testContext);
             }
           });
@@ -82,7 +82,7 @@ describe('CRUD spec', function() {
     });
   });
 
-  describe('write', function() {
+  describe('write', function () {
     writeScenarios.forEach(scenarioData => {
       const scenarioName = scenarioData[0];
       const scenario = scenarioData[1];
@@ -96,13 +96,13 @@ describe('CRUD spec', function() {
 
       enforceServerVersionLimits(metadata.requires, scenario);
 
-      describe(scenarioName, function() {
+      describe(scenarioName, function () {
         beforeEach(() => testContext.db.dropDatabase());
 
         scenario.tests.forEach(scenarioTest => {
           it(scenarioTest.description, {
             metadata,
-            test: function() {
+            test: function () {
               return executeScenario(scenario, scenarioTest, this.configuration, testContext);
             }
           });
@@ -151,7 +151,7 @@ describe('CRUD spec', function() {
   }
 
   function assertWriteExpectations(collection, outcome) {
-    return function(result) {
+    return function (result) {
       // TODO: when we fix our bulk write errors, get rid of this
       if (result instanceof BulkWriteError) {
         result = transformBulkWriteResult(result.result);
@@ -178,7 +178,7 @@ describe('CRUD spec', function() {
   }
 
   function assertReadExpectations(db, collection, outcome) {
-    return function(result) {
+    return function (result) {
       if (outcome.result && !outcome.collection) {
         expect(result).to.containSubset(outcome.result);
       }
@@ -389,10 +389,7 @@ describe('CRUD spec', function() {
     dropPromises.push(collection.drop().catch(errorHandler));
     if (scenarioTest.outcome.collection && scenarioTest.outcome.collection.name) {
       dropPromises.push(
-        context.db
-          .collection(scenarioTest.outcome.collection.name)
-          .drop()
-          .catch(errorHandler)
+        context.db.collection(scenarioTest.outcome.collection.name).drop().catch(errorHandler)
       );
     }
 
@@ -438,11 +435,11 @@ describe('CRUD spec', function() {
   }
 });
 
-describe('CRUD v2', function() {
+describe('CRUD v2', function () {
   const testContext = new TestRunnerContext();
   const testSuites = gatherTestSuites(path.resolve(__dirname, '../spec/crud/v2'));
   after(() => testContext.teardown());
-  before(function() {
+  before(function () {
     return testContext.setup(this.configuration);
   });
 

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -9,8 +9,8 @@ const { Writable } = require('stream');
 const ReadPreference = require('../../src/read_preference');
 const { ServerType } = require('../../src/sdam/common');
 
-describe('Cursor', function() {
-  before(function() {
+describe('Cursor', function () {
+  before(function () {
     return setupDatabase(this.configuration, [
       'cursorkilltest1',
       'cursor_session_tests',
@@ -25,29 +25,29 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_to_a', function(err, collection) {
+        db.createCollection('test_to_a', function (err, collection) {
           test.equal(null, err);
 
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             var cursor = collection.find({});
-            cursor.toArray(function(err) {
+            cursor.toArray(function (err) {
               test.equal(null, err);
 
               // Should fail if called again (cursor should be closed)
-              cursor.toArray(function(err) {
+              cursor.toArray(function (err) {
                 test.equal(null, err);
 
                 // Should fail if called again (cursor should be closed)
-                cursor.each(function(err, item) {
+                cursor.each(function (err, item) {
                   test.equal(null, err);
 
                   // Let's close the db
@@ -70,25 +70,25 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('close_on_next', function(err, collection) {
+        db.createCollection('close_on_next', function (err, collection) {
           test.equal(null, err);
 
           collection.insert(
             [{ a: 1 }, { a: 1 }, { a: 1 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               var cursor = collection.find({});
               cursor.batchSize(2);
-              cursor.next(function(err) {
+              cursor.next(function (err) {
                 test.equal(null, err);
 
                 cursor.close();
@@ -108,24 +108,24 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('trigger_get_more', function(err, collection) {
+        db.createCollection('trigger_get_more', function (err, collection) {
           test.equal(null, err);
 
           collection.insert(
             [{ a: 1 }, { a: 1 }, { a: 1 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               var cursor = collection.find({});
               cursor.batchSize(2);
-              cursor.toArray(function(err) {
+              cursor.toArray(function (err) {
                 test.equal(null, err);
 
                 client.close(done);
@@ -144,20 +144,20 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_explain', function(err, collection) {
+        db.createCollection('test_explain', function (err, collection) {
           test.equal(null, err);
 
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
-            collection.find({ a: 1 }).explain(function(err, explaination) {
+            collection.find({ a: 1 }).explain(function (err, explaination) {
               test.equal(null, err);
               test.ok(explaination != null);
 
@@ -177,24 +177,24 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_count', function(err, collection) {
+        db.createCollection('test_count', function (err, collection) {
           test.equal(null, err);
 
-          collection.find().count(function(err) {
+          collection.find().count(function (err) {
             test.equal(null, err);
 
             function insert(callback) {
               var total = 10;
 
               for (var i = 0; i < 10; i++) {
-                collection.insert({ x: i }, configuration.writeConcernMax(), function(e) {
+                collection.insert({ x: i }, configuration.writeConcernMax(), function (e) {
                   test.equal(null, e);
                   total = total - 1;
                   if (total === 0) callback();
@@ -203,32 +203,32 @@ describe('Cursor', function() {
             }
 
             function finished() {
-              collection.find().count(function(err, count) {
+              collection.find().count(function (err, count) {
                 test.equal(null, err);
                 test.equal(10, count);
                 test.ok(count.constructor === Number);
 
-                collection.find({}, { limit: 5 }).count(function(err, count) {
+                collection.find({}, { limit: 5 }).count(function (err, count) {
                   test.equal(null, err);
                   test.equal(5, count);
 
-                  collection.find({}, { skip: 5 }).count(function(err, count) {
+                  collection.find({}, { skip: 5 }).count(function (err, count) {
                     test.equal(null, err);
                     test.equal(5, count);
 
-                    db.collection('acollectionthatdoesn').count(function(err, count) {
+                    db.collection('acollectionthatdoesn').count(function (err, count) {
                       test.equal(null, err);
                       test.equal(0, count);
 
                       var cursor = collection.find();
-                      cursor.count(function(err, count) {
+                      cursor.count(function (err, count) {
                         test.equal(null, err);
                         test.equal(10, count);
 
-                        cursor.each(function(err, item) {
+                        cursor.each(function (err, item) {
                           test.equal(null, err);
                           if (item == null) {
-                            cursor.count(function(err, count2) {
+                            cursor.count(function (err, count2) {
                               test.equal(null, err);
                               test.equal(10, count2);
                               test.equal(count, count2);
@@ -244,7 +244,7 @@ describe('Cursor', function() {
               });
             }
 
-            insert(function() {
+            insert(function () {
               finished();
             });
           });
@@ -260,7 +260,7 @@ describe('Cursor', function() {
       requires: { topology: 'replicaset' }
     },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
@@ -280,9 +280,7 @@ describe('Cursor', function() {
 
           const selectedServerAddress = bag[0].address.replace('127.0.0.1', 'localhost');
           const selectedServer = client.topology.description.servers.get(selectedServerAddress);
-          expect(selectedServer)
-            .property('type')
-            .to.equal(ServerType.RSSecondary);
+          expect(selectedServer).property('type').to.equal(ServerType.RSSecondary);
 
           client.close(done);
         });
@@ -297,24 +295,24 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_count.ext', function(err, collection) {
+        db.createCollection('test_count.ext', function (err, collection) {
           test.equal(null, err);
 
-          collection.find().count(function(err) {
+          collection.find().count(function (err) {
             test.equal(null, err);
 
             function insert(callback) {
               var total = 10;
 
               for (var i = 0; i < 10; i++) {
-                collection.insert({ x: i }, configuration.writeConcernMax(), function(e) {
+                collection.insert({ x: i }, configuration.writeConcernMax(), function (e) {
                   test.equal(null, e);
                   total = total - 1;
                   if (total === 0) callback();
@@ -323,32 +321,32 @@ describe('Cursor', function() {
             }
 
             function finished() {
-              collection.find().count(function(err, count) {
+              collection.find().count(function (err, count) {
                 test.equal(null, err);
                 test.equal(10, count);
                 test.ok(count.constructor === Number);
 
-                collection.find({}, { limit: 5 }).count(function(err, count) {
+                collection.find({}, { limit: 5 }).count(function (err, count) {
                   test.equal(null, err);
                   test.equal(5, count);
 
-                  collection.find({}, { skip: 5 }).count(function(err, count) {
+                  collection.find({}, { skip: 5 }).count(function (err, count) {
                     test.equal(null, err);
                     test.equal(5, count);
 
-                    db.collection('acollectionthatdoesn').count(function(err, count) {
+                    db.collection('acollectionthatdoesn').count(function (err, count) {
                       test.equal(null, err);
                       test.equal(0, count);
 
                       var cursor = collection.find();
-                      cursor.count(function(err, count) {
+                      cursor.count(function (err, count) {
                         test.equal(null, err);
                         test.equal(10, count);
 
-                        cursor.each(function(err, item) {
+                        cursor.each(function (err, item) {
                           test.equal(null, err);
                           if (item == null) {
-                            cursor.count(function(err, count2) {
+                            cursor.count(function (err, count2) {
                               test.equal(null, err);
                               test.equal(10, count2);
                               test.equal(count, count2);
@@ -364,7 +362,7 @@ describe('Cursor', function() {
               });
             }
 
-            insert(function() {
+            insert(function () {
               finished();
             });
           });
@@ -380,20 +378,20 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_sort', function(err, collection) {
+        db.createCollection('test_sort', function (err, collection) {
           test.equal(null, err);
           function insert(callback) {
             var total = 10;
 
             for (var i = 0; i < 10; i++) {
-              collection.insert({ x: i }, configuration.writeConcernMax(), function(e) {
+              collection.insert({ x: i }, configuration.writeConcernMax(), function (e) {
                 test.equal(null, e);
                 total = total - 1;
                 if (total === 0) callback();
@@ -403,7 +401,7 @@ describe('Cursor', function() {
 
           function f() {
             var number_of_functions = 9;
-            var finished = function() {
+            var finished = function () {
               number_of_functions = number_of_functions - 1;
               if (number_of_functions === 0) {
                 client.close(done);
@@ -435,14 +433,11 @@ describe('Cursor', function() {
             test.deepEqual(['b', 1], entries.next().value);
             finished();
 
-            cursor = collection
-              .find()
-              .sort('a', 1)
-              .sort('a', -1);
+            cursor = collection.find().sort('a', 1).sort('a', -1);
             test.deepEqual([['a', -1]], cursor.sortValue);
             finished();
 
-            cursor.next(function(err) {
+            cursor.next(function (err) {
               test.equal(null, err);
               try {
                 cursor.sort(['a']);
@@ -455,7 +450,7 @@ describe('Cursor', function() {
             collection
               .find()
               .sort('a', 25)
-              .next(function(err) {
+              .next(function (err) {
                 test.equal(
                   "Illegal sort clause, must be of the form [['field1', '(ascending|descending)'], ['field2', '(ascending|descending)']]",
                   err.message
@@ -466,7 +461,7 @@ describe('Cursor', function() {
             collection
               .find()
               .sort(25)
-              .next(function(err) {
+              .next(function (err) {
                 test.equal(
                   "Illegal sort clause, must be of the form [['field1', '(ascending|descending)'], ['field2', '(ascending|descending)']]",
                   err.message
@@ -475,7 +470,7 @@ describe('Cursor', function() {
               });
           }
 
-          insert(function() {
+          insert(function () {
             f();
           });
         });
@@ -490,20 +485,20 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_each', function(err, collection) {
+        db.createCollection('test_each', function (err, collection) {
           test.equal(null, err);
           function insert(callback) {
             var total = 10;
 
             for (var i = 0; i < 10; i++) {
-              collection.insert({ x: i }, configuration.writeConcernMax(), function(e) {
+              collection.insert({ x: i }, configuration.writeConcernMax(), function (e) {
                 test.equal(null, e);
                 total = total - 1;
                 if (total === 0) callback();
@@ -514,14 +509,14 @@ describe('Cursor', function() {
           function finished() {
             const cursor = collection.find();
 
-            test.throws(function() {
+            test.throws(function () {
               cursor.each();
             });
 
             client.close(done);
           }
 
-          insert(function() {
+          insert(function () {
             finished();
           });
         });
@@ -536,17 +531,17 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_cursor_limit', function(err, collection) {
+        db.createCollection('test_cursor_limit', function (err, collection) {
           function insert(callback) {
             var total = 10;
 
             for (var i = 0; i < 10; i++) {
-              collection.insert({ x: i }, configuration.writeConcernMax(), function(e) {
+              collection.insert({ x: i }, configuration.writeConcernMax(), function (e) {
                 test.equal(null, e);
                 total = total - 1;
                 if (total === 0) callback();
@@ -558,7 +553,7 @@ describe('Cursor', function() {
             collection
               .find()
               .limit(5)
-              .toArray(function(err, items) {
+              .toArray(function (err, items) {
                 test.equal(5, items.length);
 
                 // Let's close the db
@@ -567,7 +562,7 @@ describe('Cursor', function() {
               });
           }
 
-          insert(function() {
+          insert(function () {
             finished();
           });
         });
@@ -582,20 +577,20 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_cursor_negative_one_limit', function(err, collection) {
+        db.createCollection('test_cursor_negative_one_limit', function (err, collection) {
           test.equal(null, err);
           function insert(callback) {
             var total = 10;
 
             for (var i = 0; i < 10; i++) {
-              collection.insert({ x: i }, configuration.writeConcernMax(), function(e) {
+              collection.insert({ x: i }, configuration.writeConcernMax(), function (e) {
                 test.equal(null, e);
                 total = total - 1;
                 if (total === 0) callback();
@@ -607,7 +602,7 @@ describe('Cursor', function() {
             collection
               .find()
               .limit(-1)
-              .toArray(function(err, items) {
+              .toArray(function (err, items) {
                 test.equal(null, err);
                 test.equal(1, items.length);
 
@@ -616,7 +611,7 @@ describe('Cursor', function() {
               });
           }
 
-          insert(function() {
+          insert(function () {
             finished();
           });
         });
@@ -631,20 +626,20 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_cursor_any_negative_limit', function(err, collection) {
+        db.createCollection('test_cursor_any_negative_limit', function (err, collection) {
           test.equal(null, err);
           function insert(callback) {
             var total = 10;
 
             for (var i = 0; i < 10; i++) {
-              collection.insert({ x: i }, configuration.writeConcernMax(), function(e) {
+              collection.insert({ x: i }, configuration.writeConcernMax(), function (e) {
                 test.equal(null, e);
                 total = total - 1;
                 if (total === 0) callback();
@@ -656,7 +651,7 @@ describe('Cursor', function() {
             collection
               .find()
               .limit(-5)
-              .toArray(function(err, items) {
+              .toArray(function (err, items) {
                 test.equal(null, err);
                 test.equal(5, items.length);
 
@@ -665,7 +660,7 @@ describe('Cursor', function() {
               });
           }
 
-          insert(function() {
+          insert(function () {
             finished();
           });
         });
@@ -680,17 +675,17 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_limit_exceptions_2', function(err, collection) {
+        db.createCollection('test_limit_exceptions_2', function (err, collection) {
           test.equal(null, err);
 
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
             const cursor = collection.find();
 
@@ -715,23 +710,23 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_limit_exceptions', function(err, collection) {
+        db.createCollection('test_limit_exceptions', function (err, collection) {
           test.equal(null, err);
 
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
           });
 
           const cursor = collection.find();
 
-          cursor.next(function(err) {
+          cursor.next(function (err) {
             test.equal(null, err);
             try {
               cursor.limit(1);
@@ -753,22 +748,22 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_limit_exceptions_1', function(err, collection) {
+        db.createCollection('test_limit_exceptions_1', function (err, collection) {
           test.equal(null, err);
 
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             const cursor = collection.find();
 
-            cursor.close(function(err, cursor) {
+            cursor.close(function (err, cursor) {
               test.equal(null, err);
               try {
                 cursor.limit(1);
@@ -792,21 +787,21 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_skip', function(err, collection) {
+        db.createCollection('test_skip', function (err, collection) {
           test.equal(null, err);
 
           function insert(callback) {
             var total = 10;
 
             for (var i = 0; i < 10; i++) {
-              collection.insert({ x: i }, configuration.writeConcernMax(), function(e) {
+              collection.insert({ x: i }, configuration.writeConcernMax(), function (e) {
                 test.equal(null, e);
 
                 total = total - 1;
@@ -817,21 +812,21 @@ describe('Cursor', function() {
 
           function finished() {
             const cursor = collection.find();
-            cursor.count(function(err, count) {
+            cursor.count(function (err, count) {
               test.equal(null, err);
               test.equal(10, count);
             });
 
-            (function() {
+            (function () {
               const cursor = collection.find();
-              cursor.toArray(function(err, items) {
+              cursor.toArray(function (err, items) {
                 test.equal(null, err);
                 test.equal(10, items.length);
 
                 collection
                   .find()
                   .skip(2)
-                  .toArray(function(err, items2) {
+                  .toArray(function (err, items2) {
                     test.equal(null, err);
                     test.equal(8, items2.length);
 
@@ -852,7 +847,7 @@ describe('Cursor', function() {
             })();
           }
 
-          insert(function() {
+          insert(function () {
             finished();
           });
         });
@@ -867,16 +862,16 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_skip_exceptions', function(err, collection) {
+        db.createCollection('test_skip_exceptions', function (err, collection) {
           test.equal(null, err);
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
           });
 
@@ -887,7 +882,7 @@ describe('Cursor', function() {
           }
 
           var cursor = collection.find();
-          cursor.next(function(err) {
+          cursor.next(function (err) {
             test.equal(null, err);
 
             try {
@@ -897,7 +892,7 @@ describe('Cursor', function() {
             }
 
             var cursor2 = collection.find();
-            cursor2.close(function(err) {
+            cursor2.close(function (err) {
               test.equal(null, err);
               try {
                 cursor2.skip(1);
@@ -920,16 +915,16 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_batchSize_exceptions', function(err, collection) {
+        db.createCollection('test_batchSize_exceptions', function (err, collection) {
           test.equal(null, err);
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
           });
           var cursor = collection.find();
@@ -942,10 +937,10 @@ describe('Cursor', function() {
           }
 
           cursor = collection.find();
-          cursor.next(function(err) {
+          cursor.next(function (err) {
             test.equal(null, err);
 
-            cursor.next(function(err) {
+            cursor.next(function (err) {
               test.equal(null, err);
 
               try {
@@ -956,7 +951,7 @@ describe('Cursor', function() {
               }
 
               var cursor2 = collection.find();
-              cursor2.close(function(err) {
+              cursor2.close(function (err) {
                 test.equal(null, err);
                 try {
                   cursor2.batchSize(1);
@@ -981,14 +976,14 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_not_multiple_batch_size', function(err, collection) {
+        db.createCollection('test_not_multiple_batch_size', function (err, collection) {
           test.equal(null, err);
 
           var records = 6;
@@ -998,20 +993,20 @@ describe('Cursor', function() {
             docs.push({ a: i });
           }
 
-          collection.insert(docs, configuration.writeConcernMax(), function() {
+          collection.insert(docs, configuration.writeConcernMax(), function () {
             test.equal(null, err);
 
             const cursor = collection.find({}, { batchSize: batchSize });
 
             //1st
-            cursor.next(function(err, items) {
+            cursor.next(function (err, items) {
               test.equal(null, err);
               //cursor.items should contain 1 since nextObject already popped one
               test.equal(1, cursor.bufferedCount());
               test.ok(items != null);
 
               //2nd
-              cursor.next(function(err, items) {
+              cursor.next(function (err, items) {
                 test.equal(null, err);
                 test.equal(0, cursor.bufferedCount());
                 test.ok(items != null);
@@ -1021,31 +1016,31 @@ describe('Cursor', function() {
                 cursor.batchSize(batchSize);
 
                 //3rd
-                cursor.next(function(err, items) {
+                cursor.next(function (err, items) {
                   test.equal(null, err);
                   test.equal(2, cursor.bufferedCount());
                   test.ok(items != null);
 
                   //4th
-                  cursor.next(function(err, items) {
+                  cursor.next(function (err, items) {
                     test.equal(null, err);
                     test.equal(1, cursor.bufferedCount());
                     test.ok(items != null);
 
                     //5th
-                    cursor.next(function(err, items) {
+                    cursor.next(function (err, items) {
                       test.equal(null, err);
                       test.equal(0, cursor.bufferedCount());
                       test.ok(items != null);
 
                       //6th
-                      cursor.next(function(err, items) {
+                      cursor.next(function (err, items) {
                         test.equal(null, err);
                         test.equal(0, cursor.bufferedCount());
                         test.ok(items != null);
 
                         //No more
-                        cursor.next(function(err, items) {
+                        cursor.next(function (err, items) {
                           test.equal(null, err);
                           test.ok(items == null);
                           test.ok(cursor.isClosed());
@@ -1071,14 +1066,14 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_multiple_batch_size', function(err, collection) {
+        db.createCollection('test_multiple_batch_size', function (err, collection) {
           test.equal(null, err);
 
           //test with the last batch that is a multiple of batchSize
@@ -1089,37 +1084,37 @@ describe('Cursor', function() {
             docs.push({ a: i });
           }
 
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             const cursor = collection.find({}, { batchSize: batchSize });
 
             //1st
-            cursor.next(function(err, items) {
+            cursor.next(function (err, items) {
               test.equal(null, err);
               test.equal(1, cursor.bufferedCount());
               test.ok(items != null);
 
               //2nd
-              cursor.next(function(err, items) {
+              cursor.next(function (err, items) {
                 test.equal(null, err);
                 test.equal(0, cursor.bufferedCount());
                 test.ok(items != null);
 
                 //3rd
-                cursor.next(function(err, items) {
+                cursor.next(function (err, items) {
                   test.equal(null, err);
                   test.equal(1, cursor.bufferedCount());
                   test.ok(items != null);
 
                   //4th
-                  cursor.next(function(err, items) {
+                  cursor.next(function (err, items) {
                     test.equal(null, err);
                     test.equal(0, cursor.bufferedCount());
                     test.ok(items != null);
 
                     //No more
-                    cursor.next(function(err, items) {
+                    cursor.next(function (err, items) {
                       test.equal(null, err);
                       test.ok(items == null);
                       test.ok(cursor.isClosed());
@@ -1143,14 +1138,14 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_limit_greater_than_batch_size', function(err, collection) {
+        db.createCollection('test_limit_greater_than_batch_size', function (err, collection) {
           test.equal(null, err);
 
           var limit = 4;
@@ -1161,31 +1156,31 @@ describe('Cursor', function() {
             docs.push({ a: i });
           }
 
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             var cursor = collection.find({}, { batchSize: batchSize, limit: limit });
             //1st
-            cursor.next(function(err) {
+            cursor.next(function (err) {
               test.equal(null, err);
               test.equal(2, cursor.bufferedCount());
 
               //2nd
-              cursor.next(function(err) {
+              cursor.next(function (err) {
                 test.equal(null, err);
                 test.equal(1, cursor.bufferedCount());
 
                 //3rd
-                cursor.next(function(err) {
+                cursor.next(function (err) {
                   test.equal(null, err);
                   test.equal(0, cursor.bufferedCount());
 
                   //4th
-                  cursor.next(function(err) {
+                  cursor.next(function (err) {
                     test.equal(null, err);
 
                     //No more
-                    cursor.next(function(err, items) {
+                    cursor.next(function (err, items) {
                       test.equal(null, err);
                       test.ok(items == null);
                       test.ok(cursor.isClosed());
@@ -1209,14 +1204,14 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_limit_less_than_batch_size', function(err, collection) {
+        db.createCollection('test_limit_less_than_batch_size', function (err, collection) {
           test.equal(null, err);
 
           var limit = 2;
@@ -1227,22 +1222,22 @@ describe('Cursor', function() {
             docs.push({ a: i });
           }
 
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             var cursor = collection.find({}, { batchSize: batchSize, limit: limit });
             //1st
-            cursor.next(function(err) {
+            cursor.next(function (err) {
               test.equal(null, err);
               test.equal(1, cursor.bufferedCount());
 
               //2nd
-              cursor.next(function(err) {
+              cursor.next(function (err) {
                 test.equal(null, err);
                 test.equal(0, cursor.bufferedCount());
 
                 //No more
-                cursor.next(function(err, items) {
+                cursor.next(function (err, items) {
                   test.equal(null, err);
                   test.ok(items == null);
                   test.ok(cursor.isClosed());
@@ -1264,10 +1259,10 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
@@ -1277,7 +1272,7 @@ describe('Cursor', function() {
           var total = 10;
 
           for (var i = 0; i < 10; i++) {
-            collection.insert({ x: i }, configuration.writeConcernMax(), function(e) {
+            collection.insert({ x: i }, configuration.writeConcernMax(), function (e) {
               test.equal(null, e);
               total = total - 1;
               if (total === 0) callback();
@@ -1286,7 +1281,7 @@ describe('Cursor', function() {
         }
 
         function finished() {
-          collection.find().toArray(function(err, items) {
+          collection.find().toArray(function (err, items) {
             test.equal(null, err);
             test.equal(10, items.length);
 
@@ -1294,7 +1289,7 @@ describe('Cursor', function() {
               .find()
               .limit(5)
               .skip(3)
-              .toArray(function(err, items2) {
+              .toArray(function (err, items2) {
                 test.equal(null, err);
                 test.equal(5, items2.length);
 
@@ -1313,7 +1308,7 @@ describe('Cursor', function() {
           });
         }
 
-        insert(function() {
+        insert(function () {
           finished();
         });
       });
@@ -1327,21 +1322,21 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_limit_skip_chaining_inline', function(err, collection) {
+        db.createCollection('test_limit_skip_chaining_inline', function (err, collection) {
           test.equal(null, err);
 
           function insert(callback) {
             var total = 10;
 
             for (var i = 0; i < 10; i++) {
-              collection.insert({ x: i }, configuration.writeConcernMax(), function(e) {
+              collection.insert({ x: i }, configuration.writeConcernMax(), function (e) {
                 test.equal(null, e);
                 total = total - 1;
                 if (total === 0) callback();
@@ -1350,7 +1345,7 @@ describe('Cursor', function() {
           }
 
           function finished() {
-            collection.find().toArray(function(err, items) {
+            collection.find().toArray(function (err, items) {
               test.equal(null, err);
               test.equal(10, items.length);
 
@@ -1358,7 +1353,7 @@ describe('Cursor', function() {
                 .find()
                 .limit(5)
                 .skip(3)
-                .toArray(function(err, items2) {
+                .toArray(function (err, items2) {
                   test.equal(null, err);
                   test.equal(5, items2.length);
 
@@ -1377,7 +1372,7 @@ describe('Cursor', function() {
             });
           }
 
-          insert(function() {
+          insert(function () {
             finished();
           });
         });
@@ -1392,17 +1387,17 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_close_no_query_sent', function(err, collection) {
+        db.createCollection('test_close_no_query_sent', function (err, collection) {
           test.equal(null, err);
 
-          collection.find().close(function(err, cursor) {
+          collection.find().close(function (err, cursor) {
             test.equal(null, err);
             test.equal(true, cursor.isClosed());
             // Let's close the db
@@ -1420,16 +1415,16 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var COUNT = 1000;
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_refill_via_get_more', function(err, collection) {
+        db.createCollection('test_refill_via_get_more', function (err, collection) {
           test.equal(null, err);
 
           function insert(callback) {
@@ -1443,36 +1438,36 @@ describe('Cursor', function() {
           }
 
           function finished() {
-            collection.count(function(err, count) {
+            collection.count(function (err, count) {
               test.equal(null, err);
               test.equal(COUNT, count);
             });
 
             var total = 0;
-            collection.find({}, {}).each(function(err, item) {
+            collection.find({}, {}).each(function (err, item) {
               test.equal(null, err);
               if (item != null) {
                 total = total + item.a;
               } else {
                 test.equal(499500, total);
 
-                collection.count(function(err, count) {
+                collection.count(function (err, count) {
                   test.equal(null, err);
                   test.equal(COUNT, count);
                 });
 
-                collection.count(function(err, count) {
+                collection.count(function (err, count) {
                   test.equal(null, err);
                   test.equal(COUNT, count);
 
                   var total2 = 0;
-                  collection.find().each(function(err, item) {
+                  collection.find().each(function (err, item) {
                     test.equal(null, err);
                     if (item != null) {
                       total2 = total2 + item.a;
                     } else {
                       test.equal(499500, total2);
-                      collection.count(function(err, count) {
+                      collection.count(function (err, count) {
                         test.equal(null, err);
                         test.equal(COUNT, count);
                         test.equal(total, total2);
@@ -1487,7 +1482,7 @@ describe('Cursor', function() {
             });
           }
 
-          insert(function() {
+          insert(function () {
             finished();
           });
         });
@@ -1502,14 +1497,14 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_refill_via_get_more_alt_coll', function(err, collection) {
+        db.createCollection('test_refill_via_get_more_alt_coll', function (err, collection) {
           test.equal(null, err);
           var COUNT = 1000;
 
@@ -1524,36 +1519,36 @@ describe('Cursor', function() {
           }
 
           function finished() {
-            collection.count(function(err, count) {
+            collection.count(function (err, count) {
               test.equal(null, err);
               test.equal(1000, count);
             });
 
             var total = 0;
-            collection.find().each(function(err, item) {
+            collection.find().each(function (err, item) {
               test.equal(null, err);
               if (item != null) {
                 total = total + item.a;
               } else {
                 test.equal(499500, total);
 
-                collection.count(function(err, count) {
+                collection.count(function (err, count) {
                   test.equal(null, err);
                   test.equal(1000, count);
                 });
 
-                collection.count(function(err, count) {
+                collection.count(function (err, count) {
                   test.equal(null, err);
                   test.equal(1000, count);
 
                   var total2 = 0;
-                  collection.find().each(function(err, item) {
+                  collection.find().each(function (err, item) {
                     test.equal(null, err);
                     if (item != null) {
                       total2 = total2 + item.a;
                     } else {
                       test.equal(499500, total2);
-                      collection.count(function(err, count) {
+                      collection.count(function (err, count) {
                         test.equal(null, err);
                         test.equal(1000, count);
                         test.equal(total, total2);
@@ -1568,7 +1563,7 @@ describe('Cursor', function() {
             });
           }
 
-          insert(function() {
+          insert(function () {
             finished();
           });
         });
@@ -1583,24 +1578,24 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_close_after_query_sent', function(err, collection) {
+        db.createCollection('test_close_after_query_sent', function (err, collection) {
           test.equal(null, err);
 
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             var cursor = collection.find({ a: 1 });
-            cursor.next(function(err) {
+            cursor.next(function (err) {
               test.equal(null, err);
 
-              cursor.close(function(err, cursor) {
+              cursor.close(function (err, cursor) {
                 test.equal(null, err);
                 test.equal(true, cursor.isClosed());
                 // Let's close the db
@@ -1620,23 +1615,23 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_count_with_fields', function(err, collection) {
+        db.createCollection('test_count_with_fields', function (err, collection) {
           test.equal(null, err);
 
-          collection.save({ x: 1, a: 2 }, configuration.writeConcernMax(), function(err) {
+          collection.save({ x: 1, a: 2 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             collection
               .find({})
               .project({ a: 1 })
-              .toArray(function(err, items) {
+              .toArray(function (err, items) {
                 test.equal(null, err);
                 test.equal(1, items.length);
                 test.equal(2, items[0].a);
@@ -1656,20 +1651,20 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('test_count_with_fields_using_exclude', function(err, collection) {
+        db.createCollection('test_count_with_fields_using_exclude', function (err, collection) {
           test.equal(null, err);
 
-          collection.save({ x: 1, a: 2 }, configuration.writeConcernMax(), function(err) {
+          collection.save({ x: 1, a: 2 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
-            collection.find({}, { fields: { x: 0 } }).toArray(function(err, items) {
+            collection.find({}, { fields: { x: 0 } }).toArray(function (err, items) {
               test.equal(null, err);
               test.equal(1, items.length);
               test.equal(2, items[0].a);
@@ -1689,7 +1684,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 1000; i++) {
@@ -1699,32 +1694,32 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('Should_correctly_execute_count_on_cursor_1', function(
+        db.createCollection('Should_correctly_execute_count_on_cursor_1', function (
           err,
           collection
         ) {
           test.equal(null, err);
 
           // insert all docs
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             var total = 0;
             // Create a cursor for the content
             var cursor = collection.find({});
-            cursor.count(function(err) {
+            cursor.count(function (err) {
               test.equal(null, err);
               // Ensure each returns all documents
-              cursor.each(function(err, item) {
+              cursor.each(function (err, item) {
                 test.equal(null, err);
                 if (item != null) {
                   total++;
                 } else {
-                  cursor.count(function(err, c) {
+                  cursor.count(function (err, c) {
                     test.equal(null, err);
                     test.equal(1000, c);
                     test.equal(1000, total);
@@ -1746,7 +1741,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 1000; i++) {
@@ -1757,15 +1752,15 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('Should_be_able_to_stream_documents', function(err, collection) {
+        db.createCollection('Should_be_able_to_stream_documents', function (err, collection) {
           test.equal(null, err);
 
           // insert all docs
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             var paused = 0,
@@ -1775,7 +1770,7 @@ describe('Cursor', function() {
 
             var stream = collection.find().stream();
 
-            stream.on('data', function(doc) {
+            stream.on('data', function (doc) {
               test.equal(true, !!doc);
               test.equal(true, !!doc.a);
               count = count + 1;
@@ -1789,19 +1784,19 @@ describe('Cursor', function() {
                 stream.pause();
                 paused++;
 
-                setTimeout(function() {
+                setTimeout(function () {
                   stream.resume();
                   resumed++;
                 }, 20);
               }
             });
 
-            stream.once('error', function(er) {
+            stream.once('error', function (er) {
               err = er;
               testDone();
             });
 
-            stream.once('end', function() {
+            stream.once('end', function () {
               closed++;
               testDone();
             });
@@ -1828,29 +1823,29 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var i = 0,
         docs = [{ b: 2 }, { b: 3 }],
         doneCalled = 0;
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         db.createCollection(
           'immediately_destroying_a_stream_prevents_the_query_from_executing',
-          function(err, collection) {
+          function (err, collection) {
             test.equal(null, err);
 
             // insert all docs
-            collection.insert(docs, configuration.writeConcernMax(), function(err) {
+            collection.insert(docs, configuration.writeConcernMax(), function (err) {
               test.equal(null, err);
 
               var stream = collection.find().stream();
 
-              stream.on('data', function() {
+              stream.on('data', function () {
                 i++;
               });
 
@@ -1860,7 +1855,7 @@ describe('Cursor', function() {
               stream.destroy();
 
               function testDone() {
-                return function(err) {
+                return function (err) {
                   ++doneCalled;
 
                   if (doneCalled === 1) {
@@ -1885,21 +1880,21 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
-        db.createCollection('destroying_a_stream_stops_it', function(err, collection) {
+        db.createCollection('destroying_a_stream_stops_it', function (err, collection) {
           test.equal(null, err);
 
           var docs = [];
           for (var ii = 0; ii < 10; ++ii) docs.push({ b: ii + 1 });
 
           // insert all docs
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             var finished = 0,
@@ -1909,7 +1904,7 @@ describe('Cursor', function() {
 
             test.strictEqual(false, stream.isClosed());
 
-            stream.on('data', function() {
+            stream.on('data', function () {
               if (++i === 5) {
                 stream.destroy();
               }
@@ -1920,7 +1915,7 @@ describe('Cursor', function() {
 
             function testDone(err) {
               ++finished;
-              setTimeout(function() {
+              setTimeout(function () {
                 test.strictEqual(undefined, err);
                 test.strictEqual(5, i);
                 test.strictEqual(1, finished);
@@ -1940,21 +1935,21 @@ describe('Cursor', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
-        db.createCollection('cursor_stream_errors', function(err, collection) {
+        db.createCollection('cursor_stream_errors', function (err, collection) {
           test.equal(null, err);
 
           var docs = [];
           for (var ii = 0; ii < 10; ++ii) docs.push({ b: ii + 1 });
 
           // insert all docs
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             var finished = 0,
@@ -1962,7 +1957,7 @@ describe('Cursor', function() {
 
             var stream = collection.find({}, { batchSize: 5 }).stream();
 
-            stream.on('data', function() {
+            stream.on('data', function () {
               if (++i === 4) {
                 // Force restart
                 configuration.manager.stop(9);
@@ -1973,16 +1968,16 @@ describe('Cursor', function() {
             stream.once('error', testDone('error'));
 
             function testDone() {
-              return function() {
+              return function () {
                 ++finished;
 
                 if (finished === 2) {
-                  setTimeout(function() {
+                  setTimeout(function () {
                     test.equal(5, i);
                     test.equal(true, stream.isClosed());
                     client.close();
 
-                    configuration.manager.start().then(function() {
+                    configuration.manager.start().then(function () {
                       done();
                     });
                   }, 150);
@@ -2002,23 +1997,23 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('cursor_stream_pipe', function(err, collection) {
+        db.createCollection('cursor_stream_pipe', function (err, collection) {
           test.equal(null, err);
 
           var docs = [];
-          'Aaden Aaron Adrian Aditya Bob Joe'.split(' ').forEach(function(name) {
+          'Aaden Aaron Adrian Aditya Bob Joe'.split(' ').forEach(function (name) {
             docs.push({ name: name });
           });
 
           // insert all docs
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             var filename = '/tmp/_nodemongodbnative_stream_out.txt',
@@ -2033,7 +2028,7 @@ describe('Cursor', function() {
             // }
 
             var stream = collection.find().stream({
-              transform: function(doc) {
+              transform: function (doc) {
                 return JSON.stringify(doc);
               }
             });
@@ -2069,17 +2064,17 @@ describe('Cursor', function() {
       sessions: { skipLeakTests: true }
     },
 
-    test: function(done) {
+    test: function (done) {
       // http://www.mongodb.org/display/DOCS/Tailable+Cursors
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         var options = { capped: true, size: 10000000 };
-        db.createCollection('test_if_dead_tailable_cursors_close', options, function(
+        db.createCollection('test_if_dead_tailable_cursors_close', options, function (
           err,
           collection
         ) {
@@ -2091,7 +2086,7 @@ describe('Cursor', function() {
           var count = 100;
           // Just hammer the server
           for (var i = 0; i < 100; i++) {
-            collection.insert({ id: i }, { w: 'majority', wtimeout: 5000 }, function(err) {
+            collection.insert({ id: i }, { w: 'majority', wtimeout: 5000 }, function (err) {
               test.equal(null, err);
               count = count - 1;
 
@@ -2100,7 +2095,7 @@ describe('Cursor', function() {
                 // let index = 0;
                 stream.resume();
 
-                stream.on('error', function(err) {
+                stream.on('error', function (err) {
                   expect(err).to.exist;
                   errorOccurred = true;
                 });
@@ -2119,8 +2114,8 @@ describe('Cursor', function() {
                 // Just hammer the server
                 for (var i = 0; i < 100; i++) {
                   const id = i;
-                  process.nextTick(function() {
-                    collection.insert({ id }, function(err) {
+                  process.nextTick(function () {
+                    collection.insert({ id }, function (err) {
                       test.equal(null, err);
 
                       if (id === 99) {
@@ -2144,29 +2139,29 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // http://www.mongodb.org/display/DOCS/Tailable+Cursors
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         var options = { capped: true, size: 8 };
-        db.createCollection('should_await_data_retry_tailable_cursor', options, function(
+        db.createCollection('should_await_data_retry_tailable_cursor', options, function (
           err,
           collection
         ) {
           test.equal(null, err);
 
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Create cursor with awaitdata, and timeout after the period specified
             var cursor = collection.find({}, { tailable: true, awaitdata: true });
             // Execute each
-            cursor.each(function(err, result) {
+            cursor.each(function (err, result) {
               if (result) {
                 cursor.kill();
               }
@@ -2191,28 +2186,28 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // http://www.mongodb.org/display/DOCS/Tailable+Cursors
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         var options = { capped: true, size: 8 };
-        db.createCollection('should_await_data_no_docs', options, function(err, collection) {
+        db.createCollection('should_await_data_no_docs', options, function (err, collection) {
           test.equal(null, err);
 
           // Create cursor with awaitdata, and timeout after the period specified
           var cursor = collection.find({}, { tailable: true, awaitdata: true });
           var rewind = cursor.rewind;
           var called = false;
-          cursor.rewind = function() {
+          cursor.rewind = function () {
             called = true;
           };
 
-          cursor.each(function(err) {
+          cursor.each(function (err) {
             if (err != null) {
               test.ok(called);
               cursor.rewind = rewind;
@@ -2231,26 +2226,26 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // http://www.mongodb.org/display/DOCS/Tailable+Cursors
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         var options = { capped: true, size: 8 };
-        db.createCollection('should_await_data_cursor_flag', options, function(err, collection) {
+        db.createCollection('should_await_data_cursor_flag', options, function (err, collection) {
           test.equal(null, err);
 
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
             // Create cursor with awaitdata, and timeout after the period specified
             var cursor = collection.find({}, {});
             cursor.addCursorFlag('tailable', true);
             cursor.addCursorFlag('awaitData', true);
-            cursor.each(function(err) {
+            cursor.each(function (err) {
               if (err != null) {
                 // Even though cursor is exhausted, should not close session
                 // unless cursor is manually closed, due to awaitdata / tailable
@@ -2300,25 +2295,25 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // http://www.mongodb.org/display/DOCS/Tailable+Cursors
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         var options = { capped: true, size: 8 };
-        db.createCollection('should_await_data', options, function(err, collection) {
+        db.createCollection('should_await_data', options, function (err, collection) {
           test.equal(null, err);
 
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Create cursor with awaitdata, and timeout after the period specified
             var cursor = collection.find({}, { tailable: true, awaitdata: true });
-            cursor.each(function(err) {
+            cursor.each(function (err) {
               if (err != null) {
                 // kill cursor b/c cursor is tailable / awaitable
                 cursor.close();
@@ -2340,7 +2335,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
       docs[0] = {
         _keywords: [
@@ -2520,29 +2515,29 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         // Insert all the docs
         var collection = db.collection('shouldCorrectExecuteExplainHonoringLimit');
-        collection.insert(docs, configuration.writeConcernMax(), function(err) {
+        collection.insert(docs, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
-          collection.ensureIndex({ _keywords: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.ensureIndex({ _keywords: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             collection
               .find({ _keywords: 'red' })
               .limit(10)
-              .toArray(function(err, result) {
+              .toArray(function (err, result) {
                 test.equal(null, err);
                 test.ok(result != null);
 
                 collection
                   .find({ _keywords: 'red' }, {})
                   .limit(10)
-                  .explain(function(err, result) {
+                  .explain(function (err, result) {
                     test.equal(null, err);
                     test.ok(result != null);
 
@@ -2562,23 +2557,23 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var doc = { name: 'camera', _keywords: ['compact', 'ii2gd', 'led', 'red', 'aet'] };
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         var collection = db.collection('shouldNotExplainWhenFalse');
-        collection.insert(doc, configuration.writeConcernMax(), function(err) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
           collection
             .find({ _keywords: 'red' })
             .limit(10)
-            .toArray(function(err, result) {
+            .toArray(function (err, result) {
               test.equal(null, err);
 
               test.equal('camera', result[0].name);
@@ -2596,10 +2591,10 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         try {
           db.collection('shouldFailToSetReadPreferenceOnCursor')
@@ -2624,14 +2619,14 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('shouldNotFailDueToStackOverflowEach', function(err, collection) {
+        db.createCollection('shouldNotFailDueToStackOverflowEach', function (err, collection) {
           test.equal(null, err);
 
           var docs = [];
@@ -2649,14 +2644,14 @@ describe('Cursor', function() {
 
           // Execute inserts
           for (i = 0; i < left; i++) {
-            collection.insert(allDocs.shift(), configuration.writeConcernMax(), function(err, d) {
+            collection.insert(allDocs.shift(), configuration.writeConcernMax(), function (err, d) {
               test.equal(null, err);
 
               left = left - 1;
               totalI = totalI + d.length;
 
               if (left === 0) {
-                collection.find({}).each(function(err, item) {
+                collection.find({}).each(function (err, item) {
                   test.equal(null, err);
                   if (item == null) {
                     test.equal(30000, total);
@@ -2680,14 +2675,14 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('shouldNotFailDueToStackOverflowToArray', function(err, collection) {
+        db.createCollection('shouldNotFailDueToStackOverflowToArray', function (err, collection) {
           test.equal(null, err);
 
           var docs = [];
@@ -2705,15 +2700,18 @@ describe('Cursor', function() {
 
           // Execute inserts
           for (i = 0; i < left; i++) {
-            setTimeout(function() {
-              collection.insert(allDocs.shift(), configuration.writeConcernMax(), function(err, d) {
+            setTimeout(function () {
+              collection.insert(allDocs.shift(), configuration.writeConcernMax(), function (
+                err,
+                d
+              ) {
                 test.equal(null, err);
 
                 left = left - 1;
                 totalI = totalI + d.length;
 
                 if (left === 0) {
-                  collection.find({}).toArray(function(err, items) {
+                  collection.find({}).toArray(function (err, items) {
                     test.equal(null, err);
 
                     test.equal(30000, items.length);
@@ -2736,10 +2734,10 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
@@ -2747,14 +2745,14 @@ describe('Cursor', function() {
         var docs = [];
         for (var i = 0; i < 100; i++) docs.push({ a: i, OrderNumber: i });
 
-        collection.insert(docs, configuration.writeConcernMax(), function(err) {
+        collection.insert(docs, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
           collection
             .find({}, { OrderNumber: 1 })
             .skip(10)
             .limit(10)
-            .toArray(function(err, items) {
+            .toArray(function (err, items) {
               test.equal(null, err);
               test.equal(10, items[0].OrderNumber);
 
@@ -2762,7 +2760,7 @@ describe('Cursor', function() {
                 .find({}, { OrderNumber: 1 })
                 .skip(10)
                 .limit(10)
-                .count(true, function(err, count) {
+                .count(true, function (err, count) {
                   test.equal(null, err);
                   test.equal(10, count);
                   client.close(done);
@@ -2780,10 +2778,10 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
@@ -2791,11 +2789,11 @@ describe('Cursor', function() {
         var docs = [];
         for (var i = 0; i < 100; i++) docs.push({ a: i, OrderNumber: i });
 
-        collection.insert(docs, configuration.writeConcernMax(), function(err) {
+        collection.insert(docs, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
           const cursor = collection.find({}, { tailable: true });
-          cursor.each(function(err) {
+          cursor.each(function (err) {
             test.ok(err instanceof Error);
             test.ok(typeof err.code === 'number');
 
@@ -2815,14 +2813,14 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
       // DOC_LINE var client = new MongoClient(new Server('localhost', 27017));
       // DOC_START
       // Establish connection to db
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
@@ -2834,16 +2832,16 @@ describe('Cursor', function() {
         }
 
         // Create a collection
-        db.createCollection('test_close_function_on_cursor_2', function(err, collection) {
+        db.createCollection('test_close_function_on_cursor_2', function (err, collection) {
           test.equal(null, err);
 
           // Insert documents into collection
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             const cursor = collection.find({});
 
-            cursor.count(function(err, count) {
+            cursor.count(function (err, count) {
               test.equal(null, err);
               test.equal(100, count);
 
@@ -2866,44 +2864,44 @@ describe('Cursor', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
       // DOC_LINE var client = new MongoClient(new Server('localhost', 27017));
       // DOC_START
       // Establish connection to db
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         var col = db.collection('count_hint');
 
-        col.insert([{ i: 1 }, { i: 2 }], { w: 1 }, function(err) {
+        col.insert([{ i: 1 }, { i: 2 }], { w: 1 }, function (err) {
           test.equal(null, err);
 
-          col.ensureIndex({ i: 1 }, function(err) {
+          col.ensureIndex({ i: 1 }, function (err) {
             test.equal(null, err);
 
-            col.find({ i: 1 }, { hint: '_id_' }).count(function(err, count) {
+            col.find({ i: 1 }, { hint: '_id_' }).count(function (err, count) {
               test.equal(null, err);
               test.equal(1, count);
 
-              col.find({}, { hint: '_id_' }).count(function(err, count) {
+              col.find({}, { hint: '_id_' }).count(function (err, count) {
                 test.equal(null, err);
                 test.equal(2, count);
 
-                col.find({ i: 1 }, { hint: 'BAD HINT' }).count(function(err) {
+                col.find({ i: 1 }, { hint: 'BAD HINT' }).count(function (err) {
                   test.ok(err != null);
 
-                  col.ensureIndex({ x: 1 }, { sparse: true }, function(err) {
+                  col.ensureIndex({ x: 1 }, { sparse: true }, function (err) {
                     test.equal(null, err);
 
-                    col.find({ i: 1 }, { hint: 'x_1' }).count(function(err, count) {
+                    col.find({ i: 1 }, { hint: 'x_1' }).count(function (err, count) {
                       test.equal(null, err);
                       test.equal(0, count);
 
-                      col.find({}, { hint: 'i_1' }).count(function(err, count) {
+                      col.find({}, { hint: 'i_1' }).count(function (err, count) {
                         test.equal(null, err);
                         test.equal(2, count);
 
@@ -2928,10 +2926,10 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
@@ -2943,15 +2941,15 @@ describe('Cursor', function() {
         }
 
         // Create a collection
-        db.createCollection('terminate_each_returning_false', function(err, collection) {
+        db.createCollection('terminate_each_returning_false', function (err, collection) {
           test.equal(null, err);
 
           // Insert documents into collection
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
             var finished = false;
 
-            collection.find({}).each(function(err, doc) {
+            collection.find({}).each(function (err, doc) {
               test.equal(null, err);
 
               if (doc) {
@@ -2975,10 +2973,10 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -2986,13 +2984,13 @@ describe('Cursor', function() {
           color: 'brown'
         };
 
-        db.collection('donkies').insertOne(donkey, function(err, result) {
+        db.collection('donkies').insertOne(donkey, function (err, result) {
           test.equal(null, err);
 
           var query = { _id: result.insertedId };
           var options = { maxTimeMS: 1000 };
 
-          db.collection('donkies').findOne(query, options, function(err, doc) {
+          db.collection('donkies').findOne(query, options, function (err, doc) {
             test.equal(null, err);
             test.equal('brown', doc.color);
 
@@ -3010,26 +3008,26 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
         const collectionName = 'should_correctly_handle_batchSize_2';
 
-        db.collection(collectionName).insert([{ x: 1 }, { x: 2 }, { x: 3 }], function(err) {
+        db.collection(collectionName).insert([{ x: 1 }, { x: 2 }, { x: 3 }], function (err) {
           test.equal(null, err);
 
           const cursor = db.collection(collectionName).find({}, { batchSize: 2 });
 
-          cursor.next(function(err) {
+          cursor.next(function (err) {
             test.equal(null, err);
 
-            cursor.next(function(err) {
+            cursor.next(function (err) {
               test.equal(null, err);
 
-              cursor.next(function(err) {
+              cursor.next(function (err) {
                 test.equal(null, err);
                 client.close(done);
               });
@@ -3043,10 +3041,10 @@ describe('Cursor', function() {
   it('Should report database name and collection name', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -3066,7 +3064,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 1000; i++) {
@@ -3076,25 +3074,25 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('Should_correctly_execute_count_on_cursor_2', function(
+        db.createCollection('Should_correctly_execute_count_on_cursor_2', function (
           err,
           collection
         ) {
           test.equal(null, err);
 
           // insert all docs
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Create a cursor for the content
             var cursor = collection.find({});
             cursor.limit(100);
             cursor.skip(10);
-            cursor.count(true, { maxTimeMS: 1000 }, function(err) {
+            cursor.count(true, { maxTimeMS: 1000 }, function (err) {
               test.equal(null, err);
 
               // Create a cursor for the content
@@ -3102,7 +3100,7 @@ describe('Cursor', function() {
               cursor.limit(100);
               cursor.skip(10);
               cursor.maxTimeMS(100);
-              cursor.count(function(err) {
+              cursor.count(function (err) {
                 test.equal(null, err);
 
                 client.close(done);
@@ -3121,7 +3119,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 1000; i++) {
@@ -3131,23 +3129,23 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('Should_correctly_execute_count_on_cursor_3', function(
+        db.createCollection('Should_correctly_execute_count_on_cursor_3', function (
           err,
           collection
         ) {
           test.equal(null, err);
 
           // insert all docs
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Create a cursor for the content
             var cursor = collection.find({}, { maxTimeMS: 100 });
-            cursor.toArray(function(err) {
+            cursor.toArray(function (err) {
               test.equal(null, err);
 
               client.close(done);
@@ -3165,7 +3163,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 1000; i++) {
@@ -3175,31 +3173,31 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var collection = db.collection('map_toArray');
 
         // insert all docs
-        collection.insert(docs, configuration.writeConcernMax(), function(err) {
+        collection.insert(docs, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
           // Create a cursor for the content
           var cursor = collection
             .find({})
-            .map(function() {
+            .map(function () {
               return { a: 1 };
             })
             .batchSize(5)
             .limit(10);
 
-          cursor.toArray(function(err, docs) {
+          cursor.toArray(function (err, docs) {
             test.equal(null, err);
             test.equal(10, docs.length);
 
             // Ensure all docs where mapped
-            docs.forEach(function(x) {
+            docs.forEach(function (x) {
               test.equal(1, x.a);
             });
 
@@ -3217,7 +3215,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 1000; i++) {
@@ -3227,26 +3225,26 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var collection = db.collection('map_next');
 
         // insert all docs
-        collection.insert(docs, configuration.writeConcernMax(), function(err) {
+        collection.insert(docs, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
           // Create a cursor for the content
           var cursor = collection
             .find({})
-            .map(function() {
+            .map(function () {
               return { a: 1 };
             })
             .batchSize(5)
             .limit(10);
 
-          cursor.next(function(err, doc) {
+          cursor.next(function (err, doc) {
             test.equal(null, err);
             test.equal(1, doc.a);
 
@@ -3266,7 +3264,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 1000; i++) {
@@ -3276,26 +3274,26 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var collection = db.collection('map_each');
 
         // insert all docs
-        collection.insert(docs, configuration.writeConcernMax(), function(err) {
+        collection.insert(docs, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
           // Create a cursor for the content
           var cursor = collection
             .find({})
-            .map(function() {
+            .map(function () {
               return { a: 1 };
             })
             .batchSize(5)
             .limit(10);
 
-          cursor.each(function(err, doc) {
+          cursor.each(function (err, doc) {
             test.equal(null, err);
 
             if (doc) {
@@ -3316,7 +3314,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 1000; i++) {
@@ -3326,33 +3324,33 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var collection = db.collection('map_forEach');
 
         // insert all docs
-        collection.insert(docs, configuration.writeConcernMax(), function(err) {
+        collection.insert(docs, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
           // Create a cursor for the content
           var cursor = collection
             .find({})
-            .map(function() {
+            .map(function () {
               return { a: 2 };
             })
-            .map(function(x) {
+            .map(function (x) {
               return { a: x.a * x.a };
             })
             .batchSize(5)
             .limit(10);
 
           cursor.forEach(
-            function(doc) {
+            function (doc) {
               test.equal(4, doc.a);
             },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               client.close(done);
             }
@@ -3369,7 +3367,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 1000; i++) {
@@ -3379,30 +3377,30 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var collection = db.collection('map_mapmapforEach');
 
         // insert all docs
-        collection.insert(docs, configuration.writeConcernMax(), function(err) {
+        collection.insert(docs, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
           // Create a cursor for the content
           var cursor = collection
             .find({})
-            .map(function() {
+            .map(function () {
               return { a: 1 };
             })
             .batchSize(5)
             .limit(10);
 
           cursor.forEach(
-            function(doc) {
+            function (doc) {
               test.equal(1, doc.a);
             },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               client.close(done);
             }
@@ -3417,10 +3415,10 @@ describe('Cursor', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -3433,7 +3431,7 @@ describe('Cursor', function() {
           ordered.insert({ a: i });
         }
 
-        ordered.execute({ w: 1 }, function(err) {
+        ordered.execute({ w: 1 }, function (err) {
           test.equal(null, err);
 
           // Let's attempt to skip and limit
@@ -3441,7 +3439,7 @@ describe('Cursor', function() {
             .find({})
             .limit(2016)
             .skip(2016)
-            .toArray(function(err, docs) {
+            .toArray(function (err, docs) {
               test.equal(null, err);
               test.equal(2016, docs.length);
 
@@ -3457,21 +3455,21 @@ describe('Cursor', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single'], mongodb: '>3.1.9' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         var options = { capped: true, size: 8 };
-        db.createCollection('should_await_data_max_awaittime_ms', options, function(
+        db.createCollection('should_await_data_max_awaittime_ms', options, function (
           err,
           collection
         ) {
           test.equal(null, err);
 
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             var s = new Date();
@@ -3482,11 +3480,11 @@ describe('Cursor', function() {
               .addCursorFlag('awaitData', true)
               .maxAwaitTimeMS(500);
 
-            cursor.each(function(err, result) {
+            cursor.each(function (err, result) {
               test.equal(null, err);
 
               if (result) {
-                setTimeout(function() {
+                setTimeout(function () {
                   cursor.kill();
                 }, 300);
               } else {
@@ -3507,10 +3505,10 @@ describe('Cursor', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -3523,16 +3521,16 @@ describe('Cursor', function() {
           ordered.insert({ a: i });
         }
 
-        ordered.execute({ w: 1 }, function(err) {
+        ordered.execute({ w: 1 }, function (err) {
           test.equal(null, err);
 
           // Let's attempt to skip and limit
           var cursor = collection.find({}).batchSize(10);
-          cursor.on('data', function() {
+          cursor.on('data', function () {
             cursor.destroy();
           });
 
-          cursor.on('close', function() {
+          cursor.on('close', function () {
             client.close(done);
           });
         });
@@ -3547,7 +3545,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 1; i++) {
@@ -3557,29 +3555,29 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('shouldCorrectlyExecuteEnsureIndexWithNoCallback', function(
+        db.createCollection('shouldCorrectlyExecuteEnsureIndexWithNoCallback', function (
           err,
           collection
         ) {
           test.equal(null, err);
 
           // ensure index of createdAt index
-          collection.ensureIndex({ createdAt: 1 }, function(err) {
+          collection.ensureIndex({ createdAt: 1 }, function (err) {
             test.equal(null, err);
 
             // insert all docs
-            collection.insert(docs, configuration.writeConcernMax(), function(err) {
+            collection.insert(docs, configuration.writeConcernMax(), function (err) {
               test.equal(null, err);
 
               // Find with sort
               collection
                 .find()
                 .sort(['createdAt', 'asc'])
-                .toArray(function(err, items) {
+                .toArray(function (err, items) {
                   test.equal(null, err);
 
                   test.equal(1, items.length);
@@ -3599,7 +3597,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
 
       for (var i = 0; i < 50; i++) {
@@ -3609,15 +3607,15 @@ describe('Cursor', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('negative_batch_size_and_limit_set', function(err, collection) {
+        db.createCollection('negative_batch_size_and_limit_set', function (err, collection) {
           test.equal(null, err);
 
           // insert all docs
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Create a cursor for the content
@@ -3625,7 +3623,7 @@ describe('Cursor', function() {
             cursor
               .limit(100)
               .skip(0)
-              .count(function(err, c) {
+              .count(function (err, c) {
                 test.equal(null, err);
                 test.equal(50, c);
 
@@ -3633,7 +3631,7 @@ describe('Cursor', function() {
                 cursor
                   .limit(100)
                   .skip(0)
-                  .toArray(function(err) {
+                  .toArray(function (err) {
                     test.equal(null, err);
                     test.equal(50, c);
 
@@ -3653,7 +3651,7 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var docs = [];
       var configuration = this.configuration;
 
@@ -3663,23 +3661,23 @@ describe('Cursor', function() {
       }
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
-        db.createCollection('Should_correctly_execute_count_on_cursor_1_', function(
+        db.createCollection('Should_correctly_execute_count_on_cursor_1_', function (
           err,
           collection
         ) {
           test.equal(null, err);
 
           // insert all docs
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Create a cursor for the content
             var cursor = collection.find({});
-            cursor.batchSize(-10).next(function(err) {
+            cursor.batchSize(-10).next(function (err) {
               test.equal(null, err);
               test.ok(cursor.cursorState.cursorId.equals(BSON.Long.ZERO));
 
@@ -3698,19 +3696,19 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var started = [];
-      var listener = require('../../src').instrument(function(err) {
+      var listener = require('../../src').instrument(function (err) {
         test.equal(null, err);
       });
 
-      listener.on('started', function(event) {
+      listener.on('started', function (event) {
         if (event.commandName === 'count') started.push(event);
       });
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -3719,7 +3717,7 @@ describe('Cursor', function() {
           .limit(5)
           .skip(5)
           .hint({ project: 1 })
-          .count(true, function(err) {
+          .count(true, function (err) {
             test.equal(null, err);
             test.equal(1, started.length);
             if (started[0].command.readConcern)
@@ -3743,20 +3741,20 @@ describe('Cursor', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var started = [];
 
-      var listener = require('../../src').instrument(function(err) {
+      var listener = require('../../src').instrument(function (err) {
         test.equal(null, err);
       });
 
-      listener.on('started', function(event) {
+      listener.on('started', function (event) {
         if (event.commandName === 'count') started.push(event);
       });
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -3770,7 +3768,7 @@ describe('Cursor', function() {
             skip: 5,
             hint: { project: 1 }
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
             test.equal(1, started.length);
             if (started[0].command.readConcern)
@@ -3796,7 +3794,7 @@ describe('Cursor', function() {
       }
     },
 
-    test: function() {
+    test: function () {
       // Load up the documents
       const docs = [];
       for (let i = 0; i < 1000; i += 1) {
@@ -3814,7 +3812,7 @@ describe('Cursor', function() {
         client
           // Connect
           .connect()
-          .then(function(client) {
+          .then(function (client) {
             cleanup = () => client.close();
             const db = client.db(configuration.db);
             const collection = db.collection('cursorkilltest1');
@@ -3881,10 +3879,10 @@ describe('Cursor', function() {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
@@ -3897,7 +3895,7 @@ describe('Cursor', function() {
         };
 
         var cursor = db.s.topology.cursor(db.namespace, findCommand, { readPreference: 42 });
-        cursor.hasNext(function(err) {
+        cursor.hasNext(function (err) {
           test.ok(err !== null);
           test.equal(err.message, 'readPreference must be a ReadPreference instance');
           done();
@@ -3915,21 +3913,21 @@ describe('Cursor', function() {
           mongodb: '>=3.6.0'
         }
       },
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
         const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
 
           const db = client.db(configuration.db);
           const collection = db.collection('cursor_session_tests');
 
-          collection.insertMany([{ a: 1, b: 2 }], function(err) {
+          collection.insertMany([{ a: 1, b: 2 }], function (err) {
             test.equal(null, err);
             const cursor = collection.find({});
 
-            cursor.next(function() {
+            cursor.next(function () {
               test.equal(client.topology.s.sessions.size, 0);
               client.close(done);
             });
@@ -3948,11 +3946,11 @@ describe('Cursor', function() {
           mongodb: '>=3.6.0'
         }
       },
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
         const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           test.equal(null, err);
 
           const db = client.db(configuration.db);
@@ -3966,16 +3964,16 @@ describe('Cursor', function() {
             { a: 9, b: 10 }
           ];
 
-          collection.insertMany(docs, function(err) {
+          collection.insertMany(docs, function (err) {
             test.equal(null, err);
             const cursor = collection.find({}, { batchSize: 3 });
-            cursor.next(function() {
+            cursor.next(function () {
               test.equal(client.topology.s.sessions.size, 1);
-              cursor.next(function() {
+              cursor.next(function () {
                 test.equal(client.topology.s.sessions.size, 1);
-                cursor.next(function() {
+                cursor.next(function () {
                   test.equal(client.topology.s.sessions.size, 1);
-                  cursor.next(function() {
+                  cursor.next(function () {
                     test.equal(client.topology.s.sessions.size, 0);
                     client.close(done);
                   });
@@ -3988,11 +3986,11 @@ describe('Cursor', function() {
     }
   );
 
-  it('should return a promise when no callback supplied to forEach method', function(done) {
+  it('should return a promise when no callback supplied to forEach method', function (done) {
     const configuration = this.configuration;
     const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
 
-    client.connect(function(err, client) {
+    client.connect(function (err, client) {
       expect(err).to.not.exist;
       const db = client.db(configuration.db);
       const collection = db.collection('cursor_session_tests2');
@@ -4006,23 +4004,23 @@ describe('Cursor', function() {
     });
   });
 
-  it('should return false when exhausted and hasNext called more than once', function(done) {
+  it('should return false when exhausted and hasNext called more than once', function (done) {
     const configuration = this.configuration;
     const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
 
-    client.connect(function(err, client) {
+    client.connect(function (err, client) {
       const db = client.db(configuration.db);
 
-      db.createCollection('cursor_hasNext_test').then(function() {
+      db.createCollection('cursor_hasNext_test').then(function () {
         const cursor = db.collection('cursor_hasNext_test').find();
 
         cursor
           .hasNext()
-          .then(function(val1) {
+          .then(function (val1) {
             expect(val1).to.equal(false);
             return cursor.hasNext();
           })
-          .then(function(val2) {
+          .then(function (val2) {
             expect(val2).to.equal(false);
             cursor.close(() => client.close(() => done()));
           })
@@ -4040,7 +4038,7 @@ describe('Cursor', function() {
     const transformFunc = config.transformFunc;
     const expectedSet = config.expectedSet;
 
-    client.connect(function(err, client) {
+    client.connect(function (err, client) {
       const db = client.db(configuration.db);
       let collection, cursor;
       const docs = [
@@ -4060,16 +4058,16 @@ describe('Cursor', function() {
         .then(_cursor => (cursor = _cursor))
         .then(() => cursor.transformStream(transformParam))
         .then(stream => {
-          stream.on('data', function(doc) {
+          stream.on('data', function (doc) {
             resultSet.add(doc);
           });
 
-          stream.once('end', function() {
+          stream.once('end', function () {
             expect(resultSet).to.deep.equal(expectedSet);
             close();
           });
 
-          stream.once('error', function(e) {
+          stream.once('error', function (e) {
             close(e);
           });
         })
@@ -4077,7 +4075,7 @@ describe('Cursor', function() {
     });
   }
 
-  it('transformStream should apply the supplied transformation function to each document in the stream', function(done) {
+  it('transformStream should apply the supplied transformation function to each document in the stream', function (done) {
     const configuration = this.configuration;
     const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
     const expectedDocs = [
@@ -4096,7 +4094,7 @@ describe('Cursor', function() {
     testTransformStream(config, done);
   });
 
-  it('transformStream should return a stream of unmodified docs if no transform function applied', function(done) {
+  it('transformStream should return a stream of unmodified docs if no transform function applied', function (done) {
     const configuration = this.configuration;
     const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
     const expectedDocs = [
@@ -4115,7 +4113,7 @@ describe('Cursor', function() {
     testTransformStream(config, done);
   });
 
-  it.skip('should apply parent read preference to count command', function(done) {
+  it.skip('should apply parent read preference to count command', function (done) {
     // NOTE: this test is skipped because mongo orchestration does not test sharded clusters
     // with secondaries. This behavior should be unit tested
 
@@ -4125,7 +4123,7 @@ describe('Cursor', function() {
       { poolSize: 1, auto_reconnect: false, connectWithNoPrimary: true }
     );
 
-    client.connect(function(err, client) {
+    client.connect(function (err, client) {
       expect(err).to.not.exist;
 
       const db = client.db(configuration.db);
@@ -4150,7 +4148,7 @@ describe('Cursor', function() {
     });
   });
 
-  it('should not consume first document on hasNext when streaming', function(done) {
+  it('should not consume first document on hasNext when streaming', function (done) {
     const configuration = this.configuration;
     const client = configuration.newClient({ w: 1 }, { poolSize: 1, auto_reconnect: false });
 
@@ -4191,8 +4189,8 @@ describe('Cursor', function() {
     });
   });
 
-  describe('transforms', function() {
-    it('should correctly apply map transform to cursor as readable stream', function(done) {
+  describe('transforms', function () {
+    it('should correctly apply map transform to cursor as readable stream', function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
       client.connect(err => {
@@ -4219,7 +4217,7 @@ describe('Cursor', function() {
       });
     });
 
-    it('should correctly apply map transform when converting cursor to array', function(done) {
+    it('should correctly apply map transform when converting cursor to array', function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
       client.connect(err => {

--- a/test/functional/cursorstream.test.js
+++ b/test/functional/cursorstream.test.js
@@ -3,8 +3,8 @@ var expect = require('chai').expect;
 const setupDatabase = require('./shared').setupDatabase;
 const { Binary } = require('../../src');
 
-describe('Cursor Streams', function() {
-  before(function() {
+describe('Cursor Streams', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -13,7 +13,7 @@ describe('Cursor Streams', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var docs = [];
       var j = 0;
@@ -31,15 +31,15 @@ describe('Cursor Streams', function() {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
-        db.createCollection('test_streaming_function_with_limit_for_fetching2', function(
+        db.createCollection('test_streaming_function_with_limit_for_fetching2', function (
           err,
           collection
         ) {
           var left = allDocs.length;
           for (var i = 0; i < allDocs.length; i++) {
-            collection.insert(allDocs[i], { w: 1 }, function(err) {
+            collection.insert(allDocs[i], { w: 1 }, function (err) {
               expect(err).to.not.exist;
 
               left = left - 1;
@@ -50,19 +50,19 @@ describe('Cursor Streams', function() {
                 var data = [];
 
                 // For each data item
-                stream.on('data', function() {
+                stream.on('data', function () {
                   data.push(1);
                   j = j + 1;
                   stream.pause();
 
-                  collection.findOne({}, function(err) {
+                  collection.findOne({}, function (err) {
                     expect(err).to.not.exist;
                     stream.resume();
                   });
                 });
 
                 // When the stream is done
-                stream.on('end', function() {
+                stream.on('end', function () {
                   setTimeout(() => {
                     let err;
                     try {
@@ -87,7 +87,7 @@ describe('Cursor Streams', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var docs = [];
 
@@ -106,15 +106,15 @@ describe('Cursor Streams', function() {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
-        db.createCollection('test_streaming_function_with_limit_for_fetching_2', function(
+        db.createCollection('test_streaming_function_with_limit_for_fetching_2', function (
           err,
           collection
         ) {
           var left = allDocs.length;
           for (var i = 0; i < allDocs.length; i++) {
-            collection.insert(allDocs[i], { w: 1 }, function(err) {
+            collection.insert(allDocs[i], { w: 1 }, function (err) {
               expect(err).to.not.exist;
               left = left - 1;
 
@@ -124,19 +124,19 @@ describe('Cursor Streams', function() {
                 var data = [];
 
                 // For each data item
-                stream.on('data', function() {
+                stream.on('data', function () {
                   j = j + 1;
                   stream.pause();
                   data.push(1);
 
-                  collection.findOne({}, function(err) {
+                  collection.findOne({}, function (err) {
                     expect(err).to.not.exist;
                     stream.resume();
                   });
                 });
 
                 // When the stream is done
-                stream.on('end', function() {
+                stream.on('end', function () {
                   setTimeout(() => {
                     let err;
                     try {
@@ -161,7 +161,7 @@ describe('Cursor Streams', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var docs = [];
       var counter = 0;
@@ -175,20 +175,20 @@ describe('Cursor Streams', function() {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
-        db.createCollection('test_streaming_function_with_limit_for_fetching_3', function(
+        db.createCollection('test_streaming_function_with_limit_for_fetching_3', function (
           err,
           collection
         ) {
-          collection.insert(docs, { w: 1 }, function(err) {
+          collection.insert(docs, { w: 1 }, function (err) {
             expect(err).to.not.exist;
 
             // Perform a find to get a cursor
             var stream = collection.find({}).stream();
 
             // For each data item
-            stream.on('data', function() {
+            stream.on('data', function () {
               counter++;
               stream.pause();
               stream.resume();
@@ -196,7 +196,7 @@ describe('Cursor Streams', function() {
             });
 
             // When the stream is done
-            stream.on('end', function() {
+            stream.on('end', function () {
               expect(counter).to.equal(1000);
               expect(counter2).to.equal(1000);
               client.close(done);
@@ -212,13 +212,13 @@ describe('Cursor Streams', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var docs = [];
 
@@ -238,7 +238,7 @@ describe('Cursor Streams', function() {
 
         var left = allDocs.length;
         for (i = 0; i < allDocs.length; i++) {
-          collection.insert(allDocs[i], { w: 1 }, function(err) {
+          collection.insert(allDocs[i], { w: 1 }, function (err) {
             expect(err).to.not.exist;
             left = left - 1;
 
@@ -247,8 +247,8 @@ describe('Cursor Streams', function() {
               // Execute find on all the documents
               var stream = cursor.stream();
 
-              stream.on('end', function() {
-                updateCollection.findOne({ id: 1 }, function(err, doc) {
+              stream.on('end', function () {
+                updateCollection.findOne({ id: 1 }, function (err, doc) {
                   expect(err).to.not.exist;
                   expect(doc.count).to.equal(2000);
 
@@ -256,14 +256,14 @@ describe('Cursor Streams', function() {
                 });
               });
 
-              stream.on('data', function() {
+              stream.on('data', function () {
                 stream.pause();
 
                 updateCollection.update(
                   { id: 1 },
                   { $inc: { count: 1 } },
                   { w: 1, upsert: true },
-                  function(err) {
+                  function (err) {
                     expect(err).to.not.exist;
                     stream.resume();
                   }
@@ -281,13 +281,13 @@ describe('Cursor Streams', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var cursor = db.collection('myCollection').find({
           timestamp: { $ltx: '1111' } // Error in query.
@@ -295,16 +295,16 @@ describe('Cursor Streams', function() {
 
         var error, streamIsClosed;
 
-        cursor.on('error', function(err) {
+        cursor.on('error', function (err) {
           error = err;
         });
 
-        cursor.on('close', function() {
+        cursor.on('close', function () {
           expect(error).to.exist;
           streamIsClosed = true;
         });
 
-        cursor.on('end', function() {
+        cursor.on('end', function () {
           expect(error).to.exist;
           expect(streamIsClosed).to.be.true;
           client.close(done);
@@ -320,13 +320,13 @@ describe('Cursor Streams', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         var docs = [];
         var received = [];
@@ -335,7 +335,7 @@ describe('Cursor Streams', function() {
           docs.push({ a: i, field: 'hello world' });
         }
 
-        db.collection('cursor_sort_stream').insertMany(docs, function(err) {
+        db.collection('cursor_sort_stream').insertMany(docs, function (err) {
           expect(err).to.not.exist;
 
           var cursor = db
@@ -344,13 +344,13 @@ describe('Cursor Streams', function() {
             .project({ a: 1 })
             .sort({ a: -1 });
 
-          cursor.on('end', function() {
+          cursor.on('end', function () {
             expect(received).to.have.length(1000);
 
             client.close(done);
           });
 
-          cursor.on('data', function(d) {
+          cursor.on('data', function (d) {
             received.push(d);
           });
         });

--- a/test/functional/custom_pk.test.js
+++ b/test/functional/custom_pk.test.js
@@ -3,8 +3,8 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const { ObjectId } = require('../../src');
 
-describe('Custom PK', function() {
-  before(function() {
+describe('Custom PK', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -13,13 +13,13 @@ describe('Custom PK', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // Custom factory (need to provide a 12 byte array);
-      var CustomPKFactory = function() {};
+      var CustomPKFactory = function () {};
       CustomPKFactory.prototype = new Object();
-      CustomPKFactory.createPk = function() {
+      CustomPKFactory.createPk = function () {
         return new ObjectId('aaaaaaaaaaaa');
       };
 
@@ -33,13 +33,13 @@ describe('Custom PK', function() {
         }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_custom_key');
 
-        collection.insert({ a: 1 }, { w: 1 }, function(err) {
+        collection.insert({ a: 1 }, { w: 1 }, function (err) {
           test.equal(null, err);
-          collection.find({ _id: new ObjectId('aaaaaaaaaaaa') }).toArray(function(err, items) {
+          collection.find({ _id: new ObjectId('aaaaaaaaaaaa') }).toArray(function (err, items) {
             test.equal(1, items.length);
 
             client.close(done);

--- a/test/functional/db.test.js
+++ b/test/functional/db.test.js
@@ -4,8 +4,8 @@ var setupDatabase = require('./shared').setupDatabase;
 const expect = require('chai').expect;
 const { Db, DBRef } = require('../../src');
 
-describe('Db', function() {
-  before(function() {
+describe('Db', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -14,7 +14,7 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Assert rename
       try {
         new Db(5);
@@ -31,31 +31,31 @@ describe('Db', function() {
       }
 
       try {
-        new Db('te$t', function() {});
+        new Db('te$t', function () {});
       } catch (err) {
         test.equal("database names cannot contain the character '$'", err.message);
       }
 
       try {
-        new Db('.test', function() {});
+        new Db('.test', function () {});
       } catch (err) {
         test.equal("database names cannot contain the character '.'", err.message);
       }
 
       try {
-        new Db('\\test', function() {});
+        new Db('\\test', function () {});
       } catch (err) {
         test.equal("database names cannot contain the character '\\'", err.message);
       }
 
       try {
-        new Db('\\test', function() {});
+        new Db('\\test', function () {});
       } catch (err) {
         test.equal("database names cannot contain the character '\\'", err.message);
       }
 
       try {
-        new Db('test test', function() {});
+        new Db('test test', function () {});
       } catch (err) {
         test.equal("database names cannot contain the character ' '", err.message);
       }
@@ -69,30 +69,30 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: true
       });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
         var count = 0;
 
-        var coll = db.collection('coll_name', function(e) {
+        var coll = db.collection('coll_name', function (e) {
           test.equal(null, e);
           count = count + 1;
         });
 
         try {
-          coll.findOne({}, null, function() {
+          coll.findOne({}, null, function () {
             //e - errors b/c findOne needs a query selector
             test.equal(1, count);
             client.close(done);
           });
         } catch (e) {
-          process.nextTick(function() {
+          process.nextTick(function () {
             test.equal(1, count);
             client.close(done);
           });
@@ -106,20 +106,20 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       let configuration = this.configuration;
       let client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: true
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         let callbackCalled = 0;
         test.equal(null, err);
         let db = client.db(configuration.db);
 
         try {
-          db.collection('collectionCallbackTest', function(e) {
+          db.collection('collectionCallbackTest', function (e) {
             callbackCalled++;
             test.equal(null, e);
             throw new Error('Erroring on purpose with a non MongoError');
@@ -137,14 +137,14 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var fs_client = configuration.newClient('mongodb://127.0.0.1:25117/test', {
         auto_reconnect: false,
         serverSelectionTimeoutMS: 10
       });
 
-      fs_client.connect(function(err) {
+      fs_client.connect(function (err) {
         test.ok(err != null);
         done();
       });
@@ -156,38 +156,38 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
-        db.dropCollection('test_resave_dbref', function() {
+        db.dropCollection('test_resave_dbref', function () {
           test.equal(null, err);
 
-          db.createCollection('test_resave_dbref', function(err, collection) {
+          db.createCollection('test_resave_dbref', function (err, collection) {
             test.equal(null, err);
 
-            collection.insert({ name: 'parent' }, { safe: true }, function(err, r) {
+            collection.insert({ name: 'parent' }, { safe: true }, function (err, r) {
               test.equal(null, err);
               test.ok(r.ops.length === 1 && r.ops[0]._id != null);
               var parent = r.ops[0];
               var child = { name: 'child', parent: new DBRef('test_resave_dbref', parent._id) };
 
-              collection.insert(child, { safe: true }, function(err) {
+              collection.insert(child, { safe: true }, function (err) {
                 test.equal(null, err);
 
-                collection.findOne({ name: 'child' }, function(err, child) {
+                collection.findOne({ name: 'child' }, function (err, child) {
                   //Child deserialized
                   test.ok(child != null);
 
-                  collection.save(child, { save: true }, function(err) {
+                  collection.save(child, { save: true }, function (err) {
                     test.equal(null, err);
 
                     collection.findOne(
                       { parent: new DBRef('test_resave_dbref', parent._id) },
-                      function(err, child) {
+                      function (err, child) {
                         test.ok(child != null); //!!!! Main test point!
                         client.close(done);
                       }
@@ -207,13 +207,13 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var _db = client.db('nonexistingdb');
 
-        _db.dropDatabase(function(err, result) {
+        _db.dropDatabase(function (err, result) {
           test.equal(null, err);
           test.equal(true, result);
 
@@ -228,14 +228,14 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(err => {
         expect(err).to.not.exist;
 
         try {
-          client.connect(function() {});
+          client.connect(function () {});
           test.ok(false);
         } catch (err) {
           client.close(done);
@@ -249,7 +249,7 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(`mongodb://127.0.0.1:27088/test`, {
         auto_reconnect: false,
@@ -258,10 +258,10 @@ describe('Db', function() {
       });
 
       // Establish connection to db
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.ok(err != null);
 
-        client.connect(function(err) {
+        client.connect(function (err) {
           test.ok(err != null);
           client.close(done);
         });
@@ -274,19 +274,19 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db1 = client.db('node972');
-        db1.collection('node972.test').insertOne({ a: 1 }, function(err) {
+        db1.collection('node972.test').insertOne({ a: 1 }, function (err) {
           test.equal(null, err);
 
-          db1.collections(function(err, collections) {
+          db1.collections(function (err, collections) {
             test.equal(null, err);
-            collections = collections.map(function(c) {
+            collections = collections.map(function (c) {
               return c.collectionName;
             });
             test.notEqual(-1, collections.indexOf('node972.test'));
@@ -302,27 +302,27 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         // Get a db we that does not have any collections
         var db1 = client.db('shouldCorrectlyUseCursorWithListCollectionsCommand');
 
         // Create a collection
-        db1.collection('test').insertOne({ a: 1 }, function(err) {
+        db1.collection('test').insertOne({ a: 1 }, function (err) {
           test.equal(null, err);
 
           // Create a collection
-          db1.collection('test1').insertOne({ a: 1 }, function() {
+          db1.collection('test1').insertOne({ a: 1 }, function () {
             test.equal(null, err);
 
             // Get listCollections filtering out the name
             var cursor = db1.listCollections({ name: 'test1' });
-            cursor.toArray(function(err, names) {
+            cursor.toArray(function (err, names) {
               test.equal(null, err);
               test.equal(1, names.length);
 
@@ -339,27 +339,27 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         // Get a db we that does not have any collections
         var db1 = client.db('shouldCorrectlyUseCursorWithListCollectionsCommandAndBatchSize');
 
         // Create a collection
-        db1.collection('test').insertOne({ a: 1 }, function(err) {
+        db1.collection('test').insertOne({ a: 1 }, function (err) {
           test.equal(null, err);
 
           // Create a collection
-          db1.collection('test1').insertOne({ a: 1 }, function() {
+          db1.collection('test1').insertOne({ a: 1 }, function () {
             test.equal(null, err);
 
             // Get listCollections filtering out the name
             var cursor = db1.listCollections({ name: 'test' }, { batchSize: 1 });
-            cursor.toArray(function(err, names) {
+            cursor.toArray(function (err, names) {
               test.equal(null, err);
               test.equal(1, names.length);
 
@@ -376,33 +376,33 @@ describe('Db', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         // Get a db we that does not have any collections
         var db1 = client.db('shouldCorrectlyListCollectionsWithDotsOnThem');
 
         // Create a collection
-        db1.collection('test.collection1').insertOne({ a: 1 }, function(err) {
+        db1.collection('test.collection1').insertOne({ a: 1 }, function (err) {
           test.equal(null, err);
 
           // Create a collection
-          db1.collection('test.collection2').insertOne({ a: 1 }, function() {
+          db1.collection('test.collection2').insertOne({ a: 1 }, function () {
             test.equal(null, err);
 
             // Get listCollections filtering out the name
             var cursor = db1.listCollections({ name: /test.collection/ });
-            cursor.toArray(function(err, names) {
+            cursor.toArray(function (err, names) {
               test.equal(null, err);
               test.equal(2, names.length);
 
               // Get listCollections filtering out the name
               var cursor = db1.listCollections({ name: 'test.collection1' }, {});
-              cursor.toArray(function(err, names) {
+              cursor.toArray(function (err, names) {
                 test.equal(null, err);
                 test.equal(1, names.length);
 
@@ -423,27 +423,27 @@ describe('Db', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         // Get a db we that does not have any collections
         var db1 = client.db('shouldCorrectlyListCollectionsWithDotsOnThemFor28');
 
         // Create a collection
-        db1.collection('test.collection1').insertOne({ a: 1 }, function(err) {
+        db1.collection('test.collection1').insertOne({ a: 1 }, function (err) {
           test.equal(null, err);
 
           // Create a collection
-          db1.collection('test.collection2').insertOne({ a: 1 }, function() {
+          db1.collection('test.collection2').insertOne({ a: 1 }, function () {
             test.equal(null, err);
 
             // Get listCollections filtering out the name
             var cursor = db1.listCollections({ name: /test.collection/ }, { batchSize: 1 });
-            cursor.toArray(function(err, names) {
+            cursor.toArray(function (err, names) {
               test.equal(null, err);
               test.equal(2, names.length);
 

--- a/test/functional/decimal128.test.js
+++ b/test/functional/decimal128.test.js
@@ -3,8 +3,8 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const { Decimal128 } = require('../../src');
 
-describe('Decimal128', function() {
-  before(function() {
+describe('Decimal128', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -18,24 +18,24 @@ describe('Decimal128', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var object = {
           id: 1,
           value: Decimal128.fromString('1')
         };
 
-        db.collection('decimal128').insertOne(object, function(err) {
+        db.collection('decimal128').insertOne(object, function (err) {
           test.equal(null, err);
 
           db.collection('decimal128').findOne(
             {
               id: 1
             },
-            function(err, doc) {
+            function (err, doc) {
               test.equal(null, err);
               test.ok(doc.value instanceof Decimal128);
               test.equal('1', doc.value.toString());

--- a/test/functional/deprecate_warning.test.js
+++ b/test/functional/deprecate_warning.test.js
@@ -13,15 +13,15 @@ const ClassWithoutLogger = utils.ClassWithoutLogger;
 const ClassWithUndefinedLogger = utils.ClassWithUndefinedLogger;
 const ensureCalledWith = utils.ensureCalledWith;
 
-describe('Deprecation Warnings', function() {
-  beforeEach(function() {
+describe('Deprecation Warnings', function () {
+  beforeEach(function () {
     this.sinon.stub(console, 'error');
   });
 
   const defaultMessage = ' is deprecated and will be removed in a later version.';
   it.skip('node --no-deprecation flag should suppress all deprecation warnings', {
     metadata: { requires: { node: '>=6.0.0' } },
-    test: function(done) {
+    test: function (done) {
       exec(
         'node --no-deprecation ./test/tools/deprecate_warning_test_program.js',
         (err, stdout, stderr) => {
@@ -36,7 +36,7 @@ describe('Deprecation Warnings', function() {
 
   it.skip('node --trace-deprecation flag should print stack trace to stderr', {
     metadata: { requires: { node: '>=6.0.0' } },
-    test: function(done) {
+    test: function (done) {
       exec(
         'node --trace-deprecation ./test/tools/deprecate_warning_test_program.js',
         (err, stdout, stderr) => {
@@ -46,10 +46,7 @@ describe('Deprecation Warnings', function() {
 
           // split stderr into separate lines, trimming the first line to just the warning message
           const split = stderr.split('\n');
-          const warning = split
-            .shift()
-            .split(')')[1]
-            .trim();
+          const warning = split.shift().split(')')[1].trim();
 
           // ensure warning message matches expected
           expect(warning).to.equal(
@@ -70,15 +67,13 @@ describe('Deprecation Warnings', function() {
 
   it.skip('node --throw-deprecation flag should throw error when deprecated function is called', {
     metadata: { requires: { node: '>=6.0.0' } },
-    test: function(done) {
+    test: function (done) {
       exec(
         'node --throw-deprecation ./test/tools/deprecate_warning_test_program.js this_arg_should_never_print',
         (err, stdout, stderr) => {
           expect(stderr).to.not.be.empty;
           expect(err).to.not.be.null;
-          expect(err)
-            .to.have.own.property('code')
-            .that.equals(1);
+          expect(err).to.have.own.property('code').that.equals(1);
 
           // ensure stdout is empty, i.e. that the program threw an error before reaching the console.log statement
           expect(stdout).to.be.empty;
@@ -88,7 +83,7 @@ describe('Deprecation Warnings', function() {
     }
   });
 
-  it('test behavior for classes with an associated logger', function() {
+  it('test behavior for classes with an associated logger', function () {
     const fakeClass = new ClassWithLogger();
     const logger = fakeClass.getLogger();
     const stub = sinon.stub(logger, 'warn');
@@ -102,7 +97,7 @@ describe('Deprecation Warnings', function() {
     ]);
   });
 
-  it('test behavior for classes without an associated logger', function() {
+  it('test behavior for classes without an associated logger', function () {
     const fakeClass = new ClassWithoutLogger();
 
     function func() {
@@ -112,7 +107,7 @@ describe('Deprecation Warnings', function() {
     expect(func).to.not.throw();
   });
 
-  it('test behavior for classes with an undefined logger', function() {
+  it('test behavior for classes with an undefined logger', function () {
     const fakeClass = new ClassWithUndefinedLogger();
 
     function func() {

--- a/test/functional/document_validation.test.js
+++ b/test/functional/document_validation.test.js
@@ -2,8 +2,8 @@
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-describe('Document Validation', function() {
-  before(function() {
+describe('Document Validation', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -17,10 +17,10 @@ describe('Document Validation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -28,28 +28,28 @@ describe('Document Validation', function() {
         var col = db.collection('createValidationCollection');
 
         // Drop the collection
-        col.drop(function() {
+        col.drop(function () {
           // Create a collection with a validator
           db.createCollection(
             'createValidationCollection',
             { validator: { a: { $exists: true } } },
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Ensure validation was correctly applied
-              col.insert({ b: 1 }, function(err) {
+              col.insert({ b: 1 }, function (err) {
                 test.ok(err != null);
 
                 // Ensure validation was correctly applied
-                col.insert({ b: 1 }, { bypassDocumentValidation: true }, function(err) {
+                col.insert({ b: 1 }, { bypassDocumentValidation: true }, function (err) {
                   test.equal(null, err);
 
                   // Bypass valiation on insert
-                  col.insertOne({ b: 1 }, { bypassDocumentValidation: true }, function(err) {
+                  col.insertOne({ b: 1 }, { bypassDocumentValidation: true }, function (err) {
                     test.equal(null, err);
 
                     // Bypass valiation on insert
-                    col.insertMany([{ b: 1 }], { bypassDocumentValidation: true }, function(err) {
+                    col.insertMany([{ b: 1 }], { bypassDocumentValidation: true }, function (err) {
                       test.equal(null, err);
 
                       client.close(done);
@@ -74,10 +74,10 @@ describe('Document Validation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -85,16 +85,16 @@ describe('Document Validation', function() {
         var col = db.collection('createValidationCollection');
 
         // Drop the collection
-        col.drop(function() {
+        col.drop(function () {
           // Create a collection with a validator
           db.createCollection(
             'createValidationCollection',
             { validator: { a: { $exists: true } } },
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Should fail
-              col.update({ b: 1 }, { $set: { b: 1 } }, { upsert: true }, function(err) {
+              col.update({ b: 1 }, { $set: { b: 1 } }, { upsert: true }, function (err) {
                 test.ok(err != null);
 
                 // Ensure validation was correctly applied
@@ -102,7 +102,7 @@ describe('Document Validation', function() {
                   { b: 1 },
                   { $set: { b: 1 } },
                   { upsert: true, bypassDocumentValidation: true },
-                  function(err) {
+                  function (err) {
                     test.equal(null, err);
 
                     // updateOne
@@ -110,7 +110,7 @@ describe('Document Validation', function() {
                       { c: 1 },
                       { $set: { c: 1 } },
                       { upsert: true, bypassDocumentValidation: true },
-                      function(err) {
+                      function (err) {
                         test.equal(null, err);
 
                         // updateMany
@@ -118,7 +118,7 @@ describe('Document Validation', function() {
                           { d: 1 },
                           { $set: { d: 1 } },
                           { upsert: true, bypassDocumentValidation: true },
-                          function(err) {
+                          function (err) {
                             test.equal(null, err);
 
                             // updateMany
@@ -126,7 +126,7 @@ describe('Document Validation', function() {
                               { e: 1 },
                               { e: 1 },
                               { upsert: true, bypassDocumentValidation: true },
-                              function(err) {
+                              function (err) {
                                 test.equal(null, err);
 
                                 client.close(done);
@@ -156,10 +156,10 @@ describe('Document Validation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -167,22 +167,22 @@ describe('Document Validation', function() {
         var col = db.collection('createValidationCollection');
 
         // Drop the collection
-        col.drop(function() {
+        col.drop(function () {
           // Create a collection with a validator
           db.createCollection(
             'createValidationCollection',
             { validator: { a: { $exists: true } } },
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Should fail
-              col.bulkWrite([{ insertOne: { b: 1 } }], function(err) {
+              col.bulkWrite([{ insertOne: { b: 1 } }], function (err) {
                 test.ok(err != null);
 
                 col.bulkWrite(
                   [{ insertOne: { b: 1 } }],
                   { bypassDocumentValidation: true },
-                  function(err) {
+                  function (err) {
                     test.equal(null, err);
 
                     client.close(done);
@@ -206,10 +206,10 @@ describe('Document Validation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -217,16 +217,16 @@ describe('Document Validation', function() {
         var col = db.collection('createValidationCollection');
 
         // Drop the collection
-        col.drop(function() {
+        col.drop(function () {
           // Create a collection with a validator
           db.createCollection(
             'createValidationCollection',
             { validator: { a: { $exists: true } } },
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Should fail
-              col.findOneAndUpdate({ b: 1 }, { $set: { b: 1 } }, { upsert: true }, function(err) {
+              col.findOneAndUpdate({ b: 1 }, { $set: { b: 1 } }, { upsert: true }, function (err) {
                 test.ok(err != null);
 
                 // Should pass
@@ -234,7 +234,7 @@ describe('Document Validation', function() {
                   { b: 1 },
                   { $set: { b: 1 } },
                   { upsert: true, bypassDocumentValidation: true },
-                  function(err) {
+                  function (err) {
                     test.equal(null, err);
 
                     // Should pass
@@ -242,7 +242,7 @@ describe('Document Validation', function() {
                       { c: 1 },
                       { c: 1 },
                       { upsert: true, bypassDocumentValidation: true },
-                      function(err) {
+                      function (err) {
                         test.equal(null, err);
 
                         client.close(done);
@@ -268,10 +268,10 @@ describe('Document Validation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Some docs for insertion
         var docs = [
@@ -293,16 +293,16 @@ describe('Document Validation', function() {
         var col = db.collection('createValidationCollectionOut');
 
         // Drop the collection
-        col.drop(function() {
+        col.drop(function () {
           // Create a collection with a validator
           db.createCollection(
             'createValidationCollectionOut',
             { validator: { a: { $exists: true } } },
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Insert the docs
-              col.insertMany(docs, { w: 1, bypassDocumentValidation: true }, function(err) {
+              col.insertMany(docs, { w: 1, bypassDocumentValidation: true }, function (err) {
                 test.equal(null, err);
 
                 // Execute aggregate, notice the pipeline is expressed as an Array
@@ -326,7 +326,7 @@ describe('Document Validation', function() {
                   { bypassDocumentValidation: true }
                 );
 
-                cursor.toArray(function(err) {
+                cursor.toArray(function (err) {
                   test.equal(null, err);
 
                   client.close(done);
@@ -349,22 +349,22 @@ describe('Document Validation', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         // Get collection
         var col = db.collection('createValidationCollectionOut');
 
         // Drop the collection
-        col.drop(function() {
+        col.drop(function () {
           // Create a collection with a validator
           db.createCollection(
             'createValidationCollectionOut',
             { validator: { a: { $exists: true } } },
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Get write concern
@@ -375,7 +375,7 @@ describe('Document Validation', function() {
               col.insertMany(
                 [{ user_id: 1 }, { user_id: 2 }],
                 { bypassDocumentValidation: true },
-                function(err) {
+                function (err) {
                   test.equal(null, err);
 
                   // String functions
@@ -389,7 +389,7 @@ describe('Document Validation', function() {
                       out: { replace: 'createValidationCollectionOut' },
                       bypassDocumentValidation: true
                     },
-                    function(err) {
+                    function (err) {
                       test.equal(null, err);
 
                       client.close(done);

--- a/test/functional/domain.test.js
+++ b/test/functional/domain.test.js
@@ -2,8 +2,8 @@
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-describe('Domains', function() {
-  before(function() {
+describe('Domains', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -12,7 +12,7 @@ describe('Domains', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var Domain = require('domain');
       var domainInstance = Domain.create();
       var configuration = this.configuration;
@@ -20,13 +20,13 @@ describe('Domains', function() {
         poolSize: 1,
         domainsEnabled: true
       });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.ok(!err);
         var collection = db.collection('test');
 
-        domainInstance.run(function() {
-          collection.count({}, function(err) {
+        domainInstance.run(function () {
+          collection.count({}, function (err) {
             test.ok(!err);
             test.ok(domainInstance === process.domain);
             domainInstance.exit();
@@ -42,18 +42,18 @@ describe('Domains', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var Domain = require('domain');
       var domainInstance = Domain.create();
 
       const client = configuration.newClient({}, { domainsEnabled: true });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.ok(!err);
         var db = client.db(configuration.db);
         var collection = db.collection('test');
-        domainInstance.run(function() {
-          collection.count({}, function(err) {
+        domainInstance.run(function () {
+          collection.count({}, function (err) {
             test.ok(!err);
             test.ok(domainInstance === process.domain);
             domainInstance.exit();
@@ -69,7 +69,7 @@ describe('Domains', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var Domain = require('domain');
       var domainInstance = Domain.create();
       var configuration = this.configuration;
@@ -78,12 +78,12 @@ describe('Domains', function() {
         { poolSize: 1, auto_reconnect: true, domainsEnabled: true }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.ok(!err);
         var db = client.db(configuration.db);
         var collection = db.collection('test');
-        domainInstance.run(function() {
-          collection.insert({ field: 123 }, function(err) {
+        domainInstance.run(function () {
+          collection.insert({ field: 123 }, function (err) {
             test.ok(!err);
             test.ok(domainInstance === process.domain);
             domainInstance.exit();

--- a/test/functional/error.test.js
+++ b/test/functional/error.test.js
@@ -5,21 +5,21 @@ const expect = chai.expect;
 const sinonChai = require('sinon-chai');
 chai.use(sinonChai);
 
-describe('Errors', function() {
-  before(function() {
+describe('Errors', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   let client;
-  beforeEach(function() {
+  beforeEach(function () {
     client = this.configuration.newClient(this.configuration.writeConcernMax(), { poolSize: 1 });
     return client.connect();
   });
-  afterEach(function() {
+  afterEach(function () {
     return client.close();
   });
 
-  it('should fail insert due to unique index', function(done) {
+  it('should fail insert due to unique index', function (done) {
     const db = client.db(this.configuration.db);
     const collection = db.collection('test_failing_insert_due_to_unique_index');
     collection.createIndexes(
@@ -46,7 +46,7 @@ describe('Errors', function() {
     );
   });
 
-  it('should fail insert due to unique index strict', function(done) {
+  it('should fail insert due to unique index strict', function (done) {
     const db = client.db(this.configuration.db);
     db.dropCollection('test_failing_insert_due_to_unique_index_strict', () => {
       db.createCollection('test_failing_insert_due_to_unique_index_strict', err => {
@@ -85,7 +85,7 @@ describe('Errors', function() {
 
   it('should return an error object with message when mixing included and excluded fields', {
     metadata: { requires: { mongodb: '>3.0' } },
-    test: function(done) {
+    test: function (done) {
       const db = client.db(this.configuration.db);
       const c = db.collection('test_error_object_should_include_message');
       c.insertOne({ a: 2, b: 5 }, { w: 1 }, err => {
@@ -100,7 +100,7 @@ describe('Errors', function() {
 
   it('should handle error throw in user callback', {
     metadata: { requires: { mongodb: '>3.0' } },
-    test: function(done) {
+    test: function (done) {
       const db = client.db(this.configuration.db);
       const c = db.collection('test_error_object_should_include_message');
       c.findOne({}, { fields: { a: 1, b: 0 } }, err => {

--- a/test/functional/find.test.js
+++ b/test/functional/find.test.js
@@ -5,8 +5,8 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const { Code, ObjectId, Long, Binary } = require('../../src');
 
-describe('Find', function() {
-  before(function() {
+describe('Find', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -18,31 +18,31 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.collection('test_find_simple', function(err, collection) {
+        db.collection('test_find_simple', function (err, collection) {
           var doc1 = null;
 
           // Insert some test documents
-          collection.insert([{ a: 2 }, { b: 3 }], configuration.writeConcernMax(), function(
+          collection.insert([{ a: 2 }, { b: 3 }], configuration.writeConcernMax(), function (
             err,
             r
           ) {
             doc1 = r.ops[0];
 
             // Ensure correct insertion testing via the cursor and the count function
-            collection.find().toArray(function(err, documents) {
+            collection.find().toArray(function (err, documents) {
               expect(err).to.not.exist;
               test.equal(2, documents.length);
 
-              collection.count(function(err, count) {
+              collection.count(function (err, count) {
                 test.equal(2, count);
 
                 // Fetch values by selection
-                collection.find({ a: doc1.a }).toArray(function(err, documents) {
+                collection.find({ a: doc1.a }).toArray(function (err, documents) {
                   test.equal(1, documents.length);
                   test.equal(doc1.a, documents[0].a);
                   // Let's close the db
@@ -64,32 +64,32 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_simple_chained', function(err) {
+        db.createCollection('test_find_simple_chained', function (err) {
           test.equal(null, err);
-          db.collection('test_find_simple_chained', function(err, collection) {
+          db.collection('test_find_simple_chained', function (err, collection) {
             var doc1 = null;
 
             // Insert some test documents
-            collection.insert([{ a: 2 }, { b: 3 }], configuration.writeConcernMax(), function(
+            collection.insert([{ a: 2 }, { b: 3 }], configuration.writeConcernMax(), function (
               err,
               r
             ) {
               doc1 = r.ops[0];
 
               // Ensure correct insertion testing via the cursor and the count function
-              collection.find().toArray(function(err, documents) {
+              collection.find().toArray(function (err, documents) {
                 test.equal(2, documents.length);
 
-                collection.count(function(err, count) {
+                collection.count(function (err, count) {
                   test.equal(2, count);
 
                   // Fetch values by selection
-                  collection.find({ a: doc1.a }).toArray(function(err, documents) {
+                  collection.find({ a: doc1.a }).toArray(function (err, documents) {
                     test.equal(1, documents.length);
                     test.equal(doc1.a, documents[0].a);
                     // Let's close the db
@@ -112,91 +112,92 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_find_advanced');
 
         // Insert some test documents
-        collection.insert([{ a: 1 }, { a: 2 }, { b: 3 }], configuration.writeConcernMax(), function(
-          err,
-          r
-        ) {
-          var doc1 = r.ops[0],
-            doc2 = r.ops[1];
+        collection.insert(
+          [{ a: 1 }, { a: 2 }, { b: 3 }],
+          configuration.writeConcernMax(),
+          function (err, r) {
+            var doc1 = r.ops[0],
+              doc2 = r.ops[1];
 
-          // Locate by less than
-          collection.find({ a: { $lt: 10 } }).toArray(function(err, documents) {
-            test.equal(2, documents.length);
-            // Check that the correct documents are returned
-            var results = [];
-            // Check that we have all the results we want
-            documents.forEach(function(doc) {
-              if (doc.a === 1 || doc.a === 2) results.push(1);
-            });
-            test.equal(2, results.length);
+            // Locate by less than
+            collection.find({ a: { $lt: 10 } }).toArray(function (err, documents) {
+              test.equal(2, documents.length);
+              // Check that the correct documents are returned
+              var results = [];
+              // Check that we have all the results we want
+              documents.forEach(function (doc) {
+                if (doc.a === 1 || doc.a === 2) results.push(1);
+              });
+              test.equal(2, results.length);
 
-            // Locate by greater than
-            collection.find({ a: { $gt: 1 } }).toArray(function(err, documents) {
-              test.equal(1, documents.length);
-              test.equal(2, documents[0].a);
-
-              // Locate by less than or equal to
-              collection.find({ a: { $lte: 1 } }).toArray(function(err, documents) {
+              // Locate by greater than
+              collection.find({ a: { $gt: 1 } }).toArray(function (err, documents) {
                 test.equal(1, documents.length);
-                test.equal(1, documents[0].a);
+                test.equal(2, documents[0].a);
 
-                // Locate by greater than or equal to
-                collection.find({ a: { $gte: 1 } }).toArray(function(err, documents) {
-                  test.equal(2, documents.length);
-                  // Check that the correct documents are returned
-                  var results = [];
-                  // Check that we have all the results we want
-                  documents.forEach(function(doc) {
-                    if (doc.a === 1 || doc.a === 2) results.push(1);
-                  });
-                  test.equal(2, results.length);
+                // Locate by less than or equal to
+                collection.find({ a: { $lte: 1 } }).toArray(function (err, documents) {
+                  test.equal(1, documents.length);
+                  test.equal(1, documents[0].a);
 
-                  // Locate by between
-                  collection.find({ a: { $gt: 1, $lt: 3 } }).toArray(function(err, documents) {
-                    test.equal(1, documents.length);
-                    test.equal(2, documents[0].a);
+                  // Locate by greater than or equal to
+                  collection.find({ a: { $gte: 1 } }).toArray(function (err, documents) {
+                    test.equal(2, documents.length);
+                    // Check that the correct documents are returned
+                    var results = [];
+                    // Check that we have all the results we want
+                    documents.forEach(function (doc) {
+                      if (doc.a === 1 || doc.a === 2) results.push(1);
+                    });
+                    test.equal(2, results.length);
 
-                    // Locate in clause
-                    collection.find({ a: { $in: [1, 2] } }).toArray(function(err, documents) {
-                      test.equal(2, documents.length);
-                      // Check that the correct documents are returned
-                      var results = [];
-                      // Check that we have all the results we want
-                      documents.forEach(function(doc) {
-                        if (doc.a === 1 || doc.a === 2) results.push(1);
-                      });
-                      test.equal(2, results.length);
+                    // Locate by between
+                    collection.find({ a: { $gt: 1, $lt: 3 } }).toArray(function (err, documents) {
+                      test.equal(1, documents.length);
+                      test.equal(2, documents[0].a);
 
-                      // Locate in _id clause
-                      collection
-                        .find({ _id: { $in: [doc1['_id'], doc2['_id']] } })
-                        .toArray(function(err, documents) {
-                          test.equal(2, documents.length);
-                          // Check that the correct documents are returned
-                          var results = [];
-                          // Check that we have all the results we want
-                          documents.forEach(function(doc) {
-                            if (doc.a === 1 || doc.a === 2) results.push(1);
-                          });
-                          test.equal(2, results.length);
-                          // Let's close the db
-                          client.close(done);
+                      // Locate in clause
+                      collection.find({ a: { $in: [1, 2] } }).toArray(function (err, documents) {
+                        test.equal(2, documents.length);
+                        // Check that the correct documents are returned
+                        var results = [];
+                        // Check that we have all the results we want
+                        documents.forEach(function (doc) {
+                          if (doc.a === 1 || doc.a === 2) results.push(1);
                         });
+                        test.equal(2, results.length);
+
+                        // Locate in _id clause
+                        collection
+                          .find({ _id: { $in: [doc1['_id'], doc2['_id']] } })
+                          .toArray(function (err, documents) {
+                            test.equal(2, documents.length);
+                            // Check that the correct documents are returned
+                            var results = [];
+                            // Check that we have all the results we want
+                            documents.forEach(function (doc) {
+                              if (doc.a === 1 || doc.a === 2) results.push(1);
+                            });
+                            test.equal(2, results.length);
+                            // Let's close the db
+                            client.close(done);
+                          });
+                      });
                     });
                   });
                 });
               });
             });
-          });
-        });
+          }
+        );
       });
     }
   });
@@ -209,15 +210,15 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_sorting', function(err) {
+        db.createCollection('test_find_sorting', function (err) {
           test.equal(null, err);
 
-          db.collection('test_find_sorting', function(err, collection) {
+          db.collection('test_find_sorting', function (err, collection) {
             // Insert some test documents
             collection.insert(
               [
@@ -227,13 +228,13 @@ describe('Find', function() {
                 { a: 4, b: 1 }
               ],
               configuration.writeConcernMax(),
-              function(err) {
+              function (err) {
                 test.equal(null, err);
 
                 // Test sorting (ascending)
                 collection
                   .find({ a: { $lt: 10 } }, { sort: [['a', 1]] })
-                  .toArray(function(err, documents) {
+                  .toArray(function (err, documents) {
                     test.equal(4, documents.length);
                     test.equal(1, documents[0].a);
                     test.equal(2, documents[1].a);
@@ -243,7 +244,7 @@ describe('Find', function() {
                     // Test sorting (descending)
                     collection
                       .find({ a: { $lt: 10 } }, { sort: [['a', -1]] })
-                      .toArray(function(err, documents) {
+                      .toArray(function (err, documents) {
                         test.equal(4, documents.length);
                         test.equal(4, documents[0].a);
                         test.equal(3, documents[1].a);
@@ -253,7 +254,7 @@ describe('Find', function() {
                         // Test sorting (descending), sort is hash
                         collection
                           .find({ a: { $lt: 10 } }, { sort: { a: -1 } })
-                          .toArray(function(err, documents) {
+                          .toArray(function (err, documents) {
                             test.equal(4, documents.length);
                             test.equal(4, documents[0].a);
                             test.equal(3, documents[1].a);
@@ -263,7 +264,7 @@ describe('Find', function() {
                             // Sorting using array of names, assumes ascending order
                             collection
                               .find({ a: { $lt: 10 } }, { sort: ['a'] })
-                              .toArray(function(err, documents) {
+                              .toArray(function (err, documents) {
                                 test.equal(4, documents.length);
                                 test.equal(1, documents[0].a);
                                 test.equal(2, documents[1].a);
@@ -273,7 +274,7 @@ describe('Find', function() {
                                 // Sorting using single name, assumes ascending order
                                 collection
                                   .find({ a: { $lt: 10 } }, { sort: 'a' })
-                                  .toArray(function(err, documents) {
+                                  .toArray(function (err, documents) {
                                     test.equal(4, documents.length);
                                     test.equal(1, documents[0].a);
                                     test.equal(2, documents[1].a);
@@ -283,7 +284,7 @@ describe('Find', function() {
                                     // Sorting using single name, assumes ascending order, sort is hash
                                     collection
                                       .find({ a: { $lt: 10 } }, { sort: { a: 1 } })
-                                      .toArray(function(err, documents) {
+                                      .toArray(function (err, documents) {
                                         test.equal(4, documents.length);
                                         test.equal(1, documents[0].a);
                                         test.equal(2, documents[1].a);
@@ -292,7 +293,7 @@ describe('Find', function() {
 
                                         collection
                                           .find({ a: { $lt: 10 } }, { sort: ['b', 'a'] })
-                                          .toArray(function(err, documents) {
+                                          .toArray(function (err, documents) {
                                             test.equal(4, documents.length);
                                             test.equal(2, documents[0].a);
                                             test.equal(4, documents[1].a);
@@ -302,14 +303,14 @@ describe('Find', function() {
                                             // Sorting using empty array, no order guarantee should not blow up
                                             collection
                                               .find({ a: { $lt: 10 } }, { sort: [] })
-                                              .toArray(function(err, documents) {
+                                              .toArray(function (err, documents) {
                                                 test.equal(4, documents.length);
 
                                                 /* NONACTUAL */
                                                 // Sorting using ordered hash
                                                 collection
                                                   .find({ a: { $lt: 10 } }, { sort: { a: -1 } })
-                                                  .toArray(function(err, documents) {
+                                                  .toArray(function (err, documents) {
                                                     // Fail test if not an error
                                                     test.equal(4, documents.length);
                                                     // Let's close the db
@@ -339,39 +340,39 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_limits', function(err) {
+        db.createCollection('test_find_limits', function (err) {
           test.equal(null, err);
 
-          db.collection('test_find_limits', function(err, collection) {
+          db.collection('test_find_limits', function (err, collection) {
             // Insert some test documents
             collection.insert(
               [{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }],
               configuration.writeConcernMax(),
-              function(err) {
+              function (err) {
                 test.equal(null, err);
 
                 // Test limits
-                collection.find({}, { limit: 1 }).toArray(function(err, documents) {
+                collection.find({}, { limit: 1 }).toArray(function (err, documents) {
                   test.equal(1, documents.length);
 
-                  collection.find({}, { limit: 2 }).toArray(function(err, documents) {
+                  collection.find({}, { limit: 2 }).toArray(function (err, documents) {
                     test.equal(2, documents.length);
 
-                    collection.find({}, { limit: 3 }).toArray(function(err, documents) {
+                    collection.find({}, { limit: 3 }).toArray(function (err, documents) {
                       test.equal(3, documents.length);
 
-                      collection.find({}, { limit: 4 }).toArray(function(err, documents) {
+                      collection.find({}, { limit: 4 }).toArray(function (err, documents) {
                         test.equal(4, documents.length);
 
-                        collection.find({}, {}).toArray(function(err, documents) {
+                        collection.find({}, {}).toArray(function (err, documents) {
                           test.equal(4, documents.length);
 
-                          collection.find({}, { limit: 99 }).toArray(function(err, documents) {
+                          collection.find({}, { limit: 99 }).toArray(function (err, documents) {
                             test.equal(4, documents.length);
                             // Let's close the db
                             client.close(done);
@@ -397,15 +398,15 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_non_quoted_values', function(err) {
+        db.createCollection('test_find_non_quoted_values', function (err) {
           test.equal(null, err);
 
-          db.collection('test_find_non_quoted_values', function(err, collection) {
+          db.collection('test_find_non_quoted_values', function (err, collection) {
             // insert test document
             collection.insert(
               [
@@ -413,9 +414,9 @@ describe('Find', function() {
                 { a: '19', b: 'teststring', c: 3984929 }
               ],
               configuration.writeConcernMax(),
-              function(err) {
+              function (err) {
                 test.equal(null, err);
-                collection.find({ a: 19 }).toArray(function(err, documents) {
+                collection.find({ a: 19 }).toArray(function (err, documents) {
                   test.equal(1, documents.length);
                   client.close(done);
                 });
@@ -435,15 +436,15 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_embedded_document', function(err) {
+        db.createCollection('test_find_embedded_document', function (err) {
           test.equal(null, err);
 
-          db.collection('test_find_embedded_document', function(err, collection) {
+          db.collection('test_find_embedded_document', function (err, collection) {
             // insert test document
             collection.insert(
               [
@@ -451,16 +452,16 @@ describe('Find', function() {
                 { a: { id: 11, value: 'foo' }, b: 'bar2', c: { id: 20, value: 'foobar' } }
               ],
               configuration.writeConcernMax(),
-              function(err) {
+              function (err) {
                 test.equal(null, err);
 
                 // test using integer value
-                collection.find({ 'a.id': 10 }).toArray(function(err, documents) {
+                collection.find({ 'a.id': 10 }).toArray(function (err, documents) {
                   test.equal(1, documents.length);
                   test.equal('bar', documents[0].b);
 
                   // test using string value
-                  collection.find({ 'a.value': 'foo' }).toArray(function(err, documents) {
+                  collection.find({ 'a.value': 'foo' }).toArray(function (err, documents) {
                     // should yield 2 documents
                     test.equal(2, documents.length);
                     test.equal('bar', documents[0].b);
@@ -484,16 +485,16 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_one_no_records', function(err) {
+        db.createCollection('test_find_one_no_records', function (err) {
           test.equal(null, err);
-          db.collection('test_find_one_no_records', function(err, collection) {
+          db.collection('test_find_one_no_records', function (err, collection) {
             test.equal(null, err);
-            collection.find({ a: 1 }, {}).toArray(function(err, documents) {
+            collection.find({ a: 1 }, {}).toArray(function (err, documents) {
               test.equal(0, documents.length);
               // Let's close the db
               client.close(done);
@@ -512,29 +513,29 @@ describe('Find', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_where', function(err, collection) {
+        db.createCollection('test_where', function (err, collection) {
           collection.insert(
             [{ a: 1 }, { a: 2 }, { a: 3 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
-              collection.count(function(err, count) {
+              collection.count(function (err, count) {
                 test.equal(null, err);
                 test.equal(3, count);
 
                 // Let's test usage of the $where statement
-                collection.find({ $where: new Code('this.a > 2') }).count(function(err, count) {
+                collection.find({ $where: new Code('this.a > 2') }).count(function (err, count) {
                   test.equal(null, err);
                   test.equal(1, count);
 
                   collection
                     .find({ $where: new Code('this.a > i', { i: 1 }) })
-                    .count(function(err, count) {
+                    .count(function (err, count) {
                       test.equal(null, err);
                       test.equal(2, count);
 
@@ -555,48 +556,48 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_hint', function(err, collection) {
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+        db.createCollection('test_hint', function (err, collection) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
             db.createIndex(
               collection.collectionName,
               'a',
               configuration.writeConcernMax(),
-              function(err) {
+              function (err) {
                 test.equal(null, err);
-                collection.find({ a: 1 }, { hint: 'a' }).toArray(function(err) {
+                collection.find({ a: 1 }, { hint: 'a' }).toArray(function (err) {
                   test.ok(err != null);
 
-                  collection.find({ a: 1 }, { hint: ['a'] }).toArray(function(err, items) {
+                  collection.find({ a: 1 }, { hint: ['a'] }).toArray(function (err, items) {
                     test.equal(1, items.length);
 
-                    collection.find({ a: 1 }, { hint: { a: 1 } }).toArray(function(err, items) {
+                    collection.find({ a: 1 }, { hint: { a: 1 } }).toArray(function (err, items) {
                       test.equal(1, items.length);
 
                       // Modify hints
                       collection.hint = 'a_1';
                       test.equal('a_1', collection.hint);
-                      collection.find({ a: 1 }).toArray(function(err, items) {
+                      collection.find({ a: 1 }).toArray(function (err, items) {
                         test.equal(1, items.length);
 
                         collection.hint = ['a'];
                         test.equal(1, collection.hint['a']);
-                        collection.find({ a: 1 }).toArray(function(err, items) {
+                        collection.find({ a: 1 }).toArray(function (err, items) {
                           test.equal(1, items.length);
 
                           collection.hint = { a: 1 };
                           test.equal(1, collection.hint['a']);
-                          collection.find({ a: 1 }).toArray(function(err, items) {
+                          collection.find({ a: 1 }).toArray(function (err, items) {
                             test.equal(1, items.length);
 
                             collection.hint = null;
                             test.ok(collection.hint == null);
-                            collection.find({ a: 1 }).toArray(function(err, items) {
+                            collection.find({ a: 1 }).toArray(function (err, items) {
                               test.equal(1, items.length);
                               // Let's close the db
                               client.close(done);
@@ -620,24 +621,24 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_by_oid', function(err, collection) {
-          collection.save({ hello: 'mike' }, configuration.writeConcernMax(), function(err, r) {
+        db.createCollection('test_find_by_oid', function (err, collection) {
+          collection.save({ hello: 'mike' }, configuration.writeConcernMax(), function (err, r) {
             var docs = r.ops[0];
             test.ok(
               docs._id instanceof ObjectId ||
                 Object.prototype.toString.call(docs._id) === '[object ObjectId]'
             );
 
-            collection.findOne({ _id: docs._id }, function(err, doc) {
+            collection.findOne({ _id: docs._id }, function (err, doc) {
               test.equal('mike', doc.hello);
 
               var id = doc._id.toString();
-              collection.findOne({ _id: new ObjectId(id) }, function(err, doc) {
+              collection.findOne({ _id: new ObjectId(id) }, function (err, doc) {
                 test.equal('mike', doc.hello);
                 // Let's close the db
                 client.close(done);
@@ -654,12 +655,12 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_by_oid_with_subdocs', function(err, collection) {
+        db.createCollection('test_find_by_oid_with_subdocs', function (err, collection) {
           var c1 = { _id: new ObjectId(), comments: [], title: 'number 1' };
           var c2 = { _id: new ObjectId(), comments: [], title: 'number 2' };
           var doc = {
@@ -669,9 +670,9 @@ describe('Find', function() {
             _id: new ObjectId()
           };
 
-          collection.insert(doc, configuration.writeConcernMax(), function(err) {
+          collection.insert(doc, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
-            collection.findOne({ _id: doc._id }, { w: 1, fields: undefined }, function(err, doc) {
+            collection.findOne({ _id: doc._id }, { w: 1, fields: undefined }, function (err, doc) {
               expect(err).to.not.exist;
               test.equal(2, doc.comments.length);
               test.equal('number 1', doc.comments[0].title);
@@ -690,24 +691,27 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var p_client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      p_client.connect(function(err, client) {
+      p_client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
-        db.createCollection('test_should_correctly_retrieve_one_record', function(err, collection) {
-          collection.insert({ a: 0 }, configuration.writeConcernMax(), function(err) {
+        db.createCollection('test_should_correctly_retrieve_one_record', function (
+          err,
+          collection
+        ) {
+          collection.insert({ a: 0 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
-            db.collection('test_should_correctly_retrieve_one_record', function(
+            db.collection('test_should_correctly_retrieve_one_record', function (
               err,
               usercollection
             ) {
-              usercollection.findOne({ a: 0 }, function(err) {
+              usercollection.findOne({ a: 0 }, function (err) {
                 test.equal(null, err);
                 p_client.close(done);
               });
@@ -723,18 +727,18 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_one_error_handling', function(err, collection) {
+        db.createCollection('test_find_one_error_handling', function (err, collection) {
           // Try to fetch an object using a totally invalid and wrong hex string... what we're interested in here
           // is the error handling of the findOne Method
           try {
             collection.findOne(
               { _id: ObjectId.createFromHexString('5e9bd59248305adf18ebc15703a1') },
-              function() {}
+              function () {}
             );
           } catch (err) {
             client.close(done);
@@ -752,28 +756,28 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_field_select_with_options', function(err) {
+        db.createCollection('test_field_select_with_options', function (err) {
           test.equal(null, err);
-          db.collection('test_field_select_with_options', function(err, collection) {
+          db.collection('test_field_select_with_options', function (err, collection) {
             var docCount = 25,
               docs = [];
 
             // Insert some test documents
             while (docCount--) docs.push({ a: docCount, b: docCount });
-            collection.insert(docs, configuration.writeConcernMax(), function(err, retDocs) {
+            collection.insert(docs, configuration.writeConcernMax(), function (err, retDocs) {
               docs = retDocs;
 
               collection
                 .find({}, { limit: 3, sort: [['a', -1]], projection: { a: 1 } })
-                .toArray(function(err, documents) {
+                .toArray(function (err, documents) {
                   test.equal(3, documents.length);
 
-                  documents.forEach(function(doc, idx) {
+                  documents.forEach(function (doc, idx) {
                     test.equal(undefined, doc.b); // making sure field select works
                     test.equal(24 - idx, doc.a); // checking limit sort object with field select
                   });
@@ -795,14 +799,14 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_and_modify_a_document_1', function(err, collection) {
+        db.createCollection('test_find_and_modify_a_document_1', function (err, collection) {
           // Test return new document on change
-          collection.insert({ a: 1, b: 2 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1, b: 2 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Let's modify the document in place
@@ -811,12 +815,12 @@ describe('Find', function() {
               [['a', 1]],
               { $set: { b: 3 } },
               { new: true },
-              function(err, updated_doc) {
+              function (err, updated_doc) {
                 test.equal(1, updated_doc.value.a);
                 test.equal(3, updated_doc.value.b);
 
                 // Test return old document on change
-                collection.insert({ a: 2, b: 2 }, configuration.writeConcernMax(), function(err) {
+                collection.insert({ a: 2, b: 2 }, configuration.writeConcernMax(), function (err) {
                   test.equal(null, err);
 
                   // Let's modify the document in place
@@ -825,12 +829,12 @@ describe('Find', function() {
                     [['a', 1]],
                     { $set: { b: 3 } },
                     configuration.writeConcernMax(),
-                    function(err, result) {
+                    function (err, result) {
                       test.equal(2, result.value.a);
                       test.equal(2, result.value.b);
 
                       // Test remove object on change
-                      collection.insert({ a: 3, b: 2 }, configuration.writeConcernMax(), function(
+                      collection.insert({ a: 3, b: 2 }, configuration.writeConcernMax(), function (
                         err
                       ) {
                         test.equal(null, err);
@@ -840,7 +844,7 @@ describe('Find', function() {
                           [],
                           { $set: { b: 3 } },
                           { remove: true },
-                          function(err, updated_doc) {
+                          function (err, updated_doc) {
                             test.equal(3, updated_doc.value.a);
                             test.equal(2, updated_doc.value.b);
 
@@ -850,7 +854,7 @@ describe('Find', function() {
                               [],
                               { $set: { b: 3 } },
                               { new: true, upsert: true },
-                              function(err, updated_doc) {
+                              function (err, updated_doc) {
                                 test.equal(4, updated_doc.value.a);
                                 test.equal(3, updated_doc.value.b);
 
@@ -858,7 +862,7 @@ describe('Find', function() {
                                 collection.insert(
                                   { a: 100, b: 101 },
                                   configuration.writeConcernMax(),
-                                  function(err, r) {
+                                  function (err, r) {
                                     test.equal(null, err);
 
                                     collection.findAndModify(
@@ -866,7 +870,7 @@ describe('Find', function() {
                                       [],
                                       { $set: { b: 5 } },
                                       { new: true, fields: { b: 1 } },
-                                      function(err, updated_doc) {
+                                      function (err, updated_doc) {
                                         test.equal(2, Object.keys(updated_doc.value).length);
                                         test.equal(
                                           r.ops[0]['_id'].toHexString(),
@@ -903,14 +907,14 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_and_modify_a_document_2', function(err, collection) {
+        db.createCollection('test_find_and_modify_a_document_2', function (err, collection) {
           // Test return new document on change
-          collection.insert({ a: 1, b: 2 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1, b: 2 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Let's modify the document in place
@@ -919,7 +923,7 @@ describe('Find', function() {
               [['a', 1]],
               { $set: { b: 3 } },
               { new: true, fields: { a: 1 } },
-              function(err, updated_doc) {
+              function (err, updated_doc) {
                 test.equal(2, Object.keys(updated_doc.value).length);
                 test.equal(1, updated_doc.value.a);
                 client.close(done);
@@ -936,12 +940,12 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('shouldCorrectlyExecuteFindOneWithAnInSearchTag', function(
+        db.createCollection('shouldCorrectlyExecuteFindOneWithAnInSearchTag', function (
           err,
           collection
         ) {
@@ -954,7 +958,7 @@ describe('Find', function() {
               meta: { visitors: 0 }
             },
             configuration.writeConcernMax(),
-            function(err, r) {
+            function (err, r) {
               // Fetch the id
               var id = r.ops[0]._id;
 
@@ -962,11 +966,11 @@ describe('Find', function() {
                 { _id: id },
                 { $inc: { 'meta.visitors': 1 } },
                 configuration.writeConcernMax(),
-                function(err, r) {
+                function (err, r) {
                   test.equal(1, r.result.n);
                   test.equal(null, err);
 
-                  collection.findOne({ _id: id }, function(err, item) {
+                  collection.findOne({ _id: id }, function (err, item) {
                     test.equal(1, item.meta.visitors);
                     client.close(done);
                   });
@@ -987,19 +991,19 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('FindAndModifyDuplicateKeyError', function(err, collection) {
-          collection.ensureIndex(['name', 1], { unique: true, w: 1 }, function(err) {
+        db.createCollection('FindAndModifyDuplicateKeyError', function (err, collection) {
+          collection.ensureIndex(['name', 1], { unique: true, w: 1 }, function (err) {
             test.equal(null, err);
             // Test return new document on change
             collection.insert(
               [{ name: 'test1' }, { name: 'test2' }],
               configuration.writeConcernMax(),
-              function(err) {
+              function (err) {
                 test.equal(null, err);
                 // Let's modify the document in place
                 collection.findAndModify(
@@ -1007,7 +1011,7 @@ describe('Find', function() {
                   [],
                   { $set: { name: 'test2' } },
                   {},
-                  function(err, updated_doc) {
+                  function (err, updated_doc) {
                     test.equal(null, updated_doc);
                     test.ok(err != null);
                     client.close(done);
@@ -1026,21 +1030,27 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('AttemptToFindAndModifyNonExistingDocument', function(err, collection) {
+        db.createCollection('AttemptToFindAndModifyNonExistingDocument', function (
+          err,
+          collection
+        ) {
           // Let's modify the document in place
-          collection.findAndModify({ name: 'test1' }, [], { $set: { name: 'test2' } }, {}, function(
-            err,
-            updated_doc
-          ) {
-            test.equal(null, updated_doc.value);
-            test.ok(err == null || err.errmsg.match('No matching object found'));
-            client.close(done);
-          });
+          collection.findAndModify(
+            { name: 'test1' },
+            [],
+            { $set: { name: 'test2' } },
+            {},
+            function (err, updated_doc) {
+              test.equal(null, updated_doc.value);
+              test.ok(err == null || err.errmsg.match('No matching object found'));
+              client.close(done);
+            }
+          );
         });
       });
     }
@@ -1051,22 +1061,22 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('skipAndLimitOnFindWithToArray', function(err, collection) {
+        db.createCollection('skipAndLimitOnFindWithToArray', function (err, collection) {
           collection.insert(
             [{ a: 1 }, { b: 2 }, { c: 3 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               collection
                 .find()
                 .skip(1)
                 .limit(-1)
-                .toArray(function(err, items) {
+                .toArray(function (err, items) {
                   test.equal(null, err);
                   test.equal(1, items.length);
                   test.equal(2, items[0].b);
@@ -1084,22 +1094,22 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('skipAndNegativeLimitOnFindWithToArray', function(err, collection) {
+        db.createCollection('skipAndNegativeLimitOnFindWithToArray', function (err, collection) {
           collection.insert(
             [{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }, { e: 5 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               collection
                 .find()
                 .skip(1)
                 .limit(-3)
-                .toArray(function(err, items) {
+                .toArray(function (err, items) {
                   test.equal(null, err);
                   test.equal(3, items.length);
                   test.equal(2, items[0].b);
@@ -1119,12 +1129,12 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('timeoutFalse', function(err, collection) {
+        db.createCollection('timeoutFalse', function (err, collection) {
           const cursor = collection.find({}, {});
           test.ok(!cursor.cmd.noCursorTimeout);
           client.close(done);
@@ -1138,12 +1148,12 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('cursor_timeout_false_0', function(err, collection) {
+        db.createCollection('cursor_timeout_false_0', function (err, collection) {
           expect(err).to.not.exist;
           const cursor = collection.find({}, { timeout: false });
           test.equal(false, cursor.cmd.noCursorTimeout);
@@ -1158,12 +1168,12 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('cursor_timeout_false_1', function(err, collection) {
+        db.createCollection('cursor_timeout_false_1', function (err, collection) {
           expect(err).to.not.exist;
           const cursor = collection.find({}, { timeout: true });
           test.equal(true, cursor.cmd.noCursorTimeout);
@@ -1181,22 +1191,22 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var p_client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      p_client.connect(function(err, client) {
+      p_client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
-        db.createCollection('shouldCorrectlyFindAndModifyDocumentWithDBStrict', function(
+        db.createCollection('shouldCorrectlyFindAndModifyDocumentWithDBStrict', function (
           err,
           collection
         ) {
           // Test return old document on change
-          collection.insert({ a: 2, b: 2 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 2, b: 2 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Let's modify the document in place
@@ -1205,7 +1215,7 @@ describe('Find', function() {
               [['a', 1]],
               { $set: { b: 3 } },
               { new: true },
-              function(err, result) {
+              function (err, result) {
                 test.equal(2, result.value.a);
                 test.equal(3, result.value.b);
                 p_client.close(done);
@@ -1225,24 +1235,24 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('shouldCorrectlyFindAndModifyDocumentThatFailsInFirstStep', function(
+        db.createCollection('shouldCorrectlyFindAndModifyDocumentThatFailsInFirstStep', function (
           err,
           collection
         ) {
           // Set up an index to force duplicate index erro
-          collection.ensureIndex([['failIndex', 1]], { unique: true, w: 1 }, function(err) {
+          collection.ensureIndex([['failIndex', 1]], { unique: true, w: 1 }, function (err) {
             test.equal(null, err);
 
             // Setup a new document
             collection.insert(
               { a: 2, b: 2, failIndex: 2 },
               configuration.writeConcernMax(),
-              function(err) {
+              function (err) {
                 test.equal(null, err);
 
                 // Let's attempt to upsert with a duplicate key error
@@ -1251,7 +1261,7 @@ describe('Find', function() {
                   [['a', 1]],
                   { a: 10, b: 10, failIndex: 2 },
                   { w: 1, upsert: true },
-                  function(err, result) {
+                  function (err, result) {
                     test.equal(null, result);
                     test.ok(err.errmsg.match('duplicate key'));
                     client.close(done);
@@ -1270,19 +1280,19 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('Should_correctly_return_new_modified_document', function(
+        db.createCollection('Should_correctly_return_new_modified_document', function (
           err,
           collection
         ) {
           var id = new ObjectId();
           var doc = { _id: id, a: 1, b: 1, c: { a: 1, b: 1 } };
 
-          collection.insert(doc, configuration.writeConcernMax(), function(err) {
+          collection.insert(doc, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Find and modify returning the new object
@@ -1291,7 +1301,7 @@ describe('Find', function() {
               [],
               { $set: { 'c.c': 100 } },
               { new: true },
-              function(err, item) {
+              function (err, item) {
                 test.equal(doc._id.toString(), item.value._id.toString());
                 test.equal(doc.a, item.value.a);
                 test.equal(doc.b, item.value.b);
@@ -1315,12 +1325,12 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('execute_find_and_modify', function(err, collection) {
+        db.createCollection('execute_find_and_modify', function (err, collection) {
           var self = { _id: new ObjectId() };
           var _uuid = 'sddffdss';
 
@@ -1329,7 +1339,7 @@ describe('Find', function() {
             [],
             { $set: { 'plays.$.active': true } },
             { new: true, fields: { plays: 0, results: 0 }, safe: true },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               client.close(done);
             }
@@ -1344,12 +1354,12 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('should_correctly_return_record_with_64bit_id', function(
+        db.createCollection('should_correctly_return_record_with_64bit_id', function (
           err,
           collection
         ) {
@@ -1361,11 +1371,11 @@ describe('Find', function() {
           var lowerDoc = { _id: _lowerId, id: lowerId };
           var higherDoc = { _id: _higherId, id: higherId };
 
-          collection.insert([lowerDoc, higherDoc], configuration.writeConcernMax(), function(err) {
+          collection.insert([lowerDoc, higherDoc], configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Select record with id of 133118461172916225 using $gt directive
-            collection.find({ id: { $gt: lowerId } }, {}).toArray(function(err, arr) {
+            collection.find({ id: { $gt: lowerId } }, {}).toArray(function (err, arr) {
               test.ok(err == null);
               test.equal(
                 arr.length,
@@ -1390,30 +1400,30 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var p_client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
-      p_client.connect(function(err, client) {
+      p_client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         db.createCollection(
           'Should_Correctly_find_a_Document_using_findOne_excluding__id_field',
-          function(err, collection) {
+          function (err, collection) {
             var doc = { _id: new ObjectId(), a: 1, c: 2 };
             // insert doc
-            collection.insert(doc, configuration.writeConcernMax(), function(err) {
+            collection.insert(doc, configuration.writeConcernMax(), function (err) {
               test.equal(null, err);
 
               // Get one document, excluding the _id field
-              collection.findOne({ a: 1 }, { fields: { _id: 0 } }, function(err, item) {
+              collection.findOne({ a: 1 }, { fields: { _id: 0 } }, function (err, item) {
                 test.equal(undefined, item._id);
                 test.equal(1, item.a);
                 test.equal(2, item.c);
 
-                collection.find({ a: 1 }, { fields: { _id: 0 } }).toArray(function(err, items) {
+                collection.find({ a: 1 }, { fields: { _id: 0 } }).toArray(function (err, items) {
                   var item = items[0];
                   test.equal(undefined, item._id);
                   test.equal(1, item.a);
@@ -1433,22 +1443,22 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.createCollection(
           'Should_correctly_execute_find_and_findOne_queries_in_the_same_way',
-          function(err, collection) {
+          function (err, collection) {
             var doc = { _id: new ObjectId(), a: 1, c: 2, comments: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] };
             // insert doc
-            collection.insert(doc, configuration.writeConcernMax(), function(err) {
+            collection.insert(doc, configuration.writeConcernMax(), function (err) {
               test.equal(null, err);
               collection
                 .find({ _id: doc._id })
                 .project({ comments: { $slice: -5 } })
-                .toArray(function(err, docs) {
+                .toArray(function (err, docs) {
                   test.equal(5, docs[0].comments.length);
                   client.close(done);
                 });
@@ -1464,15 +1474,15 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.createCollection(
           'shouldCorrectlyHandlerErrorForFindAndModifyWhenNoRecordExists',
-          function(err, collection) {
-            collection.findAndModify({ a: 1 }, [], { $set: { b: 3 } }, { new: true }, function(
+          function (err, collection) {
+            collection.findAndModify({ a: 1 }, [], { $set: { b: 3 } }, { new: true }, function (
               err,
               updated_doc
             ) {
@@ -1491,10 +1501,10 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var transaction = {};
         transaction.document = {};
@@ -1514,10 +1524,10 @@ describe('Find', function() {
           transactions: transactions
         };
 
-        db.createCollection('find_and_modify_generate_correct_bson', function(err, collection) {
+        db.createCollection('find_and_modify_generate_correct_bson', function (err, collection) {
           test.equal(null, err);
 
-          collection.insert(wrapingObject, configuration.writeConcernMax(), function(err, r) {
+          collection.insert(wrapingObject, configuration.writeConcernMax(), function (err, r) {
             test.equal(null, err);
 
             collection.findOne(
@@ -1526,7 +1536,7 @@ describe('Find', function() {
                 'funds.remaining': { $gte: 3.0 },
                 'transactions.id': { $ne: transaction.transactionId }
               },
-              function(err, item) {
+              function (err, item) {
                 test.ok(item != null);
 
                 collection.findAndModify(
@@ -1538,7 +1548,7 @@ describe('Find', function() {
                   [],
                   { $push: { transactions: transaction } },
                   { new: true, safe: true },
-                  function(err) {
+                  function (err) {
                     test.equal(null, err);
                     client.close(done);
                   }
@@ -1556,20 +1566,20 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var p_client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      p_client.connect(function(err, client) {
+      p_client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('tasks', function(err, collection) {
+        db.createCollection('tasks', function (err, collection) {
           var numberOfOperations = 0;
 
           // Test return old document on change
-          collection.insert({ a: 2, b: 2 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 2, b: 2 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
             collection
               .find(
@@ -1580,7 +1590,7 @@ describe('Find', function() {
                 },
                 { skip: 0, limit: 10, sort: { updated: -1 } }
               )
-              .count(function(err) {
+              .count(function (err) {
                 test.equal(null, err);
                 numberOfOperations = numberOfOperations + 1;
                 if (numberOfOperations === 2) {
@@ -1597,7 +1607,7 @@ describe('Find', function() {
                 },
                 { skip: 0, limit: 10, sort: { updated: -1 } }
               )
-              .count(function(err) {
+              .count(function (err) {
                 test.equal(null, err);
                 numberOfOperations = numberOfOperations + 1;
                 if (numberOfOperations === 2) {
@@ -1615,14 +1625,14 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.createCollection(
           'shouldCorrectlyReturnErrorFromMongodbOnFindAndModifyForcedError',
-          function(err, collection) {
+          function (err, collection) {
             var q = { x: 1 };
             var set = { y: 2, _id: new ObjectId() };
             var opts = { new: true, upsert: true };
@@ -1630,9 +1640,9 @@ describe('Find', function() {
             var doc = { _id: new ObjectId(), x: 1 };
 
             // Insert original doc
-            collection.insert(doc, configuration.writeConcernMax(), function(err) {
+            collection.insert(doc, configuration.writeConcernMax(), function (err) {
               test.equal(null, err);
-              collection.findAndModify(q, [], set, opts, function(/* err */) {
+              collection.findAndModify(q, [], set, opts, function (/* err */) {
                 client.close(done);
               });
             });
@@ -1647,7 +1657,7 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var p_client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
@@ -1655,18 +1665,18 @@ describe('Find', function() {
       });
       var running = true;
 
-      p_client.connect(function(err, client) {
+      p_client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Create a collection
-        db.collection('collection1', function(err, collection) {
+        db.collection('collection1', function (err, collection) {
           // Wait a bit and then execute something that will throw a duplicate error
-          setTimeout(function() {
+          setTimeout(function () {
             var id = new ObjectId();
 
-            collection.insert({ _id: id, a: 1 }, configuration.writeConcernMax(), function(err) {
+            collection.insert({ _id: id, a: 1 }, configuration.writeConcernMax(), function (err) {
               test.equal(null, err);
 
-              collection.insert({ _id: id, a: 1 }, configuration.writeConcernMax(), function(err) {
+              collection.insert({ _id: id, a: 1 }, configuration.writeConcernMax(), function (err) {
                 test.ok(err !== null);
                 running = false;
                 p_client.close(done);
@@ -1675,11 +1685,11 @@ describe('Find', function() {
           }, 200);
         });
 
-        db.collection('collection2', function(err, collection) {
+        db.collection('collection2', function (err, collection) {
           // Keep hammering in inserts
           var insert;
-          insert = function() {
-            process.nextTick(function() {
+          insert = function () {
+            process.nextTick(function () {
               collection.insert({ a: 1 });
               if (running) process.nextTick(insert);
             });
@@ -1694,7 +1704,7 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var p_client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
@@ -1703,15 +1713,15 @@ describe('Find', function() {
       var numberOfSteps = 0;
 
       // Open db connection
-      p_client.connect(function(err, client) {
+      p_client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Create a collection
         var collection = db.collection('shouldCorrectlyIterateOverCollection');
         // Insert 1000 documents
-        var insertF = function(l, callback) {
+        var insertF = function (l, callback) {
           collection.insert(
             { a: 1, b: 2, c: { d: 3, f: 'sfdsffffffffffffffffffffffffffffff' } },
-            function() {
+            function () {
               l = l - 1;
 
               if (l > 0) return insertF(l, callback);
@@ -1720,11 +1730,11 @@ describe('Find', function() {
           );
         };
 
-        insertF(500, function() {
+        insertF(500, function () {
           var cursor = collection.find({}, {});
-          cursor.count(function(err) {
+          cursor.count(function (err) {
             test.equal(null, err);
-            cursor.each(function(err, obj) {
+            cursor.each(function (err, obj) {
               if (obj == null) {
                 test.equal(500, numberOfSteps);
                 p_client.close(done);
@@ -1743,17 +1753,17 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var p_client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
-      p_client.connect(function(err, client) {
+      p_client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(err, null);
 
-        db.createCollection('shouldCorrectlyErrorOutFindAndModifyOnDuplicateRecord', function(
+        db.createCollection('shouldCorrectlyErrorOutFindAndModifyOnDuplicateRecord', function (
           err,
           collection
         ) {
@@ -1763,11 +1773,11 @@ describe('Find', function() {
           collection.insert(
             [{ login: 'user1' }, { login: 'user2' }],
             configuration.writeConcernMax(),
-            function(err, r) {
+            function (err, r) {
               test.equal(err, null);
               var id = r.ops[1]._id;
               // Set an index
-              collection.ensureIndex('login', { unique: true, w: 1 }, function(err) {
+              collection.ensureIndex('login', { unique: true, w: 1 }, function (err) {
                 test.equal(null, err);
 
                 // Attemp to modify document
@@ -1776,7 +1786,7 @@ describe('Find', function() {
                   [],
                   { $set: { login: 'user1' } },
                   {},
-                  function(err) {
+                  function (err) {
                     test.ok(err !== null);
                     p_client.close(done);
                   }
@@ -1797,28 +1807,28 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         // Create a collection we want to drop later
-        db.createCollection('simple_find_in_array', function(err, collection) {
+        db.createCollection('simple_find_in_array', function (err, collection) {
           test.equal(null, err);
 
           var docs = [];
           for (var i = 0; i < 100; i++) docs.push({ a: i });
 
           // Insert some test documentations
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Find all the variables in a specific array
             for (var i = 0; i < 100; i++) docs.push(i);
 
             // Fin all in
-            collection.find({ a: { $in: docs } }).toArray(function(err, items) {
+            collection.find({ a: { $in: docs } }).toArray(function (err, items) {
               test.equal(null, err);
               test.equal(100, items.length);
 
@@ -1835,10 +1845,10 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -1850,10 +1860,10 @@ describe('Find', function() {
             { a: 3, b: 3 }
           ],
           configuration.writeConcernMax(),
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
-            col.find({}, { skip: 1, limit: 1, fields: { a: 1, b: 0 } }).toArray(function(err) {
+            col.find({}, { skip: 1, limit: 1, fields: { a: 1, b: 0 } }).toArray(function (err) {
               test.ok(err instanceof Error);
               client.close(done);
             });
@@ -1871,14 +1881,14 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         // Create a collection we want to drop later
-        db.createCollection('simple_find_with_fields', function(err, collection) {
+        db.createCollection('simple_find_with_fields', function (err, collection) {
           test.equal(null, err);
 
           // Insert a bunch of documents for the testing
@@ -1889,14 +1899,14 @@ describe('Find', function() {
               { a: 3, b: 3 }
             ],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Perform a simple find and return all the documents
               collection
                 .find({ a: 2 })
                 .project({ b: 1 })
-                .toArray(function(err, docs) {
+                .toArray(function (err, docs) {
                   test.equal(null, err);
                   test.equal(1, docs.length);
                   test.equal(undefined, docs[0].a);
@@ -1906,7 +1916,7 @@ describe('Find', function() {
                   collection
                     .find({ a: 2 })
                     .project({ b: 1 })
-                    .toArray(function(err, docs) {
+                    .toArray(function (err, docs) {
                       test.equal(null, err);
                       test.equal(1, docs.length);
                       test.equal(undefined, docs[0].a);
@@ -1930,14 +1940,14 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         // Create a collection we want to drop later
-        db.createCollection('simple_find_with_fields_2', function(err, collection) {
+        db.createCollection('simple_find_with_fields_2', function (err, collection) {
           test.equal(null, err);
 
           // Insert a bunch of documents for the testing
@@ -1948,14 +1958,14 @@ describe('Find', function() {
               { a: 3, b: 3 }
             ],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Perform a simple find and return all the documents
               collection
                 .find({ a: 2 })
                 .project({ b: 1 })
-                .toArray(function(err, docs) {
+                .toArray(function (err, docs) {
                   test.equal(null, err);
                   test.equal(1, docs.length);
                   test.equal(undefined, docs[0].a);
@@ -1978,14 +1988,14 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         // Create a collection we want to drop later
-        db.createCollection('shouldPerformQueryWithBatchSizeDifferentToStandard', function(
+        db.createCollection('shouldPerformQueryWithBatchSizeDifferentToStandard', function (
           err,
           collection
         ) {
@@ -1997,11 +2007,11 @@ describe('Find', function() {
           }
 
           // Insert a bunch of documents for the testing
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Perform a simple find and return all the documents
-            collection.find({}, { batchSize: 1000 }).toArray(function(err, docs) {
+            collection.find({}, { batchSize: 1000 }).toArray(function (err, docs) {
               test.equal(null, err);
               test.equal(1000, docs.length);
 
@@ -2021,14 +2031,14 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         // Create a collection we want to drop later
-        db.collection('shouldCorrectlyPerformNegativeLimit', function(err, collection) {
+        db.collection('shouldCorrectlyPerformNegativeLimit', function (err, collection) {
           var docs = [];
           for (var i = 0; i < 1000; i++) {
             docs.push({
@@ -2039,14 +2049,14 @@ describe('Find', function() {
           }
 
           // Insert a bunch of documents
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Perform a simple find and return all the documents
             collection
               .find({})
               .limit(-10)
-              .toArray(function(err, docs) {
+              .toArray(function (err, docs) {
                 test.equal(null, err);
                 test.equal(10, docs.length);
 
@@ -2064,14 +2074,14 @@ describe('Find', function() {
   it('shouldCorrectlyExecuteExhaustQuery', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         // Create a collection we want to drop later
-        db.collection('shouldCorrectlyExecuteExhaustQuery', function(err, collection) {
+        db.collection('shouldCorrectlyExecuteExhaustQuery', function (err, collection) {
           test.equal(null, err);
 
           var docs1 = [];
@@ -2085,7 +2095,7 @@ describe('Find', function() {
           }
 
           // Insert a bunch of documents
-          collection.insert(docs1, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs1, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             for (var i = 0; i < 1000; i++) {
@@ -2098,11 +2108,11 @@ describe('Find', function() {
               });
             }
 
-            collection.insert(docs2, configuration.writeConcernMax(), function(err) {
+            collection.insert(docs2, configuration.writeConcernMax(), function (err) {
               test.equal(null, err);
 
               // Perform a simple find and return all the documents
-              collection.find({}, { exhaust: true }).toArray(function(err, docs3) {
+              collection.find({}, { exhaust: true }).toArray(function (err, docs3) {
                 test.equal(null, err);
                 test.equal(docs1.length + docs2.length, docs3.length);
 
@@ -2120,11 +2130,11 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -2138,12 +2148,12 @@ describe('Find', function() {
         }
 
         // Create a collection we want to drop later
-        db.collection('Readpreferencesshouldworkfine', function(err, collection) {
+        db.collection('Readpreferencesshouldworkfine', function (err, collection) {
           // Insert a bunch of documents
-          collection.insert(docs, configuration.writeConcernMax(), function(err) {
+          collection.insert(docs, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
             // Perform a simple find and return all the documents
-            collection.find({}, { exhaust: true }).toArray(function(err, docs2) {
+            collection.find({}, { exhaust: true }).toArray(function (err, docs2) {
               test.equal(null, err);
               test.equal(docs.length, docs2.length);
 
@@ -2160,16 +2170,16 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
         // Create a collection we want to drop later
-        db.collection('noresultAvailableForEachToIterate', function(err, collection) {
+        db.collection('noresultAvailableForEachToIterate', function (err, collection) {
           // Perform a simple find and return all the documents
-          collection.find({}).each(function(err, item) {
+          collection.find({}).each(function (err, item) {
             test.equal(null, item);
 
             client.close(done);
@@ -2182,25 +2192,25 @@ describe('Find', function() {
   it('shouldCorrectlyFindDocumentsByRegExp', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Serialized regexes contain extra trailing chars. Sometimes these trailing chars contain / which makes
         // the original regex invalid, and leads to segmentation fault.
-        db.createCollection('test_regex_serialization', function(err, collection) {
+        db.createCollection('test_regex_serialization', function (err, collection) {
           collection.insert(
             { keywords: ['test', 'segmentation', 'fault', 'regex', 'serialization', 'native'] },
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               var count = 20,
-                run = function(i) {
+                run = function (i) {
                   // search by regex
                   collection.findOne(
                     { keywords: { $all: [/ser/, /test/, /seg/, /fault/, /nat/] } },
-                    function(err, item) {
+                    function (err, item) {
                       test.equal(6, item.keywords.length);
 
                       if (i === 0) {
@@ -2225,30 +2235,30 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Serialized regexes contain extra trailing chars. Sometimes these trailing chars contain / which makes
         // the original regex invalid, and leads to segmentation fault.
-        db.createCollection('shouldCorrectlyDoFindMinMax', function(err, collection) {
+        db.createCollection('shouldCorrectlyDoFindMinMax', function (err, collection) {
           collection.insert(
             { _id: 123, name: 'some name', min: 1, max: 10 },
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               collection
                 .find({ _id: { $in: ['some', 'value', 123] } })
                 .project({ _id: 1, max: 1 })
-                .toArray(function(err, docs) {
+                .toArray(function (err, docs) {
                   test.equal(null, err);
                   test.equal(10, docs[0].max);
 
                   collection
                     .find({ _id: { $in: ['some', 'value', 123] } }, { fields: { _id: 1, max: 1 } })
-                    .toArray(function(err, docs) {
+                    .toArray(function (err, docs) {
                       test.equal(null, err);
                       test.equal(10, docs[0].max);
 
@@ -2272,20 +2282,20 @@ describe('Find', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         // Get the collection
         var collection = db.collection('textSearchWithSort');
-        collection.ensureIndex({ s: 'text' }, function(err) {
+        collection.ensureIndex({ s: 'text' }, function (err) {
           test.equal(null, err);
 
           collection.insert(
             [{ s: 'spam' }, { s: 'spam eggs and spam' }, { s: 'sausage and eggs' }],
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               collection
@@ -2294,7 +2304,7 @@ describe('Find', function() {
                   { fields: { _id: false, s: true, score: { $meta: 'textScore' } } }
                 )
                 .sort({ score: { $meta: 'textScore' } })
-                .toArray(function(err, items) {
+                .toArray(function (err, items) {
                   test.equal(null, err);
                   test.equal('spam eggs and spam', items[0].s);
                   client.close(done);
@@ -2311,10 +2321,10 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldNotMutateUserOptions');
         var options = { raw: 'TEST' };
@@ -2332,10 +2342,10 @@ describe('Find', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { mongodb: '>2.5.5', topology: ['single', 'replicaset'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var docs = [];
 
@@ -2347,20 +2357,20 @@ describe('Find', function() {
         // Get the collection
         var collection = db.collection('simulate_closed_cursor');
         // Insert 1000 documents in a batch
-        collection.insert(docs, function(err) {
+        collection.insert(docs, function (err) {
           test.equal(null, err);
 
           // Get the cursor
           var cursor = collection.find({}).batchSize(2);
           // Get next document
-          cursor.next(function(err, doc) {
+          cursor.next(function (err, doc) {
             test.equal(null, err);
             test.ok(doc != null);
 
             // Mess with state forcing a call to isDead on the cursor
             cursor.s.state = 2;
 
-            cursor.next(function(err) {
+            cursor.next(function (err) {
               test.ok(err !== null);
 
               // We need to close the cursor since it is not exhausted,
@@ -2382,14 +2392,14 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_find_and_modify_a_document_3', function(err, collection) {
+        db.createCollection('test_find_and_modify_a_document_3', function (err, collection) {
           // Test return new document on change
-          collection.insert({ a: 1, b: 2 }, configuration.writeConcernMax(), function(err) {
+          collection.insert({ a: 1, b: 2 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Let's modify the document in place
@@ -2398,7 +2408,7 @@ describe('Find', function() {
               [['a', 1]],
               { $set: { b: 3 } },
               { new: true },
-              function(err, updated_doc) {
+              function (err, updated_doc) {
                 test.equal(1, updated_doc.value.a);
                 test.equal(3, updated_doc.value.b);
 
@@ -2419,23 +2429,23 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.collection('test_find_simple_batchsize_0', function(err, collection) {
+        db.collection('test_find_simple_batchsize_0', function (err, collection) {
           // Insert some test documents
           collection.insert(
             [{ a: 2 }, { b: 3 }, { b: 4 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               // Ensure correct insertion testing via the cursor and the count function
               collection
                 .find()
                 .batchSize(-5)
-                .toArray(function(err, documents) {
+                .toArray(function (err, documents) {
                   test.equal(null, err);
                   test.equal(3, documents.length);
                   // Let's close the db
@@ -2456,25 +2466,25 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.collection('test_find_simple_limit_0', function(err, collection) {
+        db.collection('test_find_simple_limit_0', function (err, collection) {
           test.equal(null, err);
 
           // Insert some test documents
           collection.insert(
             [{ a: 2 }, { b: 3 }, { b: 4 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               // Ensure correct insertion testing via the cursor and the count function
               collection
                 .find()
                 .limit(-5)
-                .toArray(function(err, documents) {
+                .toArray(function (err, documents) {
                   test.equal(null, err);
                   test.equal(3, documents.length);
 
@@ -2496,12 +2506,12 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.collection('elem_match_test', function(err, collection) {
+        db.collection('elem_match_test', function (err, collection) {
           test.equal(null, err);
 
           // Insert some test documents
@@ -2511,13 +2521,13 @@ describe('Find', function() {
               { _id: 2, results: [75, 88, 89] }
             ],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Ensure correct insertion testing via the cursor and the count function
               collection
                 .find({ results: { $elemMatch: { $gte: 80, $lt: 85 } } })
-                .toArray(function(err, documents) {
+                .toArray(function (err, documents) {
                   test.equal(null, err);
                   test.deepEqual([{ _id: 1, results: [82, 85, 88] }], documents);
 
@@ -2539,12 +2549,12 @@ describe('Find', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.collection('test_find_simple_limit_101', function(err, collection) {
+        db.collection('test_find_simple_limit_101', function (err, collection) {
           test.equal(null, err);
 
           function clone(obj) {
@@ -2573,7 +2583,7 @@ describe('Find', function() {
           }
 
           // Insert some test documents
-          collection.insertMany(docs, configuration.writeConcernMax(), function(err, r) {
+          collection.insertMany(docs, configuration.writeConcernMax(), function (err, r) {
             test.equal(null, err);
             test.ok(r);
 
@@ -2581,7 +2591,7 @@ describe('Find', function() {
             collection
               .find()
               .limit(200)
-              .toArray(function(err, documents) {
+              .toArray(function (err, documents) {
                 test.equal(null, err);
                 test.equal(200, documents.length);
                 // Let's close the db
@@ -2599,25 +2609,25 @@ describe('Find', function() {
   it('Should correctly apply db level options to find cursor', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
-      var listener = require('../../src').instrument(function(err) {
+    test: function (done) {
+      var listener = require('../../src').instrument(function (err) {
         test.equal(null, err);
       });
 
       var configuration = this.configuration;
       const client = configuration.newClient({}, { ignoreUndefined: true });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_find_simple_cursor_inheritance');
 
         // Insert some test documents
-        collection.insert([{ a: 2 }, { b: 3, c: undefined }], function(err) {
+        collection.insert([{ a: 2 }, { b: 3, c: undefined }], function (err) {
           test.equal(null, err);
           // Ensure correct insertion testing via the cursor and the count function
           var cursor = collection.find({ c: undefined });
           test.equal(true, cursor.options.ignoreUndefined);
 
-          cursor.toArray(function(err, documents) {
+          cursor.toArray(function (err, documents) {
             test.equal(2, documents.length);
             // process.exit(0)
             listener.uninstrument();
@@ -2633,7 +2643,7 @@ describe('Find', function() {
   it('should respect client-level read preference', {
     metadata: { requires: { topology: ['replicaset'] } },
 
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       const client = config.newClient({}, { monitorCommands: true, readPreference: 'secondary' });
 
@@ -2641,7 +2651,7 @@ describe('Find', function() {
         expect(err).to.not.exist;
 
         let selectedServer;
-        const selectServerStub = sinon.stub(client.topology, 'selectServer').callsFake(function() {
+        const selectServerStub = sinon.stub(client.topology, 'selectServer').callsFake(function () {
           const args = Array.prototype.slice.call(arguments);
           const originalCallback = args.pop();
           args.push((err, server) => {

--- a/test/functional/find_and_modify.test.js
+++ b/test/functional/find_and_modify.test.js
@@ -4,8 +4,8 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const expect = require('chai').expect;
 
-describe('Find and Modify', function() {
-  before(function() {
+describe('Find and Modify', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -16,31 +16,31 @@ describe('Find and Modify', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var started = [];
       var succeeded = [];
 
-      var listener = require('../../src').instrument(function(err) {
+      var listener = require('../../src').instrument(function (err) {
         test.equal(null, err);
       });
 
-      listener.on('started', function(event) {
+      listener.on('started', function (event) {
         if (event.commandName === 'findAndModify') started.push(event);
       });
 
-      listener.on('succeeded', function(event) {
+      listener.on('succeeded', function (event) {
         if (event.commandName === 'findAndModify') succeeded.push(event);
       });
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var collection = db.collection('findAndModifyTEST');
         // Execute findOneAndUpdate
-        collection.findOneAndUpdate({}, { $set: { a: 1 } }, { fsync: 1 }, function(err) {
+        collection.findOneAndUpdate({}, { $set: { a: 1 } }, { fsync: 1 }, function (err) {
           test.equal(null, err);
           test.deepEqual({ fsync: 1 }, started[0].command.writeConcern);
 
@@ -49,7 +49,7 @@ describe('Find and Modify', function() {
           succeeded = [];
 
           // Execute findOneAndReplace
-          collection.findOneAndReplace({}, { b: 1 }, { fsync: 1 }, function(err) {
+          collection.findOneAndReplace({}, { b: 1 }, { fsync: 1 }, function (err) {
             test.equal(null, err);
             test.deepEqual({ fsync: 1 }, started[0].command.writeConcern);
 
@@ -58,7 +58,7 @@ describe('Find and Modify', function() {
             succeeded = [];
 
             // Execute findOneAndReplace
-            collection.findOneAndDelete({}, { fsync: 1 }, function(err) {
+            collection.findOneAndDelete({}, { fsync: 1 }, function (err) {
               test.equal(null, err);
               test.deepEqual({ fsync: 1 }, started[0].command.writeConcern);
 
@@ -78,31 +78,31 @@ describe('Find and Modify', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var started = [];
       var succeeded = [];
 
-      var listener = require('../../src').instrument(function(err) {
+      var listener = require('../../src').instrument(function (err) {
         test.equal(null, err);
       });
 
-      listener.on('started', function(event) {
+      listener.on('started', function (event) {
         if (event.commandName === 'findAndModify') started.push(event);
       });
 
-      listener.on('succeeded', function(event) {
+      listener.on('succeeded', function (event) {
         if (event.commandName === 'findAndModify') succeeded.push(event);
       });
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         var collection = db.collection('findAndModifyTEST', { fsync: 1 });
         // Execute findOneAndUpdate
-        collection.findOneAndUpdate({}, { $set: { a: 1 } }, function(err) {
+        collection.findOneAndUpdate({}, { $set: { a: 1 } }, function (err) {
           test.equal(null, err);
           test.deepEqual({ fsync: 1 }, started[0].command.writeConcern);
 
@@ -111,7 +111,7 @@ describe('Find and Modify', function() {
           succeeded = [];
 
           // Execute findOneAndReplace
-          collection.findOneAndReplace({}, { b: 1 }, function(err) {
+          collection.findOneAndReplace({}, { b: 1 }, function (err) {
             test.equal(null, err);
             test.deepEqual({ fsync: 1 }, started[0].command.writeConcern);
 
@@ -120,7 +120,7 @@ describe('Find and Modify', function() {
             succeeded = [];
 
             // Execute findOneAndReplace
-            collection.findOneAndDelete({}, function(err) {
+            collection.findOneAndDelete({}, function (err) {
               test.equal(null, err);
               test.deepEqual({ fsync: 1 }, started[0].command.writeConcern);
 
@@ -140,20 +140,20 @@ describe('Find and Modify', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var started = [];
       var succeeded = [];
 
-      var listener = require('../../src').instrument(function(err) {
+      var listener = require('../../src').instrument(function (err) {
         test.equal(null, err);
       });
 
-      listener.on('started', function(event) {
+      listener.on('started', function (event) {
         if (event.commandName === 'findAndModify') started.push(event);
       });
 
-      listener.on('succeeded', function(event) {
+      listener.on('succeeded', function (event) {
         if (event.commandName === 'findAndModify') succeeded.push(event);
       });
 
@@ -162,12 +162,12 @@ describe('Find and Modify', function() {
 
       // Establish connection to db
       const client = configuration.newClient(url, { sslValidate: false });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
         var collection = db.collection('findAndModifyTEST');
         // Execute findOneAndUpdate
-        collection.findOneAndUpdate({}, { $set: { a: 1 } }, function(err) {
+        collection.findOneAndUpdate({}, { $set: { a: 1 } }, function (err) {
           test.equal(null, err);
           test.deepEqual({ fsync: true }, started[0].command.writeConcern);
 
@@ -176,7 +176,7 @@ describe('Find and Modify', function() {
           succeeded = [];
 
           // Execute findOneAndReplace
-          collection.findOneAndReplace({}, { b: 1 }, function(err) {
+          collection.findOneAndReplace({}, { b: 1 }, function (err) {
             test.equal(null, err);
             test.deepEqual({ fsync: true }, started[0].command.writeConcern);
 
@@ -185,7 +185,7 @@ describe('Find and Modify', function() {
             succeeded = [];
 
             // Execute findOneAndReplace
-            collection.findOneAndDelete({}, function(err) {
+            collection.findOneAndDelete({}, function (err) {
               test.equal(null, err);
               test.deepEqual({ fsync: true }, started[0].command.writeConcern);
 
@@ -205,7 +205,7 @@ describe('Find and Modify', function() {
       requires: { topology: 'replicaset' }
     },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient({ readPreference: 'secondary' }, { poolSize: 1 });
       client.connect((err, client) => {

--- a/test/functional/generator_based.test.js
+++ b/test/functional/generator_based.test.js
@@ -2,8 +2,8 @@
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-describe('Generators', function() {
-  before(function() {
+describe('Generators', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -13,11 +13,11 @@ describe('Generators', function() {
       requires: { generators: true, topology: 'single', node: '>6.0.0', mongodb: '>=2.6.0' }
     },
 
-    test: function(done) {
+    test: function (done) {
       var co = require('co');
       var configuration = this.configuration;
 
-      co(function*() {
+      co(function* () {
         var instance = configuration.newClient({ w: 1 }, { poolSize: 1 });
         var client = yield instance.connect();
         var db = client.db(configuration.db);

--- a/test/functional/gridfs_stream.test.js
+++ b/test/functional/gridfs_stream.test.js
@@ -10,8 +10,8 @@ const { setupDatabase, withClient } = require('./shared');
 const { expect } = require('chai');
 const { GridFSBucket, ObjectId } = require('../../src');
 
-describe('GridFS Stream', function() {
-  before(function() {
+describe('GridFS Stream', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -24,7 +24,7 @@ describe('GridFS Stream', function() {
   it('shouldUploadFromFileStream', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
@@ -37,9 +37,9 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.dropDatabase(function(error) {
+        db.dropDatabase(function (error) {
           test.equal(error, null);
 
           var bucket = new GridFSBucket(db);
@@ -51,19 +51,19 @@ describe('GridFS Stream', function() {
           var id = uploadStream.id;
 
           // Wait for stream to finish
-          uploadStream.once('finish', function() {
+          uploadStream.once('finish', function () {
             var chunksColl = db.collection('fs.chunks');
             var chunksQuery = chunksColl.find({ files_id: id });
 
             // Get all the chunks
-            chunksQuery.toArray(function(error, docs) {
+            chunksQuery.toArray(function (error, docs) {
               test.equal(error, null);
               test.equal(docs.length, 1);
               test.equal(docs[0].data.toString('hex'), license.toString('hex'));
 
               var filesColl = db.collection('fs.files');
               var filesQuery = filesColl.find({ _id: id });
-              filesQuery.toArray(function(error, docs) {
+              filesQuery.toArray(function (error, docs) {
                 test.equal(error, null);
                 test.equal(docs.length, 1);
 
@@ -72,12 +72,12 @@ describe('GridFS Stream', function() {
                 test.equal(docs[0].md5, hash.digest('hex'));
 
                 // make sure we created indexes
-                filesColl.listIndexes().toArray(function(error, indexes) {
+                filesColl.listIndexes().toArray(function (error, indexes) {
                   test.equal(error, null);
                   test.equal(indexes.length, 2);
                   test.equal(indexes[1].name, 'filename_1_uploadDate_1');
 
-                  chunksColl.listIndexes().toArray(function(error, indexes) {
+                  chunksColl.listIndexes().toArray(function (error, indexes) {
                     test.equal(error, null);
                     test.equal(indexes.length, 2);
                     test.equal(indexes[1].name, 'files_id_1_n_1');
@@ -104,7 +104,7 @@ describe('GridFS Stream', function() {
   it('shouldUploadFromFileStreamWithCustomId', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -116,9 +116,9 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.dropDatabase(function(error) {
+        db.dropDatabase(function (error) {
           test.equal(error, null);
 
           var bucket = new GridFSBucket(db);
@@ -131,12 +131,12 @@ describe('GridFS Stream', function() {
           test.equal(1, id);
 
           // Wait for stream to finish
-          uploadStream.once('finish', function() {
+          uploadStream.once('finish', function () {
             var chunksColl = db.collection('fs.chunks');
             var chunksQuery = chunksColl.find({ files_id: id });
 
             // Get all the chunks
-            chunksQuery.toArray(function(error, docs) {
+            chunksQuery.toArray(function (error, docs) {
               test.equal(error, null);
               test.equal(docs.length, 1);
               test.equal(docs[0].data.toString('hex'), license.toString('hex'));
@@ -144,7 +144,7 @@ describe('GridFS Stream', function() {
               var filesColl = db.collection('fs.files');
               var filesQuery = filesColl.find({ _id: id });
 
-              filesQuery.toArray(function(error, docs) {
+              filesQuery.toArray(function (error, docs) {
                 test.equal(error, null);
                 test.equal(docs.length, 1);
 
@@ -153,12 +153,12 @@ describe('GridFS Stream', function() {
                 test.equal(docs[0].md5, hash.digest('hex'));
 
                 // make sure we created indexes
-                filesColl.listIndexes().toArray(function(error, indexes) {
+                filesColl.listIndexes().toArray(function (error, indexes) {
                   test.equal(error, null);
                   test.equal(indexes.length, 2);
                   test.equal(indexes[1].name, 'filename_1_uploadDate_1');
 
-                  chunksColl.listIndexes().toArray(function(error, indexes) {
+                  chunksColl.listIndexes().toArray(function (error, indexes) {
                     test.equal(error, null);
                     test.equal(indexes.length, 2);
                     test.equal(indexes[1].name, 'files_id_1_n_1');
@@ -185,7 +185,7 @@ describe('GridFS Stream', function() {
   it('shouldDownloadToUploadStream', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -197,7 +197,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var CHUNKS_COLL = 'gridfsdownload.chunks';
@@ -209,20 +209,20 @@ describe('GridFS Stream', function() {
         var license = fs.readFileSync('./LICENSE.md');
         var id = uploadStream.id;
 
-        uploadStream.once('finish', function() {
+        uploadStream.once('finish', function () {
           var downloadStream = bucket.openDownloadStream(id);
           uploadStream = bucket.openUploadStream('test2.dat');
           id = uploadStream.id;
 
-          downloadStream.pipe(uploadStream).once('finish', function() {
+          downloadStream.pipe(uploadStream).once('finish', function () {
             var chunksQuery = db.collection(CHUNKS_COLL).find({ files_id: id });
-            chunksQuery.toArray(function(error, docs) {
+            chunksQuery.toArray(function (error, docs) {
               test.equal(error, null);
               test.equal(docs.length, 1);
               test.equal(docs[0].data.toString('hex'), license.toString('hex'));
 
               var filesQuery = db.collection(FILES_COLL).find({ _id: id });
-              filesQuery.toArray(function(error, docs) {
+              filesQuery.toArray(function (error, docs) {
                 test.equal(error, null);
                 test.equal(docs.length, 1);
 
@@ -247,7 +247,7 @@ describe('GridFS Stream', function() {
   it('should fail to locate gridfs stream', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -259,15 +259,15 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
 
         // Get an unknown file
         var downloadStream = bucket.openDownloadStream(new ObjectId());
-        downloadStream.on('data', function() {});
+        downloadStream.on('data', function () {});
 
-        downloadStream.on('error', function(err) {
+        downloadStream.on('error', function (err) {
           test.equal('ENOENT', err.code);
           client.close(done);
         });
@@ -284,7 +284,7 @@ describe('GridFS Stream', function() {
   it('openDownloadStreamByName', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -296,23 +296,23 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var readStream = fs.createReadStream('./LICENSE.md');
         var uploadStream = bucket.openUploadStream('test.dat');
 
-        uploadStream.once('finish', function() {
+        uploadStream.once('finish', function () {
           var downloadStream = bucket.openDownloadStreamByName('test.dat');
 
           var gotData = false;
-          downloadStream.on('data', function(data) {
+          downloadStream.on('data', function (data) {
             test.ok(!gotData);
             gotData = true;
             test.ok(data.toString('utf8').indexOf('TERMS AND CONDITIONS') !== -1);
           });
 
-          downloadStream.on('end', function() {
+          downloadStream.on('end', function () {
             test.ok(gotData);
             client.close(done);
           });
@@ -333,7 +333,7 @@ describe('GridFS Stream', function() {
   it('start/end options for openDownloadStream', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -345,7 +345,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, {
           bucketName: 'gridfsdownload',
@@ -355,23 +355,23 @@ describe('GridFS Stream', function() {
         var readStream = fs.createReadStream('./LICENSE.md');
         var uploadStream = bucket.openUploadStream('teststart.dat');
 
-        uploadStream.once('finish', function() {
+        uploadStream.once('finish', function () {
           var downloadStream = bucket
             .openDownloadStreamByName('teststart.dat', { start: 1 })
             .end(6);
 
-          downloadStream.on('error', function(error) {
+          downloadStream.on('error', function (error) {
             test.equal(error, null);
           });
 
           var gotData = 0;
           var str = '';
-          downloadStream.on('data', function(data) {
+          downloadStream.on('data', function (data) {
             ++gotData;
             str += data.toString('utf8');
           });
 
-          downloadStream.on('end', function() {
+          downloadStream.on('end', function () {
             // Depending on different versions of node, we may get
             // different amounts of 'data' events. node 0.10 gives 2,
             // node >= 0.12 gives 3. Either is correct, but we just
@@ -391,7 +391,7 @@ describe('GridFS Stream', function() {
   it('should emit close after all chunks are received', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect((err, client) => {
@@ -404,7 +404,7 @@ describe('GridFS Stream', function() {
 
         const readStream = fs.createReadStream('./LICENSE.md');
         const uploadStream = bucket.openUploadStream('teststart.dat');
-        uploadStream.once('finish', function() {
+        uploadStream.once('finish', function () {
           const downloadStream = bucket.openDownloadStreamByName('teststart.dat');
 
           const events = [];
@@ -430,7 +430,7 @@ describe('GridFS Stream', function() {
   it('Deleting a file', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -442,7 +442,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var CHUNKS_COLL = 'gridfsdownload.chunks';
@@ -452,16 +452,16 @@ describe('GridFS Stream', function() {
         var uploadStream = bucket.openUploadStream('test.dat');
         var id = uploadStream.id;
 
-        uploadStream.once('finish', function() {
-          bucket.delete(id, function(err) {
+        uploadStream.once('finish', function () {
+          bucket.delete(id, function (err) {
             expect(err).to.not.exist;
             var chunksQuery = db.collection(CHUNKS_COLL).find({ files_id: id });
-            chunksQuery.toArray(function(error, docs) {
+            chunksQuery.toArray(function (error, docs) {
               test.equal(error, null);
               test.equal(docs.length, 0);
 
               var filesQuery = db.collection(FILES_COLL).find({ _id: id });
-              filesQuery.toArray(function(error, docs) {
+              filesQuery.toArray(function (error, docs) {
                 test.equal(error, null);
                 test.equal(docs.length, 0);
 
@@ -486,7 +486,7 @@ describe('GridFS Stream', function() {
   it('Aborting an upload', {
     metadata: { requires: { topology: ['single'], node: '>12.0.0' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -498,7 +498,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
         var CHUNKS_COLL = 'gridfsabort.chunks';
@@ -506,23 +506,23 @@ describe('GridFS Stream', function() {
 
         var id = uploadStream.id;
         var query = { files_id: id };
-        uploadStream.write('a', 'utf8', function(error) {
+        uploadStream.write('a', 'utf8', function (error) {
           expect(error).to.not.exist;
 
-          db.collection(CHUNKS_COLL).count(query, function(error, c) {
+          db.collection(CHUNKS_COLL).count(query, function (error, c) {
             test.equal(error, null);
             test.equal(c, 1);
-            uploadStream.abort(function(error) {
+            uploadStream.abort(function (error) {
               test.equal(error, null);
-              db.collection(CHUNKS_COLL).count(query, function(error, c) {
+              db.collection(CHUNKS_COLL).count(query, function (error, c) {
                 test.equal(error, null);
                 test.equal(c, 0);
-                uploadStream.write('b', 'utf8', function(error) {
+                uploadStream.write('b', 'utf8', function (error) {
                   test.equal(error.toString(), 'Error: this stream has been aborted');
-                  uploadStream.end('c', 'utf8', function(error) {
+                  uploadStream.end('c', 'utf8', function (error) {
                     test.equal(error.toString(), 'Error: this stream has been aborted');
                     // Fail if user tries to abort an aborted stream
-                    uploadStream.abort().then(null, function(error) {
+                    uploadStream.abort().then(null, function (error) {
                       test.equal(error.toString(), 'Error: Cannot call abort() on a stream twice');
                       client.close(done);
                     });
@@ -543,7 +543,7 @@ describe('GridFS Stream', function() {
   it('Destroy an upload', {
     metadata: { requires: { topology: ['single'], node: '>12.0.0' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -555,7 +555,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
         var CHUNKS_COLL = 'gridfsabort.chunks';
@@ -563,23 +563,23 @@ describe('GridFS Stream', function() {
 
         var id = uploadStream.id;
         var query = { files_id: id };
-        uploadStream.write('a', 'utf8', function(error) {
+        uploadStream.write('a', 'utf8', function (error) {
           expect(error).to.not.exist;
 
-          db.collection(CHUNKS_COLL).count(query, function(error, c) {
+          db.collection(CHUNKS_COLL).count(query, function (error, c) {
             test.equal(error, null);
             test.equal(c, 1);
-            uploadStream.abort(function(error) {
+            uploadStream.abort(function (error) {
               test.equal(error, null);
-              db.collection(CHUNKS_COLL).count(query, function(error, c) {
+              db.collection(CHUNKS_COLL).count(query, function (error, c) {
                 test.equal(error, null);
                 test.equal(c, 0);
-                uploadStream.write('b', 'utf8', function(error) {
+                uploadStream.write('b', 'utf8', function (error) {
                   test.equal(error.toString(), 'Error: this stream has been aborted');
-                  uploadStream.end('c', 'utf8', function(error) {
+                  uploadStream.end('c', 'utf8', function (error) {
                     test.equal(error.toString(), 'Error: this stream has been aborted');
                     // Fail if user tries to abort an aborted stream
-                    uploadStream.abort().then(null, function(error) {
+                    uploadStream.abort().then(null, function (error) {
                       test.equal(error.toString(), 'Error: Cannot call abort() on a stream twice');
                       client.close(done);
                     });
@@ -603,7 +603,7 @@ describe('GridFS Stream', function() {
   it('Destroying a download stream', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -615,26 +615,26 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdestroy', chunkSizeBytes: 10 });
         var readStream = fs.createReadStream('./LICENSE.md');
         var uploadStream = bucket.openUploadStream('test.dat');
 
         // Wait for stream to finish
-        uploadStream.once('finish', function() {
+        uploadStream.once('finish', function () {
           var id = uploadStream.id;
           var downloadStream = bucket.openDownloadStream(id);
           var finished = {};
-          downloadStream.on('data', function() {
+          downloadStream.on('data', function () {
             test.ok(false);
           });
 
-          downloadStream.on('error', function() {
+          downloadStream.on('error', function () {
             test.ok(false);
           });
 
-          downloadStream.on('end', function() {
+          downloadStream.on('end', function () {
             test.equal(downloadStream.s.cursor, null);
             if (finished.close) {
               client.close(done);
@@ -643,7 +643,7 @@ describe('GridFS Stream', function() {
             finished.end = true;
           });
 
-          downloadStream.on('close', function() {
+          downloadStream.on('close', function () {
             if (finished.end) {
               client.close(done);
               return;
@@ -651,7 +651,7 @@ describe('GridFS Stream', function() {
             finished.close = true;
           });
 
-          downloadStream.abort(function(error) {
+          downloadStream.abort(function (error) {
             test.equal(error, undefined);
           });
         });
@@ -671,7 +671,7 @@ describe('GridFS Stream', function() {
   it('Deleting a file using promises', {
     metadata: { requires: { topology: ['single'], node: '>12.0.0' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -683,7 +683,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var CHUNKS_COLL = 'gridfsdownload.chunks';
@@ -693,15 +693,15 @@ describe('GridFS Stream', function() {
         var uploadStream = bucket.openUploadStream('test.dat');
         var id = uploadStream.id;
 
-        uploadStream.once('finish', function() {
-          bucket.delete(id).then(function() {
+        uploadStream.once('finish', function () {
+          bucket.delete(id).then(function () {
             var chunksQuery = db.collection(CHUNKS_COLL).find({ files_id: id });
-            chunksQuery.toArray(function(error, docs) {
+            chunksQuery.toArray(function (error, docs) {
               test.equal(error, null);
               test.equal(docs.length, 0);
 
               var filesQuery = db.collection(FILES_COLL).find({ _id: id });
-              filesQuery.toArray(function(error, docs) {
+              filesQuery.toArray(function (error, docs) {
                 test.equal(error, null);
                 test.equal(docs.length, 0);
 
@@ -720,7 +720,7 @@ describe('GridFS Stream', function() {
   it('find()', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -732,7 +732,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'fs' });
 
@@ -761,7 +761,7 @@ describe('GridFS Stream', function() {
   it('drop example', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -773,7 +773,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var CHUNKS_COLL = 'gridfsdownload.chunks';
@@ -783,17 +783,17 @@ describe('GridFS Stream', function() {
         var uploadStream = bucket.openUploadStream('test.dat');
         var id = uploadStream.id;
 
-        uploadStream.once('finish', function() {
-          bucket.drop(function(err) {
+        uploadStream.once('finish', function () {
+          bucket.drop(function (err) {
             expect(err).to.not.exist;
 
             var chunksQuery = db.collection(CHUNKS_COLL).find({ files_id: id });
-            chunksQuery.toArray(function(error, docs) {
+            chunksQuery.toArray(function (error, docs) {
               test.equal(error, null);
               test.equal(docs.length, 0);
 
               var filesQuery = db.collection(FILES_COLL).find({ _id: id });
-              filesQuery.toArray(function(error, docs) {
+              filesQuery.toArray(function (error, docs) {
                 test.equal(error, null);
                 test.equal(docs.length, 0);
 
@@ -818,7 +818,7 @@ describe('GridFS Stream', function() {
   it('drop using promises', {
     metadata: { requires: { topology: ['single'], node: '>12.0.0' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -830,7 +830,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
         var CHUNKS_COLL = 'gridfsdownload.chunks';
@@ -840,15 +840,15 @@ describe('GridFS Stream', function() {
         var uploadStream = bucket.openUploadStream('test.dat');
         var id = uploadStream.id;
 
-        uploadStream.once('finish', function() {
-          bucket.drop().then(function() {
+        uploadStream.once('finish', function () {
+          bucket.drop().then(function () {
             var chunksQuery = db.collection(CHUNKS_COLL).find({ files_id: id });
-            chunksQuery.toArray(function(error, docs) {
+            chunksQuery.toArray(function (error, docs) {
               test.equal(error, null);
               test.equal(docs.length, 0);
 
               var filesQuery = db.collection(FILES_COLL).find({ _id: id });
-              filesQuery.toArray(function(error, docs) {
+              filesQuery.toArray(function (error, docs) {
                 test.equal(error, null);
                 test.equal(docs.length, 0);
 
@@ -873,7 +873,7 @@ describe('GridFS Stream', function() {
   it('find example', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -885,15 +885,15 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload_2' });
         var readStream = fs.createReadStream('./LICENSE.md');
 
         var uploadStream = bucket.openUploadStream('test.dat');
 
-        uploadStream.once('finish', function() {
-          bucket.find({}, { batchSize: 1 }).toArray(function(err, files) {
+        uploadStream.once('finish', function () {
+          bucket.find({}, { batchSize: 1 }).toArray(function (err, files) {
             test.equal(null, err);
             test.equal(1, files.length);
             client.close(done);
@@ -915,7 +915,7 @@ describe('GridFS Stream', function() {
   it('rename example', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -927,7 +927,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload_3' });
         var readStream = fs.createReadStream('./LICENSE.md');
@@ -935,9 +935,9 @@ describe('GridFS Stream', function() {
         var uploadStream = bucket.openUploadStream('test.dat');
         var id = uploadStream.id;
 
-        uploadStream.once('finish', function() {
+        uploadStream.once('finish', function () {
           // Rename the file
-          bucket.rename(id, 'renamed_it.dat', function(err) {
+          bucket.rename(id, 'renamed_it.dat', function (err) {
             expect(err).to.not.exist;
             client.close(done);
           });
@@ -952,28 +952,28 @@ describe('GridFS Stream', function() {
   it('download empty doc', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'fs' });
 
-        db.collection('fs.files').insert({ length: 0 }, function(error, result) {
+        db.collection('fs.files').insert({ length: 0 }, function (error, result) {
           test.equal(error, null);
           test.equal(Object.keys(result.insertedIds).length, 1);
           var id = result.insertedIds[0];
 
           var stream = bucket.openDownloadStream(id);
-          stream.on('error', function(error) {
+          stream.on('error', function (error) {
             test.equal(error, null);
           });
 
-          stream.on('data', function() {
+          stream.on('data', function () {
             test.ok(false);
           });
 
-          stream.on('end', function() {
+          stream.on('end', function () {
             // As per spec, make sure we didn't actually fire a query
             // because the document length is 0
             test.equal(stream.s.cursor, null);
@@ -987,14 +987,14 @@ describe('GridFS Stream', function() {
   it('should use chunkSize for download', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       if (typeof stream.pipeline !== 'function') {
         this.skip();
       }
 
       const configuration = this.configuration;
       const client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         const db = client.db(configuration.db);
         const bucket = new GridFSBucket(db, { bucketName: 'gridfs' });
 
@@ -1023,17 +1023,17 @@ describe('GridFS Stream', function() {
   });
 
   var UPLOAD_SPEC = require('../spec/gridfs/gridfs-upload.json');
-  UPLOAD_SPEC.tests.forEach(function(specTest) {
-    (function(testSpec) {
+  UPLOAD_SPEC.tests.forEach(function (specTest) {
+    (function (testSpec) {
       it(testSpec.description, {
         metadata: { requires: { topology: ['single'] } },
 
-        test: function(done) {
+        test: function (done) {
           var configuration = this.configuration;
           var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-          client.connect(function(err, client) {
+          client.connect(function (err, client) {
             var db = client.db(configuration.db);
-            db.dropDatabase(function(error) {
+            db.dropDatabase(function (error) {
               test.equal(error, null);
 
               var bucket = new GridFSBucket(db, { bucketName: 'expected' });
@@ -1043,18 +1043,18 @@ describe('GridFS Stream', function() {
               );
               var buf = Buffer.from(testSpec.act.arguments.source.$hex, 'hex');
 
-              res.on('error', function(err) {
+              res.on('error', function (err) {
                 test.equal(null, err);
               });
 
-              res.on('finish', function() {
+              res.on('finish', function () {
                 var data = testSpec.assert.data;
                 var num = data.length;
-                data.forEach(function(data) {
+                data.forEach(function (data) {
                   var collection = data.insert;
                   db.collection(collection)
                     .find({})
-                    .toArray(function(error, docs) {
+                    .toArray(function (error, docs) {
                       test.equal(data.documents.length, docs.length);
 
                       for (var i = 0; i < docs.length; ++i) {
@@ -1078,21 +1078,21 @@ describe('GridFS Stream', function() {
   });
 
   var DOWNLOAD_SPEC = require('../spec/gridfs/gridfs-download.json');
-  DOWNLOAD_SPEC.tests.forEach(function(specTest) {
-    (function(testSpec) {
+  DOWNLOAD_SPEC.tests.forEach(function (specTest) {
+    (function (testSpec) {
       it(testSpec.description, {
         metadata: { requires: { topology: ['single'] } },
 
-        test: function(done) {
+        test: function (done) {
           var configuration = this.configuration;
           var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-          client.connect(function(err, client) {
+          client.connect(function (err, client) {
             var db = client.db(configuration.db);
-            db.dropDatabase(function(err) {
+            db.dropDatabase(function (err) {
               test.equal(err, null);
               var BUCKET_NAME = 'fs';
 
-              var _runTest = function() {
+              var _runTest = function () {
                 var bucket = new GridFSBucket(db, { bucketName: BUCKET_NAME });
                 var res = Buffer.alloc(0);
 
@@ -1100,12 +1100,12 @@ describe('GridFS Stream', function() {
                   EJSON.parse(JSON.stringify(testSpec.act.arguments.id), { relaxed: true })
                 );
 
-                download.on('data', function(chunk) {
+                download.on('data', function (chunk) {
                   res = Buffer.concat([res, chunk]);
                 });
 
                 let errorReported = false;
-                download.on('error', function(error) {
+                download.on('error', function (error) {
                   errorReported = true;
                   if (!testSpec.assert.error) {
                     test.ok(false);
@@ -1125,7 +1125,7 @@ describe('GridFS Stream', function() {
                   client.close(done);
                 });
 
-                download.on('end', function() {
+                download.on('end', function () {
                   var result = testSpec.assert.result;
                   if (!result) {
                     if (errorReported) {
@@ -1153,19 +1153,19 @@ describe('GridFS Stream', function() {
 
               var keys = Object.keys(DOWNLOAD_SPEC.data);
               var numCollections = Object.keys(DOWNLOAD_SPEC.data).length;
-              keys.forEach(function(collection) {
-                var data = DOWNLOAD_SPEC.data[collection].map(function(v) {
+              keys.forEach(function (collection) {
+                var data = DOWNLOAD_SPEC.data[collection].map(function (v) {
                   return deflateTestDoc(v);
                 });
 
-                db.collection(BUCKET_NAME + '.' + collection).insertMany(data, function(error) {
+                db.collection(BUCKET_NAME + '.' + collection).insertMany(data, function (error) {
                   test.equal(error, null);
 
                   if (--numCollections === 0) {
                     if (testSpec.arrange) {
                       // only support 1 arrange op for now
                       test.equal(testSpec.arrange.data.length, 1);
-                      applyArrange(db, deflateTestDoc(testSpec.arrange.data[0]), function(error) {
+                      applyArrange(db, deflateTestDoc(testSpec.arrange.data[0]), function (error) {
                         test.equal(error, null);
                         _runTest();
                       });
@@ -1216,7 +1216,7 @@ describe('GridFS Stream', function() {
 
   function convert$hexToBuffer(doc) {
     var keys = Object.keys(doc);
-    keys.forEach(function(key) {
+    keys.forEach(function (key) {
       if (doc[key] && typeof doc[key] === 'object') {
         if (doc[key].$hex != null) {
           doc[key] = Buffer.from(doc[key].$hex, 'hex');
@@ -1263,7 +1263,7 @@ describe('GridFS Stream', function() {
   it('should correctly handle calling end function with only a callback', {
     metadata: { requires: { topology: ['single'], node: '>4.0.0' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -1275,7 +1275,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
         var CHUNKS_COLL = 'gridfsabort.chunks';
@@ -1283,28 +1283,28 @@ describe('GridFS Stream', function() {
 
         var id = uploadStream.id;
         var query = { files_id: id };
-        uploadStream.write('a', 'utf8', function(error) {
+        uploadStream.write('a', 'utf8', function (error) {
           test.equal(undefined, error);
 
-          db.collection(CHUNKS_COLL).count(query, function(error, c) {
+          db.collection(CHUNKS_COLL).count(query, function (error, c) {
             test.equal(error, null);
             test.equal(c, 1);
 
-            uploadStream.abort(function(error) {
+            uploadStream.abort(function (error) {
               test.equal(error, null);
 
-              db.collection(CHUNKS_COLL).count(query, function(error, c) {
+              db.collection(CHUNKS_COLL).count(query, function (error, c) {
                 test.equal(error, null);
                 test.equal(c, 0);
 
-                uploadStream.write('b', 'utf8', function(error) {
+                uploadStream.write('b', 'utf8', function (error) {
                   test.equal(error.toString(), 'Error: this stream has been aborted');
 
-                  uploadStream.end(function(error) {
+                  uploadStream.end(function (error) {
                     test.equal(error.toString(), 'Error: this stream has been aborted');
 
                     // Fail if user tries to abort an aborted stream
-                    uploadStream.abort().then(null, function(error) {
+                    uploadStream.abort().then(null, function (error) {
                       test.equal(error.toString(), 'Error: Cannot call abort() on a stream twice');
                       client.close(done);
                     });
@@ -1327,7 +1327,7 @@ describe('GridFS Stream', function() {
   it('NODE-829 start/end options for openDownloadStream where start-end is < size of chunk', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // LINE var MongoClient = require('mongodb').MongoClient,
@@ -1339,7 +1339,7 @@ describe('GridFS Stream', function() {
       // REMOVE-LINE done();
       // REMOVE-LINE var db = client.db(configuration.db);
       // BEGIN
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var bucket = new GridFSBucket(db, {
           bucketName: 'gridfsdownload',
@@ -1349,23 +1349,23 @@ describe('GridFS Stream', function() {
         var readStream = fs.createReadStream('./LICENSE.md');
         var uploadStream = bucket.openUploadStream('teststart.dat');
 
-        uploadStream.once('finish', function() {
+        uploadStream.once('finish', function () {
           var downloadStream = bucket
             .openDownloadStreamByName('teststart.dat', { start: 1 })
             .end(6);
 
-          downloadStream.on('error', function(error) {
+          downloadStream.on('error', function (error) {
             test.equal(error, null);
           });
 
           var gotData = 0;
           var str = '';
-          downloadStream.on('data', function(data) {
+          downloadStream.on('data', function (data) {
             ++gotData;
             str += data.toString('utf8');
           });
 
-          downloadStream.on('end', function() {
+          downloadStream.on('end', function () {
             // Depending on different versions of node, we may get
             // different amounts of 'data' events. node 0.10 gives 2,
             // node >= 0.12 gives 3. Either is correct, but we just
@@ -1382,7 +1382,7 @@ describe('GridFS Stream', function() {
     }
   });
 
-  it('should correctly handle indexes create with BSON.Double', function(done) {
+  it('should correctly handle indexes create with BSON.Double', function (done) {
     const configuration = this.configuration;
     const client = configuration.newClient();
     client.connect((err, client) => {
@@ -1402,7 +1402,7 @@ describe('GridFS Stream', function() {
     });
   });
 
-  it('NODE-2623 downloadStream should emit error on end > size', function() {
+  it('NODE-2623 downloadStream should emit error on end > size', function () {
     const configuration = this.configuration;
     return withClient.bind(this)((client, done) => {
       const db = client.db(configuration.db);
@@ -1416,11 +1416,11 @@ describe('GridFS Stream', function() {
 
       const id = uploadStream.id;
 
-      uploadStream.once('finish', function() {
+      uploadStream.once('finish', function () {
         const downloadStream = bucket.openDownloadStream(id, { end: wrongExpectedSize });
-        downloadStream.on('data', function() {});
+        downloadStream.on('data', function () {});
 
-        downloadStream.on('error', function(err) {
+        downloadStream.on('error', function (err) {
           expect(err.message).to.equal(
             `Stream end (${wrongExpectedSize}) must not be more than the length of the file (${actualSize})`
           );

--- a/test/functional/ignore_undefined.test.js
+++ b/test/functional/ignore_undefined.test.js
@@ -3,31 +3,31 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const { ObjectId } = require('../../src');
 
-describe('Ignore Undefined', function() {
-  before(function() {
+describe('Ignore Undefined', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it('Should correctly insert document ignoring undefined field', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         ignoreUndefined: true
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue');
 
         // Ignore the undefined field
-        collection.insert({ a: 1, b: undefined }, configuration.writeConcernMax(), function(err) {
+        collection.insert({ a: 1, b: undefined }, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
           // Locate the doument
-          collection.findOne(function(err, item) {
+          collection.findOne(function (err, item) {
             test.equal(1, item.a);
             test.ok(item.b === undefined);
             client.close(done);
@@ -42,7 +42,7 @@ describe('Ignore Undefined', function() {
     {
       metadata: { requires: { topology: ['single'] } },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
         const client = configuration.newClient(
           {},
@@ -53,27 +53,27 @@ describe('Ignore Undefined', function() {
           }
         );
 
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(configuration.db);
           var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue1');
-          collection.insert({ a: 1, b: undefined }, function(err) {
+          collection.insert({ a: 1, b: undefined }, function (err) {
             test.equal(null, err);
 
-            collection.findOne(function(err, item) {
+            collection.findOne(function (err, item) {
               test.equal(1, item.a);
               test.ok(item.b === undefined);
 
-              collection.insertOne({ a: 2, b: undefined }, function(err) {
+              collection.insertOne({ a: 2, b: undefined }, function (err) {
                 test.equal(null, err);
 
-                collection.findOne({ a: 2 }, function(err, item) {
+                collection.findOne({ a: 2 }, function (err, item) {
                   test.equal(2, item.a);
                   test.ok(item.b === undefined);
 
-                  collection.insertMany([{ a: 3, b: undefined }], function(err) {
+                  collection.insertMany([{ a: 3, b: undefined }], function (err) {
                     test.equal(null, err);
 
-                    collection.findOne({ a: 3 }, function(err, item) {
+                    collection.findOne({ a: 3 }, function (err, item) {
                       test.equal(3, item.a);
                       test.ok(item.b === undefined);
                       client.close(done);
@@ -91,14 +91,14 @@ describe('Ignore Undefined', function() {
   it('Should correctly update document ignoring undefined field', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         ignoreUndefined: true
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue2');
         var id = new ObjectId();
@@ -107,9 +107,9 @@ describe('Ignore Undefined', function() {
           { _id: id, a: 1, b: undefined },
           { $set: { a: 1, b: undefined } },
           { upsert: true },
-          function(err) {
+          function (err) {
             test.equal(null, err);
-            collection.findOne({ _id: id }, function(err, item) {
+            collection.findOne({ _id: id }, function (err, item) {
               test.equal(1, item.a);
               test.ok(item.b === undefined);
               var id = new ObjectId();
@@ -118,9 +118,9 @@ describe('Ignore Undefined', function() {
                 { _id: id, a: 1, b: undefined },
                 { $set: { a: 1, b: undefined } },
                 { upsert: true },
-                function(err) {
+                function (err) {
                   test.equal(null, err);
-                  collection.findOne({ _id: id }, function(err, item) {
+                  collection.findOne({ _id: id }, function (err, item) {
                     test.equal(1, item.a);
                     test.ok(item.b === undefined);
                     var id = new ObjectId();
@@ -129,9 +129,9 @@ describe('Ignore Undefined', function() {
                       { _id: id, a: 1, b: undefined },
                       { $set: { a: 1, b: undefined } },
                       { upsert: true },
-                      function(err) {
+                      function (err) {
                         test.equal(null, err);
-                        collection.findOne({ _id: id }, function(err, item) {
+                        collection.findOne({ _id: id }, function (err, item) {
                           test.equal(1, item.a);
                           test.ok(item.b === undefined);
                           client.close(done);

--- a/test/functional/index.test.js
+++ b/test/functional/index.test.js
@@ -2,8 +2,8 @@
 const { expect } = require('chai');
 const { assert: test, setupDatabase, withClient, withMonitoredClient } = require('./shared');
 
-describe('Indexes', function() {
-  before(function() {
+describe('Indexes', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -12,13 +12,13 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_index_information', function(err, collection) {
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+        db.createCollection('test_index_information', function (err, collection) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
             // Create an index on the collection
@@ -26,19 +26,19 @@ describe('Indexes', function() {
               collection.collectionName,
               'a',
               configuration.writeConcernMax(),
-              function(err, indexName) {
+              function (err, indexName) {
                 test.equal(null, err);
                 test.equal('a_1', indexName);
 
                 // Let's fetch the index information
-                db.indexInformation(collection.collectionName, function(err, collectionInfo) {
+                db.indexInformation(collection.collectionName, function (err, collectionInfo) {
                   test.equal(null, err);
                   test.ok(collectionInfo['_id_'] != null);
                   test.equal('_id', collectionInfo['_id_'][0][0]);
                   test.ok(collectionInfo['a_1'] != null);
                   test.deepEqual([['a', 1]], collectionInfo['a_1']);
 
-                  db.indexInformation(collection.collectionName, function(err, collectionInfo2) {
+                  db.indexInformation(collection.collectionName, function (err, collectionInfo2) {
                     var count1 = Object.keys(collectionInfo).length,
                       count2 = Object.keys(collectionInfo2).length;
 
@@ -68,13 +68,13 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_multiple_index_cols', function(err, collection) {
-          collection.insert({ a: 1 }, function(err) {
+        db.createCollection('test_multiple_index_cols', function (err, collection) {
+          collection.insert({ a: 1 }, function (err) {
             test.equal(null, err);
             // Create an index on the collection
             db.createIndex(
@@ -85,11 +85,11 @@ describe('Indexes', function() {
                 ['c', -1]
               ],
               configuration.writeConcernMax(),
-              function(err, indexName) {
+              function (err, indexName) {
                 expect(err).to.not.exist;
                 test.equal('a_-1_b_1_c_-1', indexName);
                 // Let's fetch the index information
-                db.indexInformation(collection.collectionName, function(err, collectionInfo) {
+                db.indexInformation(collection.collectionName, function (err, collectionInfo) {
                   var count1 = Object.keys(collectionInfo).length;
 
                   // Test
@@ -120,39 +120,39 @@ describe('Indexes', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Create a non-unique index and test inserts
-        db.createCollection('test_unique_index', function(err, collection) {
+        db.createCollection('test_unique_index', function (err, collection) {
           db.createIndex(
             collection.collectionName,
             'hello',
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               // Insert some docs
               collection.insert(
                 [{ hello: 'world' }, { hello: 'mike' }, { hello: 'world' }],
                 configuration.writeConcernMax(),
-                function(err) {
+                function (err) {
                   test.equal(null, err);
 
                   // Create a unique index and test that insert fails
-                  db.createCollection('test_unique_index2', function(err, collection) {
+                  db.createCollection('test_unique_index2', function (err, collection) {
                     db.createIndex(
                       collection.collectionName,
                       'hello',
                       { unique: true, w: 1 },
-                      function(err) {
+                      function (err) {
                         test.equal(null, err);
                         // Insert some docs
                         collection.insert(
                           [{ hello: 'world' }, { hello: 'mike' }, { hello: 'world' }],
                           configuration.writeConcernMax(),
-                          function(err) {
+                          function (err) {
                             test.ok(err != null);
                             test.equal(11000, err.code);
                             client.close(done);
@@ -175,26 +175,26 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Create a non-unique index and test inserts
-        db.createCollection('test_index_on_subfield', function(err, collection) {
+        db.createCollection('test_index_on_subfield', function (err, collection) {
           collection.insert(
             [{ hello: { a: 4, b: 5 } }, { hello: { a: 7, b: 2 } }, { hello: { a: 4, b: 10 } }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // Create a unique subfield index and test that insert fails
-              db.createCollection('test_index_on_subfield2', function(err, collection) {
+              db.createCollection('test_index_on_subfield2', function (err, collection) {
                 db.createIndex(
                   collection.collectionName,
                   'hello_a',
                   { w: 1, unique: true },
-                  function(err) {
+                  function (err) {
                     test.equal(null, err);
 
                     collection.insert(
@@ -204,7 +204,7 @@ describe('Indexes', function() {
                         { hello: { a: 4, b: 10 } }
                       ],
                       configuration.writeConcernMax(),
-                      function(err) {
+                      function (err) {
                         // Assert that we have erros
                         test.ok(err != null);
                         client.close(done);
@@ -225,26 +225,26 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_drop_indexes', function(err, collection) {
-          collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+        db.createCollection('test_drop_indexes', function (err, collection) {
+          collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
             // Create an index on the collection
             db.createIndex(
               collection.collectionName,
               'a',
               configuration.writeConcernMax(),
-              function(err, indexName) {
+              function (err, indexName) {
                 test.equal('a_1', indexName);
                 // Drop all the indexes
-                collection.dropAllIndexes(function(err, result) {
+                collection.dropAllIndexes(function (err, result) {
                   test.equal(true, result);
 
-                  collection.indexInformation(function(err, result) {
+                  collection.indexInformation(function (err, result) {
                     test.ok(result['a_1'] == null);
                     client.close(done);
                   });
@@ -262,12 +262,12 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_distinct_queries', function(err, collection) {
+        db.createCollection('test_distinct_queries', function (err, collection) {
           collection.insert(
             [
               { a: 0, b: { c: 'a' } },
@@ -278,12 +278,12 @@ describe('Indexes', function() {
               { a: 3 }
             ],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
-              collection.distinct('a', function(err, docs) {
+              collection.distinct('a', function (err, docs) {
                 test.deepEqual([0, 1, 2, 3], docs.sort());
 
-                collection.distinct('b.c', function(err, docs) {
+                collection.distinct('b.c', function (err, docs) {
                   test.deepEqual(['a', 'b', 'c'], docs.sort());
                   client.close(done);
                 });
@@ -300,22 +300,22 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_ensure_index', function(err, collection) {
+        db.createCollection('test_ensure_index', function (err, collection) {
           expect(err).to.not.exist;
           // Create an index on the collection
-          db.ensureIndex(collection.collectionName, 'a', configuration.writeConcernMax(), function(
+          db.ensureIndex(collection.collectionName, 'a', configuration.writeConcernMax(), function (
             err,
             indexName
           ) {
             expect(err).to.not.exist;
             test.equal('a_1', indexName);
             // Let's fetch the index information
-            db.indexInformation(collection.collectionName, function(err, collectionInfo) {
+            db.indexInformation(collection.collectionName, function (err, collectionInfo) {
               test.ok(collectionInfo['_id_'] != null);
               test.equal('_id', collectionInfo['_id_'][0][0]);
               test.ok(collectionInfo['a_1'] != null);
@@ -325,10 +325,10 @@ describe('Indexes', function() {
                 collection.collectionName,
                 'a',
                 configuration.writeConcernMax(),
-                function(err, indexName) {
+                function (err, indexName) {
                   test.equal('a_1', indexName);
                   // Let's fetch the index information
-                  db.indexInformation(collection.collectionName, function(err, collectionInfo) {
+                  db.indexInformation(collection.collectionName, function (err, collectionInfo) {
                     test.ok(collectionInfo['_id_'] != null);
                     test.equal('_id', collectionInfo['_id_'][0][0]);
                     test.ok(collectionInfo['a_1'] != null);
@@ -350,31 +350,31 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('create_and_use_sparse_index_test', function(err) {
+        db.createCollection('create_and_use_sparse_index_test', function (err) {
           test.equal(null, err);
-          db.collection('create_and_use_sparse_index_test', function(err, collection) {
+          db.collection('create_and_use_sparse_index_test', function (err, collection) {
             expect(err).to.not.exist;
-            collection.ensureIndex({ title: 1 }, { sparse: true, w: 1 }, function(err) {
+            collection.ensureIndex({ title: 1 }, { sparse: true, w: 1 }, function (err) {
               test.equal(null, err);
               collection.insert(
                 [{ name: 'Jim' }, { name: 'Sarah', title: 'Princess' }],
                 configuration.writeConcernMax(),
-                function(err) {
+                function (err) {
                   test.equal(null, err);
                   collection
                     .find({ title: { $ne: null } })
                     .sort({ title: 1 })
-                    .toArray(function(err, items) {
+                    .toArray(function (err, items) {
                       test.equal(1, items.length);
                       test.equal('Sarah', items[0].name);
 
                       // Fetch the info for the indexes
-                      collection.indexInformation({ full: true }, function(err, indexInfo) {
+                      collection.indexInformation({ full: true }, function (err, indexInfo) {
                         test.equal(null, err);
                         test.equal(2, indexInfo.length);
                         client.close(done);
@@ -399,22 +399,22 @@ describe('Indexes', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('geospatial_index_test', function(err) {
+        db.createCollection('geospatial_index_test', function (err) {
           test.equal(null, err);
-          db.collection('geospatial_index_test', function(err, collection) {
-            collection.ensureIndex({ loc: '2d' }, configuration.writeConcernMax(), function(err) {
+          db.collection('geospatial_index_test', function (err, collection) {
+            collection.ensureIndex({ loc: '2d' }, configuration.writeConcernMax(), function (err) {
               test.equal(null, err);
-              collection.insert({ loc: [-100, 100] }, configuration.writeConcernMax(), function(
+              collection.insert({ loc: [-100, 100] }, configuration.writeConcernMax(), function (
                 err
               ) {
                 test.equal(err, null);
 
-                collection.insert({ loc: [200, 200] }, configuration.writeConcernMax(), function(
+                collection.insert({ loc: [200, 200] }, configuration.writeConcernMax(), function (
                   err
                 ) {
                   test.ok(err.errmsg.indexOf('point not in interval of') !== -1);
@@ -440,28 +440,28 @@ describe('Indexes', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('geospatial_index_altered_test', function(err) {
+        db.createCollection('geospatial_index_altered_test', function (err) {
           test.equal(null, err);
-          db.collection('geospatial_index_altered_test', function(err, collection) {
-            collection.ensureIndex({ loc: '2d' }, { min: 0, max: 1024, w: 1 }, function(err) {
+          db.collection('geospatial_index_altered_test', function (err, collection) {
+            collection.ensureIndex({ loc: '2d' }, { min: 0, max: 1024, w: 1 }, function (err) {
               test.equal(null, err);
-              collection.insert({ loc: [100, 100] }, configuration.writeConcernMax(), function(
+              collection.insert({ loc: [100, 100] }, configuration.writeConcernMax(), function (
                 err
               ) {
                 test.equal(err, null);
-                collection.insert({ loc: [200, 200] }, configuration.writeConcernMax(), function(
+                collection.insert({ loc: [200, 200] }, configuration.writeConcernMax(), function (
                   err
                 ) {
                   test.equal(err, null);
                   collection.insert(
                     { loc: [-200, -200] },
                     configuration.writeConcernMax(),
-                    function(err) {
+                    function (err) {
                       test.ok(err.errmsg.indexOf('point not in interval of') !== -1);
                       test.ok(err.errmsg.indexOf('0') !== -1);
                       test.ok(err.errmsg.indexOf('1024') !== -1);
@@ -482,19 +482,19 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('shouldThrowDuplicateKeyErrorWhenCreatingIndex', function(
+        db.createCollection('shouldThrowDuplicateKeyErrorWhenCreatingIndex', function (
           err,
           collection
         ) {
-          collection.insert([{ a: 1 }, { a: 1 }], configuration.writeConcernMax(), function(err) {
+          collection.insert([{ a: 1 }, { a: 1 }], configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
-            collection.ensureIndex({ a: 1 }, { unique: true, w: 1 }, function(err) {
+            collection.ensureIndex({ a: 1 }, { unique: true, w: 1 }, function (err) {
               test.ok(err != null);
               client.close(done);
             });
@@ -509,19 +509,19 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('shouldThrowDuplicateKeyErrorWhenDriverInStrictMode', function(
+        db.createCollection('shouldThrowDuplicateKeyErrorWhenDriverInStrictMode', function (
           err,
           collection
         ) {
-          collection.insert([{ a: 1 }, { a: 1 }], configuration.writeConcernMax(), function(err) {
+          collection.insert([{ a: 1 }, { a: 1 }], configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
-            collection.ensureIndex({ a: 1 }, { unique: true, w: 1 }, function(err) {
+            collection.ensureIndex({ a: 1 }, { unique: true, w: 1 }, function (err) {
               test.ok(err != null);
               client.close(done);
             });
@@ -536,22 +536,22 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Establish connection to db
-        db.createCollection('shouldCorrectlyUseMinMaxForSettingRangeInEnsureIndex', function(
+        db.createCollection('shouldCorrectlyUseMinMaxForSettingRangeInEnsureIndex', function (
           err,
           collection
         ) {
           test.equal(null, err);
 
-          collection.ensureIndex({ loc: '2d' }, { min: 200, max: 1400, w: 1 }, function(err) {
+          collection.ensureIndex({ loc: '2d' }, { min: 200, max: 1400, w: 1 }, function (err) {
             test.equal(null, err);
 
-            collection.insert({ loc: [600, 600] }, configuration.writeConcernMax(), function(err) {
+            collection.insert({ loc: [600, 600] }, configuration.writeConcernMax(), function (err) {
               test.equal(null, err);
               client.close(done);
             });
@@ -566,23 +566,23 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Establish connection to db
-        db.createCollection('shouldCorrectlyCreateAnIndexWithOverridenName', function(
+        db.createCollection('shouldCorrectlyCreateAnIndexWithOverridenName', function (
           err,
           collection
         ) {
           test.equal(null, err);
 
-          collection.ensureIndex('name', { name: 'myfunky_name' }, function(err) {
+          collection.ensureIndex('name', { name: 'myfunky_name' }, function (err) {
             test.equal(null, err);
 
             // Fetch full index information
-            collection.indexInformation({ full: false }, function(err, indexInformation) {
+            collection.indexInformation({ full: false }, function (err, indexInformation) {
               test.ok(indexInformation['myfunky_name'] != null);
               client.close(done);
             });
@@ -597,18 +597,18 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var shared = require('./contexts');
 
-        db.collection('indexcontext').ensureIndex(shared.object, { background: true }, function(
+        db.collection('indexcontext').ensureIndex(shared.object, { background: true }, function (
           err
         ) {
           test.equal(null, err);
-          db.collection('indexcontext').ensureIndex(shared.array, { background: true }, function(
+          db.collection('indexcontext').ensureIndex(shared.array, { background: true }, function (
             err
           ) {
             test.equal(null, err);
@@ -624,22 +624,24 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('should_throw_error_due_to_duplicates');
-        collection.insert([{ a: 1 }, { a: 1 }, { a: 1 }], configuration.writeConcernMax(), function(
-          err
-        ) {
-          test.equal(null, err);
+        collection.insert(
+          [{ a: 1 }, { a: 1 }, { a: 1 }],
+          configuration.writeConcernMax(),
+          function (err) {
+            test.equal(null, err);
 
-          collection.ensureIndex({ a: 1 }, { w: 1, unique: true }, function(err) {
-            test.ok(err != null);
-            client.close(done);
-          });
-        });
+            collection.ensureIndex({ a: 1 }, { w: 1, unique: true }, function (err) {
+              test.ok(err != null);
+              client.close(done);
+            });
+          }
+        );
       });
     }
   });
@@ -649,16 +651,16 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('should_correctly_drop_index');
-        collection.insert([{ a: 1 }], configuration.writeConcernMax(), function(err) {
+        collection.insert([{ a: 1 }], configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
-          collection.ensureIndex({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.ensureIndex({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
             collection
               .dropIndex('a_1')
@@ -680,22 +682,22 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('should_correctly_apply_hint');
-        collection.insert([{ a: 1 }], configuration.writeConcernMax(), function(err) {
+        collection.insert([{ a: 1 }], configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
-          collection.ensureIndex({ a: 1 }, configuration.writeConcernMax(), function(err) {
+          collection.ensureIndex({ a: 1 }, configuration.writeConcernMax(), function (err) {
             test.equal(null, err);
 
-            collection.indexInformation({ full: false }, function(err) {
+            collection.indexInformation({ full: false }, function (err) {
               test.equal(null, err);
 
-              collection.find({}, { hint: 'a_1' }).toArray(function(err, docs) {
+              collection.find({}, { hint: 'a_1' }).toArray(function (err, docs) {
                 test.equal(null, err);
                 test.equal(1, docs[0].a);
                 client.close(done);
@@ -715,13 +717,13 @@ describe('Indexes', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('should_correctly_set_language_override');
-        collection.insert([{ text: 'Lorem ipsum dolor sit amet.', langua: 'italian' }], function(
+        collection.insert([{ text: 'Lorem ipsum dolor sit amet.', langua: 'italian' }], function (
           err
         ) {
           test.equal(null, err);
@@ -729,10 +731,10 @@ describe('Indexes', function() {
           collection.ensureIndex(
             { text: 'text' },
             { language_override: 'langua', name: 'language_override_index' },
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
-              collection.indexInformation({ full: true }, function(err, indexInformation) {
+              collection.indexInformation({ full: true }, function (err, indexInformation) {
                 test.equal(null, err);
                 for (var i = 0; i < indexInformation.length; i++) {
                   if (indexInformation[i].name === 'language_override_index')
@@ -753,18 +755,18 @@ describe('Indexes', function() {
       requires: { mongodb: '>=2.4.0', topology: ['single', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.collection('testListIndexes').ensureIndex({ a: 1 }, function(err) {
+        db.collection('testListIndexes').ensureIndex({ a: 1 }, function (err) {
           test.equal(null, err);
 
           // Get the list of indexes
           db.collection('testListIndexes')
             .listIndexes()
-            .toArray(function(err, indexes) {
+            .toArray(function (err, indexes) {
               test.equal(null, err);
               test.equal(2, indexes.length);
 
@@ -780,18 +782,18 @@ describe('Indexes', function() {
       requires: { mongodb: '>=2.4.0', topology: ['single', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.collection('testListIndexes_2').ensureIndex({ a: 1 }, function(err) {
+        db.collection('testListIndexes_2').ensureIndex({ a: 1 }, function (err) {
           test.equal(null, err);
 
           // Get the list of indexes
           db.collection('testListIndexes_2')
             .listIndexes()
-            .hasNext(function(err, result) {
+            .hasNext(function (err, result) {
               test.equal(null, err);
               test.equal(true, result);
 
@@ -807,18 +809,18 @@ describe('Indexes', function() {
       requires: { mongodb: '>=2.4.0', topology: ['single', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.collection('ensureIndexWithNestedStyleIndex').ensureIndex({ 'c.d': 1 }, function(err) {
+        db.collection('ensureIndexWithNestedStyleIndex').ensureIndex({ 'c.d': 1 }, function (err) {
           test.equal(null, err);
 
           // Get the list of indexes
           db.collection('ensureIndexWithNestedStyleIndex')
             .listIndexes()
-            .toArray(function(err, indexes) {
+            .toArray(function (err, indexes) {
               test.equal(null, err);
               test.equal(2, indexes.length);
 
@@ -834,20 +836,20 @@ describe('Indexes', function() {
       requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('createIndexes').createIndexes(
           [{ key: { a: 1 } }, { key: { b: 1 }, name: 'hello1' }],
-          function(err, r) {
+          function (err, r) {
             test.equal(null, err);
             test.equal(3, r.numIndexesAfter);
 
             db.collection('createIndexes')
               .listIndexes()
-              .toArray(function(err, docs) {
+              .toArray(function (err, docs) {
                 test.equal(null, err);
                 var keys = {};
 
@@ -871,12 +873,12 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.collection('text_index').createIndex({ '$**': 'text' }, { name: 'TextIndex' }, function(
+        db.collection('text_index').createIndex({ '$**': 'text' }, { name: 'TextIndex' }, function (
           err,
           r
         ) {
@@ -897,31 +899,31 @@ describe('Indexes', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var started = [];
       var succeeded = [];
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      var listener = require('../../src').instrument(function(err) {
+      var listener = require('../../src').instrument(function (err) {
         test.equal(null, err);
       });
 
-      listener.on('started', function(event) {
+      listener.on('started', function (event) {
         if (event.commandName === 'createIndexes') started.push(event);
       });
 
-      listener.on('succeeded', function(event) {
+      listener.on('succeeded', function (event) {
         if (event.commandName === 'createIndexes') succeeded.push(event);
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         db.collection('partialIndexes').createIndex(
           { a: 1 },
           { partialFilterExpression: { a: 1 } },
-          function(err) {
+          function (err) {
             test.equal(null, err);
             test.deepEqual({ a: 1 }, started[0].command.indexes[0].partialFilterExpression);
             listener.uninstrument();
@@ -940,16 +942,16 @@ describe('Indexes', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(error, client) {
+      client.connect(function (error, client) {
         var db = client.db(configuration.db);
         test.equal(error, null);
         // Can't use $exists: false in partial filter expression, see
         // https://jira.mongodb.org/browse/SERVER-17853
         var opts = { partialFilterExpression: { a: { $exists: false } } };
-        db.collection('partialIndexes').createIndex({ a: 1 }, opts, function(err) {
+        db.collection('partialIndexes').createIndex({ a: 1 }, opts, function (err) {
           test.ok(err);
           test.equal(err.code, 67);
           var msg = "key $exists must not start with '$'";
@@ -966,10 +968,10 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
         var collection = db.collection('embedded_key_indes');
@@ -983,10 +985,10 @@ describe('Indexes', function() {
               a: { a: 2 }
             }
           ],
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
-            collection.ensureIndex({ 'a.a': 1 }, function(err) {
+            collection.ensureIndex({ 'a.a': 1 }, function (err) {
               test.equal(null, err);
               client.close(done);
             });
@@ -1001,17 +1003,17 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
         var collection = db.collection('embedded_key_indes_1');
         collection.createIndex(
           { 'key.external_id': 1, 'key.type': 1 },
           { unique: true, sparse: true, name: 'indexname' },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
             client.close(done);
@@ -1026,10 +1028,10 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
         var collection = db.collection('embedded_key_indes_2');
@@ -1042,12 +1044,12 @@ describe('Indexes', function() {
               key: { external_id: 1, type: 1 }
             }
           ],
-          function(err) {
+          function (err) {
             test.equal(null, err);
             collection.createIndex(
               { 'key.external_id': 1, 'key.type': 1 },
               { unique: true, sparse: true, name: 'indexname' },
-              function(err) {
+              function (err) {
                 test.equal(11000, err.code);
 
                 client.close(done);
@@ -1099,16 +1101,16 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // insert a doc
         db.collection('messed_up_index').createIndex(
           { temporary: 1, 'store.addressLines': 1, lifecycleStatus: 1 },
           configuration.writeConcernMax(),
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
             client.close(done);
@@ -1126,26 +1128,28 @@ describe('Indexes', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('messed_up_options');
 
-        collection.ensureIndex({ 'a.one': 1, 'a.two': 1 }, { name: 'n1', sparse: false }, function(
+        collection.ensureIndex({ 'a.one': 1, 'a.two': 1 }, { name: 'n1', sparse: false }, function (
           err
         ) {
           test.equal(null, err);
 
-          collection.ensureIndex({ 'a.one': 1, 'a.two': 1 }, { name: 'n2', sparse: true }, function(
-            err
-          ) {
-            test.ok(err);
-            test.equal(85, err.code);
+          collection.ensureIndex(
+            { 'a.one': 1, 'a.two': 1 },
+            { name: 'n2', sparse: true },
+            function (err) {
+              test.ok(err);
+              test.equal(85, err.code);
 
-            client.close(done);
-          });
+              client.close(done);
+            }
+          );
         });
       });
     }
@@ -1159,17 +1163,17 @@ describe('Indexes', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('messed_up_options');
 
-        collection.createIndex({ 'b.one': 1, 'b.two': 1 }, { name: 'test' }, function(err) {
+        collection.createIndex({ 'b.one': 1, 'b.two': 1 }, { name: 'test' }, function (err) {
           test.equal(null, err);
 
-          collection.createIndex({ 'b.one': -1, 'b.two': -1 }, { name: 'test' }, function(err) {
+          collection.createIndex({ 'b.one': -1, 'b.two': -1 }, { name: 'test' }, function (err) {
             test.ok(err);
             test.equal(86, err.code);
 
@@ -1185,16 +1189,16 @@ describe('Indexes', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // insert a doc
         db.collection('messed_up_index_2').createIndex(
           { 'accessControl.get': 1 },
           { background: true },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
             client.close(done);
@@ -1204,7 +1208,7 @@ describe('Indexes', function() {
     }
   });
 
-  context('commitQuorum', function() {
+  context('commitQuorum', function () {
     function throwErrorTest(testCommand) {
       return {
         metadata: { requires: { mongodb: '<4.4' } },
@@ -1248,19 +1252,15 @@ describe('Indexes', function() {
     function commitQuorumTest(testCommand) {
       return {
         metadata: { requires: { mongodb: '>=4.4', topology: ['replicaset', 'sharded'] } },
-        test: withMonitoredClient('createIndexes', function(client, events, done) {
+        test: withMonitoredClient('createIndexes', function (client, events, done) {
           const db = client.db('test');
           const collection = db.collection('commitQuorum');
-          collection.insertOne({ a: 1 }, function(err) {
+          collection.insertOne({ a: 1 }, function (err) {
             expect(err).to.not.exist;
             testCommand(db, collection, err => {
               expect(err).to.not.exist;
-              expect(events)
-                .to.be.an('array')
-                .with.lengthOf(1);
-              expect(events[0])
-                .nested.property('command.commitQuorum')
-                .to.equal(0);
+              expect(events).to.be.an('array').with.lengthOf(1);
+              expect(events[0]).nested.property('command.commitQuorum').to.equal(0);
               collection.drop(err => {
                 expect(err).to.not.exist;
                 done();

--- a/test/functional/insert.test.js
+++ b/test/functional/insert.test.js
@@ -23,7 +23,7 @@ const {
  *
  * @param {any} string
  */
-var ISODate = function(string) {
+var ISODate = function (string) {
   var match;
 
   if (typeof string.getTime === 'function') return string;
@@ -58,8 +58,8 @@ var ISODate = function(string) {
   } else throw new Error('Invalid ISO 8601 date given.', __filename);
 };
 
-describe('Insert', function() {
-  before(function() {
+describe('Insert', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -70,16 +70,16 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyPerformSingleInsert');
-        collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err) {
+        collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
 
-          collection.findOne(function(err, item) {
+          collection.findOne(function (err, item) {
             test.equal(1, item.a);
             client.close(done);
           });
@@ -95,15 +95,15 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_multiple_insert');
         var docs = [{ a: 1 }, { a: 2 }];
 
-        collection.insert(docs, configuration.writeConcernMax(), function(err, r) {
+        collection.insert(docs, configuration.writeConcernMax(), function (err, r) {
           test.equal(2, r.result.n);
           test.equal(2, r.ops.length);
           test.equal(2, r.insertedCount);
@@ -111,7 +111,7 @@ describe('Insert', function() {
           test.ok(r.insertedIds[0]._bsontype === 'ObjectID');
           test.ok(r.insertedIds[1]._bsontype === 'ObjectID');
 
-          r.ops.forEach(function(doc) {
+          r.ops.forEach(function (doc) {
             test.ok(
               doc['_id']._bsontype === 'ObjectID' ||
                 Object.prototype.toString.call(doc['_id']) === '[object ObjectID]'
@@ -119,11 +119,11 @@ describe('Insert', function() {
           });
 
           // Let's ensure we have both documents
-          collection.find().toArray(function(err, docs) {
+          collection.find().toArray(function (err, docs) {
             test.equal(2, docs.length);
             var results = [];
             // Check that we have all the results we want
-            docs.forEach(function(doc) {
+            docs.forEach(function (doc) {
               if (doc.a === 1 || doc.a === 2) results.push(1);
             });
             test.equal(2, results.length);
@@ -142,21 +142,21 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyExecuteSaveInsertUpdate');
 
-        collection.save({ email: 'save' }, configuration.writeConcernMax(), function() {
-          collection.insert({ email: 'insert' }, configuration.writeConcernMax(), function() {
+        collection.save({ email: 'save' }, configuration.writeConcernMax(), function () {
+          collection.insert({ email: 'insert' }, configuration.writeConcernMax(), function () {
             collection.update(
               { email: 'update' },
               { email: 'update' },
               { upsert: true, w: 1 },
-              function() {
-                collection.find().toArray(function(e, a) {
+              function () {
+                collection.find().toArray(function (e, a) {
                   test.equal(3, a.length);
                   client.close(done);
                 });
@@ -175,10 +175,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_should_deserialize_large_integrated_array');
 
@@ -204,10 +204,10 @@ describe('Insert', function() {
           ]
         };
         // Insert the collection
-        collection.insert(doc, configuration.writeConcernMax(), function(err) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
           // Fetch and check the collection
-          collection.findOne({ a: 0 }, function(err, result) {
+          collection.findOne({ a: 0 }, function (err, result) {
             test.deepEqual(doc.a, result.a);
             test.deepEqual(doc.b, result.b);
             client.close(done);
@@ -224,10 +224,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_all_serialization_types');
 
@@ -255,9 +255,9 @@ describe('Insert', function() {
           dbref: new DBRef('namespace', oid, 'integration_tests_')
         };
 
-        collection.insert(motherOfAllDocuments, configuration.writeConcernMax(), function(err) {
+        collection.insert(motherOfAllDocuments, configuration.writeConcernMax(), function (err) {
           test.equal(null, err);
-          collection.findOne(function(err, doc) {
+          collection.findOne(function (err, doc) {
             // Assert correct deserialization of the values
             test.equal(motherOfAllDocuments.string, doc.string);
             test.deepEqual(motherOfAllDocuments.array, doc.array);
@@ -294,15 +294,15 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         //convience curried handler for functions of type 'a -> (err, result)
         function getResult(callback) {
-          return function(error, result) {
+          return function (error, result) {
             test.ok(error == null);
             return callback(result);
           };
@@ -310,8 +310,8 @@ describe('Insert', function() {
 
         db.collection(
           'users',
-          getResult(function(user_collection) {
-            user_collection.remove({}, configuration.writeConcernMax(), function(err) {
+          getResult(function (user_collection) {
+            user_collection.remove({}, configuration.writeConcernMax(), function (err) {
               test.equal(null, err);
 
               //first, create a user object
@@ -319,7 +319,7 @@ describe('Insert', function() {
               user_collection.insert(
                 [newUser],
                 configuration.writeConcernMax(),
-                getResult(function(r) {
+                getResult(function (r) {
                   var user = r.ops[0];
 
                   var scriptCode = "settings.block = []; settings.block.push('test');";
@@ -334,9 +334,9 @@ describe('Insert', function() {
                     { _id: user._id },
                     updateCommand,
                     configuration.writeConcernMax(),
-                    getResult(function() {
+                    getResult(function () {
                       // Fetch the object and check that the changes are persisted
-                      user_collection.findOne({ _id: user._id }, function(err, doc) {
+                      user_collection.findOne({ _id: user._id }, function (err, doc) {
                         test.ok(err == null);
                         test.equal('Test Account', doc.name);
                         test.equal('somestring', doc.settings.thisOneWorks);
@@ -361,10 +361,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_all_serialization_types_new_context');
 
@@ -405,12 +405,12 @@ describe('Insert', function() {
         // sys.puts(sys.inspect(context.motherOfAllDocuments))
         var motherOfAllDocuments = context.motherOfAllDocuments;
 
-        collection.insert(context.motherOfAllDocuments, configuration.writeConcernMax(), function(
+        collection.insert(context.motherOfAllDocuments, configuration.writeConcernMax(), function (
           err,
           docs
         ) {
           test.ok(docs);
-          collection.findOne(function(err, doc) {
+          collection.findOne(function (err, doc) {
             // Assert correct deserialization of the values
             test.equal(motherOfAllDocuments.string, doc.string);
             test.deepEqual(motherOfAllDocuments.array, doc.array);
@@ -446,19 +446,19 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_to_json_for_long');
 
         collection.insert(
           [{ value: Long.fromNumber(32222432) }],
           configuration.writeConcernMax(),
-          function(err, ids) {
+          function (err, ids) {
             test.ok(ids);
-            collection.findOne({}, function(err, item) {
+            collection.findOne({}, function (err, item) {
               test.equal(32222432, item.value);
               client.close(done);
             });
@@ -475,10 +475,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_insert_and_update_no_callback');
 
@@ -488,9 +488,9 @@ describe('Insert', function() {
         collection.update({ i: 1 }, { $set: { i: 2 } });
 
         // Make sure we leave enough time for mongodb to record the data
-        setTimeout(function() {
+        setTimeout(function () {
           // Locate document
-          collection.findOne({}, function(err, item) {
+          collection.findOne({}, function (err, item) {
             test.equal(2, item.i);
             client.close(done);
           });
@@ -506,10 +506,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_insert_and_query_timestamp');
 
@@ -517,10 +517,10 @@ describe('Insert', function() {
         collection.insert(
           { i: Timestamp.fromNumber(100), j: Long.fromNumber(200) },
           configuration.writeConcernMax(),
-          function(err, r) {
+          function (err, r) {
             test.ok(r);
             // Locate document
-            collection.findOne({}, function(err, item) {
+            collection.findOne({}, function (err, item) {
               test.ok(item.i._bsontype === 'Timestamp');
               test.equal(100, item.i.toInt());
               test.equal(200, item.j);
@@ -539,20 +539,20 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_insert_and_query_undefined');
 
         // Insert the update
-        collection.insert({ i: undefined }, configuration.writeConcernMax(), function(err, r) {
+        collection.insert({ i: undefined }, configuration.writeConcernMax(), function (err, r) {
           test.equal(null, err);
           test.ok(r);
 
           // Locate document
-          collection.findOne({}, function(err, item) {
+          collection.findOne({}, function (err, item) {
             test.equal(null, item.i);
 
             client.close(done);
@@ -569,7 +569,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var dbref = new DBRef('foo', ObjectId.createFromHexString('fc24a04d4560531f00000000'), null);
       JSON.stringify(dbref);
       done();
@@ -583,23 +583,23 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_should_throw_error_if_serializing_function');
-        var func = function() {
+        var func = function () {
           return 1;
         };
         // Insert the update
-        collection.insert({ i: 1, z: func }, { w: 1, serializeFunctions: true }, function(
+        collection.insert({ i: 1, z: func }, { w: 1, serializeFunctions: true }, function (
           err,
           result
         ) {
           test.equal(null, err);
 
-          collection.findOne({ _id: result.ops[0]._id }, function(err, object) {
+          collection.findOne({ _id: result.ops[0]._id }, function (err, object) {
             test.equal(normalizedFunctionString(func), object.z.code);
             test.equal(1, object.i);
             client.close(done);
@@ -616,23 +616,23 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_should_throw_error_if_serializing_function_1');
-        var func = function() {
+        var func = function () {
           return 1;
         };
         // Insert the update
         collection.insert(
           { i: 1, z: func },
           { w: 1, serializeFunctions: true, ordered: false },
-          function(err, result) {
+          function (err, result) {
             test.equal(null, err);
 
-            collection.findOne({ _id: result.ops[0]._id }, function(err, object) {
+            collection.findOne({ _id: result.ops[0]._id }, function (err, object) {
               test.equal(normalizedFunctionString(func), object.z.code);
               test.equal(1, object.i);
               client.close(done);
@@ -650,23 +650,23 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('insert_doc_with_uuid');
 
         collection.insert(
           { _id: '12345678123456781234567812345678', field: '1' },
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.equal(null, err);
             test.ok(result);
 
             collection
               .find({ _id: '12345678123456781234567812345678' })
-              .toArray(function(err, items) {
+              .toArray(function (err, items) {
                 test.equal(null, err);
                 test.equal(items[0]._id, '12345678123456781234567812345678');
                 test.equal(items[0].field, '1');
@@ -680,11 +680,11 @@ describe('Insert', function() {
                 collection.insert(
                   { _id: binaryUUID, field: '2' },
                   configuration.writeConcernMax(),
-                  function(err, result) {
+                  function (err, result) {
                     test.equal(null, err);
                     test.ok(result);
 
-                    collection.find({ _id: binaryUUID }).toArray(function(err, items) {
+                    collection.find({ _id: binaryUUID }).toArray(function (err, items) {
                       test.equal(null, err);
                       test.equal(items[0].field, '2');
                       client.close(done);
@@ -705,17 +705,17 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_insert_and_update_no_callback_strict');
 
         collection.insert(
           { _id: '12345678123456781234567812345678', field: '1' },
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.equal(null, err);
             test.ok(result);
 
@@ -723,7 +723,7 @@ describe('Insert', function() {
               { _id: '12345678123456781234567812345678' },
               { $set: { field: 0 } },
               configuration.writeConcernMax(),
-              function(err, r) {
+              function (err, r) {
                 test.equal(null, err);
                 test.equal(1, r.result.n);
                 client.close(done);
@@ -742,10 +742,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyInsertDBRefWithDbNotDefined');
 
@@ -753,7 +753,7 @@ describe('Insert', function() {
         var doc2 = { _id: new ObjectId() };
         var doc3 = { _id: new ObjectId() };
 
-        collection.insert(doc, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
@@ -765,12 +765,12 @@ describe('Insert', function() {
             configuration.db_name
           );
 
-          collection.insert([doc2, doc3], configuration.writeConcernMax(), function(err, result) {
+          collection.insert([doc2, doc3], configuration.writeConcernMax(), function (err, result) {
             test.equal(null, err);
             test.ok(result);
 
             // Get all items
-            collection.find().toArray(function(err, items) {
+            collection.find().toArray(function (err, items) {
               test.equal('shouldCorrectlyInsertDBRefWithDbNotDefined', items[1].ref.namespace);
               test.equal(doc._id.toString(), items[1].ref.oid.toString());
               expect(items[1].ref.db).to.be.null;
@@ -794,29 +794,29 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyInsertUpdateRemoveWithNoOptions');
 
-        collection.insert({ a: 1 }, configuration.writeConcernMax(), function(err, result) {
+        collection.insert({ a: 1 }, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
-          collection.update({ a: 1 }, { a: 2 }, configuration.writeConcernMax(), function(
+          collection.update({ a: 1 }, { a: 2 }, configuration.writeConcernMax(), function (
             err,
             result
           ) {
             test.equal(null, err);
             test.ok(result);
 
-            collection.remove({ a: 2 }, configuration.writeConcernMax(), function(err, result) {
+            collection.remove({ a: 2 }, configuration.writeConcernMax(), function (err, result) {
               test.equal(null, err);
               test.ok(result);
 
-              collection.count(function(err, count) {
+              collection.count(function (err, count) {
                 test.equal(0, count);
                 client.close(done);
               });
@@ -834,24 +834,24 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Search parameter
       var to = 'ralph';
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyExecuteMultipleFetches');
         // Execute query
         collection.insert(
           { addresses: { localPart: 'ralph' } },
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.equal(null, err);
             test.ok(result);
 
             // Let's find our user
-            collection.findOne({ 'addresses.localPart': to }, function(err, doc) {
+            collection.findOne({ 'addresses.localPart': to }, function (err, doc) {
               test.equal(null, err);
               test.equal(to, doc.addresses.localPart);
               client.close(done);
@@ -869,10 +869,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyFailWhenNoObjectToUpdate');
 
@@ -880,7 +880,7 @@ describe('Insert', function() {
           { _id: new ObjectId() },
           { email: 'update' },
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.equal(0, result.result.n);
             client.close(done);
           }
@@ -896,7 +896,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var doc = {
         _id: new ObjectId('4e886e687ff7ef5e00000162'),
@@ -909,17 +909,17 @@ describe('Insert', function() {
       };
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection(
           'Should_correctly_insert_object_and_retrieve_it_when_containing_array_and_IsoDate'
         );
 
-        collection.insert(doc, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err, result) {
           test.ok(err == null);
           test.ok(result);
 
-          collection.findOne(function(err, item) {
+          collection.findOne(function (err, item) {
             test.ok(err == null);
             test.deepEqual(doc, item);
             client.close(done);
@@ -936,7 +936,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var doc = {
         _id: new ObjectId('4e886e687ff7ef5e00000162'),
@@ -950,15 +950,15 @@ describe('Insert', function() {
       };
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('Should_correctly_insert_object_with_timestamps');
 
-        collection.insert(doc, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err, result) {
           test.ok(err == null);
           test.ok(result);
 
-          collection.findOne(function(err, item) {
+          collection.findOne(function (err, item) {
             test.ok(err == null);
             test.deepEqual(doc, item);
             client.close(done);
@@ -975,7 +975,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var doc = {
         _id: new ObjectId('4e886e687ff7ef5e00000162'),
@@ -983,10 +983,10 @@ describe('Insert', function() {
       };
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('Should_fail_on_insert_due_to_key_starting_with');
-        collection.insert(doc, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err, result) {
           test.ok(err != null);
           test.equal(null, result);
 
@@ -1003,41 +1003,41 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       var doc = {
         str: 'String',
-        func: function() {}
+        func: function () {}
       };
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection(
           'Should_Correctly_allow_for_control_of_serialization_of_functions_on_command_level'
         );
-        collection.insert(doc, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
           collection.update(
             { str: 'String' },
-            { $set: { c: 1, d: function() {} } },
+            { $set: { c: 1, d: function () {} } },
             { w: 1, serializeFunctions: false },
-            function(err, result) {
+            function (err, result) {
               test.equal(1, result.result.n);
 
-              collection.findOne({ str: 'String' }, function(err, item) {
+              collection.findOne({ str: 'String' }, function (err, item) {
                 test.equal(undefined, item.d);
 
                 // Execute a safe insert with replication to two servers
                 collection.findAndModify(
                   { str: 'String' },
                   [['a', 1]],
-                  { $set: { f: function() {} } },
+                  { $set: { f: function () {} } },
                   { new: true, safe: true, serializeFunctions: true },
-                  function(err, result) {
+                  function (err, result) {
                     test.ok(result.value.f._bsontype === 'Code');
                     client.close(done);
                   }
@@ -1057,26 +1057,26 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       var doc = {
         str: 'String',
-        func: function() {}
+        func: function () {}
       };
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection(
           'Should_Correctly_allow_for_control_of_serialization_of_functions_on_collection_level',
           { serializeFunctions: true }
         );
-        collection.insert(doc, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
-          collection.findOne({ str: 'String' }, function(err, item) {
+          collection.findOne({ str: 'String' }, function (err, item) {
             test.ok(item.func._bsontype === 'Code');
             client.close(done);
           });
@@ -1092,7 +1092,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var doc = {
         _id: new Date(),
         str: 'hello'
@@ -1100,14 +1100,14 @@ describe('Insert', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('Should_Correctly_allow_for_using_a_Date_object_as__id');
-        collection.insert(doc, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
-          collection.findOne({ str: 'hello' }, function(err, item) {
+          collection.findOne({ str: 'hello' }, function (err, item) {
             test.ok(item._id instanceof Date);
             client.close(done);
           });
@@ -1123,13 +1123,13 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('Should_Correctly_fail_to_update_returning_0_results');
-        collection.update({ a: 1 }, { $set: { a: 1 } }, configuration.writeConcernMax(), function(
+        collection.update({ a: 1 }, { $set: { a: 1 } }, configuration.writeConcernMax(), function (
           err,
           r
         ) {
@@ -1147,7 +1147,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var doc = {
         _id: new ObjectId(),
@@ -1161,10 +1161,10 @@ describe('Insert', function() {
       };
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('Should_Correctly_update_two_fields_including_a_sub_field');
-        collection.insert(doc, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
@@ -1173,11 +1173,11 @@ describe('Insert', function() {
             { _id: doc._id },
             { $set: { Prop1: 'p1_2', 'More.Sub2': 's2_2' } },
             configuration.writeConcernMax(),
-            function(err, r) {
+            function (err, r) {
               test.equal(null, err);
               test.equal(1, r.result.n);
 
-              collection.findOne({ _id: doc._id }, function(err, item) {
+              collection.findOne({ _id: doc._id }, function (err, item) {
                 test.equal(null, err);
                 test.equal('p1_2', item.Prop1);
                 test.equal('s2_2', item.More.Sub2);
@@ -1197,21 +1197,21 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection(
           'Should_Correctly_update_two_fields_including_a_sub_field_2'
         );
 
-        collection.insert({ _id: 1 }, configuration.writeConcernMax(), function(err, result) {
+        collection.insert({ _id: 1 }, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
           // Update two fields
-          collection.insert({ _id: 1 }, configuration.writeConcernMax(), function(err, r) {
+          collection.insert({ _id: 1 }, configuration.writeConcernMax(), function (err, r) {
             test.equal(r, null);
             test.ok(err != null);
             test.ok(err.result);
@@ -1230,21 +1230,21 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyInsertDocWithCustomId');
         // Insert the update
-        collection.insert({ _id: 0, test: 'hello' }, configuration.writeConcernMax(), function(
+        collection.insert({ _id: 0, test: 'hello' }, configuration.writeConcernMax(), function (
           err,
           result
         ) {
           test.equal(null, err);
           test.ok(result);
 
-          collection.findOne({ _id: 0 }, function(err, item) {
+          collection.findOne({ _id: 0 }, function (err, item) {
             test.equal(0, item._id);
             test.equal('hello', item.test);
             client.close(done);
@@ -1261,23 +1261,23 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection(
           'shouldCorrectlyPerformUpsertAgainstNewDocumentAndExistingOne'
         );
 
         // Upsert a new doc
-        collection.update({ a: 1 }, { a: 1 }, { upsert: true, w: 1 }, function(err, result) {
+        collection.update({ a: 1 }, { a: 1 }, { upsert: true, w: 1 }, function (err, result) {
           if (result.result.updatedExisting) test.equal(false, result.result.updatedExisting);
           test.equal(1, result.result.n);
           test.ok(result.result.upserted != null);
 
           // Upsert an existing doc
-          collection.update({ a: 1 }, { a: 1 }, { upsert: true, w: 1 }, function(err, result) {
+          collection.update({ a: 1 }, { a: 1 }, { upsert: true, w: 1 }, function (err, result) {
             if (result.updatedExisting) test.equal(true, result.updatedExisting);
             test.equal(1, result.result.n);
             client.close(done);
@@ -1294,10 +1294,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyPerformLargeTextInsert');
 
@@ -1308,14 +1308,14 @@ describe('Insert', function() {
           string = string + 'a';
         }
 
-        collection.insert({ a: 1, string: string }, configuration.writeConcernMax(), function(
+        collection.insert({ a: 1, string: string }, configuration.writeConcernMax(), function (
           err,
           result
         ) {
           test.equal(null, err);
           test.ok(result);
 
-          collection.findOne({ a: 1 }, function(err, doc) {
+          collection.findOne({ a: 1 }, function (err, doc) {
             test.equal(null, err);
             test.equal(50000, doc.string.length);
             client.close(done);
@@ -1332,24 +1332,24 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyPerformInsertOfObjectsUsingToBSON');
 
         // Create document with toBSON method
         var doc = { a: 1, b: 1 };
-        doc.toBSON = function() {
+        doc.toBSON = function () {
           return { c: this.a };
         };
 
-        collection.insert(doc, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(doc, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
-          collection.findOne({ c: 1 }, function(err, doc) {
+          collection.findOne({ c: 1 }, function (err, doc) {
             test.equal(null, err);
             test.deepEqual(1, doc.c);
             client.close(done);
@@ -1366,12 +1366,12 @@ describe('Insert', function() {
       requires: { topology: 'single' }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('shouldAttempToForceBsonSize', function(err, collection) {
+        db.createCollection('shouldAttempToForceBsonSize', function (err, collection) {
           // var doc = {a:1, b:new Binary(Buffer.alloc(16777216)/5)}
           var doc = [
             { a: 1, b: new Binary(Buffer.alloc(16777216 / 3)) },
@@ -1379,11 +1379,11 @@ describe('Insert', function() {
             { a: 1, b: new Binary(Buffer.alloc(16777216 / 3)) }
           ];
 
-          collection.insert(doc, configuration.writeConcernMax(), function(err, result) {
+          collection.insert(doc, configuration.writeConcernMax(), function (err, result) {
             test.equal(null, err);
             test.ok(result);
 
-            collection.findOne({ a: 1 }, function(err, doc) {
+            collection.findOne({ a: 1 }, function (err, doc) {
               test.equal(null, err);
               test.deepEqual(1, doc.a);
 
@@ -1402,14 +1402,14 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyUseCustomObjectToUpdateDocument');
 
-        collection.insert({ a: { b: { c: 1 } } }, configuration.writeConcernMax(), function(
+        collection.insert({ a: { b: { c: 1 } } }, configuration.writeConcernMax(), function (
           err,
           result
         ) {
@@ -1427,7 +1427,7 @@ describe('Insert', function() {
             query,
             { $set: { 'a.b.d': 1 } },
             configuration.writeConcernMax(),
-            function(err, r) {
+            function (err, r) {
               test.equal(null, err);
               test.equal(1, r.result.n);
 
@@ -1446,10 +1446,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldExecuteInsertWithNoCallbackAndWriteConcern');
         collection.insert({ a: { b: { c: 1 } } }).then(
@@ -1471,7 +1471,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       function cb(err) {
         test.equal(null, err);
         client.close(done);
@@ -1479,7 +1479,7 @@ describe('Insert', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('gh-completely2');
         collection.insert({ a: 1 }, { w: 0 }, cb);
@@ -1494,7 +1494,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       function cb(err) {
         test.equal(null, err);
         client.close(done);
@@ -1502,7 +1502,7 @@ describe('Insert', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('gh-completely3');
         collection.update({ a: 1 }, { a: 2 }, { upsert: true, w: 0 }, cb);
@@ -1517,7 +1517,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       function cb(err) {
         test.equal(null, err);
         client.close(done);
@@ -1525,7 +1525,7 @@ describe('Insert', function() {
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('gh-completely1');
         collection.remove({ a: 1 }, { w: 0 }, cb);
@@ -1543,10 +1543,10 @@ describe('Insert', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('bson_types_insert');
 
@@ -1560,38 +1560,38 @@ describe('Insert', function() {
           code: new Code('function () {}', { a: 55 })
         };
 
-        collection.insert(document, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(document, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
-          collection.findOne({ symbol: new BSONSymbol('abcdefghijkl') }, function(err, doc) {
+          collection.findOne({ symbol: new BSONSymbol('abcdefghijkl') }, function (err, doc) {
             test.equal(null, err);
             test.equal('abcdefghijkl', doc.symbol.toString());
 
-            collection.findOne({ objid: new ObjectId('abcdefghijkl') }, function(err, doc) {
+            collection.findOne({ objid: new ObjectId('abcdefghijkl') }, function (err, doc) {
               test.equal(null, err);
               test.equal('6162636465666768696a6b6c', doc.objid.toString());
 
-              collection.findOne({ double: new Double(1) }, function(err, doc) {
+              collection.findOne({ double: new Double(1) }, function (err, doc) {
                 test.equal(null, err);
                 test.equal(1, doc.double);
 
-                collection.findOne({ binary: new Binary(Buffer.from('hello world')) }, function(
+                collection.findOne({ binary: new Binary(Buffer.from('hello world')) }, function (
                   err,
                   doc
                 ) {
                   test.equal(null, err);
                   test.equal('hello world', doc.binary.toString());
 
-                  collection.findOne({ minkey: new MinKey() }, function(err, doc) {
+                  collection.findOne({ minkey: new MinKey() }, function (err, doc) {
                     test.equal(null, err);
                     test.ok(doc.minkey._bsontype === 'MinKey');
 
-                    collection.findOne({ maxkey: new MaxKey() }, function(err, doc) {
+                    collection.findOne({ maxkey: new MaxKey() }, function (err, doc) {
                       test.equal(null, err);
                       test.ok(doc.maxkey._bsontype === 'MaxKey');
 
-                      collection.findOne({ code: new Code('function () {}', { a: 55 }) }, function(
+                      collection.findOne({ code: new Code('function () {}', { a: 55 }) }, function (
                         err,
                         doc
                       ) {
@@ -1620,10 +1620,10 @@ describe('Insert', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('bson_types_insert_1');
 
@@ -1637,38 +1637,38 @@ describe('Insert', function() {
           code: new Code('function () {}', { a: 55 })
         };
 
-        collection.insert(document, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(document, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
-          collection.findOne({ symbol: new BSONSymbol('abcdefghijkl') }, function(err, doc) {
+          collection.findOne({ symbol: new BSONSymbol('abcdefghijkl') }, function (err, doc) {
             test.equal(null, err);
             test.equal('abcdefghijkl', doc.symbol.toString());
 
-            collection.findOne({ objid: new ObjectId('abcdefghijkl') }, function(err, doc) {
+            collection.findOne({ objid: new ObjectId('abcdefghijkl') }, function (err, doc) {
               test.equal(null, err);
               test.equal('6162636465666768696a6b6c', doc.objid.toString());
 
-              collection.findOne({ double: new Double(1) }, function(err, doc) {
+              collection.findOne({ double: new Double(1) }, function (err, doc) {
                 test.equal(null, err);
                 test.equal(1, doc.double);
 
-                collection.findOne({ binary: new Binary(Buffer.from('hello world')) }, function(
+                collection.findOne({ binary: new Binary(Buffer.from('hello world')) }, function (
                   err,
                   doc
                 ) {
                   test.equal(null, err);
                   test.equal('hello world', doc.binary.toString());
 
-                  collection.findOne({ minkey: new MinKey() }, function(err, doc) {
+                  collection.findOne({ minkey: new MinKey() }, function (err, doc) {
                     test.equal(null, err);
                     test.ok(doc.minkey._bsontype === 'MinKey');
 
-                    collection.findOne({ maxkey: new MaxKey() }, function(err, doc) {
+                    collection.findOne({ maxkey: new MaxKey() }, function (err, doc) {
                       test.equal(null, err);
                       test.ok(doc.maxkey._bsontype === 'MaxKey');
 
-                      collection.findOne({ code: new Code('function () {}', { a: 55 }) }, function(
+                      collection.findOne({ code: new Code('function () {}', { a: 55 }) }, function (
                         err,
                         doc
                       ) {
@@ -1694,25 +1694,25 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('timestamp_date');
 
         var d = new Date();
         var documents = [{ x: new Timestamp(1, 2) }, { x: d }];
 
-        collection.insert(documents, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(documents, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
-          collection.findOne({ x: new Timestamp(1, 2) }, function(err, doc) {
+          collection.findOne({ x: new Timestamp(1, 2) }, function (err, doc) {
             test.equal(null, err);
             test.ok(doc != null);
 
-            collection.findOne({ x: d }, function(err, doc) {
+            collection.findOne({ x: d }, function (err, doc) {
               test.equal(null, err);
               test.ok(doc != null);
               client.close(done);
@@ -1730,10 +1730,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('negative_pos');
 
@@ -1742,11 +1742,11 @@ describe('Insert', function() {
           neg: Number.NEGATIVE_INFINITY
         };
 
-        collection.insert(document, configuration.writeConcernMax(), function(err, result) {
+        collection.insert(document, configuration.writeConcernMax(), function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
-          collection.findOne({}, function(err, doc) {
+          collection.findOne({}, function (err, doc) {
             test.equal(null, err);
             test.equal(Number.POSITIVE_INFINITY, doc.pos);
             test.equal(Number.NEGATIVE_INFINITY, doc.neg);
@@ -1764,22 +1764,22 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var regexp = /foobar/i;
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_regex', function(err, collection) {
-          collection.insert({ b: regexp }, configuration.writeConcernMax(), function(err, ids) {
+        db.createCollection('test_regex', function (err, collection) {
+          collection.insert({ b: regexp }, configuration.writeConcernMax(), function (err, ids) {
             test.equal(null, err);
             test.ok(ids);
 
             collection
               .find({})
               .project({ b: 1 })
-              .toArray(function(err, items) {
+              .toArray(function (err, items) {
                 test.equal('' + regexp, '' + items[0].b);
                 // Let's close the db
                 client.close(done);
@@ -1797,23 +1797,23 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var regexp = /foobaré/;
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyInsertSimpleUTF8Regexp');
 
-        collection.insert({ b: regexp }, configuration.writeConcernMax(), function(err, ids) {
+        collection.insert({ b: regexp }, configuration.writeConcernMax(), function (err, ids) {
           test.equal(null, err);
           test.ok(ids);
 
           collection
             .find({})
             .project({ b: 1 })
-            .toArray(function(err, items) {
+            .toArray(function (err, items) {
               test.equal(null, err);
               test.equal('' + regexp, '' + items[0].b);
               // Let's close the db
@@ -1831,10 +1831,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var k = Buffer.alloc(15);
         for (var i = 0; i < 15; i++) k[i] = 0;
@@ -1860,7 +1860,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var o = configuration.writeConcernMax();
       o.promoteLongs = false;
@@ -1868,18 +1868,18 @@ describe('Insert', function() {
         poolSize: 1,
         promoteLongs: false
       });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteLong').insert(
           {
             doc: Long.fromNumber(10),
             array: [[Long.fromNumber(10)]]
           },
-          function(err, doc) {
+          function (err, doc) {
             test.equal(null, err);
             test.ok(doc);
 
-            db.collection('shouldCorrectlyHonorPromoteLong').findOne(function(err, doc) {
+            db.collection('shouldCorrectlyHonorPromoteLong').findOne(function (err, doc) {
               test.equal(null, err);
               test.ok(doc.doc._bsontype === 'Long');
               test.ok(doc.array[0][0]._bsontype === 'Long');
@@ -1898,7 +1898,7 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var o = configuration.writeConcernMax();
       o.promoteLongs = false;
@@ -1907,7 +1907,7 @@ describe('Insert', function() {
         poolSize: 1,
         promoteLongs: false
       });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteLongFalseNativeBSONWithGetMore').insertMany(
           [
@@ -1936,14 +1936,14 @@ describe('Insert', function() {
             { a: Long.fromNumber(10) },
             { a: Long.fromNumber(10) }
           ],
-          function(err, doc) {
+          function (err, doc) {
             test.equal(null, err);
             test.ok(doc);
 
             db.collection('shouldCorrectlyHonorPromoteLongFalseNativeBSONWithGetMore')
               .find({})
               .batchSize(2)
-              .toArray(function(err, docs) {
+              .toArray(function (err, docs) {
                 test.equal(null, err);
                 var doc = docs.pop();
 
@@ -1963,21 +1963,21 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteLongTrueNativeBSON').insert(
           {
             doc: Long.fromNumber(10),
             array: [[Long.fromNumber(10)]]
           },
-          function(err, doc) {
+          function (err, doc) {
             test.equal(null, err);
             test.ok(doc);
 
-            db.collection('shouldCorrectlyHonorPromoteLongTrueNativeBSON').findOne(function(
+            db.collection('shouldCorrectlyHonorPromoteLongTrueNativeBSON').findOne(function (
               err,
               doc
             ) {
@@ -2000,24 +2000,27 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         promoteLongs: false
       });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteLongFalseJSBSON').insert(
           {
             doc: Long.fromNumber(10),
             array: [[Long.fromNumber(10)]]
           },
-          function(err, doc) {
+          function (err, doc) {
             test.equal(null, err);
             test.ok(doc);
 
-            db.collection('shouldCorrectlyHonorPromoteLongFalseJSBSON').findOne(function(err, doc) {
+            db.collection('shouldCorrectlyHonorPromoteLongFalseJSBSON').findOne(function (
+              err,
+              doc
+            ) {
               test.equal(null, err);
               test.equal(null, err);
               test.ok(doc.doc._bsontype === 'Long');
@@ -2037,21 +2040,21 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteLongTrueJSBSON').insert(
           {
             doc: Long.fromNumber(10),
             array: [[Long.fromNumber(10)]]
           },
-          function(err, doc) {
+          function (err, doc) {
             test.equal(null, err);
             test.ok(doc);
 
-            db.collection('shouldCorrectlyHonorPromoteLongTrueJSBSON').findOne(function(err, doc) {
+            db.collection('shouldCorrectlyHonorPromoteLongTrueJSBSON').findOne(function (err, doc) {
               test.equal(null, err);
               test.equal(null, err);
               test.ok('number', typeof doc.doc);
@@ -2071,11 +2074,11 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyOverrideCheckKeysJSOnUpdate').update(
           {
@@ -2083,7 +2086,7 @@ describe('Insert', function() {
           },
           { $set: { b: 1 } },
           { checkKeys: false },
-          function(err, doc) {
+          function (err, doc) {
             test.equal(null, err);
             test.ok(doc);
 
@@ -2101,22 +2104,22 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var col = db.collection('shouldCorrectlyApplyBitOperator');
 
-        col.insert({ a: 1, b: 1 }, function(err, result) {
+        col.insert({ a: 1, b: 1 }, function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
-          col.update({ a: 1 }, { $bit: { b: { and: 0 } } }, function(err, result) {
+          col.update({ a: 1 }, { $bit: { b: { and: 0 } } }, function (err, result) {
             test.equal(null, err);
             test.ok(result);
 
-            col.findOne({ a: 1 }, function(err, doc) {
+            col.findOne({ a: 1 }, function (err, doc) {
               test.equal(null, err);
               test.equal(1, doc.a);
               test.equal(0, doc.b);
@@ -2140,10 +2143,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var col = db.collection('shouldCorrectlyPerformInsertAndUpdateWithFunctionSerialization', {
           serializeFunctions: true
@@ -2152,11 +2155,11 @@ describe('Insert', function() {
         col.insert(
           {
             a: 1,
-            f: function(x) {
+            f: function (x) {
               return x;
             }
           },
-          function(err, doc) {
+          function (err, doc) {
             test.equal(null, err);
             test.ok(doc);
 
@@ -2164,16 +2167,16 @@ describe('Insert', function() {
               { a: 1 },
               {
                 $set: {
-                  f: function(y) {
+                  f: function (y) {
                     return y;
                   }
                 }
               },
-              function(err, doc) {
+              function (err, doc) {
                 test.equal(null, err);
                 test.ok(doc);
 
-                col.findOne({ a: 1 }, function(err, doc) {
+                col.findOne({ a: 1 }, function (err, doc) {
                   test.equal(null, err);
                   test.equal(trim('function (y){return y;}'), trim(doc.f.code));
                   client.close(done);
@@ -2193,10 +2196,10 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var col = db.collection('shouldCorrectlyAllowforMoreThanAThousandDocsInsert', {
           serializeFunctions: true
@@ -2207,7 +2210,7 @@ describe('Insert', function() {
           docs.push({ a: i });
         }
 
-        col.insert(docs, function(err, doc) {
+        col.insert(docs, function (err, doc) {
           test.equal(null, err);
           test.equal(2000, doc.result.n);
           docs = [];
@@ -2216,7 +2219,7 @@ describe('Insert', function() {
             docs.push({ a: i });
           }
 
-          col.insertMany(docs, function(err, doc) {
+          col.insertMany(docs, function (err, doc) {
             test.equal(null, err);
             test.equal(2000, doc.result.n);
 
@@ -2234,25 +2237,25 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Get collection
         var col = db.collection('insertManyMultipleWriteErrors');
-        col.drop(function(err, r) {
+        col.drop(function (err, r) {
           expect(r).to.not.exist;
 
           // Create unique index
-          col.createIndex({ a: 1 }, { unique: true }, function(err, r) {
+          col.createIndex({ a: 1 }, { unique: true }, function (err, r) {
             test.equal(null, err);
             test.ok(r);
 
             col.insertMany(
               [{ a: 1 }, { a: 2 }, { a: 1 }, { a: 3 }, { a: 1 }],
               { ordered: false },
-              function(err, r) {
+              function (err, r) {
                 expect(r).to.not.exist;
                 expect(err).to.exist;
                 expect(err.result).to.exist;
@@ -2274,25 +2277,25 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Get collection
         var col = db.collection('insertManyMultipleWriteErrors1');
-        col.drop(function(err, r) {
+        col.drop(function (err, r) {
           expect(r).to.not.exist;
 
           // Create unique index
-          col.createIndex({ a: 1 }, { unique: true }, function(err, r) {
+          col.createIndex({ a: 1 }, { unique: true }, function (err, r) {
             test.equal(null, err);
             test.ok(r);
 
             col.insert(
               [{ a: 1 }, { a: 2 }, { a: 1 }, { a: 3 }, { a: 1 }],
               { ordered: false },
-              function(err, r) {
+              function (err, r) {
                 expect(r).to.not.exist;
                 expect(err).to.exist;
                 expect(err.result).to.exist;
@@ -2314,26 +2317,26 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Get collection
         var col = db.collection('insertManyMultipleWriteErrors2');
-        col.drop(function(/*err, r*/) {
+        col.drop(function (/*err, r*/) {
           // TODO: reenable once SERVER-36317 is resolved
           // expect(r).to.not.exist;
 
           // Create unique index
-          col.createIndex({ a: 1 }, { unique: true }, function(err, r) {
+          col.createIndex({ a: 1 }, { unique: true }, function (err, r) {
             test.equal(null, err);
             test.ok(r);
 
             col.insertMany(
               [{ a: 1 }, { a: 2 }, { a: 1 }, { a: 3 }, { a: 1 }],
               { ordered: true },
-              function(err, r) {
+              function (err, r) {
                 test.equal(r, null);
                 test.ok(err != null);
                 test.ok(err.result);
@@ -2354,26 +2357,26 @@ describe('Insert', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Get collection
         var col = db.collection('insertManyMultipleWriteErrors3');
-        col.drop(function(/*err, r*/) {
+        col.drop(function (/*err, r*/) {
           // TODO: reenable once SERVER-36317 is resolved
           // expect(r).to.not.exist;
 
           // Create unique index
-          col.createIndex({ a: 1 }, { unique: true }, function(err, r) {
+          col.createIndex({ a: 1 }, { unique: true }, function (err, r) {
             test.equal(null, err);
             test.ok(r);
 
             col.insert(
               [{ a: 1 }, { a: 2 }, { a: 1 }, { a: 3 }, { a: 1 }],
               { ordered: true },
-              function(err, r) {
+              function (err, r) {
                 test.equal(r, null);
                 test.ok(err != null);
                 test.ok(err.result);
@@ -2390,31 +2393,31 @@ describe('Insert', function() {
   it('Correctly allow forceServerObjectId for insertOne', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var started = [];
       var succeeded = [];
 
-      var listener = require('../../src').instrument(function(err) {
+      var listener = require('../../src').instrument(function (err) {
         test.equal(null, err);
       });
 
-      listener.on('started', function(event) {
+      listener.on('started', function (event) {
         if (event.commandName === 'insert') started.push(event);
       });
 
-      listener.on('succeeded', function(event) {
+      listener.on('succeeded', function (event) {
         if (event.commandName === 'insert') succeeded.push(event);
       });
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         db.collection('apm_test')
           .insertOne({ a: 1 }, { forceServerObjectId: true })
-          .then(function() {
+          .then(function () {
             test.equal(undefined, started[0].command.documents[0]._id);
             listener.uninstrument();
 
@@ -2427,31 +2430,31 @@ describe('Insert', function() {
   it('Correctly allow forceServerObjectId for insertMany', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var started = [];
       var succeeded = [];
 
-      var listener = require('../../src').instrument(function(err) {
+      var listener = require('../../src').instrument(function (err) {
         test.equal(null, err);
       });
 
-      listener.on('started', function(event) {
+      listener.on('started', function (event) {
         if (event.commandName === 'insert') started.push(event);
       });
 
-      listener.on('succeeded', function(event) {
+      listener.on('succeeded', function (event) {
         if (event.commandName === 'insert') succeeded.push(event);
       });
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         db.collection('apm_test')
           .insertMany([{ a: 1 }], { forceServerObjectId: true })
-          .then(function() {
+          .then(function () {
             test.equal(undefined, started[0].command.documents[0]._id);
 
             listener.uninstrument();
@@ -2464,31 +2467,31 @@ describe('Insert', function() {
   it('Correctly allow forceServerObjectId for insertMany', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var started = [];
       var succeeded = [];
 
-      var listener = require('../../src').instrument(function(err) {
+      var listener = require('../../src').instrument(function (err) {
         test.equal(null, err);
       });
 
-      listener.on('started', function(event) {
+      listener.on('started', function (event) {
         if (event.commandName === 'insert') started.push(event);
       });
 
-      listener.on('succeeded', function(event) {
+      listener.on('succeeded', function (event) {
         if (event.commandName === 'insert') succeeded.push(event);
       });
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
         db.collection('apm_test')
           .insertMany([{ a: 1 }], { forceServerObjectId: true })
-          .then(function() {
+          .then(function () {
             test.equal(undefined, started[0].command.documents[0]._id);
 
             listener.uninstrument();
@@ -2500,15 +2503,15 @@ describe('Insert', function() {
 
   it('should return correct number of ids for insertMany { ordered: true }', {
     metadata: { requires: { topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
         db.collection('inserted_ids_test')
           .insertMany([{}, {}, {}], { ordered: true })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(3, Object.keys(r.insertedIds).length);
             client.close(done);
           });
@@ -2518,15 +2521,15 @@ describe('Insert', function() {
 
   it('should return correct number of ids for insertMany { ordered: false }', {
     metadata: { requires: { topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
         db.collection('inserted_ids_test')
           .insertMany([{}, {}, {}], { ordered: false })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(null, err);
             test.equal(3, Object.keys(r.insertedIds).length);
             client.close(done);
@@ -2538,10 +2541,10 @@ describe('Insert', function() {
   it('Insert document including sub documents', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
@@ -2562,13 +2565,13 @@ describe('Insert', function() {
           products: [product]
         };
 
-        db.collection('sub_documents').insertOne(doc, function(err, r) {
+        db.collection('sub_documents').insertOne(doc, function (err, r) {
           test.equal(null, err);
           test.ok(r);
 
           db.collection('sub_documents')
             .find({})
-            .next(function(err, v) {
+            .next(function (err, v) {
               test.equal(null, err);
               test.equal('a', v.products[0].suppliers[0].shipments[0].shipment1);
 
@@ -2582,11 +2585,11 @@ describe('Insert', function() {
   it('should return result using toJSON', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         const db = client.db(configuration.db);
         db.collection('to_json').insertOne({ _id: 0 }, (err, result) => {
           const jsonResult = result.toJSON();

--- a/test/functional/ldap.test.js
+++ b/test/functional/ldap.test.js
@@ -4,15 +4,15 @@ var format = require('util').format;
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-describe('LDAP', function() {
-  before(function() {
+describe('LDAP', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it('Should correctly authenticate against ldap', {
     metadata: { requires: { topology: 'ldap' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // KDC Server
@@ -29,13 +29,13 @@ describe('LDAP', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         client
           .db('ldap')
           .collection('test')
-          .findOne(function(err, doc) {
+          .findOne(function (err, doc) {
             test.equal(null, err);
             test.equal(true, doc.ldap);
 
@@ -48,7 +48,7 @@ describe('LDAP', function() {
   it('Should correctly reauthenticate against ldap', {
     metadata: { requires: { topology: 'ldap' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // KDC Server
@@ -65,22 +65,22 @@ describe('LDAP', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         client
           .db('ldap')
           .collection('test')
-          .findOne(function(err, doc) {
+          .findOne(function (err, doc) {
             test.equal(null, err);
             test.equal(true, doc.ldap);
 
-            client.topology.once('reconnect', function() {
+            client.topology.once('reconnect', function () {
               // Await reconnect and re-authentication
               client
                 .db('ldap')
                 .collection('test')
-                .findOne(function(err, doc) {
+                .findOne(function (err, doc) {
                   test.equal(null, err);
                   test.equal(true, doc.ldap);
 
@@ -91,7 +91,7 @@ describe('LDAP', function() {
                   client
                     .db('ldap')
                     .collection('test')
-                    .findOne(function(err, doc) {
+                    .findOne(function (err, doc) {
                       test.equal(null, err);
                       test.equal(true, doc.ldap);
 

--- a/test/functional/load_esnext.js
+++ b/test/functional/load_esnext.js
@@ -11,10 +11,10 @@ function loadTests() {
     .forEach(x => require(x));
 }
 
-describe('ES2017', function() {
+describe('ES2017', function () {
   loadTests(__dirname, '..', 'examples');
 });
 
-describe('ES2018', function() {
+describe('ES2018', function () {
   loadTests(__dirname, '..', 'node-next', 'es2018');
 });

--- a/test/functional/logger.test.js
+++ b/test/functional/logger.test.js
@@ -3,20 +3,20 @@ const expect = require('chai').expect;
 const { withClient } = require('./shared');
 const Logger = require('../../src/logger');
 
-describe('Logger', function() {
+describe('Logger', function () {
   /**
    * Test a simple find
    */
   it('should correctly Enable logging', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         expect(err).to.not.exist;
 
@@ -28,7 +28,7 @@ describe('Logger', function() {
         var logged = false;
 
         // Logger.
-        Logger.setCurrentLogger(function(msg, context) {
+        Logger.setCurrentLogger(function (msg, context) {
           expect(msg).to.exist;
           expect(context.type).to.equal('debug');
           expect(context.className).to.equal('Db');
@@ -36,7 +36,7 @@ describe('Logger', function() {
         });
 
         // Execute the command
-        db.command({ ismaster: true }, function(err) {
+        db.command({ ismaster: true }, function (err) {
           expect(err).to.not.exist;
           expect(logged).to.be.true;
 
@@ -54,15 +54,15 @@ describe('Logger', function() {
   it('should not fail with undefined id', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       // set a custom logger per http://mongodb.github.io/node-mongodb-native/2.0/tutorials/logging/
-      Logger.setCurrentLogger(function() {});
+      Logger.setCurrentLogger(function () {});
       Logger.setLevel('debug');
 
       return withClient('mongodb://localhost:27017/test', (client, done) => {
         const db = client.db(this.configuration.db);
         // perform any operation that gets logged
-        db.collection('foo').findOne({}, function(err) {
+        db.collection('foo').findOne({}, function (err) {
           expect(err).to.not.exist;
 
           // Clean up
@@ -79,14 +79,14 @@ describe('Logger', function() {
   it('should correctly log cursor', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       return withClient('mongodb://localhost:27017/test', (client, done) => {
         const db = client.db(this.configuration.db);
         // Status
         var logged = false;
 
         // Set the current logger
-        Logger.setCurrentLogger(function(msg, context) {
+        Logger.setCurrentLogger(function (msg, context) {
           expect(msg).to.exist;
           expect(context.type).to.equal('debug');
           expect(context.className).to.equal('Cursor');
@@ -100,7 +100,7 @@ describe('Logger', function() {
         // perform any operation that gets logged
         db.collection('logging')
           .find()
-          .toArray(function(err) {
+          .toArray(function (err) {
             expect(err).to.not.exist;
             expect(logged).to.be.true;
 
@@ -118,20 +118,20 @@ describe('Logger', function() {
   it('should pass the logLevel down through the options', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       Logger.filter('class', ['Cursor']);
       var logged = false;
 
       return withClient('mongodb://localhost:27017/test', (client, done) => {
         const db = client.db(this.configuration.db, {
           loggerLevel: 'debug',
-          logger: function() {
+          logger: function () {
             logged = true;
           }
         });
 
         // perform any operation that gets logged
-        db.collection('foo').findOne({}, function(err) {
+        db.collection('foo').findOne({}, function (err) {
           expect(err).to.not.exist;
           expect(logged).to.be.true;
 

--- a/test/functional/mapreduce.test.js
+++ b/test/functional/mapreduce.test.js
@@ -4,8 +4,8 @@ var setupDatabase = require('./shared').setupDatabase;
 const { Code } = require('../../src');
 const { expect } = require('chai');
 
-describe('MapReduce', function() {
-  before(function() {
+describe('MapReduce', function () {
+  before(function () {
     return setupDatabase(this.configuration, ['outputCollectionDb']);
   });
 
@@ -17,40 +17,40 @@ describe('MapReduce', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_group2', function(err, collection) {
+        db.createCollection('test_group2', function (err, collection) {
           collection.group(
             [],
             {},
             { count: 0 },
             'function (obj, prev) { prev.count++; }',
             true,
-            function(err, results) {
+            function (err, results) {
               test.deepEqual([], results);
 
               // Trigger some inserts
               collection.insert(
                 [{ a: 2 }, { b: 5, a: 0 }, { a: 1 }, { c: 2, a: 0 }],
                 configuration.writeConcernMax(),
-                function(err) {
+                function (err) {
                   test.equal(null, err);
                   collection.group(
                     [],
                     {},
                     { count: 0, running_average: 0 },
-                    function(doc, out) {
+                    function (doc, out) {
                       out.count++;
                       out.running_average += doc.a;
                     },
-                    function(out) {
+                    function (out) {
                       out.average = out.running_average / out.count;
                     },
                     true,
-                    function(err, results) {
+                    function (err, results) {
                       test.equal(3, results[0].running_average);
                       test.equal(0.75, results[0].average);
                       client.close(done);
@@ -73,30 +73,30 @@ describe('MapReduce', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_map_reduce', function(err, collection) {
+        db.createCollection('test_map_reduce', function (err, collection) {
           collection.insert(
             [{ user_id: 1 }, { user_id: 2 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // String functions
               var map = 'function() { emit(this.user_id, 1); }';
               var reduce = 'function(k,vals) { return 1; }';
 
-              collection.mapReduce(map, reduce, { out: { replace: 'tempCollection' } }, function(
+              collection.mapReduce(map, reduce, { out: { replace: 'tempCollection' } }, function (
                 err,
                 collection
               ) {
-                collection.findOne({ _id: 1 }, function(err, result) {
+                collection.findOne({ _id: 1 }, function (err, result) {
                   test.equal(1, result.value);
 
-                  collection.findOne({ _id: 2 }, function(err, result) {
+                  collection.findOne({ _id: 2 }, function (err, result) {
                     test.equal(1, result.value);
                     client.close(done);
                   });
@@ -122,23 +122,23 @@ describe('MapReduce', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         var db = client.db(configuration.db);
-        db.createCollection('should_force_map_reduce_error', function(err, collection) {
+        db.createCollection('should_force_map_reduce_error', function (err, collection) {
           collection.insert(
             [{ user_id: 1 }, { user_id: 2 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               // String functions
               var map = 'function() { emiddft(this.user_id, 1); }';
               var reduce = 'function(k,vals) { return 1; }';
 
-              collection.mapReduce(map, reduce, { out: { inline: 1 } }, function(err) {
+              collection.mapReduce(map, reduce, { out: { inline: 1 } }, function (err) {
                 test.ok(err != null);
                 client.close(done);
               });
@@ -154,12 +154,12 @@ describe('MapReduce', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_map_reduce_with_functions_as_arguments', function(
+        db.createCollection('test_map_reduce_with_functions_as_arguments', function (
           err,
           collection
         ) {
@@ -167,25 +167,25 @@ describe('MapReduce', function() {
           collection.insert(
             [{ user_id: 1 }, { user_id: 2 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
 
               // String functions
-              var map = function() {
+              var map = function () {
                 emit(this.user_id, 1); // eslint-disable-line
               };
-              var reduce = function() {
+              var reduce = function () {
                 return 1;
               };
 
-              collection.mapReduce(map, reduce, { out: { replace: 'tempCollection' } }, function(
+              collection.mapReduce(map, reduce, { out: { replace: 'tempCollection' } }, function (
                 err,
                 collection
               ) {
-                collection.findOne({ _id: 1 }, function(err, result) {
+                collection.findOne({ _id: 1 }, function (err, result) {
                   test.equal(1, result.value);
 
-                  collection.findOne({ _id: 2 }, function(err, result) {
+                  collection.findOne({ _id: 2 }, function (err, result) {
                     test.equal(1, result.value);
                     client.close(done);
                   });
@@ -203,30 +203,30 @@ describe('MapReduce', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_map_reduce_with_code_objects', function(err, collection) {
+        db.createCollection('test_map_reduce_with_code_objects', function (err, collection) {
           collection.insert(
             [{ user_id: 1 }, { user_id: 2 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               // String functions
               var map = new Code('function() { emit(this.user_id, 1); }');
               var reduce = new Code('function(k,vals) { return 1; }');
 
-              collection.mapReduce(map, reduce, { out: { replace: 'tempCollection' } }, function(
+              collection.mapReduce(map, reduce, { out: { replace: 'tempCollection' } }, function (
                 err,
                 collection
               ) {
-                collection.findOne({ _id: 1 }, function(err, result) {
+                collection.findOne({ _id: 1 }, function (err, result) {
                   test.equal(1, result.value);
                 });
 
-                collection.findOne({ _id: 2 }, function(err, result) {
+                collection.findOne({ _id: 2 }, function (err, result) {
                   test.equal(1, result.value);
                   client.close(done);
                 });
@@ -243,16 +243,16 @@ describe('MapReduce', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_map_reduce_with_options', function(err, collection) {
+        db.createCollection('test_map_reduce_with_options', function (err, collection) {
           collection.insert(
             [{ user_id: 1 }, { user_id: 2 }, { user_id: 3 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               // String functions
               var map = new Code('function() { emit(this.user_id, 1); }');
@@ -262,15 +262,15 @@ describe('MapReduce', function() {
                 map,
                 reduce,
                 { out: { replace: 'tempCollection' }, query: { user_id: { $gt: 1 } } },
-                function(err, collection) {
-                  collection.count(function(err, count) {
+                function (err, collection) {
+                  collection.count(function (err, count) {
                     test.equal(2, count);
 
-                    collection.findOne({ _id: 2 }, function(err, result) {
+                    collection.findOne({ _id: 2 }, function (err, result) {
                       test.equal(1, result.value);
                     });
 
-                    collection.findOne({ _id: 3 }, function(err, result) {
+                    collection.findOne({ _id: 3 }, function (err, result) {
                       test.equal(1, result.value);
                       client.close(done);
                     });
@@ -289,16 +289,16 @@ describe('MapReduce', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_map_reduce_error', function(err, collection) {
+        db.createCollection('test_map_reduce_error', function (err, collection) {
           collection.insert(
             [{ user_id: 1 }, { user_id: 2 }, { user_id: 3 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               // String functions
               var map = new Code("function() { throw 'error'; }");
@@ -308,7 +308,7 @@ describe('MapReduce', function() {
                 map,
                 reduce,
                 { out: { inline: 1 }, query: { user_id: { $gt: 1 } } },
-                function(err) {
+                function (err) {
                   test.ok(err != null);
                   client.close(done);
                 }
@@ -328,15 +328,15 @@ describe('MapReduce', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         const outDb = client.db('outputCollectionDb');
 
         // Create a test collection
-        db.createCollection('test_map_reduce_functions', function(err, collection) {
+        db.createCollection('test_map_reduce_functions', function (err, collection) {
           // create the output collection
           outDb.createCollection('tempCollection', err => {
             test.equal(null, err);
@@ -345,14 +345,14 @@ describe('MapReduce', function() {
             collection.insert(
               [{ user_id: 1 }, { user_id: 2 }],
               configuration.writeConcernMax(),
-              function(err) {
+              function (err) {
                 test.equal(null, err);
                 // Map function
-                var map = function() {
+                var map = function () {
                   emit(this.user_id, 1); // eslint-disable-line
                 };
                 // Reduce function
-                var reduce = function() {
+                var reduce = function () {
                   return 1;
                 };
 
@@ -361,15 +361,15 @@ describe('MapReduce', function() {
                   map,
                   reduce,
                   { out: { replace: 'test_map_reduce_functions_temp', db: 'outputCollectionDb' } },
-                  function(err, collection) {
+                  function (err, collection) {
                     test.equal(null, err);
 
                     // Mapreduce returns the temporary collection with the results
-                    collection.findOne({ _id: 1 }, function(err, result) {
+                    collection.findOne({ _id: 1 }, function (err, result) {
                       test.equal(null, err);
                       test.equal(1, result.value);
 
-                      collection.findOne({ _id: 2 }, function(err, result) {
+                      collection.findOne({ _id: 2 }, function (err, result) {
                         test.equal(null, err);
                         test.equal(1, result.value);
 
@@ -394,10 +394,10 @@ describe('MapReduce', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var start = new Date().setTime(new Date().getTime() - 10000);
         var end = new Date().setTime(new Date().getTime() + 10000);
@@ -419,12 +419,12 @@ describe('MapReduce', function() {
           count: 0
         };
 
-        var reduce = function(doc, output) {
+        var reduce = function (doc, output) {
           output.count++;
         };
 
         // Execute the group
-        db.createCollection('data', function(err, collection) {
+        db.createCollection('data', function (err, collection) {
           collection.insert(
             {
               data: {
@@ -433,10 +433,10 @@ describe('MapReduce', function() {
               }
             },
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               // Execute the group
-              collection.group(keys, condition, initial, reduce, true, function(err, r) {
+              collection.group(keys, condition, initial, reduce, true, function (err, r) {
                 test.equal(1, r[0].count);
                 test.equal('smith', r[0]['data.lastname']);
                 client.close(done);
@@ -456,22 +456,22 @@ describe('MapReduce', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var util = {
-        times_one_hundred: function(x) {
+        times_one_hundred: function (x) {
           return x * 100;
         }
       };
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_map_reduce', function(err, collection) {
+        db.createCollection('test_map_reduce', function (err, collection) {
           collection.insert(
             [{ user_id: 1 }, { user_id: 2 }],
             configuration.writeConcernMax(),
-            function(err) {
+            function (err) {
               test.equal(null, err);
               // String functions
               var map = 'function() { emit(this.user_id, util.times_one_hundred(this.user_id)); }';
@@ -484,11 +484,11 @@ describe('MapReduce', function() {
                 map,
                 reduce,
                 { scope: { util: util }, out: { replace: 'test_map_reduce_temp' } },
-                function(err, collection) {
+                function (err, collection) {
                   // After MapReduce
                   test.equal(200, util.times_one_hundred(2));
 
-                  collection.findOne({ _id: 2 }, function(err, result) {
+                  collection.findOne({ _id: 2 }, function (err, result) {
                     // During MapReduce
                     test.equal(200, result.value);
 

--- a/test/functional/max_staleness.test.js
+++ b/test/functional/max_staleness.test.js
@@ -5,7 +5,7 @@ const mock = require('mongodb-mock-server');
 const { ReadPreference } = require('../../src');
 
 const test = {};
-describe('Max Staleness', function() {
+describe('Max Staleness', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => {
     return mock.createServer().then(server => {
@@ -48,20 +48,20 @@ describe('Max Staleness', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const configuration = this.configuration;
       const client = configuration.newClient(
         `mongodb://${test.server.uri()}/test?readPreference=secondary&maxStalenessSeconds=250`
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         var db = client.db(self.configuration.db);
 
         db.collection('test')
           .find({})
-          .toArray(function(err) {
+          .toArray(function (err) {
             expect(err).to.not.exist;
             expect(test.checkCommand).to.eql({
               $query: { find: 'test', filter: {}, returnKey: false, showRecordId: false },
@@ -82,10 +82,10 @@ describe('Max Staleness', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${test.server.uri()}/test`);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
 
         // Get a db with a new readPreference
@@ -96,7 +96,7 @@ describe('Max Staleness', function() {
         db1
           .collection('test')
           .find({})
-          .toArray(function(err) {
+          .toArray(function (err) {
             expect(err).to.not.exist;
             expect(test.checkCommand).to.eql({
               $query: { find: 'test', filter: {}, returnKey: false, showRecordId: false },
@@ -119,11 +119,11 @@ describe('Max Staleness', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var self = this;
         const configuration = this.configuration;
         const client = configuration.newClient(`mongodb://${test.server.uri()}/test`);
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           expect(err).to.not.exist;
           var db = client.db(self.configuration.db);
 
@@ -132,7 +132,7 @@ describe('Max Staleness', function() {
             readPreference: new ReadPreference('secondary', null, { maxStalenessSeconds: 250 })
           })
             .find({})
-            .toArray(function(err) {
+            .toArray(function (err) {
               expect(err).to.not.exist;
               expect(test.checkCommand).to.eql({
                 $query: { find: 'test', filter: {}, returnKey: false, showRecordId: false },
@@ -154,11 +154,11 @@ describe('Max Staleness', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const configuration = this.configuration;
       const client = configuration.newClient(`mongodb://${test.server.uri()}/test`);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         var db = client.db(self.configuration.db);
         var readPreference = new ReadPreference('secondary', null, { maxStalenessSeconds: 250 });
@@ -167,7 +167,7 @@ describe('Max Staleness', function() {
         db.collection('test')
           .find({})
           .setReadPreference(readPreference)
-          .toArray(function(err) {
+          .toArray(function (err) {
             expect(err).to.not.exist;
             expect(test.checkCommand).to.eql({
               $query: { find: 'test', filter: {}, returnKey: false, showRecordId: false },

--- a/test/functional/maxtimems.test.js
+++ b/test/functional/maxtimems.test.js
@@ -2,8 +2,8 @@
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-describe('Unicode', function() {
-  before(function() {
+describe('Unicode', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -18,10 +18,10 @@ describe('Unicode', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var col = db.collection('max_time_ms');
 
@@ -29,14 +29,14 @@ describe('Unicode', function() {
         var docs_1 = [{ agg_pipe: 1 }];
 
         // Simple insert
-        col.insert(docs_1, { w: 1 }, function(err) {
+        col.insert(docs_1, { w: 1 }, function (err) {
           test.equal(null, err);
 
           // Execute a find command
           col
             .find({ $where: 'sleep(100) || true' })
             .maxTimeMS(50)
-            .count(function(err) {
+            .count(function (err) {
               test.ok(err != null);
               client.close(done);
             });
@@ -56,10 +56,10 @@ describe('Unicode', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var col = db.collection('max_time_ms_2');
 
@@ -67,14 +67,14 @@ describe('Unicode', function() {
         var docs_1 = [{ agg_pipe: 1 }];
 
         // Simple insert
-        col.insert(docs_1, { w: 1 }, function(err) {
+        col.insert(docs_1, { w: 1 }, function (err) {
           test.equal(null, err);
 
           // Execute a find command
           col
             .find({ $where: 'sleep(100) || true' })
             .maxTimeMS(50)
-            .toArray(function(err) {
+            .toArray(function (err) {
               test.ok(err != null);
               client.close(done);
             });
@@ -93,10 +93,10 @@ describe('Unicode', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var col = db.collection('max_time_ms_5');
 
@@ -104,24 +104,24 @@ describe('Unicode', function() {
         var docs_1 = [{ agg_pipe: 10 }];
 
         // Simple insert
-        col.insert(docs_1, { w: 1 }, function(err) {
+        col.insert(docs_1, { w: 1 }, function (err) {
           test.equal(null, err);
 
           db.admin().command(
             { configureFailPoint: 'maxTimeAlwaysTimeOut', mode: 'alwaysOn' },
-            function(err, result) {
+            function (err, result) {
               test.equal(null, err);
               test.equal(1, result.ok);
 
               col
                 .find({})
                 .maxTimeMS(10)
-                .toArray(function(err) {
+                .toArray(function (err) {
                   test.ok(err != null);
 
                   db.admin().command(
                     { configureFailPoint: 'maxTimeAlwaysTimeOut', mode: 'off' },
-                    function(err, result) {
+                    function (err, result) {
                       test.equal(null, err);
                       test.equal(1, result.ok);
                       client.close(done);

--- a/test/functional/mongo_client.test.js
+++ b/test/functional/mongo_client.test.js
@@ -6,8 +6,8 @@ var setupDatabase = require('./shared').setupDatabase;
 const Db = require('../../src/db');
 const expect = require('chai').expect;
 
-describe('MongoClient', function() {
-  before(function() {
+describe('MongoClient', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -18,7 +18,7 @@ describe('MongoClient', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient(
         {},
@@ -31,7 +31,7 @@ describe('MongoClient', function() {
           readPreferenceTags: { loc: 'ny' },
           native_parser: false,
           forceServerObjectId: true,
-          pkFactory: function() {
+          pkFactory: function () {
             return 1;
           },
           serializeFunctions: true,
@@ -41,7 +41,7 @@ describe('MongoClient', function() {
         }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         test.equal(1, db.writeConcern.w);
@@ -69,11 +69,11 @@ describe('MongoClient', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient('user:password@localhost:27017/test');
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         expect(err).to.exist.and.to.have.property('message', 'Invalid connection string');
         done();
       });
@@ -85,13 +85,13 @@ describe('MongoClient', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient('user:password@localhost:27017/test', {
         useNewUrlParser: true
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(err.message, 'Invalid connection string');
         done();
       });
@@ -103,13 +103,13 @@ describe('MongoClient', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient('mongodb://localhost:27088/test', {
         serverSelectionTimeoutMS: 10
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.ok(err != null);
 
         done();
@@ -120,10 +120,10 @@ describe('MongoClient', function() {
   it('should correctly connect to mongodb using domain socket', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient('mongodb://%2Ftmp%2Fmongodb-27017.sock/test');
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.equal(null, err);
         client.close(done);
       });
@@ -137,13 +137,13 @@ describe('MongoClient', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient('mongodb://unknownhost:36363/ddddd', {
         serverSelectionTimeoutMS: 10
       });
 
-      client.connect(function(err) {
+      client.connect(function (err) {
         test.ok(err != null);
         done();
       });
@@ -157,7 +157,7 @@ describe('MongoClient', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       if (url.indexOf('replicaSet') !== -1) {
@@ -167,7 +167,7 @@ describe('MongoClient', function() {
       }
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         test.equal('hello world', client.topology.clientMetadata.application.name);
 
@@ -183,7 +183,7 @@ describe('MongoClient', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
 
@@ -204,7 +204,7 @@ describe('MongoClient', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient(
         {},
@@ -214,7 +214,7 @@ describe('MongoClient', function() {
         }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         var db = client.db(configuration.db);
 
@@ -243,16 +243,16 @@ describe('MongoClient', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient();
-      client.connect(function(err, mongoclient) {
+      client.connect(function (err, mongoclient) {
         test.equal(null, err);
 
         mongoclient
           .db('integration_tests')
           .collection('new_mongo_client_collection')
-          .insertOne({ a: 1 }, function(err, r) {
+          .insertOne({ a: 1 }, function (err, r) {
             test.equal(null, err);
             test.ok(r);
 
@@ -269,15 +269,15 @@ describe('MongoClient', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient();
-      client.connect().then(function(mongoclient) {
+      client.connect().then(function (mongoclient) {
         mongoclient
           .db('integration_tests')
           .collection('new_mongo_client_collection')
           .insertOne({ a: 1 })
-          .then(function(r) {
+          .then(function (r) {
             test.ok(r);
 
             mongoclient.close(done);
@@ -286,7 +286,7 @@ describe('MongoClient', function() {
     }
   });
 
-  it('should be able to access a database named "constructor"', function() {
+  it('should be able to access a database named "constructor"', function () {
     const client = this.configuration.newClient();
     let err;
     return client

--- a/test/functional/mongo_client_options.test.js
+++ b/test/functional/mongo_client_options.test.js
@@ -4,15 +4,15 @@ const test = require('./shared').assert,
   expect = require('chai').expect;
 const { MongoClient } = require('../../src');
 
-describe('MongoClient Options', function() {
-  before(function() {
+describe('MongoClient Options', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it('should error on unexpected options', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       MongoClient.connect(
         configuration.url(),
@@ -22,7 +22,7 @@ describe('MongoClient Options', function() {
           notlegal: {},
           validateOptions: true
         },
-        function(err, client) {
+        function (err, client) {
           test.ok(err.message.indexOf('option notlegal is not supported') !== -1);
           expect(client).to.not.exist;
           done();

--- a/test/functional/mongodb_aws.test.js
+++ b/test/functional/mongodb_aws.test.js
@@ -1,15 +1,15 @@
 'use strict';
 const expect = require('chai').expect;
 
-describe('MONGODB-AWS', function() {
-  before(function() {
+describe('MONGODB-AWS', function () {
+  before(function () {
     const MONGODB_URI = process.env.MONGODB_URI;
     if (!MONGODB_URI || MONGODB_URI.indexOf('MONGODB-AWS') === -1) {
       this.skip();
     }
   });
 
-  it('should not authorize when not authenticated', function(done) {
+  it('should not authorize when not authenticated', function (done) {
     const config = this.configuration;
     const client = config.newClient(config.url()); // strip provided URI of credentials
     client.connect(err => {
@@ -25,7 +25,7 @@ describe('MONGODB-AWS', function() {
     });
   });
 
-  it('should authorize when successfully authenticated', function(done) {
+  it('should authorize when successfully authenticated', function (done) {
     const config = this.configuration;
     const client = config.newClient(); // use the URI built by the test environment
     client.connect(err => {

--- a/test/functional/multiple_db.test.js
+++ b/test/functional/multiple_db.test.js
@@ -3,8 +3,8 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const { expect } = require('chai');
 
-describe('Multiple Databases', function() {
-  before(function() {
+describe('Multiple Databases', function () {
+  before(function () {
     return setupDatabase(this.configuration, ['integration_tests2']);
   });
 
@@ -16,37 +16,37 @@ describe('Multiple Databases', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 1 }, { poolSize: 1 });
       var second_test_database_client = configuration.newClient({ w: 1 }, { poolSize: 1 });
       // Just create second database
-      client.connect(function(err, client) {
-        second_test_database_client.connect(function(err, second_test_database) {
+      client.connect(function (err, client) {
+        second_test_database_client.connect(function (err, second_test_database) {
           var db = client.db(configuration.db);
           // Close second database
           second_test_database.close();
           // Let's grab a connection to the different db resusing our connection pools
           var secondDb = client.db('integration_tests2');
-          secondDb.createCollection('same_connection_two_dbs', function(err, collection) {
+          secondDb.createCollection('same_connection_two_dbs', function (err, collection) {
             // Insert a dummy document
-            collection.insert({ a: 20 }, { safe: true }, function(err) {
+            collection.insert({ a: 20 }, { safe: true }, function (err) {
               test.equal(null, err);
 
               // Query it
-              collection.findOne({}, function(err, item) {
+              collection.findOne({}, function (err, item) {
                 test.equal(20, item.a);
 
                 // Use the other db
-                db.createCollection('same_connection_two_dbs', function(err, collection) {
+                db.createCollection('same_connection_two_dbs', function (err, collection) {
                   expect(err).to.not.exist;
 
                   // Insert a dummy document
-                  collection.insert({ b: 20 }, { safe: true }, function(err) {
+                  collection.insert({ b: 20 }, { safe: true }, function (err) {
                     test.equal(null, err);
 
                     // Query it
-                    collection.findOne({}, function(err, item) {
+                    collection.findOne({}, function (err, item) {
                       test.equal(20, item.b);
 
                       test.equal(null, err);
@@ -67,18 +67,18 @@ describe('Multiple Databases', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         var db_instance = client.db('site1');
         db_instance = client.db('site2');
         db_instance = client.db('rss');
 
-        db_instance.collection('counters', function(err, collection) {
+        db_instance.collection('counters', function (err, collection) {
           expect(err).to.not.exist;
-          collection.findAndModify({}, {}, { $inc: { db: 1 } }, { new: true }, function(err) {
+          collection.findAndModify({}, {}, { $inc: { db: 1 } }, { new: true }, function (err) {
             test.equal(null, err);
             client.close(done);
           });
@@ -92,10 +92,10 @@ describe('Multiple Databases', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient({}, { sslValidate: false });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         for (var i = 0; i < 100; i++) {
           client.db('test');
         }

--- a/test/functional/object_id.test.js
+++ b/test/functional/object_id.test.js
@@ -3,8 +3,8 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const { ObjectId } = require('../../src');
 
-describe('ObjectId', function() {
-  before(function() {
+describe('ObjectId', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -13,31 +13,31 @@ describe('ObjectId', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var number_of_tests_done = 0;
 
         var collection = db.collection('test_object_id_generation.data');
         // Insert test documents (creates collections and test fetch by query)
-        collection.insert({ name: 'Fred', age: 42 }, { w: 1 }, function(err, r) {
+        collection.insert({ name: 'Fred', age: 42 }, { w: 1 }, function (err, r) {
           test.equal(1, r.ops.length);
           test.ok(r.ops[0]['_id'].toHexString().length === 24);
           // Locate the first document inserted
-          collection.findOne({ name: 'Fred' }, function(err, document) {
+          collection.findOne({ name: 'Fred' }, function (err, document) {
             test.equal(r.ops[0]['_id'].toHexString(), document._id.toHexString());
             number_of_tests_done++;
           });
         });
 
         // Insert another test document and collect using ObjectId
-        collection.insert({ name: 'Pat', age: 21 }, { w: 1 }, function(err, r) {
+        collection.insert({ name: 'Pat', age: 21 }, { w: 1 }, function (err, r) {
           test.equal(1, r.ops.length);
           test.ok(r.ops[0]['_id'].toHexString().length === 24);
           // Locate the first document inserted
-          collection.findOne(r.ops[0]['_id'], function(err, document) {
+          collection.findOne(r.ops[0]['_id'], function (err, document) {
             test.equal(r.ops[0]['_id'].toHexString(), document._id.toHexString());
             number_of_tests_done++;
           });
@@ -46,19 +46,19 @@ describe('ObjectId', function() {
         // Manually created id
         var objectId = new ObjectId(null);
         // Insert a manually created document with generated oid
-        collection.insert({ _id: objectId, name: 'Donald', age: 95 }, { w: 1 }, function(err, r) {
+        collection.insert({ _id: objectId, name: 'Donald', age: 95 }, { w: 1 }, function (err, r) {
           test.equal(1, r.ops.length);
           test.ok(r.ops[0]['_id'].toHexString().length === 24);
           test.equal(objectId.toHexString(), r.ops[0]['_id'].toHexString());
           // Locate the first document inserted
-          collection.findOne(r.ops[0]['_id'], function(err, document) {
+          collection.findOne(r.ops[0]['_id'], function (err, document) {
             test.equal(r.ops[0]['_id'].toHexString(), document._id.toHexString());
             test.equal(objectId.toHexString(), document._id.toHexString());
             number_of_tests_done++;
           });
         });
 
-        var intervalId = setInterval(function() {
+        var intervalId = setInterval(function () {
           if (number_of_tests_done === 3) {
             clearInterval(intervalId);
             client.close(done);
@@ -73,7 +73,7 @@ describe('ObjectId', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Create a new ObjectId
       var objectId = new ObjectId();
       // Verify that the hex string is 24 characters long
@@ -87,7 +87,7 @@ describe('ObjectId', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // Create a new ObjectId
       var objectId = new ObjectId();
       // Verify that the hex string is 24 characters long
@@ -101,10 +101,10 @@ describe('ObjectId', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var collection = db.collection('test_non_oid_id');
         var date = new Date();
@@ -115,9 +115,9 @@ describe('ObjectId', function() {
         date.setUTCMinutes(0);
         date.setUTCSeconds(30);
 
-        collection.insert({ _id: date }, { w: 1 }, function(err) {
+        collection.insert({ _id: date }, { w: 1 }, function (err) {
           test.equal(null, err);
-          collection.find({ _id: date }).toArray(function(err, items) {
+          collection.find({ _id: date }).toArray(function (err, items) {
             test.equal('' + date, '' + items[0]._id);
 
             // Let's close the db
@@ -133,7 +133,7 @@ describe('ObjectId', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var timestamp = Math.floor(new Date().getTime() / 1000);
       var objectID = new ObjectId(timestamp);
       var time2 = objectID.generationTime;
@@ -147,7 +147,7 @@ describe('ObjectId', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var timestamp = 1000;
       var objectID = new ObjectId();
       var id1 = objectID.id;
@@ -171,24 +171,24 @@ describe('ObjectId', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
 
         var db = client.db(configuration.db);
         var collection = db.collection('shouldCorrectlyInsertWithObjectId');
-        collection.insert({}, { w: 1 }, function(err) {
+        collection.insert({}, { w: 1 }, function (err) {
           test.equal(null, err);
           const firstCompareDate = new Date();
 
-          setTimeout(function() {
-            collection.insert({}, { w: 1 }, function(err) {
+          setTimeout(function () {
+            collection.insert({}, { w: 1 }, function (err) {
               test.equal(null, err);
               const secondCompareDate = new Date();
 
-              collection.find().toArray(function(err, items) {
+              collection.find().toArray(function (err, items) {
                 test.equal(null, err);
 
                 // Date 1

--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -9,8 +9,8 @@ const chai = require('chai');
 const expect = chai.expect;
 chai.use(require('chai-subset'));
 
-describe('Operation Examples', function() {
-  before(function() {
+describe('Operation Examples', function () {
+  before(function () {
     return setupDatabase(this.configuration, ['integration_tests_2']);
   });
 
@@ -36,10 +36,10 @@ describe('Operation Examples', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -70,7 +70,7 @@ describe('Operation Examples', function() {
         // Create a collection
         var collection = db.collection('aggregationExample1');
         // Insert the docs
-        collection.insertMany(docs, { w: 1 }, function(err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
@@ -91,7 +91,7 @@ describe('Operation Examples', function() {
             },
             { $sort: { _id: -1 } }
           ]);
-          cursor.toArray(function(err, result) {
+          cursor.toArray(function (err, result) {
             test.equal(null, err);
             test.equal('good', result[0]._id.tags);
             test.deepEqual(['bob'], result[0].authors);
@@ -122,10 +122,10 @@ describe('Operation Examples', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -156,7 +156,7 @@ describe('Operation Examples', function() {
         // Create a collection
         var collection = db.collection('aggregationExample2');
         // Insert the docs
-        collection.insertMany(docs, { w: 1 }, function(err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
@@ -181,7 +181,7 @@ describe('Operation Examples', function() {
           );
 
           // Get all the aggregation results
-          cursor.toArray(function(err, docs) {
+          cursor.toArray(function (err, docs) {
             test.equal(null, err);
             test.equal(2, docs.length);
             client.close(done);
@@ -208,10 +208,10 @@ describe('Operation Examples', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -242,7 +242,7 @@ describe('Operation Examples', function() {
         // Create a collection
         var collection = db.collection('aggregation_toArray_example');
         // Insert the docs
-        collection.insertMany(docs, { w: 1 }, function(err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           test.equal(null, err);
           test.ok(result);
 
@@ -267,7 +267,7 @@ describe('Operation Examples', function() {
           );
 
           // Get all the aggregation results
-          cursor.toArray(function(err, docs) {
+          cursor.toArray(function (err, docs) {
             test.equal(null, err);
             test.equal(2, docs.length);
             client.close(done);
@@ -294,10 +294,10 @@ describe('Operation Examples', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -328,7 +328,7 @@ describe('Operation Examples', function() {
         // Create a collection
         var collection = db.collection('aggregation_next_example');
         // Insert the docs
-        collection.insertMany(docs, { w: 1 }, function(err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
@@ -353,7 +353,7 @@ describe('Operation Examples', function() {
           );
 
           // Get all the aggregation results
-          cursor.next(function(err, docs) {
+          cursor.next(function (err, docs) {
             test.ok(docs);
             test.equal(null, err);
 
@@ -384,10 +384,10 @@ describe('Operation Examples', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -418,7 +418,7 @@ describe('Operation Examples', function() {
         // Create a collection
         var collection = db.collection('aggregation_each_example');
         // Insert the docs
-        collection.insertMany(docs, { w: 1 }, function(err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
@@ -443,7 +443,7 @@ describe('Operation Examples', function() {
           );
 
           // Get all the aggregation results
-          cursor.each(function(err, docs) {
+          cursor.each(function (err, docs) {
             test.equal(null, err);
 
             if (docs == null) {
@@ -472,10 +472,10 @@ describe('Operation Examples', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -506,7 +506,7 @@ describe('Operation Examples', function() {
         // Create a collection
         var collection = db.collection('aggregation_forEach_example');
         // Insert the docs
-        collection.insertMany(docs, { w: 1 }, function(err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
@@ -533,11 +533,11 @@ describe('Operation Examples', function() {
           var count = 0;
           // Get all the aggregation results
           cursor.forEach(
-            function(doc) {
+            function (doc) {
               test.ok(doc != null);
               count = count + 1;
             },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               test.equal(2, count);
 
@@ -566,10 +566,10 @@ describe('Operation Examples', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -600,7 +600,7 @@ describe('Operation Examples', function() {
         // Create a collection
         var collection = db.collection('aggregationExample3');
         // Insert the docs
-        collection.insertMany(docs, { w: 1 }, function(err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
@@ -626,11 +626,11 @@ describe('Operation Examples', function() {
 
           var count = 0;
           // Get all the aggregation results
-          cursor.on('data', function() {
+          cursor.on('data', function () {
             count = count + 1;
           });
 
-          cursor.once('end', function() {
+          cursor.once('end', function () {
             test.equal(2, count);
             client.close(done);
           });
@@ -651,10 +651,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -669,7 +669,7 @@ describe('Operation Examples', function() {
         // Crete the collection for the distinct example
         var collection = db.collection('countExample1');
         // Insert documents to perform distinct against
-        collection.insertMany([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4, b: 1 }], { w: 1 }, function(
+        collection.insertMany([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4, b: 1 }], { w: 1 }, function (
           err,
           ids
         ) {
@@ -677,12 +677,12 @@ describe('Operation Examples', function() {
           test.equal(null, err);
 
           // Perform a total count command
-          collection.count(function(err, count) {
+          collection.count(function (err, count) {
             test.equal(null, err);
             test.equal(4, count);
 
             // Perform a partial account where b=1
-            collection.count({ b: 1 }, function(err, count) {
+            collection.count({ b: 1 }, function (err, count) {
               test.equal(null, err);
               test.equal(1, count);
 
@@ -706,10 +706,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -732,7 +732,7 @@ describe('Operation Examples', function() {
             { a: 4, b: 4 }
           ],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -740,17 +740,17 @@ describe('Operation Examples', function() {
             collection.createIndex(
               { a: 1, b: 1 },
               { unique: true, background: true, w: 1 },
-              function(err, indexName) {
+              function (err, indexName) {
                 test.ok(indexName);
                 test.equal(null, err);
 
                 // Show that duplicate records got dropped
-                collection.find({}).toArray(function(err, items) {
+                collection.find({}).toArray(function (err, items) {
                   test.equal(null, err);
                   test.equal(4, items.length);
 
                   // Perform a query, with explain to show we hit the query
-                  collection.find({ a: 2 }).explain(function(err, explanation) {
+                  collection.find({ a: 2 }).explain(function (err, explanation) {
                     test.equal(null, err);
                     test.ok(explanation != null);
 
@@ -777,10 +777,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -795,7 +795,7 @@ describe('Operation Examples', function() {
         // Create a collection we want to drop later
         var collection = db.collection('createIndexExample2');
         // Insert a bunch of documents for the index
-        collection.insertMany([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }], { w: 1 }, function(
+        collection.insertMany([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }], { w: 1 }, function (
           err,
           result
         ) {
@@ -803,11 +803,11 @@ describe('Operation Examples', function() {
           test.equal(null, err);
 
           // Create an index on the a field
-          collection.createIndex('a', { w: 1 }, function(err, indexName) {
+          collection.createIndex('a', { w: 1 }, function (err, indexName) {
             test.equal('a_1', indexName);
 
             // Perform a query, with explain to show we hit the query
-            collection.find({ a: 2 }).explain(function(err, explanation) {
+            collection.find({ a: 2 }).explain(function (err, explanation) {
               test.equal(null, err);
               test.ok(explanation != null);
 
@@ -831,10 +831,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -857,24 +857,24 @@ describe('Operation Examples', function() {
             { a: 4, b: 4 }
           ],
           { w: 1 },
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             var options = { unique: true, background: true, w: 1 };
             // Create an index on the a field
-            collection.createIndex({ a: 1, b: 1 }, options, function(err, indexName) {
+            collection.createIndex({ a: 1, b: 1 }, options, function (err, indexName) {
               test.ok(indexName);
               test.equal(null, err);
 
               test.ok(!options.readPreference);
               // Show that duplicate records got dropped
-              collection.find({}).toArray(function(err, items) {
+              collection.find({}).toArray(function (err, items) {
                 test.equal(null, err);
                 test.equal(4, items.length);
 
                 // Perform a query, with explain to show we hit the query
-                collection.find({ a: 2 }).explain(function(err, explanation) {
+                collection.find({ a: 2 }).explain(function (err, explanation) {
                   test.equal(null, err);
                   test.ok(explanation != null);
 
@@ -900,10 +900,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -929,16 +929,16 @@ describe('Operation Examples', function() {
             { a: 3 }
           ],
           configuration.writeConcernMax(),
-          function(err, ids) {
+          function (err, ids) {
             test.ok(ids);
             test.equal(null, err);
 
             // Perform a distinct query against the a field
-            collection.distinct('a', function(err, docs) {
+            collection.distinct('a', function (err, docs) {
               test.deepEqual([0, 1, 2, 3], docs.sort());
 
               // Perform a distinct query against the sub-field b.c
-              collection.distinct('b.c', function(err, docs) {
+              collection.distinct('b.c', function (err, docs) {
                 test.deepEqual(['a', 'b', 'c'], docs.sort());
 
                 client.close(done);
@@ -962,10 +962,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -992,12 +992,12 @@ describe('Operation Examples', function() {
             { a: 5, c: 1 }
           ],
           configuration.writeConcernMax(),
-          function(err, ids) {
+          function (err, ids) {
             test.ok(ids);
             test.equal(null, err);
 
             // Perform a distinct query with a filter against the documents
-            collection.distinct('a', { c: 1 }, function(err, docs) {
+            collection.distinct('a', { c: 1 }, function (err, docs) {
               test.deepEqual([5], docs.sort());
 
               client.close(done);
@@ -1020,10 +1020,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1039,17 +1039,17 @@ describe('Operation Examples', function() {
         var collection = db.collection('test_other_drop');
 
         // Drop the collection
-        collection.drop(function(/*err, reply*/) {
+        collection.drop(function (/*err, reply*/) {
           // TODO: reenable once SERVER-36317 is resolved
           // expect(err).to.exist;
           // expect(reply).to.not.exist;
 
           // Ensure we don't have the collection in the set of names
-          db.listCollections().toArray(function(err, replies) {
+          db.listCollections().toArray(function (err, replies) {
             var found = false;
             // For each collection in the list of collection names in this db look for the
             // dropped collection
-            replies.forEach(function(document) {
+            replies.forEach(function (document) {
               if (document.name === 'test_other_drop') {
                 found = true;
                 return;
@@ -1079,10 +1079,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1094,12 +1094,12 @@ describe('Operation Examples', function() {
         // REMOVE-LINE var db = client.db(configuration.db);
         // BEGIN
         var db = client.db(configuration.db);
-        db.createCollection('dropExample1', function(err, r) {
+        db.createCollection('dropExample1', function (err, r) {
           test.ok(r);
           test.equal(null, err);
 
           // Drop the collection
-          db.collection('dropExample1').dropAllIndexes(function(err, reply) {
+          db.collection('dropExample1').dropAllIndexes(function (err, reply) {
             test.ok(reply);
             test.equal(null, err);
 
@@ -1123,10 +1123,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1148,7 +1148,7 @@ describe('Operation Examples', function() {
             { a: 4, b: 4 }
           ],
           { w: 1 },
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -1156,17 +1156,17 @@ describe('Operation Examples', function() {
             collection.ensureIndex(
               { a: 1, b: 1 },
               { unique: true, background: true, w: 1 },
-              function(err, indexName) {
+              function (err, indexName) {
                 test.ok(indexName);
                 test.equal(null, err);
 
                 // Drop the index
-                collection.dropIndex('a_1_b_1', function(err, result) {
+                collection.dropIndex('a_1_b_1', function (err, result) {
                   test.ok(result);
                   test.equal(null, err);
 
                   // Verify that the index is gone
-                  collection.indexInformation(function(err, indexInformation) {
+                  collection.indexInformation(function (err, indexInformation) {
                     test.deepEqual([['_id', 1]], indexInformation._id_);
                     test.equal(undefined, indexInformation.a_1_b_1);
 
@@ -1193,10 +1193,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1218,7 +1218,7 @@ describe('Operation Examples', function() {
             { a: 4, b: 4 }
           ],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -1227,17 +1227,17 @@ describe('Operation Examples', function() {
               'ensureIndexExample1',
               { a: 1, b: 1 },
               { unique: true, background: true, w: 1 },
-              function(err, indexName) {
+              function (err, indexName) {
                 test.ok(indexName);
                 test.equal(null, err);
 
                 // Show that duplicate records got dropped
-                collection.find({}).toArray(function(err, items) {
+                collection.find({}).toArray(function (err, items) {
                   test.equal(null, err);
                   test.equal(4, items.length);
 
                   // Perform a query, with explain to show we hit the query
-                  collection.find({ a: 2 }).explain(function(err, explanation) {
+                  collection.find({ a: 2 }).explain(function (err, explanation) {
                     test.equal(null, err);
                     test.ok(explanation != null);
 
@@ -1264,10 +1264,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1289,7 +1289,7 @@ describe('Operation Examples', function() {
             { a: 4, b: 4 }
           ],
           { w: 1 },
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -1297,17 +1297,17 @@ describe('Operation Examples', function() {
             collection.ensureIndex(
               { a: 1, b: 1 },
               { unique: true, background: true, w: 1 },
-              function(err, indexName) {
+              function (err, indexName) {
                 test.ok(indexName);
                 test.equal(null, err);
 
                 // Show that duplicate records got dropped
-                collection.find({}).toArray(function(err, items) {
+                collection.find({}).toArray(function (err, items) {
                   test.equal(null, err);
                   test.equal(4, items.length);
 
                   // Perform a query, with explain to show we hit the query
-                  collection.find({ a: 2 }).explain(function(err, explanation) {
+                  collection.find({ a: 2 }).explain(function (err, explanation) {
                     test.equal(null, err);
                     test.ok(explanation != null);
 
@@ -1334,10 +1334,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1356,12 +1356,12 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { a: 2 }, { a: 3 }],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             // Perform a simple find and return all the documents
-            collection.find().toArray(function(err, docs) {
+            collection.find().toArray(function (err, docs) {
               test.equal(null, err);
               test.equal(3, docs.length);
 
@@ -1385,10 +1385,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1406,12 +1406,12 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { a: 2 }, { a: 3 }],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             // Perform a simple find and return all the documents
-            collection.find({}).explain(function(err, explain) {
+            collection.find({}).explain(function (err, explain) {
               test.equal(null, err);
               test.ok(explain != null);
 
@@ -1435,10 +1435,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1460,7 +1460,7 @@ describe('Operation Examples', function() {
             { a: 3, b: 3 }
           ],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -1470,7 +1470,7 @@ describe('Operation Examples', function() {
               .skip(1)
               .limit(1)
               .project({ b: 1 })
-              .toArray(function(err, docs) {
+              .toArray(function (err, docs) {
                 test.equal(null, err);
                 test.equal(1, docs.length);
                 test.equal(undefined, docs[0].a);
@@ -1500,10 +1500,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1522,7 +1522,7 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { b: 1 }, { c: 1 }],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -1532,7 +1532,7 @@ describe('Operation Examples', function() {
               [['a', 1]],
               { $set: { b1: 1 } },
               { new: true },
-              function(err, doc) {
+              function (err, doc) {
                 test.equal(null, err);
                 test.equal(1, doc.value.a);
                 test.equal(1, doc.value.b1);
@@ -1544,12 +1544,12 @@ describe('Operation Examples', function() {
                   [['b', 1]],
                   { $set: { b: 2 } },
                   { remove: true },
-                  function(err, doc) {
+                  function (err, doc) {
                     test.ok(doc);
                     test.equal(null, err);
 
                     // Verify that the document is gone
-                    collection.findOne({ b: 1 }, function(err, item) {
+                    collection.findOne({ b: 1 }, function (err, item) {
                       test.equal(null, err);
                       test.equal(null, item);
 
@@ -1560,7 +1560,7 @@ describe('Operation Examples', function() {
                         [['b', 1]],
                         { d: 1, f: 1 },
                         { new: true, upsert: true, w: 1 },
-                        function(err, doc) {
+                        function (err, doc) {
                           test.equal(null, err);
                           test.equal(1, doc.value.d);
                           test.equal(1, doc.value.f);
@@ -1591,10 +1591,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1612,19 +1612,19 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { b: 1, d: 1 }, { c: 1 }],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             // Simple findAndModify command returning the old document and
             // removing it at the same time
-            collection.findAndRemove({ b: 1 }, [['b', 1]], function(err, doc) {
+            collection.findAndRemove({ b: 1 }, [['b', 1]], function (err, doc) {
               test.equal(null, err);
               test.equal(1, doc.value.b);
               test.equal(1, doc.value.d);
 
               // Verify that the document is gone
-              collection.findOne({ b: 1 }, function(err, item) {
+              collection.findOne({ b: 1 }, function (err, item) {
                 test.equal(null, err);
                 test.equal(null, item);
 
@@ -1649,10 +1649,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1674,12 +1674,12 @@ describe('Operation Examples', function() {
             { a: 3, b: 3 }
           ],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             // Perform a simple find and return all the documents
-            collection.findOne({ a: 2 }, { fields: { b: 1 } }, function(err, doc) {
+            collection.findOne({ a: 2 }, { fields: { b: 1 } }, function (err, doc) {
               test.equal(null, err);
               test.equal(undefined, doc.a);
               test.equal(2, doc.b);
@@ -1704,7 +1704,7 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
@@ -1779,10 +1779,10 @@ describe('Operation Examples', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1798,12 +1798,12 @@ describe('Operation Examples', function() {
         var collection = db.collection('test_map_reduce_functions_inline');
 
         // Insert some test documents
-        collection.insertMany([{ user_id: 1 }, { user_id: 2 }], { w: 1 }, function(err, r) {
+        collection.insertMany([{ user_id: 1 }, { user_id: 2 }], { w: 1 }, function (err, r) {
           test.ok(r);
           test.equal(null, err);
 
           // Map function
-          var map = function() {
+          var map = function () {
             emit(this.user_id, 1); // eslint-disable-line
           };
 
@@ -1814,7 +1814,7 @@ describe('Operation Examples', function() {
           };
 
           // Execute map reduce and return results inline
-          collection.mapReduce(map, reduce, { out: { inline: 1 }, verbose: true }, function(
+          collection.mapReduce(map, reduce, { out: { inline: 1 }, verbose: true }, function (
             err,
             result
           ) {
@@ -1825,7 +1825,7 @@ describe('Operation Examples', function() {
               map,
               reduce,
               { out: { replace: 'mapreduce_integration_test' }, verbose: true },
-              function(err, result) {
+              function (err, result) {
                 test.ok(result.stats != null);
                 client.close(done);
               }
@@ -1848,10 +1848,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1873,17 +1873,17 @@ describe('Operation Examples', function() {
             { user_id: 2, timestamp: new Date() }
           ],
           { w: 1 },
-          function(err, r) {
+          function (err, r) {
             test.ok(r);
             test.equal(null, err);
 
             // Map function
-            var map = function() {
+            var map = function () {
               emit(fn(this.timestamp.getYear()), 1); // eslint-disable-line
             };
 
             // Reduce function
-            var reduce = function(k, v) {
+            var reduce = function (k, v) {
               var count = 0;
               for (var i = 0; i < v.length; i++) {
                 count += v[i];
@@ -1892,7 +1892,7 @@ describe('Operation Examples', function() {
             };
 
             // Javascript function available in the map reduce scope
-            var t = function(val) {
+            var t = function (val) {
               return val + 1;
             };
 
@@ -1901,11 +1901,11 @@ describe('Operation Examples', function() {
             o.scope = { fn: new Code(t.toString()) };
             o.out = { replace: 'replacethiscollection' };
 
-            collection.mapReduce(map, reduce, o, function(err, outCollection) {
+            collection.mapReduce(map, reduce, o, function (err, outCollection) {
               expect(err).to.not.exist;
 
               // Find all entries in the map-reduce collection
-              outCollection.find().toArray(function(err, results) {
+              outCollection.find().toArray(function (err, results) {
                 test.equal(null, err);
                 test.equal(2, results[0].value);
 
@@ -1914,11 +1914,11 @@ describe('Operation Examples', function() {
                 o.scope = { fn: t };
                 o.out = { replace: 'replacethiscollection' };
 
-                collection.mapReduce(map, reduce, o, function(err, outCollection) {
+                collection.mapReduce(map, reduce, o, function (err, outCollection) {
                   test.equal(null, err);
 
                   // Find all entries in the map-reduce collection
-                  outCollection.find().toArray(function(err, results) {
+                  outCollection.find().toArray(function (err, results) {
                     expect(err).to.not.exist;
                     test.equal(2, results[0].value);
 
@@ -1945,10 +1945,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -1970,17 +1970,17 @@ describe('Operation Examples', function() {
             { user_id: 2, timestamp: new Date() }
           ],
           { w: 1 },
-          function(err, r) {
+          function (err, r) {
             test.ok(r);
             test.equal(null, err);
 
             // Map function
-            var map = function() {
+            var map = function () {
               emit(obj.fn(this.timestamp.getYear()), 1); // eslint-disable-line
             };
 
             // Reduce function
-            var reduce = function(k, v) {
+            var reduce = function (k, v) {
               var count = 0;
               for (var i = 0; i < v.length; i++) {
                 count += v[i];
@@ -1990,7 +1990,7 @@ describe('Operation Examples', function() {
             };
 
             // Javascript function available in the map reduce scope
-            var t = function(val) {
+            var t = function (val) {
               return val + 1;
             };
 
@@ -1999,11 +1999,11 @@ describe('Operation Examples', function() {
             o.scope = { obj: { fn: new Code(t.toString()) } };
             o.out = { replace: 'replacethiscollection' };
 
-            collection.mapReduce(map, reduce, o, function(err, outCollection) {
+            collection.mapReduce(map, reduce, o, function (err, outCollection) {
               test.equal(null, err);
 
               // Find all entries in the map-reduce collection
-              outCollection.find().toArray(function(err, results) {
+              outCollection.find().toArray(function (err, results) {
                 test.equal(null, err);
                 test.equal(2, results[0].value);
 
@@ -2012,11 +2012,11 @@ describe('Operation Examples', function() {
                 o.scope = { obj: { fn: t } };
                 o.out = { replace: 'replacethiscollection' };
 
-                collection.mapReduce(map, reduce, o, function(err, outCollection) {
+                collection.mapReduce(map, reduce, o, function (err, outCollection) {
                   test.equal(null, err);
 
                   // Find all entries in the map-reduce collection
-                  outCollection.find().toArray(function(err, results) {
+                  outCollection.find().toArray(function (err, results) {
                     test.equal(2, results[0].value);
                     client.close(done);
                   });
@@ -2041,10 +2041,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2059,7 +2059,7 @@ describe('Operation Examples', function() {
         // Crete the collection for the distinct example
         var collection = db.collection('simple_key_based_distinct');
         // Create a geo 2d index
-        collection.ensureIndex({ loc: '2d' }, configuration.writeConcernMax(), function(
+        collection.ensureIndex({ loc: '2d' }, configuration.writeConcernMax(), function (
           err,
           result
         ) {
@@ -2067,13 +2067,13 @@ describe('Operation Examples', function() {
           test.equal(null, err);
 
           // Create a simple single field index
-          collection.ensureIndex({ a: 1 }, configuration.writeConcernMax(), function(err, result) {
+          collection.ensureIndex({ a: 1 }, configuration.writeConcernMax(), function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
-            setTimeout(function() {
+            setTimeout(function () {
               // List all of the indexes on the collection
-              collection.indexes(function(err, indexes) {
+              collection.indexes(function (err, indexes) {
                 test.equal(3, indexes.length);
 
                 client.close(done);
@@ -2097,10 +2097,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2120,20 +2120,20 @@ describe('Operation Examples', function() {
         test.equal(null, err);
 
         // Create an index on the collection
-        collection.createIndex('a', configuration.writeConcernMax(), function(err, indexName) {
+        collection.createIndex('a', configuration.writeConcernMax(), function (err, indexName) {
           test.ok(indexName);
           test.equal(null, err);
 
           // Let's test to check if a single index exists
-          collection.indexExists('a_1', function(err, result) {
+          collection.indexExists('a_1', function (err, result) {
             test.equal(true, result);
 
             // Let's test to check if multiple indexes are available
-            collection.indexExists(['a_1', '_id_'], function(err, result) {
+            collection.indexExists(['a_1', '_id_'], function (err, result) {
               test.equal(true, result);
 
               // Check if a non existing index exists
-              collection.indexExists('c_1', function(err, result) {
+              collection.indexExists('c_1', function (err, result) {
                 test.equal(false, result);
 
                 client.close(done);
@@ -2157,10 +2157,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2183,7 +2183,7 @@ describe('Operation Examples', function() {
             { a: 4, b: 4 }
           ],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -2191,12 +2191,12 @@ describe('Operation Examples', function() {
             collection.ensureIndex(
               { a: 1, b: 1 },
               { unique: true, background: true, w: 1 },
-              function(err, indexName) {
+              function (err, indexName) {
                 test.ok(indexName);
                 test.equal(null, err);
 
                 // Fetch basic indexInformation for collection
-                db.indexInformation('more_index_information_test_2', function(
+                db.indexInformation('more_index_information_test_2', function (
                   err,
                   indexInformation
                 ) {
@@ -2210,7 +2210,7 @@ describe('Operation Examples', function() {
                   );
 
                   // Fetch full index information
-                  collection.indexInformation({ full: true }, function(err, indexInformation) {
+                  collection.indexInformation({ full: true }, function (err, indexInformation) {
                     test.deepEqual({ _id: 1 }, indexInformation[0].key);
                     test.deepEqual({ a: 1, b: 1 }, indexInformation[1].key);
 
@@ -2237,10 +2237,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2263,7 +2263,7 @@ describe('Operation Examples', function() {
             { a: 4, b: 4 }
           ],
           { w: 1 },
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -2271,12 +2271,12 @@ describe('Operation Examples', function() {
             collection.ensureIndex(
               { a: 1, b: 1 },
               { unique: true, background: true, w: 1 },
-              function(err, indexName) {
+              function (err, indexName) {
                 test.ok(indexName);
                 test.equal(null, err);
 
                 // Fetch basic indexInformation for collection
-                collection.indexInformation(function(err, indexInformation) {
+                collection.indexInformation(function (err, indexInformation) {
                   test.deepEqual([['_id', 1]], indexInformation._id_);
                   test.deepEqual(
                     [
@@ -2287,7 +2287,7 @@ describe('Operation Examples', function() {
                   );
 
                   // Fetch full index information
-                  collection.indexInformation({ full: true }, function(err, indexInformation) {
+                  collection.indexInformation({ full: true }, function (err, indexInformation) {
                     test.deepEqual({ _id: 1 }, indexInformation[0].key);
                     test.deepEqual({ a: 1, b: 1 }, indexInformation[1].key);
 
@@ -2315,10 +2315,10 @@ describe('Operation Examples', function() {
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2335,9 +2335,9 @@ describe('Operation Examples', function() {
         collection.insertOne({ hello: 'world_no_safe' });
 
         // Wait for a second before finishing up, to ensure we have written the item to disk
-        setTimeout(function() {
+        setTimeout(function () {
           // Fetch the document
-          collection.findOne({ hello: 'world_no_safe' }, function(err, item) {
+          collection.findOne({ hello: 'world_no_safe' }, function (err, item) {
             test.equal(null, err);
             test.equal('world_no_safe', item.hello);
             client.close(done);
@@ -2361,10 +2361,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2382,12 +2382,12 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ hello: 'world_safe1' }, { hello: 'world_safe2' }],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             // Fetch the document
-            collection.findOne({ hello: 'world_safe2' }, function(err, item) {
+            collection.findOne({ hello: 'world_safe2' }, function (err, item) {
               test.equal(null, err);
               test.equal('world_safe2', item.hello);
               client.close(done);
@@ -2412,10 +2412,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2436,15 +2436,15 @@ describe('Operation Examples', function() {
         collection.insertOne(
           {
             hello: 'world',
-            func: function() {}
+            func: function () {}
           },
           o,
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             // Fetch the document
-            collection.findOne({ hello: 'world' }, function(err, item) {
+            collection.findOne({ hello: 'world' }, function (err, item) {
               test.equal(null, err);
               test.ok('function() {}', item.code);
               client.close(done);
@@ -2472,10 +2472,10 @@ describe('Operation Examples', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2491,7 +2491,7 @@ describe('Operation Examples', function() {
         var collection = db.collection('keepGoingExample');
 
         // Add an unique index to title to force errors in the batch insert
-        collection.ensureIndex({ title: 1 }, { unique: true }, function(err, indexName) {
+        collection.ensureIndex({ title: 1 }, { unique: true }, function (err, indexName) {
           test.ok(indexName);
           test.equal(null, err);
 
@@ -2499,7 +2499,7 @@ describe('Operation Examples', function() {
           collection.insertMany(
             [{ name: 'Jim' }, { name: 'Sarah', title: 'Princess' }],
             configuration.writeConcernMax(),
-            function(err, result) {
+            function (err, result) {
               test.ok(result);
               test.equal(null, err);
 
@@ -2511,13 +2511,13 @@ describe('Operation Examples', function() {
                   { name: 'Gump', title: 'Gump' }
                 ],
                 { w: 1, keepGoing: true },
-                function(err, result) {
+                function (err, result) {
                   test.equal(result, null);
                   test.ok(err);
                   test.ok(err.result);
 
                   // Count the number of documents left (should not include the duplicates)
-                  collection.count(function(err, count) {
+                  collection.count(function (err, count) {
                     test.equal(3, count);
                     client.close(done);
                   });
@@ -2542,10 +2542,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2558,14 +2558,14 @@ describe('Operation Examples', function() {
         // BEGIN
         var db = client.db(configuration.db);
         // Create a test collection that we are getting the options back from
-        db.createCollection('test_collection_is_capped', { capped: true, size: 1024 }, function(
+        db.createCollection('test_collection_is_capped', { capped: true, size: 1024 }, function (
           err,
           collection
         ) {
           test.equal('test_collection_is_capped', collection.collectionName);
 
           // Let's fetch the collection options
-          collection.isCapped(function(err, capped) {
+          collection.isCapped(function (err, capped) {
             test.equal(true, capped);
 
             client.close(done);
@@ -2587,10 +2587,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2603,14 +2603,14 @@ describe('Operation Examples', function() {
         // BEGIN
         var db = client.db(configuration.db);
         // Create a test collection that we are getting the options back from
-        db.createCollection('test_collection_options', { capped: true, size: 1024 }, function(
+        db.createCollection('test_collection_options', { capped: true, size: 1024 }, function (
           err,
           collection
         ) {
           test.equal('test_collection_options', collection.collectionName);
 
           // Let's fetch the collection options
-          collection.options(function(err, options) {
+          collection.options(function (err, options) {
             test.equal(true, options.capped);
             test.ok(options.size >= 1024);
 
@@ -2633,10 +2633,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2651,7 +2651,7 @@ describe('Operation Examples', function() {
         // Fetch a collection to insert document into
         var collection = db.collection('remove_all_documents_no_safe');
         // Insert a bunch of documents
-        collection.insertMany([{ a: 1 }, { b: 2 }], { w: 1 }, function(err, result) {
+        collection.insertMany([{ a: 1 }, { b: 2 }], { w: 1 }, function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
@@ -2659,7 +2659,7 @@ describe('Operation Examples', function() {
           collection.removeMany();
 
           // Fetch all results
-          collection.find().toArray(function(err, items) {
+          collection.find().toArray(function (err, items) {
             test.equal(null, err);
             test.equal(0, items.length);
             client.close(done);
@@ -2681,10 +2681,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2701,12 +2701,12 @@ describe('Operation Examples', function() {
         // Fetch a collection to insert document into
         var collection = db.collection('remove_subset_of_documents_safe');
         // Insert a bunch of documents
-        collection.insertMany([{ a: 1 }, { b: 2 }], { w: 1 }, function(err, result) {
+        collection.insertMany([{ a: 1 }, { b: 2 }], { w: 1 }, function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
           // Remove all the document
-          collection.removeOne({ a: 1 }, { w: 1 }, function(err, r) {
+          collection.removeOne({ a: 1 }, { w: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.result.n);
             client.close(done);
@@ -2728,10 +2728,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2744,8 +2744,8 @@ describe('Operation Examples', function() {
         // BEGIN
         var db = client.db(configuration.db);
         // Open a couple of collections
-        db.createCollection('test_rename_collection', function(err, collection1) {
-          db.createCollection('test_rename_collection2', function(err, collection2) {
+        db.createCollection('test_rename_collection', function (err, collection1) {
+          db.createCollection('test_rename_collection2', function (err, collection2) {
             test.ok(collection2);
             test.equal(null, err);
 
@@ -2797,7 +2797,7 @@ describe('Operation Examples', function() {
             }
 
             // Insert a couple of documents
-            collection1.insertMany([{ x: 1 }, { x: 2 }], configuration.writeConcernMax(), function(
+            collection1.insertMany([{ x: 1 }, { x: 2 }], configuration.writeConcernMax(), function (
               err,
               docs
             ) {
@@ -2805,18 +2805,18 @@ describe('Operation Examples', function() {
               test.equal(null, err);
 
               // Attemp to rename the first collection to the second one, this will fail
-              collection1.rename('test_rename_collection2', function(err, collection) {
+              collection1.rename('test_rename_collection2', function (err, collection) {
                 test.equal(null, collection);
                 test.ok(err instanceof Error);
                 test.ok(err.message.length > 0);
 
                 // Attemp to rename the first collection to a name that does not exist
                 // this will be successful
-                collection1.rename('test_rename_collection3', function(err, collection2) {
+                collection1.rename('test_rename_collection3', function (err, collection2) {
                   test.equal('test_rename_collection3', collection2.collectionName);
 
                   // Ensure that the collection is pointing to the new one
-                  collection2.count(function(err, count) {
+                  collection2.count(function (err, count) {
                     test.equal(2, count);
                     client.close(done);
                   });
@@ -2841,10 +2841,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2862,9 +2862,9 @@ describe('Operation Examples', function() {
         collection.save({ hello: 'world' });
 
         // Wait for a second
-        setTimeout(function() {
+        setTimeout(function () {
           // Find the saved document
-          collection.findOne({ hello: 'world' }, function(err, item) {
+          collection.findOne({ hello: 'world' }, function (err, item) {
             test.equal(null, err);
             test.equal('world', item.hello);
             client.close(done);
@@ -2886,10 +2886,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2905,12 +2905,15 @@ describe('Operation Examples', function() {
         var collection = db.collection('save_a_simple_document_modify_it_and_resave_it');
 
         // Save a document with no safe option
-        collection.save({ hello: 'world' }, configuration.writeConcernMax(), function(err, result) {
+        collection.save({ hello: 'world' }, configuration.writeConcernMax(), function (
+          err,
+          result
+        ) {
           test.ok(result);
           test.equal(null, err);
 
           // Find the saved document
-          collection.findOne({ hello: 'world' }, function(err, item) {
+          collection.findOne({ hello: 'world' }, function (err, item) {
             test.equal(null, err);
             test.equal('world', item.hello);
 
@@ -2918,12 +2921,12 @@ describe('Operation Examples', function() {
             item['hello2'] = 'world2';
 
             // Save the item with the additional field
-            collection.save(item, configuration.writeConcernMax(), function(err, result) {
+            collection.save(item, configuration.writeConcernMax(), function (err, result) {
               test.ok(result);
               test.equal(null, err);
 
               // Find the changed document
-              collection.findOne({ hello: 'world' }, function(err, item) {
+              collection.findOne({ hello: 'world' }, function (err, item) {
                 test.equal(null, err);
                 test.equal('world', item.hello);
                 test.equal('world2', item.hello2);
@@ -2949,10 +2952,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2968,7 +2971,7 @@ describe('Operation Examples', function() {
         var collection = db.collection('update_a_simple_document');
 
         // Insert a document, then update it
-        collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function(err, doc) {
+        collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function (err, doc) {
           test.ok(doc);
           test.equal(null, err);
 
@@ -2976,9 +2979,9 @@ describe('Operation Examples', function() {
           collection.updateOne({ a: 1 }, { $set: { b: 2 } });
 
           // Wait for a second then fetch the document
-          setTimeout(function() {
+          setTimeout(function () {
             // Fetch the document that we modified
-            collection.findOne({ a: 1 }, function(err, item) {
+            collection.findOne({ a: 1 }, function (err, item) {
               test.equal(null, err);
               test.equal(1, item.a);
               test.equal(2, item.b);
@@ -3002,10 +3005,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3020,7 +3023,7 @@ describe('Operation Examples', function() {
         // Get a collection
         var collection = db.collection('update_a_simple_document_upsert');
         // Update the document using an upsert operation, ensuring creation if it does not exist
-        collection.updateOne({ a: 1 }, { $set: { b: 2, a: 1 } }, { upsert: true, w: 1 }, function(
+        collection.updateOne({ a: 1 }, { $set: { b: 2, a: 1 } }, { upsert: true, w: 1 }, function (
           err,
           result
         ) {
@@ -3028,7 +3031,7 @@ describe('Operation Examples', function() {
           test.equal(1, result.result.n);
 
           // Fetch the document that we modified and check if it got inserted correctly
-          collection.findOne({ a: 1 }, function(err, item) {
+          collection.findOne({ a: 1 }, function (err, item) {
             test.equal(null, err);
             test.equal(1, item.a);
             test.equal(2, item.b);
@@ -3051,10 +3054,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3076,17 +3079,17 @@ describe('Operation Examples', function() {
             { a: 1, b: 2 }
           ],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             var o = configuration.writeConcernMax();
-            collection.updateMany({ a: 1 }, { $set: { b: 0 } }, o, function(err, r) {
+            collection.updateMany({ a: 1 }, { $set: { b: 0 } }, o, function (err, r) {
               test.equal(null, err);
               test.equal(2, r.result.n);
 
               // Fetch all the documents and verify that we have changed the b value
-              collection.find().toArray(function(err, items) {
+              collection.find().toArray(function (err, items) {
                 test.equal(null, err);
                 test.equal(1, items[0].a);
                 test.equal(0, items[0].b);
@@ -3114,10 +3117,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3136,12 +3139,12 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { hello: 'world' }],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             // Retrieve the statistics for the collection
-            collection.stats(function(err, stats) {
+            collection.stats(function (err, stats) {
               test.equal(2, stats.count);
 
               client.close(done);
@@ -3164,10 +3167,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3190,7 +3193,7 @@ describe('Operation Examples', function() {
             { a: 4, b: 4, c: 4 }
           ],
           { w: 1 },
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -3198,7 +3201,7 @@ describe('Operation Examples', function() {
             collection.ensureIndex(
               { a: 1, b: 1 },
               { unique: true, background: true, w: 1 },
-              function(err, indexName) {
+              function (err, indexName) {
                 test.ok(indexName);
                 test.equal(null, err);
 
@@ -3206,14 +3209,14 @@ describe('Operation Examples', function() {
                 collection.ensureIndex(
                   { c: 1 },
                   { unique: true, background: true, w: 1 },
-                  function() {
+                  function () {
                     // Drop the index
-                    collection.dropAllIndexes(function(err, result) {
+                    collection.dropAllIndexes(function (err, result) {
                       test.ok(result);
                       test.equal(null, err);
 
                       // Verify that the index is gone
-                      collection.indexInformation(function(err, indexInformation) {
+                      collection.indexInformation(function (err, indexInformation) {
                         test.deepEqual([['_id', 1]], indexInformation._id_);
                         test.equal(undefined, indexInformation.a_1_b_1);
                         test.equal(undefined, indexInformation.c_1);
@@ -3249,10 +3252,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3285,14 +3288,14 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       // NODE-2484: investigate double close event in Unified Topology environment
       // client.on('close', function() {
       //   done();
       // });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3322,10 +3325,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
 
         // LINE var MongoClient = require('mongodb').MongoClient,
@@ -3339,7 +3342,7 @@ describe('Operation Examples', function() {
         // REMOVE-LINE var db = client.db(configuration.db);
         // BEGIN
         // Close the connection with a callback that is optional
-        client.close(function(err) {
+        client.close(function (err) {
           expect(err).to.not.exist;
           done();
         });
@@ -3357,10 +3360,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyRetrievelistCollections', {
     metadata: { requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3378,19 +3381,19 @@ describe('Operation Examples', function() {
         // Create a collection
         var collection = db1.collection('shouldCorrectlyRetrievelistCollections');
         // Ensure the collection was created
-        collection.insertOne({ a: 1 }, function(err, r) {
+        collection.insertOne({ a: 1 }, function (err, r) {
           test.ok(r);
           test.equal(null, err);
 
           // Return the information of a single collection name
           db1
             .listCollections({ name: 'shouldCorrectlyRetrievelistCollections' })
-            .toArray(function(err, items) {
+            .toArray(function (err, items) {
               test.equal(null, err);
               test.equal(1, items.length);
 
               // Return the information of a all collections, using the callback format
-              db1.listCollections().toArray(function(err, items) {
+              db1.listCollections().toArray(function (err, items) {
                 test.equal(null, err);
                 test.ok(items.length >= 1);
 
@@ -3406,10 +3409,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyRetrievelistCollectionsWiredTiger', {
     metadata: { requires: { topology: ['wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         test.equal(null, err);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3426,18 +3429,18 @@ describe('Operation Examples', function() {
         // Create a collection
         var collection = db1.collection('shouldCorrectlyRetrievelistCollections');
         // Ensure the collection was created
-        collection.insertOne({ a: 1 }, function(err, r) {
+        collection.insertOne({ a: 1 }, function (err, r) {
           test.ok(r);
           test.equal(null, err);
 
           // Return the information of a single collection name
           db1
             .listCollections({ name: 'shouldCorrectlyRetrievelistCollections' })
-            .toArray(function(err, items) {
+            .toArray(function (err, items) {
               test.equal(1, items.length);
 
               // Return the information of a all collections, using the callback format
-              db1.listCollections().toArray(function(err, items) {
+              db1.listCollections().toArray(function (err, items) {
                 test.equal(1, items.length);
 
                 client.close(done);
@@ -3459,10 +3462,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3477,22 +3480,25 @@ describe('Operation Examples', function() {
         test.equal(null, err);
 
         // Grab a collection with a callback but no safe operation
-        db.collection('test_correctly_access_collections', function(err, col2) {
+        db.collection('test_correctly_access_collections', function (err, col2) {
           test.ok(col2);
           test.equal(null, err);
 
           // Grab a collection with a callback in safe mode, ensuring it exists (should fail as it's not created)
-          db.collection('test_correctly_access_collections', { strict: true }, function(err, col3) {
+          db.collection('test_correctly_access_collections', { strict: true }, function (
+            err,
+            col3
+          ) {
             test.equal(null, col3);
             test.ok(err != null);
 
             // Create the collection
-            db.createCollection('test_correctly_access_collections', function(err, result) {
+            db.createCollection('test_correctly_access_collections', function (err, result) {
               test.ok(result);
               test.equal(null, err);
 
               // Retry to get the collection, should work as it's now created
-              db.collection('test_correctly_access_collections', { strict: true }, function(
+              db.collection('test_correctly_access_collections', { strict: true }, function (
                 err,
                 col3
               ) {
@@ -3520,10 +3526,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3538,7 +3544,7 @@ describe('Operation Examples', function() {
         test.equal(null, err);
 
         // Retry to get the collection, should work as it's now created
-        db.collections(function(err, collections) {
+        db.collections(function (err, collections) {
           test.equal(null, err);
           test.ok(collections.length > 0);
 
@@ -3558,10 +3564,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyAddUserToDb', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3576,12 +3582,12 @@ describe('Operation Examples', function() {
         test.equal(null, err);
 
         // Add a user to the database
-        db.addUser('user', 'name', function(err, result) {
+        db.addUser('user', 'name', function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
           // Remove the user from the db
-          db.removeUser('user', function(err, result) {
+          db.removeUser('user', function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -3602,11 +3608,11 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyAddAndRemoveUser', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3621,7 +3627,7 @@ describe('Operation Examples', function() {
         test.equal(null, err);
 
         // Add a user to the database
-        db.addUser('user', 'name', function(err, result) {
+        db.addUser('user', 'name', function (err, result) {
           test.ok(result);
           test.equal(null, err);
           client.close();
@@ -3630,16 +3636,16 @@ describe('Operation Examples', function() {
             'mongodb://user:name@localhost:27017/integration_tests'
           );
 
-          secondClient.connect(function(err) {
+          secondClient.connect(function (err) {
             test.equal(null, err);
             var db = secondClient.db(configuration.db);
 
             // Logout the db
-            secondClient.logout(function(err, result) {
+            secondClient.logout(function (err, result) {
               test.equal(true, result);
 
               // Remove the user from the db
-              db.removeUser('user', function(err, result) {
+              db.removeUser('user', function (err, result) {
                 test.ok(result);
                 test.equal(null, err);
 
@@ -3650,7 +3656,7 @@ describe('Operation Examples', function() {
                 );
 
                 // Authenticate
-                thirdClient.connect(function(err) {
+                thirdClient.connect(function (err) {
                   expect(err).to.exist;
                   oldClient.close();
                   done();
@@ -3675,10 +3681,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3696,11 +3702,11 @@ describe('Operation Examples', function() {
         db.createCollection(
           'a_simple_collection',
           { capped: true, size: 10000, max: 1000, w: 1 },
-          function(err, collection) {
+          function (err, collection) {
             test.equal(null, err);
 
             // Insert a document in the capped collection
-            collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function(err, result) {
+            collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function (err, result) {
               test.ok(result);
               test.equal(null, err);
 
@@ -3724,10 +3730,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3742,7 +3748,7 @@ describe('Operation Examples', function() {
         test.equal(null, err);
 
         // Execute ping against the server
-        db.command({ ping: 1 }, function(err, result) {
+        db.command({ ping: 1 }, function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
@@ -3750,11 +3756,11 @@ describe('Operation Examples', function() {
           db.createCollection(
             'a_simple_create_drop_collection',
             { capped: true, size: 10000, max: 1000, w: 1 },
-            function(err, collection) {
+            function (err, collection) {
               test.equal(null, err);
 
               // Insert a document in the capped collection
-              collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function(
+              collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function (
                 err,
                 result
               ) {
@@ -3762,12 +3768,12 @@ describe('Operation Examples', function() {
                 test.equal(null, err);
 
                 // Drop the collection from this world
-                db.dropCollection('a_simple_create_drop_collection', function(err, result) {
+                db.dropCollection('a_simple_create_drop_collection', function (err, result) {
                   test.ok(result);
                   test.equal(null, err);
 
                   // Verify that the collection is gone
-                  db.listCollections({ name: 'a_simple_create_drop_collection' }).toArray(function(
+                  db.listCollections({ name: 'a_simple_create_drop_collection' }).toArray(function (
                     err,
                     names
                   ) {
@@ -3796,10 +3802,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3814,7 +3820,7 @@ describe('Operation Examples', function() {
         test.equal(null, err);
 
         // Execute ping against the server
-        db.command({ ping: 1 }, function(err, result) {
+        db.command({ ping: 1 }, function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
@@ -3836,10 +3842,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3854,41 +3860,41 @@ describe('Operation Examples', function() {
         test.equal(null, err);
 
         // Create a collection
-        db.createCollection('simple_rename_collection', configuration.writeConcernMax(), function(
+        db.createCollection('simple_rename_collection', configuration.writeConcernMax(), function (
           err,
           collection
         ) {
           test.equal(null, err);
 
           // Insert a document in the collection
-          collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function(err, result) {
+          collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             // Retrieve the number of documents from the collection
-            collection.count(function(err, count) {
+            collection.count(function (err, count) {
               test.equal(1, count);
 
               // Rename the collection
               db.renameCollection(
                 'simple_rename_collection',
                 'simple_rename_collection_2',
-                function(err, collection2) {
+                function (err, collection2) {
                   test.equal(null, err);
 
                   // Retrieve the number of documents from the collection
-                  collection2.count(function(err, count) {
+                  collection2.count(function (err, count) {
                     test.equal(1, count);
 
                     // Verify that the collection is gone
-                    db.listCollections({ name: 'simple_rename_collection' }).toArray(function(
+                    db.listCollections({ name: 'simple_rename_collection' }).toArray(function (
                       err,
                       names
                     ) {
                       test.equal(0, names.length);
 
                       // Verify that the new collection exists
-                      db.listCollections({ name: 'simple_rename_collection_2' }).toArray(function(
+                      db.listCollections({ name: 'simple_rename_collection_2' }).toArray(function (
                         err,
                         names
                       ) {
@@ -3919,10 +3925,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -3945,7 +3951,7 @@ describe('Operation Examples', function() {
             { a: 4, b: 4 }
           ],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -3954,17 +3960,17 @@ describe('Operation Examples', function() {
               'more_complex_index_test',
               { a: 1, b: 1 },
               { unique: true, background: true, w: 1 },
-              function(err, indexName) {
+              function (err, indexName) {
                 test.ok(indexName);
                 test.equal(null, err);
 
                 // Show that duplicate records got dropped
-                collection.find({}).toArray(function(err, items) {
+                collection.find({}).toArray(function (err, items) {
                   test.equal(null, err);
                   test.equal(4, items.length);
 
                   // Perform a query, with explain to show we hit the query
-                  collection.find({ a: 2 }).explain(function(err, explanation) {
+                  collection.find({ a: 2 }).explain(function (err, explanation) {
                     test.equal(null, err);
                     test.ok(explanation != null);
 
@@ -3991,10 +3997,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4017,7 +4023,7 @@ describe('Operation Examples', function() {
             { a: 4, b: 4 }
           ],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
@@ -4026,17 +4032,17 @@ describe('Operation Examples', function() {
               'more_complex_ensure_index_db_test',
               { a: 1, b: 1 },
               { unique: true, background: true, w: 1 },
-              function(err, indexName) {
+              function (err, indexName) {
                 test.ok(indexName);
                 test.equal(null, err);
 
                 // Show that duplicate records got dropped
-                collection.find({}).toArray(function(err, items) {
+                collection.find({}).toArray(function (err, items) {
                   test.equal(null, err);
                   test.equal(4, items.length);
 
                   // Perform a query, with explain to show we hit the query
-                  collection.find({ a: 2 }).explain(function(err, explanation) {
+                  collection.find({ a: 2 }).explain(function (err, explanation) {
                     test.equal(null, err);
                     test.ok(explanation != null);
 
@@ -4061,10 +4067,10 @@ describe('Operation Examples', function() {
   it('should correctly drop the database', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4088,19 +4094,19 @@ describe('Operation Examples', function() {
             { a: 4, b: 4 }
           ],
           configuration.writeConcernMax(),
-          function(err, result) {
+          function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             // Let's drop the database
-            db.dropDatabase(function(err, result) {
+            db.dropDatabase(function (err, result) {
               test.ok(result);
               test.equal(null, err);
 
               // Wait two seconds to let it replicate across
-              setTimeout(function() {
+              setTimeout(function () {
                 // Get the admin database
-                db.admin().listDatabases(function(err, dbs) {
+                db.admin().listDatabases(function (err, dbs) {
                   // Grab the databases
                   dbs = dbs.databases;
                   // Did we find the db
@@ -4136,10 +4142,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4153,7 +4159,7 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         test.equal(null, err);
 
-        db.stats(function(err, stats) {
+        db.stats(function (err, stats) {
           test.equal(null, err);
           test.ok(stats != null);
 
@@ -4175,10 +4181,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4201,19 +4207,19 @@ describe('Operation Examples', function() {
         var multipleColl2 = secondDb.collection('multiple_db_instances');
 
         // Write a record into each and then count the records stored
-        multipleColl1.insertOne({ a: 1 }, { w: 1 }, function(err, result) {
+        multipleColl1.insertOne({ a: 1 }, { w: 1 }, function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
-          multipleColl2.insertOne({ a: 1 }, { w: 1 }, function(err, result) {
+          multipleColl2.insertOne({ a: 1 }, { w: 1 }, function (err, result) {
             test.ok(result);
             test.equal(null, err);
 
             // Count over the results ensuring only on record in each collection
-            multipleColl1.count(function(err, count) {
+            multipleColl1.count(function (err, count) {
               test.equal(1, count);
 
-              multipleColl2.count(function(err, count) {
+              multipleColl2.count(function (err, count) {
                 test.equal(1, count);
 
                 client.close(done);
@@ -4235,7 +4241,7 @@ describe('Operation Examples', function() {
   it('Should correctly connect with default replicasetNoOption', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // Replica configuration
@@ -4248,7 +4254,7 @@ describe('Operation Examples', function() {
         { replicaSet: configuration.replicasetName }
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4281,10 +4287,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyRetrieveBuildInfo', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4301,7 +4307,7 @@ describe('Operation Examples', function() {
         var adminDb = db.admin();
 
         // Retrieve the build information for the MongoDB instance
-        adminDb.buildInfo(function(err, info) {
+        adminDb.buildInfo(function (err, info) {
           test.ok(info);
           test.equal(null, err);
 
@@ -4321,10 +4327,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyRetrieveBuildInfoUsingCommand', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4340,7 +4346,7 @@ describe('Operation Examples', function() {
         // Use the admin database for the operation
         var adminDb = db.admin();
         // Retrieve the build information using the admin command
-        adminDb.command({ buildInfo: 1 }, function(err, info) {
+        adminDb.command({ buildInfo: 1 }, function (err, info) {
           test.ok(info);
           test.equal(null, err);
 
@@ -4360,10 +4366,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlySetDefaultProfilingLevel', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4381,7 +4387,7 @@ describe('Operation Examples', function() {
 
         // Force the creation of the collection by inserting a document
         // Collections are not created until the first document is inserted
-        collection.insertOne({ a: 1 }, { w: 1 }, function(err, doc) {
+        collection.insertOne({ a: 1 }, { w: 1 }, function (err, doc) {
           test.ok(doc);
           test.equal(null, err);
 
@@ -4389,7 +4395,7 @@ describe('Operation Examples', function() {
           var adminDb = client.db('admin');
 
           // Retrieve the profiling level
-          adminDb.profilingLevel(function(err, level) {
+          adminDb.profilingLevel(function (err, level) {
             test.ok(level);
             test.equal(null, err);
 
@@ -4411,10 +4417,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlySetAndExtractProfilingInfo', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4432,28 +4438,28 @@ describe('Operation Examples', function() {
 
         // Force the creation of the collection by inserting a document
         // Collections are not created until the first document is inserted
-        collection.insertOne({ a: 1 }, { w: 1 }, function(err, doc) {
+        collection.insertOne({ a: 1 }, { w: 1 }, function (err, doc) {
           test.ok(doc);
           test.equal(null, err);
 
           // Use the admin database for the operation
           // Set the profiling level to all
-          db.setProfilingLevel('all', function(err, level) {
+          db.setProfilingLevel('all', function (err, level) {
             test.ok(level);
             test.equal(null, err);
 
             // Execute a query command
-            collection.find().toArray(function(err, items) {
+            collection.find().toArray(function (err, items) {
               test.equal(null, err);
               test.ok(items.length > 0);
 
               // Turn off profiling
-              db.setProfilingLevel('off', function(err, level) {
+              db.setProfilingLevel('off', function (err, level) {
                 test.ok(level);
                 test.equal(null, err);
 
                 // Retrieve the profiling information
-                db.profilingInfo(function(err, infos) {
+                db.profilingInfo(function (err, infos) {
                   test.equal(null, err);
                   test.ok(infos.constructor === Array);
                   test.ok(infos.length >= 1);
@@ -4481,10 +4487,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyCallValidateCollection', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4501,7 +4507,7 @@ describe('Operation Examples', function() {
 
         // Force the creation of the collection by inserting a document
         // Collections are not created until the first document is inserted
-        collection.insertOne({ a: 1 }, { w: 1 }, function(err, doc) {
+        collection.insertOne({ a: 1 }, { w: 1 }, function (err, doc) {
           test.ok(doc);
           test.equal(null, err);
 
@@ -4509,7 +4515,7 @@ describe('Operation Examples', function() {
           var adminDb = db.admin();
 
           // Validate the 'test' collection
-          adminDb.validateCollection('test', function(err, doc) {
+          adminDb.validateCollection('test', function (err, doc) {
             test.ok(doc);
             test.equal(null, err);
 
@@ -4529,10 +4535,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyPingTheMongoDbInstance', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4548,7 +4554,7 @@ describe('Operation Examples', function() {
         var adminDb = db.admin();
 
         // Ping the server
-        adminDb.ping(function(err, pingResult) {
+        adminDb.ping(function (err, pingResult) {
           test.ok(pingResult);
           test.equal(null, err);
 
@@ -4568,10 +4574,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyAddAUserToAdminDb', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4587,10 +4593,10 @@ describe('Operation Examples', function() {
         var adminDb = db.admin();
 
         // Add the new user to the admin database
-        adminDb.addUser('admin11', 'admin11', function(err, result) {
+        adminDb.addUser('admin11', 'admin11', function (err, result) {
           test.ok(result);
 
-          adminDb.removeUser('admin11', function(err, result) {
+          adminDb.removeUser('admin11', function (err, result) {
             test.ok(result);
 
             client.close(done);
@@ -4609,10 +4615,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyAddAUserAndRemoveItFromAdminDb', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4628,11 +4634,11 @@ describe('Operation Examples', function() {
         var adminDb = db.admin();
 
         // Add the new user to the admin database
-        adminDb.addUser('admin12', 'admin12', function(err, result) {
+        adminDb.addUser('admin12', 'admin12', function (err, result) {
           test.ok(result);
 
           // Remove the user
-          adminDb.removeUser('admin12', function(err, result) {
+          adminDb.removeUser('admin12', function (err, result) {
             test.equal(null, err);
             test.equal(true, result);
 
@@ -4655,10 +4661,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4674,7 +4680,7 @@ describe('Operation Examples', function() {
         var adminDb = db.admin();
 
         // List all the available databases
-        adminDb.listDatabases(function(err, dbs) {
+        adminDb.listDatabases(function (err, dbs) {
           test.equal(null, err);
           test.ok(dbs.databases.length > 0);
 
@@ -4693,10 +4699,10 @@ describe('Operation Examples', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4712,7 +4718,7 @@ describe('Operation Examples', function() {
         var adminDb = db.admin();
 
         // List all the available databases
-        adminDb.listDatabases({ nameOnly: 1 }, function(err, dbs) {
+        adminDb.listDatabases({ nameOnly: 1 }, function (err, dbs) {
           expect(err).to.not.exist;
           expect(dbs.databases).to.containSubset([{ name: 'admin' }]);
 
@@ -4732,10 +4738,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyRetrieveServerInfo', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4752,7 +4758,7 @@ describe('Operation Examples', function() {
 
         // Force the creation of the collection by inserting a document
         // Collections are not created until the first document is inserted
-        collection.insertOne({ a: 1 }, { w: 1 }, function(err, doc) {
+        collection.insertOne({ a: 1 }, { w: 1 }, function (err, doc) {
           test.ok(doc);
           test.equal(null, err);
 
@@ -4760,7 +4766,7 @@ describe('Operation Examples', function() {
           var adminDb = db.admin();
 
           // Retrieve the server Info
-          adminDb.serverStatus(function(err, info) {
+          adminDb.serverStatus(function (err, info) {
             test.equal(null, err);
             test.ok(info != null);
 
@@ -4781,10 +4787,10 @@ describe('Operation Examples', function() {
   it('shouldCorrectlyRetrieveReplSetGetStatus', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4801,7 +4807,7 @@ describe('Operation Examples', function() {
 
         // Force the creation of the collection by inserting a document
         // Collections are not created until the first document is inserted
-        collection.insertOne({ a: 1 }, { w: 1 }, function(err, doc) {
+        collection.insertOne({ a: 1 }, { w: 1 }, function (err, doc) {
           test.ok(doc);
           test.equal(null, err);
 
@@ -4810,7 +4816,7 @@ describe('Operation Examples', function() {
 
           // Retrieve the server Info, returns error if we are not
           // running a replicaset
-          adminDb.replSetGetStatus(function(err, info) {
+          adminDb.replSetGetStatus(function (err, info) {
             test.ok(info);
             test.equal(null, err);
 
@@ -4841,10 +4847,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4860,12 +4866,15 @@ describe('Operation Examples', function() {
         var collection = db.collection('test_array');
 
         // Insert a test document
-        collection.insertOne({ b: [1, 2, 3] }, configuration.writeConcernMax(), function(err, ids) {
+        collection.insertOne({ b: [1, 2, 3] }, configuration.writeConcernMax(), function (
+          err,
+          ids
+        ) {
           test.ok(ids);
           test.equal(null, err);
 
           // Retrieve all the documents in the collection
-          collection.find().toArray(function(err, documents) {
+          collection.find().toArray(function (err, documents) {
             test.equal(1, documents.length);
             test.deepEqual([1, 2, 3], documents[0].b);
 
@@ -4890,10 +4899,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4909,18 +4918,18 @@ describe('Operation Examples', function() {
         var collection = db.collection('test_to_a_after_each');
 
         // Insert a document in the collection
-        collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function(err, ids) {
+        collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function (err, ids) {
           test.ok(ids);
           test.equal(null, err);
 
           // Grab a cursor
           var cursor = collection.find();
           // Execute the each command, triggers for each document
-          cursor.each(function(err, item) {
+          cursor.each(function (err, item) {
             // If the item is null then the cursor is exhausted/empty and closed
             if (item == null) {
               // Show that the cursor is closed
-              cursor.toArray(function(err, items) {
+              cursor.toArray(function (err, items) {
                 test.ok(items);
                 test.equal(null, err);
 
@@ -4948,10 +4957,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -4967,7 +4976,7 @@ describe('Operation Examples', function() {
         var collection = db.collection('test_to_a_after_for_each');
 
         // Insert a document in the collection
-        collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function(err, ids) {
+        collection.insertOne({ a: 1 }, configuration.writeConcernMax(), function (err, ids) {
           test.ok(ids);
           test.equal(null, err);
 
@@ -4977,11 +4986,11 @@ describe('Operation Examples', function() {
           var cursor = collection.find();
           // Execute the each command, triggers for each document
           cursor.forEach(
-            function(doc) {
+            function (doc) {
               test.ok(doc != null);
               count = count + 1;
             },
-            function(err) {
+            function (err) {
               test.equal(null, err);
               test.equal(1, count);
               client.close(done);
@@ -5006,10 +5015,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5033,20 +5042,20 @@ describe('Operation Examples', function() {
         var collection = db.collection('Should_correctly_rewind_and_restart_cursor');
 
         // insert all docs
-        collection.insertMany(docs, configuration.writeConcernMax(), function(err, result) {
+        collection.insertMany(docs, configuration.writeConcernMax(), function (err, result) {
           test.ok(result);
           test.equal(null, err);
 
           // Grab a cursor using the find
           var cursor = collection.find({});
           // Fetch the first object off the cursor
-          cursor.next(function(err, item) {
+          cursor.next(function (err, item) {
             test.equal(0, item.a);
             // Rewind the cursor, resetting it to point to the start of the query
             cursor.rewind();
 
             // Grab the first object again
-            cursor.next(function(err, item) {
+            cursor.next(function (err, item) {
               test.equal(0, item.a);
 
               client.close(done);
@@ -5071,10 +5080,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5090,7 +5099,7 @@ describe('Operation Examples', function() {
         var collection = db.collection('cursor_count_collection');
 
         // Insert some docs
-        collection.insertMany([{ a: 1 }, { a: 2 }], configuration.writeConcernMax(), function(
+        collection.insertMany([{ a: 1 }, { a: 2 }], configuration.writeConcernMax(), function (
           err,
           docs
         ) {
@@ -5098,7 +5107,7 @@ describe('Operation Examples', function() {
           test.equal(null, err);
 
           // Do a find and get the cursor count
-          collection.find().count(function(err, count) {
+          collection.find().count(function (err, count) {
             test.equal(null, err);
             test.equal(2, count);
 
@@ -5123,10 +5132,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5145,7 +5154,7 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { a: 2 }, { a: 3 }],
           configuration.writeConcernMax(),
-          function(err, docs) {
+          function (err, docs) {
             test.ok(docs);
             test.equal(null, err);
 
@@ -5153,7 +5162,7 @@ describe('Operation Examples', function() {
             collection
               .find()
               .sort({ a: 1 })
-              .next(function(err, item) {
+              .next(function (err, item) {
                 test.equal(null, err);
                 test.equal(1, item.a);
 
@@ -5161,7 +5170,7 @@ describe('Operation Examples', function() {
                 collection
                   .find()
                   .sort([['a', -1]])
-                  .next(function(err, item) {
+                  .next(function (err, item) {
                     test.equal(null, err);
                     test.equal(3, item.a);
 
@@ -5188,10 +5197,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5210,7 +5219,7 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { a: 2 }, { a: 3 }],
           configuration.writeConcernMax(),
-          function(err, docs) {
+          function (err, docs) {
             test.ok(docs);
             test.equal(null, err);
 
@@ -5218,7 +5227,7 @@ describe('Operation Examples', function() {
             collection
               .find()
               .limit(1)
-              .toArray(function(err, items) {
+              .toArray(function (err, items) {
                 test.equal(null, err);
                 test.equal(1, items.length);
 
@@ -5244,10 +5253,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5266,7 +5275,7 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { a: 2 }, { a: 3 }],
           configuration.writeConcernMax(),
-          function(err, docs) {
+          function (err, docs) {
             test.ok(docs);
             test.equal(null, err);
 
@@ -5274,7 +5283,7 @@ describe('Operation Examples', function() {
             collection
               .find()
               .skip(1)
-              .next(function(err, item) {
+              .next(function (err, item) {
                 test.equal(null, err);
                 test.equal(2, item.a);
 
@@ -5301,10 +5310,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5323,13 +5332,13 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { a: 2 }, { a: 3 }],
           configuration.writeConcernMax(),
-          function(err, docs) {
+          function (err, docs) {
             test.ok(docs);
             test.equal(null, err);
 
             // Do normal ascending sort
             const cursor = collection.find().batchSize(1);
-            cursor.next(function(err, item) {
+            cursor.next(function (err, item) {
               test.equal(null, err);
               test.equal(1, item.a);
 
@@ -5358,10 +5367,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5380,38 +5389,38 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { a: 2 }, { a: 3 }],
           configuration.writeConcernMax(),
-          function(err, docs) {
+          function (err, docs) {
             test.ok(docs);
             test.equal(null, err);
 
             // Do normal ascending sort
             var cursor = collection.find();
             // Perform hasNext check
-            cursor.hasNext(function(err, r) {
+            cursor.hasNext(function (err, r) {
               test.equal(null, err);
               test.ok(r);
 
-              cursor.next(function(err, r) {
+              cursor.next(function (err, r) {
                 test.equal(null, err);
                 test.equal(1, r.a);
 
-                cursor.hasNext(function(err, r) {
+                cursor.hasNext(function (err, r) {
                   test.equal(null, err);
                   test.ok(r);
 
-                  cursor.next(function(err, r) {
+                  cursor.next(function (err, r) {
                     test.equal(null, err);
                     test.equal(2, r.a);
 
-                    cursor.hasNext(function(err, r) {
+                    cursor.hasNext(function (err, r) {
                       test.equal(null, err);
                       test.ok(r);
 
-                      cursor.next(function(err, r) {
+                      cursor.next(function (err, r) {
                         test.equal(null, err);
                         test.equal(3, r.a);
 
-                        cursor.hasNext(function(err, r) {
+                        cursor.hasNext(function (err, r) {
                           test.equal(null, err);
                           test.ok(!r);
 
@@ -5443,10 +5452,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5465,12 +5474,12 @@ describe('Operation Examples', function() {
         collection.insertMany(
           [{ a: 1 }, { a: 2 }, { a: 3 }],
           configuration.writeConcernMax(),
-          function(err, docs) {
+          function (err, docs) {
             test.ok(docs);
             test.equal(null, err);
 
             // Do normal ascending sort
-            collection.find().explain(function(err, explanation) {
+            collection.find().explain(function (err, explanation) {
               test.ok(explanation);
               test.equal(null, err);
 
@@ -5496,10 +5505,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5521,7 +5530,7 @@ describe('Operation Examples', function() {
         var collection = db.collection('test_stream_function');
 
         // Insert documents into collection
-        collection.insertMany(docs, configuration.writeConcernMax(), function(err, ids) {
+        collection.insertMany(docs, configuration.writeConcernMax(), function (err, ids) {
           test.ok(ids);
           test.equal(null, err);
 
@@ -5529,11 +5538,11 @@ describe('Operation Examples', function() {
           var stream = collection.find().stream();
 
           // Execute find on all the documents
-          stream.on('end', function() {
+          stream.on('end', function () {
             client.close(done);
           });
 
-          stream.on('data', function(data) {
+          stream.on('data', function (data) {
             test.ok(data != null);
           });
         });
@@ -5555,10 +5564,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5580,7 +5589,7 @@ describe('Operation Examples', function() {
         var collection = db.collection('test_is_close_function_on_cursor');
 
         // Insert documents into collection
-        collection.insertMany(docs, configuration.writeConcernMax(), function(err, ids) {
+        collection.insertMany(docs, configuration.writeConcernMax(), function (err, ids) {
           test.ok(ids);
           test.equal(null, err);
 
@@ -5588,12 +5597,12 @@ describe('Operation Examples', function() {
           var cursor = collection.find();
 
           // Fetch the first object
-          cursor.next(function(err, object) {
+          cursor.next(function (err, object) {
             test.ok(object);
             test.equal(null, err);
 
             // Close the cursor, this is the same as reseting the query
-            cursor.close(function(err, result) {
+            cursor.close(function (err, result) {
               test.ok(result);
               test.equal(null, err);
               test.equal(true, cursor.isClosed());
@@ -5620,10 +5629,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5645,7 +5654,7 @@ describe('Operation Examples', function() {
         var collection = db.collection('test_close_function_on_cursor');
 
         // Insert documents into collection
-        collection.insertMany(docs, configuration.writeConcernMax(), function(err, ids) {
+        collection.insertMany(docs, configuration.writeConcernMax(), function (err, ids) {
           test.ok(ids);
           test.equal(null, err);
 
@@ -5653,12 +5662,12 @@ describe('Operation Examples', function() {
           var cursor = collection.find();
 
           // Fetch the first object
-          cursor.next(function(err, object) {
+          cursor.next(function (err, object) {
             test.ok(object);
             test.equal(null, err);
 
             // Close the cursor, this is the same as reseting the query
-            cursor.close(function(err, result) {
+            cursor.close(function (err, result) {
               test.ok(result);
               test.equal(null, err);
 
@@ -5682,10 +5691,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5708,7 +5717,7 @@ describe('Operation Examples', function() {
         var collection = db.collection('test_cursorstream_pause');
 
         // Insert documents into collection
-        collection.insertMany(docs, { w: 1 }, function(err, ids) {
+        collection.insertMany(docs, { w: 1 }, function (err, ids) {
           test.ok(ids);
           test.equal(null, err);
 
@@ -5716,20 +5725,20 @@ describe('Operation Examples', function() {
           var stream = collection.find().stream();
 
           // For each data item
-          stream.on('data', function(item) {
+          stream.on('data', function (item) {
             fetchedDocs.push(item);
             // Pause stream
             stream.pause();
 
             // Restart the stream after 1 miliscecond
-            setTimeout(function() {
+            setTimeout(function () {
               fetchedDocs.push(null);
               stream.resume();
             }, 1);
           });
 
           // When the stream is done
-          stream.on('end', function() {
+          stream.on('end', function () {
             test.equal(null, fetchedDocs[1]);
             client.close(done);
           });
@@ -5750,10 +5759,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5775,7 +5784,7 @@ describe('Operation Examples', function() {
         var collection = db.collection('test_cursorstream_destroy');
 
         // Insert documents into collection
-        collection.insertMany(docs, { w: 1 }, function(err, ids) {
+        collection.insertMany(docs, { w: 1 }, function (err, ids) {
           test.ok(ids);
           test.equal(null, err);
 
@@ -5783,13 +5792,13 @@ describe('Operation Examples', function() {
           var stream = collection.find().stream();
 
           // For each data item
-          stream.on('data', function() {
+          stream.on('data', function () {
             // Destroy stream
             stream.destroy();
           });
 
           // When the stream is done
-          stream.on('close', function() {
+          stream.on('close', function () {
             client.close(done);
           });
         });
@@ -5812,7 +5821,7 @@ describe('Operation Examples', function() {
   it('Should correctly connect to a replicaset', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       // Create url
@@ -5826,7 +5835,7 @@ describe('Operation Examples', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -5845,7 +5854,7 @@ describe('Operation Examples', function() {
           { a: 1 },
           { $set: { b: 1 } },
           { upsert: true },
-          function(err, result) {
+          function (err, result) {
             test.equal(null, err);
             test.equal(1, result.result.n);
 
@@ -5865,7 +5874,7 @@ describe('Operation Examples', function() {
   it('Should connect to mongos proxies using connectiong string', {
     metadata: { requires: { topology: 'sharded' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = f(
         'mongodb://%s:%s,%s:%s/sharded_test_db?w=1',
@@ -5876,7 +5885,7 @@ describe('Operation Examples', function() {
       );
 
       const client = configuration.newClient(url);
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5895,7 +5904,7 @@ describe('Operation Examples', function() {
           { a: 1 },
           { $set: { b: 1 } },
           { upsert: true },
-          function(err, result) {
+          function (err, result) {
             test.equal(null, err);
             test.equal(1, result.upsertedCount);
 
@@ -5917,7 +5926,7 @@ describe('Operation Examples', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient('mongodb://localhost:27017/integration_tests', {
         native_parser: true
@@ -5925,7 +5934,7 @@ describe('Operation Examples', function() {
 
       // DOC_START
       // Connect using the connection string
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -5943,7 +5952,7 @@ describe('Operation Examples', function() {
           { a: 1 },
           { $set: { b: 1 } },
           { upsert: true },
-          function(err, result) {
+          function (err, result) {
             test.equal(null, err);
             test.equal(1, result.result.n);
 
@@ -5973,7 +5982,7 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // LINE var ObjectId = require('mongodb').ObjectId,
       // LINE   test = require('assert');
       // REPLACE configuration.writeConcernMax() WITH {w:1}
@@ -6005,7 +6014,7 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // LINE var ObjectId = require('mongodb').ObjectId,
       // LINE   test = require('assert');
       // REPLACE configuration.writeConcernMax() WITH {w:1}
@@ -6031,7 +6040,7 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // LINE var ObjectId = require('mongodb').ObjectId,
       // LINE   test = require('assert');
       // REPLACE configuration.writeConcernMax() WITH {w:1}
@@ -6066,7 +6075,7 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // LINE var ObjectId = require('mongodb').ObjectId,
       // LINE   test = require('assert');
       // REPLACE configuration.writeConcernMax() WITH {w:1}
@@ -6098,7 +6107,7 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // LINE var ObjectId = require('mongodb').ObjectId,
       // LINE   test = require('assert');
       // REPLACE configuration.writeConcernMax() WITH {w:1}
@@ -6130,7 +6139,7 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       // LINE var ObjectId = require('mongodb').ObjectId,
       // LINE   test = require('assert');
       // REPLACE configuration.writeConcernMax() WITH {w:1}
@@ -6160,10 +6169,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6190,7 +6199,7 @@ describe('Operation Examples', function() {
         batch.find({ a: 3 }).remove({ a: 3 });
 
         // Execute the operations
-        batch.execute(function(err, result) {
+        batch.execute(function (err, result) {
           // Check state of result
           test.equal(2, result.nInserted);
           test.equal(1, result.nUpserted);
@@ -6225,10 +6234,10 @@ describe('Operation Examples', function() {
   it('Should correctly execute unordered batch with no errors', {
     metadata: { requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6256,7 +6265,7 @@ describe('Operation Examples', function() {
         batch.find({ a: 3 }).remove({ a: 3 });
 
         // Execute the operations
-        batch.execute(function(err, result) {
+        batch.execute(function (err, result) {
           // Check state of result
           test.equal(2, result.nInserted);
           test.equal(1, result.nUpserted);
@@ -6298,10 +6307,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6315,7 +6324,7 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         // Get the collection
         var col = db.collection('insert_one');
-        col.insertOne({ a: 1 }, function(err, r) {
+        col.insertOne({ a: 1 }, function (err, r) {
           test.equal(null, err);
           test.equal(1, r.insertedCount);
           // Finish up test
@@ -6337,10 +6346,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6354,7 +6363,7 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         // Get the collection
         var col = db.collection('insert_many');
-        col.insertMany([{ a: 1 }, { a: 2 }], function(err, r) {
+        col.insertMany([{ a: 1 }, { a: 2 }], function (err, r) {
           test.equal(null, err);
           test.equal(2, r.insertedCount);
           // Finish up test
@@ -6376,10 +6385,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6393,7 +6402,7 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         // Get the collection
         var col = db.collection('update_one');
-        col.updateOne({ a: 1 }, { $set: { a: 2 } }, { upsert: true }, function(err, r) {
+        col.updateOne({ a: 1 }, { $set: { a: 2 } }, { upsert: true }, function (err, r) {
           test.equal(null, err);
           test.equal(0, r.matchedCount);
           test.equal(1, r.upsertedCount);
@@ -6416,10 +6425,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6433,12 +6442,12 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         // Get the collection
         var col = db.collection('update_many');
-        col.insertMany([{ a: 1 }, { a: 1 }], function(err, r) {
+        col.insertMany([{ a: 1 }, { a: 1 }], function (err, r) {
           test.equal(null, err);
           test.equal(2, r.insertedCount);
 
           // Update all documents
-          col.updateMany({ a: 1 }, { $set: { b: 1 } }, function(err, r) {
+          col.updateMany({ a: 1 }, { $set: { b: 1 } }, function (err, r) {
             test.equal(null, err);
             test.equal(2, r.matchedCount);
             test.equal(2, r.modifiedCount);
@@ -6463,10 +6472,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6480,11 +6489,11 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         // Get the collection
         var col = db.collection('remove_one');
-        col.insertMany([{ a: 1 }, { a: 1 }], function(err, r) {
+        col.insertMany([{ a: 1 }, { a: 1 }], function (err, r) {
           test.equal(null, err);
           test.equal(2, r.insertedCount);
 
-          col.removeOne({ a: 1 }, function(err, r) {
+          col.removeOne({ a: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(1, r.deletedCount);
             // Finish up test
@@ -6507,10 +6516,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6524,12 +6533,12 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         // Get the collection
         var col = db.collection('remove_many');
-        col.insertMany([{ a: 1 }, { a: 1 }], function(err, r) {
+        col.insertMany([{ a: 1 }, { a: 1 }], function (err, r) {
           test.equal(null, err);
           test.equal(2, r.insertedCount);
 
           // Update all documents
-          col.removeMany({ a: 1 }, function(err, r) {
+          col.removeMany({ a: 1 }, function (err, r) {
             test.equal(null, err);
             test.equal(2, r.deletedCount);
 
@@ -6553,10 +6562,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6580,7 +6589,7 @@ describe('Operation Examples', function() {
             { replaceOne: { filter: { c: 3 }, replacement: { c: 4 }, upsert: true } }
           ],
           { ordered: true, w: 1 },
-          function(err, r) {
+          function (err, r) {
             test.equal(null, err);
             test.equal(1, r.nInserted);
             test.equal(2, r.nUpserted);
@@ -6615,10 +6624,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6632,11 +6641,11 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         // Get the collection
         var col = db.collection('find_one_and_delete');
-        col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function(err, r) {
+        col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
           test.equal(null, err);
           test.equal(1, r.result.n);
 
-          col.findOneAndDelete({ a: 1 }, { projection: { b: 1 }, sort: { a: 1 } }, function(
+          col.findOneAndDelete({ a: 1 }, { projection: { b: 1 }, sort: { a: 1 } }, function (
             err,
             r
           ) {
@@ -6663,10 +6672,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6680,7 +6689,7 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         // Get the collection
         var col = db.collection('find_one_and_replace');
-        col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function(err, r) {
+        col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
           test.equal(null, err);
           test.equal(1, r.result.n);
 
@@ -6693,7 +6702,7 @@ describe('Operation Examples', function() {
               returnOriginal: false,
               upsert: true
             },
-            function(err, r) {
+            function (err, r) {
               test.equal(null, err);
               test.equal(1, r.lastErrorObject.n);
               test.equal(1, r.value.b);
@@ -6719,10 +6728,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6736,7 +6745,7 @@ describe('Operation Examples', function() {
         var db = client.db(configuration.db);
         // Get the collection
         var col = db.collection('find_one_and_update');
-        col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function(err, r) {
+        col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
           test.equal(null, err);
           test.equal(1, r.result.n);
 
@@ -6749,7 +6758,7 @@ describe('Operation Examples', function() {
               returnOriginal: false,
               upsert: true
             },
-            function(err, r) {
+            function (err, r) {
               test.equal(null, err);
               test.equal(1, r.lastErrorObject.n);
               test.equal(1, r.value.b);
@@ -6775,10 +6784,10 @@ describe('Operation Examples', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -6796,14 +6805,14 @@ describe('Operation Examples', function() {
         db.createCollection(
           'a_simple_collection_2',
           { capped: true, size: 100000, max: 10000, w: 1 },
-          function(err, collection) {
+          function (err, collection) {
             test.equal(null, err);
 
             var docs = [];
             for (var i = 0; i < 1000; i++) docs.push({ a: i });
 
             // Insert a document in the capped collection
-            collection.insertMany(docs, configuration.writeConcernMax(), function(err, result) {
+            collection.insertMany(docs, configuration.writeConcernMax(), function (err, result) {
               test.ok(result);
               test.equal(null, err);
 
@@ -6815,7 +6824,7 @@ describe('Operation Examples', function() {
                 .addCursorFlag('tailable', true)
                 .addCursorFlag('awaitData', true);
 
-              cursor.on('data', function() {
+              cursor.on('data', function () {
                 total = total + 1;
 
                 if (total === 1000) {
@@ -6823,7 +6832,7 @@ describe('Operation Examples', function() {
                 }
               });
 
-              cursor.on('end', function() {
+              cursor.on('end', function () {
                 // TODO: forced because the cursor is still open/active
                 client.close(true, done);
               });

--- a/test/functional/operation_generators_example.test.js
+++ b/test/functional/operation_generators_example.test.js
@@ -9,8 +9,8 @@ const { Code } = require('../../src');
  *
  *************************************************************************/
 
-describe('Operation (Generators)', function() {
-  before(function() {
+describe('Operation (Generators)', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -25,11 +25,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, mongodb: '>2.1.0', topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -109,11 +109,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, mongodb: '>2.1.0', topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -192,11 +192,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyDoSimpleCountExamplesWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -243,11 +243,11 @@ describe('Operation (Generators)', function() {
   it('shouldCreateComplexIndexOnTwoFieldsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -303,11 +303,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyHandleDistinctIndexesWithSubQueryFilterWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -360,11 +360,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyHandleDistinctIndexesWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -418,11 +418,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyDropCollectionWithDropFunctionWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -453,7 +453,7 @@ describe('Operation (Generators)', function() {
         var found = false;
         // For each collection in the list of collection names in this db look for the
         // dropped collection
-        replies.forEach(function(document) {
+        replies.forEach(function (document) {
           if (document.name === 'test_other_drop_with_generators') {
             found = true;
             return;
@@ -479,11 +479,11 @@ describe('Operation (Generators)', function() {
   it('dropAllIndexesExample1WithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -519,11 +519,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyCreateAndDropIndexWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -579,11 +579,11 @@ describe('Operation (Generators)', function() {
   it('shouldCreateComplexEnsureIndexWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -642,11 +642,11 @@ describe('Operation (Generators)', function() {
   it('ensureIndexExampleWithCompountIndexWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -702,11 +702,11 @@ describe('Operation (Generators)', function() {
   it('shouldPerformASimpleQueryWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -753,11 +753,11 @@ describe('Operation (Generators)', function() {
   it('shouldPerformASimpleExplainQueryWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -802,11 +802,11 @@ describe('Operation (Generators)', function() {
   it('shouldPerformASimpleLimitSkipQueryWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -837,12 +837,7 @@ describe('Operation (Generators)', function() {
         );
 
         // Perform a simple find and return all the documents
-        var docs = yield collection
-          .find({})
-          .skip(1)
-          .limit(1)
-          .project({ b: 1 })
-          .toArray();
+        var docs = yield collection.find({}).skip(1).limit(1).project({ b: 1 }).toArray();
 
         test.equal(1, docs.length);
         test.equal(undefined, docs[0].a);
@@ -868,11 +863,11 @@ describe('Operation (Generators)', function() {
   it('shouldPerformSimpleFindAndModifyOperationsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -947,11 +942,11 @@ describe('Operation (Generators)', function() {
   it('shouldPerformSimpleFindAndRemoveWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1003,11 +998,11 @@ describe('Operation (Generators)', function() {
   it('shouldPerformASimpleLimitSkipFindOneQueryWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1059,11 +1054,11 @@ describe('Operation (Generators)', function() {
   it('shouldPerformSimpleMapReduceFunctionsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1088,7 +1083,7 @@ describe('Operation (Generators)', function() {
         yield collection.insertMany([{ user_id: 1 }, { user_id: 2 }], { w: 1 });
 
         // Map function
-        var map = function() {
+        var map = function () {
           emit(this.user_id, 1); // eslint-disable-line
         };
         // Reduce function
@@ -1126,11 +1121,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, mongodb: '>1.7.6', topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1155,7 +1150,7 @@ describe('Operation (Generators)', function() {
         yield collection.insertMany([{ user_id: 1 }, { user_id: 2 }], { w: 1 });
 
         // Map function
-        var map = function() {
+        var map = function () {
           emit(this.user_id, 1); // eslint-disable-line
         };
         // Reduce function
@@ -1190,11 +1185,11 @@ describe('Operation (Generators)', function() {
   it('shouldPerformMapReduceWithContextWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1225,12 +1220,12 @@ describe('Operation (Generators)', function() {
         );
 
         // Map function
-        var map = function() {
+        var map = function () {
           emit(fn(this.timestamp.getYear()), 1); // eslint-disable-line
         };
 
         // Reduce function
-        var reduce = function(k, v) {
+        var reduce = function (k, v) {
           var count = 0;
           for (var i = 0; i < v.length; i++) {
             count += v[i];
@@ -1240,7 +1235,7 @@ describe('Operation (Generators)', function() {
         };
 
         // Javascript function available in the map reduce scope
-        var t = function(val) {
+        var t = function (val) {
           return val + 1;
         };
 
@@ -1281,11 +1276,11 @@ describe('Operation (Generators)', function() {
   it.skip('shouldPerformMapReduceInContextObjectsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1316,12 +1311,12 @@ describe('Operation (Generators)', function() {
         );
 
         // Map function
-        var map = function() {
+        var map = function () {
           emit(obj.fn(this.timestamp.getYear()), 1); // eslint-disable-line
         };
 
         // Reduce function
-        var reduce = function(k, v) {
+        var reduce = function (k, v) {
           var count = 0;
           for (var i = 0; i < v.length; i++) {
             count += v[i];
@@ -1331,7 +1326,7 @@ describe('Operation (Generators)', function() {
         };
 
         // Javascript function available in the map reduce scope
-        var t = function(val) {
+        var t = function (val) {
           return val + 1;
         };
 
@@ -1372,11 +1367,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyRetrieveACollectionsIndexesWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1421,11 +1416,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyExecuteIndexExistsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1479,11 +1474,11 @@ describe('Operation (Generators)', function() {
       requires: { generators: true, topology: ['single'] }
     },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1551,11 +1546,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyShowAllTheResultsFromIndexInformationWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1621,11 +1616,11 @@ describe('Operation (Generators)', function() {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, topology: ['single'] } },
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1665,11 +1660,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1715,11 +1710,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1744,7 +1739,7 @@ describe('Operation (Generators)', function() {
         o.serializeFunctions = true;
 
         // Insert a single document
-        yield collection.insertOne({ hello: 'world', func: function() {} }, o);
+        yield collection.insertOne({ hello: 'world', func: function () {} }, o);
 
         // Fetch the document
         var item = yield collection.findOne({ hello: 'world' });
@@ -1766,11 +1761,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, mongodb: '>1.9.1', topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1830,11 +1825,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyExecuteIsCappedWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1878,11 +1873,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyRetrieveCollectionOptionsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1927,11 +1922,11 @@ describe('Operation (Generators)', function() {
   it('shouldRemoveAllDocumentsNoSafeWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -1976,11 +1971,11 @@ describe('Operation (Generators)', function() {
   it('shouldRemoveSubsetOfDocumentsSafeModeWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2022,11 +2017,11 @@ describe('Operation (Generators)', function() {
       requires: { generators: true, topology: ['single'] }
     },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2127,11 +2122,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlySaveASimpleDocumentWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2172,11 +2167,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlySaveASimpleDocumentModifyItAndResaveItWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2232,11 +2227,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyUpdateASimpleDocumentWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2283,11 +2278,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyUpsertASimpleDocumentWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2334,11 +2329,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyUpdateMultipleDocumentsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2394,11 +2389,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyReturnACollectionsStatsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2444,11 +2439,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyCreateAndDropAllIndexWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2520,11 +2515,11 @@ describe('Operation (Generators)', function() {
       requires: { generators: true, topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap'] }
     },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2573,11 +2568,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyRetrieveAllCollectionsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2613,11 +2608,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyAddUserToDbWithGenerators', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2654,11 +2649,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyAddAndRemoveUserWithGenerators', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2715,11 +2710,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyCreateACollectionWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2761,11 +2756,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyExecuteACommandAgainstTheServerWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2818,11 +2813,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyCreateDropAndVerifyThatCollectionIsGoneWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2856,11 +2851,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyRenameACollectionWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2927,11 +2922,11 @@ describe('Operation (Generators)', function() {
   it('shouldCreateOnDbComplexIndexOnTwoFieldsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -2992,11 +2987,11 @@ describe('Operation (Generators)', function() {
   it('shouldCreateComplexEnsureIndexDbWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3057,11 +3052,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyDropTheDatabaseWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3128,11 +3123,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyRetrieveDbStatsWithGeneratorsWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3167,11 +3162,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyShareConnectionPoolsAcrossMultipleDbInstancesWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3228,11 +3223,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyRetrieveBuildInfoWithGenerators', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3271,11 +3266,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyRetrieveBuildInfoUsingCommandWithGenerators', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3315,11 +3310,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyChangeProfilingLevelWithGenerators', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3389,11 +3384,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlySetAndExtractProfilingInfoWithGenerators', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3450,11 +3445,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyCallValidateCollectionWithGenerators', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3500,11 +3495,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyPingTheMongoDbInstanceWithGenerators', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3543,11 +3538,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyAddAUserToAdminDbWithGenerators', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3588,11 +3583,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyAddAUserAndRemoveItFromAdminDbWithGenerators', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3635,11 +3630,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyListAllAvailableDatabasesWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3679,11 +3674,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyRetrieveServerInfoWithGenerators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3730,11 +3725,11 @@ describe('Operation (Generators)', function() {
   it('shouldCorrectlyRetrieveReplSetGetStatusWithGenerators', {
     metadata: { requires: { generators: true, topology: ['replicaset'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3789,11 +3784,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3839,11 +3834,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3888,11 +3883,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3949,11 +3944,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -3999,11 +3994,11 @@ describe('Operation (Generators)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4061,11 +4056,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute ordered batch with no errors using write commands with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4131,11 +4126,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute unordered batch with no errors with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4207,11 +4202,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute insertOne operation with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4248,11 +4243,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute insertMany operation with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4289,11 +4284,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute updateOne operation with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4331,11 +4326,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute updateMany operation with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4378,11 +4373,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute removeOne operation with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4422,11 +4417,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute removeMany operation with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4468,11 +4463,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute bulkWrite operation with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4531,11 +4526,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute findOneAndDelete operation with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4576,11 +4571,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute findOneAndReplace operation with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4631,11 +4626,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly execute findOneAndUpdate operation with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4686,11 +4681,11 @@ describe('Operation (Generators)', function() {
   it('Should correctly add capped collection options to cursor with Generators', {
     metadata: { requires: { generators: true, topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         // Connect
         var client = yield configuration
           .newClient(configuration.writeConcernMax(), { poolSize: 1 })
@@ -4728,7 +4723,7 @@ describe('Operation (Generators)', function() {
             .addCursorFlag('tailable', true)
             .addCursorFlag('awaitData', true);
 
-          cursor.on('data', function() {
+          cursor.on('data', function () {
             total = total + 1;
 
             if (total === 1000) {
@@ -4736,7 +4731,7 @@ describe('Operation (Generators)', function() {
             }
           });
 
-          cursor.on('end', function() {
+          cursor.on('end', function () {
             // TODO: forced because the cursor is still open/active
             client.close(true, err => {
               if (err) return reject(err);
@@ -4764,11 +4759,11 @@ describe('Operation (Generators)', function() {
       ignore: { travis: true }
     },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var co = require('co');
 
-      return co(function*() {
+      return co(function* () {
         var client = configuration.newClient({ w: 1 }, { poolSize: 1 });
         client = yield client.connect();
         var db = client.db(configuration.db);
@@ -4804,15 +4799,15 @@ describe('Operation (Generators)', function() {
             options
           )
           .batchSize(10)
-          .on('error', function() {
+          .on('error', function () {
             client.close();
           })
-          .on('data', function() {
+          .on('data', function () {
             index = index + 1;
           })
           // `end` sometimes emits before any `data` events have been emitted,
           // depending on document size.
-          .on('end', function() {
+          .on('end', function () {
             test.equal(100, index);
 
             client.close();

--- a/test/functional/operation_promises_example.test.js
+++ b/test/functional/operation_promises_example.test.js
@@ -4,16 +4,16 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const { Code } = require('../../src');
 
-var delay = function(ms) {
-  return new Promise(function(resolve) {
-    setTimeout(function() {
+var delay = function (ms) {
+  return new Promise(function (resolve) {
+    setTimeout(function () {
       resolve();
     }, ms);
   });
 };
 
-describe('Operation (Promises)', function() {
-  before(function() {
+describe('Operation (Promises)', function () {
+  before(function () {
     return setupDatabase(this.configuration, ['integration_tests_2', 'hr', 'reporting']);
   });
 
@@ -34,11 +34,11 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { mongodb: '>2.1.0', topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -70,7 +70,7 @@ describe('Operation (Promises)', function() {
         // Insert the docs
         return collection
           .insertMany(docs, { w: 1 })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Execute aggregate, notice the pipeline is expressed as an Array
@@ -96,7 +96,7 @@ describe('Operation (Promises)', function() {
             // Get all the aggregation results
             return cursor.toArray();
           })
-          .then(function(docs) {
+          .then(function (docs) {
             test.equal(2, docs.length);
             return client.close();
           });
@@ -116,11 +116,11 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { mongodb: '>2.1.0', topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -152,7 +152,7 @@ describe('Operation (Promises)', function() {
         // Insert the docs
         return collection
           .insertMany(docs, { w: 1 })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Execute aggregate, notice the pipeline is expressed as an Array
@@ -178,7 +178,7 @@ describe('Operation (Promises)', function() {
             // Get all the aggregation results
             return cursor.next();
           })
-          .then(function(docs) {
+          .then(function (docs) {
             test.ok(docs);
 
             // Need to close cursor to close implicit session,
@@ -200,11 +200,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyDoSimpleCountExamplesWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -220,19 +220,19 @@ describe('Operation (Promises)', function() {
         // Insert documents to perform distinct against
         return collection
           .insertMany([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4, b: 1 }], { w: 1 })
-          .then(function(ids) {
+          .then(function (ids) {
             test.ok(ids);
 
             // Perform a total count command
             return collection.count();
           })
-          .then(function(count) {
+          .then(function (count) {
             test.equal(4, count);
 
             // Perform a partial account where b=1
             return collection.count({ b: 1 });
           })
-          .then(function(count) {
+          .then(function (count) {
             test.equal(1, count);
             return client.close();
           });
@@ -250,14 +250,14 @@ describe('Operation (Promises)', function() {
   it('shouldCreateComplexIndexOnTwoFieldsWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -281,25 +281,25 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Create an index on the a field
             return collection.createIndex({ a: 1, b: 1 }, { unique: true, background: true, w: 1 });
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
 
             // Show that duplicate records got dropped
             return collection.find({}).toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.equal(4, items.length);
 
             // Perform a query, with explain to show we hit the query
             return collection.find({ a: 2 }).explain();
           })
-          .then(function(explanation) {
+          .then(function (explanation) {
             test.ok(explanation != null);
             return client.close();
           });
@@ -317,11 +317,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyHandleDistinctIndexesWithSubQueryFilterWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -347,19 +347,19 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(ids) {
+          .then(function (ids) {
             test.ok(ids);
 
             // Perform a distinct query against the a field
             return collection.distinct('a');
           })
-          .then(function(docs) {
+          .then(function (docs) {
             test.deepEqual([0, 1, 2, 3], docs.sort());
 
             // Perform a distinct query against the sub-field b.c
             return collection.distinct('b.c');
           })
-          .then(function(docs) {
+          .then(function (docs) {
             test.deepEqual(['a', 'b', 'c'], docs.sort());
             return client.close();
           });
@@ -374,11 +374,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyHandleDistinctIndexesWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -406,13 +406,13 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(ids) {
+          .then(function (ids) {
             test.ok(ids);
 
             // Perform a distinct query with a filter against the documents
             return collection.distinct('a', { c: 1 });
           })
-          .then(function(docs) {
+          .then(function (docs) {
             test.deepEqual([5], docs.sort());
             return client.close();
           });
@@ -430,11 +430,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyDropCollectionWithDropFunctionWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -448,21 +448,21 @@ describe('Operation (Promises)', function() {
         // Create a collection we want to drop later
         return db
           .createCollection('test_other_drop_with_promise')
-          .then(function(collection) {
+          .then(function (collection) {
             // Drop the collection
             return collection.drop();
           })
-          .then(function(reply) {
+          .then(function (reply) {
             test.ok(reply);
 
             // Ensure we don't have the collection in the set of names
             return db.listCollections().toArray();
           })
-          .then(function(replies) {
+          .then(function (replies) {
             var found = false;
             // For each collection in the list of collection names in this db look for the
             // dropped collection
-            replies.forEach(function(document) {
+            replies.forEach(function (document) {
               if (document.name === 'test_other_drop_with_promise') {
                 found = true;
                 return;
@@ -489,11 +489,11 @@ describe('Operation (Promises)', function() {
   it('dropAllIndexesExample1WithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -505,13 +505,13 @@ describe('Operation (Promises)', function() {
         // BEGIN
         return db
           .createCollection('dropExample1_with_promise')
-          .then(function(r) {
+          .then(function (r) {
             test.ok(r);
 
             // Drop the collection
             return db.collection('dropExample1_with_promise').dropAllIndexes();
           })
-          .then(function(reply) {
+          .then(function (reply) {
             test.ok(reply);
 
             // Let's close the db
@@ -531,11 +531,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyCreateAndDropIndexWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1, auto_reconnect: true });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -558,24 +558,24 @@ describe('Operation (Promises)', function() {
             ],
             { w: 1 }
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Create an index on the a field
             return collection.ensureIndex({ a: 1, b: 1 }, { unique: true, background: true, w: 1 });
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
 
             // Drop the index
             return collection.dropIndex('a_1_b_1');
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Verify that the index is gone
             return collection.indexInformation();
           })
-          .then(function(indexInformation) {
+          .then(function (indexInformation) {
             test.deepEqual([['_id', 1]], indexInformation._id_);
             test.equal(undefined, indexInformation.a_1_b_1);
             return client.close();
@@ -594,14 +594,14 @@ describe('Operation (Promises)', function() {
   it('shouldCreateComplexEnsureIndexWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -624,7 +624,7 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Create an index on the a field
@@ -634,19 +634,19 @@ describe('Operation (Promises)', function() {
               { unique: true, background: true, w: 1 }
             );
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
 
             // Show that duplicate records got dropped
             return collection.find({}).toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.equal(4, items.length);
 
             // Perform a query, with explain to show we hit the query
             return collection.find({ a: 2 }).explain();
           })
-          .then(function(explanation) {
+          .then(function (explanation) {
             test.ok(explanation != null);
             return client.close();
           });
@@ -664,11 +664,11 @@ describe('Operation (Promises)', function() {
   it('ensureIndexExampleWithCompountIndexWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1, auto_reconnect: true });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -691,25 +691,25 @@ describe('Operation (Promises)', function() {
             ],
             { w: 1 }
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Create an index on the a field
             return collection.ensureIndex({ a: 1, b: 1 }, { unique: true, background: true, w: 1 });
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
 
             // Show that duplicate records got dropped
             return collection.find({}).toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.equal(4, items.length);
 
             // Perform a query, with explain to show we hit the query
             return collection.find({ a: 2 }).explain();
           })
-          .then(function(explanation) {
+          .then(function (explanation) {
             test.ok(explanation != null);
             return client.close();
           });
@@ -727,14 +727,14 @@ describe('Operation (Promises)', function() {
   it('shouldPerformASimpleQueryWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -751,13 +751,13 @@ describe('Operation (Promises)', function() {
         // Insert a bunch of documents for the testing
         return collection
           .insertMany([{ a: 1 }, { a: 2 }, { a: 3 }], configuration.writeConcernMax())
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Perform a simple find and return all the documents
             return collection.find().toArray();
           })
-          .then(function(docs) {
+          .then(function (docs) {
             test.equal(3, docs.length);
             return client.close();
           });
@@ -775,14 +775,14 @@ describe('Operation (Promises)', function() {
   it('shouldPerformASimpleExplainQueryWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -799,13 +799,13 @@ describe('Operation (Promises)', function() {
         // Insert a bunch of documents for the testing
         return collection
           .insertMany([{ a: 1 }, { a: 2 }, { a: 3 }], configuration.writeConcernMax())
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Perform a simple find and return all the documents
             return collection.find({}).explain();
           })
-          .then(function(docs) {
+          .then(function (docs) {
             test.ok(docs != null);
             return client.close();
           });
@@ -823,14 +823,14 @@ describe('Operation (Promises)', function() {
   it('shouldPerformASimpleLimitSkipQueryWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -854,18 +854,13 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Perform a simple find and return all the documents
-            return collection
-              .find({})
-              .skip(1)
-              .limit(1)
-              .project({ b: 1 })
-              .toArray();
+            return collection.find({}).skip(1).limit(1).project({ b: 1 }).toArray();
           })
-          .then(function(docs) {
+          .then(function (docs) {
             test.equal(1, docs.length);
             test.equal(undefined, docs[0].a);
             test.equal(2, docs[0].b);
@@ -889,14 +884,14 @@ describe('Operation (Promises)', function() {
   it('shouldPerformSimpleFindAndModifyOperationsWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -912,7 +907,7 @@ describe('Operation (Promises)', function() {
         // Insert some test documentations
         return collection
           .insertMany([{ a: 1 }, { b: 1 }, { c: 1 }], configuration.writeConcernMax())
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Simple findAndModify command returning the new document
@@ -923,7 +918,7 @@ describe('Operation (Promises)', function() {
               { new: true }
             );
           })
-          .then(function(doc) {
+          .then(function (doc) {
             test.equal(1, doc.value.a);
             test.equal(1, doc.value.b1);
 
@@ -936,13 +931,13 @@ describe('Operation (Promises)', function() {
               { remove: true }
             );
           })
-          .then(function(doc) {
+          .then(function (doc) {
             test.ok(doc);
 
             // Verify that the document is gone
             return collection.findOne({ b: 1 });
           })
-          .then(function(item) {
+          .then(function (item) {
             test.equal(null, item);
 
             // Simple findAndModify command performing an upsert and returning the new document
@@ -954,7 +949,7 @@ describe('Operation (Promises)', function() {
               { new: true, upsert: true, w: 1 }
             );
           })
-          .then(function(doc) {
+          .then(function (doc) {
             test.equal(1, doc.value.d);
             test.equal(1, doc.value.f);
             return client.close();
@@ -973,14 +968,14 @@ describe('Operation (Promises)', function() {
   it('shouldPerformSimpleFindAndRemoveWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -997,21 +992,21 @@ describe('Operation (Promises)', function() {
         // Insert some test documentations
         return collection
           .insertMany([{ a: 1 }, { b: 1, d: 1 }, { c: 1 }], configuration.writeConcernMax())
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Simple findAndModify command returning the old document and
             // removing it at the same time
             return collection.findAndRemove({ b: 1 }, [['b', 1]]);
           })
-          .then(function(doc) {
+          .then(function (doc) {
             test.equal(1, doc.value.b);
             test.equal(1, doc.value.d);
 
             // Verify that the document is gone
             return collection.findOne({ b: 1 });
           })
-          .then(function(item) {
+          .then(function (item) {
             test.equal(null, item);
             return client.close();
           });
@@ -1029,14 +1024,14 @@ describe('Operation (Promises)', function() {
   it('shouldPerformASimpleLimitSkipFindOneQueryWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1060,13 +1055,13 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Perform a simple find and return all the documents
             return collection.findOne({ a: 2 }, { fields: { b: 1 } });
           })
-          .then(function(doc) {
+          .then(function (doc) {
             test.equal(undefined, doc.a);
             test.equal(2, doc.b);
             return client.close();
@@ -1085,7 +1080,7 @@ describe('Operation (Promises)', function() {
   it('shouldPerformSimpleMapReduceFunctionsWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
 
@@ -1154,11 +1149,11 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { mongodb: '>1.7.6', topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1187,11 +1182,11 @@ describe('Operation (Promises)', function() {
         // Insert some test documents
         return collection
           .insertMany([{ user_id: 1 }, { user_id: 2 }], { w: 1 })
-          .then(function() {
+          .then(function () {
             // Execute map reduce and return results inline
             return collection.mapReduce(map, reduce, { out: { inline: 1 }, verbose: true });
           })
-          .then(function(result) {
+          .then(function (result) {
             test.equal(2, result.results.length);
             test.ok(result.stats != null);
 
@@ -1200,7 +1195,7 @@ describe('Operation (Promises)', function() {
               verbose: true
             });
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result.stats != null);
             return client.close();
           });
@@ -1218,11 +1213,11 @@ describe('Operation (Promises)', function() {
   it('shouldPerformMapReduceWithContextWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   Code = require('mongodb').Code,
@@ -1272,14 +1267,14 @@ describe('Operation (Promises)', function() {
             ],
             { w: 1 }
           )
-          .then(function() {
+          .then(function () {
             return collection.mapReduce(map, reduce, o);
           })
-          .then(function(outCollection) {
+          .then(function (outCollection) {
             // Find all entries in the map-reduce collection
             return outCollection.find().toArray();
           })
-          .then(function(results) {
+          .then(function (results) {
             test.equal(2, results[0].value);
 
             // mapReduce with scope containing plain function
@@ -1289,11 +1284,11 @@ describe('Operation (Promises)', function() {
 
             return collection.mapReduce(map, reduce, o);
           })
-          .then(function(outCollection) {
+          .then(function (outCollection) {
             // Find all entries in the map-reduce collection
             return outCollection.find().toArray();
           })
-          .then(function(results) {
+          .then(function (results) {
             test.equal(2, results[0].value);
             return client.close();
           });
@@ -1311,11 +1306,11 @@ describe('Operation (Promises)', function() {
   it.skip('shouldPerformMapReduceInContextObjectsWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   Code = require('mongodb').Code,
@@ -1365,14 +1360,14 @@ describe('Operation (Promises)', function() {
             ],
             { w: 1 }
           )
-          .then(function() {
+          .then(function () {
             return collection.mapReduce(map, reduce, o);
           })
-          .then(function(outCollection) {
+          .then(function (outCollection) {
             // Find all entries in the map-reduce collection
             return outCollection.find().toArray();
           })
-          .then(function(results) {
+          .then(function (results) {
             test.equal(2, results[0].value);
 
             // mapReduce with scope containing plain function
@@ -1382,11 +1377,11 @@ describe('Operation (Promises)', function() {
 
             return collection.mapReduce(map, reduce, o);
           })
-          .then(function(outCollection) {
+          .then(function (outCollection) {
             // Find all entries in the map-reduce collection
             return outCollection.find().toArray();
           })
-          .then(function(results) {
+          .then(function (results) {
             test.equal(2, results[0].value);
             return client.close();
           });
@@ -1404,11 +1399,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyRetrieveACollectionsIndexesWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1424,22 +1419,22 @@ describe('Operation (Promises)', function() {
         // Create a geo 2d index
         return collection
           .ensureIndex({ loc: '2d' }, configuration.writeConcernMax())
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Create a simple single field index
             return collection.ensureIndex({ a: 1 }, configuration.writeConcernMax());
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             return delay(1000);
           })
-          .then(function() {
+          .then(function () {
             // List all of the indexes on the collection
             return collection.indexes();
           })
-          .then(function(indexes) {
+          .then(function (indexes) {
             test.equal(3, indexes.length);
             return client.close();
           });
@@ -1457,11 +1452,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyExecuteIndexExistsWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1480,25 +1475,25 @@ describe('Operation (Promises)', function() {
         // Create an index on the collection
         return collection
           .createIndex('a', configuration.writeConcernMax())
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
 
             // Let's test to check if a single index exists
             return collection.indexExists('a_1');
           })
-          .then(function(result) {
+          .then(function (result) {
             test.equal(true, result);
 
             // Let's test to check if multiple indexes are available
             return collection.indexExists(['a_1', '_id_']);
           })
-          .then(function(result) {
+          .then(function (result) {
             test.equal(true, result);
 
             // Check if a non existing index exists
             return collection.indexExists('c_1');
           })
-          .then(function(result) {
+          .then(function (result) {
             test.equal(false, result);
             return client.close();
           });
@@ -1518,14 +1513,14 @@ describe('Operation (Promises)', function() {
       requires: { topology: ['single', 'replicaset'] }
     },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(
         { w: 0, native_parser: false },
         { poolSize: 1, auto_reconnect: false }
       );
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1550,19 +1545,19 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Create an index on the a field
             return collection.ensureIndex({ a: 1, b: 1 }, { unique: true, background: true, w: 1 });
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
 
             // Fetch basic indexInformation for collection
             return db.indexInformation('more_index_information_test_2_with_promise');
           })
-          .then(function(indexInformation) {
+          .then(function (indexInformation) {
             test.deepEqual([['_id', 1]], indexInformation._id_);
             test.deepEqual(
               [
@@ -1575,7 +1570,7 @@ describe('Operation (Promises)', function() {
             // Fetch full index information
             return collection.indexInformation({ full: true });
           })
-          .then(function(indexInformation) {
+          .then(function (indexInformation) {
             test.deepEqual({ _id: 1 }, indexInformation[0].key);
             test.deepEqual({ a: 1, b: 1 }, indexInformation[1].key);
             return client.close();
@@ -1594,11 +1589,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyShowAllTheResultsFromIndexInformationWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1, auto_reconnect: true });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1623,19 +1618,19 @@ describe('Operation (Promises)', function() {
             ],
             { w: 1 }
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Create an index on the a field
             return collection.ensureIndex({ a: 1, b: 1 }, { unique: true, background: true, w: 1 });
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
 
             // Fetch basic indexInformation for collection
             return collection.indexInformation();
           })
-          .then(function(indexInformation) {
+          .then(function (indexInformation) {
             test.deepEqual([['_id', 1]], indexInformation._id_);
             test.deepEqual(
               [
@@ -1648,7 +1643,7 @@ describe('Operation (Promises)', function() {
             // Fetch full index information
             return collection.indexInformation({ full: true });
           })
-          .then(function(indexInformation) {
+          .then(function (indexInformation) {
             test.deepEqual({ _id: 1 }, indexInformation[0].key);
             test.deepEqual({ a: 1, b: 1 }, indexInformation[1].key);
             return client.close();
@@ -1668,10 +1663,10 @@ describe('Operation (Promises)', function() {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single'] } },
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1686,11 +1681,11 @@ describe('Operation (Promises)', function() {
         // Insert a single document
         return collection
           .insertOne({ hello: 'world_no_safe' })
-          .then(function() {
+          .then(function () {
             // Fetch the document
             return collection.findOne({ hello: 'world_no_safe' });
           })
-          .then(function(item) {
+          .then(function (item) {
             test.equal('world_no_safe', item.hello);
             return client.close();
           });
@@ -1710,10 +1705,10 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1732,13 +1727,13 @@ describe('Operation (Promises)', function() {
             [{ hello: 'world_safe1' }, { hello: 'world_safe2' }],
             configuration.writeConcernMax()
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Fetch the document
             return collection.findOne({ hello: 'world_safe2' });
           })
-          .then(function(item) {
+          .then(function (item) {
             test.equal('world_safe2', item.hello);
             return client.close();
           });
@@ -1758,10 +1753,10 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1782,17 +1777,17 @@ describe('Operation (Promises)', function() {
           .insertOne(
             {
               hello: 'world',
-              func: function() {}
+              func: function () {}
             },
             o
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Fetch the document
             return collection.findOne({ hello: 'world' });
           })
-          .then(function(item) {
+          .then(function (item) {
             test.ok('function() {}', item.code);
             return client.close();
           });
@@ -1812,11 +1807,11 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { mongodb: '>1.9.1', topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1832,12 +1827,12 @@ describe('Operation (Promises)', function() {
 
         return collection
           .drop()
-          .catch(function() {})
-          .then(function() {
+          .catch(function () {})
+          .then(function () {
             // Add an unique index to title to force errors in the batch insert
             return collection.ensureIndex({ title: 1 }, { unique: true });
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
 
             // Insert some intial data into the collection
@@ -1846,7 +1841,7 @@ describe('Operation (Promises)', function() {
               configuration.writeConcernMax()
             );
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Force keep going flag, ignoring unique index issue
@@ -1859,11 +1854,11 @@ describe('Operation (Promises)', function() {
               { w: 1, keepGoing: true }
             );
           })
-          .catch(function() {
+          .catch(function () {
             // Count the number of documents left (should not include the duplicates)
             return collection.count();
           })
-          .then(function(count) {
+          .then(function (count) {
             test.equal(3, count);
             return client.close();
           });
@@ -1881,11 +1876,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyExecuteIsCappedWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1899,13 +1894,13 @@ describe('Operation (Promises)', function() {
         // Create a test collection that we are getting the options back from
         return db
           .createCollection('test_collection_is_capped_with_promise', { capped: true, size: 1024 })
-          .then(function(collection) {
+          .then(function (collection) {
             test.equal('test_collection_is_capped_with_promise', collection.collectionName);
 
             // Let's fetch the collection options
             return collection.isCapped();
           })
-          .then(function(capped) {
+          .then(function (capped) {
             test.equal(true, capped);
             return client.close();
           });
@@ -1923,11 +1918,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyRetrieveCollectionOptionsWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1941,13 +1936,13 @@ describe('Operation (Promises)', function() {
         // Create a test collection that we are getting the options back from
         return db
           .createCollection('test_collection_options_with_promise', { capped: true, size: 1024 })
-          .then(function(collection) {
+          .then(function (collection) {
             test.equal('test_collection_options_with_promise', collection.collectionName);
 
             // Let's fetch the collection options
             return collection.options();
           })
-          .then(function(options) {
+          .then(function (options) {
             test.equal(true, options.capped);
             test.ok(options.size >= 1024);
             return client.close();
@@ -1966,11 +1961,11 @@ describe('Operation (Promises)', function() {
   it('shouldRemoveAllDocumentsNoSafeWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -1987,17 +1982,17 @@ describe('Operation (Promises)', function() {
         // Insert a bunch of documents
         return collection
           .insertMany([{ a: 1 }, { b: 2 }], { w: 1 })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Remove all the document
             return collection.removeMany();
           })
-          .then(function() {
+          .then(function () {
             // Fetch all results
             return collection.find().toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.equal(0, items.length);
             return client.close();
           });
@@ -2015,11 +2010,11 @@ describe('Operation (Promises)', function() {
   it('shouldRemoveSubsetOfDocumentsSafeModeWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2036,13 +2031,13 @@ describe('Operation (Promises)', function() {
         // Insert a bunch of documents
         return collection
           .insertMany([{ a: 1 }, { b: 2 }], { w: 1 })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Remove all the document
             return collection.removeOne({ a: 1 }, { w: 1 });
           })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(1, r.result.n);
             return client.close();
           });
@@ -2062,7 +2057,7 @@ describe('Operation (Promises)', function() {
       requires: { topology: ['single'] }
     },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
@@ -2190,11 +2185,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlySaveASimpleDocumentWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2211,11 +2206,11 @@ describe('Operation (Promises)', function() {
         // Save a document with no safe option
         return collection
           .save({ hello: 'world' })
-          .then(function() {
+          .then(function () {
             // Find the saved document
             return collection.findOne({ hello: 'world' });
           })
-          .then(function(item) {
+          .then(function (item) {
             test.equal('world', item.hello);
             return client.close();
           });
@@ -2233,11 +2228,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlySaveASimpleDocumentModifyItAndResaveItWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2256,13 +2251,13 @@ describe('Operation (Promises)', function() {
         // Save a document with no safe option
         return collection
           .save({ hello: 'world' }, configuration.writeConcernMax())
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Find the saved document
             return collection.findOne({ hello: 'world' });
           })
-          .then(function(item) {
+          .then(function (item) {
             test.equal('world', item.hello);
 
             // Update the document
@@ -2271,13 +2266,13 @@ describe('Operation (Promises)', function() {
             // Save the item with the additional field
             return collection.save(item, configuration.writeConcernMax());
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Find the changed document
             return collection.findOne({ hello: 'world' });
           })
-          .then(function(item) {
+          .then(function (item) {
             test.equal('world', item.hello);
             test.equal('world2', item.hello2);
             return client.close();
@@ -2296,11 +2291,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyUpdateASimpleDocumentWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2317,16 +2312,16 @@ describe('Operation (Promises)', function() {
         // Insert a document, then update it
         return collection
           .insertOne({ a: 1 }, configuration.writeConcernMax())
-          .then(function(doc) {
+          .then(function (doc) {
             test.ok(doc);
             // Update the document with an atomic operator
             return collection.updateOne({ a: 1 }, { $set: { b: 2 } });
           })
-          .then(function() {
+          .then(function () {
             // Fetch the document that we modified
             return collection.findOne({ a: 1 });
           })
-          .then(function(item) {
+          .then(function (item) {
             test.equal(1, item.a);
             test.equal(2, item.b);
             return client.close();
@@ -2345,11 +2340,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyUpsertASimpleDocumentWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2366,13 +2361,13 @@ describe('Operation (Promises)', function() {
         // Update the document using an upsert operation, ensuring creation if it does not exist
         return collection
           .updateOne({ a: 1 }, { $set: { b: 2, a: 1 } }, { upsert: true, w: 1 })
-          .then(function(result) {
+          .then(function (result) {
             test.equal(1, result.result.n);
 
             // Fetch the document that we modified and check if it got inserted correctly
             return collection.findOne({ a: 1 });
           })
-          .then(function(item) {
+          .then(function (item) {
             test.equal(1, item.a);
             test.equal(2, item.b);
             return client.close();
@@ -2391,11 +2386,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyUpdateMultipleDocumentsWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2418,19 +2413,19 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             var o = configuration.writeConcernMax();
             return collection.updateMany({ a: 1 }, { $set: { b: 0 } }, o);
           })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(2, r.result.n);
 
             // Fetch all the documents and verify that we have changed the b value
             return collection.find().toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.equal(1, items[0].a);
             test.equal(0, items[0].b);
             test.equal(1, items[1].a);
@@ -2451,11 +2446,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyReturnACollectionsStatsWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2472,12 +2467,12 @@ describe('Operation (Promises)', function() {
         // Insert some documents
         return collection
           .insertMany([{ a: 1 }, { hello: 'world' }], configuration.writeConcernMax())
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Retrieve the statistics for the collection
             return collection.stats();
           })
-          .then(function(stats) {
+          .then(function (stats) {
             test.equal(2, stats.count);
             return client.close();
           });
@@ -2495,11 +2490,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyCreateAndDropAllIndexWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 0 }, { poolSize: 1, auto_reconnect: true });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2525,13 +2520,13 @@ describe('Operation (Promises)', function() {
               w: 1
             }
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Create an index on the a field
             return collection.ensureIndex({ a: 1, b: 1 }, { unique: true, background: true, w: 1 });
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
             // Create an additional index
             return collection.ensureIndex(
@@ -2539,17 +2534,17 @@ describe('Operation (Promises)', function() {
               { unique: true, background: true, sparse: true, w: 1 }
             );
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
             // Drop the index
             return collection.dropAllIndexes();
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Verify that the index is gone
             return collection.indexInformation();
           })
-          .then(function(indexInformation) {
+          .then(function (indexInformation) {
             test.deepEqual([['_id', 1]], indexInformation._id_);
             test.equal(undefined, indexInformation.a_1_b_1);
             test.equal(undefined, indexInformation.c_1);
@@ -2575,14 +2570,14 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyOpenASimpleDbSingleServerConnectionAndCloseWithCallbackWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2610,14 +2605,14 @@ describe('Operation (Promises)', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap'] }
     },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
         // LINE const client = new MongoClient('mongodb://localhost:27017/test');
@@ -2635,19 +2630,19 @@ describe('Operation (Promises)', function() {
         // Ensure the collection was created
         return collection
           .insertOne({ a: 1 })
-          .then(function() {
+          .then(function () {
             // Return the information of a single collection name
             return db1
               .listCollections({ name: 'shouldCorrectlyRetrievelistCollections_with_promise' })
               .toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.equal(1, items.length);
 
             // Return the information of a all collections, using the callback format
             return db1.listCollections().toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.ok(items.length >= 1);
             return client.close();
           });
@@ -2659,14 +2654,14 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyRetrievelistCollectionsWiredTigerWithPromises', {
     metadata: { requires: { topology: ['wiredtiger'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         // Get an empty db
         var db1 = client.db('listCollectionTestDb2');
 
@@ -2676,19 +2671,19 @@ describe('Operation (Promises)', function() {
         // Ensure the collection was created
         return collection
           .insertOne({ a: 1 })
-          .then(function() {
+          .then(function () {
             // Return the information of a single collection name
             return db1
               .listCollections({ name: 'shouldCorrectlyRetrievelistCollections_with_promise' })
               .toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.equal(1, items.length);
 
             // Return the information of a all collections, using the callback format
             return db1.listCollections().toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.equal(1, items.length);
             return client.close();
           });
@@ -2705,14 +2700,14 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyAccessACollectionWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2723,24 +2718,24 @@ describe('Operation (Promises)', function() {
         // REMOVE-LINE done();
         // BEGIN
         // Grab a collection with a callback but no safe operation
-        db.collection('test_correctly_access_collections_with_promise', function(err) {
+        db.collection('test_correctly_access_collections_with_promise', function (err) {
           test.equal(null, err);
 
           // Grab a collection with a callback in safe mode, ensuring it exists (should fail as it's not created)
           db.collection(
             'test_correctly_access_collections_with_promise',
             { strict: true },
-            function(err) {
+            function (err) {
               test.ok(err);
 
               // Create the collection
               db.createCollection('test_correctly_access_collections_with_promise').then(
-                function() {
+                function () {
                   // Retry to get the collection, should work as it's now created
                   db.collection(
                     'test_correctly_access_collections_with_promise',
                     { strict: true },
-                    function(err) {
+                    function (err) {
                       test.equal(null, err);
                       client.close(done);
                     }
@@ -2764,14 +2759,14 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyRetrieveAllCollectionsWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2782,7 +2777,7 @@ describe('Operation (Promises)', function() {
         // REMOVE-LINE done();
         // BEGIN
         // Retry to get the collection, should work as it's now created
-        return db.collections().then(function(collections) {
+        return db.collections().then(function (collections) {
           test.ok(collections.length > 0);
           return client.close();
         });
@@ -2800,14 +2795,14 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyAddUserToDbWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2821,12 +2816,12 @@ describe('Operation (Promises)', function() {
         // Add a user to the database
         return db
           .addUser('user', 'name')
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Remove the user from the db
             return db.removeUser('user');
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             return client.close();
           });
@@ -2844,11 +2839,11 @@ describe('Operation (Promises)', function() {
   it.skip('shouldCorrectlyAddAndRemoveUserWithPromises', {
     metadata: { requires: { topology: 'single', mongodb: '<=3.4.x' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
 
       const client = configuration.newClient();
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2862,7 +2857,7 @@ describe('Operation (Promises)', function() {
 
         return db
           .addUser('user3', 'name')
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             return client.close();
           })
@@ -2873,18 +2868,18 @@ describe('Operation (Promises)', function() {
 
             return secondClient.connect();
           })
-          .then(function(client) {
+          .then(function (client) {
             // Logout the db
-            return client.logout().then(function() {
+            return client.logout().then(function () {
               return client;
             });
           })
-          .then(function(client) {
+          .then(function (client) {
             // Remove the user
             var db = client.db(configuration.db);
             return db.removeUser('user3');
           })
-          .then(function(result) {
+          .then(function (result) {
             test.equal(true, result);
 
             // Should error out due to user no longer existing
@@ -2895,7 +2890,7 @@ describe('Operation (Promises)', function() {
 
             return thirdClient.connect();
           })
-          .catch(function(err) {
+          .catch(function (err) {
             test.ok(err);
             return client.close();
           });
@@ -2913,14 +2908,14 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyCreateACollectionWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2938,11 +2933,11 @@ describe('Operation (Promises)', function() {
             max: 1000,
             w: 1
           })
-          .then(function(collection) {
+          .then(function (collection) {
             // Insert a document in the capped collection
             return collection.insertOne({ a: 1 }, configuration.writeConcernMax());
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             return client.close();
           });
@@ -2960,14 +2955,14 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyExecuteACommandAgainstTheServerWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -2980,7 +2975,7 @@ describe('Operation (Promises)', function() {
         // Execute ping against the server
         return db
           .command({ ping: 1 })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Create a capped collection with a maximum of 1000 documents
             return db.createCollection('a_simple_create_drop_collection_with_promise', {
@@ -2990,23 +2985,23 @@ describe('Operation (Promises)', function() {
               w: 1
             });
           })
-          .then(function(collection) {
+          .then(function (collection) {
             // Insert a document in the capped collection
             return collection.insertOne({ a: 1 }, configuration.writeConcernMax());
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Drop the collection from this world
             return db.dropCollection('a_simple_create_drop_collection_with_promise');
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Verify that the collection is gone
             return db
               .listCollections({ name: 'a_simple_create_drop_collection_with_promise' })
               .toArray();
           })
-          .then(function(names) {
+          .then(function (names) {
             test.equal(0, names.length);
             return client.close();
           });
@@ -3024,14 +3019,14 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyCreateDropAndVerifyThatCollectionIsGoneWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3042,7 +3037,7 @@ describe('Operation (Promises)', function() {
         // REMOVE-LINE done();
         // BEGIN
         // Execute ping against the server
-        return db.command({ ping: 1 }).then(function(result) {
+        return db.command({ ping: 1 }).then(function (result) {
           test.ok(result);
           return client.close();
         });
@@ -3060,14 +3055,14 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyRenameACollectionWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3084,17 +3079,19 @@ describe('Operation (Promises)', function() {
             'simple_rename_collection_with_promise',
             configuration.writeConcernMax()
           )
-          .then(function(collection) {
+          .then(function (collection) {
             // Insert a document in the collection
-            return collection.insertOne({ a: 1 }, configuration.writeConcernMax()).then(function() {
-              return collection;
-            });
+            return collection
+              .insertOne({ a: 1 }, configuration.writeConcernMax())
+              .then(function () {
+                return collection;
+              });
           })
-          .then(function(collection) {
+          .then(function (collection) {
             // Retrieve the number of documents from the collection
             return collection.count();
           })
-          .then(function(count) {
+          .then(function (count) {
             test.equal(1, count);
 
             // Rename the collection
@@ -3103,17 +3100,17 @@ describe('Operation (Promises)', function() {
               'simple_rename_collection_2_with_promise'
             );
           })
-          .then(function(collection2) {
+          .then(function (collection2) {
             // Retrieve the number of documents from the collection
             return collection2.count();
           })
-          .then(function(count) {
+          .then(function (count) {
             test.equal(1, count);
 
             // Verify that the collection is gone
             return db.listCollections({ name: 'simple_rename_collection_with_promise' }).toArray();
           })
-          .then(function(names) {
+          .then(function (names) {
             test.equal(0, names.length);
 
             // Verify that the new collection exists
@@ -3121,7 +3118,7 @@ describe('Operation (Promises)', function() {
               .listCollections({ name: 'simple_rename_collection_2_with_promise' })
               .toArray();
           })
-          .then(function(names) {
+          .then(function (names) {
             test.equal(1, names.length);
             return client.close();
           });
@@ -3139,14 +3136,14 @@ describe('Operation (Promises)', function() {
   it('shouldCreateOnDbComplexIndexOnTwoFieldsWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3171,7 +3168,7 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Create an index on the a field
             return db.createIndex(
@@ -3180,18 +3177,18 @@ describe('Operation (Promises)', function() {
               { unique: true, background: true, w: 1 }
             );
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
             // Show that duplicate records got dropped
             return collection.find({}).toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.equal(4, items.length);
 
             // Perform a query, with explain to show we hit the query
             return collection.find({ a: 2 }).explain();
           })
-          .then(function(explanation) {
+          .then(function (explanation) {
             test.ok(explanation != null);
             return client.close();
           });
@@ -3209,14 +3206,14 @@ describe('Operation (Promises)', function() {
   it('shouldCreateComplexEnsureIndexDbWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3241,7 +3238,7 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Create an index on the a field
             return db.ensureIndex(
@@ -3250,18 +3247,18 @@ describe('Operation (Promises)', function() {
               { unique: true, background: true, w: 1 }
             );
           })
-          .then(function(indexName) {
+          .then(function (indexName) {
             test.ok(indexName);
             // Show that duplicate records got dropped
             return collection.find({}).toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.equal(4, items.length);
 
             // Perform a query, with explain to show we hit the query
             return collection.find({ a: 2 }).explain();
           })
-          .then(function(explanation) {
+          .then(function (explanation) {
             test.ok(explanation != null);
             return client.close();
           });
@@ -3279,14 +3276,14 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyDropTheDatabaseWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3312,19 +3309,19 @@ describe('Operation (Promises)', function() {
             ],
             configuration.writeConcernMax()
           )
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Let's drop the database
             return db.dropDatabase();
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Get the admin database
             return db.admin().listDatabases();
           })
-          .then(function(dbs) {
+          .then(function (dbs) {
             // Grab the databases
             dbs = dbs.databases;
             // Did we find the db
@@ -3354,11 +3351,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyRetrieveDbStatsWithPromisesWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3368,7 +3365,7 @@ describe('Operation (Promises)', function() {
         // REPLACE configuration.writeConcernMax() WITH {w:1}
         // REMOVE-LINE done();
         // BEGIN
-        return db.stats().then(function(stats) {
+        return db.stats().then(function (stats) {
           test.ok(stats != null);
           return client.close();
         });
@@ -3386,11 +3383,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyShareConnectionPoolsAcrossMultipleDbInstancesWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3411,21 +3408,21 @@ describe('Operation (Promises)', function() {
         // Write a record into each and then count the records stored
         return multipleColl1
           .insertOne({ a: 1 }, { w: 1 })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             return multipleColl2.insertOne({ a: 1 }, { w: 1 });
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Count over the results ensuring only on record in each collection
             return multipleColl1.count();
           })
-          .then(function(count) {
+          .then(function (count) {
             test.equal(1, count);
 
             return multipleColl2.count();
           })
-          .then(function(count) {
+          .then(function (count) {
             test.equal(1, count);
             return client.close();
           });
@@ -3449,11 +3446,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyRetrieveBuildInfoWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3469,7 +3466,7 @@ describe('Operation (Promises)', function() {
         var adminDb = db.admin();
 
         // Retrieve the build information for the MongoDB instance
-        return adminDb.buildInfo().then(function(info) {
+        return adminDb.buildInfo().then(function (info) {
           test.ok(info);
           return client.close();
         });
@@ -3487,11 +3484,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyRetrieveBuildInfoUsingCommandWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3507,7 +3504,7 @@ describe('Operation (Promises)', function() {
         var adminDb = db.admin();
 
         // Retrieve the build information using the admin command
-        return adminDb.command({ buildInfo: 1 }).then(function(info) {
+        return adminDb.command({ buildInfo: 1 }).then(function (info) {
           test.ok(info);
           return client.close();
         });
@@ -3525,11 +3522,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlySetDefaultProfilingLevelWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3548,7 +3545,7 @@ describe('Operation (Promises)', function() {
         // Collections are not created until the first document is inserted
         return collection
           .insertOne({ a: 1 }, { w: 1 })
-          .then(function(doc) {
+          .then(function (doc) {
             test.ok(doc);
             // Use the admin database for the operation
             var adminDb = client.db('admin');
@@ -3556,7 +3553,7 @@ describe('Operation (Promises)', function() {
             // Retrieve the profiling level
             return adminDb.profilingLevel();
           })
-          .then(function(level) {
+          .then(function (level) {
             test.ok(level);
             return client.close();
           });
@@ -3575,11 +3572,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyChangeProfilingLevelWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3599,45 +3596,45 @@ describe('Operation (Promises)', function() {
         // Collections are not created until the first document is inserted
         return collection
           .insertOne({ a: 1 }, { w: 1 })
-          .then(function(doc) {
+          .then(function (doc) {
             test.ok(doc);
             // Set the profiling level to only profile slow queries
             return adminDb.setProfilingLevel('slow_only');
           })
-          .then(function(level) {
+          .then(function (level) {
             test.ok(level);
             // Retrieve the profiling level and verify that it's set to slow_only
             return adminDb.profilingLevel();
           })
-          .then(function(level) {
+          .then(function (level) {
             test.equal('slow_only', level);
 
             // Turn profiling off
             return adminDb.setProfilingLevel('off');
           })
-          .then(function(level) {
+          .then(function (level) {
             test.ok(level);
             // Retrieve the profiling level and verify that it's set to off
             return adminDb.profilingLevel();
           })
-          .then(function(level) {
+          .then(function (level) {
             test.equal('off', level);
 
             // Set the profiling level to log all queries
             return adminDb.setProfilingLevel('all');
           })
-          .then(function(level) {
+          .then(function (level) {
             test.ok(level);
             // Retrieve the profiling level and verify that it's set to all
             return adminDb.profilingLevel();
           })
-          .then(function(level) {
+          .then(function (level) {
             test.equal('all', level);
 
             // Attempt to set an illegal profiling level
             return adminDb.setProfilingLevel('medium');
           })
-          .catch(function(err) {
+          .catch(function (err) {
             test.ok(err instanceof Error);
             test.equal('Error: illegal profiling level value medium', err.message);
             return client.close();
@@ -3657,11 +3654,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlySetAndExtractProfilingInfoWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3680,29 +3677,29 @@ describe('Operation (Promises)', function() {
         // Collections are not created until the first document is inserted
         return collection
           .insertOne({ a: 1 }, { w: 1 })
-          .then(function(doc) {
+          .then(function (doc) {
             test.ok(doc);
             // Use the admin database for the operation
             // Set the profiling level to all
             return db.setProfilingLevel('all');
           })
-          .then(function(level) {
+          .then(function (level) {
             test.ok(level);
             // Execute a query command
             return collection.find().toArray();
           })
-          .then(function(items) {
+          .then(function (items) {
             test.ok(items.length > 0);
 
             // Turn off profiling
             return db.setProfilingLevel('off');
           })
-          .then(function(level) {
+          .then(function (level) {
             test.ok(level);
             // Retrieve the profiling information
             return db.profilingInfo();
           })
-          .then(function(infos) {
+          .then(function (infos) {
             test.ok(infos.constructor === Array);
             test.ok(infos.length >= 1);
             test.ok(infos[0].ts.constructor === Date);
@@ -3724,11 +3721,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyCallValidateCollectionWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3747,7 +3744,7 @@ describe('Operation (Promises)', function() {
         // Collections are not created until the first document is inserted
         return collection
           .insertOne({ a: 1 }, { w: 1 })
-          .then(function(doc) {
+          .then(function (doc) {
             test.ok(doc);
             // Use the admin database for the operation
             var adminDb = db.admin();
@@ -3755,7 +3752,7 @@ describe('Operation (Promises)', function() {
             // Validate the 'test' collection
             return adminDb.validateCollection('test_with_promise');
           })
-          .then(function(doc) {
+          .then(function (doc) {
             test.ok(doc);
             return client.close();
           });
@@ -3772,11 +3769,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyPingTheMongoDbInstanceWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3792,7 +3789,7 @@ describe('Operation (Promises)', function() {
         var adminDb = db.admin();
 
         // Ping the server
-        return adminDb.ping().then(function(pingResult) {
+        return adminDb.ping().then(function (pingResult) {
           test.ok(pingResult);
           return client.close();
         });
@@ -3810,11 +3807,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyAddAUserToAdminDbWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3832,12 +3829,12 @@ describe('Operation (Promises)', function() {
         // Add the new user to the admin database
         return adminDb
           .addUser('admin11', 'admin11')
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             return adminDb.removeUser('admin11');
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             return client.close();
           });
@@ -3854,11 +3851,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyAddAUserAndRemoveItFromAdminDbWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3876,13 +3873,13 @@ describe('Operation (Promises)', function() {
         // Add the new user to the admin database
         return adminDb
           .addUser('admin12', 'admin12')
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Remove the user
             return adminDb.removeUser('admin12');
           })
-          .then(function(result) {
+          .then(function (result) {
             test.equal(true, result);
             return client.close();
           });
@@ -3900,11 +3897,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyListAllAvailableDatabasesWithPromises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3920,7 +3917,7 @@ describe('Operation (Promises)', function() {
         var adminDb = db.admin();
 
         // List all the available databases
-        return adminDb.listDatabases().then(function(dbs) {
+        return adminDb.listDatabases().then(function (dbs) {
           test.ok(dbs.databases.length > 0);
           return client.close();
         });
@@ -3938,11 +3935,11 @@ describe('Operation (Promises)', function() {
   it('shouldCorrectlyRetrieveServerInfoWithPromises', {
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -3964,22 +3961,22 @@ describe('Operation (Promises)', function() {
         // Collections are not created until the first document is inserted
         return collection
           .insertOne({ a: 1 }, { w: 1 })
-          .then(function(doc) {
+          .then(function (doc) {
             test.ok(doc);
             // Add the new user to the admin database
             return adminDb.addUser('admin13', 'admin13');
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             // Retrieve the server Info
             return adminDb.serverStatus();
           })
-          .then(function(info) {
+          .then(function (info) {
             test.ok(info != null);
 
             return adminDb.removeUser('admin13');
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
             return client.close();
           });
@@ -4005,14 +4002,14 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4030,12 +4027,12 @@ describe('Operation (Promises)', function() {
         // Insert a test document
         return collection
           .insertOne({ b: [1, 2, 3] }, configuration.writeConcernMax())
-          .then(function(ids) {
+          .then(function (ids) {
             test.ok(ids);
             // Retrieve all the documents in the collection
             return collection.find().toArray();
           })
-          .then(function(documents) {
+          .then(function (documents) {
             test.equal(1, documents.length);
             test.deepEqual([1, 2, 3], documents[0].b);
             return client.close();
@@ -4056,14 +4053,14 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4081,12 +4078,12 @@ describe('Operation (Promises)', function() {
         // Insert some docs
         return collection
           .insertMany([{ a: 1 }, { a: 2 }], configuration.writeConcernMax())
-          .then(function(docs) {
+          .then(function (docs) {
             test.ok(docs);
             // Do a find and get the cursor count
             return collection.find().count();
           })
-          .then(function(count) {
+          .then(function (count) {
             test.equal(2, count);
             return client.close();
           });
@@ -4106,14 +4103,14 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4131,12 +4128,12 @@ describe('Operation (Promises)', function() {
         // Insert some documents we can sort on
         return collection
           .insertMany([{ a: 1 }, { a: 2 }, { a: 3 }], configuration.writeConcernMax())
-          .then(function(docs) {
+          .then(function (docs) {
             test.ok(docs);
             // Do normal ascending sort
             return collection.find().next();
           })
-          .then(function(item) {
+          .then(function (item) {
             test.equal(1, item.a);
             return client.close();
           });
@@ -4156,14 +4153,14 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4181,12 +4178,12 @@ describe('Operation (Promises)', function() {
         // Insert some documents we can sort on
         return collection
           .insertMany([{ a: 1 }, { a: 2 }, { a: 3 }], configuration.writeConcernMax())
-          .then(function(docs) {
+          .then(function (docs) {
             test.ok(docs);
             // Do normal ascending sort
             return collection.find().explain();
           })
-          .then(function(explanation) {
+          .then(function (explanation) {
             test.ok(explanation);
             return client.close();
           });
@@ -4206,14 +4203,14 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4240,17 +4237,17 @@ describe('Operation (Promises)', function() {
         // Insert documents into collection
         return collection
           .insertMany(docs, configuration.writeConcernMax())
-          .then(function(ids) {
+          .then(function (ids) {
             test.ok(ids);
             // Fetch the first object
             return cursor.next();
           })
-          .then(function(object) {
+          .then(function (object) {
             test.ok(object);
             // Close the cursor, this is the same as reseting the query
             return cursor.close();
           })
-          .then(function() {
+          .then(function () {
             return client.close();
           });
       });
@@ -4272,7 +4269,7 @@ describe('Operation (Promises)', function() {
   it('Should correctly connect to a replicaset With Promises', {
     metadata: { requires: { topology: 'replicaset' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var url = f(
         'mongodb://%s,%s/%s?replicaSet=%s&readPreference=%s',
@@ -4284,7 +4281,7 @@ describe('Operation (Promises)', function() {
       );
 
       const client = configuration.newClient(url);
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4300,7 +4297,7 @@ describe('Operation (Promises)', function() {
         return db
           .collection('replicaset_mongo_client_collection_with_promise')
           .updateOne({ a: 1 }, { $set: { b: 1 } }, { upsert: true })
-          .then(function(result) {
+          .then(function (result) {
             test.equal(1, result.result.n);
             return client.close();
           });
@@ -4317,7 +4314,7 @@ describe('Operation (Promises)', function() {
   it('Should connect to mongos proxies using connectiong string With Promises', {
     metadata: { requires: { topology: 'sharded' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var url = f(
         'mongodb://%s:%s,%s:%s/sharded_test_db?w=1',
@@ -4328,7 +4325,7 @@ describe('Operation (Promises)', function() {
       );
 
       const client = configuration.newClient(url);
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4344,7 +4341,7 @@ describe('Operation (Promises)', function() {
         return db
           .collection('replicaset_mongo_client_collection_with_promise')
           .updateOne({ a: 1 }, { $set: { b: 1 } }, { upsert: true })
-          .then(function(result) {
+          .then(function (result) {
             test.equal(1, result.upsertedCount);
             return client.close();
           });
@@ -4363,7 +4360,7 @@ describe('Operation (Promises)', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: 'single' } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       const client = configuration.newClient('mongodb://localhost:27017/integration_tests', {
         native_parser: true
@@ -4371,7 +4368,7 @@ describe('Operation (Promises)', function() {
 
       // DOC_START
       // Connect using the connection string
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4385,7 +4382,7 @@ describe('Operation (Promises)', function() {
         return db
           .collection('mongoclient_test_with_promise')
           .updateOne({ a: 1 }, { $set: { b: 1 } }, { upsert: true })
-          .then(function(result) {
+          .then(function (result) {
             test.equal(1, result.result.n);
             return client.close();
           });
@@ -4409,14 +4406,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute ordered batch with no errors using write commands With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4441,7 +4438,7 @@ describe('Operation (Promises)', function() {
         batch.find({ a: 3 }).remove({ a: 3 });
 
         // Execute the operations
-        return batch.execute().then(function(result) {
+        return batch.execute().then(function (result) {
           // Check state of result
           test.equal(2, result.nInserted);
           test.equal(1, result.nUpserted);
@@ -4476,14 +4473,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute unordered batch with no errors With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4509,7 +4506,7 @@ describe('Operation (Promises)', function() {
         batch.find({ a: 3 }).remove({ a: 3 });
 
         // Execute the operations
-        return batch.execute().then(function(result) {
+        return batch.execute().then(function (result) {
           // Check state of result
           test.equal(2, result.nInserted);
           test.equal(1, result.nUpserted);
@@ -4549,14 +4546,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute insertOne operation With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4568,7 +4565,7 @@ describe('Operation (Promises)', function() {
         // BEGIN
         // Get the collection
         var col = db.collection('insert_one_with_promise');
-        return col.insertOne({ a: 1 }).then(function(r) {
+        return col.insertOne({ a: 1 }).then(function (r) {
           test.equal(1, r.insertedCount);
           // Finish up test
           return client.close();
@@ -4587,14 +4584,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute insertMany operation With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4606,7 +4603,7 @@ describe('Operation (Promises)', function() {
         // BEGIN
         // Get the collection
         var col = db.collection('insert_many_with_promise');
-        return col.insertMany([{ a: 1 }, { a: 2 }]).then(function(r) {
+        return col.insertMany([{ a: 1 }, { a: 2 }]).then(function (r) {
           test.equal(2, r.insertedCount);
           // Finish up test
           return client.close();
@@ -4625,14 +4622,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute updateOne operation With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4644,7 +4641,7 @@ describe('Operation (Promises)', function() {
         // BEGIN
         // Get the collection
         var col = db.collection('update_one_with_promise');
-        return col.updateOne({ a: 1 }, { $set: { a: 2 } }, { upsert: true }).then(function(r) {
+        return col.updateOne({ a: 1 }, { $set: { a: 2 } }, { upsert: true }).then(function (r) {
           test.equal(0, r.matchedCount);
           test.equal(1, r.upsertedCount);
           // Finish up test
@@ -4664,14 +4661,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute updateMany operation With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4685,13 +4682,13 @@ describe('Operation (Promises)', function() {
         var col = db.collection('update_many_with_promise');
         return col
           .insertMany([{ a: 1 }, { a: 1 }])
-          .then(function(r) {
+          .then(function (r) {
             test.equal(2, r.insertedCount);
 
             // Update all documents
             return col.updateMany({ a: 1 }, { $set: { b: 1 } });
           })
-          .then(function(r) {
+          .then(function (r) {
             if (r.n) {
               test.equal(2, r.n);
             } else {
@@ -4716,14 +4713,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute removeOne operation With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4737,12 +4734,12 @@ describe('Operation (Promises)', function() {
         var col = db.collection('remove_one_with_promise');
         return col
           .insertMany([{ a: 1 }, { a: 1 }])
-          .then(function(r) {
+          .then(function (r) {
             test.equal(2, r.insertedCount);
 
             return col.removeOne({ a: 1 });
           })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(1, r.deletedCount);
             // Finish up test
             return client.close();
@@ -4761,14 +4758,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute removeMany operation With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4782,13 +4779,13 @@ describe('Operation (Promises)', function() {
         var col = db.collection('remove_many_with_promise');
         return col
           .insertMany([{ a: 1 }, { a: 1 }])
-          .then(function(r) {
+          .then(function (r) {
             test.equal(2, r.insertedCount);
 
             // Update all documents
             return col.removeMany({ a: 1 });
           })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(2, r.deletedCount);
 
             // Finish up test
@@ -4808,14 +4805,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute bulkWrite operation With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4839,7 +4836,7 @@ describe('Operation (Promises)', function() {
             ],
             { ordered: true, w: 1 }
           )
-          .then(function(r) {
+          .then(function (r) {
             test.equal(1, r.nInserted);
             test.equal(2, r.nUpserted);
             test.equal(0, r.nRemoved);
@@ -4866,14 +4863,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly handle duplicate key error with bulkWrite', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // Get the collection
         var col = db.collection('bulk_write_with_promise_write_error');
@@ -4882,7 +4879,7 @@ describe('Operation (Promises)', function() {
             [{ insertOne: { document: { _id: 1 } } }, { insertOne: { document: { _id: 1 } } }],
             { ordered: true, w: 1 }
           )
-          .catch(function(err) {
+          .catch(function (err) {
             test.equal(true, err.result.hasWriteErrors());
             // Ordered bulk operation
             return client.close();
@@ -4900,14 +4897,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute findOneAndDelete operation With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4921,12 +4918,12 @@ describe('Operation (Promises)', function() {
         var col = db.collection('find_one_and_delete_with_promise');
         return col
           .insertMany([{ a: 1, b: 1 }], { w: 1 })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(1, r.result.n);
 
             return col.findOneAndDelete({ a: 1 }, { projection: { b: 1 }, sort: { a: 1 } });
           })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(1, r.lastErrorObject.n);
             test.equal(1, r.value.b);
 
@@ -4946,14 +4943,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute findOneAndReplace operation With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -4965,7 +4962,7 @@ describe('Operation (Promises)', function() {
         // BEGIN
         // Get the collection
         var col = db.collection('find_one_and_replace_with_promise');
-        return col.insertMany([{ a: 1, b: 1 }], { w: 1 }).then(function(r) {
+        return col.insertMany([{ a: 1, b: 1 }], { w: 1 }).then(function (r) {
           test.equal(1, r.result.n);
 
           return col
@@ -4979,7 +4976,7 @@ describe('Operation (Promises)', function() {
                 upsert: true
               }
             )
-            .then(function(r) {
+            .then(function (r) {
               test.equal(1, r.lastErrorObject.n);
               test.equal(1, r.value.b);
               test.equal(1, r.value.c);
@@ -5001,14 +4998,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly execute findOneAndUpdate operation With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      return client.connect().then(function(client) {
+      return client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -5022,7 +5019,7 @@ describe('Operation (Promises)', function() {
         var col = db.collection('find_one_and_update_with_promise');
         return col
           .insertMany([{ a: 1, b: 1 }], { w: 1 })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(1, r.result.n);
 
             return col.findOneAndUpdate(
@@ -5036,7 +5033,7 @@ describe('Operation (Promises)', function() {
               }
             );
           })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(1, r.lastErrorObject.n);
             test.equal(1, r.value.b);
             test.equal(1, r.value.d);
@@ -5057,14 +5054,14 @@ describe('Operation (Promises)', function() {
   it('Should correctly add capped collection options to cursor With Promises', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -5083,7 +5080,7 @@ describe('Operation (Promises)', function() {
           max: 10000,
           w: 1
         })
-          .then(function(_collection) {
+          .then(function (_collection) {
             collection = _collection;
 
             var docs = [];
@@ -5092,7 +5089,7 @@ describe('Operation (Promises)', function() {
             // Insert a document in the capped collection
             return collection.insertMany(docs, configuration.writeConcernMax());
           })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result);
 
             // Start date
@@ -5105,7 +5102,7 @@ describe('Operation (Promises)', function() {
               .addCursorFlag('tailable', true)
               .addCursorFlag('awaitData', true);
 
-            cursor.on('data', function(d) {
+            cursor.on('data', function (d) {
               test.ok(d);
               total = total + 1;
 
@@ -5114,7 +5111,7 @@ describe('Operation (Promises)', function() {
               }
             });
 
-            cursor.on('end', function() {
+            cursor.on('end', function () {
               test.ok(new Date().getTime() - s.getTime() > 1000);
 
               // TODO: forced because the cursor is still open/active
@@ -5126,8 +5123,8 @@ describe('Operation (Promises)', function() {
     }
   });
 
-  describe('Transaction Examples', function() {
-    before(function() {
+  describe('Transaction Examples', function () {
+    before(function () {
       const configuration = this.configuration;
       const client = configuration.newClient(configuration.writeConcernMax());
 
@@ -5141,7 +5138,7 @@ describe('Operation (Promises)', function() {
     // Start Transactions Intro Example 1
     it('should be able to run transactions example 1', {
       metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.8.0' } },
-      test: function() {
+      test: function () {
         const configuration = this.configuration;
         const client = configuration.newClient(configuration.writeConcernMax());
 
@@ -5202,7 +5199,7 @@ describe('Operation (Promises)', function() {
     // Start Transactions Retry Example 1
     it('should be able to run transactions retry example 1', {
       metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.8.0' } },
-      test: function() {
+      test: function () {
         // BEGIN
         function runTransactionWithRetry(txnFunc, client, session) {
           return txnFunc(client, session).catch(error => {
@@ -5263,7 +5260,7 @@ describe('Operation (Promises)', function() {
     // Start Transactions Retry Example 2
     it('should be able to run transactions retry example 2', {
       metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.8.0' } },
-      test: function() {
+      test: function () {
         // BEGIN
         function commitWithRetry(session) {
           return (
@@ -5321,7 +5318,7 @@ describe('Operation (Promises)', function() {
     // Start Transactions Retry Example 3
     it('should be able to run transactions retry example 3', {
       metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.8.0' } },
-      test: function() {
+      test: function () {
         const configuration = this.configuration;
         const client = configuration.newClient(configuration.writeConcernMax());
 

--- a/test/functional/promises_collection.test.js
+++ b/test/functional/promises_collection.test.js
@@ -3,8 +3,8 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 var f = require('util').format;
 
-describe('Promises (Collection)', function() {
-  before(function() {
+describe('Promises (Collection)', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -15,7 +15,7 @@ describe('Promises (Collection)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -24,12 +24,12 @@ describe('Promises (Collection)', function() {
           : f('%s?%s', url, 'maxPoolSize=100');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
 
         db.collection('insertOne')
           .insertOne({ a: 1 })
-          .then(function(r) {
+          .then(function (r) {
             test.equal(1, r.insertedCount);
 
             client.close(done);
@@ -45,14 +45,14 @@ describe('Promises (Collection)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -65,18 +65,18 @@ describe('Promises (Collection)', function() {
         // BEGIN
         // Get the collection
         var col = db.collection('find_one_and_delete_with_promise_no_option');
-        col.insertMany([{ a: 1, b: 1 }], { w: 1 }).then(function(r) {
+        col.insertMany([{ a: 1, b: 1 }], { w: 1 }).then(function (r) {
           test.equal(1, r.result.n);
 
           col
             .findOneAndDelete({ a: 1 })
-            .then(function(r) {
+            .then(function (r) {
               test.equal(1, r.lastErrorObject.n);
               test.equal(1, r.value.b);
 
               client.close(done);
             })
-            .catch(function(err) {
+            .catch(function (err) {
               test.ok(err != null);
             });
         });
@@ -92,14 +92,14 @@ describe('Promises (Collection)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         auto_reconnect: false
       });
 
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
         // LINE var MongoClient = require('mongodb').MongoClient,
         // LINE   test = require('assert');
@@ -112,18 +112,18 @@ describe('Promises (Collection)', function() {
         // BEGIN
         // Get the collection
         var col = db.collection('find_one_and_update_with_promise_no_option');
-        col.insertMany([{ a: 1, b: 1 }], { w: 1 }).then(function(r) {
+        col.insertMany([{ a: 1, b: 1 }], { w: 1 }).then(function (r) {
           test.equal(1, r.result.n);
 
           col
             .findOneAndUpdate({ a: 1 }, { $set: { a: 1 } })
-            .then(function(r) {
+            .then(function (r) {
               test.equal(1, r.lastErrorObject.n);
               test.equal(1, r.value.b);
 
               client.close(done);
             })
-            .catch(function(err) {
+            .catch(function (err) {
               test.ok(err != null);
             });
         });
@@ -141,14 +141,14 @@ describe('Promises (Collection)', function() {
         }
       },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
         var client = configuration.newClient(configuration.writeConcernMax(), {
           poolSize: 1,
           auto_reconnect: false
         });
 
-        client.connect().then(function(client) {
+        client.connect().then(function (client) {
           var db = client.db(configuration.db);
           // LINE var MongoClient = require('mongodb').MongoClient,
           // LINE   test = require('assert');
@@ -161,18 +161,18 @@ describe('Promises (Collection)', function() {
           // BEGIN
           // Get the collection
           var col = db.collection('find_one_and_replace_with_promise_no_option');
-          col.insertMany([{ a: 1, b: 1 }], { w: 1 }).then(function(r) {
+          col.insertMany([{ a: 1, b: 1 }], { w: 1 }).then(function (r) {
             test.equal(1, r.result.n);
 
             col
               .findOneAndReplace({ a: 1 }, { a: 1 })
-              .then(function(r) {
+              .then(function (r) {
                 test.equal(1, r.lastErrorObject.n);
                 test.equal(1, r.value.b);
 
                 client.close(done);
               })
-              .catch(function(err) {
+              .catch(function (err) {
                 test.ok(err != null);
               });
           });
@@ -189,7 +189,7 @@ describe('Promises (Collection)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
@@ -200,19 +200,19 @@ describe('Promises (Collection)', function() {
 
       client
         .connect()
-        .then(function(client) {
+        .then(function (client) {
           var db = client.db(configuration.db);
           // Get the collection
           var col = db.collection('find_one_and_replace_with_promise_no_option');
           return col.bulkWrite([{ insertOne: { document: { a: 1 } } }]);
         })
-        .then(function(r) {
+        .then(function (r) {
           result = r;
         })
-        .catch(function(err) {
+        .catch(function (err) {
           error = err;
         })
-        .then(function() {
+        .then(function () {
           test.equal(null, error);
           test.ok(result != null);
 
@@ -228,7 +228,7 @@ describe('Promises (Collection)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -237,12 +237,12 @@ describe('Promises (Collection)', function() {
           : f('%s?%s', url, 'maxPoolSize=100');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
         db.collection('insertMany_Promise_error')
           .insertMany({ a: 1 })
-          .then(function() {})
-          .catch(function(e) {
+          .then(function () {})
+          .catch(function (e) {
             test.ok(e != null);
 
             client.close(done);
@@ -258,7 +258,7 @@ describe('Promises (Collection)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -267,12 +267,12 @@ describe('Promises (Collection)', function() {
           : f('%s?%s', url, 'maxPoolSize=100');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
         db.collection('insertOne_Promise_error')
           .insertOne([{ a: 1 }])
-          .then(function() {})
-          .catch(function(e) {
+          .then(function () {})
+          .catch(function (e) {
             test.ok(e != null);
 
             client.close(done);
@@ -288,7 +288,7 @@ describe('Promises (Collection)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -297,13 +297,13 @@ describe('Promises (Collection)', function() {
           : f('%s?%s', url, 'maxPoolSize=100');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
         var bulk = db.collection('unordered_bulk_promise_form').initializeUnorderedBulkOp({ w: 1 });
         bulk.insert({ a: 1 });
         return bulk
           .execute()
-          .then(function(r) {
+          .then(function (r) {
             test.ok(r);
             test.deepEqual({ w: 1 }, bulk.s.writeConcern);
 
@@ -321,7 +321,7 @@ describe('Promises (Collection)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -330,13 +330,13 @@ describe('Promises (Collection)', function() {
           : f('%s?%s', url, 'maxPoolSize=100');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
         var bulk = db.collection('unordered_bulk_promise_form').initializeOrderedBulkOp({ w: 1 });
         bulk.insert({ a: 1 });
         return bulk
           .execute()
-          .then(function(r) {
+          .then(function (r) {
             test.ok(r);
             test.deepEqual({ w: 1 }, bulk.s.writeConcern);
 

--- a/test/functional/promises_db.test.js
+++ b/test/functional/promises_db.test.js
@@ -6,8 +6,8 @@ var f = require('util').format;
 class CustomPromise extends Promise {}
 CustomPromise.prototype.isCustomMongo = true;
 
-describe('Promises (Db)', function() {
-  before(function() {
+describe('Promises (Db)', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -18,7 +18,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function() {
+    test: function () {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -38,10 +38,10 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 1 }, { poolSize: 1 });
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         client.close(done);
       });
     }
@@ -54,7 +54,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -63,12 +63,12 @@ describe('Promises (Db)', function() {
           : f('%s?%s', url, 'maxPoolSize=5');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         // Execute ismaster
         client
           .db(configuration.db)
           .command({ ismaster: true })
-          .then(function(result) {
+          .then(function (result) {
             test.ok(result !== null);
 
             client.close(done);
@@ -84,7 +84,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -93,15 +93,15 @@ describe('Promises (Db)', function() {
           : f('%s?%s', url, 'maxPoolSize=5');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         // Execute ismaster
         client
           .db(configuration.db)
           .command({ nosuchcommand: true })
-          .then(function() {})
-          .catch(function() {
+          .then(function () {})
+          .catch(function () {
             // Execute close using promise
-            client.close().then(function() {
+            client.close().then(function () {
               done();
             });
           });
@@ -116,7 +116,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -125,16 +125,16 @@ describe('Promises (Db)', function() {
           : f('%s?%s', url, 'maxPoolSize=5');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         client
           .db(configuration.db)
           .createCollection('promiseCollection')
-          .then(function(col) {
+          .then(function (col) {
             test.ok(col != null);
 
             client.close(done);
           })
-          .catch(function(err) {
+          .catch(function (err) {
             test.ok(err != null);
           });
       });
@@ -148,7 +148,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -157,11 +157,11 @@ describe('Promises (Db)', function() {
           : f('%s?%s', url, 'maxPoolSize=5');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         client
           .db(configuration.db)
           .stats()
-          .then(function(stats) {
+          .then(function (stats) {
             test.ok(stats != null);
 
             client.close(done);
@@ -177,7 +177,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -186,17 +186,17 @@ describe('Promises (Db)', function() {
           : f('%s?%s', url, 'maxPoolSize=5');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
 
-        db.createCollection('promiseCollection1').then(function(col) {
+        db.createCollection('promiseCollection1').then(function (col) {
           test.ok(col != null);
           var db = client.db(configuration.db);
 
-          db.renameCollection('promiseCollection1', 'promiseCollection2').then(function(col) {
+          db.renameCollection('promiseCollection1', 'promiseCollection2').then(function (col) {
             test.ok(col != null);
 
-            db.dropCollection('promiseCollection2').then(function(r) {
+            db.dropCollection('promiseCollection2').then(function (r) {
               test.ok(r);
 
               client.close(done);
@@ -214,7 +214,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -223,16 +223,16 @@ describe('Promises (Db)', function() {
           : f('%s?%s', url, 'maxPoolSize=5');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         client
           .db(configuration.db)
           .dropDatabase()
-          .then(function(r) {
+          .then(function (r) {
             test.ok(r);
 
             client.close(done);
           })
-          .catch(function(e) {
+          .catch(function (e) {
             test.ok(e != null);
           });
       });
@@ -246,7 +246,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -255,16 +255,16 @@ describe('Promises (Db)', function() {
           : f('%s?%s', url, 'maxPoolSize=5');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         var db = client.db(configuration.db);
 
-        db.createCollection('promiseCollectionCollections1').then(function(col) {
+        db.createCollection('promiseCollectionCollections1').then(function (col) {
           test.ok(col != null);
 
-          db.createCollection('promiseCollectionCollections2').then(function(col) {
+          db.createCollection('promiseCollectionCollections2').then(function (col) {
             test.ok(col != null);
 
-            db.collections().then(function(r) {
+            db.collections().then(function (r) {
               test.ok(Array.isArray(r));
 
               client.close(done);
@@ -282,7 +282,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -291,11 +291,11 @@ describe('Promises (Db)', function() {
           : f('%s?%s', url, 'maxPoolSize=5');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         client
           .db(configuration.db)
           .executeDbAdminCommand({ ismaster: true })
-          .then(function(r) {
+          .then(function (r) {
             test.ok(r);
 
             client.close(done);
@@ -311,7 +311,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -320,12 +320,12 @@ describe('Promises (Db)', function() {
           : f('%s?%s', url, 'maxPoolSize=5');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         // Create an index
         client
           .db(configuration.db)
           .createIndex('promiseCollectionCollections1', { a: 1 })
-          .then(function(r) {
+          .then(function (r) {
             test.ok(r != null);
 
             client.close(done);
@@ -341,7 +341,7 @@ describe('Promises (Db)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var url = configuration.url();
       url =
@@ -350,12 +350,12 @@ describe('Promises (Db)', function() {
           : f('%s?%s', url, 'maxPoolSize=5');
 
       const client = configuration.newClient(url);
-      client.connect().then(function(client) {
+      client.connect().then(function (client) {
         // Create an index
         client
           .db(configuration.db)
           .ensureIndex('promiseCollectionCollections2', { a: 1 })
-          .then(function(r) {
+          .then(function (r) {
             test.ok(r != null);
 
             client.close(done);

--- a/test/functional/promote_buffers.test.js
+++ b/test/functional/promote_buffers.test.js
@@ -2,8 +2,8 @@
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 
-describe('Promote Buffers', function() {
-  before(function() {
+describe('Promote Buffers', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -14,23 +14,23 @@ describe('Promote Buffers', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         promoteBuffers: true
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteBuffer1').insert(
           {
             doc: Buffer.alloc(256)
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
-            db.collection('shouldCorrectlyHonorPromoteBuffer1').findOne(function(err, doc) {
+            db.collection('shouldCorrectlyHonorPromoteBuffer1').findOne(function (err, doc) {
               test.equal(null, err);
               test.ok(doc.doc instanceof Buffer);
 
@@ -49,21 +49,21 @@ describe('Promote Buffers', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       const client = configuration.newClient({}, { promoteBuffers: true });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         db.collection('shouldCorrectlyHonorPromoteBuffer2').insert(
           {
             doc: Buffer.alloc(256)
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
-            db.collection('shouldCorrectlyHonorPromoteBuffer2').findOne(function(err, doc) {
+            db.collection('shouldCorrectlyHonorPromoteBuffer2').findOne(function (err, doc) {
               test.equal(null, err);
               test.ok(doc.doc instanceof Buffer);
 
@@ -82,23 +82,23 @@ describe('Promote Buffers', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       const client = configuration.newClient({}, { promoteBuffers: true });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         db.collection('shouldCorrectlyHonorPromoteBuffer3').insert(
           {
             doc: Buffer.alloc(256)
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
             db.collection('shouldCorrectlyHonorPromoteBuffer3')
               .find()
-              .next(function(err, doc) {
+              .next(function (err, doc) {
                 test.equal(null, err);
                 test.ok(doc.doc instanceof Buffer);
 
@@ -117,22 +117,22 @@ describe('Promote Buffers', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       const client = configuration.newClient();
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteBuffer4').insert(
           {
             doc: Buffer.alloc(256)
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
             db.collection('shouldCorrectlyHonorPromoteBuffer4')
               .find({}, { promoteBuffers: true })
-              .next(function(err, doc) {
+              .next(function (err, doc) {
                 test.equal(null, err);
                 test.ok(doc.doc instanceof Buffer);
 
@@ -154,22 +154,22 @@ describe('Promote Buffers', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
 
       const client = configuration.newClient();
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteBuffer5').insert(
           {
             doc: Buffer.alloc(256)
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
             db.collection('shouldCorrectlyHonorPromoteBuffer5')
               .aggregate([{ $match: {} }], { promoteBuffers: true })
-              .next(function(err, doc) {
+              .next(function (err, doc) {
                 test.equal(null, err);
                 test.ok(doc.doc instanceof Buffer);
 

--- a/test/functional/promote_values.test.js
+++ b/test/functional/promote_values.test.js
@@ -3,8 +3,8 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const { Long, Int32, Double } = require('../../src');
 
-describe('Promote Values', function() {
-  before(function() {
+describe('Promote Values', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -15,14 +15,14 @@ describe('Promote Values', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         promoteValues: false
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
 
         db.collection('shouldCorrectlyHonorPromoteValues').insert(
@@ -32,10 +32,10 @@ describe('Promote Values', function() {
             double: 2.2222,
             array: [[Long.fromNumber(10)]]
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
-            db.collection('shouldCorrectlyHonorPromoteValues').findOne(function(err, doc) {
+            db.collection('shouldCorrectlyHonorPromoteValues').findOne(function (err, doc) {
               test.equal(null, err);
 
               test.deepEqual(Long.fromNumber(10), doc.doc);
@@ -57,10 +57,10 @@ describe('Promote Values', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient({}, { promoteValues: false });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteValues').insert(
           {
@@ -69,10 +69,10 @@ describe('Promote Values', function() {
             double: 2.2222,
             array: [[Long.fromNumber(10)]]
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
-            db.collection('shouldCorrectlyHonorPromoteValues').findOne(function(err, doc) {
+            db.collection('shouldCorrectlyHonorPromoteValues').findOne(function (err, doc) {
               test.equal(null, err);
 
               test.deepEqual(Long.fromNumber(10), doc.doc);
@@ -94,10 +94,10 @@ describe('Promote Values', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient({}, { promoteValues: false });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteValues').insert(
           {
@@ -106,12 +106,12 @@ describe('Promote Values', function() {
             double: 2.2222,
             array: [[Long.fromNumber(10)]]
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
             db.collection('shouldCorrectlyHonorPromoteValues')
               .find()
-              .next(function(err, doc) {
+              .next(function (err, doc) {
                 test.equal(null, err);
 
                 test.deepEqual(Long.fromNumber(10), doc.doc);
@@ -133,10 +133,10 @@ describe('Promote Values', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient();
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteValues').insert(
           {
@@ -145,12 +145,12 @@ describe('Promote Values', function() {
             double: 2.2222,
             array: [[Long.fromNumber(10)]]
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
             db.collection('shouldCorrectlyHonorPromoteValues')
               .find({}, { promoteValues: false })
-              .next(function(err, doc) {
+              .next(function (err, doc) {
                 test.equal(null, err);
 
                 test.deepEqual(Long.fromNumber(10), doc.doc);
@@ -172,10 +172,10 @@ describe('Promote Values', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient();
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         db.collection('shouldCorrectlyHonorPromoteValues2').insert(
           {
@@ -184,12 +184,12 @@ describe('Promote Values', function() {
             double: 2.2222,
             array: [[Long.fromNumber(10)]]
           },
-          function(err) {
+          function (err) {
             test.equal(null, err);
 
             db.collection('shouldCorrectlyHonorPromoteValues2')
               .aggregate([{ $match: {} }], { promoteValues: false })
-              .next(function(err, doc) {
+              .next(function (err, doc) {
                 test.equal(null, err);
 
                 test.deepEqual(Long.fromNumber(10), doc.doc);
@@ -211,11 +211,11 @@ describe('Promote Values', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient();
-      client.connect(function(err, client) {
-        var docs = new Array(150).fill(0).map(function(_, i) {
+      client.connect(function (err, client) {
+        var docs = new Array(150).fill(0).map(function (_, i) {
           return {
             _id: 'needle_' + i,
             is_even: i % 2,
@@ -227,14 +227,14 @@ describe('Promote Values', function() {
 
         var db = client.db(configuration.db);
 
-        db.collection('haystack').insert(docs, function(errInsert) {
+        db.collection('haystack').insert(docs, function (errInsert) {
           if (errInsert) throw errInsert;
           // change limit from 102 to 101 and this test passes.
           // seems to indicate that the promoteValues flag is used for the
           // initial find, but not for subsequent getMores
           db.collection('haystack')
             .find({}, { limit: 102, promoteValues: false })
-            .on('data', function(doc) {
+            .on('data', function (doc) {
               test.equal(typeof doc.int, 'object');
               test.equal(doc.int._bsontype, 'Int32');
               test.equal(typeof doc.long, 'object');
@@ -242,8 +242,8 @@ describe('Promote Values', function() {
               test.equal(typeof doc.double, 'object');
               test.equal(doc.double._bsontype, 'Double');
             })
-            .on('end', function() {
-              db.dropCollection('haystack', function() {
+            .on('end', function () {
+              db.dropCollection('haystack', function () {
                 client.close(done);
               });
             });

--- a/test/functional/raw.test.js
+++ b/test/functional/raw.test.js
@@ -4,8 +4,8 @@ const { Buffer } = require('buffer');
 
 const BSON = require('bson');
 
-describe('Raw', function() {
-  before(function() {
+describe('Raw', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -14,21 +14,21 @@ describe('Raw', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('shouldCorrectlySaveDocumentsAndReturnAsRaw', function(
+        db.createCollection('shouldCorrectlySaveDocumentsAndReturnAsRaw', function (
           err,
           collection
         ) {
           test.equal(null, err);
           // Insert some documents
-          collection.insert([{ a: 1 }, { b: 2000 }, { c: 2.3 }], { w: 1 }, function(err) {
+          collection.insert([{ a: 1 }, { b: 2000 }, { c: 2.3 }], { w: 1 }, function (err) {
             test.equal(null, err);
             // You have to pass at least query + fields before passing options
-            collection.find({}, { raw: true, batchSize: 2 }).toArray(function(err, items) {
+            collection.find({}, { raw: true, batchSize: 2 }).toArray(function (err, items) {
               var objects = [];
 
               for (var i = 0; i < items.length; i++) {
@@ -41,7 +41,7 @@ describe('Raw', function() {
               test.equal(2.3, objects[2].c);
 
               // Execute findOne
-              collection.findOne({ a: 1 }, { raw: true }, function(err, item) {
+              collection.findOne({ a: 1 }, { raw: true }, function (err, item) {
                 test.ok(Buffer.isBuffer(item));
                 var object = BSON.deserialize(item);
                 test.equal(1, object.a);
@@ -59,40 +59,41 @@ describe('Raw', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('shouldCorrectlySaveDocumentsAndReturnAsRaw_2', { raw: true }, function(
-          err,
-          collection
-        ) {
-          // Insert some documents
-          collection.insert([{ a: 1 }, { b: 2000 }, { c: 2.3 }], { w: 1 }, function(err) {
-            test.equal(null, err);
+        db.createCollection(
+          'shouldCorrectlySaveDocumentsAndReturnAsRaw_2',
+          { raw: true },
+          function (err, collection) {
+            // Insert some documents
+            collection.insert([{ a: 1 }, { b: 2000 }, { c: 2.3 }], { w: 1 }, function (err) {
+              test.equal(null, err);
 
-            collection.find({}, { batchSize: 2 }).toArray(function(err, items) {
-              var objects = [];
-              for (var i = 0; i < items.length; i++) {
-                test.ok(Buffer.isBuffer(items[i]));
-                objects.push(BSON.deserialize(items[i]));
-              }
+              collection.find({}, { batchSize: 2 }).toArray(function (err, items) {
+                var objects = [];
+                for (var i = 0; i < items.length; i++) {
+                  test.ok(Buffer.isBuffer(items[i]));
+                  objects.push(BSON.deserialize(items[i]));
+                }
 
-              test.equal(1, objects[0].a);
-              test.equal(2000, objects[1].b);
-              test.equal(2.3, objects[2].c);
+                test.equal(1, objects[0].a);
+                test.equal(2000, objects[1].b);
+                test.equal(2.3, objects[2].c);
 
-              // Execute findOne
-              collection.findOne({ a: 1 }, { raw: true }, function(err, item) {
-                test.ok(Buffer.isBuffer(item));
-                var object = BSON.deserialize(item);
-                test.equal(1, object.a);
-                client.close(done);
+                // Execute findOne
+                collection.findOne({ a: 1 }, { raw: true }, function (err, item) {
+                  test.ok(Buffer.isBuffer(item));
+                  var object = BSON.deserialize(item);
+                  test.equal(1, object.a);
+                  client.close(done);
+                });
               });
             });
-          });
-        });
+          }
+        );
       });
     }
   });

--- a/test/functional/readconcern.test.js
+++ b/test/functional/readconcern.test.js
@@ -3,10 +3,10 @@ const setupDatabase = require('./shared').setupDatabase;
 const filterForCommands = require('./shared').filterForCommands;
 const expect = require('chai').expect;
 
-describe('ReadConcern', function() {
+describe('ReadConcern', function () {
   let client;
 
-  before(function() {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -57,7 +57,7 @@ describe('ReadConcern', function() {
     it(test.description, {
       metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2' } },
 
-      test: function(done) {
+      test: function (done) {
         const started = [];
         const succeeded = [];
         // Get a new instance
@@ -102,7 +102,7 @@ describe('ReadConcern', function() {
     });
   });
 
-  describe('client-url specific ReadConcern', function() {
+  describe('client-url specific ReadConcern', function () {
     const urlTests = [
       {
         description: 'Should set local readConcern using MongoClient',
@@ -123,7 +123,7 @@ describe('ReadConcern', function() {
     urlTests.forEach(test => {
       it(test.description, {
         metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2' } },
-        test: function(done) {
+        test: function (done) {
           const started = [];
           const succeeded = [];
           // Get a new instance
@@ -196,7 +196,7 @@ describe('ReadConcern', function() {
     it(test.description, {
       metadata: { requires: { topology: 'replicaset', mongodb: test.mongodbVersion } },
 
-      test: function(done) {
+      test: function (done) {
         const started = [];
         const succeeded = [];
         // Get a new instance
@@ -274,7 +274,7 @@ describe('ReadConcern', function() {
   it('Should set majority readConcern aggregate command but ignore due to out', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2 < 4.1' } },
 
-    test: function(done) {
+    test: function (done) {
       const started = [];
       const succeeded = [];
       // Get a new instance
@@ -322,7 +322,7 @@ describe('ReadConcern', function() {
   it('Should set majority readConcern aggregate command against server >= 4.1', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>= 4.1' } },
 
-    test: function(done) {
+    test: function (done) {
       const started = [];
       const succeeded = [];
       // Get a new instance
@@ -370,7 +370,7 @@ describe('ReadConcern', function() {
   it('Should set majority readConcern mapReduce command but be ignored', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2' } },
 
-    test: function(done) {
+    test: function (done) {
       const started = [];
       const succeeded = [];
       // Get a new instance
@@ -415,7 +415,7 @@ describe('ReadConcern', function() {
   it('Should set local readConcern on db level when using createCollection method', {
     metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2' } },
 
-    test: function(done) {
+    test: function (done) {
       // Get a new instance
       const configuration = this.configuration;
       client = configuration.newClient({ w: 1 }, { poolSize: 1, readConcern: { level: 'local' } });

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -6,27 +6,27 @@ const withMonitoredClient = require('./shared').withMonitoredClient;
 const expect = require('chai').expect;
 const { ReadPreference } = require('../../src');
 
-describe('ReadPreference', function() {
-  before(function() {
+describe('ReadPreference', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
-  describe('::constructor', function() {
+  describe('::constructor', function () {
     const maxStalenessSeconds = 1234;
     const { PRIMARY, SECONDARY, NEAREST } = ReadPreference;
     const TAGS = [{ loc: 'dc' }];
 
-    it('should accept (mode)', function() {
+    it('should accept (mode)', function () {
       expect(new ReadPreference(PRIMARY)).to.be.an.instanceOf(ReadPreference);
     });
 
-    it('should accept valid (mode, tags)', function() {
+    it('should accept valid (mode, tags)', function () {
       expect(new ReadPreference(PRIMARY, [])).to.be.an.instanceOf(ReadPreference);
       const p0 = new ReadPreference(NEAREST, TAGS);
       expect(p0.mode).to.equal(NEAREST);
     });
 
-    it('should not accept invalid tags', function() {
+    it('should not accept invalid tags', function () {
       expect(() => new ReadPreference(PRIMARY, 'invalid')).to.throw(
         'ReadPreference tags must be an array'
       );
@@ -35,32 +35,32 @@ describe('ReadPreference', function() {
       );
     });
 
-    it('should accept (mode, options)', function() {
+    it('should accept (mode, options)', function () {
       const p1 = new ReadPreference(SECONDARY, { maxStalenessSeconds });
       expect(p1.mode).to.equal(SECONDARY);
       expect(p1.maxStalenessSeconds).to.equal(maxStalenessSeconds);
     });
 
-    it('should not accept mode=primary + tags', function() {
+    it('should not accept mode=primary + tags', function () {
       expect(() => new ReadPreference(PRIMARY, TAGS)).to.throw(
         'Primary read preference cannot be combined with tags'
       );
     });
 
-    it('should not accept mode=primary + options.maxStalenessSeconds', function() {
+    it('should not accept mode=primary + options.maxStalenessSeconds', function () {
       expect(() => new ReadPreference(PRIMARY, null, { maxStalenessSeconds })).to.throw(
         'Primary read preference cannot be combined with maxStalenessSeconds'
       );
     });
 
-    it('should accept (mode=secondary, tags=null, options)', function() {
+    it('should accept (mode=secondary, tags=null, options)', function () {
       const p2 = new ReadPreference(SECONDARY, null, { maxStalenessSeconds });
       expect(p2).to.be.an.instanceOf(ReadPreference);
       expect(p2.mode).to.equal(SECONDARY);
       expect(p2.maxStalenessSeconds).to.equal(maxStalenessSeconds);
     });
 
-    it('should accept (mode=secondary, tags, options)', function() {
+    it('should accept (mode=secondary, tags, options)', function () {
       const p3 = new ReadPreference(SECONDARY, TAGS, { maxStalenessSeconds });
       expect(p3).to.be.an.instanceOf(ReadPreference);
       expect(p3.mode).to.equal(SECONDARY);
@@ -68,7 +68,7 @@ describe('ReadPreference', function() {
       expect(p3.maxStalenessSeconds).to.equal(maxStalenessSeconds);
     });
 
-    it('should not accept (mode, options, tags)', function() {
+    it('should not accept (mode, options, tags)', function () {
       expect(() => new ReadPreference(PRIMARY, { maxStalenessSeconds }, TAGS)).to.throw(
         'ReadPreference tags must be an array'
       );
@@ -78,10 +78,10 @@ describe('ReadPreference', function() {
   it('Should correctly apply collection level read Preference to count', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         expect(err).to.not.exist;
         // Set read preference
@@ -91,7 +91,7 @@ describe('ReadPreference', function() {
         // Save checkout function
         var command = client.topology.command;
         // Set up our checker method
-        client.topology.command = function() {
+        client.topology.command = function () {
           var args = Array.prototype.slice.call(arguments, 0);
           if (args[0] === 'integration_tests.$cmd') {
             test.equal(ReadPreference.SECONDARY_PREFERRED, args[2].readPreference.mode);
@@ -101,7 +101,7 @@ describe('ReadPreference', function() {
         };
 
         // Execute count
-        collection.count(function(err) {
+        collection.count(function (err) {
           expect(err).to.not.exist;
           client.topology.command = command;
 
@@ -114,10 +114,10 @@ describe('ReadPreference', function() {
   it('Should correctly apply collection level read Preference to group', {
     metadata: { requires: { mongodb: '>=2.6.0,<=4.0.x', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         expect(err).to.not.exist;
         // Set read preference
@@ -128,7 +128,7 @@ describe('ReadPreference', function() {
         // Save checkout function
         var command = client.topology.command;
         // Set up our checker method
-        client.topology.command = function() {
+        client.topology.command = function () {
           var args = Array.prototype.slice.call(arguments, 0);
           if (args[0] === 'integration_tests.$cmd') {
             test.equal(ReadPreference.SECONDARY_PREFERRED, args[2].readPreference.mode);
@@ -138,7 +138,7 @@ describe('ReadPreference', function() {
         };
 
         // Execute count
-        collection.group([], {}, { count: 0 }, 'function (obj, prev) { prev.count++; }', function(
+        collection.group([], {}, { count: 0 }, 'function (obj, prev) { prev.count++; }', function (
           err
         ) {
           expect(err).to.not.exist;
@@ -153,10 +153,10 @@ describe('ReadPreference', function() {
   it('Should correctly apply collection level read Preference to mapReduce', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         expect(err).to.not.exist;
         // Set read preference
@@ -166,7 +166,7 @@ describe('ReadPreference', function() {
         // Save checkout function
         var command = client.topology.command;
         // Set up our checker method
-        client.topology.command = function() {
+        client.topology.command = function () {
           var args = Array.prototype.slice.call(arguments, 0);
           if (args[0] === 'integration_tests.$cmd') {
             test.equal(ReadPreference.SECONDARY_PREFERRED, args[2].readPreference.mode);
@@ -176,16 +176,16 @@ describe('ReadPreference', function() {
         };
 
         // Map function
-        var map = function() {
+        var map = function () {
           emit(this.user_id, 1); // eslint-disable-line
         };
         // Reduce function
-        var reduce = function(/* k, vals */) {
+        var reduce = function (/* k, vals */) {
           return 1;
         };
 
         // Perform the map reduce
-        collection.mapReduce(map, reduce, { out: { inline: 1 } }, function(/* err */) {
+        collection.mapReduce(map, reduce, { out: { inline: 1 } }, function (/* err */) {
           // expect(err).to.not.exist;
 
           // eslint-disable-line
@@ -202,10 +202,10 @@ describe('ReadPreference', function() {
     {
       metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-      test: function(done) {
+      test: function (done) {
         var configuration = this.configuration;
         var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           var db = client.db(configuration.db);
           expect(err).to.not.exist;
           // Set read preference
@@ -215,7 +215,7 @@ describe('ReadPreference', function() {
           // Save checkout function
           var command = client.topology.command;
           // Set up our checker method
-          client.topology.command = function() {
+          client.topology.command = function () {
             var args = Array.prototype.slice.call(arguments, 0);
             if (args[0] === 'integration_tests.$cmd') {
               test.equal(ReadPreference.SECONDARY_PREFERRED, args[2].readPreference.mode);
@@ -225,17 +225,17 @@ describe('ReadPreference', function() {
           };
 
           // Map function
-          var map = function() {
+          var map = function () {
             emit(this.user_id, 1); // eslint-disable-line
           };
 
           // Reduce function
-          var reduce = function(/* k, vals */) {
+          var reduce = function (/* k, vals */) {
             return 1;
           };
 
           // Perform the map reduce
-          collection.mapReduce(map, reduce, { out: 'inline' }, function(/* err */) {
+          collection.mapReduce(map, reduce, { out: 'inline' }, function (/* err */) {
             // expect(err).to.not.exist;
             client.topology.command = command;
             client.close(done);
@@ -248,10 +248,10 @@ describe('ReadPreference', function() {
   it('Should fail due to not using mapReduce inline with read preference', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         expect(err).to.not.exist;
         // Set read preference
@@ -259,17 +259,17 @@ describe('ReadPreference', function() {
           readPreference: ReadPreference.SECONDARY_PREFERRED
         });
         // Map function
-        var map = function() {
+        var map = function () {
           emit(this.user_id, 1); // eslint-disable-line
         };
 
         // Reduce function
-        var reduce = function(/* k, vals */) {
+        var reduce = function (/* k, vals */) {
           return 1;
         };
 
         // Perform the map reduce
-        collection.mapReduce(map, reduce, { out: { append: 'test' } }, function(err) {
+        collection.mapReduce(map, reduce, { out: { append: 'test' } }, function (err) {
           test.notEqual(err, null);
           client.close(done);
         });
@@ -280,10 +280,10 @@ describe('ReadPreference', function() {
   it('Should correctly apply collection level read Preference to aggregate', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         expect(err).to.not.exist;
         // Set read preference
@@ -293,7 +293,7 @@ describe('ReadPreference', function() {
         // Save checkout function
         var command = client.topology.command;
         // Set up our checker method
-        client.topology.command = function() {
+        client.topology.command = function () {
           var args = Array.prototype.slice.call(arguments, 0);
           if (args[0] === 'integration_tests.$cmd') {
             test.equal(ReadPreference.SECONDARY_PREFERRED, args[2].readPreference.mode);
@@ -318,7 +318,7 @@ describe('ReadPreference', function() {
           }
         ]);
 
-        cursor.toArray(function(err) {
+        cursor.toArray(function (err) {
           test.equal(null, err);
           client.topology.command = command;
 
@@ -331,10 +331,10 @@ describe('ReadPreference', function() {
   it('Should correctly apply collection level read Preference to stats', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         expect(err).to.not.exist;
         // Set read preference
@@ -344,7 +344,7 @@ describe('ReadPreference', function() {
         // Save checkout function
         var command = client.topology.command;
         // Set up our checker method
-        client.topology.command = function() {
+        client.topology.command = function () {
           var args = Array.prototype.slice.call(arguments, 0);
           if (args[0] === 'integration_tests.$cmd') {
             test.equal(ReadPreference.SECONDARY_PREFERRED, args[2].readPreference.mode);
@@ -354,7 +354,7 @@ describe('ReadPreference', function() {
         };
 
         // Perform the map reduce
-        collection.stats(function(/* err */) {
+        collection.stats(function (/* err */) {
           // expect(err).to.not.exist;
           client.topology.command = command;
           client.close(done);
@@ -366,15 +366,15 @@ describe('ReadPreference', function() {
   it('Should correctly honor the readPreferences at DB and individual command level', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient({ w: 1, readPreference: 'secondary' }, { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         // Save checkout function
         var command = client.topology.command;
         // Set up our checker method
-        client.topology.command = function() {
+        client.topology.command = function () {
           var args = Array.prototype.slice.call(arguments, 0);
           if (args[0] === 'integration_tests.$cmd') {
             test.equal(ReadPreference.SECONDARY, args[2].readPreference.mode);
@@ -383,10 +383,10 @@ describe('ReadPreference', function() {
           return command.apply(db.serverConfig, args);
         };
 
-        db.command({ dbStats: true }, function(err) {
+        db.command({ dbStats: true }, function (err) {
           expect(err).to.not.exist;
 
-          client.topology.command = function() {
+          client.topology.command = function () {
             var args = Array.prototype.slice.call(arguments, 0);
             if (args[0] === 'integration_tests.$cmd') {
               test.equal(ReadPreference.SECONDARY_PREFERRED, args[2].readPreference.mode);
@@ -395,7 +395,7 @@ describe('ReadPreference', function() {
             return command.apply(db.serverConfig, args);
           };
 
-          db.command({ dbStats: true }, { readPreference: 'secondaryPreferred' }, function(err) {
+          db.command({ dbStats: true }, { readPreference: 'secondaryPreferred' }, function (err) {
             expect(err).to.not.exist;
             client.topology.command = command;
             client.close(done);
@@ -408,15 +408,15 @@ describe('ReadPreference', function() {
   it('Should correctly apply readPreferences specified as objects', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         expect(err).to.not.exist;
         // Create read preference object.
         var mySecondaryPreferred = { mode: 'secondaryPreferred', tags: [] };
-        db.command({ dbStats: true }, { readPreference: mySecondaryPreferred }, function(err) {
+        db.command({ dbStats: true }, { readPreference: mySecondaryPreferred }, function (err) {
           expect(err).to.not.exist;
           client.close(done);
         });
@@ -427,15 +427,15 @@ describe('ReadPreference', function() {
   it('Should correctly pass readPreferences specified as objects to cursors', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         expect(err).to.not.exist;
         // Create read preference object.
         var mySecondaryPreferred = { mode: 'secondaryPreferred', tags: [] };
-        db.listCollections({}, { readPreference: mySecondaryPreferred }).toArray(function(err) {
+        db.listCollections({}, { readPreference: mySecondaryPreferred }).toArray(function (err) {
           expect(err).to.not.exist;
           client.close(done);
         });
@@ -446,16 +446,16 @@ describe('ReadPreference', function() {
   it('Should correctly pass readPreferences specified as objects to collection methods', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         expect(err).to.not.exist;
         // Create read preference object.
         var mySecondaryPreferred = { mode: 'secondaryPreferred', tags: [] };
         var cursor = db.collection('test').find({}, { readPreference: mySecondaryPreferred });
-        cursor.toArray(function(err) {
+        cursor.toArray(function (err) {
           expect(err).to.not.exist;
           client.close(done);
         });
@@ -466,10 +466,10 @@ describe('ReadPreference', function() {
   it('Should correctly pass readPreferences on the Collection to listIndexes', {
     metadata: { requires: { mongodb: '>=2.6.0', topology: ['single', 'ssl'] } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         test.equal(null, err);
         var cursor = db
@@ -481,7 +481,7 @@ describe('ReadPreference', function() {
     }
   });
 
-  it('Should throw an error on an invalid readPreference', function(done) {
+  it('Should throw an error on an invalid readPreference', function (done) {
     const configuration = this.configuration;
 
     const client = configuration.newClient();
@@ -495,10 +495,10 @@ describe('ReadPreference', function() {
     });
   });
 
-  context('hedge', function() {
+  context('hedge', function () {
     it('should set hedge using [find option & empty hedge]', {
       metadata: { requires: { mongodb: '>=3.6.0' } },
-      test: withMonitoredClient(['find'], function(client, events, done) {
+      test: withMonitoredClient(['find'], function (client, events, done) {
         const rp = new ReadPreference(ReadPreference.SECONDARY, null, { hedge: {} });
         client
           .db(this.configuration.db)
@@ -507,9 +507,7 @@ describe('ReadPreference', function() {
           .toArray(err => {
             expect(err).to.not.exist;
             const expected = { mode: ReadPreference.SECONDARY, hedge: {} };
-            expect(events[0])
-              .nested.property('command.$readPreference')
-              .to.deep.equal(expected);
+            expect(events[0]).nested.property('command.$readPreference').to.deep.equal(expected);
             done();
           });
       })
@@ -517,7 +515,7 @@ describe('ReadPreference', function() {
 
     it('should set hedge using [.setReadPreference & empty hedge] ', {
       metadata: { requires: { mongodb: '>=3.6.0' } },
-      test: withMonitoredClient(['find'], function(client, events, done) {
+      test: withMonitoredClient(['find'], function (client, events, done) {
         const rp = new ReadPreference(ReadPreference.SECONDARY, null, { hedge: {} });
         client
           .db(this.configuration.db)
@@ -527,9 +525,7 @@ describe('ReadPreference', function() {
           .toArray(err => {
             expect(err).to.not.exist;
             const expected = { mode: ReadPreference.SECONDARY, hedge: {} };
-            expect(events[0])
-              .nested.property('command.$readPreference')
-              .to.deep.equal(expected);
+            expect(events[0]).nested.property('command.$readPreference').to.deep.equal(expected);
             done();
           });
       })
@@ -537,7 +533,7 @@ describe('ReadPreference', function() {
 
     it('should set hedge using [.setReadPreference & enabled hedge] ', {
       metadata: { requires: { mongodb: '>=3.6.0' } },
-      test: withMonitoredClient(['find'], function(client, events, done) {
+      test: withMonitoredClient(['find'], function (client, events, done) {
         const rp = new ReadPreference(ReadPreference.SECONDARY, null, { hedge: { enabled: true } });
         client
           .db(this.configuration.db)
@@ -547,9 +543,7 @@ describe('ReadPreference', function() {
           .toArray(err => {
             expect(err).to.not.exist;
             const expected = { mode: ReadPreference.SECONDARY, hedge: { enabled: true } };
-            expect(events[0])
-              .nested.property('command.$readPreference')
-              .to.deep.equal(expected);
+            expect(events[0]).nested.property('command.$readPreference').to.deep.equal(expected);
             done();
           });
       })
@@ -557,7 +551,7 @@ describe('ReadPreference', function() {
 
     it('should set hedge using [.setReadPreference & disabled hedge] ', {
       metadata: { requires: { mongodb: '>=3.6.0' } },
-      test: withMonitoredClient(['find'], function(client, events, done) {
+      test: withMonitoredClient(['find'], function (client, events, done) {
         const rp = new ReadPreference(ReadPreference.SECONDARY, null, {
           hedge: { enabled: false }
         });
@@ -569,9 +563,7 @@ describe('ReadPreference', function() {
           .toArray(err => {
             expect(err).to.not.exist;
             const expected = { mode: ReadPreference.SECONDARY, hedge: { enabled: false } };
-            expect(events[0])
-              .nested.property('command.$readPreference')
-              .to.deep.equal(expected);
+            expect(events[0]).nested.property('command.$readPreference').to.deep.equal(expected);
             done();
           });
       })
@@ -579,7 +571,7 @@ describe('ReadPreference', function() {
 
     it('should set hedge using [.setReadPreference & undefined hedge] ', {
       metadata: { requires: { mongodb: '>=3.6.0' } },
-      test: withMonitoredClient(['find'], function(client, events, done) {
+      test: withMonitoredClient(['find'], function (client, events, done) {
         const rp = new ReadPreference(ReadPreference.SECONDARY, null);
         client
           .db(this.configuration.db)
@@ -589,9 +581,7 @@ describe('ReadPreference', function() {
           .toArray(err => {
             expect(err).to.not.exist;
             const expected = { mode: ReadPreference.SECONDARY };
-            expect(events[0])
-              .nested.property('command.$readPreference')
-              .to.deep.equal(expected);
+            expect(events[0]).nested.property('command.$readPreference').to.deep.equal(expected);
             done();
           });
       })

--- a/test/functional/remove.test.js
+++ b/test/functional/remove.test.js
@@ -2,8 +2,8 @@
 var test = require('./shared').assert;
 var setupDatabsae = require('./shared').setupDatabase;
 
-describe('Remove', function() {
-  before(function() {
+describe('Remove', function () {
+  before(function () {
     return setupDatabsae(this.configuration);
   });
 
@@ -12,37 +12,37 @@ describe('Remove', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         test.equal(null, err);
 
-        db.createCollection('test_clear', function(err) {
+        db.createCollection('test_clear', function (err) {
           test.equal(null, err);
 
-          db.collection('test_clear', function(err, collection) {
+          db.collection('test_clear', function (err, collection) {
             test.equal(null, err);
 
-            collection.insert({ i: 1 }, { w: 1 }, function(err) {
+            collection.insert({ i: 1 }, { w: 1 }, function (err) {
               test.equal(null, err);
 
-              collection.insert({ i: 2 }, { w: 1 }, function(err) {
+              collection.insert({ i: 2 }, { w: 1 }, function (err) {
                 test.equal(null, err);
 
-                collection.count(function(err, count) {
+                collection.count(function (err, count) {
                   test.equal(null, err);
                   test.equal(2, count);
                   // Clear the collection
-                  collection.remove({}, { w: 1 }, function(err, r) {
+                  collection.remove({}, { w: 1 }, function (err, r) {
                     test.equal(null, err);
                     test.equal(2, r.result.n);
 
-                    collection.count(function(err, count) {
+                    collection.count(function (err, count) {
                       test.equal(null, err);
                       test.equal(0, count);
                       // Let's close the db
@@ -63,30 +63,30 @@ describe('Remove', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         test.equal(null, err);
 
-        db.createCollection('test_remove_regexp', function(err) {
+        db.createCollection('test_remove_regexp', function (err) {
           test.equal(null, err);
 
-          db.collection('test_remove_regexp', function(err, collection) {
+          db.collection('test_remove_regexp', function (err, collection) {
             test.equal(null, err);
 
-            collection.insert({ address: '485 7th ave new york' }, { w: 1 }, function(err) {
+            collection.insert({ address: '485 7th ave new york' }, { w: 1 }, function (err) {
               test.equal(null, err);
 
               // Clear the collection
-              collection.remove({ address: /485 7th ave/ }, { w: 1 }, function(err, r) {
+              collection.remove({ address: /485 7th ave/ }, { w: 1 }, function (err, r) {
                 test.equal(1, r.result.n);
 
-                collection.count(function(err, count) {
+                collection.count(function (err, count) {
                   test.equal(0, count);
                   // Let's close the db
                   client.close(done);
@@ -104,30 +104,30 @@ describe('Remove', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         test.equal(null, err);
 
-        db.createCollection('shouldCorrectlyRemoveOnlyFirstDocument', function(err) {
+        db.createCollection('shouldCorrectlyRemoveOnlyFirstDocument', function (err) {
           test.equal(null, err);
 
-          db.collection('shouldCorrectlyRemoveOnlyFirstDocument', function(err, collection) {
+          db.collection('shouldCorrectlyRemoveOnlyFirstDocument', function (err, collection) {
             test.equal(null, err);
 
-            collection.insert([{ a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }], { w: 1 }, function(err) {
+            collection.insert([{ a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }], { w: 1 }, function (err) {
               test.equal(null, err);
 
               // Remove the first
-              collection.remove({ a: 1 }, { w: 1, single: true }, function(err, r) {
+              collection.remove({ a: 1 }, { w: 1, single: true }, function (err, r) {
                 test.equal(1, r.result.n);
 
-                collection.find({ a: 1 }).count(function(err, result) {
+                collection.find({ a: 1 }).count(function (err, result) {
                   test.equal(3, result);
                   client.close(done);
                 });
@@ -144,13 +144,13 @@ describe('Remove', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(self.configuration.db);
         test.equal(null, err);
         const collection = db.collection('remove_test');

--- a/test/functional/replicaset_mock.test.js
+++ b/test/functional/replicaset_mock.test.js
@@ -5,7 +5,7 @@ const { ObjectId } = require('bson');
 const Logger = require('../../src/logger');
 
 const test = {};
-describe('ReplSet (mocks)', function() {
+describe('ReplSet (mocks)', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => {
     // Default message fields
@@ -61,11 +61,11 @@ describe('ReplSet (mocks)', function() {
       }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var logger = Logger.currentLogger();
       Logger.setLevel('warn');
-      Logger.setCurrentLogger(function(msg, state) {
+      Logger.setCurrentLogger(function (msg, state) {
         expect(state.type).to.equal('warn');
         expect(state.message).to.equal(
           `expected mongos proxy, but found replicaset member mongod for server ${test.mongos2.uri()}`
@@ -75,7 +75,7 @@ describe('ReplSet (mocks)', function() {
       const client = configuration.newClient(
         `mongodb://${test.mongos1.uri()},${test.mongos2.uri()}/test`
       );
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         Logger.setCurrentLogger(logger);
         Logger.reset();
         expect(err).to.not.exist;
@@ -94,12 +94,12 @@ describe('ReplSet (mocks)', function() {
       ignore: { travis: true }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var warnings = [];
       var logger = Logger.currentLogger();
       Logger.setLevel('warn');
-      Logger.setCurrentLogger(function(msg, state) {
+      Logger.setCurrentLogger(function (msg, state) {
         expect(state.type).to.equal('warn');
         warnings.push(state);
       });
@@ -108,7 +108,7 @@ describe('ReplSet (mocks)', function() {
         `mongodb://${test.mongos1.uri()},${test.mongos2.uri()}/test`
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         Logger.setCurrentLogger(logger);
         Logger.reset();
 

--- a/test/functional/retryable_reads.test.js
+++ b/test/functional/retryable_reads.test.js
@@ -4,12 +4,12 @@ const TestRunnerContext = require('./spec-runner').TestRunnerContext;
 const generateTopologyTests = require('./spec-runner').generateTopologyTests;
 const loadSpecTests = require('../spec').loadSpecTests;
 
-describe('Retryable Reads', function() {
+describe('Retryable Reads', function () {
   const testContext = new TestRunnerContext();
   const testSuites = loadSpecTests('retryable-reads');
 
   after(() => testContext.teardown());
-  before(function() {
+  before(function () {
     return testContext.setup(this.configuration);
   });
 

--- a/test/functional/retryable_writes.test.js
+++ b/test/functional/retryable_writes.test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const loadSpecTests = require('../spec').loadSpecTests;
 const parseRunOn = require('../functional/spec-runner').parseRunOn;
 
-describe('Retryable Writes', function() {
+describe('Retryable Writes', function () {
   let ctx = {};
 
   loadSpecTests('retryable-writes').forEach(suite => {
@@ -14,9 +14,9 @@ describe('Retryable Writes', function() {
 
       describe(suiteName, {
         metadata: { requires },
-        test: function() {
+        test: function () {
           // Step 3: Test Teardown. Turn off failpoints, and close client
-          afterEach(function() {
+          afterEach(function () {
             if (!ctx.db || !ctx.client) {
               return;
             }
@@ -28,7 +28,7 @@ describe('Retryable Writes', function() {
           });
 
           suite.tests.forEach(test => {
-            it(test.description, function() {
+            it(test.description, function () {
               // Step 1: Test Setup. Includes a lot of boilerplate stuff
               // like creating a client, dropping and refilling data collections,
               // and enabling failpoints

--- a/test/functional/saslprep.test.js
+++ b/test/functional/saslprep.test.js
@@ -3,7 +3,7 @@
 const setupDatabase = require('./shared').setupDatabase;
 const withClient = require('./shared').withClient;
 
-describe('SASLPrep', function() {
+describe('SASLPrep', function () {
   // Step 4
   // To test SASLprep behavior, create two users:
   // username: "IX", password "IX"
@@ -32,11 +32,11 @@ describe('SASLPrep', function() {
     }
   ];
 
-  before(function() {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
-  before(function() {
+  before(function () {
     return withClient(this.configuration.newClient(), client => {
       const db = client.db('admin');
 
@@ -51,7 +51,7 @@ describe('SASLPrep', function() {
     });
   });
 
-  after(function() {
+  after(function () {
     return withClient(this.configuration.newClient(), client => {
       const db = client.db('admin');
 
@@ -77,7 +77,7 @@ describe('SASLPrep', function() {
           node: '>=6'
         }
       },
-      test: function() {
+      test: function () {
         const options = {
           user: username,
           password: password,

--- a/test/functional/scram.test.js
+++ b/test/functional/scram.test.js
@@ -3,8 +3,8 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const { MongoClient } = require('../../src');
 
-describe('SCRAM', function() {
-  before(function() {
+describe('SCRAM', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -14,45 +14,45 @@ describe('SCRAM', function() {
   it('Should correctly authenticate against scram', {
     metadata: { requires: { topology: 'scram', mongodb: '>=3.2.0' } },
 
-    test: function(done) {
+    test: function (done) {
       // User and password
       var user = 'test';
       var password = 'test';
 
       // Connect to the server
-      MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+      MongoClient.connect('mongodb://localhost:27017/test', function (err, db) {
         test.equal(null, err);
 
         // Create an admin user
-        db.admin().addUser(user, password, function(err) {
+        db.admin().addUser(user, password, function (err) {
           test.equal(null, err);
           db.close();
 
           // Attempt to reconnect authenticating against the admin database
           MongoClient.connect(
             'mongodb://test:test@localhost:27017/test?authMechanism=SCRAM-SHA-1&authSource=admin&maxPoolSize=5',
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
 
-              db.collection('test').insert({ a: 1 }, function(err, r) {
+              db.collection('test').insert({ a: 1 }, function (err, r) {
                 test.equal(null, err);
                 test.ok(r != null);
 
                 // Wait for a reconnect to happen
-                client.topology.once('reconnect', function() {
+                client.topology.once('reconnect', function () {
                   // Perform an insert after reconnect
-                  db.collection('test').insert({ a: 1 }, function(err, r) {
+                  db.collection('test').insert({ a: 1 }, function (err, r) {
                     test.equal(null, err);
                     test.ok(r != null);
 
                     // Attempt to reconnect authenticating against the admin database
                     MongoClient.connect(
                       'mongodb://test:test@localhost:27017/test?authMechanism=SCRAM-SHA-1&authSource=admin&maxPoolSize=5',
-                      function(err) {
+                      function (err) {
                         test.equal(null, err);
 
                         // Remove the user
-                        db.admin().removeUser(user, function(err) {
+                        db.admin().removeUser(user, function (err) {
                           test.equal(null, err);
 
                           db.close();

--- a/test/functional/scram_sha_256.test.js
+++ b/test/functional/scram_sha_256.test.js
@@ -6,7 +6,7 @@ const { Connection } = require('../../src/cmap/connection');
 const { ScramSHA256 } = require('../../src/cmap/auth/scram');
 const { setupDatabase, withClient } = require('./shared');
 
-describe('SCRAM-SHA-256 auth', function() {
+describe('SCRAM-SHA-256 auth', function () {
   const test = {};
   const userMap = {
     sha1: {
@@ -37,12 +37,12 @@ describe('SCRAM-SHA-256 auth', function() {
 
   afterEach(() => test.sandbox.restore());
 
-  before(function() {
+  before(function () {
     test.sandbox = sinon.sandbox.create();
     return setupDatabase(this.configuration);
   });
 
-  before(function() {
+  before(function () {
     return withClient(this.configuration.newClient(), client => {
       test.oldDbName = this.configuration.db;
       this.configuration.db = 'admin';
@@ -59,7 +59,7 @@ describe('SCRAM-SHA-256 auth', function() {
     });
   });
 
-  after(function() {
+  after(function () {
     return withClient(this.configuration.newClient(), client => {
       const db = client.db(this.configuration.db);
       this.configuration.db = test.oldDbName;
@@ -77,7 +77,7 @@ describe('SCRAM-SHA-256 auth', function() {
     user.mechanisms.forEach(mechanism => {
       it(`should auth ${user.description} when explicitly specifying ${mechanism}`, {
         metadata: { requires: { mongodb: '>=3.7.3' } },
-        test: function() {
+        test: function () {
           const options = {
             auth: {
               user: user.username,
@@ -95,7 +95,7 @@ describe('SCRAM-SHA-256 auth', function() {
 
       it(`should auth ${user.description} when explicitly specifying ${mechanism} in url`, {
         metadata: { requires: { mongodb: '>=3.7.3' } },
-        test: function() {
+        test: function () {
           const username = encodeURIComponent(user.username);
           const password = encodeURIComponent(user.password);
 
@@ -116,7 +116,7 @@ describe('SCRAM-SHA-256 auth', function() {
 
     it(`should auth ${user.description} using mechanism negotiaton`, {
       metadata: { requires: { mongodb: '>=3.7.3' } },
-      test: function() {
+      test: function () {
         const options = {
           auth: {
             user: user.username,
@@ -133,7 +133,7 @@ describe('SCRAM-SHA-256 auth', function() {
 
     it(`should auth ${user.description} using mechanism negotiaton and url`, {
       metadata: { requires: { mongodb: '>=3.7.3' } },
-      test: function() {
+      test: function () {
         const username = encodeURIComponent(user.username);
         const password = encodeURIComponent(user.password);
         const url = makeConnectionString(this.configuration, username, password);
@@ -151,7 +151,7 @@ describe('SCRAM-SHA-256 auth', function() {
   // drivers should verify that negotation selects SCRAM-SHA-256..
   it('should select SCRAM-SHA-256 for a user that supports both auth mechanisms', {
     metadata: { requires: { mongodb: '>=3.7.3' } },
-    test: function() {
+    test: function () {
       const options = {
         auth: {
           user: userMap.both.username,
@@ -170,7 +170,7 @@ describe('SCRAM-SHA-256 auth', function() {
 
   it('should shorten SCRAM conversations if the server supports it', {
     metadata: { requires: { mongodb: '>=4.4', topology: ['single'] } },
-    test: function() {
+    test: function () {
       const options = {
         auth: {
           user: userMap.both.username,
@@ -180,7 +180,7 @@ describe('SCRAM-SHA-256 auth', function() {
       };
 
       let runCommandSpy;
-      test.sandbox.stub(ScramSHA256.prototype, 'auth').callsFake(function(authContext, callback) {
+      test.sandbox.stub(ScramSHA256.prototype, 'auth').callsFake(function (authContext, callback) {
         const connection = authContext.connection;
         const auth = ScramSHA256.prototype.auth.wrappedMethod;
         runCommandSpy = test.sandbox.spy(connection, 'command');
@@ -202,7 +202,7 @@ describe('SCRAM-SHA-256 auth', function() {
   // For test users that support only one mechanism, verify that explictly specifying the other mechanism fails.
   it('should fail to connect if incorrect auth mechanism is explicitly specified', {
     metadata: { requires: { mongodb: '>=3.7.3' } },
-    test: function() {
+    test: function () {
       const options = {
         auth: {
           user: userMap.sha256.username,
@@ -226,7 +226,7 @@ describe('SCRAM-SHA-256 auth', function() {
   // authentication errors, not as a network or database command error.)
   it('should fail for a nonexistent username with same error type as bad password', {
     metadata: { requires: { mongodb: '>=3.7.3' } },
-    test: function() {
+    test: function () {
       const noUsernameOptions = {
         auth: {
           user: 'roth',
@@ -256,7 +256,7 @@ describe('SCRAM-SHA-256 auth', function() {
 
   it('should send speculativeAuthenticate on initial handshake on MongoDB 4.4+', {
     metadata: { requires: { mongodb: '>=4.4', topology: ['single'] } },
-    test: function() {
+    test: function () {
       const options = {
         auth: {
           user: userMap.both.username,

--- a/test/functional/sdam.test.js
+++ b/test/functional/sdam.test.js
@@ -39,12 +39,12 @@ class SDAMRunnerContext extends TestRunnerContext {
   }
 }
 
-describe('SDAM', function() {
-  context('integration spec tests', function() {
+describe('SDAM', function () {
+  context('integration spec tests', function () {
     const testContext = new SDAMRunnerContext();
     const testSuites = loadSpecTests('server-discovery-and-monitoring/integration');
     after(() => testContext.teardown());
-    before(function() {
+    before(function () {
       return testContext.setup(this.configuration);
     });
 

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -8,7 +8,7 @@ const loadSpecTests = require('../spec').loadSpecTests;
 const ignoredCommands = ['ismaster'];
 const test = {
   commands: { started: [], succeeded: [] },
-  setup: function(config) {
+  setup: function (config) {
     this.commands = { started: [], succeeded: [] };
     this.client = config.newClient(
       { w: 1 },
@@ -31,13 +31,13 @@ const test = {
   }
 };
 
-describe('Sessions', function() {
-  before(function() {
+describe('Sessions', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
-  describe('endSessions', function() {
-    beforeEach(function() {
+  describe('endSessions', function () {
+    beforeEach(function () {
       return test.setup(this.configuration);
     });
 
@@ -47,7 +47,7 @@ describe('Sessions', function() {
         // Skipping session leak tests b/c these are explicit sessions
         sessions: { skipLeakTests: true }
       },
-      test: function(done) {
+      test: function (done) {
         const client = test.client;
         let sessions = [client.startSession(), client.startSession()].map(s => s.id);
 
@@ -66,8 +66,8 @@ describe('Sessions', function() {
 
   describe('withSession', {
     metadata: { requires: { mongodb: '>3.6.0' } },
-    test: function() {
-      beforeEach(function() {
+    test: function () {
+      beforeEach(function () {
         return test.setup(this.configuration);
       });
 
@@ -75,11 +75,7 @@ describe('Sessions', function() {
         {
           description: 'should support operations that return promises',
           operation: client => session => {
-            return client
-              .db('test')
-              .collection('foo')
-              .find({}, { session })
-              .toArray();
+            return client.db('test').collection('foo').find({}, { session }).toArray();
           }
         },
         // {
@@ -113,7 +109,7 @@ describe('Sessions', function() {
           }
         }
       ].forEach(testCase => {
-        it(testCase.description, function() {
+        it(testCase.description, function () {
           const client = test.client;
 
           return client
@@ -130,16 +126,12 @@ describe('Sessions', function() {
         });
       });
 
-      it('supports passing options to ClientSession', function() {
+      it('supports passing options to ClientSession', function () {
         const client = test.client;
 
         const promise = client.withSession({ causalConsistency: false }, session => {
           expect(session.supports.causalConsistency).to.be.false;
-          return client
-            .db('test')
-            .collection('foo')
-            .find({}, { session })
-            .toArray();
+          return client.db('test').collection('foo').find({}, { session }).toArray();
         });
 
         return promise
@@ -155,7 +147,7 @@ describe('Sessions', function() {
     }
   });
 
-  describe('spec tests', function() {
+  describe('spec tests', function () {
     class SessionSpecTestContext extends TestRunnerContext {
       assertSessionNotDirty(options) {
         const session = options.session;
@@ -186,7 +178,7 @@ describe('Sessions', function() {
     const testSuites = loadSpecTests('sessions');
 
     after(() => testContext.teardown());
-    before(function() {
+    before(function () {
       return testContext.setup(this.configuration);
     });
 

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -4,34 +4,34 @@ const expect = require('chai').expect;
 
 // helpers for using chai.expect in the assert style
 const assert = {
-  equal: function(a, b) {
+  equal: function (a, b) {
     expect(a).to.equal(b);
   },
 
-  deepEqual: function(a, b) {
+  deepEqual: function (a, b) {
     expect(a).to.eql(b);
   },
 
-  strictEqual: function(a, b) {
+  strictEqual: function (a, b) {
     expect(a).to.eql(b);
   },
 
-  notEqual: function(a, b) {
+  notEqual: function (a, b) {
     expect(a).to.not.equal(b);
   },
 
-  ok: function(a) {
+  ok: function (a) {
     expect(a).to.be.ok;
   },
 
-  throws: function(func) {
+  throws: function (func) {
     expect(func).to.throw;
   }
 };
 
 function delay(timeout) {
-  return new Promise(function(resolve) {
-    setTimeout(function() {
+  return new Promise(function (resolve) {
+    setTimeout(function () {
       resolve();
     }, timeout);
   });
@@ -43,24 +43,24 @@ function dropCollection(dbObj, collectionName) {
 
 function filterForCommands(commands, bag) {
   if (typeof commands === 'function') {
-    return function(event) {
+    return function (event) {
       if (commands(event.commandName)) bag.push(event);
     };
   }
   commands = Array.isArray(commands) ? commands : [commands];
-  return function(event) {
+  return function (event) {
     if (commands.indexOf(event.commandName) !== -1) bag.push(event);
   };
 }
 
 function filterOutCommands(commands, bag) {
   if (typeof commands === 'function') {
-    return function(event) {
+    return function (event) {
       if (!commands(event.commandName)) bag.push(event);
     };
   }
   commands = Array.isArray(commands) ? commands : [commands];
-  return function(event) {
+  return function (event) {
     if (commands.indexOf(event.commandName) === -1) bag.push(event);
   };
 }
@@ -176,7 +176,7 @@ function withMonitoredClient(commands, options, callback) {
   if (!Object.prototype.hasOwnProperty.call(callback, 'prototype')) {
     throw new Error('withMonitoredClient callback can not be arrow function');
   }
-  return function() {
+  return function () {
     const monitoredClient = this.configuration.newClient(
       Object.assign({}, options.queryOptions),
       Object.assign({ monitorCommands: true }, options.clientOptions)

--- a/test/functional/shared.test.js
+++ b/test/functional/shared.test.js
@@ -2,22 +2,22 @@
 const withMonitoredClient = require('./shared').withMonitoredClient;
 const expect = require('chai').expect;
 
-describe('shared test utilities', function() {
-  context('withMonitoredClient', function() {
-    it('should throw if arrow function', function() {
+describe('shared test utilities', function () {
+  context('withMonitoredClient', function () {
+    it('should throw if arrow function', function () {
       expect(() => {
         withMonitoredClient(['find'], () => {});
       }).to.throw();
     });
 
-    it('should not throw if function', function() {
+    it('should not throw if function', function () {
       expect(() => {
         function example() {}
         withMonitoredClient(['find'], example);
       }).to.not.throw();
     });
 
-    it('should call done and close connection with callback', function(done) {
+    it('should call done and close connection with callback', function (done) {
       var c = null;
       var e = [];
       const fakeDone = () => {
@@ -25,7 +25,7 @@ describe('shared test utilities', function() {
         expect(e.length).to.equal(1);
         done();
       };
-      const encapsulatedTest = withMonitoredClient(['find'], function(client, events, innerDone) {
+      const encapsulatedTest = withMonitoredClient(['find'], function (client, events, innerDone) {
         c = client;
         e = events;
         client
@@ -39,7 +39,7 @@ describe('shared test utilities', function() {
       encapsulatedTest().then(fakeDone);
     });
 
-    it('should propagate passed error to done', function(done) {
+    it('should propagate passed error to done', function (done) {
       var c = null;
       var e = [];
       const fakeDone = err => {
@@ -48,7 +48,7 @@ describe('shared test utilities', function() {
         expect(e.length).to.equal(1);
         done();
       };
-      const encapsulatedTest = withMonitoredClient(['find'], function(client, events, innerDone) {
+      const encapsulatedTest = withMonitoredClient(['find'], function (client, events, innerDone) {
         c = client;
         e = events;
         client
@@ -62,7 +62,7 @@ describe('shared test utilities', function() {
       encapsulatedTest().catch(fakeDone);
     });
 
-    it('should call done and close connection with promise', function(done) {
+    it('should call done and close connection with promise', function (done) {
       var c = null;
       var e = [];
       const fakeDone = () => {
@@ -70,7 +70,7 @@ describe('shared test utilities', function() {
         expect(e.length).to.equal(1);
         done();
       };
-      const encapsulatedTest = withMonitoredClient(['find'], function(client, events, innerDone) {
+      const encapsulatedTest = withMonitoredClient(['find'], function (client, events, innerDone) {
         c = client;
         e = events;
         client
@@ -85,7 +85,7 @@ describe('shared test utilities', function() {
       encapsulatedTest().then(fakeDone);
     });
 
-    it('should propagate passed error to done from promise', function(done) {
+    it('should propagate passed error to done from promise', function (done) {
       var c = null;
       var e = [];
       const fakeDone = err => {
@@ -94,7 +94,7 @@ describe('shared test utilities', function() {
         expect(e.length).to.equal(1);
         done();
       };
-      const encapsulatedTest = withMonitoredClient(['find'], function(client, events, innerDone) {
+      const encapsulatedTest = withMonitoredClient(['find'], function (client, events, innerDone) {
         e = events;
         c = client;
         client

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -124,12 +124,12 @@ function generateTopologyTests(testSuites, testContext, filter) {
       const suiteName = `${testSuite.name} - ${requires.topology.join()}`;
       describe(suiteName, {
         metadata: { requires },
-        test: function() {
+        test: function () {
           beforeEach(() => prepareDatabaseForSuite(testSuite, testContext));
           afterEach(() => testContext.cleanupAfterSuite());
 
           testSuite.tests.forEach(spec => {
-            it(spec.description, function() {
+            it(spec.description, function () {
               if (
                 spec.skipReason ||
                 (filter && typeof filter === 'function' && !filter(spec, this.configuration))
@@ -395,9 +395,7 @@ function validateExpectations(commandEvents, spec, savedSessionData) {
     const actualCommand = actual.command;
     const expectedCommand = expected.command;
 
-    expect(actualCommand)
-      .withSessionData(savedSessionData)
-      .to.matchMongoSpec(expectedCommand);
+    expect(actualCommand).withSessionData(savedSessionData).to.matchMongoSpec(expectedCommand);
   });
 }
 

--- a/test/functional/spec-runner/matcher.js
+++ b/test/functional/spec-runner/matcher.js
@@ -169,11 +169,11 @@ function generateMatchAndDiff(expected, actual, metadata) {
 }
 
 function matchMongoSpec(chai, utils) {
-  chai.Assertion.addMethod('withSessionData', function(sessionData) {
+  chai.Assertion.addMethod('withSessionData', function (sessionData) {
     utils.flag(this, 'testRunnerSessionData', sessionData);
   });
 
-  chai.Assertion.addMethod('matchMongoSpec', function(expected) {
+  chai.Assertion.addMethod('matchMongoSpec', function (expected) {
     const actual = utils.flag(this, 'object');
 
     const sessionData = utils.flag(this, 'testRunnerSessionData');
@@ -191,7 +191,7 @@ function matchMongoSpec(chai, utils) {
     );
   });
 
-  chai.assert.matchMongoSpec = function(val, exp, msg) {
+  chai.assert.matchMongoSpec = function (val, exp, msg) {
     new chai.Assertion(val, msg).to.matchMongoSpec(exp);
   };
 }

--- a/test/functional/ssl_x509_connect.test.js
+++ b/test/functional/ssl_x509_connect.test.js
@@ -5,15 +5,15 @@ var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
 const { MongoClient } = require('../../src');
 
-describe('SSL (x509)', function() {
-  before(function() {
+describe('SSL (x509)', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
   it('Should correctly authenticate using x509', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server;
 
@@ -47,9 +47,9 @@ describe('SSL (x509)', function() {
       );
 
       // Purge the set
-      serverManager.purge().then(function() {
+      serverManager.purge().then(function () {
         // Start the server
-        serverManager.start().then(function() {
+        serverManager.start().then(function () {
           // Connect and validate the server certificate
           MongoClient.connect(
             'mongodb://server:27019/test?ssl=true&maxPoolSize=1',
@@ -60,12 +60,12 @@ describe('SSL (x509)', function() {
                 sslValidate: false
               }
             },
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
               var db = client.db(configuration.db);
 
               // Execute build info
-              db.command({ buildInfo: 1 }, function(err, result) {
+              db.command({ buildInfo: 1 }, function (err, result) {
                 test.equal(null, err);
                 var version = parseInt(result.versionArray.slice(0, 3).join(''), 10);
                 if (version < 253) {
@@ -83,7 +83,7 @@ describe('SSL (x509)', function() {
                       { role: 'userAdminAnyDatabase', db: 'admin' }
                     ]
                   },
-                  function(err, result) {
+                  function (err, result) {
                     test.equal(null, err);
                     test.equal(userName, result[0].user);
                     test.equal('', result[0].pwd);
@@ -103,12 +103,12 @@ describe('SSL (x509)', function() {
                           sslValidate: false
                         }
                       },
-                      function(err, client) {
+                      function (err, client) {
                         test.equal(null, err);
 
                         client.close();
 
-                        serverManager.stop().then(function() {
+                        serverManager.stop().then(function () {
                           done();
                         });
                       }
@@ -126,7 +126,7 @@ describe('SSL (x509)', function() {
   it('Should correctly handle bad x509 certificate', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server;
 
@@ -161,9 +161,9 @@ describe('SSL (x509)', function() {
       );
 
       // Purge the set
-      serverManager.purge().then(function() {
+      serverManager.purge().then(function () {
         // Start the server
-        serverManager.start().then(function() {
+        serverManager.start().then(function () {
           // Connect and validate the server certificate
           MongoClient.connect(
             'mongodb://server:27019/test?ssl=true&maxPoolSize=1',
@@ -174,12 +174,12 @@ describe('SSL (x509)', function() {
                 sslValidate: false
               }
             },
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
               var db = client.db(configuration.db);
 
               // Execute build info
-              db.command({ buildInfo: 1 }, function(err, result) {
+              db.command({ buildInfo: 1 }, function (err, result) {
                 test.equal(null, err);
                 var version = parseInt(result.versionArray.slice(0, 3).join(''), 10);
                 if (version < 253) {
@@ -197,7 +197,7 @@ describe('SSL (x509)', function() {
                       { role: 'userAdminAnyDatabase', db: 'admin' }
                     ]
                   },
-                  function(err, result) {
+                  function (err, result) {
                     test.equal(null, err);
                     test.equal(userName, result[0].user);
                     test.equal('', result[0].pwd);
@@ -217,11 +217,11 @@ describe('SSL (x509)', function() {
                           sslValidate: false
                         }
                       },
-                      function(err) {
+                      function (err) {
                         test.equal(0, err.ok);
                         test.equal('auth failed', err.errmsg);
 
-                        serverManager.stop().then(function() {
+                        serverManager.stop().then(function () {
                           done();
                         });
                       }
@@ -239,7 +239,7 @@ describe('SSL (x509)', function() {
   it('Should give reasonable error on x509 authentication failure', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server;
 
@@ -273,9 +273,9 @@ describe('SSL (x509)', function() {
       );
 
       // Purge the set
-      serverManager.purge().then(function() {
+      serverManager.purge().then(function () {
         // Start the server
-        serverManager.start().then(function() {
+        serverManager.start().then(function () {
           // Connect and validate the server certificate
           MongoClient.connect(
             'mongodb://server:27019/test?ssl=true&maxPoolSize=1',
@@ -286,12 +286,12 @@ describe('SSL (x509)', function() {
                 sslValidate: false
               }
             },
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
               var db = client.db(configuration.db);
 
               // Execute build info
-              db.command({ buildInfo: 1 }, function(err, result) {
+              db.command({ buildInfo: 1 }, function (err, result) {
                 test.equal(null, err);
                 var version = parseInt(result.versionArray.slice(0, 3).join(''), 10);
                 if (version < 253) {
@@ -309,7 +309,7 @@ describe('SSL (x509)', function() {
                       { role: 'userAdminAnyDatabase', db: 'admin' }
                     ]
                   },
-                  function(err, result) {
+                  function (err, result) {
                     test.equal(null, err);
                     test.equal(userName, result[0].user);
                     test.equal('', result[0].pwd);
@@ -329,11 +329,11 @@ describe('SSL (x509)', function() {
                           sslValidate: false
                         }
                       },
-                      function(err) {
+                      function (err) {
                         test.equal(0, err.ok);
                         test.equal('auth failed', err.errmsg);
 
-                        serverManager.stop().then(function() {
+                        serverManager.stop().then(function () {
                           done();
                         });
                       }
@@ -351,7 +351,7 @@ describe('SSL (x509)', function() {
   it('Should give helpful error when attempting to use x509 without SSL', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server;
 
@@ -375,9 +375,9 @@ describe('SSL (x509)', function() {
       );
 
       // Purge the set
-      serverManager.purge().then(function() {
+      serverManager.purge().then(function () {
         // Start the server
-        serverManager.start().then(function() {
+        serverManager.start().then(function () {
           // Connect and validate the server certificate
           MongoClient.connect(
             'mongodb://server:27019/test?ssl=false&maxPoolSize=1',
@@ -388,12 +388,12 @@ describe('SSL (x509)', function() {
                 sslValidate: false
               }
             },
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
               var db = client.db(configuration.db);
 
               // Execute build info
-              db.command({ buildInfo: 1 }, function(err, result) {
+              db.command({ buildInfo: 1 }, function (err, result) {
                 test.equal(null, err);
                 var version = parseInt(result.versionArray.slice(0, 3).join(''), 10);
                 if (version < 253) {
@@ -411,7 +411,7 @@ describe('SSL (x509)', function() {
                       { role: 'userAdminAnyDatabase', db: 'admin' }
                     ]
                   },
-                  function(err, result) {
+                  function (err, result) {
                     test.equal(null, err);
                     test.equal(userName, result[0].user);
                     test.equal('', result[0].pwd);
@@ -431,7 +431,7 @@ describe('SSL (x509)', function() {
                           sslValidate: false
                         }
                       },
-                      function(err) {
+                      function (err) {
                         test.ok(!!err);
                         test.equal(0, err.ok);
                         test.equal(
@@ -439,7 +439,7 @@ describe('SSL (x509)', function() {
                           err.errmsg
                         );
 
-                        serverManager.stop().then(function() {
+                        serverManager.stop().then(function () {
                           done();
                         });
                       }
@@ -457,7 +457,7 @@ describe('SSL (x509)', function() {
   it('Should correctly reauthenticate against x509', {
     metadata: { requires: { topology: 'ssl' } },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var ServerManager = require('mongodb-topology-manager').Server;
 
@@ -491,9 +491,9 @@ describe('SSL (x509)', function() {
       );
 
       // Purge the set
-      serverManager.purge().then(function() {
+      serverManager.purge().then(function () {
         // Start the server
-        serverManager.start().then(function() {
+        serverManager.start().then(function () {
           // Connect and validate the server certificate
           MongoClient.connect(
             'mongodb://server:27019/test?ssl=true&maxPoolSize=1',
@@ -504,12 +504,12 @@ describe('SSL (x509)', function() {
                 sslValidate: false
               }
             },
-            function(err, client) {
+            function (err, client) {
               test.equal(null, err);
               var db = client.db(configuration.db);
 
               // Execute build info
-              db.command({ buildInfo: 1 }, function(err, result) {
+              db.command({ buildInfo: 1 }, function (err, result) {
                 test.equal(null, err);
                 var version = parseInt(result.versionArray.slice(0, 3).join(''), 10);
                 if (version < 253) {
@@ -527,7 +527,7 @@ describe('SSL (x509)', function() {
                       { role: 'userAdminAnyDatabase', db: 'admin' }
                     ]
                   },
-                  function(err, result) {
+                  function (err, result) {
                     test.equal(null, err);
                     test.equal(userName, result[0].user);
                     test.equal('', result[0].pwd);
@@ -547,20 +547,20 @@ describe('SSL (x509)', function() {
                           sslValidate: false
                         }
                       },
-                      function(err, client) {
+                      function (err, client) {
                         test.equal(null, err);
                         var db = client.db(configuration.db);
 
-                        db.collection('x509collection').insert({ a: 1 }, function(err) {
+                        db.collection('x509collection').insert({ a: 1 }, function (err) {
                           test.equal(null, err);
 
-                          db.collection('x509collection').findOne(function(err, doc) {
+                          db.collection('x509collection').findOne(function (err, doc) {
                             test.equal(null, err);
                             test.equal(1, doc.a);
 
-                            client.topology.once('reconnect', function() {
+                            client.topology.once('reconnect', function () {
                               // Await reconnect and re-authentication
-                              db.collection('x509collection').findOne(function(err, doc) {
+                              db.collection('x509collection').findOne(function (err, doc) {
                                 test.equal(null, err);
                                 test.equal(1, doc.a);
 
@@ -568,13 +568,13 @@ describe('SSL (x509)', function() {
                                 client.topology.connections()[0].destroy();
 
                                 // Await reconnect and re-authentication
-                                db.collection('x509collection').findOne(function(err, doc) {
+                                db.collection('x509collection').findOne(function (err, doc) {
                                   test.equal(null, err);
                                   test.equal(1, doc.a);
 
                                   client.close();
 
-                                  serverManager.stop().then(function() {
+                                  serverManager.stop().then(function () {
                                     done();
                                   });
                                 });

--- a/test/functional/transactions.test.js
+++ b/test/functional/transactions.test.js
@@ -80,7 +80,7 @@ class TransactionsRunnerContext extends TestRunnerContext {
   }
 }
 
-describe('Transactions', function() {
+describe('Transactions', function () {
   const testContext = new TransactionsRunnerContext();
 
   [
@@ -90,10 +90,10 @@ describe('Transactions', function() {
       specPath: 'transactions/convenient-api'
     }
   ].forEach(suiteSpec => {
-    describe(suiteSpec.name, function() {
+    describe(suiteSpec.name, function () {
       const testSuites = loadSpecTests(suiteSpec.specPath);
       after(() => testContext.teardown());
-      before(function() {
+      before(function () {
         return testContext.setup(this.configuration);
       });
 
@@ -132,7 +132,7 @@ describe('Transactions', function() {
     });
   });
 
-  describe('withTransaction', function() {
+  describe('withTransaction', function () {
     let session, sessionPool;
     beforeEach(() => {
       const topology = new Topology('localhost:27017');
@@ -146,7 +146,7 @@ describe('Transactions', function() {
 
     it('should provide a useful error if a Promise is not returned', {
       metadata: { requires: { topology: ['replicaset', 'sharded'], mongodb: '>=4.1.5' } },
-      test: function(done) {
+      test: function (done) {
         function fnThatDoesntReturnPromise() {
           return false;
         }
@@ -161,7 +161,7 @@ describe('Transactions', function() {
 
     it('should return readable error if promise rejected with no reason', {
       metadata: { requires: { topology: ['replicaset', 'sharded'], mongodb: '>=4.0.2' } },
-      test: function(done) {
+      test: function (done) {
         function fnThatReturnsBadPromise() {
           return Promise.reject();
         }
@@ -177,10 +177,10 @@ describe('Transactions', function() {
     });
   });
 
-  describe('startTransaction', function() {
+  describe('startTransaction', function () {
     it('should error if transactions are not supported', {
       metadata: { requires: { topology: ['sharded'], mongodb: '4.0.x' } },
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
         const client = configuration.newClient(configuration.url());
 
@@ -204,7 +204,7 @@ describe('Transactions', function() {
 
     it('should not error if transactions are supported', {
       metadata: { requires: { topology: ['sharded'], mongodb: '>=4.1.0' } },
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
         const client = configuration.newClient(configuration.url());
 
@@ -225,10 +225,10 @@ describe('Transactions', function() {
     });
   });
 
-  describe('TransientTransactionError', function() {
+  describe('TransientTransactionError', function () {
     it('should have a TransientTransactionError label inside of a transaction', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=4.0.0' } },
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
         const client = configuration.newClient({ w: 1 });
 
@@ -273,7 +273,7 @@ describe('Transactions', function() {
 
     it('should not have a TransientTransactionError label outside of a transaction', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=4.0.0' } },
-      test: function(done) {
+      test: function (done) {
         const configuration = this.configuration;
         const client = configuration.newClient({ w: 1 });
 

--- a/test/functional/unicode.test.js
+++ b/test/functional/unicode.test.js
@@ -1,8 +1,8 @@
 'use strict';
 const { assert: test, setupDatabase } = require('./shared');
 
-describe('Unicode', function() {
-  before(function() {
+describe('Unicode', function () {
+  before(function () {
     return setupDatabase(this.configuration);
   });
 
@@ -11,10 +11,10 @@ describe('Unicode', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
         var doc = {
           statuses_count: 1687,
@@ -60,15 +60,15 @@ describe('Unicode', function() {
             'http://a3.twimg.com/profile_images/107142257/passbild-square_normal.jpg'
         };
 
-        db.createCollection('test_should_correctly_save_unicode_containing_document', function(
+        db.createCollection('test_should_correctly_save_unicode_containing_document', function (
           err,
           collection
         ) {
           doc['_id'] = 'felixge';
 
-          collection.save(doc, { w: 1 }, function(err) {
+          collection.save(doc, { w: 1 }, function (err) {
             test.equal(null, err);
-            collection.findOne(function(err, doc) {
+            collection.findOne(function (err, doc) {
               test.equal('felixge', doc._id);
               client.close(done);
             });
@@ -83,20 +83,20 @@ describe('Unicode', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('unicode_test_collection', function(err, collection) {
+        db.createCollection('unicode_test_collection', function (err, collection) {
           var test_strings = ['ouooueauiOUOOUEAUI', 'öüóőúéáűíÖÜÓŐÚÉÁŰÍ', '本荘由利地域に洪水警報'];
-          collection.insert({ id: 0, text: test_strings[0] }, { w: 1 }, function(err) {
+          collection.insert({ id: 0, text: test_strings[0] }, { w: 1 }, function (err) {
             test.equal(null, err);
-            collection.insert({ id: 1, text: test_strings[1] }, { w: 1 }, function(err) {
+            collection.insert({ id: 1, text: test_strings[1] }, { w: 1 }, function (err) {
               test.equal(null, err);
-              collection.insert({ id: 2, text: test_strings[2] }, { w: 1 }, function(err) {
+              collection.insert({ id: 2, text: test_strings[2] }, { w: 1 }, function (err) {
                 test.equal(null, err);
-                collection.find().each(function(err, item) {
+                collection.find().each(function (err, item) {
                   if (item != null) {
                     test.equal(test_strings[item.id], item.text);
                   } else {
@@ -116,23 +116,23 @@ describe('Unicode', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var object = { 客家话: 'Hello' };
 
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('create_object_with_chinese_object_name', function(err) {
+        db.createCollection('create_object_with_chinese_object_name', function (err) {
           test.equal(null, err);
-          db.collection('create_object_with_chinese_object_name', function(err, collection) {
+          db.collection('create_object_with_chinese_object_name', function (err, collection) {
             test.equal(null, err);
-            collection.insert(object, { w: 1 }, function(err) {
+            collection.insert(object, { w: 1 }, function (err) {
               test.equal(null, err);
-              collection.findOne(function(err, item) {
+              collection.findOne(function (err, item) {
                 test.equal(object['客家话'], item['客家话']);
 
-                collection.find().toArray(function(err, items) {
+                collection.find().toArray(function (err, items) {
                   test.equal(object['客家话'], items[0]['客家话']);
                   client.close(done);
                 });
@@ -149,18 +149,18 @@ describe('Unicode', function() {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function(done) {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db);
-        db.createCollection('test_utf8_key_name', function(err, collection) {
-          collection.insert({ šđžčćŠĐŽČĆ: 1 }, { w: 1 }, function(err) {
+        db.createCollection('test_utf8_key_name', function (err, collection) {
+          collection.insert({ šđžčćŠĐŽČĆ: 1 }, { w: 1 }, function (err) {
             test.equal(null, err);
             collection
               .find({})
               .project({ šđžčćŠĐŽČĆ: 1 })
-              .toArray(function(err, items) {
+              .toArray(function (err, items) {
                 test.equal(1, items[0]['šđžčćŠĐŽČĆ']);
                 // Let's close the db
                 client.close(done);

--- a/test/functional/uri.test.js
+++ b/test/functional/uri.test.js
@@ -4,13 +4,13 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const NativeTopology = require('../../src/topologies/native_topology');
 
-describe('URI', function() {
+describe('URI', function () {
   it('should correctly allow for w:0 overriding on the connect url', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
 
       // Connect using the connection string
@@ -18,11 +18,11 @@ describe('URI', function() {
         'mongodb://localhost:27017/integration_tests?w=0'
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         var db = client.db(self.configuration.db);
 
-        db.collection('mongoclient_test').update({ a: 1 }, { b: 1 }, { upsert: true }, function(
+        db.collection('mongoclient_test').update({ a: 1 }, { b: 1 }, { upsert: true }, function (
           err,
           result
         ) {
@@ -45,7 +45,7 @@ describe('URI', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       if (process.platform === 'win32') {
         return done();
       }
@@ -54,7 +54,7 @@ describe('URI', function() {
         'mongodb://%2Ftmp%2Fmongodb-27017.sock?safe=false'
       );
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         client.close(done);
       });
@@ -66,7 +66,7 @@ describe('URI', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       const client = this.configuration.newClient('mongodb://127.0.0.1:27017/?fsync=true');
       client.connect((err, client) => {
         var db = client.db(this.configuration.db);
@@ -81,20 +81,20 @@ describe('URI', function() {
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: { requires: { topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const configuration = this.configuration;
       const client = configuration.newClient('mongodb://localhost:27017/integration_tests', {
         native_parser: true
       });
 
-      client.connect(function(err, client) {
+      client.connect(function (err, client) {
         expect(err).to.not.exist;
         var user = 'u$ser',
           pass = '$specialch@rs';
         var db = client.db(self.configuration.db);
 
-        db.addUser(user, pass, function(err) {
+        db.addUser(user, pass, function (err) {
           expect(err).to.not.exist;
           var uri =
             'mongodb://' +
@@ -104,7 +104,7 @@ describe('URI', function() {
             '@localhost:27017/integration_tests';
 
           const aclient = configuration.newClient(uri, { native_parser: true });
-          aclient.connect(function(err, aclient) {
+          aclient.connect(function (err, aclient) {
             expect(err).to.not.exist;
 
             client.close(() => aclient.close(done));
@@ -116,7 +116,7 @@ describe('URI', function() {
 
   it('should correctly translate uri options using new parser', {
     metadata: { requires: { topology: 'replicaset' } },
-    test: function(done) {
+    test: function (done) {
       const config = this.configuration;
       const uri = `mongodb://${config.host}:${config.port}/${config.db}?replicaSet=${config.replicasetName}`;
 
@@ -133,7 +133,7 @@ describe('URI', function() {
 
   it('should generate valid credentials with X509 and the new parser', {
     metadata: { requires: { topology: 'single' } },
-    test: function(done) {
+    test: function (done) {
       function validateConnect(options /*, callback */) {
         expect(options).to.have.property('credentials');
         expect(options.credentials.mechanism).to.eql('x509');

--- a/test/functional/uri_options_spec.test.js
+++ b/test/functional/uri_options_spec.test.js
@@ -8,7 +8,7 @@ const { parseConnectionString: parse } = require('../../src/connection_string');
 const { MongoParseError } = require('../../src/error');
 const { loadSpecTests } = require('../spec');
 
-describe('URI Options (spec)', function() {
+describe('URI Options (spec)', function () {
   loadSpecTests('uri-options').forEach(suite => {
     describe(suite.name, () => {
       suite.tests.forEach(test => {
@@ -16,7 +16,7 @@ describe('URI Options (spec)', function() {
 
         itFn(test.description, {
           metadata: { requires: { topology: 'single' } },
-          test: function(done) {
+          test: function (done) {
             parse(test.uri, {}, (err, result) => {
               if (test.valid === true) {
                 expect(err).to.not.exist;

--- a/test/functional/view.test.js
+++ b/test/functional/view.test.js
@@ -4,11 +4,11 @@ var expect = require('chai').expect,
   co = require('co');
 const { Long } = require('../../src');
 
-describe('Views', function() {
+describe('Views', function () {
   it('should successfully pass through collation to findAndModify command', {
     metadata: { requires: { generators: true, topology: 'single' } },
 
-    test: function(done) {
+    test: function (done) {
       var self = this;
       const configuration = this.configuration;
 
@@ -19,7 +19,7 @@ describe('Views', function() {
       var primary = [Object.assign({}, defaultFields)];
 
       // Boot the mock
-      co(function*() {
+      co(function* () {
         const singleServer = yield mock.createServer();
 
         singleServer.setMessageHandler(request => {
@@ -47,12 +47,12 @@ describe('Views', function() {
 
         // Connect to the mocks
         const client = configuration.newClient(`mongodb://${singleServer.uri()}/test`);
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           expect(err).to.not.exist;
           var db = client.db(self.configuration.db);
 
           // Simple findAndModify command returning the new document
-          db.createCollection('test', { viewOn: 'users', pipeline: [{ $match: {} }] }, function(
+          db.createCollection('test', { viewOn: 'users', pipeline: [{ $match: {} }] }, function (
             err,
             r
           ) {

--- a/test/functional/write_concern.test.js
+++ b/test/functional/write_concern.test.js
@@ -7,13 +7,13 @@ const generateTopologyTests = require('./spec-runner').generateTopologyTests;
 const loadSpecTests = require('../spec').loadSpecTests;
 const { withMonitoredClient } = require('./shared');
 
-describe('Write Concern', function() {
-  describe('spec tests', function() {
+describe('Write Concern', function () {
+  describe('spec tests', function () {
     const testContext = new TestRunnerContext();
     const testSuites = loadSpecTests('read-write-concern/operation');
 
     after(() => testContext.teardown());
-    before(function() {
+    before(function () {
       return testContext.setup(this.configuration);
     });
 
@@ -21,7 +21,7 @@ describe('Write Concern', function() {
   });
 
   // TODO: once `read-write-concern/connection-string` spec tests are implemented these can likely be removed
-  describe('test journal connection string option', function() {
+  describe('test journal connection string option', function () {
     function journalOptionTest(client, events, done) {
       expect(client).to.have.nested.property('s.options');
       const clientOptions = client.s.options;
@@ -32,9 +32,7 @@ describe('Write Concern', function() {
         .insertOne({ a: 1 }, (err, result) => {
           expect(err).to.not.exist;
           expect(result).to.exist;
-          expect(events)
-            .to.be.an('array')
-            .with.lengthOf(1);
+          expect(events).to.be.an('array').with.lengthOf(1);
           expect(events[0]).to.containSubset({
             commandName: 'insert',
             command: {

--- a/test/manual/atlas_connectivity.test.js
+++ b/test/manual/atlas_connectivity.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const { MongoClient } = require('../../src');
 
-describe('Atlas Connectivity', function() {
+describe('Atlas Connectivity', function () {
   if (process.env.ATLAS_CONNECTIVITY == null) {
     console.log(
       'skipping atlas connectivity tests, ATLAS_CONNECTIVITY environment variable is not defined'
@@ -12,7 +12,7 @@ describe('Atlas Connectivity', function() {
 
   const CONFIGS = JSON.parse(process.env.ATLAS_CONNECTIVITY);
   Object.keys(CONFIGS).forEach(configName => {
-    context(configName, function() {
+    context(configName, function () {
       CONFIGS[configName].forEach(connectionString => {
         const name = connectionString.indexOf('mongodb+srv') >= 0 ? 'mongodb+srv' : 'normal';
         it(`${name}`, makeConnectionTest(connectionString));
@@ -22,18 +22,13 @@ describe('Atlas Connectivity', function() {
 });
 
 function makeConnectionTest(connectionString, clientOptions) {
-  return function() {
+  return function () {
     const client = new MongoClient(connectionString, clientOptions);
 
     return client
       .connect()
       .then(() => client.db('admin').command({ ismaster: 1 }))
-      .then(() =>
-        client
-          .db('test')
-          .collection('test')
-          .findOne({})
-      )
+      .then(() => client.db('test').collection('test').findOne({}))
       .then(() => client.close());
   };
 }

--- a/test/manual/ocsp_support.test.js
+++ b/test/manual/ocsp_support.test.js
@@ -7,8 +7,8 @@ const OCSP_TLS_SHOULD_SUCCEED = process.env.OCSP_TLS_SHOULD_SUCCEED;
 const CA_FILE = process.env.CA_FILE;
 
 // NOTE: this file is NOT run through the normal test runner
-describe('OCSP Support', function() {
-  before(function() {
+describe('OCSP Support', function () {
+  before(function () {
     if (OCSP_TLS_SHOULD_SUCCEED == null || CA_FILE == null) {
       this.skip();
     }
@@ -28,17 +28,17 @@ describe('OCSP Support', function() {
     });
   }
 
-  it('should support OCSP with tlsInsecure', function(done) {
+  it('should support OCSP with tlsInsecure', function (done) {
     // should always succeed
     connect('tls=true&tlsInsecure=true', done);
   });
 
-  it('should support OCSP with tlsAllowInvalidCertificates', function(done) {
+  it('should support OCSP with tlsAllowInvalidCertificates', function (done) {
     // should always succeed
     connect('tls=true&tlsAllowInvalidCertificates=true', done);
   });
 
-  it('should support OCSP with `tls=true`', function(done) {
+  it('should support OCSP with `tls=true`', function (done) {
     connect('tls=true', err => {
       if (OCSP_TLS_SHOULD_SUCCEED) {
         expect(err).to.not.exist;

--- a/test/node-next/es2018/cursor_async_iterator.test.js
+++ b/test/node-next/es2018/cursor_async_iterator.test.js
@@ -2,9 +2,9 @@
 
 const { expect } = require('chai');
 
-describe('Cursor Async Iterator Tests', function() {
+describe('Cursor Async Iterator Tests', function () {
   let client, collection;
-  before(async function() {
+  before(async function () {
     client = this.configuration.newClient();
 
     await client.connect();
@@ -17,7 +17,7 @@ describe('Cursor Async Iterator Tests', function() {
     await client.close();
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     client = this.configuration.newClient();
     await client.connect();
     collection = client.db(this.configuration.db).collection('async_cursor_tests');
@@ -27,7 +27,7 @@ describe('Cursor Async Iterator Tests', function() {
 
   it('should be able to use a for-await loop on a find command cursor', {
     metadata: { requires: { node: '>=10.5.0' } },
-    test: async function() {
+    test: async function () {
       const cursor = collection.find({ bar: 1 });
 
       let counter = 0;
@@ -42,7 +42,7 @@ describe('Cursor Async Iterator Tests', function() {
 
   it('should be able to use a for-await loop on an aggregation cursor', {
     metadata: { requires: { node: '>=10.5.0' } },
-    test: async function() {
+    test: async function () {
       const cursor = collection.aggregate([{ $match: { bar: 1 } }]);
 
       let counter = 0;
@@ -57,7 +57,7 @@ describe('Cursor Async Iterator Tests', function() {
 
   it('should be able to use a for-await loop on a command cursor', {
     metadata: { requires: { node: '>=10.5.0', mongodb: '>=3.0.0' } },
-    test: async function() {
+    test: async function () {
       const cursor1 = collection.listIndexes();
       const cursor2 = collection.listIndexes();
 
@@ -74,7 +74,7 @@ describe('Cursor Async Iterator Tests', function() {
 
   it('should properly stop when cursor is closed', {
     metadata: { requires: { node: '>=10.5.0' } },
-    test: async function() {
+    test: async function () {
       const cursor = collection.find();
 
       let count = 0;

--- a/test/tools/runner/config.js
+++ b/test/tools/runner/config.js
@@ -32,7 +32,7 @@ class NativeConfiguration {
       parsedURI.options
     );
 
-    this.writeConcern = function() {
+    this.writeConcern = function () {
       return { w: 1 };
     };
   }

--- a/test/tools/runner/index.js
+++ b/test/tools/runner/index.js
@@ -52,7 +52,7 @@ function filterOutTests(suite) {
   suite.suites.forEach(suite => filterOutTests(suite));
 }
 
-before(function(_done) {
+before(function (_done) {
   // NOTE: if we first parse the connection string and redact auth, then we can reenable this
   // const usingUnifiedTopology = !!process.env.MONGODB_UNIFIED_TOPOLOGY;
   // console.log(
@@ -112,7 +112,7 @@ chai.config.truncateThreshold = 0;
 // install signal handlers for printing open/active handles
 function dumpAndExit() {
   // let other potential handlers run before exiting
-  process.nextTick(function() {
+  process.nextTick(function () {
     try {
       wtfnode.dump();
     } catch (e) {

--- a/test/tools/runner/metadata_ui.js
+++ b/test/tools/runner/metadata_ui.js
@@ -14,10 +14,10 @@ var Mocha = require('mocha'),
  *
  * @param {any} suite
  */
-module.exports = Mocha.interfaces.metadata_ui = function(suite) {
+module.exports = Mocha.interfaces.metadata_ui = function (suite) {
   var suites = [suite];
 
-  suite.on('pre-require', function(context, file, mocha) {
+  suite.on('pre-require', function (context, file, mocha) {
     var common = require('mocha/lib/interfaces/common')(suites, context, mocha);
 
     context.before = common.before;
@@ -31,7 +31,7 @@ module.exports = Mocha.interfaces.metadata_ui = function(suite) {
      *
      * @param {any} args
      */
-    var _parseArgs = function(args) {
+    var _parseArgs = function (args) {
       var testData = {};
       if (typeof args[0] !== 'string') {
         throw new Error('First argument must be a string.');
@@ -90,7 +90,7 @@ module.exports = Mocha.interfaces.metadata_ui = function(suite) {
      *
      * @param {any} opts
      */
-    var _create = function(opts) {
+    var _create = function (opts) {
       var testData = _parseArgs(opts.args);
 
       // Creating the Suite object
@@ -125,7 +125,7 @@ module.exports = Mocha.interfaces.metadata_ui = function(suite) {
      * and callback `fn` containing nested suites
      * and/or tests.
      */
-    context.describe = context.context = function() {
+    context.describe = context.context = function () {
       return _create({
         args: arguments
       });
@@ -134,7 +134,7 @@ module.exports = Mocha.interfaces.metadata_ui = function(suite) {
     /**
      * Pending describe.
      */
-    context.xdescribe = context.xcontext = context.describe.skip = function() {
+    context.xdescribe = context.xcontext = context.describe.skip = function () {
       return _create({
         args: arguments,
         pending: true
@@ -144,7 +144,7 @@ module.exports = Mocha.interfaces.metadata_ui = function(suite) {
     /**
      * Exclusive suite.
      */
-    context.describe.only = function() {
+    context.describe.only = function () {
       return _create({
         args: arguments,
         isOnly: true
@@ -156,7 +156,7 @@ module.exports = Mocha.interfaces.metadata_ui = function(suite) {
      * with the given `title` and callback `fn`
      * acting as a thunk.
      */
-    context.it = context.specify = function() {
+    context.it = context.specify = function () {
       var testData = _parseArgs(arguments);
 
       var testSuite = suites[0];
@@ -174,7 +174,7 @@ module.exports = Mocha.interfaces.metadata_ui = function(suite) {
     /**
      * Exclusive test-case
      */
-    context.it.only = function() {
+    context.it.only = function () {
       if (arguments.length === 1) {
         return common.test.only(mocha, context.it(arguments[0]));
       } else if (arguments.length === 2) {
@@ -191,7 +191,7 @@ module.exports = Mocha.interfaces.metadata_ui = function(suite) {
      *
      * @param {any} title
      */
-    context.xit = context.xspecify = context.it.skip = function(title) {
+    context.xit = context.xspecify = context.it.skip = function (title) {
       context.it(title);
     };
 
@@ -200,7 +200,7 @@ module.exports = Mocha.interfaces.metadata_ui = function(suite) {
      *
      * @param {any} n
      */
-    context.it.retries = function(n) {
+    context.it.retries = function (n) {
       context.retries(n);
     };
   });

--- a/test/tools/runner/plugins/client_leak_checker.js
+++ b/test/tools/runner/plugins/client_leak_checker.js
@@ -5,7 +5,7 @@ const chalk = require('chalk');
 
 let activeClients = [];
 const $newClient = TestConfiguration.prototype.newClient;
-TestConfiguration.prototype.newClient = function() {
+TestConfiguration.prototype.newClient = function () {
   const client = $newClient.apply(this, arguments);
   client.trace = new Error().stack;
   activeClients.push(client);
@@ -29,7 +29,7 @@ function unifiedTopologyIsConnected(client) {
   );
 }
 
-after(function() {
+after(function () {
   const traces = [];
   const openClientCount = activeClients.reduce((count, client) => {
     if (unifiedTopologyIsConnected(client)) {

--- a/test/tools/runner/plugins/deferred.js
+++ b/test/tools/runner/plugins/deferred.js
@@ -37,7 +37,7 @@ const kDeferred = Symbol('deferred');
     };
   }
 
-  Context.prototype.defer = function(fn) {
+  Context.prototype.defer = function (fn) {
     const test = this.test;
     if (test[kDeferred] == null) {
       test[kDeferred] = new Set();

--- a/test/tools/runner/plugins/session_leak_checker.js
+++ b/test/tools/runner/plugins/session_leak_checker.js
@@ -27,13 +27,13 @@ beforeEach('Session Leak Before Each - Set up clean test environment', () => {
   activeSessionsBeforeClose = new Set();
 });
 
-beforeEach('Session Leak Before Each - setup session tracking', function() {
+beforeEach('Session Leak Before Each - setup session tracking', function () {
   if (!this.currentTest || getSessionLeakMetadata(this.currentTest).skipLeakTests) {
     return;
   }
 
   const _acquire = ServerSessionPool.prototype.acquire;
-  sandbox.stub(ServerSessionPool.prototype, 'acquire').callsFake(function() {
+  sandbox.stub(ServerSessionPool.prototype, 'acquire').callsFake(function () {
     const session = _acquire.apply(this, arguments);
     session.trace = new Error().stack;
     activeSessions.add(session);
@@ -41,7 +41,7 @@ beforeEach('Session Leak Before Each - setup session tracking', function() {
   });
 
   const _release = ServerSessionPool.prototype.release;
-  sandbox.stub(ServerSessionPool.prototype, 'release').callsFake(function(session) {
+  sandbox.stub(ServerSessionPool.prototype, 'release').callsFake(function (session) {
     activeSessions.delete(session);
     pooledSessions.add(session);
 
@@ -49,14 +49,14 @@ beforeEach('Session Leak Before Each - setup session tracking', function() {
   });
 
   const _endAllPooledSessions = ServerSessionPool.prototype.endAllPooledSessions;
-  sandbox.stub(ServerSessionPool.prototype, 'endAllPooledSessions').callsFake(function() {
+  sandbox.stub(ServerSessionPool.prototype, 'endAllPooledSessions').callsFake(function () {
     pooledSessions.clear();
     return _endAllPooledSessions.apply(this, arguments);
   });
 
   [Topology].forEach(topology => {
     const _endSessions = topology.prototype.endSessions;
-    sandbox.stub(topology.prototype, 'endSessions').callsFake(function(sessions) {
+    sandbox.stub(topology.prototype, 'endSessions').callsFake(function (sessions) {
       sessions = Array.isArray(sessions) ? sessions : [sessions];
       sessions.forEach(session => pooledSessions.delete(session));
       return _endSessions.apply(this, arguments);
@@ -64,13 +64,13 @@ beforeEach('Session Leak Before Each - setup session tracking', function() {
   });
 
   const _close = MongoClient.prototype.close;
-  sandbox.stub(MongoClient.prototype, 'close').callsFake(function() {
+  sandbox.stub(MongoClient.prototype, 'close').callsFake(function () {
     activeSessionsBeforeClose = new Set(activeSessions);
     return _close.apply(this, arguments);
   });
 });
 
-afterEach('Session Leak After Each - ensure no leaks', function() {
+afterEach('Session Leak After Each - ensure no leaks', function () {
   if (
     this.currentTest == null ||
     this.currentTest.state === 'failed' ||

--- a/test/tools/ts-pipeline.js
+++ b/test/tools/ts-pipeline.js
@@ -7,7 +7,7 @@ const prettier = require('gulp-prettier');
 const through = require('through2');
 
 function preserveNewlines() {
-  return through.obj(function(file, encoding, callback) {
+  return through.obj(function (file, encoding, callback) {
     const data = file.contents.toString('utf8');
     const fixedUp = data.replace(/\n\n/g, '\n/** THIS_IS_A_NEWLINE **/');
     file.contents = Buffer.from(fixedUp, 'utf8');
@@ -16,7 +16,7 @@ function preserveNewlines() {
 }
 
 function restoreNewlines() {
-  return through.obj(function(file, encoding, callback) {
+  return through.obj(function (file, encoding, callback) {
     const data = file.contents.toString('utf8');
     const fixedUp = data.replace(/\/\*\* THIS_IS_A_NEWLINE \*\*\//g, '\n');
     file.contents = Buffer.from(fixedUp, 'utf8');
@@ -25,9 +25,9 @@ function restoreNewlines() {
 }
 
 const tsConfig = JSON.parse(fs.readFileSync(path.join(__dirname, '../../tsconfig.json')));
-const prettierConfig = JSON.parse(fs.readFileSync(path.join(__dirname, '../../.prettierrc')));
+const prettierConfig = JSON.parse(fs.readFileSync(path.join(__dirname, '../../.prettierrc.json')));
 
-gulp.task('default', function() {
+gulp.task('default', function () {
   return gulp
     .src('../../src/**/*.ts')
     .pipe(preserveNewlines())

--- a/test/tools/utils.js
+++ b/test/tools/utils.js
@@ -31,7 +31,7 @@ ClassWithLogger.prototype.f = makeTestFunction({
   optionsIndex: 0
 });
 
-ClassWithLogger.prototype.getLogger = function() {
+ClassWithLogger.prototype.getLogger = function () {
   return this.logger;
 };
 
@@ -53,7 +53,7 @@ ClassWithUndefinedLogger.prototype.f = makeTestFunction({
   optionsIndex: 0
 });
 
-ClassWithUndefinedLogger.prototype.getLogger = function() {
+ClassWithUndefinedLogger.prototype.getLogger = function () {
   return undefined;
 };
 

--- a/test/unit/bulk_write.test.js
+++ b/test/unit/bulk_write.test.js
@@ -3,7 +3,7 @@
 const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
 
-describe('Bulk Writes', function() {
+describe('Bulk Writes', function () {
   const test = {};
 
   let documents;
@@ -20,7 +20,7 @@ describe('Bulk Writes', function() {
   });
   afterEach(() => mock.cleanup());
 
-  it('should propagate errors', function(done) {
+  it('should propagate errors', function (done) {
     const client = this.configuration.newClient(`mongodb://${test.server.uri()}/test`);
 
     let close = e => {
@@ -47,12 +47,12 @@ describe('Bulk Writes', function() {
       }
     });
 
-    client.connect(function(err) {
+    client.connect(function (err) {
       expect(err).to.be.null;
 
       const coll = client.db('foo').collection('bar');
 
-      coll.insert(documents, { ordered: false }, function(err) {
+      coll.insert(documents, { ordered: false }, function (err) {
         try {
           expect(err).to.be.an.instanceOf(Error);
           close();

--- a/test/unit/bypass_validation.test.js
+++ b/test/unit/bypass_validation.test.js
@@ -3,7 +3,7 @@
 const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
 
-describe('bypass document validation', function() {
+describe('bypass document validation', function () {
   const test = {};
   beforeEach(() => {
     return mock.createServer().then(server => {
@@ -45,7 +45,7 @@ describe('bypass document validation', function() {
       }
     });
 
-    client.connect(function(err, client) {
+    client.connect(function (err, client) {
       expect(err).to.not.exist;
       const db = client.db('test');
       const collection = db.collection('test_c');
@@ -61,11 +61,11 @@ describe('bypass document validation', function() {
     });
   }
   // aggregate
-  it('should only set bypass document validation if strictly true in aggregate', function(done) {
+  it('should only set bypass document validation if strictly true in aggregate', function (done) {
     testAggregate(this.configuration, { expected: true, actual: true }, done);
   });
 
-  it('should not set bypass document validation if not strictly true in aggregate', function(done) {
+  it('should not set bypass document validation if not strictly true in aggregate', function (done) {
     testAggregate(this.configuration, { expected: undefined, actual: false }, done);
   });
 
@@ -98,7 +98,7 @@ describe('bypass document validation', function() {
       }
     });
 
-    client.connect(function(err, client) {
+    client.connect(function (err, client) {
       expect(err).to.not.exist;
       const db = client.db('test');
       const collection = db.collection('test_c');
@@ -119,11 +119,11 @@ describe('bypass document validation', function() {
     });
   }
   // map reduce
-  it('should only set bypass document validation if strictly true in mapReduce', function(done) {
+  it('should only set bypass document validation if strictly true in mapReduce', function (done) {
     testMapReduce(this.configuration, { expected: true, actual: true }, done);
   });
 
-  it('should not set bypass document validation if not strictly true in mapReduce', function(done) {
+  it('should not set bypass document validation if not strictly true in mapReduce', function (done) {
     testMapReduce(this.configuration, { expected: undefined, actual: false }, done);
   });
 
@@ -155,7 +155,7 @@ describe('bypass document validation', function() {
       }
     });
 
-    client.connect(function(err, client) {
+    client.connect(function (err, client) {
       expect(err).to.not.exist;
       const db = client.db('test');
       const collection = db.collection('test_c');
@@ -174,11 +174,11 @@ describe('bypass document validation', function() {
     });
   }
   // find and modify
-  it('should only set bypass document validation if strictly true in findAndModify', function(done) {
+  it('should only set bypass document validation if strictly true in findAndModify', function (done) {
     testFindAndModify(this.configuration, { expected: true, actual: true }, done);
   });
 
-  it('should not set bypass document validation if not strictly true in findAndModify', function(done) {
+  it('should not set bypass document validation if not strictly true in findAndModify', function (done) {
     testFindAndModify(this.configuration, { expected: undefined, actual: false }, done);
   });
 
@@ -210,7 +210,7 @@ describe('bypass document validation', function() {
       }
     });
 
-    client.connect(function(err, client) {
+    client.connect(function (err, client) {
       expect(err).to.not.exist;
       const db = client.db('test');
       const collection = db.collection('test_c');
@@ -224,20 +224,20 @@ describe('bypass document validation', function() {
     });
   }
   // ordered bulk write, testing change in ordered.js
-  it('should only set bypass document validation if strictly true in ordered bulkWrite', function(done) {
+  it('should only set bypass document validation if strictly true in ordered bulkWrite', function (done) {
     testBulkWrite(this.configuration, { expected: true, actual: true, ordered: true }, done);
   });
 
-  it('should not set bypass document validation if not strictly true in ordered bulkWrite', function(done) {
+  it('should not set bypass document validation if not strictly true in ordered bulkWrite', function (done) {
     testBulkWrite(this.configuration, { expected: undefined, actual: false, ordered: true }, done);
   });
 
   // unordered bulk write, testing change in ordered.js
-  it('should only set bypass document validation if strictly true in unordered bulkWrite', function(done) {
+  it('should only set bypass document validation if strictly true in unordered bulkWrite', function (done) {
     testBulkWrite(this.configuration, { expected: true, actual: true, ordered: false }, done);
   });
 
-  it('should not set bypass document validation if not strictly true in unordered bulkWrite', function(done) {
+  it('should not set bypass document validation if not strictly true in unordered bulkWrite', function (done) {
     testBulkWrite(this.configuration, { expected: undefined, actual: false, ordered: false }, done);
   });
 });

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -3,7 +3,7 @@
 const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
 
-describe('Client (unit)', function() {
+describe('Client (unit)', function () {
   let server;
 
   afterEach(() => mock.cleanup());
@@ -11,7 +11,7 @@ describe('Client (unit)', function() {
     return mock.createServer().then(_server => (server = _server));
   });
 
-  it('should let wrapping libraries amend the client metadata', function() {
+  it('should let wrapping libraries amend the client metadata', function () {
     let handshake;
     server.setMessageHandler(request => {
       const doc = request.document;
@@ -35,9 +35,7 @@ describe('Client (unit)', function() {
       this.defer(() => client.close());
 
       expect(handshake).to.have.nested.property('client.driver');
-      expect(handshake)
-        .nested.property('client.driver.name')
-        .to.equal('nodejs|mongoose');
+      expect(handshake).nested.property('client.driver.name').to.equal('nodejs|mongoose');
       expect(handshake)
         .nested.property('client.driver.version')
         .to.match(/|5.7.10/);

--- a/test/unit/cmap/connection.test.js
+++ b/test/unit/cmap/connection.test.js
@@ -5,12 +5,12 @@ const connect = require('../../../src/cmap/connect');
 const Connection = require('../../../src/cmap/connection').Connection;
 const expect = require('chai').expect;
 
-describe('Connection', function() {
+describe('Connection', function () {
   let server;
   after(() => mock.cleanup());
   before(() => mock.createServer().then(s => (server = s)));
 
-  it('should support fire-and-forget messages', function(done) {
+  it('should support fire-and-forget messages', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
@@ -33,7 +33,7 @@ describe('Connection', function() {
     });
   });
 
-  it('should destroy streams which time out', function(done) {
+  it('should destroy streams which time out', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
@@ -51,9 +51,7 @@ describe('Connection', function() {
         expect(err).to.exist;
         expect(result).to.not.exist;
 
-        expect(conn)
-          .property('stream')
-          .property('destroyed').to.be.true;
+        expect(conn).property('stream').property('destroyed').to.be.true;
 
         done();
       });

--- a/test/unit/cmap/connection_pool.test.js
+++ b/test/unit/cmap/connection_pool.test.js
@@ -37,12 +37,12 @@ function closePool(pool) {
   });
 }
 
-describe('Connection Pool', function() {
+describe('Connection Pool', function () {
   let server;
   after(() => mock.cleanup());
   before(() => mock.createServer().then(s => (server = s)));
 
-  it('should destroy connections which have been closed', function(done) {
+  it('should destroy connections which have been closed', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
@@ -69,9 +69,7 @@ describe('Connection Pool', function() {
 
         expect(events).to.have.length(1);
         const closeEvent = events[0];
-        expect(closeEvent)
-          .have.property('reason')
-          .equal('error');
+        expect(closeEvent).have.property('reason').equal('error');
       });
     });
 
@@ -86,7 +84,7 @@ describe('Connection Pool', function() {
     );
   });
 
-  it('should propagate socket timeouts to connections', function(done) {
+  it('should propagate socket timeouts to connections', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
@@ -114,7 +112,7 @@ describe('Connection Pool', function() {
     );
   });
 
-  it('should clear timed out wait queue members if no connections are available', function(done) {
+  it('should clear timed out wait queue members if no connections are available', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
@@ -141,17 +139,15 @@ describe('Connection Pool', function() {
         sinon.stub(pool, 'availableConnectionCount').get(() => 0);
         pool.checkIn(conn);
 
-        expect(pool)
-          .property('waitQueueSize')
-          .to.equal(0);
+        expect(pool).property('waitQueueSize').to.equal(0);
 
         done();
       });
     });
   });
 
-  describe('withConnection', function() {
-    it('should manage a connection for a successful operation', function(done) {
+  describe('withConnection', function () {
+    it('should manage a connection for a successful operation', function (done) {
       server.setMessageHandler(request => {
         const doc = request.document;
         if (doc.ismaster) {
@@ -176,7 +172,7 @@ describe('Connection Pool', function() {
       }, callback);
     });
 
-    it('should allow user interaction with an error', function(done) {
+    it('should allow user interaction with an error', function (done) {
       server.setMessageHandler(request => {
         const doc = request.document;
         if (doc.ismaster) {
@@ -199,7 +195,7 @@ describe('Connection Pool', function() {
       }, callback);
     });
 
-    it('should return an error to the original callback', function(done) {
+    it('should return an error to the original callback', function (done) {
       server.setMessageHandler(request => {
         const doc = request.document;
         if (doc.ismaster) {
@@ -221,7 +217,7 @@ describe('Connection Pool', function() {
       }, callback);
     });
 
-    it('should still manage a connection if no callback is provided', function(done) {
+    it('should still manage a connection if no callback is provided', function (done) {
       server.setMessageHandler(request => {
         const doc = request.document;
         if (doc.ismaster) {
@@ -249,7 +245,7 @@ describe('Connection Pool', function() {
     });
   });
 
-  describe('spec tests', function() {
+  describe('spec tests', function () {
     const threads = new Map();
     const connections = new Map();
     const orphans = new Set();
@@ -284,7 +280,7 @@ describe('Connection Pool', function() {
     }
 
     const OPERATION_FUNCTIONS = {
-      checkOut: function(op) {
+      checkOut: function (op) {
         return PROMISIFIED_POOL_FUNCTIONS.checkOut.call(pool).then(connection => {
           if (op.label != null) {
             connections.set(op.label, connection);
@@ -293,7 +289,7 @@ describe('Connection Pool', function() {
           }
         });
       },
-      checkIn: function(op) {
+      checkIn: function (op) {
         const connection = connections.get(op.connection);
         connections.delete(op.connection);
 
@@ -303,22 +299,22 @@ describe('Connection Pool', function() {
 
         return pool.checkIn(connection);
       },
-      clear: function() {
+      clear: function () {
         return pool.clear();
       },
-      close: function() {
+      close: function () {
         return PROMISIFIED_POOL_FUNCTIONS.close.call(pool);
       },
-      wait: function(options) {
+      wait: function (options) {
         const ms = options.ms;
         return new Promise(r => setTimeout(r, ms));
       },
-      start: function(options) {
+      start: function (options) {
         const target = options.target;
         const thread = getThread(target);
         thread.start();
       },
-      waitForThread: function(options) {
+      waitForThread: function (options) {
         const name = options.name;
         const target = options.target;
         const suppressError = options.suppressError;
@@ -335,7 +331,7 @@ describe('Connection Pool', function() {
           }
         });
       },
-      waitForEvent: function(options) {
+      waitForEvent: function (options) {
         const event = options.event;
         const count = options.count;
         return new Promise(resolve => {
@@ -428,7 +424,7 @@ describe('Connection Pool', function() {
     });
 
     loadSpecTests('connection-monitoring-and-pooling').forEach(test => {
-      it(test.description, function() {
+      it(test.description, function () {
         const operations = test.operations;
         const expectedEvents = test.events || [];
         const ignoreEvents = test.ignore || [];
@@ -471,9 +467,7 @@ describe('Connection Pool', function() {
 
             if (expectedError) {
               expect(actualError).to.exist;
-              expect(actualError)
-                .property('message')
-                .to.equal(expectedError.message);
+              expect(actualError).property('message').to.equal(expectedError.message);
             } else if (actualError) {
               throw actualError;
             }

--- a/test/unit/cmap/message_stream.test.js
+++ b/test/unit/cmap/message_stream.test.js
@@ -17,8 +17,8 @@ function bufferToStream(buffer) {
   return stream;
 }
 
-describe('Message Stream', function() {
-  describe('reading', function() {
+describe('Message Stream', function () {
+  describe('reading', function () {
     [
       {
         description: 'valid OP_REPLY',
@@ -85,7 +85,7 @@ describe('Message Stream', function() {
         error: 'Invalid message size: 67108865, max allowed: 67108864'
       }
     ].forEach(test => {
-      it(test.description, function(done) {
+      it(test.description, function (done) {
         const error = test.error;
         const expectedMessageCount = test.expectedMessageCount || 1;
         const inputStream = bufferToStream(test.data);
@@ -102,9 +102,7 @@ describe('Message Stream', function() {
           msg.parse();
 
           if (test.documents) {
-            expect(msg)
-              .to.have.property('documents')
-              .that.deep.equals(test.documents);
+            expect(msg).to.have.property('documents').that.deep.equals(test.documents);
           }
 
           if (messageCount === expectedMessageCount) {
@@ -118,9 +116,7 @@ describe('Message Stream', function() {
             return;
           }
 
-          expect(err)
-            .to.have.property('message')
-            .that.equals(error);
+          expect(err).to.have.property('message').that.equals(error);
 
           done();
         });
@@ -130,8 +126,8 @@ describe('Message Stream', function() {
     });
   });
 
-  describe('writing', function() {
-    it('should write a message to the stream', function(done) {
+  describe('writing', function () {
+    it('should write a message to the stream', function (done) {
       const readableStream = new Readable({ read() {} });
       const writeableStream = new Writable({
         write: (chunk, _, callback) => {

--- a/test/unit/collection.test.js
+++ b/test/unit/collection.test.js
@@ -15,10 +15,10 @@ class MockTopology extends EventEmitter {
   }
 }
 
-describe('Collection', function() {
+describe('Collection', function () {
   it('should not allow atomic operators for findOneAndReplace', {
     metadata: { requires: { topology: 'single' } },
-    test: function() {
+    test: function () {
       const db = new Db('fakeDb', new MockTopology());
       const collection = db.collection('test');
       expect(() => {

--- a/test/unit/core/apm.test.js
+++ b/test/unit/core/apm.test.js
@@ -6,12 +6,12 @@ const { CommandStartedEvent } = require('../../../src/cmap/events');
 
 const conn = { id: '<some id>', address: '<some address>' };
 
-describe('APM tests', function() {
-  describe('CommandStartedEvent', function() {
+describe('APM tests', function () {
+  describe('CommandStartedEvent', function () {
     // Only run on single topology since these are unit tests
     const metadata = { requires: { topology: ['single'] } };
 
-    it('should wrap a basic query option', metadata, function() {
+    it('should wrap a basic query option', metadata, function () {
       const db = 'test1';
       const coll = 'testingQuery';
       const query = new Query(
@@ -28,15 +28,11 @@ describe('APM tests', function() {
       expect(startEvent).to.have.property('commandName', 'testCmd');
       expect(startEvent).to.have.property('databaseName', db);
       expect(startEvent).to.have.property('requestId', query.requestId);
-      expect(startEvent)
-        .to.have.property('connectionId')
-        .that.is.a('string');
-      expect(startEvent)
-        .to.have.property('command')
-        .that.deep.equals(query.query);
+      expect(startEvent).to.have.property('connectionId').that.is.a('string');
+      expect(startEvent).to.have.property('command').that.deep.equals(query.query);
     });
 
-    it('should wrap a basic killCursor command', metadata, function() {
+    it('should wrap a basic killCursor command', metadata, function () {
       const db = 'test2';
       const coll = 'testingKillCursors';
       const killCursor = new KillCursor(`${db}.${coll}`, [12, 42, 57]);
@@ -46,18 +42,14 @@ describe('APM tests', function() {
       expect(startEvent).to.have.property('commandName', 'killCursors');
       expect(startEvent).to.have.property('databaseName', db);
       expect(startEvent).to.have.property('requestId', killCursor.requestId);
-      expect(startEvent)
-        .to.have.property('connectionId')
-        .that.is.a('string');
-      expect(startEvent)
-        .to.have.property('command')
-        .that.deep.equals({
-          killCursors: coll,
-          cursors: killCursor.cursorIds
-        });
+      expect(startEvent).to.have.property('connectionId').that.is.a('string');
+      expect(startEvent).to.have.property('command').that.deep.equals({
+        killCursors: coll,
+        cursors: killCursor.cursorIds
+      });
     });
 
-    it('should wrap a basic GetMore command', metadata, function() {
+    it('should wrap a basic GetMore command', metadata, function () {
       const db = 'test3';
       const coll = 'testingGetMore';
       const numberToReturn = 321;
@@ -68,22 +60,18 @@ describe('APM tests', function() {
       expect(startEvent).to.have.property('commandName', 'getMore');
       expect(startEvent).to.have.property('databaseName', db);
       expect(startEvent).to.have.property('requestId', getMore.requestId);
-      expect(startEvent)
-        .to.have.property('connectionId')
-        .that.is.a('string');
-      expect(startEvent)
-        .to.have.property('command')
-        .that.deep.equals({
-          getMore: getMore.cursorId,
-          collection: coll,
-          batchSize: numberToReturn
-        });
+      expect(startEvent).to.have.property('connectionId').that.is.a('string');
+      expect(startEvent).to.have.property('command').that.deep.equals({
+        getMore: getMore.cursorId,
+        collection: coll,
+        batchSize: numberToReturn
+      });
     });
 
     it(
       'should upconvert a Query wrapping a command into the corresponding command',
       metadata,
-      function() {
+      function () {
         const db = 'admin';
         const coll = '$cmd';
         const query = new Query(
@@ -105,16 +93,12 @@ describe('APM tests', function() {
         expect(startEvent).to.have.property('commandName', 'testCmd');
         expect(startEvent).to.have.property('databaseName', db);
         expect(startEvent).to.have.property('requestId', query.requestId);
-        expect(startEvent)
-          .to.have.property('connectionId')
-          .that.is.a('string');
-        expect(startEvent)
-          .to.have.property('command')
-          .that.deep.equals(query.query.$query);
+        expect(startEvent).to.have.property('connectionId').that.is.a('string');
+        expect(startEvent).to.have.property('command').that.deep.equals(query.query.$query);
       }
     );
 
-    it('should upconvert a Query wrapping a query into a find command', metadata, function() {
+    it('should upconvert a Query wrapping a query into a find command', metadata, function () {
       const db = 'test5';
       const coll = 'testingFindCommand';
       const query = new Query(
@@ -134,17 +118,13 @@ describe('APM tests', function() {
       expect(startEvent).to.have.property('commandName', 'find');
       expect(startEvent).to.have.property('databaseName', db);
       expect(startEvent).to.have.property('requestId', query.requestId);
-      expect(startEvent)
-        .to.have.property('connectionId')
-        .that.is.a('string');
-      expect(startEvent)
-        .to.have.property('command')
-        .that.deep.equals({
-          find: coll,
-          filter: query.query.$query,
-          batchSize: 0,
-          skip: 0
-        });
+      expect(startEvent).to.have.property('connectionId').that.is.a('string');
+      expect(startEvent).to.have.property('command').that.deep.equals({
+        find: coll,
+        filter: query.query.$query,
+        batchSize: 0,
+        skip: 0
+      });
     });
   });
 });

--- a/test/unit/core/connect.test.js
+++ b/test/unit/core/connect.test.js
@@ -9,7 +9,7 @@ const { MongoCredentials } = require('../../../src/cmap/auth/mongo_credentials')
 const { genClusterTime } = require('./common');
 const { MongoNetworkError } = require('../../../src/error');
 
-describe('Connect Tests', function() {
+describe('Connect Tests', function () {
   const test = {};
   beforeEach(() => {
     return mock.createServer().then(mockServer => {
@@ -28,7 +28,7 @@ describe('Connect Tests', function() {
   });
 
   afterEach(() => mock.cleanup());
-  it('should auth against a non-arbiter', function(done) {
+  it('should auth against a non-arbiter', function (done) {
     const whatHappened = {};
 
     test.server.setMessageHandler(request => {
@@ -60,7 +60,7 @@ describe('Connect Tests', function() {
     });
   });
 
-  it('should not auth against an arbiter', function(done) {
+  it('should not auth against an arbiter', function (done) {
     const whatHappened = {};
     test.server.setMessageHandler(request => {
       const doc = request.document;
@@ -91,14 +91,14 @@ describe('Connect Tests', function() {
     });
   });
 
-  it('should emit `MongoNetworkError` for network errors', function(done) {
+  it('should emit `MongoNetworkError` for network errors', function (done) {
     connect({ host: 'non-existent', port: 27018 }, err => {
       expect(err).to.be.instanceOf(MongoNetworkError);
       done();
     });
   });
 
-  it('should allow a cancellaton token', function(done) {
+  it('should allow a cancellaton token', function (done) {
     const cancellationToken = new EventEmitter();
     setTimeout(() => cancellationToken.emit('cancel'), 500);
     // set no response handler for mock server, effecively blackhole requests

--- a/test/unit/core/connection_string.test.js
+++ b/test/unit/core/connection_string.test.js
@@ -28,8 +28,8 @@ const skipTests = [
   'may support deprecated gssapiServiceName option (GSSAPI)'
 ];
 
-describe('Connection String', function() {
-  it('should support auth passed in through options', function(done) {
+describe('Connection String', function () {
+  it('should support auth passed in through options', function (done) {
     const optionsWithUser = {
       authMechanism: 'SCRAM-SHA-1',
       auth: { user: 'testing', password: 'llamas' }
@@ -61,32 +61,32 @@ describe('Connection String', function() {
     });
   });
 
-  it('should provide a default port if one is not provided', function(done) {
-    parseConnectionString('mongodb://hostname', function(err, result) {
+  it('should provide a default port if one is not provided', function (done) {
+    parseConnectionString('mongodb://hostname', function (err, result) {
       expect(err).to.not.exist;
       expect(result.hosts[0].port).to.equal(27017);
       done();
     });
   });
 
-  it('should correctly parse arrays', function(done) {
-    parseConnectionString('mongodb://hostname?foo=bar&foo=baz', function(err, result) {
+  it('should correctly parse arrays', function (done) {
+    parseConnectionString('mongodb://hostname?foo=bar&foo=baz', function (err, result) {
       expect(err).to.not.exist;
       expect(result.options.foo).to.deep.equal(['bar', 'baz']);
       done();
     });
   });
 
-  it('should parse boolean values', function(done) {
-    parseConnectionString('mongodb://hostname?retryWrites=1', function(err, result) {
+  it('should parse boolean values', function (done) {
+    parseConnectionString('mongodb://hostname?retryWrites=1', function (err, result) {
       expect(err).to.not.exist;
       expect(result.options.retryWrites).to.equal(false);
 
-      parseConnectionString('mongodb://hostname?retryWrites=false', function(err, result) {
+      parseConnectionString('mongodb://hostname?retryWrites=false', function (err, result) {
         expect(err).to.not.exist;
         expect(result.options.retryWrites).to.equal(false);
 
-        parseConnectionString('mongodb://hostname?retryWrites=true', function(err, result) {
+        parseConnectionString('mongodb://hostname?retryWrites=true', function (err, result) {
           expect(err).to.not.exist;
           expect(result.options.retryWrites).to.equal(true);
           done();
@@ -95,7 +95,7 @@ describe('Connection String', function() {
     });
   });
 
-  it('should parse compression options', function(done) {
+  it('should parse compression options', function (done) {
     parseConnectionString(
       'mongodb://localhost/?compressors=zlib&zlibCompressionLevel=4',
       (err, result) => {
@@ -111,7 +111,7 @@ describe('Connection String', function() {
     );
   });
 
-  it('should parse `readConcernLevel`', function(done) {
+  it('should parse `readConcernLevel`', function (done) {
     parseConnectionString('mongodb://localhost/?readConcernLevel=local', (err, result) => {
       expect(err).to.not.exist;
       expect(result.options).to.have.property('readConcern');
@@ -120,7 +120,7 @@ describe('Connection String', function() {
     });
   });
 
-  it('should parse `authMechanismProperties`', function(done) {
+  it('should parse `authMechanismProperties`', function (done) {
     parseConnectionString(
       'mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,SERVICE_REALM:blah,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI',
       (err, result) => {
@@ -141,7 +141,7 @@ describe('Connection String', function() {
     );
   });
 
-  it('should parse a numeric authSource with variable width', function(done) {
+  it('should parse a numeric authSource with variable width', function (done) {
     parseConnectionString('mongodb://test@localhost/?authSource=0001', (err, result) => {
       expect(err).to.not.exist;
       expect(result.options).to.have.property('authSource');
@@ -151,7 +151,7 @@ describe('Connection String', function() {
     });
   });
 
-  it('should parse a replicaSet with a leading number', function(done) {
+  it('should parse a replicaSet with a leading number', function (done) {
     parseConnectionString('mongodb://localhost/?replicaSet=123abc', (err, result) => {
       expect(err).to.not.exist;
       expect(result.options).to.have.property('replicaSet');
@@ -161,7 +161,7 @@ describe('Connection String', function() {
     });
   });
 
-  it('should parse multiple readPreferenceTags', function(done) {
+  it('should parse multiple readPreferenceTags', function (done) {
     parseConnectionString(
       'mongodb://localhost/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny',
       (err, result) => {
@@ -177,8 +177,8 @@ describe('Connection String', function() {
     );
   });
 
-  describe('validation', function() {
-    it('should validate compression options', function(done) {
+  describe('validation', function () {
+    it('should validate compression options', function (done) {
       parseConnectionString('mongodb://localhost/?zlibCompressionLevel=15', err => {
         expect(err).to.exist;
 
@@ -190,21 +190,21 @@ describe('Connection String', function() {
       });
     });
 
-    it('should validate authMechanism', function(done) {
+    it('should validate authMechanism', function (done) {
       parseConnectionString('mongodb://localhost/?authMechanism=DOGS', err => {
         expect(err).to.exist;
         done();
       });
     });
 
-    it('should validate readPreference', function(done) {
+    it('should validate readPreference', function (done) {
       parseConnectionString('mongodb://localhost/?readPreference=llamasPreferred', err => {
         expect(err).to.exist;
         done();
       });
     });
 
-    it('should validate non-equal tls values', function(done) {
+    it('should validate non-equal tls values', function (done) {
       parseConnectionString('mongodb://localhost/?tls=true&tls=false', err => {
         expect(err).to.have.property('message', 'All values of tls must be the same.');
         done();
@@ -212,21 +212,21 @@ describe('Connection String', function() {
     });
   });
 
-  describe('spec tests', function() {
+  describe('spec tests', function () {
     const suites = loadSpecTests('connection-string').concat(loadSpecTests('auth'));
 
     suites.forEach(suite => {
-      describe(suite.name, function() {
+      describe(suite.name, function () {
         suite.tests.forEach(test => {
           it(test.description, {
             metadata: { requires: { topology: 'single' } },
-            test: function(done) {
+            test: function (done) {
               if (skipTests.indexOf(test.description) !== -1) {
                 return this.skip();
               }
 
               const valid = test.valid;
-              parseConnectionString(test.uri, { caseTranslate: false }, function(err, result) {
+              parseConnectionString(test.uri, { caseTranslate: false }, function (err, result) {
                 if (valid === false) {
                   expect(err).to.exist;
                   expect(err).to.be.instanceOf(MongoParseError);

--- a/test/unit/core/mongodb_srv.test.js
+++ b/test/unit/core/mongodb_srv.test.js
@@ -4,8 +4,8 @@ const path = require('path');
 const parseConnectionString = require('../../../src/connection_string').parseConnectionString;
 const expect = require('chai').expect;
 
-describe('mongodb+srv', function() {
-  it('should parse a default database', function(done) {
+describe('mongodb+srv', function () {
+  it('should parse a default database', function (done) {
     parseConnectionString('mongodb+srv://test1.test.build.10gen.cc/somedb', (err, result) => {
       expect(err).to.not.exist;
       expect(result.auth.db).to.eql('somedb');
@@ -13,7 +13,7 @@ describe('mongodb+srv', function() {
     });
   });
 
-  describe('spec tests', function() {
+  describe('spec tests', function () {
     const specPath = path.join(__dirname, '../../spec', 'initial-dns-seedlist-discovery');
     const testFiles = fs
       .readdirSync(specPath)
@@ -28,7 +28,7 @@ describe('mongodb+srv', function() {
 
       it(test[1].comment, {
         metadata: { requires: { topology: ['single'] } },
-        test: function(done) {
+        test: function (done) {
           parseConnectionString(test[1].uri, (err, result) => {
             if (test[1].error) {
               expect(err).to.exist;
@@ -37,9 +37,7 @@ describe('mongodb+srv', function() {
               expect(err).to.not.exist;
               expect(result).to.exist;
               if (test[1].options) {
-                expect(result)
-                  .property('options')
-                  .to.matchMongoSpec(test[1].options);
+                expect(result).property('options').to.matchMongoSpec(test[1].options);
               }
               if (
                 test[1].parsed_options &&

--- a/test/unit/core/response_test.js.test.js
+++ b/test/unit/core/response_test.js.test.js
@@ -7,7 +7,7 @@ const { Topology } = require('../../../src/sdam/topology');
 const { Long } = require('bson');
 
 const test = {};
-describe('Response', function() {
+describe('Response', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => {
     return mock.createServer().then(mockServer => {
@@ -17,7 +17,7 @@ describe('Response', function() {
 
   it('should throw when document is error', {
     metadata: { requires: { topology: ['single'] } },
-    test: function(done) {
+    test: function (done) {
       const errdoc = {
         errmsg: 'Cursor not found (namespace: "liveearth.entityEvents", id: 2018648316188432590).'
       };
@@ -51,7 +51,7 @@ describe('Response', function() {
         const cursor = client.cursor('test.test', { find: 'test' });
 
         // Execute next
-        cursor._next(function(err) {
+        cursor._next(function (err) {
           expect(err).to.exist;
           expect(err).to.be.instanceof(MongoError);
           expect(err.message).to.equal(errdoc.errmsg);

--- a/test/unit/core/scram_iterations.test.js
+++ b/test/unit/core/scram_iterations.test.js
@@ -5,7 +5,7 @@ const mock = require('mongodb-mock-server');
 const { Topology } = require('../../../src/sdam/topology');
 const { MongoCredentials } = require('../../../src/cmap/auth/mongo_credentials');
 
-describe('SCRAM Iterations Tests', function() {
+describe('SCRAM Iterations Tests', function () {
   const test = {};
 
   beforeEach(() => {
@@ -16,7 +16,7 @@ describe('SCRAM Iterations Tests', function() {
 
   afterEach(() => mock.cleanup());
 
-  it('should error if iteration count is less than 4096', function(_done) {
+  it('should error if iteration count is less than 4096', function (_done) {
     const scramResponse =
       'r=IE+xNFeOcslsupAA+zkDVzHd5HfwoRuP7Wi8S4py+erf8PcNm7XIdXQyT52Nj3+M,s=AzomrlMs99A7oFxDLpgFvVb+CSvdyXuNagoWVw==,i=4000';
 
@@ -65,7 +65,7 @@ describe('SCRAM Iterations Tests', function() {
     client.connect();
   });
 
-  it('should error if server digest is invalid', function(_done) {
+  it('should error if server digest is invalid', function (_done) {
     const credentials = new MongoCredentials({
       mechanism: 'default',
       source: 'db',
@@ -112,7 +112,7 @@ describe('SCRAM Iterations Tests', function() {
     client.connect();
   });
 
-  it('should properly handle network errors on `saslContinue`', function(_done) {
+  it('should properly handle network errors on `saslContinue`', function (_done) {
     const credentials = new MongoCredentials({
       mechanism: 'default',
       source: 'db',

--- a/test/unit/core/sessions.test.js
+++ b/test/unit/core/sessions.test.js
@@ -8,11 +8,11 @@ const { ServerSessionPool, ServerSession, ClientSession } = require('../../../sr
 const { now } = require('../../../src/utils');
 
 let test = {};
-describe('Sessions', function() {
-  describe('ClientSession', function() {
+describe('Sessions', function () {
+  describe('ClientSession', function () {
     it('should throw errors with invalid parameters', {
       metadata: { requires: { topology: 'single' } },
-      test: function() {
+      test: function () {
         expect(() => {
           new ClientSession();
         }).to.throw(/ClientSession requires a topology/);
@@ -29,7 +29,7 @@ describe('Sessions', function() {
 
     it('should default to `null` for `clusterTime`', {
       metadata: { requires: { topology: 'single' } },
-      test: function(done) {
+      test: function (done) {
         const client = new Topology('localhost:27017');
         const sessionPool = client.s.sessionPool;
         const session = new ClientSession(client, sessionPool);
@@ -42,7 +42,7 @@ describe('Sessions', function() {
 
     it('should set the internal clusterTime to `initialClusterTime` if provided', {
       metadata: { requires: { topology: 'single' } },
-      test: function(done) {
+      test: function (done) {
         const clusterTime = genClusterTime(Date.now());
         const client = new Topology('localhost:27017');
         const sessionPool = client.s.sessionPool;
@@ -55,7 +55,7 @@ describe('Sessions', function() {
     });
   });
 
-  describe('ServerSessionPool', function() {
+  describe('ServerSessionPool', function () {
     afterEach(() => {
       test.client.destroy();
       return mock.cleanup();
@@ -88,7 +88,7 @@ describe('Sessions', function() {
 
     it('should throw errors with invalid parameters', {
       metadata: { requires: { topology: 'single' } },
-      test: function() {
+      test: function () {
         expect(() => {
           new ServerSessionPool();
         }).to.throw(/ServerSessionPool requires a topology/);
@@ -97,7 +97,7 @@ describe('Sessions', function() {
 
     it('should create a new session if the pool is empty', {
       metadata: { requires: { topology: 'single' } },
-      test: function(done) {
+      test: function (done) {
         const pool = new ServerSessionPool(test.client);
         done = sessionCleanupHandler(null, pool, done);
         expect(pool.sessions).to.have.length(0);
@@ -114,7 +114,7 @@ describe('Sessions', function() {
     it('should reuse sessions which have not timed out yet on acquire', {
       metadata: { requires: { topology: 'single' } },
 
-      test: function(done) {
+      test: function (done) {
         const oldSession = new ServerSession();
         const pool = new ServerSessionPool(test.client);
         done = sessionCleanupHandler(null, pool, done);
@@ -132,7 +132,7 @@ describe('Sessions', function() {
     it('should remove sessions which have timed out on acquire, and return a fresh session', {
       metadata: { requires: { topology: 'single' } },
 
-      test: function(done) {
+      test: function (done) {
         const oldSession = new ServerSession();
         oldSession.lastUse = now() - 30 * 60 * 1000; // add 30min
 
@@ -152,7 +152,7 @@ describe('Sessions', function() {
     it('should remove sessions which have timed out on release', {
       metadata: { requires: { topology: 'single' } },
 
-      test: function(done) {
+      test: function (done) {
         const newSession = new ServerSession();
         const oldSessions = [new ServerSession(), new ServerSession()].map(session => {
           session.lastUse = now() - 30 * 60 * 1000; // add 30min
@@ -173,7 +173,7 @@ describe('Sessions', function() {
     it('should not reintroduce a soon-to-expire session to the pool on release', {
       metadata: { requires: { topology: 'single' } },
 
-      test: function(done) {
+      test: function (done) {
         const session = new ServerSession();
         session.lastUse = now() - 9.5 * 60 * 1000; // add 9.5min
 
@@ -188,7 +188,7 @@ describe('Sessions', function() {
 
     it('should maintain a LIFO queue of sessions', {
       metadata: { requires: { topology: 'single' } },
-      test: function(done) {
+      test: function (done) {
         const pool = new ServerSessionPool(test.client);
         done = sessionCleanupHandler(null, pool, done);
 

--- a/test/unit/core/write_concern_error.test.js
+++ b/test/unit/core/write_concern_error.test.js
@@ -5,7 +5,7 @@ const { ReplSetFixture } = require('./common');
 const { MongoWriteConcernError } = require('../../../src/error');
 const { expect } = require('chai');
 
-describe('WriteConcernError', function() {
+describe('WriteConcernError', function () {
   let test;
   const RAW_USER_WRITE_CONCERN_CMD = {
     createUser: 'foo2',
@@ -83,7 +83,7 @@ describe('WriteConcernError', function() {
     replSet.connect();
   }
 
-  it('should expose a user command writeConcern error like a normal WriteConcernError', function(done) {
+  it('should expose a user command writeConcern error like a normal WriteConcernError', function (done) {
     test.primaryServer.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
@@ -120,7 +120,7 @@ describe('WriteConcernError', function() {
     });
   });
 
-  it('should propagate writeConcernError.errInfo ', function(done) {
+  it('should propagate writeConcernError.errInfo ', function (done) {
     test.primaryServer.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {

--- a/test/unit/create_index_error.test.js
+++ b/test/unit/create_index_error.test.js
@@ -3,12 +3,12 @@
 const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
 
-describe('CreateIndexError', function() {
+describe('CreateIndexError', function () {
   const test = {};
   beforeEach(() => mock.createServer().then(_server => (test.server = _server)));
   afterEach(() => mock.cleanup());
 
-  it('should error when createIndex fails', function(done) {
+  it('should error when createIndex fails', function (done) {
     const ERROR_RESPONSE = {
       ok: 0,
       errmsg:

--- a/test/unit/db_list_collections.test.js
+++ b/test/unit/db_list_collections.test.js
@@ -3,7 +3,7 @@
 const mock = require('mongodb-mock-server');
 const expect = require('chai').expect;
 
-describe('db.listCollections', function() {
+describe('db.listCollections', function () {
   const testHarness = {};
   afterEach(() => mock.cleanup());
   beforeEach(() => {

--- a/test/unit/deprecate_warning.test.js
+++ b/test/unit/deprecate_warning.test.js
@@ -9,12 +9,12 @@ chai.use(sinonChai);
 const makeTestFunction = require('../tools/utils').makeTestFunction;
 const ensureCalledWith = require('../tools/utils').ensureCalledWith;
 
-describe('Deprecation Warnings', function() {
+describe('Deprecation Warnings', function () {
   let messages = [];
   const deprecatedOptions = ['maxScan', 'snapshot', 'fields'];
   const defaultMessage = ' is deprecated and will be removed in a later version.';
 
-  before(function() {
+  before(function () {
     if (process.emitWarning) {
       process.on('warning', warning => {
         messages.push(warning.message);
@@ -23,16 +23,16 @@ describe('Deprecation Warnings', function() {
     return;
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     this.sinon.stub(console, 'error');
   });
 
-  afterEach(function() {
+  afterEach(function () {
     messages.length = 0;
   });
 
-  describe('Mult functions with same options', function() {
-    beforeEach(function() {
+  describe('Mult functions with same options', function () {
+    beforeEach(function () {
       const f1 = makeTestFunction({
         name: 'f1',
         deprecatedOptions: deprecatedOptions,
@@ -49,7 +49,7 @@ describe('Deprecation Warnings', function() {
 
     it('multiple functions with the same deprecated options should both warn', {
       metadata: { requires: { node: '>=6.0.0' } },
-      test: function(done) {
+      test: function (done) {
         process.nextTick(() => {
           expect(messages).to.deep.equal([
             'f1 option [maxScan]' + defaultMessage,
@@ -63,7 +63,7 @@ describe('Deprecation Warnings', function() {
 
     it('multiple functions with the same deprecated options should both warn', {
       metadata: { requires: { node: '<6.0.0' } },
-      test: function(done) {
+      test: function (done) {
         ensureCalledWith(console.error, [
           'f1 option [maxScan]' + defaultMessage,
           'f2 option [maxScan]' + defaultMessage
@@ -74,8 +74,8 @@ describe('Deprecation Warnings', function() {
     });
   });
 
-  describe('Empty options object', function() {
-    beforeEach(function() {
+  describe('Empty options object', function () {
+    beforeEach(function () {
       const f = makeTestFunction({
         name: 'f',
         deprecatedOptions: deprecatedOptions,
@@ -86,7 +86,7 @@ describe('Deprecation Warnings', function() {
 
     it('should not warn if empty options object passed in', {
       metadata: { requires: { node: '>=6.0.0' } },
-      test: function(done) {
+      test: function (done) {
         process.nextTick(() => {
           expect(messages).to.have.a.lengthOf(0);
           done();
@@ -96,15 +96,15 @@ describe('Deprecation Warnings', function() {
 
     it('should not warn if empty options object passed in', {
       metadata: { requires: { node: '<6.0.0' } },
-      test: function(done) {
+      test: function (done) {
         expect(console.error).to.have.not.been.called;
         done();
       }
     });
   });
 
-  describe('Custom Message Handler', function() {
-    beforeEach(function() {
+  describe('Custom Message Handler', function () {
+    beforeEach(function () {
       const customMsgHandler = (name, option) => {
         return 'custom msg for function ' + name + ' and option ' + option;
       };
@@ -121,7 +121,7 @@ describe('Deprecation Warnings', function() {
 
     it('should use user-specified message handler', {
       metadata: { requires: { node: '>=6.0.0' } },
-      test: function(done) {
+      test: function (done) {
         process.nextTick(() => {
           expect(messages).to.deep.equal([
             'custom msg for function f and option maxScan',
@@ -136,7 +136,7 @@ describe('Deprecation Warnings', function() {
 
     it('should use user-specified message handler', {
       metadata: { requires: { node: '<6.0.0' } },
-      test: function(done) {
+      test: function (done) {
         ensureCalledWith(console.error, [
           'custom msg for function f and option maxScan',
           'custom msg for function f and option snapshot',
@@ -148,8 +148,8 @@ describe('Deprecation Warnings', function() {
     });
   });
 
-  describe('Warn once', function() {
-    beforeEach(function() {
+  describe('Warn once', function () {
+    beforeEach(function () {
       const f = makeTestFunction({
         name: 'f',
         deprecatedOptions: deprecatedOptions,
@@ -161,7 +161,7 @@ describe('Deprecation Warnings', function() {
 
     it('each function should only warn once per deprecated option', {
       metadata: { requires: { node: '>=6.0.0' } },
-      test: function(done) {
+      test: function (done) {
         process.nextTick(() => {
           expect(messages).to.deep.equal([
             'f option [maxScan]' + defaultMessage,
@@ -175,7 +175,7 @@ describe('Deprecation Warnings', function() {
 
     it('each function should only warn once per deprecated option', {
       metadata: { requires: { node: '<6.0.0' } },
-      test: function(done) {
+      test: function (done) {
         ensureCalledWith(console.error, [
           'f option [maxScan]' + defaultMessage,
           'f option [fields]' + defaultMessage
@@ -186,8 +186,8 @@ describe('Deprecation Warnings', function() {
     });
   });
 
-  describe('Maintain functionality', function() {
-    beforeEach(function() {
+  describe('Maintain functionality', function () {
+    beforeEach(function () {
       const config = {
         name: 'f',
         deprecatedOptions: ['multiply', 'add'],
@@ -214,7 +214,7 @@ describe('Deprecation Warnings', function() {
 
     it('wrapped functions should maintain original functionality', {
       metadata: { requires: { node: '>=6.0.0' } },
-      test: function(done) {
+      test: function (done) {
         process.nextTick(() => {
           expect(messages).to.deep.equal([
             'f option [multiply]' + defaultMessage,
@@ -228,7 +228,7 @@ describe('Deprecation Warnings', function() {
 
     it('wrapped functions should maintain original functionality', {
       metadata: { requires: { node: '<6.0.0' } },
-      test: function(done) {
+      test: function (done) {
         ensureCalledWith(console.error, [
           'f option [multiply]' + defaultMessage,
           'f option [add]' + defaultMessage
@@ -239,7 +239,7 @@ describe('Deprecation Warnings', function() {
     });
   });
 
-  it('optionsIndex pointing to undefined should not error', function(done) {
+  it('optionsIndex pointing to undefined should not error', function (done) {
     const f = makeTestFunction({
       name: 'f',
       deprecatedOptions: deprecatedOptions,
@@ -249,7 +249,7 @@ describe('Deprecation Warnings', function() {
     done();
   });
 
-  it('optionsIndex not pointing to object should not error', function(done) {
+  it('optionsIndex not pointing to object should not error', function (done) {
     const f = makeTestFunction({
       name: 'f',
       deprecatedOptions: deprecatedOptions,

--- a/test/unit/execute_legacy_operation.test.js
+++ b/test/unit/execute_legacy_operation.test.js
@@ -3,8 +3,8 @@
 const expect = require('chai').expect;
 const executeLegacyOperation = require('../../src/utils').executeLegacyOperation;
 
-describe('executeLegacyOperation', function() {
-  it('should call callback with errors on throw errors, and rethrow error', function() {
+describe('executeLegacyOperation', function () {
+  it('should call callback with errors on throw errors, and rethrow error', function () {
     const expectedError = new Error('THIS IS AN ERROR');
     let callbackError, caughtError;
 
@@ -28,7 +28,7 @@ describe('executeLegacyOperation', function() {
     expect(caughtError).to.equal(expectedError);
   });
 
-  it('should reject promise with errors on throw errors, and rethrow error', function(done) {
+  it('should reject promise with errors on throw errors, and rethrow error', function (done) {
     const expectedError = new Error('THIS IS AN ERROR');
     let callbackError;
 

--- a/test/unit/sdam/monitoring.test.js
+++ b/test/unit/sdam/monitoring.test.js
@@ -14,15 +14,15 @@ class MockServer {
   }
 }
 
-describe('monitoring', function() {
+describe('monitoring', function () {
   let mockServer;
 
   after(() => mock.cleanup());
-  beforeEach(function() {
+  beforeEach(function () {
     return mock.createServer().then(server => (mockServer = server));
   });
 
-  it('should record roundTripTime', function(done) {
+  it('should record roundTripTime', function (done) {
     mockServer.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
@@ -38,22 +38,17 @@ describe('monitoring', function() {
       expect(err).to.not.exist;
 
       setTimeout(() => {
-        expect(topology)
-          .property('description')
-          .property('servers')
-          .to.have.length(1);
+        expect(topology).property('description').property('servers').to.have.length(1);
 
         const serverDescription = Array.from(topology.description.servers.values())[0];
-        expect(serverDescription)
-          .property('roundTripTime')
-          .to.be.greaterThan(0);
+        expect(serverDescription).property('roundTripTime').to.be.greaterThan(0);
 
         topology.close(done);
       }, 500);
     });
   });
 
-  it('should recover on error during initial connect', function(done) {
+  it('should recover on error during initial connect', function (done) {
     // This test should take ~1s because initial server selection fails and an immediate check
     // is requested. If the behavior of the immediate check is broken, the test will take ~10s
     // to complete. We want to ensure validation of the immediate check behavior, and therefore
@@ -82,22 +77,17 @@ describe('monitoring', function() {
     const topology = new Topology(mockServer.uri());
     topology.connect(err => {
       expect(err).to.not.exist;
-      expect(topology)
-        .property('description')
-        .property('servers')
-        .to.have.length(1);
+      expect(topology).property('description').property('servers').to.have.length(1);
 
       const serverDescription = Array.from(topology.description.servers.values())[0];
-      expect(serverDescription)
-        .property('roundTripTime')
-        .to.be.greaterThan(0);
+      expect(serverDescription).property('roundTripTime').to.be.greaterThan(0);
 
       topology.close(done);
     });
   });
 
-  describe('Monitor', function() {
-    it('should connect and issue an initial server check', function(done) {
+  describe('Monitor', function () {
+    it('should connect and issue an initial server check', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
         if (doc.ismaster) {
@@ -114,7 +104,7 @@ describe('monitoring', function() {
       monitor.connect();
     });
 
-    it('should ignore attempts to connect when not already closed', function(done) {
+    it('should ignore attempts to connect when not already closed', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
         if (doc.ismaster) {
@@ -132,7 +122,7 @@ describe('monitoring', function() {
       monitor.connect();
     });
 
-    it('should not initiate another check if one is in progress', function(done) {
+    it('should not initiate another check if one is in progress', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
         if (doc.ismaster) {
@@ -170,7 +160,7 @@ describe('monitoring', function() {
       });
     });
 
-    it('should not close the monitor on a failed heartbeat', function(done) {
+    it('should not close the monitor on a failed heartbeat', function (done) {
       let isMasterCount = 0;
       mockServer.setMessageHandler(request => {
         const doc = request.document;

--- a/test/unit/sdam/server_description.test.js
+++ b/test/unit/sdam/server_description.test.js
@@ -2,8 +2,8 @@
 const { ServerDescription } = require('../../../src/sdam/server_description');
 const expect = require('chai').expect;
 
-describe('ServerDescription', function() {
-  describe('error equality', function() {
+describe('ServerDescription', function () {
+  describe('error equality', function () {
     [
       {
         description: 'equal error types and messages',
@@ -36,13 +36,13 @@ describe('ServerDescription', function() {
         equal: false
       }
     ].forEach(test => {
-      it(test.description, function() {
+      it(test.description, function () {
         expect(test.lhs.equals(test.rhs)).to.equal(test.equal);
       });
     });
   });
 
-  it('should sensibly parse an ipv6 address', function() {
+  it('should sensibly parse an ipv6 address', function () {
     const description = new ServerDescription('abcd:f::abcd:abcd:abcd:abcd:27017');
     expect(description.host).to.equal('abcd:f::abcd:abcd:abcd:abcd');
     expect(description.port).to.equal(27017);

--- a/test/unit/sdam/server_selection/select_servers.test.js
+++ b/test/unit/sdam/server_selection/select_servers.test.js
@@ -5,29 +5,29 @@ const ReadPreference = require('../../../../src/read_preference');
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-describe('selectServer', function() {
-  beforeEach(function() {
+describe('selectServer', function () {
+  beforeEach(function () {
     this.sinon = sinon.sandbox.create();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     this.sinon.restore();
   });
 
-  it('should schedule monitoring if no suitable server is found', function(done) {
+  it('should schedule monitoring if no suitable server is found', function (done) {
     const topology = new Topology('someserver:27019');
     const requestCheck = this.sinon.stub(Server.prototype, 'requestCheck');
 
     // satisfy the initial connect, then restore the original method
     const selectServer = this.sinon
       .stub(Topology.prototype, 'selectServer')
-      .callsFake(function(selector, options, callback) {
+      .callsFake(function (selector, options, callback) {
         const server = Array.from(this.s.servers.values())[0];
         selectServer.restore();
         callback(null, server);
       });
 
-    this.sinon.stub(Server.prototype, 'connect').callsFake(function() {
+    this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
       this.s.state = 'connected';
       this.emit('connect');
     });
@@ -40,18 +40,16 @@ describe('selectServer', function() {
 
         // When server is created `connect` is called on the monitor. When server selection
         // occurs `requestCheck` will be called for an immediate check.
-        expect(requestCheck)
-          .property('callCount')
-          .to.equal(1);
+        expect(requestCheck).property('callCount').to.equal(1);
 
         topology.close(done);
       });
     });
   });
 
-  it('should disallow selection when the topology is explicitly closed', function(done) {
+  it('should disallow selection when the topology is explicitly closed', function (done) {
     const topology = new Topology('someserver:27019');
-    this.sinon.stub(Server.prototype, 'connect').callsFake(function() {
+    this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
       this.s.state = 'connected';
       this.emit('connect');
     });
@@ -65,18 +63,18 @@ describe('selectServer', function() {
     });
   });
 
-  describe('waitQueue', function() {
-    it('should process all wait queue members, including selection with errors', function(done) {
+  describe('waitQueue', function () {
+    it('should process all wait queue members, including selection with errors', function (done) {
       const topology = new Topology('someserver:27019');
       const selectServer = this.sinon
         .stub(Topology.prototype, 'selectServer')
-        .callsFake(function(selector, options, callback) {
+        .callsFake(function (selector, options, callback) {
           const server = Array.from(this.s.servers.values())[0];
           selectServer.restore();
           callback(null, server);
         });
 
-      this.sinon.stub(Server.prototype, 'connect').callsFake(function() {
+      this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
         this.s.state = 'connected';
         this.emit('connect');
       });

--- a/test/unit/sdam/server_selection/spec.test.js
+++ b/test/unit/sdam/server_selection/spec.test.js
@@ -49,10 +49,10 @@ function collectSelectionTests(specDir) {
   return tests;
 }
 
-describe('Server Selection (spec)', function() {
+describe('Server Selection (spec)', function () {
   let serverConnect;
   before(() => {
-    serverConnect = sinon.stub(Server.prototype, 'connect').callsFake(function() {
+    serverConnect = sinon.stub(Server.prototype, 'connect').callsFake(function () {
       this.s.state = 'connected';
     });
   });
@@ -63,25 +63,25 @@ describe('Server Selection (spec)', function() {
 
   const specTests = collectSelectionTests(selectionSpecDir);
   Object.keys(specTests).forEach(topologyType => {
-    describe(topologyType, function() {
+    describe(topologyType, function () {
       Object.keys(specTests[topologyType]).forEach(subType => {
-        describe(subType, function() {
+        describe(subType, function () {
           specTests[topologyType][subType].forEach(test => {
             // NOTE: node does not support PossiblePrimary
             const maybeIt = test.name.match(/Possible/) ? it.skip : it;
 
-            maybeIt(test.name, function(done) {
+            maybeIt(test.name, function (done) {
               executeServerSelectionTest(test, { checkLatencyWindow: false }, done);
             });
           });
         });
 
-        describe(subType + ' (within latency window)', function() {
+        describe(subType + ' (within latency window)', function () {
           specTests[topologyType][subType].forEach(test => {
             // NOTE: node does not support PossiblePrimary
             const maybeIt = test.name.match(/Possible/) ? it.skip : it;
 
-            maybeIt(test.name, function(done) {
+            maybeIt(test.name, function (done) {
               executeServerSelectionTest(test, { checkLatencyWindow: true }, done);
             });
           });
@@ -115,10 +115,10 @@ function collectStalenessTests(specDir) {
   return tests;
 }
 
-describe('Max Staleness (spec)', function() {
+describe('Max Staleness (spec)', function () {
   let serverConnect;
   before(() => {
-    serverConnect = sinon.stub(Server.prototype, 'connect').callsFake(function() {
+    serverConnect = sinon.stub(Server.prototype, 'connect').callsFake(function () {
       this.s.state = 'connected';
     });
   });
@@ -133,7 +133,7 @@ describe('Max Staleness (spec)', function() {
       specTests[specTestName].forEach(testData => {
         it(testData.description, {
           metadata: { requires: { topology: 'single' } },
-          test: function(done) {
+          test: function (done) {
             executeServerSelectionTest(testData, { checkLatencyWindow: false }, done);
           }
         });
@@ -240,7 +240,7 @@ function executeServerSelectionTest(testDefinition, options, testDone) {
   // call to `selectServers` call a fake, and then immediately restore the original behavior.
   let topologySelectServers = sinon
     .stub(Topology.prototype, 'selectServer')
-    .callsFake(function(selector, options, callback) {
+    .callsFake(function (selector, options, callback) {
       topologySelectServers.restore();
 
       const fakeServer = { s: { state: 'connected' }, removeListener: () => {} };

--- a/test/unit/sdam/spec.test.js
+++ b/test/unit/sdam/spec.test.js
@@ -42,10 +42,10 @@ function collectTests() {
   return tests;
 }
 
-describe('Server Discovery and Monitoring (spec)', function() {
+describe('Server Discovery and Monitoring (spec)', function () {
   let serverConnect;
   before(() => {
-    serverConnect = sinon.stub(Server.prototype, 'connect').callsFake(function() {
+    serverConnect = sinon.stub(Server.prototype, 'connect').callsFake(function () {
       this.s.state = 'connected';
       this.emit('connect');
     });
@@ -72,7 +72,7 @@ describe('Server Discovery and Monitoring (spec)', function() {
         const type = skip ? it.skip : it;
         type(testData.description, {
           metadata: { requires: { topology: 'single' } },
-          test: function(done) {
+          test: function (done) {
             executeSDAMTest(testData, done);
           }
         });
@@ -181,7 +181,7 @@ function executeSDAMTest(testData, testDone) {
     // call to `selectServers` call a fake, and then immediately restore the original behavior.
     let topologySelectServers = sinon
       .stub(Topology.prototype, 'selectServer')
-      .callsFake(function(selector, options, callback) {
+      .callsFake(function (selector, options, callback) {
         topologySelectServers.restore();
 
         const fakeServer = { s: { state: 'connected' }, removeListener: () => {} };
@@ -281,7 +281,7 @@ function executeSDAMTest(testData, testDone) {
 }
 
 function withConnectionStubImpl(appError) {
-  return function(fn, callback) {
+  return function (fn, callback) {
     const connectionPool = this; // we are stubbing `withConnection` on the `ConnectionPool` class
     const fakeConnection = {
       generation:

--- a/test/unit/sdam/srv_polling.test.js
+++ b/test/unit/sdam/srv_polling.test.js
@@ -15,7 +15,7 @@ const mock = require('mongodb-mock-server');
 const expect = chai.expect;
 chai.use(require('sinon-chai'));
 
-describe('Mongos SRV Polling', function() {
+describe('Mongos SRV Polling', function () {
   const context = {};
   const SRV_HOST = 'darmok.tanagra.com';
 
@@ -43,39 +43,37 @@ describe('Mongos SRV Polling', function() {
   }
 
   function stubDns(err, records) {
-    context.sinon.stub(dns, 'resolveSrv').callsFake(function(_srvAddress, callback) {
+    context.sinon.stub(dns, 'resolveSrv').callsFake(function (_srvAddress, callback) {
       process.nextTick(() => callback(err, records));
     });
   }
 
-  before(function() {
+  before(function () {
     context.sinon = sinon.createSandbox();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     context.sinon.restore();
   });
 
-  after(function() {
+  after(function () {
     delete context.sinon;
   });
 
-  describe('SrvPoller', function() {
+  describe('SrvPoller', function () {
     function stubPoller(poller) {
       context.sinon.stub(poller, 'success');
       context.sinon.stub(poller, 'failure');
       context.sinon.stub(poller, 'parentDomainMismatch');
     }
 
-    it('should always return a valid value for `intervalMS`', function() {
+    it('should always return a valid value for `intervalMS`', function () {
       const poller = new SrvPoller({ srvHost: SRV_HOST });
-      expect(poller)
-        .property('intervalMS')
-        .to.equal(60000);
+      expect(poller).property('intervalMS').to.equal(60000);
     });
 
-    describe('success', function() {
-      it('should emit event, disable haMode, and schedule another poll', function(done) {
+    describe('success', function () {
+      it('should emit event, disable haMode, and schedule another poll', function (done) {
         const records = [srvRecord('jalad.tanagra.com'), srvRecord('thebeast.tanagra.com')];
         const poller = new SrvPoller({ srvHost: SRV_HOST });
 
@@ -99,8 +97,8 @@ describe('Mongos SRV Polling', function() {
       });
     });
 
-    describe('failure', function() {
-      it('should enable haMode and schedule', function() {
+    describe('failure', function () {
+      it('should enable haMode and schedule', function () {
         const poller = new SrvPoller({ srvHost: SRV_HOST });
 
         context.sinon.stub(poller, 'schedule');
@@ -111,13 +109,13 @@ describe('Mongos SRV Polling', function() {
       });
     });
 
-    describe('poll', function() {
-      it('should throw if srvHost is not passed in', function() {
+    describe('poll', function () {
+      it('should throw if srvHost is not passed in', function () {
         expect(() => new SrvPoller()).to.throw(TypeError);
         expect(() => new SrvPoller({})).to.throw(TypeError);
       });
 
-      it('should poll dns srv records', function() {
+      it('should poll dns srv records', function () {
         const poller = new SrvPoller({ srvHost: SRV_HOST });
 
         context.sinon.stub(dns, 'resolveSrv');
@@ -130,7 +128,7 @@ describe('Mongos SRV Polling', function() {
         );
       });
 
-      it('should not succeed or fail if poller was stopped', function(done) {
+      it('should not succeed or fail if poller was stopped', function (done) {
         const poller = new SrvPoller({ srvHost: SRV_HOST });
 
         stubDns(null, []);
@@ -146,7 +144,7 @@ describe('Mongos SRV Polling', function() {
         });
       });
 
-      it('should fail if dns returns error', function(done) {
+      it('should fail if dns returns error', function (done) {
         const poller = new SrvPoller({ srvHost: SRV_HOST });
 
         stubDns(new Error('Some Error'));
@@ -161,7 +159,7 @@ describe('Mongos SRV Polling', function() {
         });
       });
 
-      it('should fail if dns returns no records', function(done) {
+      it('should fail if dns returns no records', function (done) {
         const poller = new SrvPoller({ srvHost: SRV_HOST });
 
         stubDns(null, []);
@@ -178,7 +176,7 @@ describe('Mongos SRV Polling', function() {
         });
       });
 
-      it('should fail if dns returns no records that match parent domain', function(done) {
+      it('should fail if dns returns no records that match parent domain', function (done) {
         const poller = new SrvPoller({ srvHost: SRV_HOST });
         const records = [srvRecord('jalad.tanagra.org'), srvRecord('shaka.walls.com')];
 
@@ -198,7 +196,7 @@ describe('Mongos SRV Polling', function() {
         });
       });
 
-      it('should succeed when valid records are returned by dns', function(done) {
+      it('should succeed when valid records are returned by dns', function (done) {
         const poller = new SrvPoller({ srvHost: SRV_HOST });
         const records = [srvRecord('jalad.tanagra.com'), srvRecord('thebeast.tanagra.com')];
 
@@ -214,7 +212,7 @@ describe('Mongos SRV Polling', function() {
         });
       });
 
-      it('should succeed when some valid records are returned and some do not match parent domain', function(done) {
+      it('should succeed when some valid records are returned and some do not match parent domain', function (done) {
         const poller = new SrvPoller({ srvHost: SRV_HOST });
         const records = [srvRecord('jalad.tanagra.com'), srvRecord('thebeast.walls.com')];
 
@@ -232,7 +230,7 @@ describe('Mongos SRV Polling', function() {
     });
   });
 
-  describe('topology', function() {
+  describe('topology', function () {
     class FakeSrvPoller extends EventEmitter {
       start() {}
       stop() {}
@@ -241,7 +239,7 @@ describe('Mongos SRV Polling', function() {
       }
     }
 
-    it('should not make an srv poller if there is no srv host', function() {
+    it('should not make an srv poller if there is no srv host', function () {
       const srvPoller = new FakeSrvPoller({ srvHost: SRV_HOST });
 
       const topology = new Topology(['localhost:27017,localhost:27018'], { srvPoller });
@@ -249,7 +247,7 @@ describe('Mongos SRV Polling', function() {
       expect(topology).to.not.have.property('srvPoller');
     });
 
-    it('should make an srvPoller if there is an srvHost', function() {
+    it('should make an srvPoller if there is an srvHost', function () {
       const srvPoller = new FakeSrvPoller({ srvHost: SRV_HOST });
 
       const topology = new Topology(['localhost:27017,localhost:27018'], {
@@ -257,12 +255,10 @@ describe('Mongos SRV Polling', function() {
         srvPoller
       });
 
-      expect(topology.s)
-        .to.have.property('srvPoller')
-        .that.equals(srvPoller);
+      expect(topology.s).to.have.property('srvPoller').that.equals(srvPoller);
     });
 
-    it('should only start polling if topology description changes to sharded', function() {
+    it('should only start polling if topology description changes to sharded', function () {
       const srvPoller = new FakeSrvPoller({ srvHost: SRV_HOST });
       sinon.stub(srvPoller, 'start');
 
@@ -294,7 +290,7 @@ describe('Mongos SRV Polling', function() {
       expect(srvPoller.start).to.have.been.calledOnce;
     });
 
-    describe('prose tests', function() {
+    describe('prose tests', function () {
       function srvAddresses(records) {
         return records.map(r => `${r.name}:${r.port}`);
       }
@@ -303,7 +299,7 @@ describe('Mongos SRV Polling', function() {
         msg: 'isdbgrid'
       });
 
-      beforeEach(function() {
+      beforeEach(function () {
         return Promise.all(Array.from({ length: 4 }).map(() => mock.createServer())).then(
           servers => {
             context.servers = servers;
@@ -311,11 +307,11 @@ describe('Mongos SRV Polling', function() {
         );
       });
 
-      afterEach(function() {
+      afterEach(function () {
         return mock.cleanup();
       });
 
-      afterEach(function(done) {
+      afterEach(function (done) {
         if (context.topology) {
           context.topology.close(done);
         } else {
@@ -351,8 +347,8 @@ describe('Mongos SRV Polling', function() {
 
             expect(servers).to.deep.equal(srvAddresses(recordSets[0]));
 
-            topology.once('topologyDescriptionChanged', function() {
-              tryDone(done, function() {
+            topology.once('topologyDescriptionChanged', function () {
+              tryDone(done, function () {
                 const servers = Array.from(topology.description.servers.keys());
 
                 expect(servers).to.deep.equal(srvAddresses(recordSets[1]));
@@ -368,7 +364,7 @@ describe('Mongos SRV Polling', function() {
 
       // The addition of a new DNS record:
       // _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27019  localhost.test.build.10gen.cc.
-      it('should handle the addition of a new DNS record', function(done) {
+      it('should handle the addition of a new DNS record', function (done) {
         const recordSets = [
           [srvRecord(context.servers[0]), srvRecord(context.servers[1])],
           [
@@ -382,7 +378,7 @@ describe('Mongos SRV Polling', function() {
 
       // The removal of an existing DNS record:
       // _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27018  localhost.test.build.10gen.cc.
-      it('should handle the removal of an existing DNS record', function(done) {
+      it('should handle the removal of an existing DNS record', function (done) {
         const recordSets = [
           [srvRecord(context.servers[0]), srvRecord(context.servers[1])],
           [srvRecord(context.servers[0])]
@@ -394,7 +390,7 @@ describe('Mongos SRV Polling', function() {
       // _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27018  localhost.test.build.10gen.cc.
       // replace by:
       // _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27019  localhost.test.build.10gen.cc.
-      it('should handle the replacement of a DNS record', function(done) {
+      it('should handle the replacement of a DNS record', function (done) {
         const recordSets = [
           [srvRecord(context.servers[0]), srvRecord(context.servers[1])],
           [srvRecord(context.servers[0]), srvRecord(context.servers[2])]
@@ -404,7 +400,7 @@ describe('Mongos SRV Polling', function() {
 
       // The replacement of both existing DNS records with one new record:
       // _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27019  localhost.test.build.10gen.cc.
-      it('should handle the replacement of both existing DNS records with one new record', function(done) {
+      it('should handle the replacement of both existing DNS records with one new record', function (done) {
         const recordSets = [
           [srvRecord(context.servers[0]), srvRecord(context.servers[1])],
           [srvRecord(context.servers[2])]
@@ -415,7 +411,7 @@ describe('Mongos SRV Polling', function() {
       // The replacement of both existing DNS records with two new records:
       // _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27019  localhost.test.build.10gen.cc.
       // _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27020  localhost.test.build.10gen.cc.
-      it('should handle the replacement of both existing DNS records with two new records', function(done) {
+      it('should handle the replacement of both existing DNS records with two new records', function (done) {
         const recordSets = [
           [srvRecord(context.servers[0]), srvRecord(context.servers[1])],
           [srvRecord(context.servers[2]), srvRecord(context.servers[3])]

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -7,8 +7,8 @@ const { Topology } = require('../../../src/sdam/topology');
 const { Server } = require('../../../src/sdam/server');
 const { ServerDescription } = require('../../../src/sdam/server_description');
 
-describe('Topology (unit)', function() {
-  describe('client metadata', function() {
+describe('Topology (unit)', function () {
+  describe('client metadata', function () {
     let mockServer;
     before(() => mock.createServer().then(server => (mockServer = server)));
     after(() => mock.cleanup());
@@ -16,7 +16,7 @@ describe('Topology (unit)', function() {
     it('should correctly pass appname', {
       metadata: { requires: { topology: 'single' } },
 
-      test: function(done) {
+      test: function (done) {
         // Attempt to connect
         var server = new Topology(
           [{ host: this.configuration.host, port: this.configuration.port }],
@@ -30,7 +30,7 @@ describe('Topology (unit)', function() {
       }
     });
 
-    it('should report the correct platform in client metadata', function(done) {
+    it('should report the correct platform in client metadata', function (done) {
       const ismasters = [];
       mockServer.setMessageHandler(request => {
         const doc = request.document;
@@ -63,15 +63,15 @@ describe('Topology (unit)', function() {
     });
   });
 
-  describe('shouldCheckForSessionSupport', function() {
-    beforeEach(function() {
+  describe('shouldCheckForSessionSupport', function () {
+    beforeEach(function () {
       this.sinon = sinon.sandbox.create();
 
       // these are mocks we want across all tests
       this.sinon.stub(Server.prototype, 'requestCheck');
       this.sinon
         .stub(Topology.prototype, 'selectServer')
-        .callsFake(function(selector, options, callback) {
+        .callsFake(function (selector, options, callback) {
           setTimeout(() => {
             const server = Array.from(this.s.servers.values())[0];
             callback(null, server);
@@ -79,13 +79,13 @@ describe('Topology (unit)', function() {
         });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       this.sinon.restore();
     });
 
-    it('should check for sessions if connected to a single server and has no known servers', function(done) {
+    it('should check for sessions if connected to a single server and has no known servers', function (done) {
       const topology = new Topology('someserver:27019');
-      this.sinon.stub(Server.prototype, 'connect').callsFake(function() {
+      this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
         this.s.state = 'connected';
         this.emit('connect');
       });
@@ -96,9 +96,9 @@ describe('Topology (unit)', function() {
       });
     });
 
-    it('should not check for sessions if connected to a single server', function(done) {
+    it('should not check for sessions if connected to a single server', function (done) {
       const topology = new Topology('someserver:27019');
-      this.sinon.stub(Server.prototype, 'connect').callsFake(function() {
+      this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
         this.s.state = 'connected';
         this.emit('connect');
 
@@ -116,9 +116,9 @@ describe('Topology (unit)', function() {
       });
     });
 
-    it('should check for sessions if there are no data-bearing nodes', function(done) {
+    it('should check for sessions if there are no data-bearing nodes', function (done) {
       const topology = new Topology('mongos:27019,mongos:27018,mongos:27017');
-      this.sinon.stub(Server.prototype, 'connect').callsFake(function() {
+      this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
         this.s.state = 'connected';
         this.emit('connect');
 
@@ -137,12 +137,12 @@ describe('Topology (unit)', function() {
     });
   });
 
-  describe('black holes', function() {
+  describe('black holes', function () {
     let mockServer;
     beforeEach(() => mock.createServer().then(server => (mockServer = server)));
     afterEach(() => mock.cleanup());
 
-    it('should time out operations against servers that have been blackholed', function(done) {
+    it('should time out operations against servers that have been blackholed', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
 
@@ -170,12 +170,12 @@ describe('Topology (unit)', function() {
     });
   });
 
-  describe('error handling', function() {
+  describe('error handling', function () {
     let mockServer;
     beforeEach(() => mock.createServer().then(server => (mockServer = server)));
     afterEach(() => mock.cleanup());
 
-    it('should set server to unknown and reset pool on `node is recovering` error', function(done) {
+    it('should set server to unknown and reset pool on `node is recovering` error', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
         if (doc.ismaster) {
@@ -212,7 +212,7 @@ describe('Topology (unit)', function() {
       });
     });
 
-    it('should set server to unknown and NOT reset pool on stepdown errors', function(done) {
+    it('should set server to unknown and NOT reset pool on stepdown errors', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
         if (doc.ismaster) {
@@ -249,7 +249,7 @@ describe('Topology (unit)', function() {
       });
     });
 
-    it('should set server to unknown on non-timeout network error', function(done) {
+    it('should set server to unknown on non-timeout network error', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
         if (doc.ismaster) {

--- a/test/unit/sessions/client.test.js
+++ b/test/unit/sessions/client.test.js
@@ -4,8 +4,8 @@ const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
 
 const test = {};
-describe('Sessions', function() {
-  describe('Client', function() {
+describe('Sessions', function () {
+  describe('Client', function () {
     afterEach(() => mock.cleanup());
     beforeEach(() => {
       return mock.createServer().then(server => {
@@ -15,7 +15,7 @@ describe('Sessions', function() {
 
     it('should throw an exception if sessions are not supported', {
       metadata: { requires: { topology: 'single' } },
-      test: function(done) {
+      test: function (done) {
         test.server.setMessageHandler(request => {
           var doc = request.document;
           if (doc.ismaster) {
@@ -26,7 +26,7 @@ describe('Sessions', function() {
         });
 
         const client = this.configuration.newClient(`mongodb://${test.server.uri()}/test`);
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           expect(err).to.not.exist;
           expect(() => {
             client.startSession();
@@ -40,7 +40,7 @@ describe('Sessions', function() {
     it('should return a client session when requested if the topology supports it', {
       metadata: { requires: { topology: 'single' } },
 
-      test: function(done) {
+      test: function (done) {
         test.server.setMessageHandler(request => {
           var doc = request.document;
           if (doc.ismaster) {
@@ -55,7 +55,7 @@ describe('Sessions', function() {
         });
 
         const client = this.configuration.newClient(`mongodb://${test.server.uri()}/test`);
-        client.connect(function(err, client) {
+        client.connect(function (err, client) {
           expect(err).to.not.exist;
           let session = client.startSession();
           expect(session).to.exist;

--- a/test/unit/sessions/collection.test.js
+++ b/test/unit/sessions/collection.test.js
@@ -4,8 +4,8 @@ const { expect } = require('chai');
 const mock = require('mongodb-mock-server');
 
 const test = {};
-describe('Sessions', function() {
-  describe('Collection', function() {
+describe('Sessions', function () {
+  describe('Collection', function () {
     afterEach(() => mock.cleanup());
     beforeEach(() => {
       return mock.createServer().then(server => {
@@ -16,7 +16,7 @@ describe('Sessions', function() {
     it('should include `afterClusterTime` in read command with causal consistency', {
       metadata: { requires: { topology: 'single' } },
 
-      test: function() {
+      test: function () {
         let findCommand;
         let insertOperationTime = Timestamp.fromNumber(Date.now());
         test.server.setMessageHandler(request => {
@@ -55,7 +55,7 @@ describe('Sessions', function() {
     it('does not mutate command options', {
       metadata: { requires: { topology: 'single' } },
 
-      test: function() {
+      test: function () {
         const options = Object.freeze({});
         test.server.setMessageHandler(request => {
           const doc = request.document;

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -3,9 +3,9 @@ const { eachAsync, now, makeInterruptableAsyncInterval } = require('../../src/ut
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-describe('utils', function() {
-  context('eachAsync', function() {
-    it('should callback with an error', function(done) {
+describe('utils', function () {
+  context('eachAsync', function () {
+    it('should callback with an error', function (done) {
       eachAsync(
         [{ error: false }, { error: true }],
         (item, cb) => {
@@ -18,7 +18,7 @@ describe('utils', function() {
       );
     });
 
-    it('should propagate a synchronously thrown error', function(done) {
+    it('should propagate a synchronously thrown error', function (done) {
       expect(() =>
         eachAsync(
           [{}],
@@ -35,16 +35,16 @@ describe('utils', function() {
     });
   });
 
-  context('makeInterruptableAsyncInterval', function() {
-    before(function() {
+  context('makeInterruptableAsyncInterval', function () {
+    before(function () {
       this.clock = sinon.useFakeTimers();
     });
 
-    after(function() {
+    after(function () {
       this.clock.restore();
     });
 
-    it('should execute a method in an repeating interval', function(done) {
+    it('should execute a method in an repeating interval', function (done) {
       let lastTime = now();
       const marks = [];
       const executor = makeInterruptableAsyncInterval(
@@ -66,7 +66,7 @@ describe('utils', function() {
       this.clock.tick(51);
     });
 
-    it('should schedule execution sooner if requested within min interval threshold', function(done) {
+    it('should schedule execution sooner if requested within min interval threshold', function (done) {
       let lastTime = now();
       const marks = [];
       const executor = makeInterruptableAsyncInterval(
@@ -90,7 +90,7 @@ describe('utils', function() {
       this.clock.tick(100);
     });
 
-    it('should debounce multiple requests to wake the interval sooner', function(done) {
+    it('should debounce multiple requests to wake the interval sooner', function (done) {
       let lastTime = now();
       const marks = [];
       const executor = makeInterruptableAsyncInterval(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "lib": ["ES2018"],
     "noEmitHelpers": true,
     "noEmitOnError": true,
-    "outDir": "lib"
+    "outDir": "lib",
+    "importsNotUsedAsValues": "error"
   },
   "ts-node": {
     "transpileOnly": true,


### PR DESCRIPTION
I separated the config changes from the formatting changes for easier viewing, I prevented prettier from adding trailing commas. I can't prevent it from adding a space after `function` and that in turn made some lines that were over 100 characters reflow making the diff a bit larger in a few places. I also enabled `importsNotUsedAsValues` which revealed only two instances of importing types and I corrected them in, `src/bson.ts` and `src/operations/run_command.ts`