### PR TITLE
test: avoid unable to acquire lock errors on primary stepdown

### DIFF
--- a/test/functional/connections_stepdown.test.js
+++ b/test/functional/connections_stepdown.test.js
@@ -92,7 +92,10 @@ describe('Connections survive primary step down', function() {
               return connectionCount(checkClient).then(initialConnectionCount => {
                 return db
                   .executeDbAdminCommand({ replSetFreeze: 0 }, { readPreference: 'secondary' })
-                  .then(err => expect(err).to.not.exist)
+                  .then(result => {
+                    expect(result).to.have.property('ok', 1);
+                    expect(result).to.have.property('info', 'unfreezing');
+                  })
                   .then(() =>
                     db.executeDbAdminCommand(
                       { replSetStepDown: 30, force: true },

--- a/test/functional/connections_stepdown.test.js
+++ b/test/functional/connections_stepdown.test.js
@@ -91,9 +91,13 @@ describe('Connections survive primary step down', function() {
             .then(() => {
               return connectionCount(checkClient).then(initialConnectionCount => {
                 return db
-                  .executeDbAdminCommand(
-                    { replSetStepDown: 5, force: true },
-                    { readPreference: 'primary' }
+                  .executeDbAdminCommand({ replSetFreeze: 0 }, { readPreference: 'secondary' })
+                  .then(err => expect(err).to.not.exist)
+                  .then(() =>
+                    db.executeDbAdminCommand(
+                      { replSetStepDown: 30, force: true },
+                      { readPreference: 'primary' }
+                    )
                   )
                   .then(() => cursor.next())
                   .then(item => expect(item.a).to.equal(3))

--- a/test/functional/connections_stepdown.test.js
+++ b/test/functional/connections_stepdown.test.js
@@ -92,10 +92,11 @@ describe('Connections survive primary step down', function() {
               return connectionCount(checkClient).then(initialConnectionCount => {
                 return db
                   .executeDbAdminCommand({ replSetFreeze: 0 }, { readPreference: 'secondary' })
-                  .then(result => {
-                    expect(result).to.have.property('ok', 1);
-                    expect(result).to.have.property('info', 'unfreezing');
-                  })
+                  .then(result =>
+                    expect(result)
+                      .property('info')
+                      .to.equal('unfreezing')
+                  )
                   .then(() =>
                     db.executeDbAdminCommand(
                       { replSetStepDown: 30, force: true },

--- a/test/functional/spec-runner/context.js
+++ b/test/functional/spec-runner/context.js
@@ -169,8 +169,8 @@ class TestRunnerContext {
     expect(matchingEvents).to.have.lengthOf.at.least(count);
   }
 
-  runAdminCommand(command) {
-    return this.sharedClient.db('admin').command(command);
+  runAdminCommand(command, options) {
+    return this.sharedClient.db('admin').command(command, options);
   }
 
   // simulated thread helpers

--- a/test/spec/server-discovery-and-monitoring/integration/rediscover-quickly-after-step-down.json
+++ b/test/spec/server-discovery-and-monitoring/integration/rediscover-quickly-after-step-down.json
@@ -48,11 +48,24 @@
         {
           "name": "runAdminCommand",
           "object": "testRunner",
+          "command_name": "replSetFreeze",
+          "arguments": {
+            "command": {
+              "replSetFreeze": 0
+            },
+            "readPreference": {
+              "mode": "Secondary"
+            }
+          }
+        },
+        {
+          "name": "runAdminCommand",
+          "object": "testRunner",
           "command_name": "replSetStepDown",
           "arguments": {
             "command": {
-              "replSetStepDown": 1,
-              "secondaryCatchUpPeriodSecs": 1,
+              "replSetStepDown": 30,
+              "secondaryCatchUpPeriodSecs": 30,
               "force": false
             }
           }
@@ -61,7 +74,7 @@
           "name": "waitForPrimaryChange",
           "object": "testRunner",
           "arguments": {
-            "timeoutMS": 5000
+            "timeoutMS": 15000
           }
         },
         {

--- a/test/spec/server-discovery-and-monitoring/integration/rediscover-quickly-after-step-down.yml
+++ b/test/spec/server-discovery-and-monitoring/integration/rediscover-quickly-after-step-down.yml
@@ -31,19 +31,30 @@ tests:
             - _id: 4
       - name: recordPrimary
         object: testRunner
+      # Unfreeze a secondary with replSetFreeze:0 to ensure a speedy election.
+      - name: runAdminCommand
+        object: testRunner
+        command_name: replSetFreeze
+        arguments:
+          command:
+            replSetFreeze: 0
+          readPreference:
+            mode: Secondary
       # Run replSetStepDown on the meta client.
       - name: runAdminCommand
         object: testRunner
         command_name: replSetStepDown
         arguments:
           command:
-            replSetStepDown: 1
-            secondaryCatchUpPeriodSecs: 1
+            replSetStepDown: 30
+            secondaryCatchUpPeriodSecs: 30
             force: false
       - name: waitForPrimaryChange
         object: testRunner
         arguments:
-          timeoutMS: 5000
+          # We use a relatively large timeout here to workaround slow
+          # elections on Windows, possibly caused by SERVER-48154.
+          timeoutMS: 15000
       # Rediscover the new primary.
       - name: insertMany
         object: collection


### PR DESCRIPTION
## Description

[NODE-2659](https://jira.mongodb.org/browse/NODE-2659)

**What changed?**

**Are there any files to ignore?**
