### PR TITLE
fix: allow client connect after close

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -346,19 +346,29 @@ export class MongoClient extends EventEmitter implements OperationParent {
     const force = typeof forceOrCallback === 'boolean' ? forceOrCallback : false;
 
     return maybePromise(callback, cb => {
+      const completeClose = (err?: AnyError) => {
+        // clear out references to old topology
+        this.topology = undefined;
+        this.s.dbCache = new Map();
+        this.s.sessions = new Set();
+
+        cb(err);
+      };
+
       if (this.topology == null) {
-        return cb();
+        completeClose();
+        return;
       }
 
       const topology = this.topology;
       topology.close({ force }, err => {
         const autoEncrypter = topology.s.options.autoEncrypter;
         if (!autoEncrypter) {
-          cb(err);
+          completeClose(err);
           return;
         }
 
-        autoEncrypter.teardown(force, err2 => cb(err || err2));
+        autoEncrypter.teardown(force, err2 => completeClose(err || err2));
       });
     });
   }

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -199,7 +199,7 @@ export function connect(
 
   // Has a connection already been established?
   if (mongoClient.topology && mongoClient.topology.isConnected()) {
-    throw new Error(`'connect' cannot be called when already connected`);
+    throw new MongoError(`'connect' cannot be called when already connected`);
   }
 
   let didRequestAuthentication = false;

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -197,6 +197,11 @@ export function connect(
     throw new Error('no callback function provided');
   }
 
+  // Has a connection already been established?
+  if (mongoClient.topology && mongoClient.topology.isConnected()) {
+    throw new Error(`'connect' cannot be called when already connected`);
+  }
+
   let didRequestAuthentication = false;
   const logger = new Logger('MongoClient', options);
 

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -276,7 +276,7 @@ describe('Connection', function () {
   });
 
   it('should be able to connect again after close', function () {
-    return withClient.call(this, (client, done) => {
+    return withClient.bind(this)((client, done) => {
       expect(client.isConnected()).to.be.true;
 
       const collection = () => client.db('testReconnect').collection('test');

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -287,9 +287,11 @@ describe('Connection', function () {
 
         client.close(err => {
           expect(err).to.not.exist;
+          expect(client.isConnected()).to.be.false;
 
           client.connect(err => {
             expect(err).to.not.exist;
+            expect(client.isConnected()).to.be.true;
 
             collection().insertOne({ b: 2 }, (err, result) => {
               expect(err).to.not.exist;

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -275,8 +275,9 @@ describe('Connection', function () {
     }
   });
 
-  it('should be able to connect again after close', function () {
-    return withClient.bind(this)((client, done) => {
+  it(
+    'should be able to connect again after close',
+    withClient(function (client, done) {
       expect(client.isConnected()).to.be.true;
 
       const collection = () => client.db('testReconnect').collection('test');
@@ -299,6 +300,6 @@ describe('Connection', function () {
           });
         });
       });
-    });
-  });
+    })
+  );
 });

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -123,7 +123,7 @@ describe('Sessions', function () {
               // verify that the `endSessions` command was sent
               const lastCommand = test.commands.started[test.commands.started.length - 1];
               expect(lastCommand.commandName).to.equal('endSessions');
-              expect(client.topology.s.sessionPool.sessions).to.have.length(0);
+              expect(client.topology).to.not.exist;
             });
         });
       });
@@ -143,7 +143,7 @@ describe('Sessions', function () {
             // verify that the `endSessions` command was sent
             const lastCommand = test.commands.started[test.commands.started.length - 1];
             expect(lastCommand.commandName).to.equal('endSessions');
-            expect(client.topology.s.sessionPool.sessions).to.have.length(0);
+            expect(client.topology).to.not.exist;
           });
       });
     }


### PR DESCRIPTION
`connect` doesn't work again after `close` has been called once on a `MongoClient`.

Cleaning up some state beforehand fixes the issue.

NODE-2544
