### PR TITLE
chore(ci): add tls support test to evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -453,8 +453,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
-          TOPOLOGY: server-unified
+          TOPOLOGY: server
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-latest-replica_set-unified
     tags:
       - latest
@@ -464,8 +466,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
-          TOPOLOGY: replica_set-unified
+          TOPOLOGY: replica_set
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-latest-sharded_cluster-unified
     tags:
       - latest
@@ -475,8 +479,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
-          TOPOLOGY: sharded_cluster-unified
+          TOPOLOGY: sharded_cluster
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-4.4-server
     tags:
       - '4.4'
@@ -519,8 +525,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
-          TOPOLOGY: server-unified
+          TOPOLOGY: server
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-4.4-replica_set-unified
     tags:
       - '4.4'
@@ -530,8 +538,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
-          TOPOLOGY: replica_set-unified
+          TOPOLOGY: replica_set
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-4.4-sharded_cluster-unified
     tags:
       - '4.4'
@@ -541,8 +551,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
-          TOPOLOGY: sharded_cluster-unified
+          TOPOLOGY: sharded_cluster
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-4.2-server
     tags:
       - '4.2'
@@ -585,8 +597,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
-          TOPOLOGY: server-unified
+          TOPOLOGY: server
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-4.2-replica_set-unified
     tags:
       - '4.2'
@@ -596,8 +610,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
-          TOPOLOGY: replica_set-unified
+          TOPOLOGY: replica_set
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-4.2-sharded_cluster-unified
     tags:
       - '4.2'
@@ -607,8 +623,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
-          TOPOLOGY: sharded_cluster-unified
+          TOPOLOGY: sharded_cluster
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-4.0-server
     tags:
       - '4.0'
@@ -651,8 +669,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
-          TOPOLOGY: server-unified
+          TOPOLOGY: server
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-4.0-replica_set-unified
     tags:
       - '4.0'
@@ -662,8 +682,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
-          TOPOLOGY: replica_set-unified
+          TOPOLOGY: replica_set
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-4.0-sharded_cluster-unified
     tags:
       - '4.0'
@@ -673,8 +695,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
-          TOPOLOGY: sharded_cluster-unified
+          TOPOLOGY: sharded_cluster
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.6-server
     tags:
       - '3.6'
@@ -717,8 +741,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
-          TOPOLOGY: server-unified
+          TOPOLOGY: server
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.6-replica_set-unified
     tags:
       - '3.6'
@@ -728,8 +754,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
-          TOPOLOGY: replica_set-unified
+          TOPOLOGY: replica_set
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.6-sharded_cluster-unified
     tags:
       - '3.6'
@@ -739,8 +767,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
-          TOPOLOGY: sharded_cluster-unified
+          TOPOLOGY: sharded_cluster
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.4-server
     tags:
       - '3.4'
@@ -783,8 +813,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.4'
-          TOPOLOGY: server-unified
+          TOPOLOGY: server
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.4-replica_set-unified
     tags:
       - '3.4'
@@ -794,8 +826,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.4'
-          TOPOLOGY: replica_set-unified
+          TOPOLOGY: replica_set
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.4-sharded_cluster-unified
     tags:
       - '3.4'
@@ -805,8 +839,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.4'
-          TOPOLOGY: sharded_cluster-unified
+          TOPOLOGY: sharded_cluster
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.2-server
     tags:
       - '3.2'
@@ -849,8 +885,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.2'
-          TOPOLOGY: server-unified
+          TOPOLOGY: server
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.2-replica_set-unified
     tags:
       - '3.2'
@@ -860,8 +898,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.2'
-          TOPOLOGY: replica_set-unified
+          TOPOLOGY: replica_set
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.2-sharded_cluster-unified
     tags:
       - '3.2'
@@ -871,8 +911,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.2'
-          TOPOLOGY: sharded_cluster-unified
+          TOPOLOGY: sharded_cluster
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.0-server
     tags:
       - '3.0'
@@ -915,8 +957,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.0'
-          TOPOLOGY: server-unified
+          TOPOLOGY: server
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.0-replica_set-unified
     tags:
       - '3.0'
