### PR TITLE
docs(README): remove link to mongodb-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Description
 
-The official [MongoDB](https://www.mongodb.com/) driver for Node.js. Provides a high-level API on top of [mongodb-core](https://www.npmjs.com/package/mongodb-core) that is meant for end users.
+The official [MongoDB](https://www.mongodb.com/) driver for Node.js.
 
 **NOTE: v3.x was recently released with breaking API changes. You can find a list of changes [here](CHANGES_3.0.0.md).**
 


### PR DESCRIPTION
## Description

Now that the driver doesn't use mongodb-core anymore under the hood, I think it's worth removing it from the README.

**What changed?**

Quick change to readme

**Are there any files to ignore?**

No
