### PR TITLE
refactor: remove `CommandResult`

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -459,13 +459,11 @@ export class ChangeStreamCursor extends Cursor<AggregateOperation, ChangeStreamC
   }
 
   _initializeCursor(callback: Callback) {
-    super._initializeCursor((err, result) => {
-      if (err || result == null) {
-        callback(err, result);
+    super._initializeCursor((err, response) => {
+      if (err || response == null) {
+        callback(err, response);
         return;
       }
-
-      const response = result.documents[0];
 
       if (
         this.startAtOperationTime == null &&
@@ -478,9 +476,9 @@ export class ChangeStreamCursor extends Cursor<AggregateOperation, ChangeStreamC
 
       this._processBatch('firstBatch', response);
 
-      this.emit('init', result);
+      this.emit('init', response);
       this.emit('response');
-      callback(err, result);
+      callback(err, response);
     });
   }
 

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -45,10 +45,9 @@ export class GSSAPI extends AuthProvider {
           autoAuthorize: 1
         };
 
-        connection.command('$external.$cmd', command, (err, result) => {
+        connection.command('$external.$cmd', command, (err, doc) => {
           if (err) return callback(err, false);
 
-          const doc = result.result;
           authProcess.transition(doc.payload, (err, payload) => {
             if (err) return callback(err, false);
             const command = {
@@ -57,10 +56,9 @@ export class GSSAPI extends AuthProvider {
               payload
             };
 
-            connection.command('$external.$cmd', command, (err, result) => {
+            connection.command('$external.$cmd', command, (err, doc) => {
               if (err) return callback(err, false);
 
-              const doc = result.result;
               authProcess.transition(doc.payload, (err, payload) => {
                 if (err) return callback(err, false);
                 const command = {
@@ -69,10 +67,9 @@ export class GSSAPI extends AuthProvider {
                   payload
                 };
 
-                connection.command('$external.$cmd', command, (err, result) => {
+                connection.command('$external.$cmd', command, (err, response) => {
                   if (err) return callback(err, false);
 
-                  const response = result.result;
                   authProcess.transition(null, err => {
                     if (err) return callback(err);
                     callback(undefined, response);

--- a/src/cmap/auth/mongocr.ts
+++ b/src/cmap/auth/mongocr.ts
@@ -12,13 +12,12 @@ export class MongoCR extends AuthProvider {
     const username = credentials.username;
     const password = credentials.password;
     const source = credentials.source;
-    connection.command(`${source}.$cmd`, { getnonce: 1 }, (err, result) => {
+    connection.command(`${source}.$cmd`, { getnonce: 1 }, (err, r) => {
       let nonce = null;
       let key = null;
 
       // Get nonce
       if (err == null) {
-        const r = result.result;
         nonce = r.nonce;
 
         // Use node md5 generator

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -70,10 +70,9 @@ export class MongoDBAWS extends AuthProvider {
         payload: BSON.serialize({ r: nonce, p: ASCII_N }, bsonOptions)
       };
 
-      connection.command(`${db}.$cmd`, saslStart, (err, result) => {
+      connection.command(`${db}.$cmd`, saslStart, (err, res) => {
         if (err) return callback(err);
 
-        const res = result.result;
         const serverResponse = BSON.deserialize(res.payload.buffer, bsonOptions);
         const host = serverResponse.h;
         const serverNonce = serverResponse.s.buffer;

--- a/src/cmap/commands.ts
+++ b/src/cmap/commands.ts
@@ -2,9 +2,9 @@ import { ReadPreference } from '../read_preference';
 import * as BSON from '../bson';
 import { databaseNamespace } from '../utils';
 import { OP_QUERY, OP_GETMORE, OP_KILL_CURSORS, OP_MSG } from './wire_protocol/constants';
-import type { Connection } from './connection';
 import type { Long, Document, BSONSerializeOptions } from '../bson';
 import type { ClientSession } from '../sessions';
+import type { CommandOptions } from './wire_protocol/command';
 
 // Incrementing request id
 let _requestId = 0;
@@ -28,7 +28,7 @@ const AWAIT_CAPABLE = 8;
 export type WriteProtocolMessageType = Query | Msg | GetMore | KillCursor;
 
 /** @internal */
-export interface OpQueryOptions {
+export interface OpQueryOptions extends CommandOptions {
   socketTimeout?: number;
   session?: ClientSession;
   documentsReturnedIn?: string;
@@ -846,37 +846,5 @@ export class BinMsg {
     }
 
     this.parsed = true;
-  }
-}
-
-/**
- * Creates a new CommandResult instance
- * @internal
- *
- * @param result - CommandResult object
- * @param connection - A connection instance associated with this result
- */
-export class CommandResult {
-  ok?: number;
-  result: Document;
-  connection: Connection;
-  message: Document;
-
-  constructor(result: Document, connection: Connection, message: Document) {
-    this.result = result;
-    this.connection = connection;
-    this.message = message;
-  }
-
-  /** Convert CommandResult to JSON */
-  toJSON(): Document {
-    const result: Partial<CommandResult> = Object.assign({}, this, this.result);
-    delete result.message;
-    return result;
-  }
-
-  /** Convert CommandResult to String representation */
-  toString(): string {
-    return JSON.stringify(this.toJSON());
   }
 }

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -111,14 +111,13 @@ function performInitialHandshake(
     }
 
     const start = new Date().getTime();
-    conn.command('admin.$cmd', handshakeDoc, handshakeOptions, (err, result) => {
+    conn.command('admin.$cmd', handshakeDoc, handshakeOptions, (err, response) => {
       if (err) {
         callback(err);
         return;
       }
 
-      const response = result.result;
-      if (response.ok === 0) {
+      if (response?.ok === 0) {
         callback(new MongoError(response));
         return;
       }

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -18,8 +18,8 @@ import {
   ConnectionCheckedInEvent,
   ConnectionPoolClearedEvent
 } from './events';
-import type { CommandResult } from './commands';
 import type { CommandOptions } from './wire_protocol/command';
+import type { Document } from '../bson';
 
 const kLogger = Symbol('logger');
 const kConnections = Symbol('connections');
@@ -133,7 +133,7 @@ export interface ConnectionPool {
   write(
     message: any,
     commandOptions: CommandOptions,
-    callback: (err: MongoError, ...args: CommandResult[]) => void
+    callback: (err: MongoError, ...args: Document[]) => void
   ): void;
 }
 

--- a/src/cmap/events.ts
+++ b/src/cmap/events.ts
@@ -1,4 +1,4 @@
-import { GetMore, KillCursor, Msg, CommandResult, WriteProtocolMessageType } from './commands';
+import { GetMore, KillCursor, Msg, WriteProtocolMessageType } from './commands';
 import { calculateDurationInMs } from '../utils';
 import type { ConnectionPool, ConnectionPoolOptions } from './connection_pool';
 import type { Connection } from './connection';
@@ -224,7 +224,7 @@ export class CommandSucceededEvent {
   constructor(
     pool: Connection | ConnectionPool,
     command: WriteProtocolMessageType,
-    reply: CommandResult | undefined,
+    reply: Document | undefined,
     started: number
   ) {
     const cmd = extractCommand(command);
@@ -297,7 +297,7 @@ const extractCommandName = (commandDoc: Document) => Object.keys(commandDoc)[0];
 const namespace = (command: WriteProtocolMessageType) => command.ns;
 const databaseName = (command: WriteProtocolMessageType) => command.ns.split('.')[0];
 const collectionName = (command: WriteProtocolMessageType) => command.ns.split('.')[1];
-const maybeRedact = (commandName: string, result?: CommandResult | Error | Document) =>
+const maybeRedact = (commandName: string, result?: Error | Document) =>
   SENSITIVE_COMMANDS.has(commandName) ? {} : result;
 
 const LEGACY_FIND_QUERY_MAP: { [key: string]: string } = {
@@ -393,7 +393,7 @@ function extractCommand(command: WriteProtocolMessageType): Document {
   return command.query ? command.query : command;
 }
 
-function extractReply(command: WriteProtocolMessageType, reply?: CommandResult) {
+function extractReply(command: WriteProtocolMessageType, reply?: Document) {
   if (command instanceof KillCursor) {
     return {
       ok: 1,
@@ -409,9 +409,9 @@ function extractReply(command: WriteProtocolMessageType, reply?: CommandResult) 
     return {
       ok: 1,
       cursor: {
-        id: reply.message.cursorId,
+        id: reply.cursorId,
         ns: namespace(command),
-        nextBatch: reply.message.documents
+        nextBatch: reply.documents
       }
     };
   }
@@ -425,9 +425,9 @@ function extractReply(command: WriteProtocolMessageType, reply?: CommandResult) 
     return {
       ok: 1,
       cursor: {
-        id: reply.message.cursorId,
+        id: reply.cursorId,
         ns: namespace(command),
-        firstBatch: reply.message.documents
+        firstBatch: reply.documents
       }
     };
   }

--- a/src/cmap/message_stream.ts
+++ b/src/cmap/message_stream.ts
@@ -1,14 +1,6 @@
 import BufferList = require('bl');
 import { Duplex, DuplexOptions } from 'stream';
-import {
-  Response,
-  Msg,
-  BinMsg,
-  Query,
-  WriteProtocolMessageType,
-  MessageHeader,
-  CommandResult
-} from './commands';
+import { Response, Msg, BinMsg, Query, WriteProtocolMessageType, MessageHeader } from './commands';
 import { MongoError, MongoParseError } from '../error';
 import { OP_COMPRESSED, OP_MSG } from './wire_protocol/constants';
 import {
@@ -36,7 +28,7 @@ export interface MessageStreamOptions extends DuplexOptions {
 /** @internal */
 export interface OperationDescription extends BSONSerializeOptions {
   started: number;
-  cb: Callback<CommandResult>;
+  cb: Callback<Document>;
   command: boolean;
   documentsReturnedIn?: string;
   fullResult: boolean;

--- a/src/cmap/wire_protocol/command.ts
+++ b/src/cmap/wire_protocol/command.ts
@@ -1,4 +1,4 @@
-import { Query, Msg, CommandResult } from '../commands';
+import { Query, Msg } from '../commands';
 import { getReadPreference, isSharded } from './shared';
 import { isTransactionCommand } from '../../transactions';
 import { applySession, ClientSession } from '../../sessions';
@@ -13,7 +13,7 @@ import type { WriteCommandOptions } from './write_command';
 
 /** @internal */
 export interface CommandOptions extends BSONSerializeOptions {
-  command?: Document;
+  command?: boolean;
   slaveOk?: boolean;
   /** Specify read preference if command supports it */
   readPreference?: ReadPreferenceLike;
@@ -44,24 +44,24 @@ export function command(
   server: Server,
   ns: string,
   cmd: Document,
-  callback: Callback<CommandResult>
+  callback: Callback<Document>
 ): void;
 export function command(
   server: Server,
   ns: string,
   cmd: Document,
   options: CommandOptions,
-  callback?: Callback<CommandResult>
+  callback?: Callback<Document>
 ): void;
 export function command(
   server: Server,
   ns: string,
   cmd: Document,
   _options: Callback | CommandOptions,
-  _callback?: Callback<CommandResult>
+  _callback?: Callback<Document>
 ): void {
   let options = _options as CommandOptions;
-  const callback = (_callback ?? _options) as Callback<CommandResult>;
+  const callback = (_callback ?? _options) as Callback<Document>;
   if ('function' === typeof options) {
     options = {};
   }
@@ -88,8 +88,8 @@ function _command(
   server: Server,
   ns: string,
   cmd: Document,
-  options: CommandOptions | WriteCommandOptions,
-  callback: Callback<CommandResult>
+  options: CommandOptions,
+  callback: Callback<Document>
 ) {
   const pool = server.s.pool;
   const readPreference = getReadPreference(cmd, options);
@@ -145,7 +145,7 @@ function _command(
 
   const inTransaction = session && (session.inTransaction() || isTransactionCommand(finalCmd));
   const commandResponseHandler = inTransaction
-    ? (err: MongoError, ...args: CommandResult[]) => {
+    ? (err: MongoError, ...args: Document[]) => {
         // We need to add a TransientTransactionError errorLabel, as stated in the transaction spec.
         if (
           err &&
@@ -210,16 +210,7 @@ function _cryptCommand(
       return;
     }
 
-    autoEncrypter.decrypt(response.result, options, (err, decrypted) => {
-      if (err) {
-        callback(err, null);
-        return;
-      }
-
-      response.result = decrypted;
-      response.message.documents = [decrypted];
-      callback(undefined, response);
-    });
+    autoEncrypter.decrypt(response, options, callback);
   };
 
   autoEncrypter.encrypt(ns, cmd, options, (err, encrypted) => {

--- a/src/cmap/wire_protocol/kill_cursors.ts
+++ b/src/cmap/wire_protocol/kill_cursors.ts
@@ -59,17 +59,16 @@ export function killCursors(
     cursors: cursorIds
   };
 
-  const options: CommandOptions = {};
+  const options: CommandOptions = { fullResult: true };
   if (typeof cursorState.session === 'object') {
     options.session = cursorState.session;
   }
 
-  command(server, ns, killCursorCmd, options, (err, result) => {
-    if (err || !result) {
+  command(server, ns, killCursorCmd, options, (err, response) => {
+    if (err || !response) {
       return callback(err);
     }
 
-    const response = result.message;
     if (response.cursorNotFound) {
       return callback(new MongoNetworkError('cursor killed or timed out'), null);
     }

--- a/src/cmap/wire_protocol/query.ts
+++ b/src/cmap/wire_protocol/query.ts
@@ -33,6 +33,8 @@ export function query(
   if (maxWireVersion(server) < 4) {
     const query = prepareLegacyFindQuery(server, ns, cmd, cursorState, options);
     const queryOptions = applyCommonQueryOptions({}, cursorState);
+    queryOptions.fullResult = true;
+
     if (typeof query.documentsReturnedIn === 'string') {
       queryOptions.documentsReturnedIn = query.documentsReturnedIn;
     }

--- a/src/cursor/core_cursor.ts
+++ b/src/cursor/core_cursor.ts
@@ -510,15 +510,13 @@ export class CoreCursor<
       callback(err, result);
     };
 
-    const queryCallback: Callback = (err, r) => {
+    const queryCallback: Callback = (err, result) => {
       if (err) {
         return done(err);
       }
 
-      const result = r.message;
-
-      if (Array.isArray(result.documents) && result.documents.length === 1) {
-        const document = result.documents[0];
+      if (result.cursor) {
+        const document = result;
 
         if (result.queryFailure) {
           return done(new MongoError(document), null);
@@ -557,7 +555,7 @@ export class CoreCursor<
       // Otherwise fall back to regular find path
       const cursorId = result.cursorId || 0;
       this.cursorState.cursorId = cursorId instanceof Long ? cursorId : Long.fromNumber(cursorId);
-      this.cursorState.documents = result.documents;
+      this.cursorState.documents = result.documents || [result];
       this.cursorState.lastCursorId = result.cursorId;
 
       // Transform the results with passed in transformation method if provided

--- a/src/cursor/cursor.ts
+++ b/src/cursor/cursor.ts
@@ -905,7 +905,6 @@ export class Cursor<
     //       subclass `CommandOperationV2`. To be removed asap.
     if (this.operation && this.operation.cmd == null) {
       this.operation.options.explain = true;
-      this.operation.fullResponse = false;
       return executeOperation(this.topology, this.operation as any, callback);
     }
 

--- a/src/gridfs-stream/index.ts
+++ b/src/gridfs-stream/index.ts
@@ -216,7 +216,7 @@ function _delete(bucket: GridFSBucket, id: TFileId, callback: Callback<void>): v
       }
 
       // Delete orphaned chunks before returning FileNotFound
-      if (!res?.result.n) {
+      if (!res?.deletedCount) {
         var errmsg = 'FileNotFound: no file with id ' + id + ' found';
         return callback(new Error(errmsg));
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,6 @@ export type {
 export type { AuthMechanism } from './cmap/auth/defaultAuthProviders';
 export type { MongoCredentials, MongoCredentialsOptions } from './cmap/auth/mongo_credentials';
 export type {
-  CommandResult,
   WriteProtocolMessageType,
   Query,
   GetMore,

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -32,7 +32,6 @@ export interface AggregateOptions extends CommandOperationOptions {
   collation?: CollationOptions;
   /** Add an index selection hint to an aggregation command */
   hint?: Hint;
-  full?: boolean;
   out?: string;
 }
 
@@ -43,7 +42,7 @@ export class AggregateOperation<T = Document> extends CommandOperation<Aggregate
   hasWriteStage: boolean;
 
   constructor(parent: OperationParent, pipeline: Document[], options?: AggregateOptions) {
-    super(parent, { fullResponse: true, ...options });
+    super(parent, options);
 
     this.target =
       parent.s.namespace && parent.s.namespace.collection
@@ -115,7 +114,6 @@ export class AggregateOperation<T = Document> extends CommandOperation<Aggregate
     }
 
     if (options.explain) {
-      options.full = false;
       command.explain = options.explain;
     }
 

--- a/src/operations/common_functions.ts
+++ b/src/operations/common_functions.ts
@@ -172,9 +172,9 @@ export function removeDocuments(
     if (callback == null) return;
     if (err) return callback(err);
     if (result == null) return callback();
-    if (result.result.code) return callback(new MongoError(result.result));
-    if (result.result.writeErrors) {
-      return callback(new MongoError(result.result.writeErrors[0]));
+    if (result.code) return callback(new MongoError(result));
+    if (result.writeErrors) {
+      return callback(new MongoError(result.writeErrors[0]));
     }
 
     // Return the results
@@ -262,8 +262,8 @@ export function updateDocuments(
       if (callback == null) return;
       if (err) return callback(err);
       if (result == null) return callback();
-      if (result.result.code) return callback(new MongoError(result.result));
-      if (result.result.writeErrors) return callback(new MongoError(result.result.writeErrors[0]));
+      if (result.code) return callback(new MongoError(result));
+      if (result.writeErrors) return callback(new MongoError(result.writeErrors[0]));
       // Return the results
       callback(undefined, result);
     }

--- a/src/operations/count_documents.ts
+++ b/src/operations/count_documents.ts
@@ -39,7 +39,7 @@ export class CountDocumentsOperation extends AggregateOperation<number> {
       }
 
       // NOTE: We're avoiding creating a cursor here to reduce the callstack.
-      const response = ((result as unknown) as Document).result;
+      const response = (result as unknown) as Document;
       if (response.cursor == null || response.cursor.firstBatch == null) {
         callback(undefined, 0);
         return;

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -74,7 +74,7 @@ export class DeleteOneOperation extends CommandOperation<DeleteOptions, DeleteRe
         return callback(undefined, { acknowledged: true, deletedCount: 0, result: { ok: 1 } });
       }
 
-      r.deletedCount = r.result.n;
+      r.deletedCount = r.n;
       if (callback) callback(undefined, r);
     });
   }
@@ -112,7 +112,7 @@ export class DeleteManyOperation extends CommandOperation<DeleteOptions, DeleteR
         return callback(undefined, { acknowledged: true, deletedCount: 0, result: { ok: 1 } });
       }
 
-      r.deletedCount = r.result.n;
+      r.deletedCount = r.n;
       if (callback) callback(undefined, r);
     });
   }

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -100,7 +100,13 @@ export class FindOperation extends OperationBase<FindOptions, Document> {
 
     // TODO: use `MongoDBNamespace` through and through
     const cursorState = this.cursorState || {};
-    server.query(this.ns.toString(), this.cmd, cursorState, this.options, callback);
+    server.query(
+      this.ns.toString(),
+      this.cmd,
+      cursorState,
+      { fullResult: !!this.fullResponse, ...this.options },
+      callback
+    );
   }
 }
 

--- a/src/operations/group.ts
+++ b/src/operations/group.ts
@@ -97,11 +97,4 @@ export class EvalGroupOperation extends EvalOperation {
 
     super(collection, new Code(groupfn, scope), undefined, options);
   }
-
-  execute(server: Server, callback: Callback<Document>) {
-    super.execute(server, (err?: any, results?: any) => {
-      if (err) return callback(err);
-      callback(undefined, results.result || results);
-    });
-  }
 }

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -319,7 +319,7 @@ export class ListIndexesOperation extends CommandOperation<ListIndexesOptions, D
   collectionNamespace: MongoDBNamespace;
 
   constructor(collection: Collection, options?: ListIndexesOptions) {
-    super(collection, { fullResponse: true, ...options });
+    super(collection, options);
 
     this.collectionNamespace = collection.s.namespace;
   }

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -79,7 +79,7 @@ export class InsertOneOperation extends CommandOperation<InsertOneOptions, Inser
       // Workaround for pre 2.6 servers
       if (r == null) return callback(undefined, { insertedCount: 0, result: { ok: 1 } });
       // Add values to top level to ensure crud spec compatibility
-      r.insertedCount = r.result.n;
+      r.insertedCount = r.n;
       r.insertedId = doc._id;
       if (callback) callback(undefined, r as InsertOneResult);
     });
@@ -118,8 +118,8 @@ function insertDocuments(
       if (callback == null) return;
       if (err) return callback(err);
       if (result == null) return callback();
-      if (result.result.code) return callback(new MongoError(result.result));
-      if (result.result.writeErrors) return callback(new MongoError(result.result.writeErrors[0]));
+      if (result.code) return callback(new MongoError(result));
+      if (result.writeErrors) return callback(new MongoError(result.writeErrors[0]));
       // Add docs to the list
       result.ops = docs;
       // Return the results

--- a/src/operations/list_collections.ts
+++ b/src/operations/list_collections.ts
@@ -41,7 +41,7 @@ export class ListCollectionsOperation extends CommandOperation<ListCollectionsOp
   batchSize?: number;
 
   constructor(db: Db, filter: Document, options: ListCollectionsOptions) {
-    super(db, { fullResponse: true, ...options });
+    super(db, options);
 
     this.db = db;
     this.filter = filter;
@@ -85,13 +85,8 @@ export class ListCollectionsOperation extends CommandOperation<ListCollectionsOp
         { batchSize: this.batchSize || 1000 },
         {},
         (err, result) => {
-          if (
-            result &&
-            result.message &&
-            result.message.documents &&
-            Array.isArray(result.message.documents)
-          ) {
-            result.message.documents = result.message.documents.map(transforms.doc);
+          if (result && result.documents && Array.isArray(result.documents)) {
+            result.documents = result.documents.map(transforms.doc);
           }
 
           callback(err, result);

--- a/src/operations/replace_one.ts
+++ b/src/operations/replace_one.ts
@@ -60,18 +60,14 @@ export class ReplaceOneOperation extends CommandOperation<ReplaceOptions, Update
       if (err || !r) return callback(err);
 
       const result: UpdateResult = {
-        modifiedCount: r.result.nModified != null ? r.result.nModified : r.result.n,
+        modifiedCount: r.nModified != null ? r.nModified : r.n,
         upsertedId:
-          Array.isArray(r.result.upserted) && r.result.upserted.length > 0
-            ? r.result.upserted[0] // FIXME(major): should be `r.result.upserted[0]._id`
+          Array.isArray(r.upserted) && r.upserted.length > 0
+            ? r.upserted[0] // FIXME(major): should be `r.upserted[0]._id`
             : null,
-        upsertedCount:
-          Array.isArray(r.result.upserted) && r.result.upserted.length
-            ? r.result.upserted.length
-            : 0,
-        matchedCount:
-          Array.isArray(r.result.upserted) && r.result.upserted.length > 0 ? 0 : r.result.n,
-        result: r.result
+        upsertedCount: Array.isArray(r.upserted) && r.upserted.length ? r.upserted.length : 0,
+        matchedCount: Array.isArray(r.upserted) && r.upserted.length > 0 ? 0 : r.n,
+        result: r
       };
 
       callback(undefined, result);

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -95,18 +95,14 @@ export class UpdateOneOperation extends CommandOperation<UpdateOptions, UpdateRe
       if (err || !r) return callback(err);
 
       const result: UpdateResult = {
-        modifiedCount: r.result.nModified != null ? r.result.nModified : r.result.n,
+        modifiedCount: r.nModified != null ? r.nModified : r.n,
         upsertedId:
-          Array.isArray(r.result.upserted) && r.result.upserted.length > 0
-            ? r.result.upserted[0] // FIXME(major): should be `r.result.upserted[0]._id`
+          Array.isArray(r.upserted) && r.upserted.length > 0
+            ? r.upserted[0] // FIXME(major): should be `r.upserted[0]._id`
             : null,
-        upsertedCount:
-          Array.isArray(r.result.upserted) && r.result.upserted.length
-            ? r.result.upserted.length
-            : 0,
-        matchedCount:
-          Array.isArray(r.result.upserted) && r.result.upserted.length > 0 ? 0 : r.result.n,
-        result: r.result
+        upsertedCount: Array.isArray(r.upserted) && r.upserted.length ? r.upserted.length : 0,
+        matchedCount: Array.isArray(r.upserted) && r.upserted.length > 0 ? 0 : r.n,
+        result: r
       };
 
       callback(undefined, result);
@@ -141,18 +137,14 @@ export class UpdateManyOperation extends CommandOperation<UpdateOptions, UpdateR
       if (err || !r) return callback(err);
 
       const result: UpdateResult = {
-        modifiedCount: r.result.nModified != null ? r.result.nModified : r.result.n,
+        modifiedCount: r.nModified != null ? r.nModified : r.n,
         upsertedId:
-          Array.isArray(r.result.upserted) && r.result.upserted.length > 0
-            ? r.result.upserted[0] // FIXME(major): should be `r.result.upserted[0]._id`
+          Array.isArray(r.upserted) && r.upserted.length > 0
+            ? r.upserted[0] // FIXME(major): should be `r.upserted[0]._id`
             : null,
-        upsertedCount:
-          Array.isArray(r.result.upserted) && r.result.upserted.length
-            ? r.result.upserted.length
-            : 0,
-        matchedCount:
-          Array.isArray(r.result.upserted) && r.result.upserted.length > 0 ? 0 : r.result.n,
-        result: r.result
+        upsertedCount: Array.isArray(r.upserted) && r.upserted.length ? r.upserted.length : 0,
+        matchedCount: Array.isArray(r.upserted) && r.upserted.length > 0 ? 0 : r.n,
+        result: r
       };
 
       callback(undefined, result);

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -229,13 +229,12 @@ function checkServer(monitor: Monitor, callback: Callback<Document>) {
       );
     }
 
-    connection.command('admin.$cmd', cmd, options, (err, result) => {
+    connection.command('admin.$cmd', cmd, options, (err, isMaster) => {
       if (err) {
         failureHandler(err);
         return;
       }
 
-      const isMaster = result.result;
       const rttPinger = monitor[kRTTPinger];
       const duration =
         isAwaitable && rttPinger ? rttPinger.roundTripTime : calculateDurationInMs(start);

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -734,10 +734,7 @@ export class Topology extends EventEmitter {
 
     return new CursorClass(
       topology,
-      new RunCommandOperation({ s: { namespace: MongoDBNamespace.fromString(ns) } }, cmd, {
-        fullResponse: true,
-        ...options
-      }),
+      new RunCommandOperation({ s: { namespace: MongoDBNamespace.fromString(ns) } }, cmd, options),
       options
     );
   }

--- a/test/functional/cmap/connection.test.js
+++ b/test/functional/cmap/connection.test.js
@@ -20,10 +20,7 @@ describe('Connection', function () {
       expect(err).to.not.exist;
       this.defer(_done => conn.destroy(_done));
 
-      conn.command('admin.$cmd', { ismaster: 1 }, (err, result) => {
-        // NODE-2382: remove `result.result` when command returns just a raw response
-        const ismaster = result.result;
-
+      conn.command('admin.$cmd', { ismaster: 1 }, (err, ismaster) => {
         expect(err).to.not.exist;
         expect(ismaster).to.exist;
         expect(ismaster.ok).to.equal(1);
@@ -47,10 +44,7 @@ describe('Connection', function () {
       conn.on('commandSucceeded', event => events.push(event));
       conn.on('commandFailed', event => events.push(event));
 
-      conn.command('admin.$cmd', { ismaster: 1 }, (err, result) => {
-        // NODE-2382: remove `result.result` when command returns just a raw response
-        const ismaster = result.result;
-
+      conn.command('admin.$cmd', { ismaster: 1 }, (err, ismaster) => {
         expect(err).to.not.exist;
         expect(ismaster).to.exist;
         expect(ismaster.ok).to.equal(1);
@@ -93,13 +87,13 @@ describe('Connection', function () {
 
         conn.command(ns, { insert: 'test', documents }, (err, res) => {
           expect(err).to.not.exist;
-          expect(res).nested.property('result.n').to.equal(documents.length);
+          expect(res).nested.property('n').to.equal(documents.length);
 
           let totalDocumentsRead = 0;
           conn.command(ns, { find: 'test', batchSize: 100 }, (err, result) => {
             expect(err).to.not.exist;
-            expect(result).nested.property('result.cursor').to.exist;
-            const cursor = result.result.cursor;
+            expect(result).nested.property('cursor').to.exist;
+            const cursor = result.cursor;
             totalDocumentsRead += cursor.firstBatch.length;
 
             conn.command(
@@ -108,8 +102,8 @@ describe('Connection', function () {
               { exhaustAllowed: true },
               (err, result) => {
                 expect(err).to.not.exist;
-                expect(result).nested.property('result.cursor').to.exist;
-                const cursor = result.result.cursor;
+                expect(result).nested.property('cursor').to.exist;
+                const cursor = result.cursor;
                 totalDocumentsRead += cursor.nextBatch.length;
 
                 if (cursor.id === 0 || cursor.id.isZero()) {

--- a/test/functional/collection.test.js
+++ b/test/functional/collection.test.js
@@ -91,6 +91,8 @@ describe('Collection', function () {
                   expect(err).to.not.exist;
                   // Assert collections
                   db.collections((err, collections) => {
+                    expect(err).to.not.exist;
+
                     let found_spiderman = false;
                     let found_mario = false;
                     let found_does_not_exist = false;
@@ -334,7 +336,7 @@ describe('Collection', function () {
               configuration.writeConcernMax(),
               err => {
                 expect(err).to.not.exist;
-                expect(r.result.n).to.equal(1);
+                expect(r.n).to.equal(1);
 
                 // Remove safely
                 collection.deleteOne({}, configuration.writeConcernMax(), err => {

--- a/test/functional/core/cursor.test.js
+++ b/test/functional/core/cursor.test.js
@@ -34,7 +34,7 @@ describe('Cursor tests', function () {
             },
             (err, results) => {
               expect(err).to.not.exist;
-              expect(results.result.n).to.equal(3);
+              expect(results.n).to.equal(3);
 
               // Execute find
               var cursor = topology.cursor(ns, {
@@ -91,7 +91,7 @@ describe('Cursor tests', function () {
             },
             (err, results) => {
               expect(err).to.not.exist;
-              expect(results.result.n).to.equal(5);
+              expect(results.n).to.equal(5);
 
               // Execute find
               const cursor = topology.cursor(ns, {
@@ -151,7 +151,7 @@ describe('Cursor tests', function () {
             },
             (err, results) => {
               expect(err).to.not.exist;
-              expect(results.result.n).to.equal(1);
+              expect(results.n).to.equal(1);
 
               // Execute find
               const cursor = topology.cursor(ns, { find: 'cursor3', filter: {}, batchSize: 5 });
@@ -207,7 +207,7 @@ describe('Cursor tests', function () {
             },
             (err, results) => {
               expect(err).to.not.exist;
-              expect(results.result.n).to.equal(3);
+              expect(results.n).to.equal(3);
 
               // Execute find
               const cursor = topology.cursor(ns, { find: 'cursor4', filter: {}, batchSize: 2 });
@@ -263,7 +263,7 @@ describe('Cursor tests', function () {
             },
             (err, results) => {
               expect(err).to.not.exist;
-              expect(results.result.n).to.equal(3);
+              expect(results.n).to.equal(3);
 
               // Execute find
               const cursor = topology.cursor(ns, { find: 'cursor4', filter: {}, batchSize: 2 });
@@ -320,7 +320,7 @@ describe('Cursor tests', function () {
           },
           function (err, results) {
             expect(err).to.not.exist;
-            expect(results.result.n).to.equal(3);
+            expect(results.n).to.equal(3);
 
             // Execute find
             var cursor = _server.cursor(ns, { find: 'cursor5', filter: {}, batchSize: 2 });
@@ -385,7 +385,7 @@ describe('Cursor tests', function () {
   //         },
   //         function(err, results) {
   //           expect(err).to.not.exist;
-  //           expect(results.result.n).to.equal(1);
+  //           expect(results.n).to.equal(1);
 
   //           // Execute slow find
   //           var cursor = server.cursor(ns, {

--- a/test/functional/core/extend_cursor.test.js
+++ b/test/functional/core/extend_cursor.test.js
@@ -64,7 +64,7 @@ describe('Extend cursor tests', function () {
             },
             (err, results) => {
               expect(err).to.not.exist;
-              expect(results.result.n).to.equal(3);
+              expect(results).property('n').to.equal(3);
 
               // Execute find
               const cursor = topology.cursor(ns, { find: 'inserts_extend_cursors', filter: {} });

--- a/test/functional/core/tailable_cursor.test.js
+++ b/test/functional/core/tailable_cursor.test.js
@@ -42,7 +42,7 @@ describe('Tailable cursor tests', function () {
                 },
                 (insertErr, results) => {
                   expect(insertErr).to.not.exist;
-                  expect(results.result.n).to.equal(1);
+                  expect(results.n).to.equal(1);
 
                   // Execute find
                   const cursor = topology.cursor(ns, {

--- a/test/functional/core/undefined.test.js
+++ b/test/functional/core/undefined.test.js
@@ -36,7 +36,7 @@ describe('A server', function () {
               },
               (insertErr, results) => {
                 expect(insertErr).to.not.exist;
-                expect(results.result.n).to.eql(1);
+                expect(results.n).to.eql(1);
 
                 // Execute find
                 var cursor = topology.cursor(ns, {
@@ -96,7 +96,7 @@ describe('A server', function () {
               },
               (insertErr, results) => {
                 expect(insertErr).to.not.exist;
-                expect(results.result.n).to.eql(1);
+                expect(results.n).to.eql(1);
 
                 // Execute find
                 const cursor = topology.cursor(ns, {
@@ -153,7 +153,7 @@ describe('A server', function () {
               },
               (insertErr, results) => {
                 expect(insertErr).to.not.exist;
-                expect(results.result.n).to.eql(2);
+                expect(results.n).to.eql(2);
 
                 // Execute the write
                 server.remove(
@@ -171,7 +171,7 @@ describe('A server', function () {
                   },
                   (removeErr, removeResults) => {
                     expect(removeErr).to.not.exist;
-                    expect(removeResults.result.n).to.eql(2);
+                    expect(removeResults.n).to.eql(2);
 
                     // Destroy the connection
                     server.destroy(done);
@@ -217,7 +217,7 @@ describe('A server', function () {
               },
               (insertErr, results) => {
                 expect(insertErr).to.not.exist;
-                expect(results.result.n).to.eql(2);
+                expect(results.n).to.eql(2);
 
                 // Execute the write
                 server.remove(
@@ -234,7 +234,7 @@ describe('A server', function () {
                   },
                   (removeErr, removeResults) => {
                     expect(removeErr).to.not.exist;
-                    expect(removeResults.result.n).to.eql(1);
+                    expect(removeResults.n).to.eql(1);
 
                     // Destroy the connection
                     server.destroy();

--- a/test/functional/crud_api.test.js
+++ b/test/functional/crud_api.test.js
@@ -313,7 +313,7 @@ describe('CRUD API', function () {
         var insertOne = function () {
           db.collection('t2_3').insertOne({ a: 1 }, { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('insertedCount').to.equal(1);
             test.equal(1, r.insertedCount);
             test.ok(r.insertedId != null);
 
@@ -343,7 +343,7 @@ describe('CRUD API', function () {
         var bulkWriteUnOrdered = function () {
           db.collection('t2_5').insertMany([{ c: 1 }], { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('insertedCount').to.equal(1);
 
             db.collection('t2_5').bulkWrite(
               [
@@ -424,7 +424,7 @@ describe('CRUD API', function () {
         var bulkWriteOrdered = function () {
           db.collection('t2_7').insertMany([{ c: 1 }], { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('insertedCount').to.equal(1);
 
             db.collection('t2_7').bulkWrite(
               [
@@ -462,7 +462,7 @@ describe('CRUD API', function () {
         var bulkWriteOrderedCrudSpec = function () {
           db.collection('t2_8').insertMany([{ c: 1 }], { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('insertedCount').to.equal(1);
 
             db.collection('t2_8').bulkWrite(
               [
@@ -521,7 +521,7 @@ describe('CRUD API', function () {
             r
           ) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('upsertedCount').to.equal(1);
 
             updateOne();
           });
@@ -533,7 +533,7 @@ describe('CRUD API', function () {
         var updateOne = function () {
           db.collection('t3_2').insertMany([{ c: 1 }], { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('insertedCount').to.equal(1);
 
             db.collection('t3_2').updateOne(
               { a: 1 },
@@ -541,13 +541,13 @@ describe('CRUD API', function () {
               { upsert: true },
               function (err, r) {
                 expect(err).to.not.exist;
-                test.equal(1, r.result.n);
+                expect(r).property('upsertedCount').to.equal(1);
                 test.equal(0, r.matchedCount);
                 test.ok(r.upsertedId != null);
 
                 db.collection('t3_2').updateOne({ c: 1 }, { $set: { a: 1 } }, function (err, r) {
                   expect(err).to.not.exist;
-                  test.equal(1, r.result.n);
+                  expect(r).property('modifiedCount').to.equal(1);
                   test.equal(1, r.matchedCount);
                   test.ok(r.upsertedId == null);
 
@@ -564,7 +564,7 @@ describe('CRUD API', function () {
         var replaceOne = function () {
           db.collection('t3_3').replaceOne({ a: 1 }, { a: 2 }, { upsert: true }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('upsertedCount').to.equal(1);
             test.equal(0, r.matchedCount);
             test.ok(r.upsertedId != null);
 
@@ -573,7 +573,7 @@ describe('CRUD API', function () {
               r
             ) {
               expect(err).to.not.exist;
-              test.equal(1, r.result.n);
+              expect(r).property('modifiedCount').to.equal(1);
               test.ok(r.result.upserted == null);
 
               test.equal(1, r.matchedCount);
@@ -590,7 +590,7 @@ describe('CRUD API', function () {
         var updateMany = function () {
           db.collection('t3_4').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(2, r.result.n);
+            expect(r).property('insertedCount').to.equal(2);
 
             db.collection('t3_4').updateMany(
               { a: 1 },
@@ -598,7 +598,7 @@ describe('CRUD API', function () {
               { upsert: true, w: 1 },
               function (err, r) {
                 expect(err).to.not.exist;
-                test.equal(2, r.result.n);
+                expect(r).property('modifiedCount').to.equal(2);
                 test.equal(2, r.matchedCount);
                 test.ok(r.upsertedId == null);
 
@@ -643,11 +643,11 @@ describe('CRUD API', function () {
         var legacyRemove = function () {
           db.collection('t4_1').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(2, r.result.n);
+            test.equal(2, r.insertedCount);
 
             db.collection('t4_1').remove({ a: 1 }, { single: true }, function (err, r) {
               expect(err).to.not.exist;
-              test.equal(1, r.result.n);
+              test.equal(1, r.deletedCount);
 
               deleteOne();
             });
@@ -658,14 +658,13 @@ describe('CRUD API', function () {
         // Update one method
         // -------------------------------------------------
         var deleteOne = function () {
-          db.collection('t4_2').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function (err, r) {
+          db.collection('t4_2').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, (err, r) => {
             expect(err).to.not.exist;
-            test.equal(2, r.result.n);
+            expect(r).property('insertedCount').to.equal(2);
 
-            db.collection('t4_2').deleteOne({ a: 1 }, function (err, r) {
+            db.collection('t4_2').deleteOne({ a: 1 }, (err, r) => {
               expect(err).to.not.exist;
-              test.equal(1, r.result.n);
-              test.equal(1, r.deletedCount);
+              expect(r).property('deletedCount').to.equal(1);
 
               deleteMany();
             });
@@ -676,14 +675,13 @@ describe('CRUD API', function () {
         // Update many method
         // -------------------------------------------------
         var deleteMany = function () {
-          db.collection('t4_3').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, function (err, r) {
+          db.collection('t4_3').insertMany([{ a: 1 }, { a: 1 }], { w: 1 }, (err, r) => {
             expect(err).to.not.exist;
-            test.equal(2, r.result.n);
+            expect(r).property('insertedCount').to.equal(2);
 
-            db.collection('t4_3').deleteMany({ a: 1 }, function (err, r) {
+            db.collection('t4_3').deleteMany({ a: 1 }, (err, r) => {
               expect(err).to.not.exist;
-              test.equal(2, r.result.n);
-              test.equal(2, r.deletedCount);
+              expect(r).property('deletedCount').to.equal(2);
 
               client.close(done);
             });
@@ -714,7 +712,7 @@ describe('CRUD API', function () {
         var findOneAndRemove = function () {
           db.collection('t5_1').insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('insertedCount').to.equal(1);
 
             db.collection('t5_1').findOneAndDelete(
               { a: 1 },
@@ -736,7 +734,7 @@ describe('CRUD API', function () {
         var findOneAndReplace = function () {
           db.collection('t5_2').insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('insertedCount').to.equal(1);
 
             db.collection('t5_2').findOneAndReplace(
               { a: 1 },
@@ -765,7 +763,7 @@ describe('CRUD API', function () {
         var findOneAndUpdate = function () {
           db.collection('t5_3').insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('insertedCount').to.equal(1);
 
             db.collection('t5_3').findOneAndUpdate(
               { a: 1 },
@@ -834,27 +832,27 @@ describe('CRUD API', function () {
         var col = db.collection('shouldCorrectlyExecuteInsertOneWithW0');
         col.insertOne({ a: 1 }, { w: 0 }, function (err, result) {
           expect(err).to.not.exist;
-          test.equal(1, result.result.ok);
+          test.equal(1, result.ok);
 
           col.insertMany([{ a: 1 }], { w: 0 }, function (err, result) {
             expect(err).to.not.exist;
-            test.equal(1, result.result.ok);
+            expect(result).to.exist;
 
             col.updateOne({ a: 1 }, { $set: { b: 1 } }, { w: 0 }, function (err, result) {
               expect(err).to.not.exist;
-              test.equal(1, result.result.ok);
+              expect(result).to.exist;
 
               col.updateMany({ a: 1 }, { $set: { b: 1 } }, { w: 0 }, function (err, result) {
                 expect(err).to.not.exist;
-                test.equal(1, result.result.ok);
+                expect(result).to.exist;
 
                 col.deleteOne({ a: 1 }, { w: 0 }, function (err, result) {
                   expect(err).to.not.exist;
-                  test.equal(1, result.result.ok);
+                  expect(result).to.exist;
 
                   col.deleteMany({ a: 1 }, { w: 0 }, function (err, result) {
                     expect(err).to.not.exist;
-                    test.equal(1, result.result.ok);
+                    expect(result).to.exist;
 
                     client.close(done);
                   });

--- a/test/functional/insert.test.js
+++ b/test/functional/insert.test.js
@@ -2527,28 +2527,4 @@ describe('Insert', function () {
       });
     }
   });
-
-  it('should return result using toJSON', {
-    metadata: { requires: { topology: ['single'] } },
-
-    test: function (done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
-
-      client.connect(function (err, client) {
-        const db = client.db(configuration.db);
-        db.collection('to_json').insertOne({ _id: 0 }, (err, result) => {
-          const jsonResult = result.toJSON();
-          expect(jsonResult.ok).to.equal(1);
-          expect(jsonResult.n).to.equal(1);
-          expect(jsonResult.insertedCount).to.equal(1);
-          expect(jsonResult.ops).to.deep.equal([{ _id: 0 }]);
-          expect(jsonResult.insertedId).to.equal(0);
-          expect(jsonResult.result).to.deep.equal({ n: 1, ok: 1 });
-
-          client.close(done);
-        });
-      });
-    }
-  });
 });

--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -2715,7 +2715,7 @@ describe('Operation Examples', function () {
           // Remove all the document
           collection.removeOne({ a: 1 }, { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(1, r.result.n);
+            expect(r).property('deletedCount').to.equal(1);
             client.close(done);
           });
         });

--- a/test/functional/operation_generators_example.test.js
+++ b/test/functional/operation_generators_example.test.js
@@ -2000,7 +2000,7 @@ describe('Operation (Generators)', function () {
         yield collection.insertMany([{ a: 1 }, { b: 2 }], { w: 1 });
         // Remove all the document
         var r = yield collection.removeOne({ a: 1 }, { w: 1 });
-        test.equal(1, r.result.n);
+        expect(r).property('deletedCount').to.equal(1);
         yield client.close();
       });
       // END

--- a/test/functional/operation_promises_example.test.js
+++ b/test/functional/operation_promises_example.test.js
@@ -2039,7 +2039,7 @@ describe('Operation (Promises)', function () {
             return collection.removeOne({ a: 1 }, { w: 1 });
           })
           .then(function (r) {
-            test.equal(1, r.result.n);
+            expect(r).property('deletedCount').to.equal(1);
             return client.close();
           });
       });

--- a/test/functional/remove.test.js
+++ b/test/functional/remove.test.js
@@ -1,11 +1,10 @@
 'use strict';
-var test = require('./shared').assert;
 const { expect } = require('chai');
-var setupDatabsae = require('./shared').setupDatabase;
+const { setupDatabase } = require('./shared');
 
 describe('Remove', function () {
   before(function () {
-    return setupDatabsae(this.configuration);
+    return setupDatabase(this.configuration);
   });
 
   it('should correctly clear out collection', {
@@ -14,13 +13,13 @@ describe('Remove', function () {
     },
 
     test: function (done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
+      const self = this;
+      const client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
       client.connect(function (err, client) {
-        var db = client.db(self.configuration.db);
+        const db = client.db(self.configuration.db);
         expect(err).to.not.exist;
 
         db.createCollection('test_clear', function (err) {
@@ -37,15 +36,17 @@ describe('Remove', function () {
 
                 collection.count(function (err, count) {
                   expect(err).to.not.exist;
-                  test.equal(2, count);
+                  expect(count).to.equal(2);
+
                   // Clear the collection
                   collection.remove({}, { w: 1 }, function (err, r) {
                     expect(err).to.not.exist;
-                    test.equal(2, r.result.n);
+                    expect(r).property('deletedCount').to.equal(2);
 
                     collection.count(function (err, count) {
                       expect(err).to.not.exist;
-                      test.equal(0, count);
+                      expect(count).to.equal(0);
+
                       // Let's close the db
                       client.close(done);
                     });
@@ -65,13 +66,13 @@ describe('Remove', function () {
     },
 
     test: function (done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
+      const self = this;
+      const client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
       client.connect(function (err, client) {
-        var db = client.db(self.configuration.db);
+        const db = client.db(self.configuration.db);
         expect(err).to.not.exist;
 
         db.createCollection('test_remove_regexp', function (err) {
@@ -85,10 +86,12 @@ describe('Remove', function () {
 
               // Clear the collection
               collection.remove({ address: /485 7th ave/ }, { w: 1 }, function (err, r) {
-                test.equal(1, r.result.n);
+                expect(r).property('deletedCount').to.equal(1);
 
                 collection.count(function (err, count) {
-                  test.equal(0, count);
+                  expect(err).to.not.exist;
+                  expect(count).to.equal(0);
+
                   // Let's close the db
                   client.close(done);
                 });
@@ -106,13 +109,13 @@ describe('Remove', function () {
     },
 
     test: function (done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
+      const self = this;
+      const client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
       client.connect(function (err, client) {
-        var db = client.db(self.configuration.db);
+        const db = client.db(self.configuration.db);
         expect(err).to.not.exist;
 
         db.createCollection('shouldCorrectlyRemoveOnlyFirstDocument', function (err) {
@@ -126,10 +129,10 @@ describe('Remove', function () {
 
               // Remove the first
               collection.remove({ a: 1 }, { w: 1, single: true }, function (err, r) {
-                test.equal(1, r.result.n);
+                expect(r).property('deletedCount').to.equal(1);
 
                 collection.find({ a: 1 }).count(function (err, result) {
-                  test.equal(3, result);
+                  expect(result).to.equal(3);
                   client.close(done);
                 });
               });
@@ -146,13 +149,13 @@ describe('Remove', function () {
     },
 
     test: function (done) {
-      var self = this;
-      var client = self.configuration.newClient(self.configuration.writeConcernMax(), {
+      const self = this;
+      const client = self.configuration.newClient(self.configuration.writeConcernMax(), {
         poolSize: 1
       });
 
       client.connect(function (err, client) {
-        var db = client.db(self.configuration.db);
+        const db = client.db(self.configuration.db);
         expect(err).to.not.exist;
         const collection = db.collection('remove_test');
 


### PR DESCRIPTION
We no longer special case some paths for command responses, and always return the server's repsonse document. This allows us to fully isolate the connection layer from the rest of the codebase by preventing the propagation of connections to the response handlers of all operations.

NODE-2780