@@ -926,8 +970,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.0'
-          TOPOLOGY: replica_set-unified
+          TOPOLOGY: replica_set
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-3.0-sharded_cluster-unified
     tags:
       - '3.0'
@@ -937,8 +983,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.0'
-          TOPOLOGY: sharded_cluster-unified
+          TOPOLOGY: sharded_cluster
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-2.6-server
     tags:
       - '2.6'
@@ -981,8 +1029,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '2.6'
-          TOPOLOGY: server-unified
+          TOPOLOGY: server
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-2.6-replica_set-unified
     tags:
       - '2.6'
@@ -992,8 +1042,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '2.6'
-          TOPOLOGY: replica_set-unified
+          TOPOLOGY: replica_set
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-2.6-sharded_cluster-unified
     tags:
       - '2.6'
@@ -1003,8 +1055,10 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '2.6'
-          TOPOLOGY: sharded_cluster-unified
+          TOPOLOGY: sharded_cluster
       - func: run tests
+        vars:
+          UNIFIED: 1
   - name: test-atlas-connectivity
     tags:
       - atlas-connect

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -74,11 +74,12 @@ functions:
   bootstrap mongo-orchestration:
     - command: shell.exec
       params:
-        script: >
+        script: |
           ${PREPARE_SHELL}
-
-          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} bash
-          ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} \
+          AUTH=${AUTH} SSL=${SSL} \
+          ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
+          bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: expansions.update
       params:
         file: mo-expansion.yml
@@ -100,9 +101,8 @@ functions:
       type: test
       params:
         working_dir: src
-        script: >
+        script: |
           ${PREPARE_SHELL}
-
 
           if [ -n "${CLIENT_ENCRYPTION}" ]; then
             # Disable xtrace (just in case it was accidentally set).
@@ -111,9 +111,8 @@ functions:
             rm -f ./prepare_client_encryption.sh
           fi
 
-
-          AUTH=${AUTH} SSL=${SSL} UNIFIED=${UNIFIED} MONGODB_URI="${MONGODB_URI}" bash
-          ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          AUTH=${AUTH} SSL=${SSL} UNIFIED=${UNIFIED} MONGODB_URI="${MONGODB_URI}" \
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
   run checks:
     - command: shell.exec
       type: test
@@ -173,6 +172,23 @@ functions:
           rm -f ./prepare_atlas_connectivity.sh
 
           NODE_LTS_NAME='${NODE_LTS_NAME}' bash ${PROJECT_DIRECTORY}/.evergreen/run-atlas-tests.sh
+  run ldap tests:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        script: |
+          MONGODB_URI='${plain_auth_mongodb_uri}' NODE_LTS_NAME='${NODE_LTS_NAME}' \
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-ldap-tests.sh
+  run tls tests:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        script: |
+          NODE_LTS_NAME=${NODE_LTS_NAME} DRIVERS_TOOLS="${DRIVERS_TOOLS}" \
+          SSL_CA_FILE="${SSL_CA_FILE}" SSL_KEY_FILE="${SSL_KEY_FILE}" \
+          MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-tls-tests.sh
   add aws auth variables to file:
     - command: shell.exec
       type: test
@@ -437,10 +453,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
-          TOPOLOGY: server
+          TOPOLOGY: server-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-latest-replica_set-unified
     tags:
       - latest
@@ -450,10 +464,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
-          TOPOLOGY: replica_set
+          TOPOLOGY: replica_set-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-latest-sharded_cluster-unified
     tags:
       - latest
@@ -463,10 +475,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: sharded_cluster-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-4.4-server
     tags:
       - '4.4'
@@ -509,10 +519,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
-          TOPOLOGY: server
+          TOPOLOGY: server-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-4.4-replica_set-unified
     tags:
       - '4.4'
@@ -522,10 +530,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
-          TOPOLOGY: replica_set
+          TOPOLOGY: replica_set-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-4.4-sharded_cluster-unified
     tags:
       - '4.4'
@@ -535,10 +541,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: sharded_cluster-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-4.2-server
     tags:
       - '4.2'
