### PR TITLE
docs: fix JSDocs for GridFSBucketReadStream constructor

### DIFF
--- a/src/gridfs-stream/download.ts
+++ b/src/gridfs-stream/download.ts
@@ -12,7 +12,7 @@ import { Readable } from 'stream';
  * @param {object} readPreference The read preference to use
  * @param {object} filter The query to use to find the file document
  * @param {object} [options] Optional settings.
- * @param {number} [options.sort] Optional sort for the file find query
+ * @param {(array|object)} [options.sort] Optional sort for the file find query. Array of indexes, [['a', 1]] etc.
  * @param {number} [options.skip] Optional skip for the file find query
  * @param {number} [options.start] Optional 0-based offset in bytes to start streaming from
  * @param {number} [options.end] Optional 0-based offset in bytes to stop streaming before


### PR DESCRIPTION
## Description

It's clear from https://github.com/mongodb/node-mongodb-native/blob/5808e12f13e39bfddb26cc15fe9b4dd751e1f363/src/gridfs-stream/index.ts#L227 and https://github.com/mongodb/node-mongodb-native/blob/5808e12f13e39bfddb26cc15fe9b4dd751e1f363/src/gridfs-stream/download.ts#L258 that `GridFSBucketReadStream` `options.sort` accepts object or array rather than a number, just like https://github.com/mongodb/node-mongodb-native/blob/4aeaedf3b12a196127852522bcc81d8b507676d5/src/collection.ts#L1828