### PR TITLE
refactor: remove Topology#command method

### DIFF
--- a/src/cmap/wire_protocol/command.ts
+++ b/src/cmap/wire_protocol/command.ts
@@ -26,10 +26,8 @@ export interface CommandOptions extends BSONSerializeOptions {
   documentsReturnedIn?: string;
   noResponse?: boolean;
 
-  // NOTE: these are for retryable writes and will be removed soon
+  // FIXME: NODE-2802
   willRetryWrite?: boolean;
-  retryWrites?: boolean;
-  retrying?: boolean;
 
   // FIXME: NODE-2781
   writeConcern?: WriteConcernOptions | WriteConcern | W;
@@ -137,7 +135,6 @@ function _command(
 
   // This value is not overridable
   commandOptions.slaveOk = readPreference.slaveOk();
-
   const cmdNs = `${databaseNamespace(ns)}.$cmd`;
   const message = shouldUseOpMsg
     ? new Msg(cmdNs, finalCmd, commandOptions)

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -14,13 +14,12 @@ const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
 
 /** @public */
 export interface CommandOperationOptions extends OperationOptions, WriteConcernOptions {
+  /** Return the full server response for the command */
   fullResponse?: boolean;
   /** Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported) */
   readConcern?: ReadConcern;
   /** The preferred read preference (ReadPreference.primary, ReadPreference.primary_preferred, ReadPreference.secondary, ReadPreference.secondary_preferred, ReadPreference.nearest). */
   readPreference?: ReadPreferenceLike;
-  /** Specify ClientSession for this command */
-  session?: ClientSession;
   /** Collation */
   collation?: CollationOptions;
   maxTimeMS?: number;
@@ -32,6 +31,7 @@ export interface CommandOperationOptions extends OperationOptions, WriteConcernO
   // Admin command overrides.
   dbName?: string;
   authdb?: string;
+  noResponse?: boolean;
 }
 
 /** @internal */
@@ -56,7 +56,7 @@ export abstract class CommandOperation<
   fullResponse?: boolean;
   logger?: Logger;
 
-  constructor(parent: OperationParent, options?: T) {
+  constructor(parent?: OperationParent, options?: T) {
     super(options);
 
     // NOTE: this was explicitly added for the add/remove user operations, it's likely
@@ -65,7 +65,9 @@ export abstract class CommandOperation<
     const dbNameOverride = options?.dbName || options?.authdb;
     this.ns = dbNameOverride
       ? new MongoDBNamespace(dbNameOverride, '$cmd')
-      : parent.s.namespace.withCollection('$cmd');
+      : parent
+      ? parent.s.namespace.withCollection('$cmd')
+      : new MongoDBNamespace('admin', '$cmd');
 
     const propertyProvider = this.hasAspect(Aspect.NO_INHERIT_OPTIONS) ? undefined : parent;
     this.readPreference = this.hasAspect(Aspect.WRITE_OPERATION)
@@ -82,7 +84,7 @@ export abstract class CommandOperation<
     this.options.readPreference = this.readPreference;
 
     // TODO(NODE-2056): make logger another "inheritable" property
-    if (parent.logger) {
+    if (parent && parent.logger) {
       this.logger = parent.logger;
     }
   }

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -21,8 +21,11 @@ export interface OperationConstructor extends Function {
 
 /** @internal */
 export interface OperationOptions extends BSONSerializeOptions {
-  explain?: boolean;
+  /** Specify ClientSession for this command */
   session?: ClientSession;
+
+  explain?: boolean;
+  willRetryWrites?: boolean;
 }
 
 /**

--- a/src/operations/run_command.ts
+++ b/src/operations/run_command.ts
@@ -14,7 +14,7 @@ export class RunCommandOperation<
 > extends CommandOperation<T, TResult> {
   command: Document;
 
-  constructor(parent: OperationParent, command: Document, options?: T) {
+  constructor(parent: OperationParent | undefined, command: Document, options?: T) {
     super(parent, options);
     this.command = command;
   }
@@ -29,7 +29,7 @@ export class RunAdminCommandOperation<
   T extends RunCommandOptions = RunCommandOptions,
   TResult = Document
 > extends RunCommandOperation<T, TResult> {
-  constructor(parent: OperationParent, command: Document, options?: T) {
+  constructor(parent: OperationParent | undefined, command: Document, options?: T) {
     super(parent, command, options);
     this.ns = new MongoDBNamespace('admin');
   }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -20,6 +20,8 @@ import type { MongoClientOptions } from './mongo_client';
 import type { Cursor } from './cursor/cursor';
 import type { CoreCursor } from './cursor/core_cursor';
 import type { WriteCommandOptions } from './cmap/wire_protocol/write_command';
+import { executeOperation } from './operations/execute_operation';
+import { RunAdminCommandOperation } from './operations/run_command';
 
 const minWireVersionForShardedTransactions = 8;
 
@@ -197,7 +199,8 @@ class ClientSession extends EventEmitter {
   /** Increment the transaction number on the internal ServerSession */
   incrementTransactionNumber(): void {
     if (this.serverSession) {
-      this.serverSession.txnNumber++;
+      this.serverSession.txnNumber =
+        typeof this.serverSession.txnNumber === 'number' ? this.serverSession.txnNumber + 1 : 0;
     }
   }
 
@@ -521,25 +524,39 @@ function endTransaction(session: ClientSession, commandName: string, callback: C
   }
 
   // send the command
-  session.topology.command('admin.$cmd', command, { session }, (err, reply) => {
-    if (err && isRetryableError(err as MongoError)) {
-      // SPEC-1185: apply majority write concern when retrying commitTransaction
-      if (command.commitTransaction) {
-        // per txns spec, must unpin session in this case
-        session.transaction.unpinServer();
+  executeOperation(
+    session.topology,
+    new RunAdminCommandOperation(undefined, command, {
+      session,
+      readPreference: ReadPreference.primary
+    }),
+    (err, reply) => {
+      if (err && isRetryableError(err as MongoError)) {
+        // SPEC-1185: apply majority write concern when retrying commitTransaction
+        if (command.commitTransaction) {
+          // per txns spec, must unpin session in this case
+          session.transaction.unpinServer();
 
-        command.writeConcern = Object.assign({ wtimeout: 10000 }, command.writeConcern, {
-          w: 'majority'
-        });
+          command.writeConcern = Object.assign({ wtimeout: 10000 }, command.writeConcern, {
+            w: 'majority'
+          });
+        }
+
+        executeOperation(
+          session.topology,
+          new RunAdminCommandOperation(undefined, command, {
+            session,
+            readPreference: ReadPreference.primary
+          }),
+          (_err, _reply) => commandHandler(_err as MongoError, _reply)
+        );
+
+        return;
       }
 
-      return session.topology.command('admin.$cmd', command, { session }, (_err, _reply) =>
-        commandHandler(_err as MongoError, _reply)
-      );
+      commandHandler(err as MongoError, reply);
     }
-
-    commandHandler(err as MongoError, reply);
-  });
+  );
 }
 
 function supportsRecoveryToken(session: ClientSession) {
@@ -558,15 +575,15 @@ export type ServerSessionId = { id: Binary };
 class ServerSession {
   id: ServerSessionId;
   lastUse: number;
-  txnNumber: number;
   isDirty: boolean;
+  txnNumber: number;
 
   /** @internal */
   constructor() {
     this.id = { id: new Binary(uuidV4(), Binary.SUBTYPE_UUID) };
     this.lastUse = now();
-    this.txnNumber = 0;
     this.isDirty = false;
+    this.txnNumber = 0;
   }
 
   /**

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -575,15 +575,15 @@ export type ServerSessionId = { id: Binary };
 class ServerSession {
   id: ServerSessionId;
   lastUse: number;
-  isDirty: boolean;
   txnNumber: number;
+  isDirty: boolean;
 
   /** @internal */
   constructor() {
     this.id = { id: new Binary(uuidV4(), Binary.SUBTYPE_UUID) };
     this.lastUse = now();
-    this.isDirty = false;
     this.txnNumber = 0;
+    this.isDirty = false;
   }
 
   /**

--- a/test/functional/core/cursor.test.js
+++ b/test/functional/core/cursor.test.js
@@ -2,7 +2,7 @@
 
 const expect = require('chai').expect;
 const f = require('util').format;
-const setupDatabase = require('./shared').setupDatabase;
+const setupDatabase = require('../shared').setupDatabase;
 
 describe('Cursor tests', function () {
   before(function () {

--- a/test/functional/core/tailable_cursor.test.js
+++ b/test/functional/core/tailable_cursor.test.js
@@ -1,6 +1,6 @@
 'use strict';
 const expect = require('chai').expect;
-const setupDatabase = require('./shared').setupDatabase;
+const setupDatabase = require('../shared').setupDatabase;
 
 describe('Tailable cursor tests', function () {
   before(function () {

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -159,12 +159,16 @@ describe('Topology (unit)', function () {
       topology.connect(err => {
         expect(err).to.not.exist;
 
-        topology.command('admin.$cmd', { ping: 1 }, { socketTimeout: 250 }, (err, result) => {
-          expect(result).to.not.exist;
-          expect(err).to.exist;
-          expect(err).to.match(/timed out/);
+        topology.selectServer('primary', (err, server) => {
+          expect(err).to.not.exist;
 
-          topology.close(done);
+          server.command('admin.$cmd', { ping: 1 }, { socketTimeout: 250 }, (err, result) => {
+            expect(result).to.not.exist;
+            expect(err).to.exist;
+            expect(err).to.match(/timed out/);
+
+            topology.close(done);
+          });
         });
       });
     });


### PR DESCRIPTION
This is a minor refactoring that ensures that wire protocol primitives are only available on the `Server` type. The primary benefit here is that we no longer hide any server selection behind `Topology` API, all commands issued are always the result of server selection and a command being executed against a specific server.

NODE-2801