### PR TITLE
fix: assert update/replace atomic requirements in bulk operations

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -11,6 +11,8 @@ const applyRetryableWrites = require('../utils').applyRetryableWrites;
 const applyWriteConcern = require('../utils').applyWriteConcern;
 const executeLegacyOperation = require('../utils').executeLegacyOperation;
 const isPromiseLike = require('../utils').isPromiseLike;
+const hasAtomicOperators = require('../utils').hasAtomicOperators;
+const maxWireVersion = require('../core/utils').maxWireVersion;
 
 // Error codes
 const WRITE_CONCERN_ERROR = 64;
@@ -641,6 +643,10 @@ class FindOperators {
       document.hint = updateDocument.hint;
     }
 
+    if (!hasAtomicOperators(updateDocument)) {
+      throw new TypeError('Update document requires atomic operators');
+    }
+
     // Clear out current Op
     this.s.currentOp = null;
     return this.s.options.addToOperationsList(this, UPDATE, document);
@@ -650,12 +656,33 @@ class FindOperators {
    * Add a replace one operation to the bulk operation
    *
    * @method
-   * @param {object} updateDocument the new document to replace the existing one with
+   * @param {object} replacement the new document to replace the existing one with
    * @throws {MongoError} If operation cannot be added to bulk write
    * @return {OrderedBulkOperation|UnorderedBulkOperation} A reference to the parent BulkOperation
    */
-  replaceOne(updateDocument) {
-    this.updateOne(updateDocument);
+  replaceOne(replacement) {
+    // Perform upsert
+    const upsert = typeof this.s.currentOp.upsert === 'boolean' ? this.s.currentOp.upsert : false;
+
+    // Establish the update command
+    const document = {
+      q: this.s.currentOp.selector,
+      u: replacement,
+      multi: false,
+      upsert: upsert
+    };
+
+    if (replacement.hint) {
+      document.hint = replacement.hint;
+    }
+
+    if (hasAtomicOperators(replacement)) {
+      throw new TypeError('Replacement document must not use atomic operators');
+    }
+
+    // Clear out current Op
+    this.s.currentOp = null;
+    return this.s.options.addToOperationsList(this, UPDATE, document);
   }
 
   /**
@@ -943,6 +970,12 @@ class BulkOperationBase {
 
     // Crud spec update format
     if (op.updateOne || op.updateMany || op.replaceOne) {
+      if (op.replaceOne && hasAtomicOperators(op[key].replacement)) {
+        throw new TypeError('Replacement document must not use atomic operators');
+      } else if ((op.updateOne || op.updateMany) && !hasAtomicOperators(op[key].update)) {
+        throw new TypeError('Update document requires atomic operators');
+      }
+
       const multi = op.updateOne || op.replaceOne ? false : true;
       const operation = {
         q: op[key].filter,
@@ -960,7 +993,15 @@ class BulkOperationBase {
       } else {
         if (op[key].upsert) operation.upsert = true;
       }
-      if (op[key].arrayFilters) operation.arrayFilters = op[key].arrayFilters;
+      if (op[key].arrayFilters) {
+        // TODO: this check should be done at command construction against a connection, not a topology
+        if (maxWireVersion(this.s.topology) < 6) {
+          throw new TypeError('arrayFilters are only supported on MongoDB 3.6+');
+        }
+
+        operation.arrayFilters = op[key].arrayFilters;
+      }
+
       return this.s.options.addToOperationsList(this, UPDATE, operation);
     }
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -5,7 +5,6 @@ const deprecateOptions = require('./utils').deprecateOptions;
 const checkCollectionName = require('./utils').checkCollectionName;
 const ObjectID = require('./core').BSON.ObjectID;
 const MongoError = require('./core').MongoError;
-const toError = require('./utils').toError;
 const normalizeHintField = require('./utils').normalizeHintField;
 const decorateCommand = require('./utils').decorateCommand;
 const decorateWithCollation = require('./utils').decorateWithCollation;
@@ -23,7 +22,6 @@ const AggregationCursor = require('./aggregation_cursor');
 const CommandCursor = require('./command_cursor');
 
 // Operations
-const checkForAtomicOperators = require('./operations/collection_ops').checkForAtomicOperators;
 const ensureIndex = require('./operations/collection_ops').ensureIndex;
 const group = require('./operations/collection_ops').group;
 const parallelCollectionScan = require('./operations/collection_ops').parallelCollectionScan;
@@ -747,14 +745,6 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  */
 Collection.prototype.updateOne = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
-  options = options || {};
-
-  const err = checkForAtomicOperators(update);
-  if (err) {
-    if (typeof callback === 'function') return callback(err);
-    return this.s.promiseLibrary.reject(err);
-  }
-
   options = Object.assign({}, options);
 
   // Add ignoreUndefined
@@ -763,9 +753,11 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  const updateOneOperation = new UpdateOneOperation(this, filter, update, options);
-
-  return executeOperation(this.s.topology, updateOneOperation, callback);
+  return executeOperation(
+    this.s.topology,
+    new UpdateOneOperation(this, filter, update, options),
+    callback
+  );
 };
 
 /**
@@ -798,9 +790,11 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  const replaceOneOperation = new ReplaceOneOperation(this, filter, doc, options);
-
-  return executeOperation(this.s.topology, replaceOneOperation, callback);
+  return executeOperation(
+    this.s.topology,
+    new ReplaceOneOperation(this, filter, doc, options),
+    callback
+  );
 };
 
 /**
@@ -826,14 +820,6 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  */
 Collection.prototype.updateMany = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
-  options = options || {};
-
-  const err = checkForAtomicOperators(update);
-  if (err) {
-    if (typeof callback === 'function') return callback(err);
-    return this.s.promiseLibrary.reject(err);
-  }
-
   options = Object.assign({}, options);
 
   // Add ignoreUndefined
@@ -842,9 +828,11 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
     options.ignoreUndefined = this.s.options.ignoreUndefined;
   }
 
