### PR TITLE
fix: add host/port to cmap connection

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -179,7 +179,7 @@ functions:
         working_dir: src
         script: |
           KRB5_KEYTAB='${gssapi_auth_keytab_base64}' KRB5_PRINCIPAL='${gssapi_auth_principal}' \
-          MONGODB_URI='${gssapi_auth_mongodb_uri}' \
+          MONGODB_URI='${gssapi_auth_mongodb_uri}' UNIFIED=${UNIFIED} \
           NODE_LTS_NAME='${NODE_LTS_NAME}' bash ${PROJECT_DIRECTORY}/.evergreen/run-kerberos-tests.sh
   run ldap tests:
     - command: shell.exec
@@ -788,13 +788,26 @@ tasks:
     commands:
       - func: install dependencies
       - func: run atlas tests
-  - name: test-auth-kerberos
+  - name: test-auth-kerberos-legacy
     tags:
       - auth
       - kerberos
+      - legacy
     commands:
       - func: install dependencies
       - func: run kerberos tests
+        vars:
+          UNIFIED: 0
+  - name: test-auth-kerberos-unified
+    tags:
+      - auth
+      - kerberos
+      - unified
+    commands:
+      - func: install dependencies
+      - func: run kerberos tests
+        vars:
+          UNIFIED: 1
   - name: test-auth-ldap
     tags:
       - auth
@@ -877,7 +890,8 @@ buildvariants:
       - test-2.6-replica_set-unified
       - test-2.6-sharded_cluster-unified
       - test-atlas-connectivity
-      - test-auth-kerberos
+      - test-auth-kerberos-legacy
+      - test-auth-kerberos-unified
       - test-auth-ldap
       - test-tls-support
   - name: macos-1014-dubnium
@@ -977,7 +991,8 @@ buildvariants:
       - test-2.6-replica_set-unified
       - test-2.6-sharded_cluster-unified
       - test-atlas-connectivity
-      - test-auth-kerberos
+      - test-auth-kerberos-legacy
+      - test-auth-kerberos-unified
       - test-auth-ldap
   - name: ubuntu-14.04-dubnium
     display_name: Ubuntu 14.04 Node Dubnium
@@ -1047,7 +1062,8 @@ buildvariants:
       - test-3.2-replica_set-unified
       - test-3.2-sharded_cluster-unified
       - test-atlas-connectivity
-      - test-auth-kerberos
+      - test-auth-kerberos-legacy
+      - test-auth-kerberos-unified
       - test-auth-ldap
       - test-tls-support
   - name: ubuntu-18.04-dubnium

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -218,7 +218,7 @@ functions:
         working_dir: src
         script: |
           KRB5_KEYTAB='${gssapi_auth_keytab_base64}' KRB5_PRINCIPAL='${gssapi_auth_principal}' \
-          MONGODB_URI='${gssapi_auth_mongodb_uri}' \
+          MONGODB_URI='${gssapi_auth_mongodb_uri}' UNIFIED=${UNIFIED} \
           NODE_LTS_NAME='${NODE_LTS_NAME}' bash ${PROJECT_DIRECTORY}/.evergreen/run-kerberos-tests.sh
 
   "run ldap tests":

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -108,11 +108,27 @@ TASKS.push(
     commands: [{ func: 'install dependencies' }, { func: 'run atlas tests' }]
   },
   {
-    name: 'test-auth-kerberos',
-    tags: ['auth', 'kerberos'],
+    name: 'test-auth-kerberos-legacy',
+    tags: ['auth', 'kerberos', 'legacy'],
     commands: [
       { func: 'install dependencies' },
-      { func: 'run kerberos tests' }
+      { func: 'run kerberos tests',
+        vars: {
+          UNIFIED: 0
+        }
+      }
+    ]
+  },
+  {
+    name: 'test-auth-kerberos-unified',
+    tags: ['auth', 'kerberos', 'unified'],
+    commands: [
+      { func: 'install dependencies' },
+      { func: 'run kerberos tests',
+        vars: {
+          UNIFIED: 1
+        }
+      }
     ]
   },
   {
@@ -152,6 +168,11 @@ const getTaskList = (() => {
     const ret = TASKS.filter(task => {
       const tasksWithVars = task.commands.filter(task => !!task.vars);
       if (!tasksWithVars.length) {
+        return true;
+      }
+
+      // kerberos tests don't require mongo orchestration
+      if (task.tags.filter(tag => tag === 'kerberos').length) {
         return true;
       }
 

--- a/lib/cmap/connection.js
+++ b/lib/cmap/connection.js
@@ -32,6 +32,8 @@ class Connection extends EventEmitter {
     this.address = streamIdentifier(stream);
     this.bson = options.bson;
     this.socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 360000;
+    this.host = options.host || 'localhost';
+    this.port = options.port || 27017;
     this.monitorCommands =
       typeof options.monitorCommands === 'boolean' ? options.monitorCommands : false;
     this.closed = false;

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "scripts": {
     "atlas": "mocha --opts '{}' ./test/manual/atlas_connectivity.test.js",
-    "check:kerberos": "mocha --opts '{}' test/manual/kerberos.test.js",
+    "check:kerberos": "mocha --opts '{}' -t 60000 test/manual/kerberos.test.js",
     "check:ldap": "mocha --opts '{}' test/manual/ldap.test.js",
     "check:tls": "mocha --opts '{}' test/manual/tls_support.test.js",
     "test": "npm run lint && mocha --recursive test/functional test/unit test/core",


### PR DESCRIPTION
Also runs the `auth-kerberos` evergreen tests on `legacy` and `unified` topologies.

[NODE-2731](https://jira.mongodb.org/browse/NODE-2731)