### PR TITLE
refactor: add complete type information to the bulk API

### DIFF
--- a/src/bulk/ordered.ts
+++ b/src/bulk/ordered.ts
@@ -1,14 +1,24 @@
 import * as BSON from '../bson';
-import { BulkOperationBase, Batch, BatchType, BulkWriteOptions } from './common';
+import {
+  BulkOperationBase,
+  Batch,
+  BatchType,
+  BulkWriteOptions,
+  UpdateStatement,
+  DeleteStatement
+} from './common';
 import type { Document } from '../bson';
 import type { Collection } from '../collection';
 
-class OrderedBulkOperation extends BulkOperationBase {
+export class OrderedBulkOperation extends BulkOperationBase {
   constructor(collection: Collection, options: BulkWriteOptions) {
     super(collection, options, true);
   }
 
-  addToOperationsList(batchType: BatchType, document: Document): OrderedBulkOperation {
+  addToOperationsList(
+    batchType: BatchType,
+    document: Document | UpdateStatement | DeleteStatement
+  ): this {
     // Get the bsonSize
     const bsonSize = BSON.calculateObjectSize(document, {
       checkKeys: false,
@@ -51,7 +61,10 @@ class OrderedBulkOperation extends BulkOperationBase {
     }
 
     if (batchType === BatchType.INSERT) {
-      this.s.bulkResult.insertedIds.push({ index: this.s.currentIndex, _id: document._id });
+      this.s.bulkResult.insertedIds.push({
+        index: this.s.currentIndex,
+        _id: (document as Document)._id
+      });
     }
 
     // We have an array of documents
@@ -66,8 +79,4 @@ class OrderedBulkOperation extends BulkOperationBase {
     this.s.currentIndex += 1;
     return this;
   }
-}
-
-export function initializeOrderedBulkOp(collection: Collection, options: BulkWriteOptions) {
-  return new OrderedBulkOperation(collection, options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,11 @@ export {
   MongoParseError,
   MongoWriteConcernError
 } from './error';
-export { BulkWriteError as MongoBulkWriteError } from './bulk/common';
+export {
+  BulkWriteError as MongoBulkWriteError,
+  BulkWriteOptions,
+  AnyBulkWriteOperation
+} from './bulk/common';
 export {
   // Utils
   instrument,
@@ -74,7 +78,21 @@ export {
 export type { AdminPrivate } from './admin';
 export type { Instrumentation } from './apm';
 export type { Document, BSONSerializeOptions } from './bson';
-export type { BulkWriteResult, WriteError, WriteConcernError } from './bulk/common';
+export type {
+  InsertOneModel,
+  ReplaceOneModel,
+  UpdateOneModel,
+  UpdateManyModel,
+  DeleteOneModel,
+  DeleteManyModel,
+  BulkResult,
+  BulkWriteResult,
+  WriteError,
+  WriteConcernError,
+  BulkWriteOperationError,
+  UpdateStatement,
+  DeleteStatement
+} from './bulk/common';
 export type {
   ChangeStream,
   ChangeStreamOptions,

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -2,17 +2,25 @@ import { applyRetryableWrites, applyWriteConcern, Callback } from '../utils';
 import { MongoError } from '../error';
 import { OperationBase } from './operation';
 import { WriteConcern } from '../write_concern';
-import type { Document } from '../bson';
 import type { Collection } from '../collection';
-import type { BulkOperationBase, BulkWriteResult, BulkWriteOptions } from '../bulk/common';
+import type {
+  BulkOperationBase,
+  BulkWriteResult,
+  BulkWriteOptions,
+  AnyBulkWriteOperation
+} from '../bulk/common';
 import type { Server } from '../sdam/server';
 
 /** @internal */
 export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWriteResult> {
   collection: Collection;
-  operations: Document[];
+  operations: AnyBulkWriteOperation[];
 
-  constructor(collection: Collection, operations: Document[], options: BulkWriteOptions) {
+  constructor(
+    collection: Collection,
+    operations: AnyBulkWriteOperation[],
+    options: BulkWriteOptions
+  ) {
     super(options);
 
     this.collection = collection;
@@ -42,14 +50,6 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
     // for each op go through and add to the bulk
     try {
       for (let i = 0; i < operations.length; i++) {
-        // Get the operation type
-        const key = Object.keys(operations[i])[0];
-        // Check if we have a collation
-        if (operations[i][key].collation) {
-          collation = true;
-        }
-
-        // Pass to the raw bulk
         bulk.raw(operations[i]);
       }
     } catch (err) {

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -49,12 +49,7 @@ export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertM
     docs = prepareDocs(coll, docs, options);
 
     // Generate the bulk write operations
-    const operations = [
-      {
-        insertMany: docs
-      }
-    ];
-
+    const operations = [{ insertMany: docs }];
     const bulkWriteOperation = new BulkWriteOperation(coll, operations, options);
 
     bulkWriteOperation.execute(server, (err, result) => {

--- a/test/functional/collations.test.js
+++ b/test/functional/collations.test.js
@@ -616,6 +616,8 @@ describe('Collation', function () {
           request.reply(primary[0]);
         } else if (doc.update) {
           request.reply({ ok: 1 });
+        } else if (doc.delete) {
+          request.reply({ ok: 1 });
         } else if (doc.endSessions) {
           request.reply({ ok: 1 });
         }
@@ -640,10 +642,12 @@ describe('Collation', function () {
             ],
             { ordered: true }
           )
-          .then(() => Promise.reject('should not succeed'))
+          .then(() => {
+            throw new Error('should not succeed');
+          })
           .catch(err => {
             expect(err).to.exist;
-            expect(err.message).to.equal('server/primary/mongos does not support collation');
+            expect(err.message).to.match(/does not support collation/);
           })
           .then(() => client.close());
       });

--- a/test/functional/crud_api.test.js
+++ b/test/functional/crud_api.test.js
@@ -356,6 +356,7 @@ describe('CRUD API', function () {
               ],
               { ordered: false, w: 1 },
               function (err, r) {
+                if (err) console.dir(err);
                 expect(err).to.not.exist;
                 test.equal(3, r.nInserted);
                 test.equal(1, r.nUpserted);


### PR DESCRIPTION
The primary focus of this patch is to provide correct types for the top-level API for the Bulk API. Specifically, type information for write models, as well as bulk write operations were added as well as formal models for "update" and "delete" statements as defined and supported by the "update" and "delete" commands.

NODE-2786