### PR TITLE
fix: correctly extend the "command" object with "user"

### DIFF
--- a/lib/core/auth/x509.js
+++ b/lib/core/auth/x509.js
@@ -26,7 +26,7 @@ class X509 extends AuthProvider {
 function x509AuthenticateCommand(credentials) {
   const command = { authenticate: 1, mechanism: 'MONGODB-X509' };
   if (credentials.username) {
-    Object.apply(command, { user: credentials.username });
+    Object.assign(command, { user: credentials.username });
   }
 
   return command;


### PR DESCRIPTION
I believe there should be `Object.assign` and not `Object.apply` otherwise `user` isn't added to the `command` object and authentication that requires this field fails.
