### PR TITLE
DOCSP-9667: add link to new reference docs 3.2

### DIFF
--- a/docs/reference/config.toml
+++ b/docs/reference/config.toml
@@ -1,8 +1,11 @@
-baseurl = "/node-mongodb-native/steverenaker/DOCS-8756"
+baseurl = "/node-mongodb-native/3.2"
 languageCode = "en-us"
 title = "MongoDB Node.js Driver"
 theme = "mongodb"
 canonifyurls = false
+
+[params]
+    referenceDocsUrl = "https://docs.mongodb.com/drivers/node"
 
 [blackfriday]
   plainIdAnchors = true

--- a/docs/reference/layouts/partials/header.html
+++ b/docs/reference/layouts/partials/header.html
@@ -25,3 +25,5 @@
               <div class="documentwrapper">
                 <div class="bodywrapper">
                   <div class="body">
+
+                    {{ partial "new_version.html" . }}

--- a/docs/reference/layouts/partials/new_version.html
+++ b/docs/reference/layouts/partials/new_version.html
@@ -1,0 +1,4 @@
+<div class="alert alert-info" role="alert">
+  Note: You are currently viewing version 3.2 of the Node.js driver documentation.
+  <a href="{{.Site.Params.ReferenceDocsUrl}}">Click here</a> for the latest version.
+</div>


### PR DESCRIPTION
## Note: Do not publish until 4.4 GA

[DOCSP-9667](https://jira.mongodb.org/browse/DOCSP-9667)

### Changes:
* Added banner with link to the new reference documentation site

See https://github.com/mongodb/node-mongodb-native/pull/2458 for preview