@@ -581,10 +585,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
-          TOPOLOGY: server
+          TOPOLOGY: server-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-4.2-replica_set-unified
     tags:
       - '4.2'
@@ -594,10 +596,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
-          TOPOLOGY: replica_set
+          TOPOLOGY: replica_set-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-4.2-sharded_cluster-unified
     tags:
       - '4.2'
@@ -607,10 +607,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: sharded_cluster-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-4.0-server
     tags:
       - '4.0'
@@ -653,10 +651,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
-          TOPOLOGY: server
+          TOPOLOGY: server-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-4.0-replica_set-unified
     tags:
       - '4.0'
@@ -666,10 +662,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
-          TOPOLOGY: replica_set
+          TOPOLOGY: replica_set-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-4.0-sharded_cluster-unified
     tags:
       - '4.0'
@@ -679,10 +673,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: sharded_cluster-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.6-server
     tags:
       - '3.6'
@@ -725,10 +717,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
-          TOPOLOGY: server
+          TOPOLOGY: server-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.6-replica_set-unified
     tags:
       - '3.6'
@@ -738,10 +728,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
-          TOPOLOGY: replica_set
+          TOPOLOGY: replica_set-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.6-sharded_cluster-unified
     tags:
       - '3.6'
@@ -751,10 +739,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: sharded_cluster-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.4-server
     tags:
       - '3.4'
@@ -797,10 +783,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.4'
-          TOPOLOGY: server
+          TOPOLOGY: server-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.4-replica_set-unified
     tags:
       - '3.4'
@@ -810,10 +794,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.4'
-          TOPOLOGY: replica_set
+          TOPOLOGY: replica_set-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.4-sharded_cluster-unified
     tags:
       - '3.4'
@@ -823,10 +805,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.4'
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: sharded_cluster-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.2-server
     tags:
       - '3.2'
@@ -869,10 +849,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.2'
-          TOPOLOGY: server
+          TOPOLOGY: server-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.2-replica_set-unified
     tags:
       - '3.2'
@@ -882,10 +860,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.2'
-          TOPOLOGY: replica_set
+          TOPOLOGY: replica_set-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.2-sharded_cluster-unified
     tags:
       - '3.2'
@@ -895,10 +871,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.2'
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: sharded_cluster-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.0-server
     tags:
       - '3.0'
@@ -941,10 +915,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.0'
-          TOPOLOGY: server
+          TOPOLOGY: server-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.0-replica_set-unified
     tags:
       - '3.0'
@@ -954,10 +926,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.0'
-          TOPOLOGY: replica_set
+          TOPOLOGY: replica_set-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-3.0-sharded_cluster-unified
     tags:
       - '3.0'
@@ -967,10 +937,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.0'
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: sharded_cluster-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-2.6-server
     tags:
       - '2.6'
@@ -1013,10 +981,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '2.6'
-          TOPOLOGY: server
+          TOPOLOGY: server-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-2.6-replica_set-unified
     tags:
       - '2.6'
@@ -1026,10 +992,8 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '2.6'
-          TOPOLOGY: replica_set
+          TOPOLOGY: replica_set-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-2.6-sharded_cluster-unified
     tags:
       - '2.6'
@@ -1039,16 +1003,25 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '2.6'
-          TOPOLOGY: sharded_cluster
+          TOPOLOGY: sharded_cluster-unified
       - func: run tests
-        vars:
-          UNIFIED: 1
   - name: test-atlas-connectivity
     tags:
       - atlas-connect
     commands:
       - func: install dependencies
       - func: run atlas tests
+  - name: test-tls-support
+    tags:
+      - tls-support
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          SSL: ssl
+          VERSION: latest
+          TOPOLOGY: server
+      - func: run tls tests
   - name: test-latest-ocsp-valid-cert-server-staples
     tags:
       - ocsp
@@ -1343,6 +1316,7 @@ buildvariants:
       - test-2.6-replica_set-unified
       - test-2.6-sharded_cluster-unified
       - test-atlas-connectivity
