### PR TITLE
fix: connection leak if waitque cancelled

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -561,15 +561,11 @@ function processWaitQueue(pool: ConnectionPool) {
   if (pool.waitQueueSize && (maxPoolSize <= 0 || pool.totalConnectionCount < maxPoolSize)) {
     createConnection(pool, (err, connection) => {
       const waitQueueMember = pool[kWaitQueue].shift();
-      if (!waitQueueMember) {
+      if (!waitQueueMember || waitQueueMember[kCancelled]) {
         if (!err && connection) {
           pool[kConnections].push(connection);
         }
 
-        return;
-      }
-
-      if (waitQueueMember[kCancelled]) {
         return;
       }
 


### PR DESCRIPTION
## Description
cmap/connection_pool
connection may be leak if waitque cancelled

**What changed?**

**Are there any files to ignore?**
