### PR TITLE
fix: assert update/replace atomic requirements in bulk operations [4.0]

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -7,8 +7,11 @@ import {
   applyWriteConcern,
   applyRetryableWrites,
   executeLegacyOperation,
-  isPromiseLike
+  isPromiseLike,
+  hasAtomicOperators,
+  maxWireVersion
 } from '../utils';
+
 // Error codes
 const WRITE_CONCERN_ERROR = 64;
 
@@ -663,6 +666,10 @@ class FindOperators {
       document.hint = updateDocument.hint;
     }
 
+    if (!hasAtomicOperators(updateDocument)) {
+      throw new TypeError('Update document requires atomic operators');
+    }
+
     // Clear out current Op
     this.s.currentOp = null;
     return this.s.options.addToOperationsList(this, UPDATE, document);
@@ -671,13 +678,33 @@ class FindOperators {
   /**
    * Add a replace one operation to the bulk operation
    *
-   * @function
-   * @param {object} updateDocument the new document to replace the existing one with
+   * @param {object} replacement the new document to replace the existing one with
    * @throws {MongoError} If operation cannot be added to bulk write
    * @returns {void} A reference to the parent BulkOperation
    */
-  replaceOne(updateDocument: object): void {
-    this.updateOne(updateDocument);
+  replaceOne(replacement: any) {
+    // Perform upsert
+    const upsert = typeof this.s.currentOp.upsert === 'boolean' ? this.s.currentOp.upsert : false;
+
+    // Establish the update command
+    const document = {
+      q: this.s.currentOp.selector,
+      u: replacement,
+      multi: false,
+      upsert: upsert
+    } as any;
+
+    if (replacement.hint) {
+      document.hint = replacement.hint;
+    }
+
+    if (hasAtomicOperators(replacement)) {
+      throw new TypeError('Replacement document must not use atomic operators');
+    }
+
+    // Clear out current Op
+    this.s.currentOp = null;
+    return this.s.options.addToOperationsList(this, UPDATE, document);
   }
 
   /**
@@ -965,6 +992,12 @@ class BulkOperationBase {
 
     // Crud spec update format
     if (op.updateOne || op.updateMany || op.replaceOne) {
+      if (op.replaceOne && hasAtomicOperators(op[key].replacement)) {
+        throw new TypeError('Replacement document must not use atomic operators');
+      } else if ((op.updateOne || op.updateMany) && !hasAtomicOperators(op[key].update)) {
+        throw new TypeError('Update document requires atomic operators');
+      }
+
       const multi = op.updateOne || op.replaceOne ? false : true;
       const operation = {
         q: op[key].filter,
@@ -982,7 +1015,15 @@ class BulkOperationBase {
       } else {
         if (op[key].upsert) operation.upsert = true;
       }
-      if (op[key].arrayFilters) operation.arrayFilters = op[key].arrayFilters;
+      if (op[key].arrayFilters) {
+        // TODO: this check should be done at command construction against a connection, not a topology
+        if (maxWireVersion(this.s.topology) < 6) {
+          throw new TypeError('arrayFilters are only supported on MongoDB 3.6+');
+        }
+
+        operation.arrayFilters = op[key].arrayFilters;
+      }
+
       return this.s.options.addToOperationsList(this, UPDATE, operation);
     }
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -3,7 +3,6 @@ import PromiseProvider = require('./promise_provider');
 import ReadPreference = require('./read_preference');
 import { deprecate } from 'util';
 import {
-  toError,
   normalizeHintField,
   decorateCommand,
   decorateWithCollation,
@@ -323,9 +322,7 @@ class Collection {
       options.ignoreUndefined = this.s.options.ignoreUndefined;
     }
 
-    const insertOneOperation = new InsertOneOperation(this, doc, options);
-
-    return executeOperation(this.s.topology, insertOneOperation, callback);
+    return executeOperation(this.s.topology, new InsertOneOperation(this, doc, options), callback);
   }
 
   /**
@@ -353,9 +350,11 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options ? Object.assign({}, options) : { ordered: true };
 
-    const insertManyOperation = new InsertManyOperation(this, docs, options);
-
-    return executeOperation(this.s.topology, insertManyOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new InsertManyOperation(this, docs, options),
+      callback
+    );
   }
 
   /**
@@ -428,9 +427,11 @@ class Collection {
       });
     }
 
-    const bulkWriteOperation = new BulkWriteOperation(this, operations, options);
-
-    return executeOperation(this.s.topology, bulkWriteOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new BulkWriteOperation(this, operations, options),
+      callback
+    );
   }
 
   /**
@@ -481,15 +482,6 @@ class Collection {
    */
   updateOne(filter: object, update: object, options?: any, callback?: Function): Promise<void> {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
-    const Promise = PromiseProvider.get();
-
-    const err = checkForAtomicOperators(update);
-    if (err) {
-      if (typeof callback === 'function') return callback(err);
-      return Promise.reject(err);
-    }
-
     options = Object.assign({}, options);
 
     // Add ignoreUndefined
@@ -498,9 +490,11 @@ class Collection {
       options.ignoreUndefined = this.s.options.ignoreUndefined;
     }
 
-    const updateOneOperation = new UpdateOneOperation(this, filter, update, options);
-
-    return executeOperation(this.s.topology, updateOneOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new UpdateOneOperation(this, filter, update, options),
+      callback
+    );
   }
 
   /**
@@ -534,9 +528,11 @@ class Collection {
       options.ignoreUndefined = this.s.options.ignoreUndefined;
     }
 
-    const replaceOneOperation = new ReplaceOneOperation(this, filter, doc, options);
-
-    return executeOperation(this.s.topology, replaceOneOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new ReplaceOneOperation(this, filter, doc, options),
+      callback
+    );
   }
 
   /**
@@ -564,14 +560,6 @@ class Collection {
   updateMany(filter: object, update: object, options?: any, callback?: Function): Promise<void> {
     const Promise = PromiseProvider.get();
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
-
-    const err = checkForAtomicOperators(update);
-    if (err) {
-      if (typeof callback === 'function') return callback(err);
-      return Promise.reject(err);
-    }
-
     options = Object.assign({}, options);
 
     // Add ignoreUndefined
@@ -580,9 +568,11 @@ class Collection {
       options.ignoreUndefined = this.s.options.ignoreUndefined;
     }
 
-    const updateManyOperation = new UpdateManyOperation(this, filter, update, options);
-
-    return executeOperation(this.s.topology, updateManyOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new UpdateManyOperation(this, filter, update, options),
+      callback
+    );
   }
 
   /**
@@ -630,9 +620,11 @@ class Collection {
       options.ignoreUndefined = this.s.options.ignoreUndefined;
     }
 
-    const deleteOneOperation = new DeleteOneOperation(this, filter, options);
-
-    return executeOperation(this.s.topology, deleteOneOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new DeleteOneOperation(this, filter, options),
+      callback
+    );
   }
 
   /**
@@ -663,9 +655,11 @@ class Collection {
       options.ignoreUndefined = this.s.options.ignoreUndefined;
     }
 
-    const deleteManyOperation = new DeleteManyOperation(this, filter, options);
-
-    return executeOperation(this.s.topology, deleteManyOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new DeleteManyOperation(this, filter, options),
+      callback
+    );
   }
 
   /**
@@ -691,9 +685,7 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
 
-    const renameOperation = new RenameOperation(this, newName, options);
-
-    return executeOperation(this.s.topology, renameOperation, callback);
+    return executeOperation(this.s.topology, new RenameOperation(this, newName, options), callback);
   }
 
   /**
@@ -713,13 +705,11 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    const dropCollectionOperation = new DropCollectionOperation(
-      this.s.db,
-      this.collectionName,
-      options
+    return executeOperation(
+      this.s.topology,
+      new DropCollectionOperation(this.s.db, this.collectionName, options),
+      callback
     );
-
-    return executeOperation(this.s.topology, dropCollectionOperation, callback);
   }
 
   /**
@@ -735,9 +725,7 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    const optionsOperation = new OptionsOperation(this, options);
-
-    return executeOperation(this.s.topology, optionsOperation, callback);
+    return executeOperation(this.s.topology, new OptionsOperation(this, options), callback);
   }
 
   /**
@@ -753,9 +741,7 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    const isCappedOperation = new IsCappedOperation(this, options);
-
-    return executeOperation(this.s.topology, isCappedOperation, callback);
+    return executeOperation(this.s.topology, new IsCappedOperation(this, options), callback);
   }
 
   /**
@@ -806,14 +792,11 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    const createIndexesOperation = new CreateIndexOperation(
-      this,
-      this.collectionName,
-      fieldOrSpec,
-      options
+    return executeOperation(
+      this.s.topology,
+      new CreateIndexOperation(this, this.collectionName, fieldOrSpec, options),
+      callback
     );
-
-    return executeOperation(this.s.topology, createIndexesOperation, callback);
   }
 
   /**
@@ -851,19 +834,14 @@ class Collection {
    */
   createIndexes(indexSpecs: any, options?: any, callback?: Function): Promise<void> {
     if (typeof options === 'function') (callback = options), (options = {});
-
     options = options ? Object.assign({}, options) : {};
-
     if (typeof options.maxTimeMS !== 'number') delete options.maxTimeMS;
 
-    const createIndexesOperation = new CreateIndexesOperation(
-      this,
-      this.collectionName,
-      indexSpecs,
-      options
+    return executeOperation(
+      this.s.topology,
+      new CreateIndexesOperation(this, this.collectionName, indexSpecs, options),
+      callback
     );
-
-    return executeOperation(this.s.topology, createIndexesOperation, callback);
   }
 
   /**
@@ -883,14 +861,16 @@ class Collection {
   dropIndex(indexName: string, options?: any, callback?: Function): Promise<void> {
     const args = Array.prototype.slice.call(arguments, 1);
     callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
-
     options = args.length ? args.shift() || {} : {};
+
     // Run only against primary
     options.readPreference = ReadPreference.PRIMARY;
 
-    const dropIndexOperation = new DropIndexOperation(this, indexName, options);
-
-    return executeOperation(this.s.topology, dropIndexOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new DropIndexOperation(this, indexName, options),
+      callback
+    );
   }
 
   /**
@@ -906,12 +886,9 @@ class Collection {
   dropIndexes(options?: any, callback?: Function): Promise<void> {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options ? Object.assign({}, options) : {};
-
     if (typeof options.maxTimeMS !== 'number') delete options.maxTimeMS;
 
-    const dropIndexesOperation = new DropIndexesOperation(this, options);
-
-    return executeOperation(this.s.topology, dropIndexesOperation, callback);
+    return executeOperation(this.s.topology, new DropIndexesOperation(this, options), callback);
   }
 
   /**
@@ -948,9 +925,11 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    const indexExistsOperation = new IndexExistsOperation(this, indexes, options);
-
-    return executeOperation(this.s.topology, indexExistsOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new IndexExistsOperation(this, indexes, options),
+      callback
+    );
   }
 
   /**
@@ -968,13 +947,11 @@ class Collection {
     callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
     options = args.length ? args.shift() || {} : {};
 
-    const indexInformationOperation = new IndexInformationOperation(
-      this.s.db,
-      this.collectionName,
-      options
+    return executeOperation(
+      this.s.topology,
+      new IndexInformationOperation(this.s.db, this.collectionName, options),
+      callback
     );
-
-    return executeOperation(this.s.topology, indexInformationOperation, callback);
   }
 
   /**
@@ -990,9 +967,11 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    const estimatedDocumentCountOperation = new EstimatedDocumentCountOperation(this, options);
-
-    return executeOperation(this.s.topology, estimatedDocumentCountOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new EstimatedDocumentCountOperation(this, options),
+      callback
+    );
   }
 
   /**
@@ -1033,9 +1012,11 @@ class Collection {
     query = args.length ? args.shift() || {} : {};
     options = args.length ? args.shift() || {} : {};
 
-    const countDocumentsOperation = new CountDocumentsOperation(this, query, options);
-
-    return executeOperation(this.s.topology, countDocumentsOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new CountDocumentsOperation(this, query, options),
+      callback
+    );
   }
 
   /**
@@ -1058,9 +1039,11 @@ class Collection {
     const queryOption = args.length ? args.shift() || {} : {};
     const optionsOption = args.length ? args.shift() || {} : {};
 
-    const distinctOperation = new DistinctOperation(this, key, queryOption, optionsOption);
-
-    return executeOperation(this.s.topology, distinctOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new DistinctOperation(this, key, queryOption, optionsOption),
+      callback
+    );
   }
 
   /**
@@ -1076,9 +1059,7 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    const indexesOperation = new IndexesOperation(this, options);
-
-    return executeOperation(this.s.topology, indexesOperation, callback);
+    return executeOperation(this.s.topology, new IndexesOperation(this, options), callback);
   }
 
   /**
@@ -1096,8 +1077,7 @@ class Collection {
     callback = typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
     options = args.length ? args.shift() || {} : {};
 
-    const statsOperation = new CollStatsOperation(this, options);
-    return executeOperation(this.s.topology, statsOperation, callback);
+    return executeOperation(this.s.topology, new CollStatsOperation(this, options), callback);
   }
 
   /**
@@ -1136,13 +1116,11 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    // Basic validation
-    if (filter == null || typeof filter !== 'object')
-      throw toError('filter parameter must be an object');
-
-    const findOneAndDeleteOperation = new FindOneAndDeleteOperation(this, filter, options);
-
-    return executeOperation(this.s.topology, findOneAndDeleteOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new FindOneAndDeleteOperation(this, filter, options),
+      callback
+    );
   }
 
   /**
@@ -1176,27 +1154,11 @@ class Collection {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    // Basic validation
-    if (filter == null || typeof filter !== 'object')
-      throw toError('filter parameter must be an object');
-    if (replacement == null || typeof replacement !== 'object')
-      throw toError('replacement parameter must be an object');
-
-    // Check that there are no atomic operators
-    const keys = Object.keys(replacement);
-
-    if (keys[0] && keys[0][0] === '$') {
-      throw toError('The replacement document must not contain atomic operators.');
-    }
-
-    const findOneAndReplaceOperation = new FindOneAndReplaceOperation(
-      this,
-      filter,
-      replacement,
-      options
+    return executeOperation(
+      this.s.topology,
+      new FindOneAndReplaceOperation(this, filter, replacement, options),
+      callback
     );
-
-    return executeOperation(this.s.topology, findOneAndReplaceOperation, callback);
   }
 
   /**
@@ -1228,26 +1190,14 @@ class Collection {
     options?: any,
     callback?: Function
   ): Promise<void> {
-    const Promise = PromiseProvider.get();
-
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    // Basic validation
-    if (filter == null || typeof filter !== 'object')
-      throw toError('filter parameter must be an object');
-    if (update == null || typeof update !== 'object')
-      throw toError('update parameter must be an object');
-
-    const err = checkForAtomicOperators(update);
-    if (err) {
-      if (typeof callback === 'function') return callback(err);
-      return Promise.reject(err);
-    }
-
-    const findOneAndUpdateOperation = new FindOneAndUpdateOperation(this, filter, update, options);
-
-    return executeOperation(this.s.topology, findOneAndUpdateOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new FindOneAndUpdateOperation(this, filter, update, options),
+      callback
+    );
   }
 
   /**
@@ -1395,9 +1345,12 @@ class Collection {
     if ('function' === typeof options.finalize) {
       options.finalize = options.finalize.toString();
     }
-    const mapReduceOperation = new MapReduceOperation(this, map, reduce, options);
 
-    return executeOperation(this.s.topology, mapReduceOperation, callback);
+    return executeOperation(
+      this.s.topology,
+      new MapReduceOperation(this, map, reduce, options),
+      callback
+    );
   }
 
   /**
@@ -1927,9 +1880,7 @@ Collection.prototype.findOne = deprecateOptions(
     query = query || {};
     options = options || {};
 
-    const findOneOperation = new FindOneOperation(this, query, options);
-
-    return executeOperation(this.s.topology, findOneOperation, callback);
+    return executeOperation(this.s.topology, new FindOneOperation(this, query, options), callback);
   }
 );
 
@@ -2207,25 +2158,6 @@ Collection.prototype.group = deprecate(function(
   );
 },
 'MongoDB 3.6 or higher no longer supports the group command. We recommend rewriting using the aggregation framework.');
-
-
-// Check the update operation to ensure it has atomic operators.
-function checkForAtomicOperators(update: any): any {
-  if (Array.isArray(update)) {
-    return update.reduce((err?: any, u?: any) => err || checkForAtomicOperators(u), null);
-  }
-
-  const keys = Object.keys(update);
-
-  // same errors as the server would give for update doc lacking atomic operators
-  if (keys.length === 0) {
-    return toError('The update operation document must contain at least one atomic operator.');
-  }
-
-  if (keys[0][0] !== '$') {
-    return toError('the update operation document must contain atomic operators.');
-  }
-}
 
 /**
  * Save a document.

--- a/src/operations/replace_one.ts
+++ b/src/operations/replace_one.ts
@@ -1,31 +1,36 @@
 import { OperationBase } from './operation';
 import { updateDocuments } from './common_functions';
+import { hasAtomicOperators } from '../utils';
 
 class ReplaceOneOperation extends OperationBase {
   collection: any;
   filter: any;
-  doc: any;
+  replacement: any;
 
-  constructor(collection: any, filter: any, doc: any, options: any) {
+  constructor(collection: any, filter: any, replacement: any, options: any) {
     super(options);
+
+    if (hasAtomicOperators(replacement)) {
+      throw new TypeError('Replacement document must not contain atomic operators');
+    }
 
     this.collection = collection;
     this.filter = filter;
-    this.doc = doc;
+    this.replacement = replacement;
   }
 
   execute(callback: Function) {
     const coll = this.collection;
     const filter = this.filter;
-    const doc = this.doc;
+    const replacement = this.replacement;
     const options = this.options;
 
     // Set single document update
     options.multi = false;
 
     // Execute update
-    updateDocuments(coll, filter, doc, options, (err?: any, r?: any) =>
-      replaceCallback(err, r, doc, callback)
+    updateDocuments(coll, filter, replacement, options, (err: Error, r: any) =>
+      replaceCallback(err, r, replacement, callback)
     );
   }
 }

--- a/src/operations/update_one.ts
+++ b/src/operations/update_one.ts
@@ -1,5 +1,6 @@
 import { OperationBase } from './operation';
 import { updateDocuments } from './common_functions';
+import { hasAtomicOperators } from '../utils';
 
 class UpdateOneOperation extends OperationBase {
   collection: any;
@@ -8,6 +9,10 @@ class UpdateOneOperation extends OperationBase {
 
   constructor(collection: any, filter: any, update: any, options: any) {
     super(options);
+
+    if (!hasAtomicOperators(update)) {
+      throw new TypeError('Update document requires atomic operators');
+    }
 
     this.collection = collection;
     this.filter = filter;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1026,6 +1026,15 @@ function makeInterruptableAsyncInterval(fn: Function, options?: any) {
   return { wake, stop };
 }
 
+function hasAtomicOperators(doc: any): boolean {
+  if (Array.isArray(doc)) {
+    return doc.reduce((err, u) => err || hasAtomicOperators(u), null);
+  }
+
+  const keys = Object.keys(doc);
+  return keys.length > 0 && keys[0][0] === '$';
+}
+
 export {
   filterOptions,
   mergeOptions,
@@ -1071,5 +1080,6 @@ export {
   noop,
   now,
   calculateDurationInMs,
-  makeInterruptableAsyncInterval
+  makeInterruptableAsyncInterval,
+  hasAtomicOperators
 };

--- a/test/disabled/replset_operations.test.js
+++ b/test/disabled/replset_operations.test.js
@@ -234,7 +234,10 @@ describe('ReplSet (Operations)', function () {
             // Initialize the Ordered Batch
             const batch = col.initializeUnorderedBulkOp();
             batch.insert({ a: 1 });
-            batch.find({ a: 3 }).upsert().updateOne({ a: 3, b: 1 });
+            batch
+              .find({ a: 3 })
+              .upsert()
+              .updateOne({ $set: { a: 3, b: 1 } });
             batch.insert({ a: 2 });
 
             // Execute the operations

--- a/test/functional/crud_api.test.js
+++ b/test/functional/crud_api.test.js
@@ -1,7 +1,6 @@
 'use strict';
-var test = require('./shared').assert,
-  setupDatabase = require('./shared').setupDatabase,
-  expect = require('chai').expect;
+const test = require('./shared').assert;
+const setupDatabase = require('./shared').setupDatabase;
 
 // instanceof cannot be use reliably to detect the new models in js due to scoping and new
 // contexts killing class info find/distinct/count thus cannot be overloaded without breaking
@@ -992,113 +991,6 @@ describe('CRUD API', function () {
           test.ok(err !== null);
           client.close(done);
         });
-      });
-    }
-  });
-
-  it('should correctly throw error if update doc for findOneAndUpdate lacks atomic operator', function (done) {
-    let configuration = this.configuration;
-    let client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-    client.connect(function (err, client) {
-      expect(err).to.not.exist;
-      let db = client.db(configuration.db);
-      let col = db.collection('t21_1');
-      col.insertOne({ a: 1, b: 2, c: 3 }, function (err, r) {
-        expect(err).to.not.exist;
-        expect(r.insertedCount).to.equal(1);
-
-        // empty update document
-        col.findOneAndUpdate({ a: 1 }, {}, function (err, r) {
-          expect(err).to.exist;
-          expect(r).to.not.exist;
-
-          // update document non empty but still lacks atomic operator
-          col.findOneAndUpdate({ a: 1 }, { b: 5 }, function (err, r) {
-            expect(err).to.exist;
-            expect(r).to.not.exist;
-
-            client.close(done);
-          });
-        });
-      });
-    });
-  });
-
-  it('should correctly throw error if update doc for updateOne lacks atomic operator', {
-    // Add a tag that our runner can trigger on
-    // in this case we are setting that node needs to be higher than 0.10.X to run
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    test: function (done) {
-      var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function (err, client) {
-        expect(err).to.not.exist;
-        var db = client.db(configuration.db);
-        var col = db.collection('t21_1');
-        col.insertOne({ a: 1, b: 2, c: 3 }, function (err, r) {
-          expect(err).to.not.exist;
-          expect(r.insertedCount).to.equal(1);
-
-          // empty update document
-          col.updateOne({ a: 1 }, {}, function (err, r) {
-            expect(err).to.exist;
-            expect(r).to.not.exist;
-
-            // update document non empty but still lacks atomic operator
-            col.updateOne({ a: 1 }, { b: 5 }, function (err, r) {
-              expect(err).to.exist;
-              expect(r).to.not.exist;
-
-              client.close(done);
-            });
-          });
-        });
-      });
-    }
-  });
-
-  it('should correctly throw error if update doc for updateMany lacks atomic operator', {
-    // Add a tag that our runner can trigger on
-    // in this case we are setting that node needs to be higher than 0.10.X to run
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-
-    test: function (done) {
-      var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
-      client.connect(function (err, client) {
-        expect(err).to.not.exist;
-        var db = client.db(configuration.db);
-        var col = db.collection('t22_1');
-        col.insertMany(
-          [
-            { a: 1, b: 2 },
-            { a: 1, b: 3 },
-            { a: 1, b: 4 }
-          ],
-          function (err, r) {
-            expect(err).to.not.exist;
-            expect(r.insertedCount).to.equal(3);
-
-            // empty update document
-            col.updateMany({ a: 1 }, {}, function (err, r) {
-              expect(err).to.exist;
-              expect(r).to.not.exist;
-
-              // update document non empty but still lacks atomic operator
-              col.updateMany({ a: 1 }, { b: 5 }, function (err, r) {
-                expect(err).to.exist;
-                expect(r).to.not.exist;
-
-                client.close(done);
-              });
-            });
-          }
-        );
       });
     }
   });

--- a/test/functional/crud_spec.test.js
+++ b/test/functional/crud_spec.test.js
@@ -393,45 +393,74 @@ describe('CRUD spec', function () {
       );
     }
 
+    function promiseTry(callback) {
+      return new Promise((resolve, reject) => {
+        try {
+          resolve(callback());
+        } catch (e) {
+          reject(e);
+        }
+      });
+    }
+
+    const outcome = scenarioTest.outcome;
     return Promise.all(dropPromises)
       .then(() =>
         scenario.data && scenario.data.length
           ? collection.insertMany(scenario.data)
           : Promise.resolve()
       )
-      .then(() => {
-        switch (scenarioTest.operation.name) {
-          case 'aggregate':
-            return executeAggregateTest(scenarioTest, context.db, collection);
-          case 'count':
-            return executeCountTest(scenarioTest, context.db, collection);
-          case 'countDocuments':
-            return executeCountDocumentsTest(scenarioTest, context.db, collection);
-          case 'estimatedDocumentCount':
-            return executeEstimatedDocumentCountTest(scenarioTest, context.db, collection);
-          case 'distinct':
-            return executeDistinctTest(scenarioTest, context.db, collection);
-          case 'find':
-            return executeFindTest(scenarioTest, context.db, collection);
-          case 'deleteOne':
-          case 'deleteMany':
-            return executeDeleteTest(scenarioTest, context.db, collection);
-          case 'replaceOne':
-            return executeReplaceTest(scenarioTest, context.db, collection);
-          case 'updateOne':
-          case 'updateMany':
-            return executeUpdateTest(scenarioTest, context.db, collection);
-          case 'findOneAndReplace':
-          case 'findOneAndUpdate':
-          case 'findOneAndDelete':
-            return executeFindOneTest(scenarioTest, context.db, collection);
-          case 'insertOne':
-          case 'insertMany':
-            return executeInsertTest(scenarioTest, context.db, collection);
-          case 'bulkWrite':
-            return executeBulkTest(scenarioTest, context.db, collection);
+      .then(() =>
+        promiseTry(() => {
+          switch (scenarioTest.operation.name) {
+            case 'aggregate':
+              return executeAggregateTest(scenarioTest, context.db, collection);
+            case 'count':
+              return executeCountTest(scenarioTest, context.db, collection);
+            case 'countDocuments':
+              return executeCountDocumentsTest(scenarioTest, context.db, collection);
+            case 'estimatedDocumentCount':
+              return executeEstimatedDocumentCountTest(scenarioTest, context.db, collection);
+            case 'distinct':
+              return executeDistinctTest(scenarioTest, context.db, collection);
+            case 'find':
+              return executeFindTest(scenarioTest, context.db, collection);
+            case 'deleteOne':
+            case 'deleteMany':
+              return executeDeleteTest(scenarioTest, context.db, collection);
+            case 'replaceOne':
+              return executeReplaceTest(scenarioTest, context.db, collection);
+            case 'updateOne':
+            case 'updateMany':
+              return executeUpdateTest(scenarioTest, context.db, collection);
+            case 'findOneAndReplace':
+            case 'findOneAndUpdate':
+            case 'findOneAndDelete':
+              return executeFindOneTest(scenarioTest, context.db, collection);
+            case 'insertOne':
+            case 'insertMany':
+              return executeInsertTest(scenarioTest, context.db, collection);
+            case 'bulkWrite':
+              return executeBulkTest(scenarioTest, context.db, collection);
+          }
+        })
+      )
+      .then(
+        () => {
+          if (
+            outcome.error === true &&
+            scenarioTest.operation.name !== 'bulkWrite' &&
+            scenarioTest.operation.name !== 'insertMany'
+          ) {
+            throw new Error('Error expected!');
+          }
+        },
+        err => {
+          if (outcome && (outcome.error == null || outcome.error === false)) {
+            throw err;
+          }
         }
-      });
+      );
   }
 });
 

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -163,8 +163,8 @@ function generateTopologyTests(testSuites, testContext, filter) {
 
 // Test runner helpers
 function prepareDatabaseForSuite(suite, context) {
-  context.dbName = suite.database_name;
-  context.collectionName = suite.collection_name;
+  context.dbName = suite.database_name || 'spec_db';
+  context.collectionName = suite.collection_name || 'spec_collection';
 
   const db = context.sharedClient.db(context.dbName);
   const setupPromise = db
@@ -178,7 +178,7 @@ function prepareDatabaseForSuite(suite, context) {
       throw err;
     });
 
-  if (context.collectionName == null) {
+  if (context.collectionName == null || context.dbName === 'admin') {
     return setupPromise;
   }
 

--- a/test/spec/crud/v1/write/findOneAndReplace.json
+++ b/test/spec/crud/v1/write/findOneAndReplace.json
@@ -268,6 +268,49 @@
           ]
         }
       }
+    },
+    {
+      "description": "FindOneAndReplace require no atomic operators in replacement document",
+      "operation": {
+        "name": "findOneAndReplace",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "replacement": {
+            "$set": {
+              "x": 44
+            }
+          },
+          "projection": {
+            "x": 1,
+            "_id": 0
+          },
+          "returnDocument": "After",
+          "sort": {
+            "x": 1
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/spec/crud/v1/write/findOneAndReplace.yml
+++ b/test/spec/crud/v1/write/findOneAndReplace.yml
@@ -9,7 +9,7 @@ tests:
         operation:
             name: findOneAndReplace
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
                 replacement: {x: 32}
                 projection: {x: 1, _id: 0}
@@ -27,7 +27,7 @@ tests:
         operation:
             name: findOneAndReplace
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
                 replacement: {x: 32}
                 projection: {x: 1, _id: 0}
@@ -106,6 +106,24 @@ tests:
 
         outcome:
             result: null
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+    -
+        description: "FindOneAndReplace require no atomic operators in replacement document"
+        operation:
+            name: findOneAndReplace
+            arguments:
+                filter: { _id: 4 }
+                replacement: { $set: { x: 44 } }
+                projection: { x: 1, _id: 0 }
+                returnDocument: After
+                sort: { x: 1 }
+
+        outcome:
+            error: true
             collection:
                 data:
                     - {_id: 1, x: 11}

--- a/test/spec/crud/v1/write/findOneAndUpdate.json
+++ b/test/spec/crud/v1/write/findOneAndUpdate.json
@@ -374,6 +374,48 @@
           ]
         }
       }
+    },
+    {
+      "description": "FindOneAndUpdate require atomic operators for update document",
+      "operation": {
+        "name": "findOneAndUpdate",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "update": {
+            "x": 1
+          },
+          "projection": {
+            "x": 1,
+            "_id": 0
+          },
+          "returnDocument": "After",
+          "sort": {
+            "x": 1
+          },
+          "upsert": true
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/spec/crud/v1/write/findOneAndUpdate.yml
+++ b/test/spec/crud/v1/write/findOneAndUpdate.yml
@@ -9,9 +9,9 @@ tests:
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -28,9 +28,9 @@ tests:
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -49,7 +49,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 2}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -67,7 +67,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 2}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -86,7 +86,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -104,7 +104,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 # Omit the sort option as it has no effect when no documents
@@ -127,7 +127,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -146,7 +146,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -161,3 +161,22 @@ tests:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
                     - {_id: 4, x: 1}
+    -
+        description: "FindOneAndUpdate require atomic operators for update document"
+        operation:
+            name: findOneAndUpdate
+            arguments:
+                filter: { _id: 4 }
+                update: { x: 1 }
+                projection: { x: 1, _id: 0 }
+                returnDocument: After
+                sort: { x: 1 }
+                upsert: true
+
+        outcome:
+            error: true
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}

--- a/test/spec/crud/v1/write/replaceOne-collation.yml
+++ b/test/spec/crud/v1/write/replaceOne-collation.yml
@@ -9,9 +9,9 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {x: 'PING'}
-                replacement: {_id: 2, x: 'pong'}
-                collation: {locale: 'en_US', strength: 2} # https://docs.mongodb.com/master/reference/collation/#collation-document
+                filter: { x: 'PING' }
+                replacement: { _id: 2, x: 'pong' }
+                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/master/reference/collation/#collation-document
 
         outcome:
             result:

--- a/test/spec/crud/v1/write/replaceOne.json
+++ b/test/spec/crud/v1/write/replaceOne.json
@@ -200,6 +200,43 @@
           ]
         }
       }
+    },
+    {
+      "description": "ReplaceOne require no atomic operators in replacement document",
+      "operation": {
+        "name": "replaceOne",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "replacement": {
+            "$set": {
+              "_id": 4,
+              "x": 1
+            }
+          },
+          "upsert": true
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/spec/crud/v1/write/replaceOne.yml
+++ b/test/spec/crud/v1/write/replaceOne.yml
@@ -10,9 +10,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: 
-                    _id: {$gt: 1}
-                replacement: {x: 111}
+                filter: { _id: {$gt: 1} }
+                replacement: { x: 111 }
 
         outcome:
             result:
@@ -26,8 +25,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 1}
-                replacement: {_id: 1, x: 111}
+                filter: { _id: 1 }
+                replacement: { _id: 1, x: 111 }
 
         outcome:
             result:
@@ -44,8 +43,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {_id: 4, x: 1}
+                filter: { _id: 4 }
+                replacement: { _id: 4, x: 1 }
 
         outcome:
             result:
@@ -62,8 +61,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {x: 1}
+                filter: { _id: 4 }
+                replacement: { x: 1 }
                 upsert: true
 
         outcome:
@@ -84,8 +83,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {_id: 4, x: 1}
+                filter: { _id: 4 }
+                replacement: { _id: 4, x: 1 }
                 upsert: true
 
         outcome:
@@ -100,3 +99,18 @@ tests:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
                     - {_id: 4, x: 1}
+    -
+        description: "ReplaceOne require no atomic operators in replacement document"
+        operation:
+            name: "replaceOne"
+            arguments:
+                filter: { _id: 4 }
+                replacement: { $set: { _id: 4, x: 1 } }
+                upsert: true
+        outcome:
+            error: true
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}

--- a/test/spec/crud/v1/write/updateOne.json
+++ b/test/spec/crud/v1/write/updateOne.json
@@ -162,6 +162,40 @@
           ]
         }
       }
+    },
+    {
+      "description": "UpdateOne require atomic operators in update document",
+      "operation": {
+        "name": "updateOne",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "update": {
+            "x": 1
+          },
+          "upsert": true
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/spec/crud/v1/write/updateOne.yml
+++ b/test/spec/crud/v1/write/updateOne.yml
@@ -10,9 +10,9 @@ tests:
         operation:
             name: "updateOne"
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -28,7 +28,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -47,7 +47,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -66,7 +66,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 upsert: true
 
@@ -82,3 +82,18 @@ tests:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
                     - {_id: 4, x: 1}
+    -
+        description: "UpdateOne require atomic operators in update document"
+        operation:
+            name: "updateOne"
+            arguments:
+                filter: { _id: 4 }
+                update: { x: 1 }
+                upsert: true
+        outcome:
+            error: true
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}

--- a/test/spec/crud/v2/bulkWrite-arrayFilters-clientError.json
+++ b/test/spec/crud/v2/bulkWrite-arrayFilters-clientError.json
@@ -1,0 +1,110 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "3.5.5"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "y": [
+        {
+          "b": 3
+        },
+        {
+          "b": 1
+        }
+      ]
+    },
+    {
+      "_id": 2,
+      "y": [
+        {
+          "b": 0
+        },
+        {
+          "b": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite on server that doesn't support arrayFilters",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {},
+                  "update": {
+                    "$set": {
+                      "y.0.b": 2
+                    }
+                  },
+                  "arrayFilters": [
+                    {
+                      "i.b": 1
+                    }
+                  ]
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": []
+    },
+    {
+      "description": "BulkWrite on server that doesn't support arrayFilters with arrayFilters on second op",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {},
+                  "update": {
+                    "$set": {
+                      "y.0.b": 2
+                    }
+                  }
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {},
+                  "update": {
+                    "$set": {
+                      "y.$[i].b": 2
+                    }
+                  },
+                  "arrayFilters": [
+                    {
+                      "i.b": 1
+                    }
+                  ]
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": []
+    }
+  ]
+}

--- a/test/spec/crud/v2/bulkWrite-arrayFilters-clientError.yml
+++ b/test/spec/crud/v2/bulkWrite-arrayFilters-clientError.yml
@@ -1,0 +1,50 @@
+runOn:
+  -
+    # arrayFilters support first introduced in 3.5.6
+    maxServerVersion: "3.5.5"
+
+data:
+  - {_id: 1, y: [{b: 3}, {b: 1}]}
+  - {_id: 2, y: [{b: 0}, {b: 1}]}
+
+tests:
+  -
+    description: "BulkWrite on server that doesn't support arrayFilters"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              # UpdateOne with with arrayFilters
+              name: "updateOne"
+              arguments:
+                filter: {}
+                update: { $set: { "y.0.b": 2 } }
+                arrayFilters: [ { "i.b": 1 } ]
+          options: { ordered: true }
+        error: true
+    expectations: []
+  -
+    description: "BulkWrite on server that doesn't support arrayFilters with arrayFilters on second op"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              # UpdateOne with no arrayFilters
+              name: "updateOne"
+              arguments:
+                filter: {}
+                update: { $set: { "y.0.b": 2 } }
+            -
+              # UpdateMany with arrayFilters
+              name: "updateMany"
+              arguments:
+                filter: {}
+                update: { $set: { "y.$[i].b": 2 } }
+                arrayFilters: [ { "i.b": 1 } ]
+          options: { ordered: true }
+        error: true
+    expectations: []

--- a/test/spec/crud/v2/bulkWrite-arrayFilters.yml
+++ b/test/spec/crud/v2/bulkWrite-arrayFilters.yml
@@ -1,10 +1,10 @@
 runOn:
-    -
-        minServerVersion: "3.5.6"
+  -
+    minServerVersion: "3.5.6"
 
 data:
-    - {_id: 1, y: [{b: 3}, {b: 1}]}
-    - {_id: 2, y: [{b: 0}, {b: 1}]}
+  - {_id: 1, y: [{b: 3}, {b: 1}]}
+  - {_id: 2, y: [{b: 0}, {b: 1}]}
 
 collection_name: &collection_name "test"
 database_name: &database_name "crud-tests"

--- a/test/spec/crud/v2/bulkWrite-update-validation.json
+++ b/test/spec/crud/v2/bulkWrite-update-validation.json
@@ -1,0 +1,151 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite replaceOne prohibits atomic modifiers",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "$set": {
+                      "x": 22
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite updateOne requires atomic modifiers",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "x": 22
+                  }
+                }
+              }
+            ]
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite updateMany requires atomic modifiers",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "update": {
+                    "x": 44
+                  }
+                }
+              }
+            ]
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/bulkWrite-update-validation.yml
+++ b/test/spec/crud/v2/bulkWrite-update-validation.yml
@@ -1,0 +1,75 @@
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+
+tests:
+  -
+    description: "BulkWrite replaceOne prohibits atomic modifiers"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "replaceOne"
+              arguments:
+                filter: { _id: 1 }
+                # Only the first field is tested, as the spec permits drivers to
+                # only check that and rely on the server to check subsequent
+                # fields.
+                replacement: { $set: { x: 22 }}
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
+          - {_id: 3, x: 33 }
+  -
+    description: "BulkWrite updateOne requires atomic modifiers"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "updateOne"
+              arguments:
+                filter: { _id: 1 }
+                # Only the first field is tested, as the spec permits drivers to
+                # only check that and rely on the server to check subsequent
+                # fields.
+                update: { x: 22 }
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
+          - {_id: 3, x: 33 }
+  -
+    description: "BulkWrite updateMany requires atomic modifiers"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "updateMany"
+              arguments:
+                filter: { _id: { $gt: 1 }}
+                # Only the first field is tested, as the spec permits drivers to
+                # only check that and rely on the server to check subsequent
+                # fields.
+                update: { x: 44 }
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 22 }
+          - {_id: 3, x: 33 }

--- a/test/spec/crud/v2/replaceOne-validation.json
+++ b/test/spec/crud/v2/replaceOne-validation.json
@@ -1,0 +1,41 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    }
+  ],
+  "tests": [
+    {
+      "description": "ReplaceOne prohibits atomic modifiers",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "$set": {
+                "x": 22
+              }
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/replaceOne-validation.yml
+++ b/test/spec/crud/v2/replaceOne-validation.yml
@@ -1,0 +1,21 @@
+data:
+  - { _id: 1, x: 11 }
+
+tests:
+  -
+    description: "ReplaceOne prohibits atomic modifiers"
+    operations:
+      -
+        object: collection
+        name: replaceOne
+        arguments:
+          filter: { _id: 1 }
+          # Only the first field is tested, as the spec permits drivers to only
+          # check that and rely on the server to check subsequent fields.
+          replacement: { $set: { x: 22 }}
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - { _id: 1, x: 11 }

--- a/test/spec/crud/v2/updateMany-validation.json
+++ b/test/spec/crud/v2/updateMany-validation.json
@@ -1,0 +1,57 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne requires atomic modifiers",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "x": 44
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/updateMany-validation.yml
+++ b/test/spec/crud/v2/updateMany-validation.yml
@@ -1,0 +1,25 @@
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+
+tests:
+  -
+    description: "UpdateOne requires atomic modifiers"
+    operations:
+      -
+        object: collection
+        name: updateMany
+        arguments:
+          filter: { _id: { $gt: 1 }}
+          # Only the first field is tested, as the spec permits drivers to only
+          # check that and rely on the server to check subsequent fields.
+          update: { x: 44 }
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 11}
+          - {_id: 2, x: 22}
+          - {_id: 3, x: 33}

--- a/test/spec/crud/v2/updateOne-validation.json
+++ b/test/spec/crud/v2/updateOne-validation.json
@@ -1,0 +1,39 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne requires atomic modifiers",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 22
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/crud/v2/updateOne-validation.yml
+++ b/test/spec/crud/v2/updateOne-validation.yml
@@ -1,0 +1,21 @@
+data:
+  - { _id: 1, x: 11 }
+
+tests:
+  -
+    description: "UpdateOne requires atomic modifiers"
+    operations:
+      -
+        object: collection
+        name: updateOne
+        arguments:
+          filter: { _id: 1 }
+          # Only the first field is tested, as the spec permits drivers to only
+          # check that and rely on the server to check subsequent fields.
+          update: { x: 22 }
+        error: true
+    expectations: []
+    outcome:
+      collection:
+        data:
+          - { _id: 1, x: 11 }

--- a/test/unit/collection.test.js
+++ b/test/unit/collection.test.js
@@ -23,7 +23,7 @@ describe('Collection', function () {
       const collection = db.collection('test');
       expect(() => {
         collection.findOneAndReplace({ a: 1 }, { $set: { a: 14 } });
-      }).to.throw('The replacement document must not contain atomic operators.');
+      }).to.throw(/must not contain atomic operators/);
     }
   });
 });


### PR DESCRIPTION
**NOTE:** port to the 4.0 branch

`checkForAtomicOperators` was refactored into the more versatile `hasAtomicOperators` and the logic for asserting atomic operator requirements was streamlined across all crud operations as well as bulk operations.

NODE-2660