### PR TITLE
test: Update connection-monitoring-and-pooling specs (port to 4.0)

### DIFF
--- a/etc/update-spec-tests.sh
+++ b/etc/update-spec-tests.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This script is used to fetch the latest tests for the specified spec.
+# It puts the tests in the direcory $spec_root. It should be run from the root of the repository.
+
+set -o errexit
+set -o nounset
+
+if [ ! -d ".git" ]; then
+    echo "$0: This script must be run from the root of the repository" >&2
+    exit 1
+fi
+
+if [ $# -ne 1 ]; then
+    echo "$0: This script must be passed exactly one argument for which tests to sync" >&2
+    exit 1
+fi
+
+spec_root="test/spec"
+
+tmpdir=$(mktemp -d -t spec_testsXXXX)
+curl -sL "https://github.com/mongodb/specifications/archive/master.zip" -o "$tmpdir/specs.zip"
+unzip -d "$tmpdir" "$tmpdir/specs.zip" > /dev/null
+mkdir -p "$spec_root/$1"
+rsync -ah --exclude '*.rst' "$tmpdir/specifications-master/source/$1/tests/" "$spec_root/$1" --delete
+rm -rf "$tmpdir"

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-connection.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-connection.json
@@ -13,14 +13,22 @@
       "address": 42
     },
     {
+      "type": "ConnectionCreated",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
       "type": "ConnectionCheckedOut",
       "connectionId": 1,
       "address": 42
     }
   ],
   "ignore": [
-    "ConnectionPoolCreated",
-    "ConnectionCreated",
-    "ConnectionReady"
+    "ConnectionPoolCreated"
   ]
 }

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-connection.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-connection.yml
@@ -6,10 +6,14 @@ operations:
 events:
   - type: ConnectionCheckOutStarted
     address: 42
+  - type: ConnectionCreated
+    connectionId: 1
+    address: 42
+  - type: ConnectionReady
+    connectionId: 1
+    address: 42
   - type: ConnectionCheckedOut
     connectionId: 1
     address: 42
 ignore:
   - ConnectionPoolCreated
-  - ConnectionCreated
-  - ConnectionReady

--- a/test/spec/connection-monitoring-and-pooling/pool-create-min-size.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-create-min-size.json
@@ -12,6 +12,11 @@
       "count": 3
     },
     {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 3
+    },
+    {
       "name": "checkOut"
     }
   ],

--- a/test/spec/connection-monitoring-and-pooling/pool-create-min-size.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-create-min-size.yml
@@ -7,6 +7,9 @@ operations:
   - name: waitForEvent
     event: ConnectionCreated
     count: 3
+  - name: waitForEvent
+    event: ConnectionReady
+    count: 3
   - name: checkOut
 events:
   - type: ConnectionPoolCreated

--- a/test/spec/connection-monitoring-and-pooling/wait-queue-timeout.json
+++ b/test/spec/connection-monitoring-and-pooling/wait-queue-timeout.json
@@ -4,7 +4,7 @@
   "description": "must aggressively timeout threads enqueued longer than waitQueueTimeoutMS",
   "poolOptions": {
     "maxPoolSize": 1,
-    "waitQueueTimeoutMS": 100
+    "waitQueueTimeoutMS": 20
   },
   "operations": [
     {

--- a/test/spec/connection-monitoring-and-pooling/wait-queue-timeout.yml
+++ b/test/spec/connection-monitoring-and-pooling/wait-queue-timeout.yml
@@ -3,7 +3,7 @@ style: unit
 description: must aggressively timeout threads enqueued longer than waitQueueTimeoutMS
 poolOptions:
   maxPoolSize: 1
-  waitQueueTimeoutMS: 100
+  waitQueueTimeoutMS: 20
 operations:
   # Check out only possible connection
   - name: checkOut


### PR DESCRIPTION
Update connection-monitoring-and-pooling tests
ensuring ConnectionCreated proceed ConnectionReady events
Add a script for spec fetching convenience

## Description
 Port of #2555 to 4.0