-  const updateManyOperation = new UpdateManyOperation(this, filter, update, options);
-
-  return executeOperation(this.s.topology, updateManyOperation, callback);
+  return executeOperation(
+    this.s.topology,
+    new UpdateManyOperation(this, filter, update, options),
+    callback
+  );
 };
 
 /**
@@ -1679,13 +1667,11 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  // Basic validation
-  if (filter == null || typeof filter !== 'object')
-    throw toError('filter parameter must be an object');
-
-  const findOneAndDeleteOperation = new FindOneAndDeleteOperation(this, filter, options);
-
-  return executeOperation(this.s.topology, findOneAndDeleteOperation, callback);
+  return executeOperation(
+    this.s.topology,
+    new FindOneAndDeleteOperation(this, filter, options),
+    callback
+  );
 };
 
 /**
@@ -1714,27 +1700,11 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  // Basic validation
-  if (filter == null || typeof filter !== 'object')
-    throw toError('filter parameter must be an object');
-  if (replacement == null || typeof replacement !== 'object')
-    throw toError('replacement parameter must be an object');
-
-  // Check that there are no atomic operators
-  const keys = Object.keys(replacement);
-
-  if (keys[0] && keys[0][0] === '$') {
-    throw toError('The replacement document must not contain atomic operators.');
-  }
-
-  const findOneAndReplaceOperation = new FindOneAndReplaceOperation(
-    this,
-    filter,
-    replacement,
-    options
+  return executeOperation(
+    this.s.topology,
+    new FindOneAndReplaceOperation(this, filter, replacement, options),
+    callback
   );
-
-  return executeOperation(this.s.topology, findOneAndReplaceOperation, callback);
 };
 
 /**
@@ -1764,21 +1734,11 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
-  // Basic validation
-  if (filter == null || typeof filter !== 'object')
-    throw toError('filter parameter must be an object');
-  if (update == null || typeof update !== 'object')
-    throw toError('update parameter must be an object');
-
-  const err = checkForAtomicOperators(update);
-  if (err) {
-    if (typeof callback === 'function') return callback(err);
-    return this.s.promiseLibrary.reject(err);
-  }
-
-  const findOneAndUpdateOperation = new FindOneAndUpdateOperation(this, filter, update, options);
-
-  return executeOperation(this.s.topology, findOneAndUpdateOperation, callback);
+  return executeOperation(
+    this.s.topology,
+    new FindOneAndUpdateOperation(this, filter, update, options),
+    callback
+  );
 };
 
 /**

--- a/lib/operations/collection_ops.js
+++ b/lib/operations/collection_ops.js
@@ -13,7 +13,6 @@ const indexInformationDb = require('./db_ops').indexInformation;
 const Long = require('../core').BSON.Long;
 const MongoError = require('../core').MongoError;
 const ReadPreference = require('../core').ReadPreference;
-const toError = require('../utils').toError;
 const insertDocuments = require('./common_functions').insertDocuments;
 const updateDocuments = require('./common_functions').updateDocuments;
 
@@ -50,24 +49,6 @@ const updateDocuments = require('./common_functions').updateDocuments;
 // }.toString();
 const groupFunction =
   'function () {\nvar c = db[ns].find(condition);\nvar map = new Map();\nvar reduce_function = reduce;\n\nwhile (c.hasNext()) {\nvar obj = c.next();\nvar key = {};\n\nfor (var i = 0, len = keys.length; i < len; ++i) {\nvar k = keys[i];\nkey[k] = obj[k];\n}\n\nvar aggObj = map.get(key);\n\nif (aggObj == null) {\nvar newObj = Object.extend({}, key);\naggObj = Object.extend(newObj, initial);\nmap.put(key, aggObj);\n}\n\nreduce_function(obj, aggObj);\n}\n\nreturn { "result": map.values() };\n}';
-
-// Check the update operation to ensure it has atomic operators.
-function checkForAtomicOperators(update) {
-  if (Array.isArray(update)) {
-    return update.reduce((err, u) => err || checkForAtomicOperators(u), null);
-  }
-
-  const keys = Object.keys(update);
-
-  // same errors as the server would give for update doc lacking atomic operators
-  if (keys.length === 0) {
-    return toError('The update operation document must contain at least one atomic operator.');
-  }
-
-  if (keys[0][0] !== '$') {
-    return toError('the update operation document must contain atomic operators.');
-  }
-}
 
 /**
  * Create an index on the db and collection.
@@ -360,7 +341,6 @@ function save(coll, doc, options, callback) {
 }
 
 module.exports = {
-  checkForAtomicOperators,
   createIndex,
   createIndexes,
   ensureIndex,

--- a/lib/operations/find_one_and_delete.js
+++ b/lib/operations/find_one_and_delete.js
@@ -9,6 +9,11 @@ class FindOneAndDeleteOperation extends FindAndModifyOperation {
     finalOptions.fields = options.projection;
     finalOptions.remove = true;
 
+    // Basic validation
+    if (filter == null || typeof filter !== 'object') {
+      throw new TypeError('Filter parameter must be an object');
+    }
+
     super(collection, filter, finalOptions.sort, null, finalOptions);
   }
 }

--- a/lib/operations/find_one_and_replace.js
+++ b/lib/operations/find_one_and_replace.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const FindAndModifyOperation = require('./find_and_modify');
+const hasAtomicOperators = require('../utils').hasAtomicOperators;
 
 class FindOneAndReplaceOperation extends FindAndModifyOperation {
   constructor(collection, filter, replacement, options) {
@@ -10,6 +11,18 @@ class FindOneAndReplaceOperation extends FindAndModifyOperation {
     finalOptions.update = true;
     finalOptions.new = options.returnOriginal !== void 0 ? !options.returnOriginal : false;
     finalOptions.upsert = options.upsert !== void 0 ? !!options.upsert : false;
+
+    if (filter == null || typeof filter !== 'object') {
+      throw new TypeError('Filter parameter must be an object');
+    }
+
+    if (replacement == null || typeof replacement !== 'object') {
+      throw new TypeError('Replacement parameter must be an object');
+    }
+
+    if (hasAtomicOperators(replacement)) {
+      throw new TypeError('Replacement document must not contain atomic operators');
+    }
 
     super(collection, filter, finalOptions.sort, replacement, finalOptions);
   }

--- a/lib/operations/find_one_and_update.js
+++ b/lib/operations/find_one_and_update.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const FindAndModifyOperation = require('./find_and_modify');
+const { hasAtomicOperators } = require('../utils');
 
 class FindOneAndUpdateOperation extends FindAndModifyOperation {
   constructor(collection, filter, update, options) {
@@ -11,6 +12,18 @@ class FindOneAndUpdateOperation extends FindAndModifyOperation {
     finalOptions.new =
       typeof options.returnOriginal === 'boolean' ? !options.returnOriginal : false;
     finalOptions.upsert = typeof options.upsert === 'boolean' ? options.upsert : false;
+
+    if (filter == null || typeof filter !== 'object') {
+      throw new TypeError('Filter parameter must be an object');
+    }
+
+    if (update == null || typeof update !== 'object') {
+      throw new TypeError('Update parameter must be an object');
+    }
+
+    if (!hasAtomicOperators(update)) {
+      throw new TypeError('Update document requires atomic operators');
+    }
 
     super(collection, filter, finalOptions.sort, update, finalOptions);
   }

--- a/lib/operations/replace_one.js
+++ b/lib/operations/replace_one.js
@@ -2,27 +2,34 @@
 
 const OperationBase = require('./operation').OperationBase;
 const updateDocuments = require('./common_functions').updateDocuments;
+const hasAtomicOperators = require('../utils').hasAtomicOperators;
 
 class ReplaceOneOperation extends OperationBase {
-  constructor(collection, filter, doc, options) {
+  constructor(collection, filter, replacement, options) {
     super(options);
+
+    if (hasAtomicOperators(replacement)) {
+      throw new TypeError('Replacement document must not contain atomic operators');
+    }
 
     this.collection = collection;
     this.filter = filter;
-    this.doc = doc;
+    this.replacement = replacement;
   }
 
   execute(callback) {
     const coll = this.collection;
     const filter = this.filter;
-    const doc = this.doc;
+    const replacement = this.replacement;
     const options = this.options;
 
     // Set single document update
     options.multi = false;
 
     // Execute update
-    updateDocuments(coll, filter, doc, options, (err, r) => replaceCallback(err, r, doc, callback));
+    updateDocuments(coll, filter, replacement, options, (err, r) =>
+      replaceCallback(err, r, replacement, callback)
+    );
   }
 }
 

--- a/lib/operations/update_many.js
+++ b/lib/operations/update_many.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { hasAtomicOperators } = require('../utils');
+
 const OperationBase = require('./operation').OperationBase;
 const updateCallback = require('./common_functions').updateCallback;
 const updateDocuments = require('./common_functions').updateDocuments;
@@ -7,6 +9,10 @@ const updateDocuments = require('./common_functions').updateDocuments;
 class UpdateManyOperation extends OperationBase {
   constructor(collection, filter, update, options) {
     super(options);
+
+    if (!hasAtomicOperators(update)) {
+      throw new TypeError('Update document requires atomic operators');
+    }
 
     this.collection = collection;
     this.filter = filter;

--- a/lib/operations/update_one.js
+++ b/lib/operations/update_one.js
@@ -2,10 +2,15 @@
 
 const OperationBase = require('./operation').OperationBase;
 const updateDocuments = require('./common_functions').updateDocuments;
+const hasAtomicOperators = require('../utils').hasAtomicOperators;
 
 class UpdateOneOperation extends OperationBase {
   constructor(collection, filter, update, options) {
     super(options);
+
+    if (!hasAtomicOperators(update)) {
+      throw new TypeError('Update document requires atomic operators');
+    }
 
     this.collection = collection;
     this.filter = filter;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -776,6 +776,15 @@ function makeInterruptableAsyncInterval(fn, options) {
   return { wake, stop };
 }
 
+function hasAtomicOperators(doc) {
+  if (Array.isArray(doc)) {
+    return doc.reduce((err, u) => err || hasAtomicOperators(u), null);
+  }
+
+  const keys = Object.keys(doc);
+  return keys.length > 0 && keys[0][0] === '$';
+}
+
 module.exports = {
   filterOptions,
   mergeOptions,
@@ -807,5 +816,6 @@ module.exports = {
   maybePromise,
   now,
   calculateDurationInMs,
-  makeInterruptableAsyncInterval
+  makeInterruptableAsyncInterval,
+  hasAtomicOperators
 };

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -304,63 +304,6 @@ describe('Bulk', function() {
   });
 
   it(
-    'should Correctly Fail Ordered Batch Operation due to illegal Operations using write commands',
-    {
-      metadata: {
-        requires: {
-          mongodb: '>2.5.4',
-          topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger']
-        }
-      },
-
-      test: function(done) {
-        var self = this;
-        var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-          poolSize: 1
-        });
-
-        client.connect(function(err, client) {
-          var db = client.db(self.configuration.db);
-          var col = db.collection('batch_write_ordered_ops_5');
-
-          // Add unique index on b field causing all updates to fail
-          col.ensureIndex({ b: 1 }, { unique: true, sparse: false }, function(err) {
-            test.equal(err, null);
-
-            var batch = col.initializeOrderedBulkOp();
-
-            // Add illegal insert operation
-            batch.insert({ $set: { a: 1 } });
-
-            // Execute the operations
-            batch.execute(function(err) {
-              test.ok(err != null);
-
-              var batch = col.initializeOrderedBulkOp();
-              // Add illegal remove
-              batch.find({ $set: { a: 1 } }).removeOne();
-              // Execute the operations
-              batch.execute(function(err) {
-                test.ok(err != null);
-
-                var batch = col.initializeOrderedBulkOp();
-                // Add illegal update
-                batch.find({ a: { $set2: 1 } }).updateOne({ c: { $set: { a: 1 } } });
-                // Execute the operations
-                batch.execute(function(err) {
-                  test.ok(err != null);
-
-                  client.close(done);
-                });
-              });
-            });
-          });
-        });
-      }
-    }
-  );
-
-  it(
     'should Correctly Execute Ordered Batch of Write Operations with duplicate key errors on updates',
     {
       metadata: {
@@ -778,68 +721,6 @@ describe('Bulk', function() {
 
           // Finish up test
           client.close(done);
-        });
-      });
-    }
-  });
-
-  it('should Correctly Fail Unordered Batch Operation due to illegal Operations', {
-    metadata: {
-      requires: {
-        mongodb: '>2.5.4',
-        topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger']
-      }
-    },
-
-    test: function(done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
-
-      client.connect(function(err, client) {
-        var db = client.db(self.configuration.db);
-        var col = db.collection('batch_write_unordered_ops_legacy_5');
-
-        // Write concern
-        var writeConcern = self.configuration.writeConcernMax();
-        writeConcern.unique = true;
-        writeConcern.sparse = false;
-
-        // Add unique index on b field causing all updates to fail
-        col.ensureIndex({ b: 1 }, writeConcern, function(err) {
-          test.equal(err, null);
-
-          // Initialize the unordered Batch
-          var batch = col.initializeUnorderedBulkOp();
-
-          // Add illegal insert operation
-          batch.insert({ $set: { a: 1 } });
-
-          // Execute the operations
-          batch.execute(function(err) {
-            test.ok(err != null);
-
-            // Initialize the unordered Batch
-            var batch = col.initializeUnorderedBulkOp();
-            // Add illegal remove
-            batch.find({ $set: { a: 1 } }).removeOne();
-            // Execute the operations
-            batch.execute(function(err) {
-              test.ok(err != null);
-
-              // Initialize the unordered Batch
-              var batch = col.initializeUnorderedBulkOp();
-              // Add illegal update
-              batch.find({ $set: { a: 1 } }).updateOne({ c: { $set: { a: 1 } } });
-              // Execute the operations
-              batch.execute(function(err) {
-                test.ok(err != null);
-
-                client.close(done);
-              });
-            });
-          });
         });
       });
     }

--- a/test/functional/crud_api.test.js
+++ b/test/functional/crud_api.test.js
@@ -1,7 +1,6 @@
 'use strict';
-var test = require('./shared').assert,
-  setupDatabase = require('./shared').setupDatabase,
-  expect = require('chai').expect;
+const test = require('./shared').assert;
+const setupDatabase = require('./shared').setupDatabase;
 
 // instanceof cannot be use reliably to detect the new models in js due to scoping and new
 // contexts killing class info find/distinct/count thus cannot be overloaded without breaking
@@ -1010,115 +1009,6 @@ describe('CRUD API', function() {
           test.ok(err !== null);
           client.close(done);
         });
-      });
-    }
-  });
-
-  it('should correctly throw error if update doc for findOneAndUpdate lacks atomic operator', function(done) {
-    let configuration = this.configuration;
-    let client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-    client.connect(function(err, client) {
-      expect(err).to.not.exist;
-      let db = client.db(configuration.db);
-      let col = db.collection('t21_1');
-      col.insertOne({ a: 1, b: 2, c: 3 }, function(err, r) {
-        expect(err).to.not.exist;
-        expect(r.insertedCount).to.equal(1);
-
-        // empty update document
-        col.findOneAndUpdate({ a: 1 }, {}, function(err, r) {
-          expect(err).to.exist;
-          expect(r).to.not.exist;
-
-          // update document non empty but still lacks atomic operator
-          col.findOneAndUpdate({ a: 1 }, { b: 5 }, function(err, r) {
-            expect(err).to.exist;
-            expect(r).to.not.exist;
-
-            client.close(done);
-          });
-        });
-      });
-    });
-  });
-
-  it('should correctly throw error if update doc for updateOne lacks atomic operator', {
-    // Add a tag that our runner can trigger on
-    // in this case we are setting that node needs to be higher than 0.10.X to run
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
-        expect(err).to.not.exist;
-        var db = client.db(configuration.db);
-        var col = db.collection('t21_1');
-        col.insertOne({ a: 1, b: 2, c: 3 }, function(err, r) {
-          expect(err).to.not.exist;
-          expect(r.insertedCount).to.equal(1);
-
-          // empty update document
-          col.updateOne({ a: 1 }, {}, function(err, r) {
-            expect(err).to.exist;
-            expect(r).to.not.exist;
-
-            // update document non empty but still lacks atomic operator
-            col.updateOne({ a: 1 }, { b: 5 }, function(err, r) {
-              expect(err).to.exist;
-              expect(r).to.not.exist;
-
-              client.close(done);
-            });
-          });
-        });
-      });
-    }
-  });
-
-  it('should correctly throw error if update doc for updateMany lacks atomic operator', {
-    // Add a tag that our runner can trigger on
-    // in this case we are setting that node needs to be higher than 0.10.X to run
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    // The actual test we wish to run
-    test: function(done) {
-      var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function(err, client) {
-        expect(err).to.not.exist;
-        var db = client.db(configuration.db);
-        var col = db.collection('t22_1');
-        col.insertMany(
-          [
-            { a: 1, b: 2 },
-            { a: 1, b: 3 },
-            { a: 1, b: 4 }
-          ],
-          function(err, r) {
-            expect(err).to.not.exist;
-            expect(r.insertedCount).to.equal(3);
-
-            // empty update document
-            col.updateMany({ a: 1 }, {}, function(err, r) {
-              expect(err).to.exist;
-              expect(r).to.not.exist;
-
-              // update document non empty but still lacks atomic operator
-              col.updateMany({ a: 1 }, { b: 5 }, function(err, r) {
-                expect(err).to.exist;
-                expect(r).to.not.exist;
-
-                client.close(done);
-              });
-            });
-          }
-        );
       });
     }
   });

--- a/test/functional/crud_spec.test.js
+++ b/test/functional/crud_spec.test.js
@@ -396,45 +396,74 @@ describe('CRUD spec', function() {
       );
     }
 
+    function promiseTry(callback) {
+      return new Promise((resolve, reject) => {
+        try {
+          resolve(callback());
+        } catch (e) {
+          reject(e);
+        }
+      });
+    }
+
+    const outcome = scenarioTest.outcome;
     return Promise.all(dropPromises)
       .then(() =>
         scenario.data && scenario.data.length
           ? collection.insertMany(scenario.data)
           : Promise.resolve()
       )
-      .then(() => {
-        switch (scenarioTest.operation.name) {
-          case 'aggregate':
-            return executeAggregateTest(scenarioTest, context.db, collection);
-          case 'count':
-            return executeCountTest(scenarioTest, context.db, collection);
-          case 'countDocuments':
-            return executeCountDocumentsTest(scenarioTest, context.db, collection);
-          case 'estimatedDocumentCount':
-            return executeEstimatedDocumentCountTest(scenarioTest, context.db, collection);
-          case 'distinct':
-            return executeDistinctTest(scenarioTest, context.db, collection);
-          case 'find':
-            return executeFindTest(scenarioTest, context.db, collection);
-          case 'deleteOne':
-          case 'deleteMany':
-            return executeDeleteTest(scenarioTest, context.db, collection);
-          case 'replaceOne':
-            return executeReplaceTest(scenarioTest, context.db, collection);
-          case 'updateOne':
-          case 'updateMany':
-            return executeUpdateTest(scenarioTest, context.db, collection);
-          case 'findOneAndReplace':
-          case 'findOneAndUpdate':
-          case 'findOneAndDelete':
-            return executeFindOneTest(scenarioTest, context.db, collection);
-          case 'insertOne':
-          case 'insertMany':
-            return executeInsertTest(scenarioTest, context.db, collection);
-          case 'bulkWrite':
-            return executeBulkTest(scenarioTest, context.db, collection);
+      .then(() =>
+        promiseTry(() => {
+          switch (scenarioTest.operation.name) {
+            case 'aggregate':
+              return executeAggregateTest(scenarioTest, context.db, collection);
+            case 'count':
+              return executeCountTest(scenarioTest, context.db, collection);
+            case 'countDocuments':
+              return executeCountDocumentsTest(scenarioTest, context.db, collection);
+            case 'estimatedDocumentCount':
+              return executeEstimatedDocumentCountTest(scenarioTest, context.db, collection);
+            case 'distinct':
+              return executeDistinctTest(scenarioTest, context.db, collection);
+            case 'find':
+              return executeFindTest(scenarioTest, context.db, collection);
+            case 'deleteOne':
+            case 'deleteMany':
+              return executeDeleteTest(scenarioTest, context.db, collection);
+            case 'replaceOne':
+              return executeReplaceTest(scenarioTest, context.db, collection);
+            case 'updateOne':
+            case 'updateMany':
+              return executeUpdateTest(scenarioTest, context.db, collection);
+            case 'findOneAndReplace':
+            case 'findOneAndUpdate':
+            case 'findOneAndDelete':
+              return executeFindOneTest(scenarioTest, context.db, collection);
+            case 'insertOne':
+            case 'insertMany':
+              return executeInsertTest(scenarioTest, context.db, collection);
+            case 'bulkWrite':
+              return executeBulkTest(scenarioTest, context.db, collection);
+          }
+        })
+      )
+      .then(
+        () => {
+          if (
+            outcome.error === true &&
+            scenarioTest.operation.name !== 'bulkWrite' &&
+            scenarioTest.operation.name !== 'insertMany'
+          ) {
+            throw new Error('Error expected!');
+          }
+        },
+        err => {
+          if (outcome && (outcome.error == null || outcome.error === false)) {
+            throw err;
+          }
         }
-      });
+      );
   }
 });
 

--- a/test/functional/replset_operations.test.js
+++ b/test/functional/replset_operations.test.js
@@ -252,7 +252,7 @@ describe('ReplSet (Operations)', function() {
             batch
               .find({ a: 3 })
               .upsert()
-              .updateOne({ a: 3, b: 1 });
+              .updateOne({ $set: { a: 3, b: 1 } });
             batch.insert({ a: 2 });
 
             // Execute the operations

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -163,8 +163,8 @@ function generateTopologyTests(testSuites, testContext, filter) {
 
 // Test runner helpers
 function prepareDatabaseForSuite(suite, context) {
-  context.dbName = suite.database_name;
-  context.collectionName = suite.collection_name;
+  context.dbName = suite.database_name || 'spec_db';
+  context.collectionName = suite.collection_name || 'spec_collection';
 
   const db = context.sharedClient.db(context.dbName);
   const setupPromise = db
@@ -178,7 +178,7 @@ function prepareDatabaseForSuite(suite, context) {
       throw err;
     });
 
-  if (context.collectionName == null) {
+  if (context.collectionName == null || context.dbName === 'admin') {
     return setupPromise;
   }
 

--- a/test/spec/crud/v1/write/findOneAndReplace.json
+++ b/test/spec/crud/v1/write/findOneAndReplace.json
@@ -268,6 +268,49 @@
           ]
         }
       }
+    },
+    {
+      "description": "FindOneAndReplace require no atomic operators in replacement document",
+      "operation": {
+        "name": "findOneAndReplace",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "replacement": {
+            "$set": {
+              "x": 44
+            }
+          },
+          "projection": {
+            "x": 1,
+            "_id": 0
+          },
+          "returnDocument": "After",
+          "sort": {
+            "x": 1
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/spec/crud/v1/write/findOneAndReplace.yml
+++ b/test/spec/crud/v1/write/findOneAndReplace.yml
@@ -9,7 +9,7 @@ tests:
         operation:
             name: findOneAndReplace
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
                 replacement: {x: 32}
                 projection: {x: 1, _id: 0}
@@ -27,7 +27,7 @@ tests:
         operation:
             name: findOneAndReplace
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
                 replacement: {x: 32}
                 projection: {x: 1, _id: 0}
@@ -106,6 +106,24 @@ tests:
 
         outcome:
             result: null
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+    -
+        description: "FindOneAndReplace require no atomic operators in replacement document"
+        operation:
+            name: findOneAndReplace
+            arguments:
+                filter: { _id: 4 }
+                replacement: { $set: { x: 44 } }
+                projection: { x: 1, _id: 0 }
+                returnDocument: After
+                sort: { x: 1 }
+
+        outcome:
+            error: true
             collection:
                 data:
                     - {_id: 1, x: 11}

--- a/test/spec/crud/v1/write/findOneAndUpdate.json
+++ b/test/spec/crud/v1/write/findOneAndUpdate.json
@@ -374,6 +374,48 @@
           ]
         }
       }
+    },
+    {
+      "description": "FindOneAndUpdate require atomic operators for update document",
+      "operation": {
+        "name": "findOneAndUpdate",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "update": {
+            "x": 1
+          },
+          "projection": {
+            "x": 1,
+            "_id": 0
+          },
+          "returnDocument": "After",
+          "sort": {
+            "x": 1
+          },
+          "upsert": true
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/spec/crud/v1/write/findOneAndUpdate.yml
+++ b/test/spec/crud/v1/write/findOneAndUpdate.yml
@@ -9,9 +9,9 @@ tests:
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -28,9 +28,9 @@ tests:
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -49,7 +49,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 2}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -67,7 +67,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 2}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -86,7 +86,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -104,7 +104,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 # Omit the sort option as it has no effect when no documents
@@ -127,7 +127,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -146,7 +146,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -161,3 +161,22 @@ tests:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
                     - {_id: 4, x: 1}
+    -
+        description: "FindOneAndUpdate require atomic operators for update document"
+        operation:
+            name: findOneAndUpdate
+            arguments:
+                filter: { _id: 4 }
+                update: { x: 1 }
+                projection: { x: 1, _id: 0 }
+                returnDocument: After
+                sort: { x: 1 }
+                upsert: true
+
+        outcome:
+            error: true
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}

--- a/test/spec/crud/v1/write/replaceOne-collation.yml
+++ b/test/spec/crud/v1/write/replaceOne-collation.yml
@@ -9,9 +9,9 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {x: 'PING'}
-                replacement: {_id: 2, x: 'pong'}
-                collation: {locale: 'en_US', strength: 2} # https://docs.mongodb.com/master/reference/collation/#collation-document
+                filter: { x: 'PING' }
+                replacement: { _id: 2, x: 'pong' }
+                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/master/reference/collation/#collation-document
 
         outcome:
             result:

--- a/test/spec/crud/v1/write/replaceOne.json
+++ b/test/spec/crud/v1/write/replaceOne.json
@@ -200,6 +200,43 @@
           ]
         }
       }
+    },
+    {
+      "description": "ReplaceOne require no atomic operators in replacement document",
+      "operation": {
+        "name": "replaceOne",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "replacement": {
+            "$set": {
+              "_id": 4,
+              "x": 1
+            }
+          },
+          "upsert": true
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/spec/crud/v1/write/replaceOne.yml
+++ b/test/spec/crud/v1/write/replaceOne.yml
@@ -10,9 +10,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: 
-                    _id: {$gt: 1}
-                replacement: {x: 111}
+                filter: { _id: {$gt: 1} }
+                replacement: { x: 111 }
 
         outcome:
             result:
@@ -26,8 +25,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 1}
-                replacement: {_id: 1, x: 111}
+                filter: { _id: 1 }
+                replacement: { _id: 1, x: 111 }
 
         outcome:
             result:
@@ -44,8 +43,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {_id: 4, x: 1}
+                filter: { _id: 4 }
+                replacement: { _id: 4, x: 1 }
 
         outcome:
             result:
@@ -62,8 +61,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {x: 1}
+                filter: { _id: 4 }
+                replacement: { x: 1 }
                 upsert: true
 
         outcome:
@@ -84,8 +83,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {_id: 4, x: 1}
+                filter: { _id: 4 }
+                replacement: { _id: 4, x: 1 }
                 upsert: true
 
         outcome:
@@ -100,3 +99,18 @@ tests:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
                     - {_id: 4, x: 1}
+    -
+        description: "ReplaceOne require no atomic operators in replacement document"
+        operation:
+            name: "replaceOne"
+            arguments:
+                filter: { _id: 4 }
+                replacement: { $set: { _id: 4, x: 1 } }
+                upsert: true
+        outcome:
+            error: true
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}

--- a/test/spec/crud/v1/write/updateOne.json
+++ b/test/spec/crud/v1/write/updateOne.json
@@ -162,6 +162,40 @@
           ]
         }
       }
+    },
+    {
+      "description": "UpdateOne require atomic operators in update document",
+      "operation": {
+        "name": "updateOne",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "update": {
+            "x": 1
+          },
+          "upsert": true
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/spec/crud/v1/write/updateOne.yml
+++ b/test/spec/crud/v1/write/updateOne.yml
@@ -10,9 +10,9 @@ tests:
         operation:
             name: "updateOne"
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -28,7 +28,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -47,7 +47,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -66,7 +66,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 upsert: true
 
@@ -82,3 +82,18 @@ tests:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
                     - {_id: 4, x: 1}
+    -
+        description: "UpdateOne require atomic operators in update document"
+        operation:
+            name: "updateOne"
+            arguments:
+                filter: { _id: 4 }
+                update: { x: 1 }
+                upsert: true
+        outcome:
+            error: true
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}

--- a/test/spec/crud/v2/bulkWrite-arrayFilters-clientError.json
+++ b/test/spec/crud/v2/bulkWrite-arrayFilters-clientError.json
@@ -1,0 +1,110 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "3.5.5"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "y": [
+        {
+          "b": 3
+        },
+        {
+          "b": 1
+        }
+      ]
+    },
+    {
+      "_id": 2,
+      "y": [
+        {
+          "b": 0
+        },
+        {
+          "b": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite on server that doesn't support arrayFilters",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {},
+                  "update": {
+                    "$set": {
+                      "y.0.b": 2
+                    }
+                  },
+                  "arrayFilters": [
+                    {
+                      "i.b": 1
+                    }
+                  ]
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": []
+    },
+    {
+      "description": "BulkWrite on server that doesn't support arrayFilters with arrayFilters on second op",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {},
+                  "update": {
+                    "$set": {
+                      "y.0.b": 2
+                    }
+                  }
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {},
+                  "update": {
+                    "$set": {
+                      "y.$[i].b": 2
+                    }
+                  },
+                  "arrayFilters": [
+                    {
+                      "i.b": 1
+                    }
+                  ]
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": []
+    }
+  ]
+}

--- a/test/spec/crud/v2/bulkWrite-arrayFilters-clientError.yml
+++ b/test/spec/crud/v2/bulkWrite-arrayFilters-clientError.yml
@@ -1,0 +1,50 @@
+runOn:
+  -
+    # arrayFilters support first introduced in 3.5.6
+    maxServerVersion: "3.5.5"
+
+data:
+  - {_id: 1, y: [{b: 3}, {b: 1}]}
+  - {_id: 2, y: [{b: 0}, {b: 1}]}
+
+tests:
+  -
+    description: "BulkWrite on server that doesn't support arrayFilters"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              # UpdateOne with with arrayFilters
+              name: "updateOne"
+              arguments:
+                filter: {}
+                update: { $set: { "y.0.b": 2 } }
+                arrayFilters: [ { "i.b": 1 } ]
+          options: { ordered: true }
+        error: true
+    expectations: []
+  -
+    description: "BulkWrite on server that doesn't support arrayFilters with arrayFilters on second op"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              # UpdateOne with no arrayFilters
+              name: "updateOne"
+              arguments:
+                filter: {}
+                update: { $set: { "y.0.b": 2 } }
+            -
+              # UpdateMany with arrayFilters
+              name: "updateMany"
+              arguments:
+                filter: {}
+                update: { $set: { "y.$[i].b": 2 } }
+                arrayFilters: [ { "i.b": 1 } ]
+          options: { ordered: true }
+        error: true
+    expectations: []

--- a/test/spec/crud/v2/bulkWrite-arrayFilters.yml
+++ b/test/spec/crud/v2/bulkWrite-arrayFilters.yml
@@ -1,10 +1,10 @@
 runOn:
-    -
-        minServerVersion: "3.5.6"
+  -
+    minServerVersion: "3.5.6"
 
 data:
-    - {_id: 1, y: [{b: 3}, {b: 1}]}
-    - {_id: 2, y: [{b: 0}, {b: 1}]}
+  - {_id: 1, y: [{b: 3}, {b: 1}]}
+  - {_id: 2, y: [{b: 0}, {b: 1}]}
 
 collection_name: &collection_name "test"
 database_name: &database_name "crud-tests"

--- a/test/spec/crud/v2/bulkWrite-update-validation.json
+++ b/test/spec/crud/v2/bulkWrite-update-validation.json
@@ -1,0 +1,151 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite replaceOne prohibits atomic modifiers",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "$set": {
+                      "x": 22
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite updateOne requires atomic modifiers",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "x": 22
+                  }
+                }
+              }
+            ]
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite updateMany requires atomic modifiers",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "update": {
+                    "x": 44
+                  }
+                }
+              }
+            ]
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/bulkWrite-update-validation.yml
+++ b/test/spec/crud/v2/bulkWrite-update-validation.yml
@@ -1,0 +1,75 @@
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+
+tests:
+  -
+    description: "BulkWrite replaceOne prohibits atomic modifiers"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "replaceOne"
+              arguments:
+                filter: { _id: 1 }
+                # Only the first field is tested, as the spec permits drivers to
+                # only check that and rely on the server to check subsequent
+                # fields.
+                replacement: { $set: { x: 22 }}
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
+          - {_id: 3, x: 33 }
+  -
+    description: "BulkWrite updateOne requires atomic modifiers"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "updateOne"
+              arguments:
+                filter: { _id: 1 }
+                # Only the first field is tested, as the spec permits drivers to
+                # only check that and rely on the server to check subsequent
+                # fields.
+                update: { x: 22 }
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
+          - {_id: 3, x: 33 }
+  -
+    description: "BulkWrite updateMany requires atomic modifiers"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "updateMany"
+              arguments:
+                filter: { _id: { $gt: 1 }}
+                # Only the first field is tested, as the spec permits drivers to
+                # only check that and rely on the server to check subsequent
+                # fields.
+                update: { x: 44 }
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
+          - {_id: 3, x: 33 }

--- a/test/spec/crud/v2/replaceOne-validation.json
+++ b/test/spec/crud/v2/replaceOne-validation.json
@@ -1,0 +1,41 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    }
+  ],
+  "tests": [
+    {
+      "description": "ReplaceOne prohibits atomic modifiers",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "$set": {
+                "x": 22
+              }
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/replaceOne-validation.yml
+++ b/test/spec/crud/v2/replaceOne-validation.yml
@@ -1,0 +1,21 @@
+data:
+  - { _id: 1, x: 11 }
+
+tests:
+  -
+    description: "ReplaceOne prohibits atomic modifiers"
+    operations:
+      -
+        object: collection
+        name: replaceOne
+        arguments:
+          filter: { _id: 1 }
+          # Only the first field is tested, as the spec permits drivers to only
+          # check that and rely on the server to check subsequent fields.
+          replacement: { $set: { x: 22 }}
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - { _id: 1, x: 11 }

--- a/test/spec/crud/v2/updateMany-validation.json
+++ b/test/spec/crud/v2/updateMany-validation.json
@@ -1,0 +1,57 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne requires atomic modifiers",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "x": 44
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/updateMany-validation.yml
+++ b/test/spec/crud/v2/updateMany-validation.yml
@@ -1,0 +1,25 @@
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+
+tests:
+  -
+    description: "UpdateOne requires atomic modifiers"
+    operations:
+      -
+        object: collection
+        name: updateMany
+        arguments:
+          filter: { _id: { $gt: 1 }}
+          # Only the first field is tested, as the spec permits drivers to only
+          # check that and rely on the server to check subsequent fields.
+          update: { x: 44 }
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 11}
+          - {_id: 2, x: 22}
+          - {_id: 3, x: 33}

--- a/test/spec/crud/v2/updateOne-validation.json
+++ b/test/spec/crud/v2/updateOne-validation.json
@@ -1,0 +1,39 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne requires atomic modifiers",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 22
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/updateOne-validation.yml
+++ b/test/spec/crud/v2/updateOne-validation.yml
@@ -1,0 +1,21 @@
+data:
+  - { _id: 1, x: 11 }
+
+tests:
+  -
+    description: "UpdateOne requires atomic modifiers"
+    operations:
+      -
+        object: collection
+        name: updateOne
+        arguments:
+          filter: { _id: 1 }
+          # Only the first field is tested, as the spec permits drivers to only
+          # check that and rely on the server to check subsequent fields.
+          update: { x: 22 }
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - { _id: 1, x: 11 }

--- a/test/unit/collection.test.js
+++ b/test/unit/collection.test.js
@@ -26,7 +26,7 @@ describe('Collection', function() {
       const collection = db.collection('test');
       expect(() => {
         collection.findOneAndReplace({ a: 1 }, { $set: { a: 14 } });
-      }).to.throw('The replacement document must not contain atomic operators.');
+      }).to.throw(/must not contain atomic operators/);
     }
   });
 });


### PR DESCRIPTION
`checkForAtomicOperators` was refactored into the more versatile `hasAtomicOperators` and the logic for asserting atomic operator requirements was streamlined across all crud operations as well as bulk operations.

NODE-2660