### PR TITLE
refactor: move find command building to FindOperation

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -48,3 +48,24 @@ export interface BSONSerializeOptions extends SerializeOptions {
 
   raw?: boolean;
 }
+
+export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSerializeOptions {
+  const {
+    fieldsAsRaw,
+    promoteValues,
+    promoteBuffers,
+    promoteLongs,
+    serializeFunctions,
+    ignoreUndefined,
+    raw
+  } = options;
+  return {
+    fieldsAsRaw,
+    promoteValues,
+    promoteBuffers,
+    promoteLongs,
+    serializeFunctions,
+    ignoreUndefined,
+    raw
+  };
+}

--- a/src/cmap/wire_protocol/get_more.ts
+++ b/src/cmap/wire_protocol/get_more.ts
@@ -1,5 +1,5 @@
 import { GetMore } from '../commands';
-import { Long, Document } from '../../bson';
+import { Long, Document, pluckBSONSerializeOptions } from '../../bson';
 import { MongoError, MongoNetworkError } from '../../error';
 import { applyCommonQueryOptions } from './shared';
 import { maxWireVersion, collectionNamespace, Callback } from '../../utils';
@@ -71,7 +71,11 @@ export function getMore(
 
   if (wireVersion < 4) {
     const getMoreOp = new GetMore(ns, cursorId, { numberToReturn: batchSize });
-    const queryOptions = applyCommonQueryOptions({}, cursorState);
+    const queryOptions = applyCommonQueryOptions(
+      {},
+      Object.assign({ bsonOptions: pluckBSONSerializeOptions(options) }, cursorState)
+    );
+
     queryOptions.fullResult = true;
     queryOptions.command = true;
     server.s.pool.write(getMoreOp, queryOptions, queryCallback);

--- a/src/cmap/wire_protocol/query.ts
+++ b/src/cmap/wire_protocol/query.ts
@@ -3,7 +3,7 @@ import { Query } from '../commands';
 import { MongoError } from '../../error';
 import { maxWireVersion, collectionNamespace, Callback } from '../../utils';
 import { getReadPreference, isSharded, applyCommonQueryOptions } from './shared';
-import type { Document } from '../../bson';
+import { Document, pluckBSONSerializeOptions } from '../../bson';
 import type { Server } from '../../sdam/server';
 import type { ReadPreferenceLike } from '../../read_preference';
 import type { InternalCursorState } from '../../cursor/core_cursor';
@@ -32,9 +32,12 @@ export function query(
 
   if (maxWireVersion(server) < 4) {
     const query = prepareLegacyFindQuery(server, ns, cmd, cursorState, options);
-    const queryOptions = applyCommonQueryOptions({}, cursorState);
-    queryOptions.fullResult = true;
+    const queryOptions = applyCommonQueryOptions(
+      {},
+      Object.assign({ bsonOptions: pluckBSONSerializeOptions(options) }, cursorState)
+    );
 
+    queryOptions.fullResult = true;
     if (typeof query.documentsReturnedIn === 'string') {
       queryOptions.documentsReturnedIn = query.documentsReturnedIn;
     }

--- a/src/cmap/wire_protocol/shared.ts
+++ b/src/cmap/wire_protocol/shared.ts
@@ -3,12 +3,12 @@ import { TopologyDescription } from '../../sdam/topology_description';
 import { MongoError } from '../../error';
 import { ReadPreference } from '../../read_preference';
 import type { Document } from '../../bson';
-import type { CommandOptions } from './command';
 import type { OpQueryOptions } from '../commands';
 import type { Topology } from '../../sdam/topology';
 import type { Server } from '../../sdam/server';
 import type { ServerDescription } from '../../sdam/server_description';
 import type { ReadPreferenceLike } from '../../read_preference';
+import type { InternalCursorState } from '../../cursor/core_cursor';
 
 export interface ReadPreferenceOption {
   readPreference?: ReadPreferenceLike;
@@ -35,27 +35,28 @@ export function getReadPreference(cmd: Document, options: ReadPreferenceOption):
 
 export function applyCommonQueryOptions(
   queryOptions: OpQueryOptions,
-  options: CommandOptions
+  cursorState: InternalCursorState
 ): OpQueryOptions {
-  Object.assign(queryOptions, {
-    raw: typeof options.raw === 'boolean' ? options.raw : false,
-    promoteLongs: typeof options.promoteLongs === 'boolean' ? options.promoteLongs : true,
-    promoteValues: typeof options.promoteValues === 'boolean' ? options.promoteValues : true,
-    promoteBuffers: typeof options.promoteBuffers === 'boolean' ? options.promoteBuffers : false,
-    monitoring: typeof options.monitoring === 'boolean' ? options.monitoring : false,
-    fullResult: typeof options.fullResult === 'boolean' ? options.fullResult : false
-  });
-
-  if (typeof options.socketTimeout === 'number') {
-    queryOptions.socketTimeout = options.socketTimeout;
+  if (cursorState.bsonOptions) {
+    Object.assign(queryOptions, {
+      raw: typeof cursorState.bsonOptions.raw === 'boolean' ? cursorState.bsonOptions.raw : false,
+      promoteLongs:
+        typeof cursorState.bsonOptions.promoteLongs === 'boolean'
+          ? cursorState.bsonOptions.promoteLongs
+          : true,
+      promoteValues:
+        typeof cursorState.bsonOptions.promoteValues === 'boolean'
+          ? cursorState.bsonOptions.promoteValues
+          : true,
+      promoteBuffers:
+        typeof cursorState.bsonOptions.promoteBuffers === 'boolean'
+          ? cursorState.bsonOptions.promoteBuffers
+          : false
+    });
   }
 
-  if (options.session) {
-    queryOptions.session = options.session;
-  }
-
-  if (typeof options.documentsReturnedIn === 'string') {
-    queryOptions.documentsReturnedIn = options.documentsReturnedIn;
+  if (cursorState.session) {
+    queryOptions.session = cursorState.session;
   }
 
   return queryOptions;

--- a/src/cursor/cursor.ts
+++ b/src/cursor/cursor.ts
@@ -405,6 +405,14 @@ export class Cursor<
       throw new MongoError(`flag ${flag} must be a boolean value`);
     }
 
+    if (flag === 'tailable') {
+      this.cursorState.tailable = value;
+    }
+
+    if (flag === 'awaitData') {
+      this.cursorState.awaitData = value;
+    }
+
     this.cmd[flag] = value;
     return this;
   }

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -82,11 +82,7 @@ export class CreateCollectionOperation extends CommandOperation<
         return callback(err);
       }
 
-      try {
-        callback(undefined, new Collection(db, name, options));
-      } catch (err) {
-        callback(err);
-      }
+      callback(undefined, new Collection(db, name, options));
     };
 
     const cmd: Document = { create: name };

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -1,7 +1,12 @@
-import { OperationBase, Hint } from './operation';
-import { Aspect, defineAspects } from './operation';
+import { Aspect, defineAspects, Hint } from './operation';
 import { ReadPreference } from '../read_preference';
-import { maxWireVersion, MongoDBNamespace, Callback } from '../utils';
+import {
+  maxWireVersion,
+  MongoDBNamespace,
+  Callback,
+  formattedOrderClause,
+  normalizeHintField
+} from '../utils';
 import { MongoError } from '../error';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
@@ -9,6 +14,7 @@ import type { Collection } from '../collection';
 import type { InternalCursorState } from '../cursor/core_cursor';
 import type { CollationOptions } from '../cmap/wire_protocol/write_command';
 import type { QueryOptions } from '../cmap/wire_protocol/query';
+import { CommandOperation } from './command';
 
 /** @public */
 export type SortDirection = 1 | -1 | 'asc' | 'desc' | { $meta: string };
@@ -26,16 +32,12 @@ export interface FindOptions extends QueryOptions {
   sort?: Sort;
   /** The fields to return in the query. Object of fields to either include or exclude (one of, not both), `{'a':1, 'b': 1}` **or** `{'a': 0, 'b': 0}` */
   projection?: Document;
-  /** @deprecated Use `options.projection` instead */
-  fields?: Document;
   /** Set to skip N documents ahead in your query (useful for pagination). */
   skip?: number;
   /** Tell the query to use specific indexes in the query. Object of indexes to use, `{'_id':1}` */
   hint?: Hint;
   /** Explain the query instead of returning the data. */
   explain?: boolean;
-  /** @deprecated Snapshot query. */
-  snapshot?: boolean;
   /** Specify if the cursor can timeout. */
   timeout?: boolean;
   /** Specify if the cursor is tailable. */
@@ -44,20 +46,14 @@ export interface FindOptions extends QueryOptions {
   awaitData?: boolean;
   /** Set the batchSize for the getMoreCommand when iterating over the query results. */
   batchSize?: number;
-  /** Only return the index key. */
+  /** If true, returns only the index keys in the resulting documents. */
   returnKey?: boolean;
-  /** @deprecated Limit the number of items to scan. */
-  maxScan?: number;
   /** Set index bounds. */
   min?: number;
   /** Set index bounds. */
   max?: number;
-  /** Show disk location of results. */
-  showDiskLoc?: boolean;
   /** You can put a $comment field on a query to make looking in the profiler logs simpler. */
   comment?: string | Document;
-  /** Specify if the cursor should return partial results when querying against a sharded system */
-  partial?: boolean;
   /** Number of milliseconds to wait before aborting the query. */
   maxTimeMS?: number;
   /** The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query. Requires `tailable` and `awaitData` to be true */
@@ -68,43 +64,221 @@ export interface FindOptions extends QueryOptions {
   collation?: CollationOptions;
   /** Enables writing to temporary files on the server. */
   allowDiskUse?: boolean;
+  /** Determines whether to close the cursor after the first batch. Defaults to false. */
+  singleBatch?: boolean;
+  /** For queries against a sharded collection, allows the command (or subsequent getMore commands) to return partial results, rather than an error, if one or more queried shards are unavailable. */
+  allowPartialResults?: boolean;
+  /** Determines whether to return the record identifier for each document. If true, adds a field $recordId to the returned documents. */
+  showRecordId?: boolean;
+
+  /** @deprecated Use `awaitData` instead */
+  awaitdata?: boolean;
+  /** @deprecated Use `projection` instead */
+  fields?: Document;
+  /** @deprecated Limit the number of items to scan. */
+  maxScan?: number;
+  /** @deprecated An internal command for replaying a replica set’s oplog. */
+  oplogReplay?: boolean;
+  /** @deprecated Snapshot query. */
+  snapshot?: boolean;
+  /** @deprecated Show disk location of results. */
+  showDiskLoc?: boolean;
+  /** @deprecated Use `allowPartialResults` instead */
+  partial?: boolean;
 }
 
+const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
+
 /** @internal */
-export class FindOperation extends OperationBase<FindOptions, Document> {
+export class FindOperation extends CommandOperation<FindOptions, Document> {
   cmd: Document;
+  filter: Document;
   readPreference: ReadPreference;
   cursorState?: InternalCursorState;
+
+  hint?: Hint;
 
   constructor(
     collection: Collection,
     ns: MongoDBNamespace,
-    command: Document,
-    options: FindOptions
+    filter: Document = {},
+    options: FindOptions = {}
   ) {
-    super(options);
-
+    super(collection, options);
     this.ns = ns;
-    this.cmd = command;
     this.readPreference = ReadPreference.resolve(collection, this.options);
+
+    if (typeof filter !== 'object' || Array.isArray(filter)) {
+      throw new MongoError('Query filter must be a plain object or ObjectId');
+    }
+
+    // If the filter is a buffer, validate that is a valid BSON document
+    if (Buffer.isBuffer(filter)) {
+      const objectSize = filter[0] | (filter[1] << 8) | (filter[2] << 16) | (filter[3] << 24);
+      if (objectSize !== filter.length) {
+        throw new TypeError(
+          `query filter raw message size does not match message header size [${filter.length}] != [${objectSize}]`
+        );
+      }
+    }
+
+    // special case passing in an ObjectId as a filter
+    this.filter = filter != null && filter._bsontype === 'ObjectID' ? { _id: filter } : filter;
+
+    // FIXME: this should be removed as part of NODE-2790
+    this.cmd = {
+      find: this.ns.toString(),
+      query: this.filter
+    };
+
+    // TODO: figure out our story about inheriting BSON serialization options
+    this.bsonOptions = {
+      raw: options.raw ?? collection.s.raw ?? false,
+      promoteLongs: options.promoteLongs ?? collection.s.promoteLongs ?? true,
+      promoteValues: options.promoteValues ?? collection.s.promoteValues ?? true,
+      promoteBuffers: options.promoteBuffers ?? collection.s.promoteBuffers ?? false,
+      ignoreUndefined: options.ignoreUndefined ?? collection.s.ignoreUndefined ?? false
+    };
   }
 
   execute(server: Server, callback: Callback<Document>): void {
     // copied from `CommandOperationV2`, to be subclassed in the future
     this.server = server;
+    const serverWireVersion = maxWireVersion(server);
 
-    if (typeof this.cmd.allowDiskUse !== 'undefined' && maxWireVersion(server) < 4) {
+    const options = this.options;
+    if (typeof options.allowDiskUse !== 'undefined' && serverWireVersion < 4) {
       callback(new MongoError('The `allowDiskUse` option is not supported on MongoDB < 3.2'));
       return;
+    }
+
+    const findCommand: Document = Object.assign({}, this.cmd);
+
+    if (options.sort) {
+      findCommand.sort = formattedOrderClause(options.sort);
+    }
+
+    if (options.projection || options.fields) {
+      let projection = options.projection || options.fields;
+      if (projection && !Buffer.isBuffer(projection) && Array.isArray(projection)) {
+        projection = projection.length
+          ? projection.reduce((result, field) => {
+              result[field] = 1;
+              return result;
+            }, {})
+          : { _id: 1 };
+      }
+
+      findCommand.fields = projection;
+    }
+
+    if (options.hint) {
+      findCommand.hint = normalizeHintField(options.hint);
+    }
+
+    if (typeof options.skip === 'number') {
+      findCommand.skip = options.skip;
+    }
+
+    if (typeof options.limit === 'number') {
+      findCommand.limit = options.limit;
+    }
+
+    if (typeof options.batchSize === 'number') {
+      findCommand.batchSize = options.batchSize;
+    }
+
+    if (typeof options.singleBatch === 'boolean') {
+      findCommand.singleBatch = options.singleBatch;
+    }
+
+    if (options.comment) {
+      findCommand.comment = options.comment;
+    }
+
+    if (typeof options.maxTimeMS === 'number') {
+      findCommand.maxTimeMS = options.maxTimeMS;
+    }
+
+    if (this.readConcern && (!this.session || !this.session.inTransaction())) {
+      findCommand.readConcern = this.readConcern;
+    }
+
+    if (options.max) {
+      findCommand.max = options.max;
+    }
+
+    if (options.min) {
+      findCommand.min = options.min;
+    }
+
+    if (typeof options.returnKey === 'boolean') {
+      findCommand.returnKey = options.returnKey;
+    }
+
+    if (typeof options.showRecordId === 'boolean') {
+      findCommand.showRecordId = options.showRecordId;
+    }
+
+    if (typeof options.tailable === 'boolean') {
+      findCommand.tailable = options.tailable;
+    }
+
+    if (typeof options.oplogReplay === 'boolean') {
+      findCommand.oplogReplay = options.oplogReplay;
+    }
+
+    if (typeof options.timeout === 'boolean') {
+      findCommand.noCursorTimeout = options.timeout;
+    } else if (typeof options.noCursorTimeout === 'boolean') {
+      findCommand.noCursorTimeout = options.noCursorTimeout;
+    }
+
+    if (typeof options.awaitData === 'boolean') {
+      findCommand.awaitData = options.awaitData;
+    } else if (typeof options.awaitdata === 'boolean') {
+      findCommand.awaitData = options.awaitdata;
+    }
+
+    if (typeof options.allowPartialResults === 'boolean') {
+      findCommand.allowPartialResults = options.allowPartialResults;
+    } else if (typeof options.partial === 'boolean') {
+      findCommand.allowPartialResults = options.partial;
+    }
+
+    if (options.collation) {
+      if (serverWireVersion < SUPPORTS_WRITE_CONCERN_AND_COLLATION) {
+        callback(
+          new MongoError(
+            `Server ${server.name}, which reports wire version ${serverWireVersion}, does not support collation`
+          )
+        );
+
+        return;
+      }
+
+      findCommand.collation = options.collation;
+    }
+
+    if (typeof options.allowDiskUse === 'boolean') {
+      findCommand.allowDiskUse = options.allowDiskUse;
+    }
+
+    if (typeof options.snapshot === 'boolean') {
+      findCommand.snapshot = options.snapshot;
+    }
+
+    if (typeof options.showDiskLoc === 'boolean') {
+      findCommand.showDiskLoc = options.showDiskLoc;
     }
 
     // TODO: use `MongoDBNamespace` through and through
     const cursorState = this.cursorState || {};
     server.query(
       this.ns.toString(),
-      this.cmd,
+      findCommand,
       cursorState,
-      { fullResult: !!this.fullResponse, ...this.options },
+      { fullResult: !!this.fullResponse, ...this.options, ...this.bsonOptions },
       callback
     );
   }

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -50,6 +50,9 @@ export abstract class OperationBase<
   cursorState?: InternalCursorState;
   fullResponse?: boolean;
 
+  // BSON serialization options
+  bsonOptions?: BSONSerializeOptions;
+
   constructor(options: T = {} as T) {
     this.options = Object.assign({}, options);
     this.readPreference = ReadPreference.primary;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -695,21 +695,25 @@ export function maybePromise<T>(
       };
     });
   }
+
   wrapper((err, res) => {
     if (err != null) {
       try {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         callback!(err);
       } catch (error) {
-        return process.nextTick(() => {
+        process.nextTick(() => {
           throw error;
         });
       }
+
       return;
     }
+
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     callback!(err, res);
   });
+
   return result;
 }
 

--- a/test/functional/collations.test.js
+++ b/test/functional/collations.test.js
@@ -506,7 +506,7 @@ describe('Collation', function () {
           .then(() => Promise.reject('this test should fail'))
           .catch(err => {
             expect(err).to.exist;
-            expect(err.message).to.match(/topology does not support collation/);
+            expect(err.message).to.match(/does not support collation/);
             return client.close();
           });
       });

--- a/test/functional/collection.test.js
+++ b/test/functional/collection.test.js
@@ -296,17 +296,6 @@ describe('Collection', function () {
       });
     });
 
-    it('should return invalid collection name error by callback for createCollection', function (done) {
-      db.dropDatabase(err => {
-        expect(err).to.not.exist;
-
-        db.createCollection('test/../', err => {
-          expect(err).to.be.instanceof(Error);
-          expect(err.message).to.equal('collection names cannot be empty');
-          done();
-        });
-      });
-    });
     it('should correctly count on non-existent collection', function (done) {
       db.collection('test_multiple_insert_2', (err, collection) => {
         collection.countDocuments((err, count) => {
@@ -441,7 +430,7 @@ describe('Collection', function () {
       },
       {
         title: 'should correctly update with pipeline',
-        collectionName: 'test_should_correctly_do_update_with_pipeline',
+        collectionName: 'test_should_correctly_do_update_with_atomic_modifier',
         filterObject: {},
         updateObject: { $set: { a: 1, b: 1, d: 1 } }
       }


### PR DESCRIPTION
The primary work of this ticket was to make the `Collection#find` method behave like other read operations by moving the command construction to the `FindOperation` itself. Along the way a number of improvements were made:

 - cursors now know they are tailable and/or awaitData upon construction, rather than observing the internal `cmd` they are built around. As much as possible the cursor implementation now no longer alters behavior after initialization based on what is in the internal `cmd` document

 - a number of supported, but undocumented options were added to the `find` method itself

 - `bsonOptions` were introduced to the `OperationBase` class as a first step towards improving our story around overriding these values and passing them to wire protocol methods

NODE-2830
