### PR TITLE
chore: configure scripts to build driver

### DIFF
--- a/etc/prepare.js
+++ b/etc/prepare.js
@@ -3,7 +3,12 @@ var cp = require('child_process');
 var fs = require('fs');
 
 if (fs.existsSync('src')) {
-  cp.spawn('npm', ['run', 'build:dts'], { stdio: 'inherit' });
+  const result = cp.spawnSync('npm', ['run', 'build:dts'], { stdio: 'inherit', shell: true });
+  if (result.status !== 0) {
+    // We need devDependencies to build the driver
+    cp.spawnSync('npm', ['install', '--ignore-scripts'], { stdio: 'inherit', shell: true });
+    cp.spawnSync('npm', ['run', 'build:dts'], { stdio: 'inherit', shell: true });
+  }
 } else {
   if (!fs.existsSync('lib')) {
     console.warn('MongoDB: No compiled javascript present, the driver is not installed correctly.');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "files": [
     "lib",
     "etc/prepare.js",
-    "mongodb.d.ts"
+    "mongodb.d.ts",
+    "src",
+    "tsconfig.json",
+    "api-extractor.json"
   ],
   "types": "mongodb.d.ts",
   "repository": {
@@ -100,7 +103,7 @@
     "check:kerberos": "mocha --config \"test/manual/mocharc.json\" test/manual/kerberos.test.js",
     "check:tls": "mocha --config \"test/manual/mocharc.json\" test/manual/tls_support.test.js",
     "check:ldap": "mocha --config \"test/manual/mocharc.json\" test/manual/ldap.test.js",
-    "prepare": "node etc/prepare.js",
+    "postinstall": "node etc/prepare.js",
     "release": "standard-version -i HISTORY.md",
     "test": "npm run check:lint && npm run check:test"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,8 @@
     // API-Extractor uses declaration maps to report problems in source, no need to distribute
     "declaration": true,
     "declarationMap": true,
-    // inline the source so the original content can be debugged
-    "inlineSources": true,
+    // we include sources in distribution
+    "inlineSources": false,
     // Prevents web types from being suggested by vscode.
     "types": ["node"],
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Using the postinstall hook, the prepare script will install
the necessary dependencies to compile the driver if using
git versioning of the module.

NODE-2791