### PR TITLE
fix: allow client connect after close

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -258,6 +258,12 @@ MongoClient.prototype.close = function(force, callback) {
       }
 
       client.removeAllListeners('close');
+
+      // clear out references to old topology
+      client.topology = undefined;
+      client.s.dbCache = new Map();
+      client.s.sessions = new Set();
+
       cb(err);
     };
 

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -272,8 +272,9 @@ MongoClient.prototype.close = function(force, callback) {
       return;
     }
 
-    client.topology.close(force, err => {
-      const autoEncrypter = client.topology.s.options.autoEncrypter;
+    const topology = this.topology;
+    topology.close(force, err => {
+      const autoEncrypter = topology.s.options.autoEncrypter;
       if (!autoEncrypter) {
         completeClose(err);
         return;

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -266,6 +266,11 @@ function connect(mongoClient, url, options, callback) {
     throw new Error('no callback function provided');
   }
 
+  // Has a connection already been established?
+  if (mongoClient.topology && mongoClient.topology.isConnected()) {
+    throw new MongoError(`'connect' cannot be called when already connected`);
+  }
+
   let didRequestAuthentication = false;
   const logger = Logger('MongoClient', options);
 

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -2,6 +2,7 @@
 const test = require('./shared').assert,
   setupDatabase = require('./shared').setupDatabase,
   expect = require('chai').expect;
+const withClient = require('./shared').withClient;
 
 describe('Connection', function() {
   before(function() {
@@ -451,6 +452,39 @@ describe('Connection', function() {
       done();
     }
   });
+
+  /**
+   * @ignore
+   */
+  it(
+    'should be able to connect again after close',
+    withClient(function (client, done) {
+      expect(client.isConnected()).to.be.true;
+
+      const collection = () => client.db('testReconnect').collection('test');
+      collection().insertOne({ a: 1 }, (err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+
+        client.close(err => {
+          expect(err).to.not.exist;
+          expect(client.isConnected()).to.be.false;
+
+          client.connect(err => {
+            expect(err).to.not.exist;
+            expect(client.isConnected()).to.be.true;
+
+            collection().insertOne({ b: 2 }, (err, result) => {
+              expect(err).to.not.exist;
+              expect(result).to.exist;
+              expect(client.topology.isDestroyed()).to.be.false;
+              done();
+            });
+          });
+        });
+      });
+    })
+  );
 
   /**
    * @ignore

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -458,7 +458,7 @@ describe('Connection', function() {
    */
   it(
     'should be able to connect again after close',
-    withClient(function (client, done) {
+    withClient(function(client, done) {
       expect(client.isConnected()).to.be.true;
 
       const collection = () => client.db('testReconnect').collection('test');

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -127,7 +127,7 @@ describe('Sessions', function() {
               // verify that the `endSessions` command was sent
               const lastCommand = test.commands.started[test.commands.started.length - 1];
               expect(lastCommand.commandName).to.equal('endSessions');
-              expect(client.topology.s.sessionPool.sessions).to.have.length(0);
+              expect(client.topology).to.not.exist;
             });
         });
       });
@@ -151,7 +151,7 @@ describe('Sessions', function() {
             // verify that the `endSessions` command was sent
             const lastCommand = test.commands.started[test.commands.started.length - 1];
             expect(lastCommand.commandName).to.equal('endSessions');
-            expect(client.topology.s.sessionPool.sessions).to.have.length(0);
+            expect(client.topology).to.not.exist;
           });
       });
     }


### PR DESCRIPTION
`connect` doesn't work again after close has been called once on a `MongoClient`.

Cleaning up some state beforehand fixes the issue.

NODE-2544

port to `3.6`