### PR TITLE
fix: correctly re-establishes pipe destinations

### DIFF
--- a/lib/change_stream.js
+++ b/lib/change_stream.js
@@ -437,7 +437,7 @@ function createChangeStreamCursor(self, options) {
 
   if (self.pipeDestinations) {
     const cursorStream = changeStreamCursor.stream(self.streamOptions);
-    for (let pipeDestination in self.pipeDestinations) {
+    for (let pipeDestination of self.pipeDestinations) {
       cursorStream.pipe(pipeDestination);
     }
   }

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -1475,7 +1475,7 @@ describe('Change Streams', function() {
     }
   });
 
-  it('should resume piping of Change Streams when a resumable error is encountered', {
+  it.only('should resume piping of Change Streams when a resumable error is encountered', {
     metadata: {
       requires: {
         generators: true,
@@ -1490,9 +1490,6 @@ describe('Change Streams', function() {
       const ObjectId = configuration.require.ObjectId;
       const Timestamp = configuration.require.Timestamp;
       const Long = configuration.require.Long;
-
-      // Contain mock server
-      let primaryServer = null;
 
       // Default message fields
       const defaultFields = {
@@ -1509,9 +1506,8 @@ describe('Change Streams', function() {
         hosts: ['localhost:32000', 'localhost:32001', 'localhost:32002']
       };
 
-      co(function*() {
-        primaryServer = yield mock.createServer(32000, 'localhost');
-
+      mock.createServer(32000, 'localhost').then(primaryServer => {
+        this.defer(() => mock.cleanup());
         let counter = 0;
         primaryServer.setMessageHandler(request => {
           const doc = request.document;
@@ -1597,6 +1593,7 @@ describe('Change Streams', function() {
 
         client.connect((err, client) => {
           expect(err).to.not.exist;
+          this.defer(() => client.close());
 
           const database = client.db('integration_tests5');
           const collection = database.collection('MongoNetworkErrorTestPromises');
@@ -1605,22 +1602,17 @@ describe('Change Streams', function() {
           const outStream = fs.createWriteStream(filename);
 
           changeStream.stream({ transform: JSON.stringify }).pipe(outStream);
-
+          this.defer(() => changeStream.close());
           // Listen for changes to the file
-          const watcher = fs.watch(filename, function(eventType) {
+          const watcher = fs.watch(filename, eventType => {
+            this.defer(() => watcher.close());
             expect(eventType).to.equal('change');
 
             const fileContents = fs.readFileSync(filename, 'utf8');
             const parsedFileContents = JSON.parse(fileContents);
             expect(parsedFileContents).to.have.nested.property('fullDocument.a', 1);
 
-            watcher.close();
-
-            changeStream.close(err => {
-              expect(err).to.not.exist;
-
-              mock.cleanup(() => done());
-            });
+            done();
           });
         });
       });

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -1510,7 +1510,7 @@ describe('Change Streams', function() {
       };
 
       co(function*() {
-        primaryServer = yield mock.createServer();
+        primaryServer = yield mock.createServer(32000, 'localhost');
 
         let counter = 0;
         primaryServer.setMessageHandler(request => {

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -1475,7 +1475,7 @@ describe('Change Streams', function() {
     }
   });
 
-  it.only('should resume piping of Change Streams when a resumable error is encountered', {
+  it('should resume piping of Change Streams when a resumable error is encountered', {
     metadata: {
       requires: {
         generators: true,


### PR DESCRIPTION
NODE-2172

I tried pretty hard to recreate this locally, and I ran into issues, I was also considering stubbing out the `#pipe` here and testing the `createChangeStreamCursor` function directly but that would mean exporting it which would make it public. I can't get this code to fire and it does not exist in master anymore. 

It does seem verifiably wrong.

```js
const x = ['pipe1', 'pipe2', 'pipe3']
> for (let pipe in x) { console.log(pipe) }
0
1
2
> for (let pipe of x) { console.log(pipe) }
pipe1
pipe2
pipe3
```