### PR TITLE
fix: SASL's signature consists of the string representation of the payload, not base64

### DIFF
--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -181,11 +181,9 @@ function continueScramConversation(
   const clientKey = HMAC(cryptoMethod, saltedPassword, 'Client Key');
   const serverKey = HMAC(cryptoMethod, saltedPassword, 'Server Key');
   const storedKey = H(cryptoMethod, clientKey);
-  const authMessage = [
-    clientFirstMessageBare(username, nonce),
-    payload.value().toString('base64'),
-    withoutProof
-  ].join(',');
+  const authMessage = [clientFirstMessageBare(username, nonce), payload.value(), withoutProof].join(
+    ','
+  );
 
   const clientSignature = HMAC(cryptoMethod, storedKey, authMessage);
   const clientProof = `p=${xor(clientKey, clientSignature)}`;


### PR DESCRIPTION
`payload.value()` already returns a string, so calling on it `toString('base64')`
implies the signature consists of a base64 representation, but the plain string is required.
The first argument ('base64') of String.toString is dropped, so although the code works
as expected (by accident) it implies that it was desired to have a base64 there, which is wrong.

Dropped the toString() call to not confuse driver authors when they want to get inspiration
from this JS driver.