### PR TITLE
fix: permit waking async interval with unreliable clocks

### DIFF
--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -114,5 +114,51 @@ describe('utils', function () {
 
       this.clock.tick(250);
     });
+
+    it('should immediately schedule if the clock is unreliable', function (done) {
+      let clockCalled = 0;
+      let lastTime = now();
+      const marks = [];
+      const executor = makeInterruptableAsyncInterval(
+        callback => {
+          marks.push(now() - lastTime);
+          lastTime = now();
+          callback();
+        },
+        {
+          interval: 50,
+          minInterval: 10,
+          immediate: true,
+          clock() {
+            clockCalled += 1;
+
+            // needs to happen on the third call because `wake` checks
+            // the `currentTime` at the beginning of the function
+            if (clockCalled === 3) {
+              return now() - 100000;
+            }
+
+            return now();
+          }
+        }
+      );
+
+      // force mark at 20ms, and then the unreliable system clock
+      // will report a very stale `lastCallTime` on this mark.
+      setTimeout(() => executor.wake(), 10);
+
+      // try to wake again in another `minInterval + immediate`, now
+      // using a very old `lastCallTime`. This should result in an
+      // immediate scheduling: 0ms (immediate), 20ms (wake with minIterval)
+      // and then 10ms for another immediate.
+      setTimeout(() => executor.wake(), 30);
+
+      setTimeout(() => {
+        executor.stop();
+        expect(marks).to.eql([0, 20, 10, 50, 50, 50, 50]);
+        done();
+      }, 250);
+      this.clock.tick(250);
+    });
   });
 });


### PR DESCRIPTION
The logic for waking the AsyncInterruptibleInterval sooner than its interval is dependent on an ability to reliably mark the last call made to the wrapped function. In environments like AWS Lambda where instances can be frozen and later thawed, it's possible for the last call to be in a distant past even though the internal timer has not completed yet. This change ensures that we immediately reschedule in these situations.

NODE-2829