### PR TITLE
fix: remove translateOptions export in src/utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1005,7 +1005,6 @@ function hasAtomicOperators(doc: any): boolean {
 export {
   filterOptions,
   mergeOptions,
-  translateOptions,
   getSingleProperty,
   checkCollectionName,
   toError,


### PR DESCRIPTION
This function is not defined and so exporting it was causing issues in typescript type checker

## Description

**What changed?**
I just removed the wrong export
