### PR TITLE
refactor: clean up bulk operations for easier typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "build:docs": "gulp doc",
     "check:bench": "node test/benchmarks/driverBench",
     "check:coverage": "nyc npm run check:test",
-    "check:lint": "eslint -v && eslint --max-warnings=258 --ext '.js,.ts' src test",
+    "check:lint": "eslint -v && eslint --max-warnings=0 --ext '.js,.ts' src test",
     "check:test": "mocha --recursive test/functional test/unit",
     "check:ts": "tsc --noEmit",
     "check:atlas": "mocha --config \"test/manual/mocharc.json\" test/manual/atlas_connectivity.test.js",

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1,43 +1,61 @@
 import { PromiseProvider } from '../promise_provider';
-import { Long, ObjectId } from '../bson';
-import { MongoError, MongoWriteConcernError } from '../error';
+import { Long, ObjectId, Document } from '../bson';
+import { MongoError, MongoWriteConcernError, AnyError } from '../error';
 import {
   applyWriteConcern,
   applyRetryableWrites,
   executeLegacyOperation,
-  isPromiseLike,
   hasAtomicOperators,
   maxWireVersion,
-  Callback
+  Callback,
+  MongoDBNamespace
 } from '../utils';
 import { executeOperation } from '../operations/execute_operation';
 import { InsertOperation } from '../operations/insert';
 import { UpdateOperation } from '../operations/update';
 import { DeleteOperation } from '../operations/delete';
-import type { WriteConcern } from '../write_concern';
+import { WriteConcern } from '../write_concern';
+import type { Collection } from '../collection';
+import type { Topology } from '../sdam/topology';
+import type { CommandOperationOptions } from '../operations/command';
 
 // Error codes
 const WRITE_CONCERN_ERROR = 64;
 
-// Insert types
-const INSERT = 1;
-const UPDATE = 2;
-const REMOVE = 3;
+export enum BatchType {
+  INSERT = 1,
+  UPDATE = 2,
+  REMOVE = 3
+}
+
+interface BulkResult {
+  ok: number;
+  writeErrors: WriteError[];
+  writeConcernErrors: WriteConcernError[];
+  insertedIds: Document[];
+  nInserted: number;
+  nUpserted: number;
+  nMatched: number;
+  nModified: number;
+  nRemoved: number;
+  upserted: Document[];
+  opTime?: Document;
+}
 
 /**
  * Keeps the state of a unordered batch so we can rewrite the results
  * correctly after command execution
  */
