### PR TITLE
updated bl version because of CVE-2020-8244

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -527,9 +527,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.1.tgz",
-      "integrity": "sha512-HnYlg/BRF8uC1FyKRFZwRaCPTPYKa+6I8QiUZFLredaGOou481cgFS4wKRFyKvQtX8xudqkSdBczJHIYSQYKrQ==",
+      "version": "14.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
+      "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -2317,9 +2317,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.3.0.tgz",
-      "integrity": "sha512-RvDLH26ILwX2J60P7tlNdz5IlTFeC52TEFgAC12+nz/lOx4a7n3/hP8fBPFZrQP07WA1t9ZOO8H/i7cEs2BTnA==",
+      "version": "30.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.3.1.tgz",
+      "integrity": "sha512-185ARou6Wj/68DP0g9kLLBnvmVwgg6/E/7Z8Z7Dz7Z63WgvRNaSvOLQiXkzIOEwstQfwI9PCuFPh4qBJov907A==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.7.6",
@@ -4724,9 +4724,9 @@
       }
     },
     "mocha": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.2.tgz",
-      "integrity": "sha512-I8FRAcuACNMLQn3lS4qeWLxXqLvGf6r2CaLstDpZmMUUSmvW6Cnm1AuHxgbc7ctZVRcfwspCRbDHymPsi3dkJw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.3.tgz",
+      "integrity": "sha512-ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==",
       "dev": true,
       "requires": {
         "ansi-colors": "4.1.1",
@@ -7485,9 +7485,9 @@
       }
     },
     "wtfnode": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/wtfnode/-/wtfnode-0.8.1.tgz",
-      "integrity": "sha512-S7S7D8CGHVCtlTn1IWX+nEbxavpL9+fk3vk02RPZHiExyZFb9oKTTig3nEnMCL2yaJ4047V5lAkuulXuO2OsOw==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/wtfnode/-/wtfnode-0.8.2.tgz",
+      "integrity": "sha512-x9R+x7wX8uZUnP2i5VjyEkOc410zXHY5gp+Ipsc13MFjqEobis+VSO3GDbiUdbtmc+TVyy7ZeUthSv0tLLWV/A==",
       "dev": true
     },
     "xmlcreate": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bson-ext": "^2.0.0"
   },
   "dependencies": {
-    "bl": "^2.2.0",
+    "bl": "^2.2.1",
     "bson": "^4.0.4",
     "denque": "^1.4.1"
   },
@@ -38,7 +38,7 @@
     "@types/bl": "^2.1.0",
     "@types/bson": "^4.0.2",
     "@types/kerberos": "^1.1.0",
-    "@types/node": "^14.6.0",
+    "@types/node": "^14.6.4",
     "@types/saslprep": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^3.10.0",
     "@typescript-eslint/parser": "^3.10.0",
@@ -49,14 +49,14 @@
     "coveralls": "^3.0.11",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-jsdoc": "^30.3.1",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-jsdoc": "^30.2.4",
     "eslint-plugin-tsdoc": "^0.2.6",
     "jsdoc": "^3.6.4",
     "lodash.camelcase": "^4.3.0",
     "madge": "^3.9.0",
-    "mocha": "^8.0.1",
+    "mocha": "^8.1.3",
     "mocha-sinon": "^2.1.0",
     "mongodb-mock-server": "^2.0.1",
     "nyc": "^15.1.0",
@@ -75,7 +75,7 @@
     "typescript": "^4.0.2",
     "typescript-cached-transpile": "^0.0.6",
     "worker-farm": "^1.5.0",
-    "wtfnode": "^0.8.0",
+    "wtfnode": "^0.8.2",
     "yargs": "^14.2.0"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description
According to this [CVE](https://github.com/advisories/GHSA-pp7h-53gx-mx7r) there is buffer over-read vulnerability in bl < 2.2.1.
**What changed?**
updated bl to version 2.2.1

**Are there any files to ignore?**
