### PR TITLE
fix(bulk): allow upsert with empty update when using `bulkWrite()`

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -973,7 +973,9 @@ class BulkOperationBase {
       if (op.replaceOne && hasAtomicOperators(op[key].replacement)) {
         throw new TypeError('Replacement document must not use atomic operators');
       } else if ((op.updateOne || op.updateMany) && !hasAtomicOperators(op[key].update)) {
-        throw new TypeError('Update document requires atomic operators');
+        if (Object.keys(op[key].update) > 0 || !op[key].upsert) {
+          throw new TypeError('Update document requires atomic operators');
+        }
       }
 
       const multi = op.updateOne || op.replaceOne ? false : true;


### PR DESCRIPTION
## Description

In v3.5 `bulkWrite()` could do an `updateOne` with an empty `update`, so long as `upsert` was set. For example, the below script succeeds in v3.5.8 but throws a "Update document requires atomic operators" error in v3.6.

```javascript
const { MongoClient, ObjectId } = require('mongodb');

void async function() {
  const client = await MongoClient.connect('mongodb://localhost:27017/test', {
    useNewUrlParser: true,
    useUnifiedTopology: true
  });

  const db = client.db();
  
  await db.collection('Test').bulkWrite([{
    updateOne: { filter: { name: 'test' }, update: {}, upsert: true }
  }]);

  console.log('Done');
  process.exit(0);
}();

```

**What changed?**

Added a check to allow the above script to pass

**Are there any files to ignore?**

Nope