-class Batch {
-  originalZeroIndex: any;
-  currentIndex: any;
-  originalIndexes: any;
-  batchType: any;
-  operations: any;
-  size: any;
-  sizeBytes: any;
+export class Batch {
+  originalZeroIndex: number;
+  currentIndex: number;
+  originalIndexes: number[];
+  batchType: BatchType;
+  operations: Document[];
+  size: number;
+  sizeBytes: number;
 
-  constructor(batchType: any, originalZeroIndex: any) {
+  constructor(batchType: BatchType, originalZeroIndex: number) {
     this.originalZeroIndex = originalZeroIndex;
     this.currentIndex = 0;
     this.originalIndexes = [];
@@ -53,8 +71,7 @@ class Batch {
  * The result of a bulk write.
  */
 export class BulkWriteResult {
-  result: any;
-  n: number;
+  result: BulkResult;
 
   /** Number of documents inserted. */
   insertedCount: number;
@@ -73,12 +90,9 @@ export class BulkWriteResult {
 
   /**
    * Create a new BulkWriteResult instance
-   *
-   * **NOTE:** Internal Type, do not instantiate directly
-   *
-   * @param bulkResult
+   * @internal
    */
-  constructor(bulkResult: any) {
+  constructor(bulkResult: BulkResult) {
     this.result = bulkResult;
     this.insertedCount = bulkResult.nInserted;
     this.matchedCount = bulkResult.nMatched;
@@ -87,9 +101,6 @@ export class BulkWriteResult {
     this.upsertedCount = bulkResult.upserted.length;
     this.upsertedIds = {};
     this.insertedIds = {};
-
-    // Update the n
-    this.n = bulkResult.insertedCount;
 
     // Inserted documents
     const inserted = bulkResult.insertedIds;
@@ -106,150 +117,84 @@ export class BulkWriteResult {
     }
   }
 
-  /**
-   * Evaluates to true if the bulk operation correctly executes
-   *
-   * @type {boolean}
-   */
-  get ok() {
+  /** Evaluates to true if the bulk operation correctly executes */
+  get ok(): number {
     return this.result.ok;
   }
 
-  /**
-   * The number of inserted documents
-   *
-   * @type {number}
-   */
-  get nInserted() {
+  /** The number of inserted documents */
+  get nInserted(): number {
     return this.result.nInserted;
   }
 
-  /**
-   * Number of upserted documents
-   *
-   * @type {number}
-   */
-  get nUpserted() {
+  /** Number of upserted documents */
+  get nUpserted(): number {
     return this.result.nUpserted;
   }
 
-  /**
-   * Number of matched documents
-   *
-   * @type {number}
-   */
-  get nMatched() {
+  /** Number of matched documents */
+  get nMatched(): number {
     return this.result.nMatched;
   }
 
-  /**
-   * Number of documents updated physically on disk
-   *
-   * @type {number}
-   */
-  get nModified() {
+  /** Number of documents updated physically on disk */
+  get nModified(): number {
     return this.result.nModified;
   }
 
-  /**
-   * Number of removed documents
-   *
-   * @type {number}
-   */
-  get nRemoved() {
+  /** Number of removed documents */
+  get nRemoved(): number {
     return this.result.nRemoved;
   }
 
-  /**
-   * Returns an array of all inserted ids
-   *
-   * @returns {object[]}
-   */
-  getInsertedIds(): object[] {
+  /** Returns an array of all inserted ids */
+  getInsertedIds(): Document[] {
     return this.result.insertedIds;
   }
 
-  /**
-   * Returns an array of all upserted ids
-   *
-   * @returns {object[]}
-   */
-  getUpsertedIds(): object[] {
+  /** Returns an array of all upserted ids */
+  getUpsertedIds(): Document[] {
     return this.result.upserted;
   }
 
-  /**
-   * Returns the upserted id at the given index
-   *
-   * @param index the number of the upserted id to return, returns undefined if no result for passed in index
-   * @returns {object}
-   */
-  getUpsertedIdAt(index: number): object {
+  /** Returns the upserted id at the given index */
+  getUpsertedIdAt(index: number): Document | undefined {
     return this.result.upserted[index];
   }
 
-  /**
-   * Returns raw internal result
-   *
-   * @returns {object}
-   */
-  getRawResponse(): object {
+  /** Returns raw internal result */
+  getRawResponse(): Document {
     return this.result;
   }
 
-  /**
-   * Returns true if the bulk operation contains a write error
-   *
-   * @returns {boolean}
-   */
+  /** Returns true if the bulk operation contains a write error */
   hasWriteErrors(): boolean {
     return this.result.writeErrors.length > 0;
   }
 
-  /**
-   * Returns the number of write errors off the bulk operation
-   *
-   * @returns {number}
-   */
+  /** Returns the number of write errors off the bulk operation */
   getWriteErrorCount(): number {
     return this.result.writeErrors.length;
   }
 
-  /**
-   * Returns a specific write error object
-   *
-   * @param index of the write error to return, returns null if there is no result for passed in index
-   * @returns {WriteError|undefined}
-   */
+  /** Returns a specific write error object */
   getWriteErrorAt(index: number): WriteError | undefined {
     if (index < this.result.writeErrors.length) {
       return this.result.writeErrors[index];
     }
   }
 
-  /**
-   * Retrieve all write errors
-   *
-   * @returns {WriteError[]}
-   */
+  /** Retrieve all write errors */
   getWriteErrors(): WriteError[] {
     return this.result.writeErrors;
   }
 
-  /**
-   * Retrieve lastOp if available
-   *
-   * @returns {object}
-   */
-  getLastOp(): object {
-    return this.result.lastOp;
+  /** Retrieve lastOp if available */
+  getLastOp(): Document | undefined {
+    return this.result.opTime;
   }
 
-  /**
-   * Retrieve the write concern error if any
-   *
-   * @returns {WriteConcernError|undefined}
-   */
+  /** Retrieve the write concern error if one exists */
   getWriteConcernError(): WriteConcernError | undefined {
     if (this.result.writeConcernErrors.length === 0) {
       return;
@@ -271,23 +216,14 @@ export class BulkWriteResult {
     }
   }
 
-  /**
-   * @returns {object}
-   */
   toJSON(): object {
     return this.result;
   }
 
-  /**
-   * @returns {string}
-   */
   toString(): string {
     return `BulkWriteResult(${this.toJSON()})`;
   }
 
-  /**
-   * @returns {boolean}
-   */
   isOk(): boolean {
     return this.result.ok === 1;
   }
@@ -301,45 +237,24 @@ export class BulkWriteResult {
 export class WriteConcernError {
   err: any;
 
-  /**
-   * Create a new WriteConcernError instance
-   *
-   * **NOTE:** Internal Type, do not instantiate directly
-   *
-   * @param err
-   */
   constructor(err: any) {
     this.err = err;
   }
 
-  /**
-   * Write concern error code.
-   *
-   * @type {number}
-   */
-  get code() {
+  /** Write concern error code. */
+  get code(): number {
     return this.err.code;
   }
 
-  /**
-   * Write concern error message.
-   *
-   * @type {string}
-   */
-  get errmsg() {
+  /** Write concern error message. */
+  get errmsg(): string {
     return this.err.errmsg;
   }
 
-  /**
-   * @returns {object}
-   */
-  toJSON(): object {
+  toJSON(): { code: number; errmsg: string } {
     return { code: this.err.code, errmsg: this.err.errmsg };
   }
 
-  /**
-   * @returns {string}
-   */
   toString(): string {
     return `WriteConcernError(${this.err.errmsg})`;
   }
@@ -353,83 +268,54 @@ export class WriteConcernError {
 export class WriteError {
   err: any;
 
-  /**
-   * Create a new WriteError instance
-   *
-   * **NOTE:** Internal Type, do not instantiate directly
-   *
-   * @param err
-   */
   constructor(err: any) {
     this.err = err;
   }
 
-  /**
-   * WriteError code.
-   *
-   * @type {number}
-   */
-  get code() {
+  /** WriteError code. */
+  get code(): number {
     return this.err.code;
   }
 
-  /**
-   * WriteError original bulk operation index.
-   *
-   * @type {number}
-   */
-  get index() {
+  /** WriteError original bulk operation index. */
+  get index(): number {
     return this.err.index;
   }
 
-  /**
-   * WriteError message.
-   *
-   * @type {string}
-   */
-  get errmsg() {
+  /** WriteError message. */
+  get errmsg(): string | undefined {
     return this.err.errmsg;
   }
 
-  /**
-   * Returns the underlying operation that caused the error
-   *
-   * @returns {object}
-   */
-  getOperation(): object {
+  /** Returns the underlying operation that caused the error */
+  getOperation(): any {
     return this.err.op;
   }
 
-  /**
-   * @returns {object}
-   */
-  toJSON(): object {
+  toJSON(): { code: number; index: number; errmsg?: string; op: any } {
     return { code: this.err.code, index: this.err.index, errmsg: this.err.errmsg, op: this.err.op };
   }
 
-  /**
-   * @returns {string}
-   */
   toString(): string {
     return `WriteError(${JSON.stringify(this.toJSON())})`;
   }
 }
 
-/**
- * Merges results into shared data structure
- *
- * @param batch
- * @param bulkResult
- * @param err
- * @param result
- */
-function mergeBatchResults(batch: any, bulkResult: any, err: any, result: any) {
+/** Merges results into shared data structure */
+function mergeBatchResults(
+  batch: Batch,
+  bulkResult: BulkResult,
+  err?: AnyError,
+  result?: Document
+): void {
   // If we have an error set the result to be the err object
   if (err) {
     result = err;
   } else if (result && result.result) {
     result = result.result;
-  } else if (result == null) {
+  }
+
+  if (result == null) {
     return;
   }
 
@@ -458,22 +344,22 @@ function mergeBatchResults(batch: any, bulkResult: any, err: any, result: any) {
 
     // We have a time stamp
     if (opTime && opTime._bsontype === 'Timestamp') {
-      if (bulkResult.lastOp == null) {
-        bulkResult.lastOp = opTime;
-      } else if (opTime.greaterThan(bulkResult.lastOp)) {
-        bulkResult.lastOp = opTime;
+      if (bulkResult.opTime == null) {
+        bulkResult.opTime = opTime;
+      } else if (opTime.greaterThan(bulkResult.opTime)) {
+        bulkResult.opTime = opTime;
       }
     } else {
       // Existing TS
-      if (bulkResult.lastOp) {
+      if (bulkResult.opTime) {
         lastOpTS =
-          typeof bulkResult.lastOp.ts === 'number'
-            ? Long.fromNumber(bulkResult.lastOp.ts)
-            : bulkResult.lastOp.ts;
+          typeof bulkResult.opTime.ts === 'number'
+            ? Long.fromNumber(bulkResult.opTime.ts)
+            : bulkResult.opTime.ts;
         lastOpT =
-          typeof bulkResult.lastOp.t === 'number'
-            ? Long.fromNumber(bulkResult.lastOp.t)
-            : bulkResult.lastOp.t;
+          typeof bulkResult.opTime.t === 'number'
+            ? Long.fromNumber(bulkResult.opTime.t)
+            : bulkResult.opTime.t;
       }
 
       // Current OpTime TS
@@ -481,25 +367,25 @@ function mergeBatchResults(batch: any, bulkResult: any, err: any, result: any) {
       const opTimeT = typeof opTime.t === 'number' ? Long.fromNumber(opTime.t) : opTime.t;
 
       // Compare the opTime's
-      if (bulkResult.lastOp == null) {
-        bulkResult.lastOp = opTime;
+      if (bulkResult.opTime == null) {
+        bulkResult.opTime = opTime;
       } else if (opTimeTS.greaterThan(lastOpTS)) {
-        bulkResult.lastOp = opTime;
+        bulkResult.opTime = opTime;
       } else if (opTimeTS.equals(lastOpTS)) {
         if (opTimeT.greaterThan(lastOpT)) {
-          bulkResult.lastOp = opTime;
+          bulkResult.opTime = opTime;
         }
       }
     }
   }
 
   // If we have an insert Batch type
-  if (batch.batchType === INSERT && result.n) {
+  if (batch.batchType === BatchType.INSERT && result.n) {
     bulkResult.nInserted = bulkResult.nInserted + result.n;
   }
 
   // If we have an insert Batch type
-  if (batch.batchType === REMOVE && result.n) {
+  if (batch.batchType === BatchType.REMOVE && result.n) {
     bulkResult.nRemoved = bulkResult.nRemoved + result.n;
   }
 
@@ -525,7 +411,7 @@ function mergeBatchResults(batch: any, bulkResult: any, err: any, result: any) {
   }
 
   // If we have an update Batch type
-  if (batch.batchType === UPDATE && result.n) {
+  if (batch.batchType === BatchType.UPDATE && result.n) {
     const nModified = result.nModified;
     bulkResult.nUpserted = bulkResult.nUpserted + nUpserted;
     bulkResult.nMatched = bulkResult.nMatched + (result.n - nUpserted);
@@ -533,7 +419,7 @@ function mergeBatchResults(batch: any, bulkResult: any, err: any, result: any) {
     if (typeof nModified === 'number') {
       bulkResult.nModified = bulkResult.nModified + nModified;
     } else {
-      bulkResult.nModified = null;
+      bulkResult.nModified = 0;
     }
   }
 
@@ -555,14 +441,18 @@ function mergeBatchResults(batch: any, bulkResult: any, err: any, result: any) {
   }
 }
 
-function executeCommands(bulkOperation: any, options: any, callback: Callback<BulkWriteResult>) {
+function executeCommands(
+  bulkOperation: BulkOperationBase,
+  options: BulkWriteOptions,
+  callback: Callback<BulkWriteResult>
+) {
   if (bulkOperation.s.batches.length === 0) {
     return callback(undefined, new BulkWriteResult(bulkOperation.s.bulkResult));
   }
 
-  const batch = bulkOperation.s.batches.shift();
+  const batch = bulkOperation.s.batches.shift() as Batch;
 
-  function resultHandler(err?: any, result?: any) {
+  function resultHandler(err?: any, result?: Document) {
     // Error is a driver related error not a bulk op error, terminate
     if (((err && err.driver) || (err && err.message)) && !(err instanceof MongoWriteConcernError)) {
       return callback(err);
@@ -587,28 +477,91 @@ function executeCommands(bulkOperation: any, options: any, callback: Callback<Bu
     executeCommands(bulkOperation, options, callback);
   }
 
-  bulkOperation.finalOptionsHandler({ options, batch, resultHandler }, callback);
+  const finalOptions = Object.assign({ ordered: bulkOperation.isOrdered }, options);
+  if (bulkOperation.s.writeConcern != null) {
+    finalOptions.writeConcern = bulkOperation.s.writeConcern;
+  }
+
+  if (finalOptions.bypassDocumentValidation !== true) {
+    delete finalOptions.bypassDocumentValidation;
+  }
+
+  // Set an operationIf if provided
+  if (bulkOperation.operationId) {
+    resultHandler.operationId = bulkOperation.operationId;
+  }
+
+  // Serialize functions
+  if (bulkOperation.s.options.serializeFunctions) {
+    finalOptions.serializeFunctions = true;
+  }
+
+  // Ignore undefined
+  if (bulkOperation.s.options.ignoreUndefined) {
+    finalOptions.ignoreUndefined = true;
+  }
+
+  // Is the bypassDocumentValidation options specific
+  if (bulkOperation.s.bypassDocumentValidation === true) {
+    finalOptions.bypassDocumentValidation = true;
+  }
+
+  // Is the checkKeys option disabled
+  if (bulkOperation.s.checkKeys === false) {
+    finalOptions.checkKeys = false;
+  }
+
+  if (finalOptions.retryWrites) {
+    if (batch.batchType === BatchType.UPDATE) {
+      finalOptions.retryWrites = finalOptions.retryWrites && !batch.operations.some(op => op.multi);
+    }
+
+    if (batch.batchType === BatchType.REMOVE) {
+      finalOptions.retryWrites =
+        finalOptions.retryWrites && !batch.operations.some(op => op.limit === 0);
+    }
+  }
+
+  try {
+    if (batch.batchType === BatchType.INSERT) {
+      executeOperation(
+        bulkOperation.s.topology,
+        new InsertOperation(bulkOperation.s.namespace, batch.operations, finalOptions),
+        resultHandler
+      );
+    } else if (batch.batchType === BatchType.UPDATE) {
+      executeOperation(
+        bulkOperation.s.topology,
+        new UpdateOperation(bulkOperation.s.namespace, batch.operations, finalOptions),
+        resultHandler
+      );
+    } else if (batch.batchType === BatchType.REMOVE) {
+      executeOperation(
+        bulkOperation.s.topology,
+        new DeleteOperation(bulkOperation.s.namespace, batch.operations, finalOptions),
+        resultHandler
+      );
+    }
+  } catch (err) {
+    // Force top level error
+    err.ok = 0;
+    // Merge top level error and return
+    mergeBatchResults(batch, bulkOperation.s.bulkResult, err, undefined);
+    callback();
+  }
 }
 
-/**
- * handles write concern error
- *
- * @param batch
- * @param bulkResult
- * @param err
- * @param callback
- */
 function handleMongoWriteConcernError(
-  batch: object,
-  bulkResult: object,
-  err: any,
-  callback: Callback
+  batch: Batch,
+  bulkResult: BulkResult,
+  err: MongoWriteConcernError,
+  callback: Callback<BulkWriteResult>
 ) {
-  mergeBatchResults(batch, bulkResult, null, err.result);
+  mergeBatchResults(batch, bulkResult, undefined, err.result);
 
   const wrappedWriteConcernError = new WriteConcernError({
-    errmsg: err.result.writeConcernError.errmsg,
-    code: err.result.writeConcernError.result
+    errmsg: err.result?.writeConcernError.errmsg,
+    code: err.result?.writeConcernError.result
   });
 
   callback(
@@ -621,15 +574,10 @@ function handleMongoWriteConcernError(
  * @public
  * @category Error
  */
-class BulkWriteError extends MongoError {
-  result: any;
+export class BulkWriteError extends MongoError {
+  result?: BulkWriteResult;
 
-  /**
-   * Creates a new BulkWriteError
-   *
-   * @param error The error message
-   * @param result The result of the bulk write operation
-   */
+  /** Creates a new BulkWriteError */
   constructor(error?: any, result?: BulkWriteResult) {
     const message = error.err || error.errmsg || error.errMessage || error;
     super(message);
@@ -642,73 +590,60 @@ class BulkWriteError extends MongoError {
 }
 
 /**
- * @classdesc A builder object that is returned from {@link BulkOperationBase#find}.
+ * A builder object that is returned from {@link BulkOperationBase#find}.
  * Is used to build a write operation that involves a query filter.
  */
 class FindOperators {
-  s: any;
+  bulkOperation: BulkOperationBase;
 
   /**
    * Creates a new FindOperators object.
-   *
-   * **NOTE:** Internal Type, do not instantiate directly
-   *
-   * @param bulkOperation
+   * @internal
    */
-  constructor(bulkOperation: any) {
-    this.s = bulkOperation.s;
+  constructor(bulkOperation: BulkOperationBase) {
+    this.bulkOperation = bulkOperation;
   }
 
-  /**
-   * Add a multiple update operation to the bulk operation
-   *
-   * @function
-   * @param updateDocument An update field for an update operation. See {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-u u documentation}
-   * @param reference for more information.
-   * @throws MongoError If operation cannot be added to bulk write
-   * @returns {any} A reference to the parent BulkOperation
-   */
-  update(updateDocument: any): any {
+  /** Add a multiple update operation to the bulk operation */
+  update(updateDocument: Document): BulkOperationBase {
     // Perform upsert
-    const upsert = typeof this.s.currentOp.upsert === 'boolean' ? this.s.currentOp.upsert : false;
+    const upsert =
+      typeof this.bulkOperation.s.currentOp.upsert === 'boolean'
+        ? this.bulkOperation.s.currentOp.upsert
+        : false;
 
     // Establish the update command
-    const document = {
-      q: this.s.currentOp.selector,
+    const document: Document = {
+      q: this.bulkOperation.s.currentOp.selector,
       u: updateDocument,
       multi: true,
       upsert: upsert
-    } as any;
+    };
 
     if (updateDocument.hint) {
       document.hint = updateDocument.hint;
     }
 
     // Clear out current Op
-    this.s.currentOp = null;
-    return this.s.options.addToOperationsList(this, UPDATE, document);
+    this.bulkOperation.s.currentOp = null;
+    return this.bulkOperation.addToOperationsList(BatchType.UPDATE, document);
   }
 
-  /**
-   * Add a single update operation to the bulk operation
-   *
-   * @function
-   * @param updateDocument An update field for an update operation. See {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-u u documentation}
-   * @param reference for more information.
-   * @throws {MongoError} If operation cannot be added to bulk write
-   * @returns {any} A reference to the parent BulkOperation
-   */
-  updateOne(updateDocument: any): any {
+  /** Add a single update operation to the bulk operation */
+  updateOne(updateDocument: Document): BulkOperationBase {
     // Perform upsert
-    const upsert = typeof this.s.currentOp.upsert === 'boolean' ? this.s.currentOp.upsert : false;
+    const upsert =
+      typeof this.bulkOperation.s.currentOp.upsert === 'boolean'
+        ? this.bulkOperation.s.currentOp.upsert
+        : false;
 
     // Establish the update command
-    const document = {
-      q: this.s.currentOp.selector,
+    const document: Document = {
+      q: this.bulkOperation.s.currentOp.selector,
       u: updateDocument,
       multi: false,
       upsert: upsert
-    } as any;
+    };
 
     if (updateDocument.hint) {
       document.hint = updateDocument.hint;
@@ -719,28 +654,25 @@ class FindOperators {
     }
 
     // Clear out current Op
-    this.s.currentOp = null;
-    return this.s.options.addToOperationsList(this, UPDATE, document);
+    this.bulkOperation.s.currentOp = null;
+    return this.bulkOperation.addToOperationsList(BatchType.UPDATE, document);
   }
 
-  /**
-   * Add a replace one operation to the bulk operation
-   *
-   * @param replacement the new document to replace the existing one with
-   * @throws {MongoError} If operation cannot be added to bulk write
-   * @returns {void} A reference to the parent BulkOperation
-   */
-  replaceOne(replacement: any) {
+  /** Add a replace one operation to the bulk operation */
+  replaceOne(replacement: Document): BulkOperationBase {
     // Perform upsert
-    const upsert = typeof this.s.currentOp.upsert === 'boolean' ? this.s.currentOp.upsert : false;
+    const upsert =
+      typeof this.bulkOperation.s.currentOp.upsert === 'boolean'
+        ? this.bulkOperation.s.currentOp.upsert
+        : false;
 
     // Establish the update command
-    const document = {
-      q: this.s.currentOp.selector,
+    const document: Document = {
+      q: this.bulkOperation.s.currentOp.selector,
       u: replacement,
       multi: false,
       upsert: upsert
-    } as any;
+    };
 
     if (replacement.hint) {
       document.hint = replacement.hint;
@@ -751,98 +683,115 @@ class FindOperators {
     }
 
     // Clear out current Op
-    this.s.currentOp = null;
-    return this.s.options.addToOperationsList(this, UPDATE, document);
+    this.bulkOperation.s.currentOp = undefined;
+    return this.bulkOperation.addToOperationsList(BatchType.UPDATE, document);
   }
 
-  /**
-   * Upsert modifier for update bulk operation, noting that this operation is an upsert.
-   *
-   * @function
-   * @throws {MongoError} If operation cannot be added to bulk write
-   * @returns {FindOperators} reference to self
-   */
-  upsert(): FindOperators {
-    this.s.currentOp.upsert = true;
+  /** Upsert modifier for update bulk operation, noting that this operation is an upsert. */
+  upsert(): this {
+    this.bulkOperation.s.currentOp.upsert = true;
     return this;
   }
 
-  /**
-   * Add a delete one operation to the bulk operation
-   *
-   * @function
-   * @throws {MongoError} If operation cannot be added to bulk write
-   * @returns {any} A reference to the parent BulkOperation
-   */
-  deleteOne(): any {
+  /** Add a delete one operation to the bulk operation */
+  deleteOne(): BulkOperationBase {
     // Establish the update command
     const document = {
-      q: this.s.currentOp.selector,
+      q: this.bulkOperation.s.currentOp.selector,
       limit: 1
     };
 
     // Clear out current Op
-    this.s.currentOp = null;
-    return this.s.options.addToOperationsList(this, REMOVE, document);
+    this.bulkOperation.s.currentOp = null;
+    return this.bulkOperation.addToOperationsList(BatchType.REMOVE, document);
   }
 
-  /**
-   * Add a delete many operation to the bulk operation
-   *
-   * @function
-   * @throws {MongoError} If operation cannot be added to bulk write
-   * @returns {any} A reference to the parent BulkOperation
-   */
-  delete(): any {
+  /** Add a delete many operation to the bulk operation */
+  delete(): BulkOperationBase {
     // Establish the update command
     const document = {
-      q: this.s.currentOp.selector,
+      q: this.bulkOperation.s.currentOp.selector,
       limit: 0
     };
 
     // Clear out current Op
-    this.s.currentOp = null;
-    return this.s.options.addToOperationsList(this, REMOVE, document);
+    this.bulkOperation.s.currentOp = null;
+    return this.bulkOperation.addToOperationsList(BatchType.REMOVE, document);
   }
 
-  /**
-   * backwards compatability for deleteOne
-   */
   removeOne() {
     return this.deleteOne();
   }
 
-  /**
-   * backwards compatability for delete
-   */
   remove() {
     return this.delete();
   }
 }
 
-/**
- * @classdesc Parent class to OrderedBulkOperation and UnorderedBulkOperation
- *
- * **NOTE:** Internal Type, do not instantiate directly
- */
-class BulkOperationBase {
-  isOrdered: any;
-  s: any;
-  operationId: any;
+interface BulkOperationPrivate {
+  bulkResult: BulkResult;
+  currentBatch?: Batch;
+  currentIndex: number;
+  // ordered specific
+  currentBatchSize: number;
+  currentBatchSizeBytes: number;
+  // unordered specific
+  currentInsertBatch?: Batch;
+  currentUpdateBatch?: Batch;
+  currentRemoveBatch?: Batch;
+  batches: Batch[];
+  // Write concern
+  writeConcern?: WriteConcern;
+  // Max batch size options
+  maxBsonObjectSize: number;
+  maxBatchSizeBytes: number;
+  maxWriteBatchSize: number;
+  maxKeySize: number;
+  // Namespace
+  namespace: MongoDBNamespace;
+  // Topology
+  topology: Topology;
+  // Options
+  options: BulkWriteOptions;
+  // Current operation
+  currentOp?: any;
+  // Executed
+  executed: boolean;
+  // Collection
+  collection: Collection;
+  // Fundamental error
+  err?: AnyError;
+  // check keys
+  checkKeys: boolean;
+  bypassDocumentValidation?: boolean;
+}
+
+/** @public */
+export interface BulkWriteOptions extends CommandOperationOptions {
+  /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
+  bypassDocumentValidation?: boolean;
+  /** If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails. */
+  ordered?: boolean;
+  /** @deprecated use `ordered` instead */
+  keepGoing?: boolean;
+  /** Force server to assign _id values instead of driver. */
+  forceServerObjectId?: boolean;
+}
+
+export abstract class BulkOperationBase {
+  isOrdered: boolean;
+  s: BulkOperationPrivate;
+  operationId?: number;
 
   /**
    * Create a new OrderedBulkOperation or UnorderedBulkOperation instance
-   *
-   * @property {number} length Get the number of operations in the bulk.
-   * @param topology
-   * @param collection
-   * @param options
-   * @param isOrdered
+   * @internal
    */
-  constructor(topology: any, collection: any, options: any, isOrdered: any) {
+  constructor(collection: Collection, options: BulkWriteOptions, isOrdered: boolean) {
     // determine whether bulkOperation is ordered or unordered
     this.isOrdered = isOrdered;
 
+    const topology = collection.s.topology;
     options = options == null ? {} : options;
     // TODO Bring from driver information in isMaster
     // Get the namespace for the write operations
@@ -876,10 +825,9 @@ class BulkOperationBase {
     let finalOptions = Object.assign({}, options);
     finalOptions = applyRetryableWrites(finalOptions, collection.s.db);
     finalOptions = applyWriteConcern(finalOptions, { collection: collection }, options);
-    const writeConcern = finalOptions.writeConcern;
 
     // Final results
-    const bulkResult = {
+    const bulkResult: BulkResult = {
       ok: 1,
       writeErrors: [],
       writeConcernErrors: [],
@@ -895,39 +843,39 @@ class BulkOperationBase {
     // Internal state
     this.s = {
       // Final result
-      bulkResult: bulkResult,
+      bulkResult,
       // Current batch state
-      currentBatch: null,
+      currentBatch: undefined,
       currentIndex: 0,
       // ordered specific
       currentBatchSize: 0,
       currentBatchSizeBytes: 0,
       // unordered specific
-      currentInsertBatch: null,
-      currentUpdateBatch: null,
-      currentRemoveBatch: null,
+      currentInsertBatch: undefined,
+      currentUpdateBatch: undefined,
+      currentRemoveBatch: undefined,
       batches: [],
       // Write concern
-      writeConcern: writeConcern,
+      writeConcern: WriteConcern.fromOptions(options),
       // Max batch size options
       maxBsonObjectSize,
       maxBatchSizeBytes,
       maxWriteBatchSize,
       maxKeySize,
       // Namespace
-      namespace: namespace,
+      namespace,
       // Topology
-      topology: topology,
+      topology,
       // Options
       options: finalOptions,
       // Current operation
-      currentOp: currentOp,
+      currentOp,
       // Executed
-      executed: executed,
+      executed,
       // Collection
-      collection: collection,
+      collection,
       // Fundamental error
-      err: null,
+      err: undefined,
       // check keys
       checkKeys: typeof options.checkKeys === 'boolean' ? options.checkKeys : true
     };
@@ -941,35 +889,32 @@ class BulkOperationBase {
   /**
    * Add a single insert document to the bulk operation
    *
-   * @param document the document to insert
-   * @throws {MongoError}
-   * @returns {BulkOperationBase} A reference to self
-   *
    * @example
+   * ```js
    * const bulkOp = collection.initializeOrderedBulkOp();
+   *
    * // Adds three inserts to the bulkOp.
    * bulkOp
    *   .insert({ a: 1 })
    *   .insert({ b: 2 })
    *   .insert({ c: 3 });
    * await bulkOp.execute();
+   * ```
    */
-  insert(document: any): BulkOperationBase {
-    if (this.s.collection.s.db.options.forceServerObjectId !== true && document._id == null)
+  insert(document: Document): BulkOperationBase {
+    if (document._id == null && shouldForceServerObjectId(this)) {
       document._id = new ObjectId();
-    return this.s.options.addToOperationsList(this, INSERT, document);
+    }
+
+    return this.addToOperationsList(BatchType.INSERT, document);
   }
 
   /**
    * Builds a find operation for an update/updateOne/delete/deleteOne/replaceOne.
    * Returns a builder object used to complete the definition of the operation.
    *
-   * @function
-   * @param selector The selector for the bulk operation. See {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-q q documentation}
-   * @throws {MongoError} if a selector is not specified
-   * @returns {FindOperators} A helper object with which the write operation can be defined.
-   *
    * @example
+   * ```js
    * const bulkOp = collection.initializeOrderedBulkOp();
    *
    * // Add an updateOne to the bulkOp
@@ -997,8 +942,9 @@ class BulkOperationBase {
    *
    * // All of the ops will now be executed
    * await bulkOp.execute();
+   * ```
    */
-  find(selector: object): FindOperators {
+  find(selector: Document): FindOperators {
     if (!selector) {
       throw TypeError('Bulk find operation must specify a selector');
     }
@@ -1011,22 +957,9 @@ class BulkOperationBase {
     return new FindOperators(this);
   }
 
-  /**
-   * Specifies a raw operation to perform in the bulk write.
-   *
-   * @function
-   * @param op The raw operation to perform.
-   * @param reference for more information.
-   * @returns {BulkOperationBase} A reference to self
-   */
-  raw(op: any): BulkOperationBase {
+  /** Specifies a raw operation to perform in the bulk write. */
+  raw(op: Document): BulkOperationBase {
     const key = Object.keys(op)[0];
-
-    // Set up the force server object id
-    const forceServerObjectId =
-      typeof this.s.options.forceServerObjectId === 'boolean'
-        ? this.s.options.forceServerObjectId
-        : this.s.collection.s.db.options.forceServerObjectId;
 
     // Update operations
     if (
@@ -1035,7 +968,7 @@ class BulkOperationBase {
       (op.replaceOne && op.replaceOne.q)
     ) {
       op[key].multi = op.updateOne || op.replaceOne ? false : true;
-      return this.s.options.addToOperationsList(this, UPDATE, op[key]);
+      return this.addToOperationsList(BatchType.UPDATE, op[key]);
     }
 
     // Crud spec update format
@@ -1047,11 +980,11 @@ class BulkOperationBase {
       }
 
       const multi = op.updateOne || op.replaceOne ? false : true;
-      const operation = {
+      const operation: Document = {
         q: op[key].filter,
         u: op[key].update || op[key].replacement,
         multi: multi
-      } as any;
+      };
 
       if (op[key].hint) {
         operation.hint = op[key].hint;
@@ -1072,7 +1005,7 @@ class BulkOperationBase {
         operation.arrayFilters = op[key].arrayFilters;
       }
 
-      return this.s.options.addToOperationsList(this, UPDATE, operation);
+      return this.addToOperationsList(BatchType.UPDATE, operation);
     }
 
     // Remove operations
@@ -1083,38 +1016,39 @@ class BulkOperationBase {
       (op.deleteMany && op.deleteMany.q)
     ) {
       op[key].limit = op.removeOne ? 1 : 0;
-      return this.s.options.addToOperationsList(this, REMOVE, op[key]);
+      return this.addToOperationsList(BatchType.REMOVE, op[key]);
     }
 
     // Crud spec delete operations, less efficient
     if (op.deleteOne || op.deleteMany) {
       const limit = op.deleteOne ? 1 : 0;
-      const operation = { q: op[key].filter, limit: limit } as any;
+      const operation: Document = { q: op[key].filter, limit: limit };
       if (op[key].hint) {
         operation.hint = op[key].hint;
       }
       if (this.isOrdered) {
         if (op.collation) operation.collation = op.collation;
       }
-      return this.s.options.addToOperationsList(this, REMOVE, operation);
+      return this.addToOperationsList(BatchType.REMOVE, operation);
     }
 
     // Insert operations
+    const forceServerObjectId = shouldForceServerObjectId(this);
     if (op.insertOne && op.insertOne.document == null) {
       if (forceServerObjectId !== true && op.insertOne._id == null)
         op.insertOne._id = new ObjectId();
-      return this.s.options.addToOperationsList(this, INSERT, op.insertOne);
+      return this.addToOperationsList(BatchType.INSERT, op.insertOne);
     } else if (op.insertOne && op.insertOne.document) {
       if (forceServerObjectId !== true && op.insertOne.document._id == null)
         op.insertOne.document._id = new ObjectId();
-      return this.s.options.addToOperationsList(this, INSERT, op.insertOne.document);
+      return this.addToOperationsList(BatchType.INSERT, op.insertOne.document);
     }
 
     if (op.insertMany) {
       for (let i = 0; i < op.insertMany.length; i++) {
         if (forceServerObjectId !== true && op.insertMany[i]._id == null)
           op.insertMany[i]._id = new ObjectId();
-        this.s.options.addToOperationsList(this, INSERT, op.insertMany[i]);
+        this.addToOperationsList(BatchType.INSERT, op.insertMany[i]);
       }
 
       return this;
@@ -1126,37 +1060,13 @@ class BulkOperationBase {
     );
   }
 
-  /**
-   * helper function to assist with promiseOrCallback behavior
-   *
-   * @param err
-   * @param callback
-   */
-  _handleEarlyError(err?: any, callback?: any): Promise<void> | void {
-    const Promise = PromiseProvider.get();
-
-    if (typeof callback === 'function') {
-      callback(err, null);
-      return;
-    }
-
-    return Promise.reject(err);
-  }
-
-  /**
-   * An internal helper method. Do not invoke directly. Will be going away in the future
-   *
-   * @function
-   * @param _writeConcern
-   * @param options
-   * @param callback
-   */
-  bulkExecute(
+  /** An internal helper method. Do not invoke directly. Will be going away in the future */
+  execute(
     _writeConcern?: WriteConcern,
-    options?: object,
-    callback?: Callback
-  ): Promise<void> | { options: any; callback?: Callback } | void {
-    if (typeof options === 'function') (callback = options as Callback), (options = {});
+    options?: BulkWriteOptions,
+    callback?: Callback<BulkWriteResult>
+  ): Promise<void> | void {
+    if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
     if (typeof _writeConcern === 'function') {
@@ -1167,7 +1077,7 @@ class BulkOperationBase {
 
     if (this.s.executed) {
       const executedError = new MongoError('batch cannot be re-executed');
-      return this._handleEarlyError(executedError, callback);
+      return handleEarlyError(executedError, callback);
     }
 
     // If we have current batch
@@ -1181,142 +1091,20 @@ class BulkOperationBase {
     // If we have no operations in the bulk raise an error
     if (this.s.batches.length === 0) {
       const emptyBatchError = new TypeError('Invalid Operation, no operations specified');
-      return this._handleEarlyError(emptyBatchError, callback);
+      return handleEarlyError(emptyBatchError, callback);
     }
-    return { options, callback };
-  }
-
-  /**
-   * The callback format for results
-   *
-   * @callback BulkOperationBase~resultCallback
-   * @param error An error instance representing the error during the execution.
-   * @param result The bulk write result.
-   */
-
-  /**
-   * Execute the bulk operation
-   *
-   * @function
-   * @param [_writeConcern] Optional write concern. Can also be specified through options.
-   * @param [options] Optional settings.
-   * @param [options.w] The write concern.
-   * @param [options.wtimeout] The write concern timeout.
-   * @param [options.j=false] Specify a journal write concern.
-   * @param [options.fsync=false] Specify a file sync write concern.
-   * @param [callback] A callback that will be invoked when bulkWrite finishes/errors
-   * @throws {MongoError} Throws error if the bulk object has already been executed
-   * @throws {MongoError} Throws error if the bulk object does not have any operations
-   * @returns {Promise<void>|void} returns Promise if no callback passed
-   */
-  execute(_writeConcern?: WriteConcern, options?: any, callback?: Callback): Promise<void> | void {
-    const ret = this.bulkExecute(_writeConcern, options, callback!);
-    if (!ret || isPromiseLike(ret as any)) {
-      return ret as Promise<void>;
-    }
-
-    options = (ret as any).options;
-    callback = (ret as any).callback;
 
     return executeLegacyOperation(this.s.topology, executeCommands, [this, options, callback]);
   }
 
   /**
-   * Handles final options before executing command
-   *
-   * An internal method. Do not invoke. Will not be accessible in the future
-   *
-   * @param config
-   * @param config.options
-   * @param config.batch
-   * @param config.resultHandler
-   * @param callback
-   */
-  finalOptionsHandler(config: any, callback: Callback) {
-    const finalOptions = Object.assign({ ordered: this.isOrdered }, config.options);
-    if (this.s.writeConcern != null) {
-      finalOptions.writeConcern = this.s.writeConcern;
-    }
-
-    if (finalOptions.bypassDocumentValidation !== true) {
-      delete finalOptions.bypassDocumentValidation;
-    }
-
-    // Set an operationIf if provided
-    if (this.operationId) {
-      config.resultHandler.operationId = this.operationId;
-    }
-
-    // Serialize functions
-    if (this.s.options.serializeFunctions) {
-      finalOptions.serializeFunctions = true;
-    }
-
-    // Ignore undefined
-    if (this.s.options.ignoreUndefined) {
-      finalOptions.ignoreUndefined = true;
-    }
-
-    // Is the bypassDocumentValidation options specific
-    if (this.s.bypassDocumentValidation === true) {
-      finalOptions.bypassDocumentValidation = true;
-    }
-
-    // Is the checkKeys option disabled
-    if (this.s.checkKeys === false) {
-      finalOptions.checkKeys = false;
-    }
-
-    if (finalOptions.retryWrites) {
-      if (config.batch.batchType === UPDATE) {
-        finalOptions.retryWrites =
-          finalOptions.retryWrites && !config.batch.operations.some((op: any) => op.multi);
-      }
-
-      if (config.batch.batchType === REMOVE) {
-        finalOptions.retryWrites =
-          finalOptions.retryWrites && !config.batch.operations.some((op: any) => op.limit === 0);
-      }
-    }
-
-    try {
-      if (config.batch.batchType === INSERT) {
-        executeOperation(
-          this.s.topology,
-          new InsertOperation(this.s.namespace, config.batch.operations, finalOptions),
-          config.resultHandler
-        );
-      } else if (config.batch.batchType === UPDATE) {
-        executeOperation(
-          this.s.topology,
-          new UpdateOperation(this.s.namespace, config.batch.operations, finalOptions),
-          config.resultHandler
-        );
-      } else if (config.batch.batchType === REMOVE) {
-        executeOperation(
-          this.s.topology,
-          new DeleteOperation(this.s.namespace, config.batch.operations, finalOptions),
-          config.resultHandler
-        );
-      }
-    } catch (err) {
-      // Force top level error
-      err.ok = 0;
-      // Merge top level error and return
-      callback(undefined, mergeBatchResults(config.batch, this.s.bulkResult, err, null));
-    }
-  }
-
-  /**
    * Handles the write error before executing commands
-   *
-   * An internal helper method. Do not invoke directly. Will be going away in the future
-   *
-   * @param callback
-   * @param writeResult
-   * @returns {boolean|undefined}
+   * @internal
    */
-  handleWriteError(callback: Callback, writeResult: any): boolean | undefined {
+  handleWriteError(
+    callback: Callback<BulkWriteResult>,
+    writeResult: BulkWriteResult
+  ): boolean | undefined {
     if (this.s.bulkResult.writeErrors.length > 0) {
       const msg = this.s.bulkResult.writeErrors[0].errmsg
         ? this.s.bulkResult.writeErrors[0].errmsg
@@ -1336,11 +1124,14 @@ class BulkOperationBase {
       return true;
     }
 
-    if (writeResult.getWriteConcernError()) {
-      callback(new BulkWriteError(new MongoError(writeResult.getWriteConcernError()), writeResult));
+    const writeConcernError = writeResult.getWriteConcernError();
+    if (writeConcernError) {
+      callback(new BulkWriteError(new MongoError(writeConcernError), writeResult));
       return true;
     }
   }
+
+  abstract addToOperationsList(batchType: BatchType, document: Document): BulkOperationBase;
 }
 
 Object.defineProperty(BulkOperationBase.prototype, 'length', {
@@ -1350,4 +1141,28 @@ Object.defineProperty(BulkOperationBase.prototype, 'length', {
   }
 });
 
-export { Batch, BulkOperationBase, INSERT, UPDATE, REMOVE, BulkWriteError };
+/** helper function to assist with promiseOrCallback behavior */
+function handleEarlyError(
+  err?: AnyError,
+  callback?: Callback<BulkWriteResult>
+): Promise<void> | void {
+  const Promise = PromiseProvider.get();
+  if (typeof callback === 'function') {
+    callback(err);
+    return;
+  }
+
+  return Promise.reject(err);
+}
+
+function shouldForceServerObjectId(bulkOperation: BulkOperationBase): boolean {
+  if (typeof bulkOperation.s.options.forceServerObjectId === 'boolean') {
+    return bulkOperation.s.options.forceServerObjectId;
+  }
+
+  if (typeof bulkOperation.s.collection.s.db.options?.forceServerObjectId === 'boolean') {
+    return bulkOperation.s.collection.s.db.options?.forceServerObjectId;
+  }
+
+  return false;
+}

--- a/src/bulk/ordered.ts
+++ b/src/bulk/ordered.ts
@@ -1,108 +1,73 @@
 import * as BSON from '../bson';
-import { BulkOperationBase, Batch, INSERT } from './common';
+import { BulkOperationBase, Batch, BatchType, BulkWriteOptions } from './common';
+import type { Document } from '../bson';
+import type { Collection } from '../collection';
 
-/**
- * Add to internal list of Operations
- *
- * @param bulkOperation
- * @param docType number indicating the document type
- * @param document
- * @returns {OrderedBulkOperation}
- */
-function addToOperationsList(
-  bulkOperation: OrderedBulkOperation,
-  docType: number,
-  document: any
-): OrderedBulkOperation {
-  // Get the bsonSize
-  const bsonSize = BSON.calculateObjectSize(document, {
-    checkKeys: false,
-    // Since we don't know what the user selected for BSON options here,
-    // err on the safe side, and check the size with ignoreUndefined: false.
-    ignoreUndefined: false
-  } as any);
-
-  // Throw error if the doc is bigger than the max BSON size
-  if (bsonSize >= bulkOperation.s.maxBsonObjectSize)
-    throw new TypeError(
-      `Document is larger than the maximum size ${bulkOperation.s.maxBsonObjectSize}`
-    );
-
-  // Create a new batch object if we don't have a current one
-  if (bulkOperation.s.currentBatch == null)
-    bulkOperation.s.currentBatch = new Batch(docType, bulkOperation.s.currentIndex);
-
-  const maxKeySize = bulkOperation.s.maxKeySize;
-
-  // Check if we need to create a new batch
-  if (
-    // New batch if we exceed the max batch op size
-    bulkOperation.s.currentBatchSize + 1 >= bulkOperation.s.maxWriteBatchSize ||
-    // New batch if we exceed the maxBatchSizeBytes. Only matters if batch already has a doc,
-    // since we can't sent an empty batch
-    (bulkOperation.s.currentBatchSize > 0 &&
-      bulkOperation.s.currentBatchSizeBytes + maxKeySize + bsonSize >=
-        bulkOperation.s.maxBatchSizeBytes) ||
-    // New batch if the new op does not have the same op type as the current batch
-    bulkOperation.s.currentBatch.batchType !== docType
-  ) {
-    // Save the batch to the execution stack
-    bulkOperation.s.batches.push(bulkOperation.s.currentBatch);
-
-    // Create a new batch
-    bulkOperation.s.currentBatch = new Batch(docType, bulkOperation.s.currentIndex);
-
-    // Reset the current size trackers
-    bulkOperation.s.currentBatchSize = 0;
-    bulkOperation.s.currentBatchSizeBytes = 0;
+class OrderedBulkOperation extends BulkOperationBase {
+  constructor(collection: Collection, options: BulkWriteOptions) {
+    super(collection, options, true);
   }
 
-  if (docType === INSERT) {
-    bulkOperation.s.bulkResult.insertedIds.push({
-      index: bulkOperation.s.currentIndex,
-      _id: document._id
-    });
-  }
+  addToOperationsList(batchType: BatchType, document: Document): OrderedBulkOperation {
+    // Get the bsonSize
+    const bsonSize = BSON.calculateObjectSize(document, {
+      checkKeys: false,
+      // Since we don't know what the user selected for BSON options here,
+      // err on the safe side, and check the size with ignoreUndefined: false.
+      ignoreUndefined: false
+    } as any);
 
-  // We have an array of documents
-  if (Array.isArray(document)) {
-    throw new TypeError('Operation passed in cannot be an Array');
-  }
+    // Throw error if the doc is bigger than the max BSON size
+    if (bsonSize >= this.s.maxBsonObjectSize)
+      throw new TypeError(`Document is larger than the maximum size ${this.s.maxBsonObjectSize}`);
 
-  bulkOperation.s.currentBatch.originalIndexes.push(bulkOperation.s.currentIndex);
-  bulkOperation.s.currentBatch.operations.push(document);
-  bulkOperation.s.currentBatchSize += 1;
-  bulkOperation.s.currentBatchSizeBytes += maxKeySize + bsonSize;
-  bulkOperation.s.currentIndex += 1;
+    // Create a new batch object if we don't have a current one
+    if (this.s.currentBatch == null) {
+      this.s.currentBatch = new Batch(batchType, this.s.currentIndex);
+    }
 
-  // Return bulkOperation
-  return bulkOperation;
-}
+    const maxKeySize = this.s.maxKeySize;
 
-/**
- * Create a new OrderedBulkOperation instance (INTERNAL TYPE, do not instantiate directly)
- *
- * @class
- * @extends BulkOperationBase
- * @property {number} length Get the number of operations in the bulk.
- * @returns {OrderedBulkOperation} a OrderedBulkOperation instance.
- */
-export class OrderedBulkOperation extends BulkOperationBase {
-  constructor(topology: any, collection: any, options: any) {
-    options = options || {};
-    options = Object.assign(options, { addToOperationsList });
+    // Check if we need to create a new batch
+    if (
+      // New batch if we exceed the max batch op size
+      this.s.currentBatchSize + 1 >= this.s.maxWriteBatchSize ||
+      // New batch if we exceed the maxBatchSizeBytes. Only matters if batch already has a doc,
+      // since we can't sent an empty batch
+      (this.s.currentBatchSize > 0 &&
+        this.s.currentBatchSizeBytes + maxKeySize + bsonSize >= this.s.maxBatchSizeBytes) ||
+      // New batch if the new op does not have the same op type as the current batch
+      this.s.currentBatch.batchType !== batchType
+    ) {
+      // Save the batch to the execution stack
+      this.s.batches.push(this.s.currentBatch);
 
-    super(topology, collection, options, true);
+      // Create a new batch
+      this.s.currentBatch = new Batch(batchType, this.s.currentIndex);
+
+      // Reset the current size trackers
+      this.s.currentBatchSize = 0;
+      this.s.currentBatchSizeBytes = 0;
+    }
+
+    if (batchType === BatchType.INSERT) {
+      this.s.bulkResult.insertedIds.push({ index: this.s.currentIndex, _id: document._id });
+    }
+
+    // We have an array of documents
+    if (Array.isArray(document)) {
+      throw new TypeError('Operation passed in cannot be an Array');
+    }
+
+    this.s.currentBatch.originalIndexes.push(this.s.currentIndex);
+    this.s.currentBatch.operations.push(document);
+    this.s.currentBatchSize += 1;
+    this.s.currentBatchSizeBytes += maxKeySize + bsonSize;
+    this.s.currentIndex += 1;
+    return this;
   }
 }
 
-/**
- * Returns an unordered batch object
- *
- * @param topology
- * @param collection
- * @param options
- */
-export function initializeOrderedBulkOp(topology: any, collection: any, options: any) {
-  return new OrderedBulkOperation(topology, collection, options);
+export function initializeOrderedBulkOp(collection: Collection, options: BulkWriteOptions) {
+  return new OrderedBulkOperation(collection, options);
 }

--- a/src/bulk/unordered.ts
+++ b/src/bulk/unordered.ts
@@ -1,124 +1,14 @@
 import * as BSON from '../bson';
-import { BulkOperationBase, Batch, INSERT, UPDATE, REMOVE } from './common';
+import { BulkOperationBase, Batch, BatchType, BulkWriteOptions } from './common';
 import type { Callback } from '../utils';
+import type { Document } from '../bson';
+import type { Collection } from '../collection';
 
-/**
- * Add to internal list of Operations
- *
- * @param bulkOperation
- * @param docType number indicating the document type
- * @param document
- * @returns {UnorderedBulkOperation}
- */
-function addToOperationsList(
-  bulkOperation: UnorderedBulkOperation,
-  docType: number,
-  document: any
-): UnorderedBulkOperation {
-  // Get the bsonSize
-  const bsonSize = BSON.calculateObjectSize(document, {
-    checkKeys: false,
-
-    // Since we don't know what the user selected for BSON options here,
-    // err on the safe side, and check the size with ignoreUndefined: false.
-    ignoreUndefined: false
-  } as any);
-  // Throw error if the doc is bigger than the max BSON size
-  if (bsonSize >= bulkOperation.s.maxBsonObjectSize) {
-    throw new TypeError(
-      `Document is larger than the maximum size ${bulkOperation.s.maxBsonObjectSize}`
-    );
+class UnorderedBulkOperation extends BulkOperationBase {
+  constructor(collection: Collection, options: BulkWriteOptions) {
+    super(collection, options, false);
   }
 
-  // Holds the current batch
-  bulkOperation.s.currentBatch = null;
-  // Get the right type of batch
-  if (docType === INSERT) {
-    bulkOperation.s.currentBatch = bulkOperation.s.currentInsertBatch;
-  } else if (docType === UPDATE) {
-    bulkOperation.s.currentBatch = bulkOperation.s.currentUpdateBatch;
-  } else if (docType === REMOVE) {
-    bulkOperation.s.currentBatch = bulkOperation.s.currentRemoveBatch;
-  }
-
-  const maxKeySize = bulkOperation.s.maxKeySize;
-
-  // Create a new batch object if we don't have a current one
-  if (bulkOperation.s.currentBatch == null)
-    bulkOperation.s.currentBatch = new Batch(docType, bulkOperation.s.currentIndex);
-
-  // Check if we need to create a new batch
-  if (
-    // New batch if we exceed the max batch op size
-    bulkOperation.s.currentBatch.size + 1 >= bulkOperation.s.maxWriteBatchSize ||
-    // New batch if we exceed the maxBatchSizeBytes. Only matters if batch already has a doc,
-    // since we can't sent an empty batch
-    (bulkOperation.s.currentBatch.size > 0 &&
-      bulkOperation.s.currentBatch.sizeBytes + maxKeySize + bsonSize >=
-        bulkOperation.s.maxBatchSizeBytes) ||
-    // New batch if the new op does not have the same op type as the current batch
-    bulkOperation.s.currentBatch.batchType !== docType
-  ) {
-    // Save the batch to the execution stack
-    bulkOperation.s.batches.push(bulkOperation.s.currentBatch);
-
-    // Create a new batch
-    bulkOperation.s.currentBatch = new Batch(docType, bulkOperation.s.currentIndex);
-  }
-
-  // We have an array of documents
-  if (Array.isArray(document)) {
-    throw new TypeError('Operation passed in cannot be an Array');
-  }
-
-  bulkOperation.s.currentBatch.operations.push(document);
-  bulkOperation.s.currentBatch.originalIndexes.push(bulkOperation.s.currentIndex);
-  bulkOperation.s.currentIndex = bulkOperation.s.currentIndex + 1;
-
-  // Save back the current Batch to the right type
-  if (docType === INSERT) {
-    bulkOperation.s.currentInsertBatch = bulkOperation.s.currentBatch;
-    bulkOperation.s.bulkResult.insertedIds.push({
-      index: bulkOperation.s.bulkResult.insertedIds.length,
-      _id: document._id
-    });
-  } else if (docType === UPDATE) {
-    bulkOperation.s.currentUpdateBatch = bulkOperation.s.currentBatch;
-  } else if (docType === REMOVE) {
-    bulkOperation.s.currentRemoveBatch = bulkOperation.s.currentBatch;
-  }
-
-  // Update current batch size
-  bulkOperation.s.currentBatch.size += 1;
-  bulkOperation.s.currentBatch.sizeBytes += maxKeySize + bsonSize;
-
-  // Return bulkOperation
-  return bulkOperation;
-}
-
-/**
- * Create a new UnorderedBulkOperation instance (INTERNAL TYPE, do not instantiate directly)
- *
- * @class
- * @extends BulkOperationBase
- * @property {number} length Get the number of operations in the bulk.
- * @returns {UnorderedBulkOperation} a UnorderedBulkOperation instance.
- */
-export class UnorderedBulkOperation extends BulkOperationBase {
-  s: any;
-
-  constructor(topology: any, collection: any, options: any) {
-    options = options || {};
-    options = Object.assign(options, { addToOperationsList });
-
-    super(topology, collection, options, false);
-  }
-
-  /**
-   * @param callback
-   * @param writeResult
-   * @returns {boolean|undefined}
-   */
   handleWriteError(callback: Callback, writeResult: any): boolean | undefined {
     if (this.s.batches.length) {
       return false;
@@ -126,15 +16,87 @@ export class UnorderedBulkOperation extends BulkOperationBase {
 
     return super.handleWriteError(callback, writeResult);
   }
+
+  addToOperationsList(batchType: BatchType, document: Document): UnorderedBulkOperation {
+    // Get the bsonSize
+    const bsonSize = BSON.calculateObjectSize(document, {
+      checkKeys: false,
+
+      // Since we don't know what the user selected for BSON options here,
+      // err on the safe side, and check the size with ignoreUndefined: false.
+      ignoreUndefined: false
+    } as any);
+    // Throw error if the doc is bigger than the max BSON size
+    if (bsonSize >= this.s.maxBsonObjectSize) {
+      throw new TypeError(`Document is larger than the maximum size ${this.s.maxBsonObjectSize}`);
+    }
+
+    // Holds the current batch
+    this.s.currentBatch = undefined;
+    // Get the right type of batch
+    if (batchType === BatchType.INSERT) {
+      this.s.currentBatch = this.s.currentInsertBatch;
+    } else if (batchType === BatchType.UPDATE) {
+      this.s.currentBatch = this.s.currentUpdateBatch;
+    } else if (batchType === BatchType.REMOVE) {
+      this.s.currentBatch = this.s.currentRemoveBatch;
+    }
+
+    const maxKeySize = this.s.maxKeySize;
+
+    // Create a new batch object if we don't have a current one
+    if (this.s.currentBatch == null) {
+      this.s.currentBatch = new Batch(batchType, this.s.currentIndex);
+    }
+
+    // Check if we need to create a new batch
+    if (
+      // New batch if we exceed the max batch op size
+      this.s.currentBatch.size + 1 >= this.s.maxWriteBatchSize ||
+      // New batch if we exceed the maxBatchSizeBytes. Only matters if batch already has a doc,
+      // since we can't sent an empty batch
+      (this.s.currentBatch.size > 0 &&
+        this.s.currentBatch.sizeBytes + maxKeySize + bsonSize >= this.s.maxBatchSizeBytes) ||
+      // New batch if the new op does not have the same op type as the current batch
+      this.s.currentBatch.batchType !== batchType
+    ) {
+      // Save the batch to the execution stack
+      this.s.batches.push(this.s.currentBatch);
+
+      // Create a new batch
+      this.s.currentBatch = new Batch(batchType, this.s.currentIndex);
+    }
+
+    // We have an array of documents
+    if (Array.isArray(document)) {
+      throw new TypeError('Operation passed in cannot be an Array');
+    }
+
+    this.s.currentBatch.operations.push(document);
+    this.s.currentBatch.originalIndexes.push(this.s.currentIndex);
+    this.s.currentIndex = this.s.currentIndex + 1;
+
+    // Save back the current Batch to the right type
+    if (batchType === BatchType.INSERT) {
+      this.s.currentInsertBatch = this.s.currentBatch;
+      this.s.bulkResult.insertedIds.push({
+        index: this.s.bulkResult.insertedIds.length,
+        _id: document._id
+      });
+    } else if (batchType === BatchType.UPDATE) {
+      this.s.currentUpdateBatch = this.s.currentBatch;
+    } else if (batchType === BatchType.REMOVE) {
+      this.s.currentRemoveBatch = this.s.currentBatch;
+    }
+
+    // Update current batch size
+    this.s.currentBatch.size += 1;
+    this.s.currentBatch.sizeBytes += maxKeySize + bsonSize;
+
+    return this;
+  }
 }
 
-/**
- * Returns an unordered batch object
- *
- * @param topology
- * @param collection
- * @param options
- */
-export function initializeUnorderedBulkOp(topology: any, collection: any, options: any) {
-  return new UnorderedBulkOperation(topology, collection, options);
+export function initializeUnorderedBulkOp(collection: Collection, options: BulkWriteOptions) {
+  return new UnorderedBulkOperation(collection, options);
 }

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -55,7 +55,7 @@ import {
   FindAndModifyOptions
 } from './operations/find_and_modify';
 import { InsertManyOperation, InsertManyResult } from './operations/insert_many';
-import { InsertOneOperation, InsertOptions, InsertOneResult } from './operations/insert';
+import { InsertOneOperation, InsertOneOptions, InsertOneResult } from './operations/insert';
 import {
   UpdateOneOperation,
   UpdateManyOperation,
@@ -85,7 +85,7 @@ import type { Db } from './db';
 import type { OperationOptions, Hint } from './operations/operation';
 import type { IndexInformationOptions } from './operations/common_functions';
 import type { CountOptions } from './operations/count';
-import type { BulkWriteResult } from './bulk/common';
+import type { BulkWriteResult, BulkWriteOptions } from './bulk/common';
 import type { PkFactory } from './mongo_client';
 import type { Topology } from './sdam/topology';
 import type { Logger, LoggerOptions } from './logger';
@@ -292,11 +292,11 @@ export class Collection implements OperationParent {
    */
   insertOne(doc: Document): Promise<InsertOneResult>;
   insertOne(doc: Document, callback: Callback<InsertOneResult>): void;
-  insertOne(doc: Document, options: InsertOptions): Promise<InsertOneResult>;
-  insertOne(doc: Document, options: InsertOptions, callback: Callback<InsertOneResult>): void;
+  insertOne(doc: Document, options: InsertOneOptions): Promise<InsertOneResult>;
+  insertOne(doc: Document, options: InsertOneOptions, callback: Callback<InsertOneResult>): void;
   insertOne(
     doc: Document,
-    options?: InsertOptions | Callback<InsertOneResult>,
+    options?: InsertOneOptions | Callback<InsertOneResult>,
     callback?: Callback<InsertOneResult>
   ): Promise<InsertOneResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
@@ -322,11 +322,15 @@ export class Collection implements OperationParent {
    */
   insertMany(docs: Document[]): Promise<InsertManyResult>;
   insertMany(docs: Document[], callback: Callback<InsertManyResult>): void;
-  insertMany(docs: Document[], options: InsertOptions): Promise<InsertManyResult>;
-  insertMany(docs: Document[], options: InsertOptions, callback: Callback<InsertManyResult>): void;
+  insertMany(docs: Document[], options: BulkWriteOptions): Promise<InsertManyResult>;
   insertMany(
     docs: Document[],
-    options?: InsertOptions | Callback<InsertManyResult>,
+    options: BulkWriteOptions,
+    callback: Callback<InsertManyResult>
+  ): void;
+  insertMany(
+    docs: Document[],
+    options?: BulkWriteOptions | Callback<InsertManyResult>,
     callback?: Callback<InsertManyResult>
   ): Promise<InsertManyResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
@@ -371,15 +375,15 @@ export class Collection implements OperationParent {
    */
   bulkWrite(operations: Document[]): Promise<BulkWriteResult>;
   bulkWrite(operations: Document[], callback: Callback<BulkWriteResult>): void;
-  bulkWrite(operations: Document[], options: InsertOptions): Promise<BulkWriteResult>;
+  bulkWrite(operations: Document[], options: BulkWriteOptions): Promise<BulkWriteResult>;
   bulkWrite(
     operations: Document[],
-    options: InsertOptions,
+    options: BulkWriteOptions,
     callback: Callback<BulkWriteResult>
   ): void;
   bulkWrite(
     operations: Document[],
-    options?: InsertOptions | Callback<BulkWriteResult>,
+    options?: BulkWriteOptions | Callback<BulkWriteResult>,
     callback?: Callback<BulkWriteResult>
   ): Promise<BulkWriteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
@@ -1465,25 +1469,25 @@ export class Collection implements OperationParent {
   }
 
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
-  initializeUnorderedBulkOp(options?: any): any {
+  initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
     options = options || {};
     // Give function's options precedence over session options.
     if (options.ignoreUndefined == null) {
       options.ignoreUndefined = this.s.options.ignoreUndefined;
     }
 
-    return unordered(this.s.topology, this, options);
+    return unordered(this, options);
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
-  initializeOrderedBulkOp(options?: any): any {
+  initializeOrderedBulkOp(options?: BulkWriteOptions): any {
     options = options || {};
     // Give function's options precedence over session's options.
     if (options.ignoreUndefined == null) {
       options.ignoreUndefined = this.s.options.ignoreUndefined;
     }
 
-    return ordered(this.s.topology, this, options);
+    return ordered(this, options);
   }
 
   /** Get the db scoped logger */
@@ -1507,7 +1511,7 @@ export class Collection implements OperationParent {
    */
   insert(
     docs: Document[],
-    options: InsertOptions,
+    options: BulkWriteOptions,
     callback: Callback<InsertManyResult>
   ): Promise<InsertManyResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,7 @@ export type {
   ListIndexesOptions,
   IndexDirection
 } from './operations/indexes';
-export type { InsertOneResult, InsertOptions } from './operations/insert';
+export type { InsertOneResult, InsertOneOptions } from './operations/insert';
 export type { InsertManyResult } from './operations/insert_many';
 export type { ListCollectionsOptions } from './operations/list_collections';
 export type { ListDatabasesResult, ListDatabasesOptions } from './operations/list_databases';

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -1,19 +1,18 @@
 import { applyRetryableWrites, applyWriteConcern, Callback } from '../utils';
 import { MongoError } from '../error';
-import { OperationBase, OperationOptions } from './operation';
+import { OperationBase } from './operation';
 import { WriteConcern } from '../write_concern';
 import type { Document } from '../bson';
 import type { Collection } from '../collection';
-import type { BulkOperationBase, BulkWriteResult } from '../bulk/common';
-import type { InsertOptions } from './insert';
+import type { BulkOperationBase, BulkWriteResult, BulkWriteOptions } from '../bulk/common';
 import type { Server } from '../sdam/server';
 
 /** @internal */
-export class BulkWriteOperation extends OperationBase<OperationOptions, BulkWriteResult> {
+export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWriteResult> {
   collection: Collection;
   operations: Document[];
 
-  constructor(collection: Collection, operations: Document[], options: InsertOptions) {
+  constructor(collection: Collection, operations: Document[], options: BulkWriteOptions) {
     super(options);
 
     this.collection = collection;
@@ -23,7 +22,7 @@ export class BulkWriteOperation extends OperationBase<OperationOptions, BulkWrit
   execute(server: Server, callback: Callback<BulkWriteResult>): void {
     const coll = this.collection;
     const operations = this.operations;
-    let options = this.options as InsertOptions;
+    let options = this.options;
 
     // Add ignoreUndefined
     if (coll.s.options.ignoreUndefined) {

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -2,7 +2,7 @@ import { defineAspects, Aspect, OperationBase } from './operation';
 import { removeDocuments } from './common_functions';
 import { CommandOperation, CommandOperationOptions } from './command';
 import { isObject } from 'util';
-import type { Callback } from '../utils';
+import type { Callback, MongoDBNamespace } from '../utils';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
@@ -28,12 +28,11 @@ export interface DeleteResult {
 
 /** @internal */
 export class DeleteOperation extends OperationBase<DeleteOptions, Document> {
-  namespace: string;
   operations: Document[];
 
-  constructor(ns: string, ops: Document[], options: DeleteOptions) {
+  constructor(ns: MongoDBNamespace, ops: Document[], options: DeleteOptions) {
     super(options);
-    this.namespace = ns;
+    this.ns = ns;
     this.operations = ops;
   }
 
@@ -43,7 +42,7 @@ export class DeleteOperation extends OperationBase<DeleteOptions, Document> {
 
   execute(server: Server, callback: Callback): void {
     server.remove(
-      this.namespace.toString(),
+      this.ns.toString(),
       this.operations,
       this.options as WriteCommandOptions,
       callback

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -4,9 +4,8 @@ import { MongoError } from '../error';
 import { prepareDocs } from './common_functions';
 import type { Callback } from '../utils';
 import type { Collection } from '../collection';
-import type { InsertOptions } from './insert';
 import type { ObjectId, Document } from '../bson';
-import type { BulkWriteResult } from '../bulk/common';
+import type { BulkWriteResult, BulkWriteOptions } from '../bulk/common';
 import type { Server } from '../sdam/server';
 
 /** @public */
@@ -22,11 +21,11 @@ export interface InsertManyResult {
 }
 
 /** @internal */
-export class InsertManyOperation extends OperationBase<InsertOptions, InsertManyResult> {
+export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertManyResult> {
   collection: Collection;
   docs: Document[];
 
-  constructor(collection: Collection, docs: Document[], options: InsertOptions) {
+  constructor(collection: Collection, docs: Document[], options: BulkWriteOptions) {
     super(options);
 
     this.collection = collection;

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -42,12 +42,11 @@ export interface UpdateResult {
 
 /** @internal */
 export class UpdateOperation extends OperationBase<UpdateOptions, Document> {
-  namespace: MongoDBNamespace;
   operations: Document[];
 
   constructor(ns: MongoDBNamespace, ops: Document[], options: UpdateOptions) {
     super(options);
-    this.namespace = ns;
+    this.ns = ns;
     this.operations = ops;
   }
 
@@ -57,7 +56,7 @@ export class UpdateOperation extends OperationBase<UpdateOptions, Document> {
 
   execute(server: Server, callback: Callback<Document>): void {
     server.update(
-      this.namespace.toString(),
+      this.ns.toString(),
       this.operations,
       this.options as WriteCommandOptions,
       callback


### PR DESCRIPTION
This work reduces some of the complexity of typing the bulk API by removing tricky patterns, reducing the number of helper methods and refactoring to improve readability:
  - `addToOperationsList` is now an abstract method on the base `BulkOperationBase` class
  - `finalOptionsHandler` is removed, improving readability of the `executeCommands` function
  - typedoc errors were resolved
  - `BulkWriteOptions` were introduced and reused throughout the rest of the public API

NODE-2786

**NOTE:** This does not touch the public api for bulk at all, and as a result a number of `any` types are left in. That will be completed in a subsequent PR