+      - test-tls-support
       - test-latest-ocsp-valid-cert-server-staples
       - test-latest-ocsp-invalid-cert-server-staples
       - test-latest-ocsp-valid-cert-server-does-not-staple
@@ -1528,6 +1502,7 @@ buildvariants:
       - test-3.2-replica_set-unified
       - test-3.2-sharded_cluster-unified
       - test-atlas-connectivity
+      - test-tls-support
       - test-latest-ocsp-valid-cert-server-staples
       - test-latest-ocsp-invalid-cert-server-staples
       - test-latest-ocsp-valid-cert-server-does-not-staple

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -94,7 +94,10 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} \
+          AUTH=${AUTH} SSL=${SSL} \
+          ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
+          bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update
       params:
@@ -128,7 +131,8 @@ functions:
             rm -f ./prepare_client_encryption.sh
           fi
 
-          AUTH=${AUTH} SSL=${SSL} UNIFIED=${UNIFIED} MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          AUTH=${AUTH} SSL=${SSL} UNIFIED=${UNIFIED} MONGODB_URI="${MONGODB_URI}" \
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "run checks":
     - command: shell.exec
@@ -206,6 +210,25 @@ functions:
           rm -f ./prepare_atlas_connectivity.sh
 
           NODE_LTS_NAME='${NODE_LTS_NAME}' bash ${PROJECT_DIRECTORY}/.evergreen/run-atlas-tests.sh
+
+  "run ldap tests":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          MONGODB_URI='${plain_auth_mongodb_uri}' NODE_LTS_NAME='${NODE_LTS_NAME}' \
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-ldap-tests.sh
+
+  "run tls tests":  
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          NODE_LTS_NAME=${NODE_LTS_NAME} DRIVERS_TOOLS="${DRIVERS_TOOLS}" \
+          SSL_CA_FILE="${SSL_CA_FILE}" SSL_KEY_FILE="${SSL_KEY_FILE}" \
+          MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-tls-tests.sh
 
   "add aws auth variables to file":
     - command: shell.exec

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -88,28 +88,46 @@ function makeTask({ mongoVersion, topology }) {
         func: 'bootstrap mongo-orchestration',
         vars: {
           VERSION: mongoVersion,
-          TOPOLOGY: topologyForTest
+          TOPOLOGY: topology
         }
       },
-      runTestsCommand
+      { func: 'run tests' }
     ]
   };
 }
 
 MONGODB_VERSIONS.forEach(mongoVersion => {
-  TOPOLOGIES.forEach(topology => {
-    TASKS.push(makeTask({ mongoVersion, topology }));
-  });
+  TOPOLOGIES.forEach(topology =>
+    TASKS.push(makeTask({ mongoVersion, topology }))
+  );
 });
 
-TASKS.push({
-  name: 'test-atlas-connectivity',
-  tags: ['atlas-connect'],
-  commands: [
-    { func: 'install dependencies' },
-    { func: 'run atlas tests' }
-  ]
-});
+TASKS.push(
+  {
+    name: 'test-atlas-connectivity',
+    tags: ['atlas-connect'],
+    commands: [
+      { func: 'install dependencies' },
+      { func: 'run atlas tests' }
+    ]
+  },
+  {
+    name: 'test-tls-support',
+    tags: ['tls-support'],
+    commands: [
+      { func: 'install dependencies' },
+      {
+        func: 'bootstrap mongo-orchestration',
+        vars: {
+          SSL: 'ssl',
+          VERSION: 'latest',
+          TOPOLOGY: 'server'
+        }
+      },
+      { func: 'run tls tests' }
+    ]
+  }
+);
 
 OCSP_VERSIONS.forEach(VERSION => {
   // manually added tasks

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -88,10 +88,10 @@ function makeTask({ mongoVersion, topology }) {
         func: 'bootstrap mongo-orchestration',
         vars: {
           VERSION: mongoVersion,
-          TOPOLOGY: topology
+          TOPOLOGY: topologyForTest
         }
       },
-      { func: 'run tests' }
+      runTestsCommand
     ]
   };
 }

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -10,9 +10,15 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       MARCH                   Machine Architecture. Defaults to lowercase uname -m
 
 AUTH=${AUTH:-noauth}
