### PR TITLE
remove PromiseProvider.set from MongoClient#connect

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -430,10 +430,6 @@ export class MongoClient extends EventEmitter implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    if (options && options.promiseLibrary) {
-      PromiseProvider.set(options.promiseLibrary);
-    }
-
     // Create client
     const mongoClient = new MongoClient(url, options);
     // Execute the connect method


### PR DESCRIPTION
Doesn't seem necessary to set the promise in `MongoClient#connect` when it's happening in the constructor of MongoClient.

The overall ticket has already been done, no other methods take a `promiseLibrary`.

NODE-1753