### PR TITLE
NODE-2696/options-parsing-coercer

### DIFF
--- a/src/options/coerce.ts
+++ b/src/options/coerce.ts
@@ -1,0 +1,577 @@
+import { CoerceError, CoerceDeprecate, CoerceUnrecognized } from './coerce_error';
+
+// prettier-ignore
+type UnionToIntersection<U> =
+  (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+
+export type Func = (...args: any[]) => any;
+export type Funcs = Func[];
+export type ReturnTypes<T extends Funcs> = ReturnType<T[number]>;
+export type StripCoerceError<T> = Exclude<T, CoerceError>;
+export type CoerceType<F extends Func> = StripCoerceError<ReturnType<F>>;
+
+export type CoerceMatch = ReturnType<typeof CoerceObject['match']>;
+export type CoerceObjectMatch = (match: CoerceMatch) => any;
+export type CoerceObjectMatches = CoerceObjectMatch[];
+
+export type CoerceMatchExact = ReturnType<typeof CoerceObject['matchExact']>;
+export type CoerceObjectMatchExact = (match: CoerceMatchExact) => any;
+export type CoerceObjectMatchesExact = CoerceObjectMatch[];
+
+export type ReturnTypeUnion<T extends Funcs> = UnionToIntersection<ReturnTypes<T>>;
+export type Unionize<K extends string | readonly string[]> = (K extends string ? [K] : K)[number];
+
+export interface CoerceOptions {
+  id?: string;
+  warn?: boolean;
+  typeSuffix?: string;
+  warnDeprecated?: boolean;
+  warnUnrecognized?: boolean;
+  applyDefaults?: boolean;
+}
+export type Coercer<T> = (value: any, options?: CoerceOptions) => T | CoerceError;
+
+/** these are all created to get the last function return type in an array of functions  */
+type LengthOfTuple<T extends Funcs> = T extends { length: infer L } ? L : never;
+// prettier-ignore
+type DropFirstInTuple<T extends Funcs> =
+  ((...args: T) => any) extends (arg: any, ...rest: infer U) => any ? U : T;
+type LastInTuple<T extends Funcs> = T[LengthOfTuple<DropFirstInTuple<T>>];
+type LastFnReturns<Fns extends Funcs> = ReturnType<LastInTuple<Fns>>;
+type ComposeReturn<T extends Funcs> = LastFnReturns<T>;
+
+/** Coerces nested objects into a given shape using primitive coerce functions */
+export class CoerceObject {
+  static matchExact<V extends { [key: string]: any }>(
+    value: V,
+    key: keyof V,
+    options?: CoerceOptions
+  ) {
+    return <K extends string, F extends Coercer<any>>(
+      matchKey: K,
+      fn: F
+    ): CoerceError extends ReturnType<F>
+      ? Partial<Record<K, Exclude<ReturnType<F>, CoerceError>>>
+      : Record<K, Exclude<ReturnType<F>, CoerceError>> => {
+      if (key !== matchKey) return {} as any;
+      const propValue = value[key];
+      const result = fn(propValue, { ...options, id: key as string });
+      if (result instanceof CoerceError) return {} as any;
+      return { [matchKey]: result } as any;
+    };
+  }
+  static match<V extends { [key: string]: any }>(
+    value: V,
+    key: keyof V,
+    keyLower: string,
+    options?: CoerceOptions
+  ) {
+    return <K extends string, F extends Coercer<any>>(
+      matchKey: K,
+      fn: F
+    ): CoerceError extends ReturnType<F>
+      ? Partial<Record<K, Exclude<ReturnType<F>, CoerceError>>>
+      : Record<K, Exclude<ReturnType<F>, CoerceError>> => {
+      if (keyLower !== matchKey.toLowerCase()) return {} as any;
+      const propValue = value[key];
+      const result = fn(propValue, { ...options, id: key as string });
+      if (result instanceof CoerceError) return {} as any;
+      return { [matchKey]: result } as any;
+    };
+  }
+  static requireMatch<V extends { [key: string]: any }>(value: V) {
+    return <K extends string, F extends Coercer<any>>(matchKey: K, fn: F) => {
+      fn(value[matchKey], { id: matchKey, warn: false });
+    };
+  }
+  static defaultMatch(options?: CoerceOptions) {
+    return <K extends string, F extends Coercer<any>>(
+      matchKey: K,
+      fn: F
+    ): CoerceError extends ReturnType<F>
+      ? Partial<Record<K, Exclude<ReturnType<F>, CoerceError>>>
+      : Record<K, Exclude<ReturnType<F>, CoerceError>> => {
+      try {
+        const result = fn(undefined, { ...options, id: matchKey, warn: false });
+        if (result instanceof CoerceError) return {} as any;
+        return { [matchKey]: result } as any;
+      } catch (e) {
+        return {} as any;
+      }
+    };
+  }
+  static gatherMatch<K extends string>(matchKey: K) {
+    return { [matchKey]: true } as any;
+  }
+  static objectExact<F extends CoerceObjectMatchesExact>(...cbs: F) {
+    return <V extends { [key: string]: any }>(
+      value: V,
+      options?: CoerceOptions
+    ): ReturnTypeUnion<F> | CoerceError => {
+      if (!Coerce.isPlainObject(value)) {
+        return new CoerceError('object', value, options);
+      }
+      const results = Object.keys(value).reduce((acq: any, key: keyof V) => {
+        const match = CoerceObject.matchExact(value, key, options);
+        const collected = cbs.reduce((acq, cb) => {
+          return { ...acq, ...cb(match) };
+        }, {});
+        return { ...acq, ...collected };
+      }, {});
+      // fire errors for required options
+      cbs.map(cb => cb(CoerceObject.requireMatch(results) as any));
+      // warn unrecognized properties
+      if (options?.warn !== false && options?.warnUnrecognized !== false) {
+        const data = cbs.reduce((acq, cb) => {
+          return { ...acq, ...cb(CoerceObject.gatherMatch as any) };
+        }, {});
+        const recognizedKeys = Object.keys(data);
+        const providedKeys = Object.keys(value);
+        const unrecognized = providedKeys.filter(pk => !recognizedKeys.includes(pk));
+        unrecognized.forEach(key => new CoerceUnrecognized(key).warn());
+      }
+      // set defaults
+      if (options?.applyDefaults !== false) {
+        const defaultValues = cbs.reduce((acq, cb) => {
+          return { ...acq, ...cb(CoerceObject.defaultMatch(options) as any) };
+        }, {});
+        return { ...defaultValues, ...results };
+      }
+      return results;
+    };
+  }
+  static object<F extends CoerceObjectMatches>(...cbs: F) {
+    return <V extends { [key: string]: any }>(
+      value: V,
+      options?: CoerceOptions
+    ): ReturnTypeUnion<F> | CoerceError => {
+      if (!Coerce.isPlainObject(value)) {
+        return new CoerceError('object', value, options);
+      }
+      const results = Object.keys(value).reduce((acq: any, key: keyof V) => {
+        const keyLower = (key as string).toLowerCase();
+        const match = CoerceObject.match(value, key, keyLower, options);
+        const collected = cbs.reduce((acq, cb) => {
+          return { ...acq, ...cb(match) };
+        }, {});
+        return { ...acq, ...collected };
+      }, {});
+      // fire errors for required options
+      cbs.map(cb => cb(CoerceObject.requireMatch(results) as any));
+      // warn unrecognized properties
+      if (options?.warn !== false && options?.warnUnrecognized !== false) {
+        const data = cbs.reduce((acq, cb) => {
+          return { ...acq, ...cb(CoerceObject.gatherMatch as any) };
+        }, {});
+        const recognizedKeys = Object.keys(data);
+        const recognizedKeysLc = recognizedKeys.map(v => v.toLowerCase());
+        const providedKeys = Object.keys(value);
+        const unrecognized = providedKeys.filter(pk => {
+          return !(recognizedKeys.includes(pk) || recognizedKeysLc.includes(pk.toLowerCase()));
+        });
+        unrecognized.forEach(key => new CoerceUnrecognized(key).warn());
+      }
+      // set defaults
+      if (options?.applyDefaults !== false) {
+        const defaultValues = cbs.reduce((acq, cb) => {
+          return { ...acq, ...cb(CoerceObject.defaultMatch(options) as any) };
+        }, {});
+        return { ...defaultValues, ...results };
+      }
+      return results;
+    };
+  }
+
+  /**
+   * NOTE TO REVIEWERS:
+   * Below are alternative versions of .object and .objectExact that loop over
+   * all keys rather than provided keys, they work functionally the same as the
+   * once above and pass the same tests. I made an attempt to do performance
+   * testing on them and had negligible results. I'm interested if there's a
+   * preference toward either-or implementation.
+   */
+
+  // static caseMatch<K extends string>(matchKey: K, fn?: Coercer<any>) {
+  //   const keyLower = matchKey.toLowerCase();
+  //   return { [keyLower]: { keyLower, key: matchKey, fn } } as any;
+  // }
+
+  // static lowerKeys(value: any) {
+  //   var key,
+  //     keys = Object.keys(value);
+  //   var n = keys.length;
+  //   const result: any = {};
+  //   while (n--) {
+  //     key = keys[n];
+  //     const keyLower = key.toLowerCase();
+  //     result[keyLower] = {
+  //       keyLower,
+  //       key,
+  //       value: value[key]
+  //     };
+  //   }
+  //   return result;
+  // }
+
+  // static objectB<F extends CoerceObjectMatches>(...cbs: F) {
+  //   return <V extends { [key: string]: any }>(
+  //     value: V,
+  //     options?: CoerceOptions
+  //   ): ReturnTypeUnion<F> | CoerceError => {
+  //     if (!Coerce.isPlainObject(value)) {
+  //       return new CoerceError('object', value, options);
+  //     }
+  //     value = CoerceObject.lowerKeys(value);
+  //     const data: any = cbs.reduce((acq, cb) => {
+  //       return { ...acq, ...cb(CoerceObject.caseMatch as any) };
+  //     }, {});
+  //     const recognizedKeys = Object.keys(data);
+  //     if (options?.warn !== false && options?.warnUnrecognized !== false) {
+  //       const recognizedKeysLc = recognizedKeys.map((v: any) => data[v].keyLower);
+  //       const providedKeys = Object.keys(value).map((v: any) => value[v].key);
+
+  //       const unrecognized = providedKeys.filter(pk => {
+  //         return !(recognizedKeys.includes(pk) || recognizedKeysLc.includes(pk.toLowerCase()));
+  //       });
+  //       unrecognized.forEach(key => new CoerceUnrecognized(key).warn());
+  //     }
+  //     return recognizedKeys.reduce((acq: any, id: string) => {
+  //       const { key, fn } = data[id];
+  //       // run try / catch with empty value for default value;
+  //       try {
+  //         const result = fn(undefined, { ...options, id, warn: false });
+  //         if (!(result instanceof CoerceError)) {
+  //           acq = { ...acq, [id]: result };
+  //         }
+  //       } catch (e) {
+  //         // no op
+  //       }
+  //       // if it has value
+  //       if (Object.prototype.hasOwnProperty.call(value, id)) {
+  //         const result = fn(value[id].value, { ...options, id: key });
+  //         if (result instanceof CoerceError) return acq;
+  //         return { ...acq, [key]: result };
+  //       } else {
+  //         // trigger requires
+  //         fn(undefined, { id, warn: false });
+  //       }
+  //       return acq;
+  //     }, {});
+  //   };
+  // }
+
+  // static caseMatchExact<K extends string>(matchKey: K, fn?: Coercer<any>) {
+  //   return { [matchKey]: fn } as any;
+  // }
+
+  // static objectExactB<F extends CoerceObjectMatches>(...cbs: F) {
+  //   return <V extends { [key: string]: any }>(
+  //     value: V,
+  //     options?: CoerceOptions
+  //   ): ReturnTypeUnion<F> | CoerceError => {
+  //     if (!Coerce.isPlainObject(value)) {
+  //       return new CoerceError('object', value, options);
+  //     }
+  //     const data: any = cbs.reduce((acq, cb) => {
+  //       return { ...acq, ...cb(CoerceObject.caseMatchExact as any) };
+  //     }, {});
+  //     const recognizedKeys = Object.keys(data);
+  //     if (options?.warn !== false && options?.warnUnrecognized !== false) {
+  //       const unrecognized = Object.keys(value).filter(pk => {
+  //         return !recognizedKeys.includes(pk);
+  //       });
+  //       unrecognized.forEach(key => new CoerceUnrecognized(key).warn());
+  //     }
+  //     return recognizedKeys.reduce((acq: any, id) => {
+  //       // run try / catch with empty value for default value;
+  //       const fn = data[id];
+  //       try {
+  //         const result = fn(undefined, { ...options, id, warn: false });
+  //         if (!(result instanceof CoerceError)) {
+  //           acq = { ...acq, [id]: result };
+  //         }
+  //       } catch (e) {
+  //         // no op
+  //       }
+  //       // if it has value
+  //       if (Object.prototype.hasOwnProperty.call(value, id)) {
+  //         const result = fn(value[id], { ...options, id });
+  //         if (result instanceof CoerceError) return acq;
+  //         acq = { ...acq, [id]: result };
+  //       } else {
+  //         // trigger requires
+  //         fn(undefined, { id, warn: false });
+  //       }
+  //       return acq;
+  //     }, {});
+  //   };
+  // }
+}
+
+/** Coerces values, acts as a type guard. Validates and transforms values. */
+export class Coerce {
+  // FUNCTIONAL UTILITIES
+  /** wraps function and enables warning error */
+  static warn<F extends Coercer<any>>(fn: F) {
+    return (value: any, options?: CoerceOptions): ReturnType<F> => {
+      const warn = options?.warn !== false;
+      const warnDeprecated = options?.warnDeprecated !== false;
+      const warnUnrecognized = options?.warnUnrecognized !== false;
+      const result = fn(value, { ...options, warn, warnDeprecated, warnUnrecognized });
+      return result;
+    };
+  }
+  /** wraps function and provides default if applicable */
+  static default<F extends Coercer<any>>(fn: F, defaultValue: CoerceType<F>) {
+    return (value: Parameters<F>[0], options?: CoerceOptions): CoerceType<F> => {
+      if (options?.applyDefaults !== false && value === undefined) return defaultValue;
+      return fn(value, options);
+    };
+  }
+  /** wraps function and warns deprecation notice if applicable */
+  static deprecate<F extends Coercer<any>>(fn: F, favor?: string) {
+    return (value: any, options?: CoerceOptions): ReturnType<F> => {
+      if (options?.warn !== false && options?.warnDeprecated !== false) {
+        new CoerceDeprecate(options?.id, favor).warn();
+      }
+      const result = fn(value, options);
+      return result;
+    };
+  }
+  /** wraps function and throws if invalid value */
+  static require<F extends Coercer<any>>(fn: F) {
+    return (value: Parameters<F>[0], options?: CoerceOptions): CoerceType<F> => {
+      const result = fn(value, options);
+      if (result instanceof CoerceError) throw result;
+      return result;
+    };
+  }
+  /** warps function and returns bool if it's valid false if it's a CoerceError */
+  static validate<F extends Coercer<any>>(fn: F) {
+    return (value: Parameters<F>[0], options?: CoerceOptions): Boolean => {
+      const result = fn(value, options);
+      if (result instanceof CoerceError) return false;
+      return true;
+    };
+  }
+
+  // PRIMITIVE TYPES
+
+  /** will coerce value to a boolean */
+  static boolean(value: any, options?: CoerceOptions): boolean | CoerceError {
+    if (Array.isArray(value)) return Coerce.boolean(value[value.length - 1], options);
+    if (typeof value === 'boolean') return value;
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return new CoerceError('boolean', value, options);
+  }
+  /** will coerce value to a string */
+  static string(value: any, options?: CoerceOptions): string | CoerceError {
+    if (Array.isArray(value)) return Coerce.string(value[value.length - 1], options);
+    if (typeof value === 'string') return value;
+    return new CoerceError('string', value, options);
+  }
+  /** will coerce value to a number */
+  static number(value: any, options?: CoerceOptions): number | CoerceError {
+    if (Array.isArray(value)) return Coerce.number(value[value.length - 1], options);
+    if (typeof value === 'number') return value;
+    if (parseInt(value)) return parseInt(value);
+    return new CoerceError('number', value, options);
+  }
+  /** will coerce value to a node compatible buffer */
+  static buffer(value: any, options?: CoerceOptions): Buffer | CoerceError {
+    if (Buffer.isBuffer(value)) return value;
+    return new CoerceError('buffer', value, options);
+  }
+  /** will coerce value to a function */
+  static function(value: any, options?: CoerceOptions): Function | CoerceError {
+    if (typeof value === 'function') return value;
+    return new CoerceError('function', value, options);
+  }
+  /** will match value to null */
+  static null(value: any, options?: CoerceOptions): null | CoerceError {
+    if (value === null) return value;
+    return new CoerceError('null', value, options);
+  }
+  /** will match value to null */
+  static any<T>(value: T): T {
+    return value;
+  }
+  static isPlainObject = Coerce.validate(Coerce.plainObject);
+  /** will coerce value to ensure it's a plainObject */
+  static plainObject(value: any, options?: CoerceOptions): { [key: string]: any } | CoerceError {
+    const is = (value: any) => {
+      if (Object.prototype.toString.call(value) !== '[object Object]') return false;
+      const prototype = Object.getPrototypeOf(value);
+      return prototype === null || prototype === Object.prototype;
+    };
+    if (is(value)) return value;
+    return new CoerceError('plainObject', value, options);
+  }
+  /** will coerce value to ensure it's an array of tags */
+  static tags(value: any, options?: CoerceOptions): string[] | CoerceError {
+    if (typeof value === 'string') return value.split(',');
+    if (Array.isArray(value)) return value;
+    if (Coerce.isPlainObject(value)) {
+      return Object.keys(value).reduce((acq: string[], key: string) => {
+        const val = value[key];
+        const result = Coerce.string(val, { ...options, typeSuffix: 'tag value' });
+        if (!(result instanceof CoerceError)) {
+          return [...acq, `${key}:${result}`];
+        }
+        return acq;
+      }, []);
+    }
+    return new CoerceError('tags', value, options);
+  }
+  /** will that value loosely matchings given value  */
+  static given<V>(exact: V) {
+    return (value: any, options?: CoerceOptions) => {
+      if (typeof exact === 'string' && typeof value === 'string') {
+        if (exact.toLowerCase() === value.toLowerCase()) return exact;
+      }
+      if (value === exact) return value;
+      return new CoerceError(`${CoerceError.displayValue(exact)}`, value, options);
+    };
+  }
+  /** will that value is exactly matching given value  */
+  static givenExact<V>(given: V) {
+    return (value: any, options?: CoerceOptions) => {
+      if (value === given) return value;
+      return new CoerceError(`${CoerceError.displayValue(given)}`, value, options);
+    };
+  }
+  /** will coerce case-insensitive string to a enum */
+  static enum<E>(e: { [name: string]: E }) {
+    const inner = (value: any, options?: CoerceOptions): keyof E | CoerceError => {
+      if (Array.isArray(value)) return inner(value[value.length - 1], options);
+      const name = Object.keys(e)[0];
+      const dict = Object.values(e)[0];
+      const iterate = Object.values(dict);
+      if (typeof value === 'string') {
+        const lcValue = value.toLowerCase();
+        const result = iterate.reduce((prev, current) => {
+          if (typeof prev !== 'undefined') return prev;
+          if (current.toLowerCase() === lcValue) return current;
+          return prev;
+        }, undefined);
+        if (typeof result !== 'undefined') return result as keyof E;
+      }
+      return new CoerceError(`enum ${name}`, value, options);
+    };
+    return inner;
+  }
+  /** will coerce case-sensitive string to a enum */
+  static enumExact<E>(e: { [name: string]: E }) {
+    const inner = (value: any, options?: CoerceOptions): keyof E | CoerceError => {
+      if (Array.isArray(value)) return inner(value[value.length - 1], options);
+      const name = Object.keys(e)[0];
+      const dict = Object.values(e)[0];
+      if (typeof value === 'string') {
+        if (Object.values(dict).includes(value)) return value as keyof E;
+      }
+      return new CoerceError(`enum ${name}`, value, options);
+    };
+    return inner;
+  }
+  /** will coerce array to a type passed in */
+  static array<F extends Coercer<any>>(fn: F) {
+    const inner = (value: any, options?: CoerceOptions): CoerceType<F>[] => {
+      if (!Array.isArray(value)) return inner([value], options);
+      const results = value.reduce((acq: any[], item: any) => {
+        const result = fn(item, { ...options, typeSuffix: 'array' });
+        if (result instanceof CoerceError) {
+          if (options?.warn !== false) result.warn();
+          return acq;
+        }
+        return [...acq, result];
+      }, []);
+      return results;
+    };
+    return inner;
+  }
+  /** will merge several types to form one coercer */
+  static union<FS extends Coercer<any>[]>(...fns: FS) {
+    return (value: any, options?: CoerceOptions): ReturnTypes<FS> | CoerceError => {
+      const types: string[] = [];
+      const DEFAULT = Symbol('DEFAULT');
+      const result: any = fns.reduce((acq: any, fn: Func) => {
+        if (acq !== DEFAULT) return acq;
+        const result = fn(value, options);
+        if (result instanceof CoerceError) {
+          if (result.typeName) types.push(result.typeName);
+          return acq;
+        }
+        return result;
+      }, DEFAULT);
+      if (result !== DEFAULT) return result;
+      return new CoerceError(`union (${types.join(' | ')})`, value, options);
+    };
+  }
+  /** will coerce object to a set of properties */
+  static object = CoerceObject.object;
+  /** will coerce array to a type passed in */
+  static objectExact = CoerceObject.objectExact;
+  /** will transform comma separated key:value set into object. */
+  static keyValue(value: any, options?: CoerceObject): { [key: string]: string } | CoerceError {
+    if (typeof value === 'string') {
+      const segments = value.split(',');
+      return segments.reduce((acq: { [key: string]: string }, segment: string) => {
+        const [key, value] = segment.split(':');
+        if (key && value) {
+          return { ...acq, [key]: value };
+        }
+        return acq;
+      }, {});
+    }
+    return new CoerceError(`keyValue`, value, options);
+  }
+  static commaSeparated(value: any, options?: CoerceOptions): string[] | CoerceError {
+    if (typeof value === 'string') {
+      return value.split(',');
+    }
+    return new CoerceError(`commaSeparated`, value, options);
+  }
+  /** iterates Coercers from left to right until finished or encounters error */
+  static compose<F extends Coercer<any>[]>(...fns: F) {
+    return (value: any, options?: CoerceOptions): ComposeReturn<F> => {
+      return fns.reduce((acq, fn) => {
+        // exit the chain if hit CoerceError
+        if (acq instanceof CoerceError) return acq;
+        try {
+          const results = fn(acq, options);
+          return results;
+        } catch (e) {
+          return e;
+        }
+      }, value);
+    };
+  }
+  /** helps find non-default value in set of  functions */
+  static collide<T>(def: T) {
+    return (...choices: (T | undefined)[]) => {
+      return choices.reduce((acq: T, choice: T | undefined) => {
+        if (acq !== def) return acq;
+        if (choice === undefined) return acq;
+        if (choice !== def) return choice as T;
+        return acq;
+      }, def);
+    };
+  }
+  /** returns empty object if undefined value, and creates {key: value} otherwise  */
+  static spreadValue<K extends string | readonly string[], T>(
+    key: K,
+    value: T
+  ): undefined extends T ? Partial<Record<Unionize<K>, T>> : Record<Unionize<K>, T> {
+    if (value === undefined) return {} as any;
+    if (Array.isArray(key)) {
+      return key.reduce((acq: any, k: string) => {
+        return { ...acq, [k]: value };
+      }, {});
+    }
+    if (typeof key === 'string') {
+      return { [key]: value } as any;
+    }
+    return {} as any;
+  }
+}

--- a/src/options/coerce_error.ts
+++ b/src/options/coerce_error.ts
@@ -1,0 +1,82 @@
+interface CoerceErrorOptions {
+  id?: string;
+  warn?: boolean;
+  typeSuffix?: string;
+}
+
+export class CoerceError extends Error {
+  typeName?: string;
+  id?: string;
+  value: any;
+  constructor(typeName?: string, value?: any, options?: CoerceErrorOptions) {
+    const id = options?.id;
+    typeName = options?.typeSuffix && typeName ? `${typeName} ${options.typeSuffix}` : typeName;
+    const msg = CoerceError.createMessage(typeName, value, id);
+    super(msg);
+    this.typeName = typeName;
+    this.value = value;
+    this.id = id;
+    if (options?.warn) this.warn();
+  }
+  static displayValue(value: any) {
+    if (value === null) return '"null"';
+    if (value === undefined) return '"undefined"';
+    if (Array.isArray(value)) return '"[...]"';
+    if (typeof value === 'object') return '"{...}"';
+    return `"${JSON.stringify(value)}"`;
+  }
+  static createMessage(typeName?: string, value?: any, id?: string): string {
+    const prefix = 'Invalid type';
+    const display = this.displayValue(value);
+    if (typeName && display && id) {
+      return `${prefix}: "${id}" with value ${display} is not valid "${typeName}"`;
+    }
+    if (typeName && display) return `${prefix}: value ${display} is not valid "${typeName}"`;
+    return `${prefix}`;
+  }
+  /* istanbul ignore next */
+  warn() {
+    console.warn(this.message);
+  }
+}
+
+export class CoerceDeprecate extends Error {
+  id?: string;
+  favor?: string;
+  constructor(id?: string, favor?: string) {
+    const msg = CoerceDeprecate.createMessage(id, favor);
+    super(msg);
+    this.id = id;
+    this.favor = favor;
+  }
+  static createMessage(id?: string, favor?: string) {
+    if (id && favor) {
+      return `Deprecation notice: '${id}' is deprecated, please use '${favor}' instead`;
+    }
+    if (id) return `Deprecation notice: '${id}' is deprecated`;
+    return `Deprecation notice: something used was deprecated, however no reference was passed`;
+  }
+  /* istanbul ignore next */
+  warn() {
+    console.warn(this.message);
+  }
+}
+
+export class CoerceUnrecognized extends Error {
+  id?: string;
+  constructor(id?: string) {
+    const msg = CoerceUnrecognized.createMessage(id);
+    super(msg);
+    this.id = id;
+  }
+  static createMessage(id?: string) {
+    if (!id) {
+      return `Unrecognized notice: something used was unrecognized, however no reference was passed`;
+    }
+    return `Unrecognized notice: property '${id}' is not recognized`;
+  }
+  /* istanbul ignore next */
+  warn() {
+    console.warn(this.message);
+  }
+}

--- a/test/functional/options/coerce.test.js
+++ b/test/functional/options/coerce.test.js
@@ -1,0 +1,672 @@
+'use strict';
+
+const sinon = require('sinon');
+const { Coerce } = require('../../../src/options/coerce');
+const chai = require('chai');
+const { CoerceError } = require('../../../src/options/coerce_error');
+const expect = chai.expect;
+const Errors = require('../../../src/options/coerce_error');
+
+/** this is an mock enum */
+const Compressor = {
+  snappy: 'snappy',
+  zlib: 'zlib'
+};
+
+describe('Coerce', () => {
+  let errorWarningStub;
+  let deprecationWarningStub;
+  let unrecognizedWarningStub;
+  beforeEach(() => {
+    errorWarningStub = sinon.stub(Errors.CoerceError.prototype, 'warn').returns({});
+    deprecationWarningStub = sinon.stub(Errors.CoerceDeprecate.prototype, 'warn').returns({});
+    unrecognizedWarningStub = sinon.stub(Errors.CoerceUnrecognized.prototype, 'warn').returns({});
+  });
+
+  afterEach(() => {
+    Errors.CoerceError.prototype.warn.restore();
+    Errors.CoerceDeprecate.prototype.warn.restore();
+    Errors.CoerceUnrecognized.prototype.warn.restore();
+  });
+
+  context('.string()', () => {
+    it('should coerce', () => {
+      // prettier-ignore
+      [
+        Coerce.string('hi'),
+        Coerce.string(['hi'])
+      ].forEach(v => {
+        expect(v).to.equal('hi');
+      });
+    });
+    it('should result in CoerceError', () => {
+      // prettier-ignore
+      [
+        Coerce.string(1),
+        Coerce.string([1]),
+        Coerce.string(true),
+        Coerce.string([true]),
+      ].forEach(v => {
+        expect(v).to.be.instanceof(CoerceError);
+      });
+    });
+  });
+
+  context('.number()', () => {
+    it('should coerce', () => {
+      // prettier-ignore
+      [
+        Coerce.number(1),
+        Coerce.number('1'),
+        Coerce.number([1]),
+        Coerce.number(['1']),
+      ].forEach(v => {
+        expect(v).to.equal(1);
+      });
+    });
+    it('should result in CoerceError', () => {
+      // prettier-ignore
+      [
+        Coerce.number(true),
+        Coerce.number([true]),
+      ].forEach(v => {
+        expect(v).to.be.instanceof(CoerceError);
+      });
+    });
+  });
+
+  context('.boolean()', () => {
+    it('should coerce true', () => {
+      [
+        Coerce.boolean(true),
+        Coerce.boolean('true'),
+        Coerce.boolean([true]),
+        Coerce.boolean(['true'])
+      ].forEach(v => {
+        expect(v).to.equal(true);
+      });
+    });
+    it('should coerce false', () => {
+      [
+        Coerce.boolean(false),
+        Coerce.boolean('false'),
+        Coerce.boolean([false]),
+        Coerce.boolean(['false'])
+      ].forEach(v => {
+        expect(v).to.equal(false);
+      });
+    });
+    it('should result in CoerceError', () => {
+      // prettier-ignore
+      [
+        Coerce.boolean('TRUE'),
+        Coerce.boolean(1),
+        Coerce.boolean(['TRUE']),
+        Coerce.boolean([1])
+      ].forEach(v => {
+        expect(v).to.be.instanceof(CoerceError);
+      });
+    });
+  });
+
+  context('.union()', () => {
+    it('should coerce (number | string)', () => {
+      const union = Coerce.union(Coerce.number, Coerce.string);
+      expect(union(1)).to.equal(1);
+      expect(union('1')).to.equal(1);
+      expect(union([1])).to.equal(1);
+      expect(union(['1'])).to.equal(1);
+      expect(union('hi')).to.equal('hi');
+      expect(union(['hi'])).to.equal('hi');
+    });
+    it('should fail to coerce (number | string)', () => {
+      const union = Coerce.union(Coerce.number, Coerce.string);
+      expect(union(true)).to.be.instanceOf(CoerceError);
+      expect(union(null)).to.be.instanceOf(CoerceError);
+      expect(union(undefined)).to.be.instanceOf(CoerceError);
+    });
+    it('should not include typeName when missing', () => {
+      const union = Coerce.union(() => new CoerceError());
+      expect(union(true)).to.be.instanceOf(CoerceError);
+      expect(union(null)).to.be.instanceOf(CoerceError);
+      expect(union(undefined)).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.object()', () => {
+    it('should coerce ', () => {
+      const example = Coerce.object(match => ({
+        ...match('foo', Coerce.boolean),
+        ...match('bar', Coerce.boolean)
+      }));
+      const expected = {
+        foo: true,
+        bar: true
+      };
+      expect(example({ foo: true, bar: true })).to.deep.equal(expected);
+      expect(example({ foo: 'true', bar: 'true' })).to.deep.equal(expected);
+      expect(example({ foo: ['true'], bar: ['true'] })).to.deep.equal(expected);
+    });
+    it('should return error if not invoked with object', () => {
+      const example = Coerce.object(match => ({
+        ...match('foo', Coerce.boolean),
+        ...match('bar', Coerce.boolean)
+      }));
+      expect(example(1)).to.be.instanceOf(CoerceError);
+    });
+    it('should ignore property values that are invalid ', () => {
+      const example = Coerce.object(match => ({
+        ...match('foo', Coerce.boolean),
+        ...match('bar', Coerce.boolean)
+      }));
+      expect(example({ foo: 1, bar: true })).to.deep.equal({ bar: true });
+    });
+    it('should warn invalid property values that are invalid ', () => {
+      const objMatcher = Coerce.object(match => ({
+        ...match('foo', Coerce.boolean),
+        ...match('bar', Coerce.boolean)
+      }));
+      const example = Coerce.warn(objMatcher);
+      expect(example({ foo: 1, bar: true })).to.deep.equal({ bar: true });
+    });
+
+    it('should apply default', () => {
+      const example = Coerce.object(match => ({
+        ...match('foo', Coerce.default(Coerce.boolean, true)),
+        ...match('bar', Coerce.boolean)
+      }));
+      expect(example({})).to.deep.equal({ foo: true });
+    });
+
+    it('should not apply default', () => {
+      const example = Coerce.object(match => ({
+        ...match('foo', Coerce.default(Coerce.boolean, true)),
+        ...match('bar', Coerce.boolean)
+      }));
+      expect(example({}, { applyDefaults: false })).to.deep.equal({});
+    });
+
+    it('should catch required property in defaultMatch', () => {
+      const example = Coerce.object(match => ({
+        ...match('foo', Coerce.require(Coerce.boolean)),
+        ...match('bar', Coerce.boolean)
+      }));
+      expect(example({ foo: true })).to.deep.equal({ foo: true });
+    });
+
+    it('should throw when required property is missing', () => {
+      const example = Coerce.object(match => ({
+        ...match('foo', Coerce.require(Coerce.boolean)),
+        ...match('bar', Coerce.boolean)
+      }));
+      expect(() => example({})).to.throw();
+    });
+
+    context('unrecognized property warnings', () => {
+      it('should warn unrecognized by default', () => {
+        const core = Coerce.object(match => ({
+          ...match('foo', Coerce.boolean),
+          ...match('bar', Coerce.boolean)
+        }));
+        const example = Coerce.warn(core);
+        expect(example({ baz: true })).to.deep.equal({});
+        expect(unrecognizedWarningStub.calledOnce).to.equal(true);
+      });
+      it('should warn unrecognized explicit warn', () => {
+        const example = Coerce.object(match => ({
+          ...match('foo', Coerce.boolean),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(example({ baz: true }, { warn: true })).to.deep.equal({});
+        expect(unrecognizedWarningStub.calledOnce).to.equal(true);
+      });
+      it('should warn unrecognized explicit warnUnrecognized', () => {
+        const example = Coerce.object(match => ({
+          ...match('foo', Coerce.boolean),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(example({ baz: true }, { warnUnrecognized: true })).to.deep.equal({});
+        expect(unrecognizedWarningStub.calledOnce).to.equal(true);
+      });
+      it('should not warn unrecognized mismatch warn: false', () => {
+        const example = Coerce.object(match => ({
+          ...match('foo', Coerce.boolean),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(example({ baz: true }, { warn: false, warnUnrecognized: true })).to.deep.equal({});
+        expect(unrecognizedWarningStub.calledOnce).to.equal(false);
+      });
+      it('should not warn unrecognized mismatch warnUnrecognized: false', () => {
+        const example = Coerce.object(match => ({
+          ...match('foo', Coerce.boolean),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(example({ baz: true }, { warn: true, warnUnrecognized: false })).to.deep.equal({});
+        expect(unrecognizedWarningStub.calledOnce).to.equal(false);
+      });
+      it('should add default value to object', () => {
+        const example = Coerce.object(match => ({
+          ...match('foo', Coerce.default(Coerce.boolean, true)),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(example({}, { warn: true, warnUnrecognized: false })).to.deep.equal({
+          foo: true
+        });
+        expect(unrecognizedWarningStub.calledOnce).to.equal(false);
+      });
+    });
+  });
+
+  context('.objectExact()', () => {
+    it('should coerce', () => {
+      const example = Coerce.objectExact(match => ({
+        ...match('foo', Coerce.boolean),
+        ...match('bar', Coerce.boolean)
+      }));
+      const expected = { foo: true };
+      expect(example({ foo: true, BAR: true })).to.deep.equal(expected);
+      expect(example({ foo: 'true', BAR: 'true' })).to.deep.equal(expected);
+      expect(example({ foo: ['true'], BAR: ['true'] })).to.deep.equal(expected);
+    });
+    it('should warn when invalid property', () => {
+      const core = Coerce.objectExact(match => ({
+        ...match('foo', Coerce.boolean),
+        ...match('bar', Coerce.boolean)
+      }));
+      const example = Coerce.warn(core);
+      expect(example({ foo: 1 })).to.deep.equal({});
+      expect(errorWarningStub.calledOnce).to.equal(true);
+    });
+    it('should return error if not invoked with object', () => {
+      const example = Coerce.objectExact(match => ({
+        ...match('foo', Coerce.boolean),
+        ...match('bar', Coerce.boolean)
+      }));
+      expect(example(1)).to.be.instanceOf(CoerceError);
+    });
+    it('should not apply default', () => {
+      const example = Coerce.objectExact(match => ({
+        ...match('foo', Coerce.default(Coerce.boolean, true)),
+        ...match('bar', Coerce.boolean)
+      }));
+      expect(example({}, { applyDefaults: false })).to.deep.equal({});
+    });
+    context('unrecognized property warnings', () => {
+      it('should warn unrecognized by default', () => {
+        const core = Coerce.objectExact(match => ({
+          ...match('foo', Coerce.boolean),
+          ...match('bar', Coerce.boolean)
+        }));
+        const example = Coerce.warn(core);
+        expect(example({ baz: true })).to.deep.equal({});
+        expect(unrecognizedWarningStub.calledOnce).to.equal(true);
+      });
+      it('should warn unrecognized explicit warn', () => {
+        const example = Coerce.objectExact(match => ({
+          ...match('foo', Coerce.boolean),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(example({ baz: true }, { warn: true })).to.deep.equal({});
+        expect(unrecognizedWarningStub.calledOnce).to.equal(true);
+      });
+      it('should warn unrecognized explicit warnUnrecognized', () => {
+        const example = Coerce.objectExact(match => ({
+          ...match('foo', Coerce.boolean),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(example({ baz: true }, { warnUnrecognized: true })).to.deep.equal({});
+        expect(unrecognizedWarningStub.calledOnce).to.equal(true);
+      });
+      it('should not warn unrecognized mismatch warn: false', () => {
+        const example = Coerce.objectExact(match => ({
+          ...match('foo', Coerce.boolean),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(example({ baz: true }, { warn: false, warnUnrecognized: true })).to.deep.equal({});
+        expect(unrecognizedWarningStub.calledOnce).to.equal(false);
+      });
+      it('should not warn unrecognized mismatch warnUnrecognized: false', () => {
+        const example = Coerce.objectExact(match => ({
+          ...match('foo', Coerce.boolean),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(example({ baz: true }, { warn: true, warnUnrecognized: false })).to.deep.equal({});
+        expect(unrecognizedWarningStub.calledOnce).to.equal(false);
+      });
+      it('should add default value to object', () => {
+        const example = Coerce.objectExact(match => ({
+          ...match('foo', Coerce.default(Coerce.boolean, true)),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(example({}, { warn: true, warnUnrecognized: false })).to.deep.equal({
+          foo: true
+        });
+        expect(unrecognizedWarningStub.calledOnce).to.equal(false);
+      });
+      it('should throw when required property is missing', () => {
+        const example = Coerce.objectExact(match => ({
+          ...match('foo', Coerce.require(Coerce.boolean)),
+          ...match('bar', Coerce.boolean)
+        }));
+        expect(() => example({})).to.throw();
+      });
+    });
+  });
+
+  context('.enum()', () => {
+    it('should coerce', () => {
+      const example = Coerce.enum({ Compressor });
+      expect(example('snappy')).to.equal('snappy');
+      expect(example('SnApPy')).to.equal('snappy');
+      expect(example('SNAPPY')).to.equal('snappy');
+    });
+    it('should coerce array of strings', () => {
+      const example = Coerce.enum({ Compressor });
+      expect(example(['snappy'])).to.equal('snappy');
+      expect(example(['SnApPy'])).to.equal('snappy');
+      expect(example(['SNAPPY'])).to.equal('snappy');
+    });
+    it('should iterate enum using second enum', () => {
+      const example = Coerce.enum({ Compressor });
+      expect(example('zlib')).to.equal('zlib');
+      expect(example('ZLIB')).to.equal('zlib');
+    });
+    it('should fail', () => {
+      const example = Coerce.enum({ Compressor });
+      expect(example('meow')).to.be.instanceOf(CoerceError);
+    });
+    it('should error if invalid type', () => {
+      const example = Coerce.enum({ Compressor });
+      expect(example(1)).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.enumExact()', () => {
+    it('should coerce', () => {
+      const example = Coerce.enumExact({ Compressor });
+      expect(example('snappy')).to.equal('snappy');
+      expect(example('SnApPy')).to.be.instanceof(CoerceError);
+      expect(example('SNAPPY')).to.be.instanceof(CoerceError);
+    });
+    it('should coerce string of arrays', () => {
+      const example = Coerce.enumExact({ Compressor });
+      expect(example(['snappy'])).to.equal('snappy');
+      expect(example(['SnApPy'])).to.be.instanceof(CoerceError);
+      expect(example(['SNAPPY'])).to.be.instanceof(CoerceError);
+    });
+    it('should be an error', () => {
+      const example = Coerce.enumExact({ Compressor });
+      expect(example('meow')).to.be.instanceof(CoerceError);
+      expect(example(1)).to.be.instanceof(CoerceError);
+    });
+  });
+
+  context('.default()', () => {
+    it('should apply default', () => {
+      const example = Coerce.default(Coerce.string, 'love');
+      expect(example()).to.equal('love');
+      expect(example('hi')).to.equal('hi');
+    });
+  });
+
+  context('.require()', () => {
+    it('should throw if error', () => {
+      const example = Coerce.require(Coerce.string);
+      expect(() => example()).to.throw();
+      expect(() => example('hi')).not.to.throw();
+    });
+  });
+
+  context('.tags()', () => {
+    it('should coerce', () => {
+      const example = Coerce.tags;
+      expect(example('loc:nyc,abc:dc')).to.deep.equal(['loc:nyc', 'abc:dc']);
+      expect(example(['loc:nyc', 'abc:dc'])).to.deep.equal(['loc:nyc', 'abc:dc']);
+      expect(example({ loc: 'nyc', abc: 'dc' })).to.deep.equal(['loc:nyc', 'abc:dc']);
+    });
+    it('should filter out non-string options', () => {
+      const example = Coerce.tags;
+      expect(example({ loc: true, abc: 'dc' })).to.deep.equal(['abc:dc']);
+      expect(example({ loc: null, abc: 'dc' })).to.deep.equal(['abc:dc']);
+      expect(example({ loc: 1, abc: 'dc' })).to.deep.equal(['abc:dc']);
+    });
+    it('should not coerce', () => {
+      const example = Coerce.tags;
+      expect(example(1)).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.keyValue()', () => {
+    it('should coerce', () => {
+      const value = 'SERVICE_NAME:foo,CANONICALIZE_HOST_NAME:true,SERVICE_REALM:bar';
+      expect(Coerce.keyValue(value)).to.deep.equal({
+        SERVICE_NAME: 'foo',
+        CANONICALIZE_HOST_NAME: 'true',
+        SERVICE_REALM: 'bar'
+      });
+    });
+
+    it('should not include key:value when missing :', () => {
+      const value = 'SERVICE_NAMEfoo,CANONICALIZE_HOST_NAME:true,SERVICE_REALM:bar';
+      expect(Coerce.keyValue(value)).to.deep.equal({
+        CANONICALIZE_HOST_NAME: 'true',
+        SERVICE_REALM: 'bar'
+      });
+    });
+
+    it('should result in CoerceError', () => {
+      expect(Coerce.keyValue(true)).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.deprecate()', () => {
+    it('should give deprecate warning', () => {
+      const s = Coerce.deprecate(Coerce.string);
+      expect(s('hi')).to.equal('hi');
+      expect(deprecationWarningStub.calledOnce).to.equal(true);
+    });
+    it('should give better deprecate warning when id is passed', () => {
+      const s = Coerce.deprecate(Coerce.string);
+      expect(s('hi', { id: 'some test variable' })).to.equal('hi');
+      expect(deprecationWarningStub.calledOnce).to.equal(true);
+    });
+    it('should not give deprecate warning when explicit warn: false', () => {
+      const s = Coerce.deprecate(Coerce.string);
+      expect(s('hi', { warn: false })).to.equal('hi');
+      expect(deprecationWarningStub.calledOnce).to.equal(false);
+    });
+    it('should not give deprecate warning when explicit warnDeprecated: false', () => {
+      const s = Coerce.deprecate(Coerce.string);
+      expect(s('hi', { warnDeprecated: false })).to.equal('hi');
+      expect(deprecationWarningStub.calledOnce).to.equal(false);
+    });
+  });
+
+  context('.warn()', () => {
+    it('should not warn when no issues', () => {
+      const s = Coerce.warn(Coerce.string);
+      expect(s('hi')).to.equal('hi');
+      expect(errorWarningStub.calledOnce).to.equal(false);
+    });
+    it('should warn when issues by default', () => {
+      const s = Coerce.warn(Coerce.string);
+      expect(s(1)).to.be.instanceOf(CoerceError);
+      expect(errorWarningStub.calledOnce).to.equal(true);
+    });
+    it('should not warn when explicitly flagged', () => {
+      const s = Coerce.warn(Coerce.string);
+      expect(s(1, { warn: false })).to.be.instanceOf(CoerceError);
+      expect(errorWarningStub.calledOnce).to.equal(false);
+    });
+  });
+
+  context('.buffer()', () => {
+    it('should coerce', () => {
+      const buffBaby = Buffer.alloc(10);
+      expect(Coerce.buffer(buffBaby)).to.equal(buffBaby);
+    });
+    it('should not coerce', () => {
+      expect(Coerce.buffer('hi')).to.be.instanceOf(CoerceError);
+      expect(Coerce.buffer(1)).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.function()', () => {
+    it('should coerce', () => {
+      const fn = () => {};
+      expect(Coerce.function(fn)).to.equal(fn);
+    });
+    it('should not coerce', () => {
+      expect(Coerce.function('hi')).to.be.instanceOf(CoerceError);
+      expect(Coerce.function(1)).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.null()', () => {
+    it('should coerce', () => {
+      expect(Coerce.null(null)).to.equal(null);
+    });
+    it('should not coerce', () => {
+      expect(Coerce.null('hi')).to.be.instanceOf(CoerceError);
+      expect(Coerce.null(1)).to.be.instanceOf(CoerceError);
+      expect(Coerce.null(undefined)).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.any()', () => {
+    it('should coerce', () => {
+      expect(Coerce.any(1)).to.equal(1);
+      expect(Coerce.any('hello')).to.equal('hello');
+      expect(Coerce.any(true)).to.equal(true);
+    });
+  });
+
+  context('.given()', () => {
+    it('should coerce given number', () => {
+      const example = Coerce.given(1);
+      expect(example(1)).to.equal(1);
+      expect(example(2)).to.be.instanceOf(CoerceError);
+      expect(example(null)).to.be.instanceOf(CoerceError);
+      expect(example('hi')).to.be.instanceOf(CoerceError);
+      expect(example(1000)).to.be.instanceOf(CoerceError);
+    });
+    it('should coerce given string', () => {
+      const example = Coerce.given('hello');
+      expect(example('HELLO')).to.equal('hello');
+      expect(example('hello')).to.equal('hello');
+      expect(example(2)).to.be.instanceOf(CoerceError);
+      expect(example(null)).to.be.instanceOf(CoerceError);
+      expect(example('hi')).to.be.instanceOf(CoerceError);
+      expect(example(1000)).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.givenExact()', () => {
+    it('should coerce given string', () => {
+      const example = Coerce.givenExact('hello');
+      expect(example('hello')).to.equal('hello');
+      expect(example('HELLO')).to.be.instanceOf(CoerceError);
+      expect(example(2)).to.be.instanceOf(CoerceError);
+      expect(example(null)).to.be.instanceOf(CoerceError);
+      expect(example('hi')).to.be.instanceOf(CoerceError);
+      expect(example(1000)).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.array()', () => {
+    it('should coerce array of strings', () => {
+      const example = Coerce.array(Coerce.string);
+      expect(example('meow')).to.deep.equal(['meow']);
+      expect(example(['meow'])).to.deep.equal(['meow']);
+      expect(example([])).to.deep.equal([]);
+    });
+    it('should warn if array contains invalid value', () => {
+      const example = Coerce.array(Coerce.string);
+      expect(example([null, 'meow'])).to.deep.equal(['meow']);
+      expect(errorWarningStub.calledOnce).to.equal(true);
+    });
+    it('should not warn if explicit', () => {
+      const example = Coerce.array(Coerce.string);
+      expect(example([null, 'meow'], { warn: false })).to.deep.equal(['meow']);
+      expect(errorWarningStub.calledOnce).to.equal(false);
+    });
+  });
+
+  context('.compose()', () => {
+    it('should chain keyValue with object', () => {
+      const loveObj = Coerce.object(match => ({
+        ...match('love', Coerce.boolean)
+      }));
+      const example = Coerce.compose(Coerce.keyValue, loveObj);
+      expect(example('love:true')).to.deep.equal({ love: true });
+    });
+    it('should error', () => {
+      const loveObj = Coerce.object(match => ({
+        ...match('love', Coerce.boolean),
+        ...match('marriage', Coerce.require(Coerce.boolean))
+      }));
+      const example = Coerce.compose(Coerce.keyValue, loveObj);
+      expect(example('love:true')).to.be.instanceOf(CoerceError);
+    });
+    it('should should halt once error has bubbled', () => {
+      const loveObj = Coerce.object(match => ({
+        ...match('love', Coerce.boolean),
+        ...match('marriage', Coerce.require(Coerce.boolean))
+      }));
+      const example = Coerce.compose(Coerce.keyValue, loveObj, () => {});
+      expect(example('love:true')).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.commaSeparated()', () => {
+    it('should coerce comma separated string', () => {
+      expect(Coerce.commaSeparated('snappy,zlib')).to.deep.equal(['snappy', 'zlib']);
+      expect(Coerce.commaSeparated('snappy')).to.deep.equal(['snappy']);
+    });
+    it('should be error', () => {
+      expect(Coerce.commaSeparated(1)).to.be.instanceOf(CoerceError);
+    });
+  });
+
+  context('.collide()', () => {
+    it('should handle collisions', () => {
+      expect(Coerce.collide(true)(false, false)).to.equal(false);
+      expect(Coerce.collide(true)(true, false)).to.equal(false);
+      expect(Coerce.collide(true)(true, false)).to.equal(false);
+      expect(Coerce.collide(true)(true, true)).to.equal(true);
+
+      expect(Coerce.collide('foo')('foo', 'foo')).to.equal('foo');
+      expect(Coerce.collide('foo')('bar', 'baz')).to.equal('bar');
+      expect(Coerce.collide('foo')('foo', 'baz')).to.equal('baz');
+      expect(Coerce.collide('foo')(undefined, 'foo')).to.equal('foo');
+      expect(Coerce.collide('foo')('foo', undefined, 'baz')).to.equal('baz');
+    });
+  });
+
+  context('.spreadValue()', () => {
+    it('should spread value', () => {
+      const result = {
+        ...Coerce.spreadValue('foo', true),
+        ...Coerce.spreadValue('bar', undefined)
+      };
+      expect(result).to.deep.equal({ foo: true });
+    });
+
+    it('should return empty {} with non-string key', () => {
+      const result = {
+        ...Coerce.spreadValue(1, true)
+      };
+      expect(result).to.deep.equal({});
+    });
+
+    it('should apply to multiple keys', () => {
+      const result = {
+        ...Coerce.spreadValue(['wtimeoutMS', 'wtimeout'], 1000)
+      };
+      expect(result).to.deep.equal({
+        wtimeoutMS: 1000,
+        wtimeout: 1000
+      });
+    });
+  });
+});

--- a/test/functional/options/coerce_error.test.js
+++ b/test/functional/options/coerce_error.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const {
+  CoerceError,
+  CoerceDeprecate,
+  CoerceUnrecognized
+} = require('../../../src/options/coerce_error');
+const Errors = require('../../../src/options/coerce_error');
+
+describe('CoerceError', () => {
+  let warningStub;
+  beforeEach(() => {
+    warningStub = sinon.stub(Errors.CoerceError.prototype, 'warn').returns({});
+  });
+
+  afterEach(() => {
+    Errors.CoerceError.prototype.warn.restore();
+  });
+
+  context('constructor()', () => {
+    it('basic constructor', () => {
+      const options = { id: 'id', warn: false, typeSuffix: 'typeSuffix' };
+      const inst = new CoerceError('example', false, options);
+      expect(inst.typeName).to.deep.equals('example typeSuffix');
+      expect(inst.value).to.deep.equals(false);
+      expect(inst.id).to.deep.equals('id');
+      expect(warningStub.calledOnce).to.equal(false);
+    });
+    it('constructor warns', () => {
+      const options = { id: 'id', warn: true, typeSuffix: 'typeSuffix' };
+      const inst = new CoerceError('example', true, options);
+      expect(inst.typeName).to.deep.equals('example typeSuffix');
+      expect(inst.value).to.deep.equals(true);
+      expect(inst.id).to.deep.equals('id');
+      expect(warningStub.calledOnce).to.equal(true);
+    });
+    it('empty options does not warn', () => {
+      new CoerceError('example', true);
+      expect(warningStub.calledOnce).to.equal(false);
+    });
+  });
+  context('.displayValue()', () => {
+    it('should create display value based on value', () => {
+      expect(CoerceError.displayValue(undefined)).to.equal(`"undefined"`);
+      expect(CoerceError.displayValue(null)).to.equal(`"null"`);
+      expect(CoerceError.displayValue(true)).to.equal(`"true"`);
+      expect(CoerceError.displayValue(false)).to.equal(`"false"`);
+      expect(CoerceError.displayValue(['anything'])).to.equal(`"[...]"`);
+      expect(CoerceError.displayValue({ anything: true })).to.equal(`"{...}"`);
+      expect(CoerceError.displayValue(1)).to.equal(`"1"`);
+    });
+  });
+
+  context('.createMessage()', () => {
+    it('should create display value based on value', () => {
+      expect(CoerceError.createMessage()).to.equal(`Invalid type`);
+      expect(CoerceError.createMessage('boolean')).to.equal(
+        `Invalid type: value "undefined" is not valid "boolean"`
+      );
+      expect(CoerceError.createMessage('boolean', 1)).to.equal(
+        `Invalid type: value "1" is not valid "boolean"`
+      );
+      expect(CoerceError.createMessage('boolean', 1, 'enabled')).to.equal(
+        `Invalid type: "enabled" with value "1" is not valid "boolean"`
+      );
+    });
+  });
+
+  context('.warn()', () => {
+    it('should warn', () => {
+      const inst = new CoerceError('example', false);
+      inst.warn();
+      expect(warningStub.calledOnce).to.equal(true);
+    });
+  });
+});
+
+describe('CoerceDeprecate', () => {
+  let warningStub;
+  beforeEach(() => {
+    warningStub = sinon.stub(Errors.CoerceDeprecate.prototype, 'warn').returns({});
+  });
+
+  afterEach(() => {
+    Errors.CoerceDeprecate.prototype.warn.restore();
+  });
+
+  context('constructor()', () => {
+    it('basic constructor', () => {
+      const inst = new CoerceDeprecate('id', 'favor');
+      expect(inst.id).to.deep.equals('id');
+      expect(inst.favor).to.deep.equals('favor');
+      expect(warningStub.calledOnce).to.equal(false);
+    });
+  });
+
+  context('.createMessage()', () => {
+    it('should create display value based on value', () => {
+      expect(CoerceDeprecate.createMessage()).to.equal(
+        `Deprecation notice: something used was deprecated, however no reference was passed`
+      );
+      expect(CoerceDeprecate.createMessage('id')).to.equal(
+        `Deprecation notice: 'id' is deprecated`
+      );
+      expect(CoerceDeprecate.createMessage('id', 'favor')).to.equal(
+        `Deprecation notice: 'id' is deprecated, please use 'favor' instead`
+      );
+    });
+  });
+
+  context('.warn()', () => {
+    it('should warn', () => {
+      const inst = new CoerceDeprecate('example', false);
+      inst.warn();
+      expect(warningStub.calledOnce).to.equal(true);
+    });
+  });
+});
+
+describe('CoerceUnrecognized', () => {
+  let warningStub;
+  beforeEach(() => {
+    warningStub = sinon.stub(Errors.CoerceUnrecognized.prototype, 'warn').returns({});
+  });
+
+  afterEach(() => {
+    Errors.CoerceUnrecognized.prototype.warn.restore();
+  });
+
+  context('constructor()', () => {
+    it('basic constructor', () => {
+      const inst = new CoerceUnrecognized('id');
+      expect(inst.id).to.deep.equals('id');
+      expect(warningStub.calledOnce).to.equal(false);
+    });
+  });
+
+  context('.createMessage()', () => {
+    it('should create display value based on value', () => {
+      expect(CoerceUnrecognized.createMessage()).to.equal(
+        `Unrecognized notice: something used was unrecognized, however no reference was passed`
+      );
+      expect(CoerceUnrecognized.createMessage('id')).to.equal(
+        `Unrecognized notice: property 'id' is not recognized`
+      );
+    });
+  });
+
+  context('.warn()', () => {
+    it('should warn', () => {
+      const inst = new CoerceUnrecognized('example', false);
+      inst.warn();
+      expect(warningStub.calledOnce).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
* Here's a bare-bones PR for just the `Coerce` and `CoerceError`, `CoerceUnrecognized`, `CoerceDeprecate` classes.
* Everything is 100% covered in testing.
* There are some additions to the [design doc](https://docs.google.com/document/d/1qd8J0-tP07u65Vc4XBt9v05LIgy04LD4bHzWazdancY/edit#heading=h.rgcvzgoigu2s) reflecting some changes to the design.
* There is a code-comment to reviewers regarding a [alternate implementation for a `.object` and `.objectExact` functions here.](https://github.com/mongodb/node-mongodb-native/pull/2479/files#diff-ba4238a177e553e4d02b79bb710d857cR185-R192)

Question: Do these tests belong in `functional` or `unit`?

https://jira.mongodb.org/browse/NODE-2696