-SSL=${SSL:-nossl}
 UNIFIED=${UNIFIED:-}
 MONGODB_URI=${MONGODB_URI:-}
+
+# ssl setup
+SSL=${SSL:-nossl}
+if [ "$SSL" != "nossl" ]; then
+   export SSL_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
+   export SSL_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
+fi
 
 # run tests
 echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"

--- a/.evergreen/run-tls-tests.sh
+++ b/.evergreen/run-tls-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit  # Exit the script with error if any of the commands fail
+
+export PROJECT_DIRECTORY="$(pwd)"
+NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
+export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+export SSL_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
+export SSL_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
+
+npm run check:tls

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "scripts": {
     "atlas": "mocha --opts '{}' ./test/manual/atlas_connectivity.test.js",
+    "check:tls": "mocha --opts '{}' test/manual/tls_support.test.js",
     "test": "npm run lint && mocha --recursive test/functional test/unit test/core",
     "test-nolint": "mocha --recursive test/functional test/unit test/core",
     "coverage": "istanbul cover mongodb-test-runner -- -t 60000 test/core test/unit test/functional",

--- a/test/manual/tls_support.test.js
+++ b/test/manual/tls_support.test.js
@@ -1,0 +1,33 @@
+'use strict';
+const MongoClient = require('../..').MongoClient;
+
+const REQUIRED_ENV = ['MONGODB_URI', 'SSL_KEY_FILE', 'SSL_CA_FILE'];
+
+describe('TLS Support', function () {
+  for (let key of REQUIRED_ENV) {
+    if (process.env[key] == null) {
+      throw new Error(`skipping SSL tests, ${key} environment variable is not defined`);
+    }
+  }
+
+  const connectionString = process.env.MONGODB_URI;
+  const tlsCertificateKeyFile = process.env.SSL_KEY_FILE;
+  const tlsCAFile = process.env.SSL_CA_FILE;
+
+  it(
+    'should connect with tls',
+    makeConnectionTest(connectionString, { tls: true, tlsCertificateKeyFile, tlsCAFile })
+  );
+});
+
+function makeConnectionTest(connectionString, clientOptions) {
+  return function () {
+    const client = new MongoClient(connectionString, clientOptions);
+
+    return client
+      .connect()
+      .then(() => client.db('admin').command({ ismaster: 1 }))
+      .then(() => client.db('test').collection('test').findOne({}))
+      .then(() => client.close());
+  };
+}

--- a/test/manual/tls_support.test.js
+++ b/test/manual/tls_support.test.js
@@ -3,7 +3,7 @@ const MongoClient = require('../..').MongoClient;
 
 const REQUIRED_ENV = ['MONGODB_URI', 'SSL_KEY_FILE', 'SSL_CA_FILE'];
 
-describe('TLS Support', function () {
+describe('TLS Support', function() {
   for (let key of REQUIRED_ENV) {
     if (process.env[key] == null) {
       throw new Error(`skipping SSL tests, ${key} environment variable is not defined`);
@@ -21,13 +21,18 @@ describe('TLS Support', function () {
 });
 
 function makeConnectionTest(connectionString, clientOptions) {
-  return function () {
+  return function() {
     const client = new MongoClient(connectionString, clientOptions);
 
     return client
       .connect()
       .then(() => client.db('admin').command({ ismaster: 1 }))
-      .then(() => client.db('test').collection('test').findOne({}))
+      .then(() =>
+        client
+          .db('test')
+          .collection('test')
+          .findOne({})
+      )
       .then(() => client.close());
   };
 }

--- a/test/spec/apm/updateOne.json
+++ b/test/spec/apm/updateOne.json
@@ -131,6 +131,7 @@
     },
     {
       "description": "A successful update one command with write errors",
+      "ignore_if_server_version_greater_than": "4.5",
       "operation": {
         "name": "updateOne",
         "arguments": {


### PR DESCRIPTION
[NODE-877](https://jira.mongodb.org/browse/NODE-877)

port to `3.6`

## Description

**What changed?**

**Are there any files to ignore?**
