### PR TITLE
refactor: unify means of applying `ignoreUndefined`

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -1,3 +1,4 @@
+import type { OperationParent } from './operations/command';
 // import type * as _BSON from 'bson';
 // let BSON: typeof _BSON = require('bson');
 // try {
@@ -71,30 +72,23 @@ export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSe
 }
 
 /**
- * Merge the given BSONSerializeOptions, preferring options over parentOptions, and optionally
+ * Merge the given BSONSerializeOptions, preferring options over the parent's options, and
  * substituting defaults for values not set.
  *
  * @internal
- *
- * @param options - The primary options to use
- * @param parentOptions - The secondary options to use
- * @param includeDefaultOptions - Whether to include default options for any values not set
  */
-export function inheritBSONOptions(
+export function resolveBSONOptions(
   options?: BSONSerializeOptions,
-  parentOptions?: BSONSerializeOptions,
-  includeDefaultOptions?: boolean
+  parent?: OperationParent
 ): BSONSerializeOptions {
-  const defaults = {
-    raw: false,
-    promoteLongs: true,
-    promoteValues: true,
-    promoteBuffers: false,
-    ignoreUndefined: false,
-    serializeFunctions: false,
-    fieldsAsRaw: {}
+  const parentOptions = parent?.bsonOptions;
+  return {
+    raw: options?.raw ?? parentOptions?.raw ?? false,
+    promoteLongs: options?.promoteLongs ?? parentOptions?.promoteLongs ?? true,
+    promoteValues: options?.promoteValues ?? parentOptions?.promoteValues ?? true,
+    promoteBuffers: options?.promoteBuffers ?? parentOptions?.promoteBuffers ?? false,
+    ignoreUndefined: options?.ignoreUndefined ?? parentOptions?.ignoreUndefined ?? false,
+    serializeFunctions: options?.serializeFunctions ?? parentOptions?.serializeFunctions ?? false,
+    fieldsAsRaw: options?.fieldsAsRaw ?? parentOptions?.fieldsAsRaw ?? {}
   };
-
-  const base = includeDefaultOptions ? defaults : {};
-  return pluckBSONSerializeOptions({ ...base, ...parentOptions, ...options });
 }

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -70,14 +70,12 @@ export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSe
   };
 }
 
-// TODO: naming
-// TODO: testing
+// Merge the given BSONSerializeOptions, preferring options over parentOptions, and substituting a
+// default for values not set.
 export function inheritOrDefaultBSONSerializableOptions(
   options?: BSONSerializeOptions,
   parentOptions?: BSONSerializeOptions
 ): BSONSerializeOptions {
-  // Merge the BSONSerializeOptions, preferring options over parentOptions, and substituting a
-  // default for values not set.
   return {
     raw: options?.raw ?? parentOptions?.raw ?? false,
     promoteLongs: options?.promoteLongs ?? parentOptions?.promoteLongs ?? true,

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -69,3 +69,21 @@ export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSe
     raw
   };
 }
+
+// TODO: naming
+// TODO: testing
+export function inheritOrDefaultBSONSerializableOptions(
+  options?: BSONSerializeOptions,
+  parentOptions?: BSONSerializeOptions
+): BSONSerializeOptions {
+  // Merge the BSONSerializeOptions, preferring options over parentOptions, and substituting a
+  // default for values not set.
+  // Note that we exclude fieldsAsRaw and serializeFunctions because I was not sure about their usage
+  return {
+    raw: options?.raw ?? parentOptions?.raw ?? false,
+    promoteLongs: options?.promoteLongs ?? parentOptions?.promoteLongs ?? true,
+    promoteValues: options?.promoteValues ?? parentOptions?.promoteValues ?? true,
+    promoteBuffers: options?.promoteBuffers ?? parentOptions?.promoteBuffers ?? false,
+    ignoreUndefined: options?.ignoreUndefined ?? parentOptions?.ignoreUndefined ?? false
+  };
+}

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -78,12 +78,13 @@ export function inheritOrDefaultBSONSerializableOptions(
 ): BSONSerializeOptions {
   // Merge the BSONSerializeOptions, preferring options over parentOptions, and substituting a
   // default for values not set.
-  // Note that we exclude fieldsAsRaw and serializeFunctions because I was not sure about their usage //TODO: serialize functions?
   return {
     raw: options?.raw ?? parentOptions?.raw ?? false,
     promoteLongs: options?.promoteLongs ?? parentOptions?.promoteLongs ?? true,
     promoteValues: options?.promoteValues ?? parentOptions?.promoteValues ?? true,
     promoteBuffers: options?.promoteBuffers ?? parentOptions?.promoteBuffers ?? false,
-    ignoreUndefined: options?.ignoreUndefined ?? parentOptions?.ignoreUndefined ?? false
+    ignoreUndefined: options?.ignoreUndefined ?? parentOptions?.ignoreUndefined ?? false,
+    serializeFunctions: options?.serializeFunctions ?? parentOptions?.serializeFunctions ?? false,
+    fieldsAsRaw: options?.fieldsAsRaw ?? parentOptions?.fieldsAsRaw ?? {}
   };
 }

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -71,21 +71,30 @@ export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSe
 }
 
 /**
- * Merge the given BSONSerializeOptions, preferring options over parentOptions, and substituting
- * defaults for values not set.
+ * Merge the given BSONSerializeOptions, preferring options over parentOptions, and optionally
+ * substituting defaults for values not set.
+ *
  * @internal
+ *
+ * @param options - The primary options to use
+ * @param parentOptions - The secondary options to use
+ * @param includeDefaultOptions - Whether to include default options for any values not set
  */
 export function inheritBSONOptions(
   options?: BSONSerializeOptions,
-  parentOptions?: BSONSerializeOptions
+  parentOptions?: BSONSerializeOptions,
+  includeDefaultOptions?: boolean
 ): BSONSerializeOptions {
-  return {
-    raw: options?.raw ?? parentOptions?.raw ?? false,
-    promoteLongs: options?.promoteLongs ?? parentOptions?.promoteLongs ?? true,
-    promoteValues: options?.promoteValues ?? parentOptions?.promoteValues ?? true,
-    promoteBuffers: options?.promoteBuffers ?? parentOptions?.promoteBuffers ?? false,
-    ignoreUndefined: options?.ignoreUndefined ?? parentOptions?.ignoreUndefined ?? false,
-    serializeFunctions: options?.serializeFunctions ?? parentOptions?.serializeFunctions ?? false,
-    fieldsAsRaw: options?.fieldsAsRaw ?? parentOptions?.fieldsAsRaw ?? {}
+  const defaults = {
+    raw: false,
+    promoteLongs: true,
+    promoteValues: true,
+    promoteBuffers: false,
+    ignoreUndefined: false,
+    serializeFunctions: false,
+    fieldsAsRaw: {}
   };
+
+  const base = includeDefaultOptions ? defaults : {};
+  return pluckBSONSerializeOptions({ ...base, ...parentOptions, ...options });
 }

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -78,7 +78,7 @@ export function inheritOrDefaultBSONSerializableOptions(
 ): BSONSerializeOptions {
   // Merge the BSONSerializeOptions, preferring options over parentOptions, and substituting a
   // default for values not set.
-  // Note that we exclude fieldsAsRaw and serializeFunctions because I was not sure about their usage
+  // Note that we exclude fieldsAsRaw and serializeFunctions because I was not sure about their usage //TODO: serialize functions?
   return {
     raw: options?.raw ?? parentOptions?.raw ?? false,
     promoteLongs: options?.promoteLongs ?? parentOptions?.promoteLongs ?? true,

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -70,9 +70,12 @@ export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSe
   };
 }
 
-// Merge the given BSONSerializeOptions, preferring options over parentOptions, and substituting
-// defaults for values not set.
-export function inheritOrDefaultBSONSerializableOptions(
+/**
+ * Merge the given BSONSerializeOptions, preferring options over parentOptions, and substituting
+ * defaults for values not set.
+ * @internal
+ */
+export function inheritBSONOptions(
   options?: BSONSerializeOptions,
   parentOptions?: BSONSerializeOptions
 ): BSONSerializeOptions {

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -70,8 +70,8 @@ export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSe
   };
 }
 
-// Merge the given BSONSerializeOptions, preferring options over parentOptions, and substituting a
-// default for values not set.
+// Merge the given BSONSerializeOptions, preferring options over parentOptions, and substituting
+// defaults for values not set.
 export function inheritOrDefaultBSONSerializableOptions(
   options?: BSONSerializeOptions,
   parentOptions?: BSONSerializeOptions

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1378,12 +1378,6 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    // Add ignoreUndefined
-    if (this.s.options.ignoreUndefined) {
-      options = Object.assign({}, options);
-      options.ignoreUndefined = this.s.options.ignoreUndefined;
-    }
-
     return this.updateMany(selector, update, options, callback);
   }
 
@@ -1402,12 +1396,6 @@ export class Collection implements OperationParent {
   ): Promise<DeleteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
-
-    // Add ignoreUndefined
-    if (this.s.options.ignoreUndefined) {
-      options = Object.assign({}, options);
-      options.ignoreUndefined = this.s.options.ignoreUndefined;
-    }
 
     return this.deleteMany(selector, options, callback);
   }

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -8,7 +8,7 @@ import {
   MongoDBNamespace,
   Callback
 } from './utils';
-import { ObjectId, Document, BSONSerializeOptions } from './bson';
+import { ObjectId, Document, BSONSerializeOptions, inheritBSONOptions } from './bson';
 import { MongoError } from './error';
 import { UnorderedBulkOperation } from './bulk/unordered';
 import { OrderedBulkOperation } from './bulk/ordered';
@@ -127,12 +127,6 @@ export interface CollectionPrivate {
   namespace: MongoDBNamespace;
   readPreference?: ReadPreference;
   slaveOk?: boolean;
-  serializeFunctions?: boolean;
-  raw?: boolean;
-  promoteLongs?: boolean;
-  promoteValues?: boolean;
-  promoteBuffers?: boolean;
-  ignoreUndefined?: boolean;
   collectionHint?: Hint;
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
@@ -190,29 +184,11 @@ export class Collection implements OperationParent {
       readPreference: ReadPreference.fromOptions(options),
       readConcern: ReadConcern.fromOptions(options),
       writeConcern: WriteConcern.fromOptions(options),
-      slaveOk: options == null || options.slaveOk == null ? db.slaveOk : options.slaveOk,
-      serializeFunctions:
-        options == null || options.serializeFunctions == null
-          ? db.s.options?.serializeFunctions
-          : options.serializeFunctions,
-      raw: options == null || options.raw == null ? db.s.options?.raw : options.raw,
-      promoteLongs:
-        options == null || options.promoteLongs == null
-          ? db.s.options?.promoteLongs
-          : options.promoteLongs,
-      promoteValues:
-        options == null || options.promoteValues == null
-          ? db.s.options?.promoteValues
-          : options.promoteValues,
-      promoteBuffers:
-        options == null || options.promoteBuffers == null
-          ? db.s.options?.promoteBuffers
-          : options.promoteBuffers,
-      ignoreUndefined:
-        options == null || options.ignoreUndefined == null
-          ? db.s.options?.ignoreUndefined
-          : options.ignoreUndefined
+      slaveOk: options == null || options.slaveOk == null ? db.slaveOk : options.slaveOk
     };
+
+    // Modify internal state with inherited BSON options
+    this.s.options = { ...this.s.options, ...inheritBSONOptions(options, db.s.options, false) };
   }
 
   /**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -301,12 +301,6 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
-    // Add ignoreUndefined
-    if (this.s.options.ignoreUndefined) {
-      options = Object.assign({}, options);
-      options.ignoreUndefined = this.s.options.ignoreUndefined;
-    }
-
     return executeOperation(this.s.topology, new InsertOneOperation(this, doc, options), callback);
   }
 
@@ -428,12 +422,6 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
     options = Object.assign({}, options);
 
-    // Add ignoreUndefined
-    if (this.s.options.ignoreUndefined) {
-      options = Object.assign({}, options);
-      options.ignoreUndefined = this.s.options.ignoreUndefined;
-    }
-
     return executeOperation(
       this.s.topology,
       new UpdateOneOperation(this, filter, update, options),
@@ -471,12 +459,6 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
     options = Object.assign({}, options);
 
-    // Add ignoreUndefined
-    if (this.s.options.ignoreUndefined) {
-      options = Object.assign({}, options);
-      options.ignoreUndefined = this.s.options.ignoreUndefined;
-    }
-
     return executeOperation(
       this.s.topology,
       new ReplaceOneOperation(this, filter, replacement, options),
@@ -510,12 +492,6 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
     options = Object.assign({}, options);
 
-    // Add ignoreUndefined
-    if (this.s.options.ignoreUndefined) {
-      options = Object.assign({}, options);
-      options.ignoreUndefined = this.s.options.ignoreUndefined;
-    }
-
     return executeOperation(
       this.s.topology,
       new UpdateManyOperation(this, filter, update, options),
@@ -541,12 +517,6 @@ export class Collection implements OperationParent {
   ): Promise<DeleteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
     options = Object.assign({}, options);
-
-    // Add ignoreUndefined
-    if (this.s.options.ignoreUndefined) {
-      options = Object.assign({}, options);
-      options.ignoreUndefined = this.s.options.ignoreUndefined;
-    }
 
     return executeOperation(
       this.s.topology,
@@ -585,12 +555,6 @@ export class Collection implements OperationParent {
     }
 
     options = Object.assign({}, options);
-
-    // Add ignoreUndefined
-    if (this.s.options.ignoreUndefined) {
-      options = Object.assign({}, options);
-      options.ignoreUndefined = this.s.options.ignoreUndefined;
-    }
 
     return executeOperation(
       this.s.topology,

--- a/src/db.ts
+++ b/src/db.ts
@@ -340,11 +340,6 @@ export class Db implements OperationParent {
     // If we have not set a collection level readConcern set the db level one
     options.readConcern = ReadConcern.fromOptions(options) ?? this.readConcern;
 
-    // Do we have ignoreUndefined set
-    if (this.s.options?.ignoreUndefined) {
-      options.ignoreUndefined = this.s.options.ignoreUndefined;
-    }
-
     // Merge in all needed options and ensure correct writeConcern merging from db level
     const finalOptions = mergeOptionsAndWriteConcern(
       options,

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -10,7 +10,7 @@ import { connect, validOptions } from './operations/connect';
 import { PromiseProvider } from './promise_provider';
 import { Logger } from './logger';
 import { ReadConcern, ReadConcernLevelLike, ReadConcernLike } from './read_concern';
-import type { BSONSerializeOptions, Document } from './bson';
+import { BSONSerializeOptions, Document, resolveBSONOptions } from './bson';
 import type { AutoEncryptionOptions } from './deps';
 import type { CompressorName } from './cmap/wire_protocol/compression';
 import type { AuthMechanism } from './cmap/auth/defaultAuthProviders';
@@ -222,6 +222,7 @@ export interface MongoClientPrivate {
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
   readPreference: ReadPreference;
+  bsonOptions: BSONSerializeOptions;
   namespace: MongoDBNamespace;
   logger: Logger;
 }
@@ -284,6 +285,7 @@ export class MongoClient extends EventEmitter implements OperationParent {
       readConcern: ReadConcern.fromOptions(options),
       writeConcern: WriteConcern.fromOptions(options),
       readPreference: ReadPreference.fromOptions(options) || ReadPreference.primary,
+      bsonOptions: resolveBSONOptions(options),
       namespace: new MongoDBNamespace('admin'),
       logger: options?.logger ?? new Logger('MongoClient')
     };
@@ -299,6 +301,10 @@ export class MongoClient extends EventEmitter implements OperationParent {
 
   get readPreference(): ReadPreference {
     return this.s.readPreference;
+  }
+
+  get bsonOptions(): BSONSerializeOptions {
+    return this.s.bsonOptions;
   }
 
   get logger(): Logger {

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -1,6 +1,6 @@
 import { applyRetryableWrites, applyWriteConcern, Callback } from '../utils';
 import { OperationBase } from './operation';
-import { inheritBSONOptions } from '../bson';
+import { resolveBSONOptions } from '../bson';
 import { WriteConcern } from '../write_concern';
 import type { Collection } from '../collection';
 import type {
@@ -27,7 +27,7 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
     this.operations = operations;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    this.bsonOptions = inheritBSONOptions(options, collection.s.options, true);
+    this.bsonOptions = resolveBSONOptions(options, collection);
   }
 
   execute(server: Server, callback: Callback<BulkWriteResult>): void {

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -27,7 +27,7 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
     this.operations = operations;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    Object.assign(this, inheritBSONOptions(options, collection.s.options, true));
+    this.bsonOptions = inheritBSONOptions(options, collection.s.options, true);
   }
 
   execute(server: Server, callback: Callback<BulkWriteResult>): void {

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -1,6 +1,6 @@
 import { applyRetryableWrites, applyWriteConcern, Callback } from '../utils';
 import { OperationBase } from './operation';
-import { inheritOrDefaultBSONSerializableOptions } from '../bson';
+import { inheritBSONOptions } from '../bson';
 import { WriteConcern } from '../write_concern';
 import type { Collection } from '../collection';
 import type {
@@ -27,13 +27,13 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
     this.operations = operations;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, collection.s));
+    Object.assign(this, inheritBSONOptions(options, collection.s));
   }
 
   execute(server: Server, callback: Callback<BulkWriteResult>): void {
     const coll = this.collection;
     const operations = this.operations;
-    const options = Object.assign({}, this.options, this.bsonOptions);
+    const options = { ...this.options, ...this.bsonOptions };
 
     // Create the bulk operation
     const bulk: BulkOperationBase =

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -26,7 +26,7 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
     this.collection = collection;
     this.operations = operations;
 
-    // Assign all bsonOptions to OperationBase obj, preferring command options over parent options
+    // Assign BSON serialize options to OperationBase, preferring options over collection options
     Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, collection.s));
   }
 

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -33,7 +33,7 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
   execute(server: Server, callback: Callback<BulkWriteResult>): void {
     const coll = this.collection;
     const operations = this.operations;
-    const options = this.options;
+    const options = Object.assign({}, this.options, this.bsonOptions);
 
     // Create the bulk operation
     const bulk: BulkOperationBase =
@@ -51,7 +51,7 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
     }
 
     // Final options for retryable writes and write concern
-    let finalOptions = Object.assign({}, options, this.bsonOptions);
+    let finalOptions = Object.assign({}, options);
     finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
     finalOptions = applyWriteConcern(finalOptions, { db: coll.s.db, collection: coll }, options);
 

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -27,7 +27,7 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
     this.operations = operations;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    Object.assign(this, inheritBSONOptions(options, collection.s));
+    Object.assign(this, inheritBSONOptions(options, collection.s.options, true));
   }
 
   execute(server: Server, callback: Callback<BulkWriteResult>): void {

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -101,8 +101,7 @@ export abstract class CommandOperation<
     }
 
     // Assign all bsonOptions to OperationBase obj, preferring command options over parent options
-    // TODO, for collection it makes sense to take it from parent.s -- is this true for others?
-    // TODO: downside of this is after the command is created these values are *fixed* because they are already set to default/inherited values
+    // base accounts for the fact that Collection stores bson options in s, while Db stores bson options in s.options
     const base = Object.assign({}, parent?.s.options, parent?.s);
     Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, base));
   }

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -7,7 +7,7 @@ import { commandSupportsReadConcern } from '../sessions';
 import { MongoError } from '../error';
 import type { Logger } from '../logger';
 import type { Server } from '../sdam/server';
-import { Document, inheritOrDefaultBSONSerializableOptions } from '../bson';
+import { BSONSerializeOptions, Document, inheritOrDefaultBSONSerializableOptions } from '../bson';
 import type { CollationOptions } from '../cmap/wire_protocol/write_command';
 import type { ReadConcernLike } from './../read_concern';
 
@@ -45,6 +45,7 @@ export interface OperationParent {
     promoteValues?: boolean;
     promoteBuffers?: boolean;
     ignoreUndefined?: boolean;
+    options?: BSONSerializeOptions;
   };
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
@@ -102,7 +103,8 @@ export abstract class CommandOperation<
     // Assign all bsonOptions to OperationBase obj, preferring command options over parent options
     // TODO, for collection it makes sense to take it from parent.s -- is this true for others?
     // TODO: downside of this is after the command is created these values are *fixed* because they are already set to default/inherited values
-    Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, parent?.s));
+    const base = Object.assign({}, parent?.s.options, parent?.s);
+    Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, base));
   }
 
   abstract execute(server: Server, callback: Callback<TResult>): void;

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -38,7 +38,7 @@ export interface CommandOperationOptions extends OperationOptions, WriteConcernO
 /** @internal */
 export interface OperationParent {
   s: {
-    namespace: MongoDBNamespace; // TODO: how to improve?
+    namespace: MongoDBNamespace;
     serializeFunctions?: boolean;
     raw?: boolean;
     promoteLongs?: boolean;
@@ -100,7 +100,7 @@ export abstract class CommandOperation<
       this.logger = parent.logger;
     }
 
-    // Assign all bsonOptions to OperationBase obj, preferring command options over parent options.
+    // Assign BSON serialize options to OperationBase, preferring options over parent options.
     // base accounts for the fact that Collection stores bson options in s, while other parents,
     // like Db, stores bson options in s.options
     const base = Object.assign({}, parent?.s.options, parent?.s);

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -7,7 +7,7 @@ import { commandSupportsReadConcern } from '../sessions';
 import { MongoError } from '../error';
 import type { Logger } from '../logger';
 import type { Server } from '../sdam/server';
-import { BSONSerializeOptions, Document, inheritBSONOptions } from '../bson';
+import { BSONSerializeOptions, Document, resolveBSONOptions } from '../bson';
 import type { CollationOptions } from '../cmap/wire_protocol/write_command';
 import type { ReadConcernLike } from './../read_concern';
 
@@ -37,14 +37,12 @@ export interface CommandOperationOptions extends OperationOptions, WriteConcernO
 
 /** @internal */
 export interface OperationParent {
-  s: {
-    namespace: MongoDBNamespace;
-    options?: BSONSerializeOptions;
-  };
+  s: { namespace: MongoDBNamespace };
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
   readPreference?: ReadPreference;
   logger?: Logger;
+  bsonOptions?: BSONSerializeOptions;
 }
 
 /** @internal */
@@ -95,7 +93,7 @@ export abstract class CommandOperation<
     }
 
     // Assign BSON serialize options to OperationBase, preferring options over parent options.
-    this.bsonOptions = inheritBSONOptions(options, parent?.s.options, true);
+    this.bsonOptions = resolveBSONOptions(options, parent);
   }
 
   abstract execute(server: Server, callback: Callback<TResult>): void;

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -95,7 +95,7 @@ export abstract class CommandOperation<
     }
 
     // Assign BSON serialize options to OperationBase, preferring options over parent options.
-    Object.assign(this, inheritBSONOptions(options, parent?.s.options, true));
+    this.bsonOptions = inheritBSONOptions(options, parent?.s.options, true);
   }
 
   abstract execute(server: Server, callback: Callback<TResult>): void;

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -39,12 +39,6 @@ export interface CommandOperationOptions extends OperationOptions, WriteConcernO
 export interface OperationParent {
   s: {
     namespace: MongoDBNamespace;
-    serializeFunctions?: boolean;
-    raw?: boolean;
-    promoteLongs?: boolean;
-    promoteValues?: boolean;
-    promoteBuffers?: boolean;
-    ignoreUndefined?: boolean;
     options?: BSONSerializeOptions;
   };
   readConcern?: ReadConcern;
@@ -101,9 +95,7 @@ export abstract class CommandOperation<
     }
 
     // Assign BSON serialize options to OperationBase, preferring options over parent options.
-    // Here, we account for the fact that Collection stores bson options in s, while other parents,
-    // like Db, stores bson options in s.options
-    Object.assign(this, inheritBSONOptions(options, { ...parent?.s.options, ...parent?.s }));
+    Object.assign(this, inheritBSONOptions(options, parent?.s.options, true));
   }
 
   abstract execute(server: Server, callback: Callback<TResult>): void;

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -100,8 +100,9 @@ export abstract class CommandOperation<
       this.logger = parent.logger;
     }
 
-    // Assign all bsonOptions to OperationBase obj, preferring command options over parent options
-    // base accounts for the fact that Collection stores bson options in s, while Db stores bson options in s.options
+    // Assign all bsonOptions to OperationBase obj, preferring command options over parent options.
+    // base accounts for the fact that Collection stores bson options in s, while other parents,
+    // like Db, stores bson options in s.options
     const base = Object.assign({}, parent?.s.options, parent?.s);
     Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, base));
   }

--- a/src/operations/common_functions.ts
+++ b/src/operations/common_functions.ts
@@ -250,7 +250,8 @@ export function updateDocuments(
   // Do we return the actual result document
   // Either use override on the function, or go back to default on either the collection
   // level or db
-  finalOptions.serializeFunctions = options.serializeFunctions || coll.s.options.serializeFunctions;
+  finalOptions.serializeFunctions =
+    options.serializeFunctions || coll.bsonOptions.serializeFunctions;
 
   // Execute the operation
   const op: Document = { q: selector, u: document };

--- a/src/operations/common_functions.ts
+++ b/src/operations/common_functions.ts
@@ -250,7 +250,7 @@ export function updateDocuments(
   // Do we return the actual result document
   // Either use override on the function, or go back to default on either the collection
   // level or db
-  finalOptions.serializeFunctions = options.serializeFunctions || coll.s.serializeFunctions;
+  finalOptions.serializeFunctions = options.serializeFunctions || coll.s.options.serializeFunctions;
 
   // Execute the operation
   const op: Document = { q: selector, u: document };

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -65,7 +65,7 @@ export class DeleteOneOperation extends CommandOperation<DeleteOptions, DeleteRe
   execute(server: Server, callback: Callback<DeleteResult>): void {
     const coll = this.collection;
     const filter = this.filter;
-    const options = this.options;
+    const options = Object.assign({}, this.options, this.bsonOptions);
 
     options.single = true;
     removeDocuments(server, coll, filter, options, (err, r) => {
@@ -99,7 +99,7 @@ export class DeleteManyOperation extends CommandOperation<DeleteOptions, DeleteR
   execute(server: Server, callback: Callback<DeleteResult>): void {
     const coll = this.collection;
     const filter = this.filter;
-    const options = this.options;
+    const options = Object.assign({}, this.options, this.bsonOptions);
 
     // a user can pass `single: true` in to `deleteMany` to remove a single document, theoretically
     if (typeof options.single !== 'boolean') {

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -65,7 +65,7 @@ export class DeleteOneOperation extends CommandOperation<DeleteOptions, DeleteRe
   execute(server: Server, callback: Callback<DeleteResult>): void {
     const coll = this.collection;
     const filter = this.filter;
-    const options = Object.assign({}, this.options, this.bsonOptions);
+    const options = { ...this.options, ...this.bsonOptions };
 
     options.single = true;
     removeDocuments(server, coll, filter, options, (err, r) => {
@@ -99,7 +99,7 @@ export class DeleteManyOperation extends CommandOperation<DeleteOptions, DeleteR
   execute(server: Server, callback: Callback<DeleteResult>): void {
     const coll = this.collection;
     const filter = this.filter;
-    const options = Object.assign({}, this.options, this.bsonOptions);
+    const options = { ...this.options, ...this.bsonOptions };
 
     // a user can pass `single: true` in to `deleteMany` to remove a single document, theoretically
     if (typeof options.single !== 'boolean') {

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -128,15 +128,6 @@ export class FindOperation extends CommandOperation<FindOptions, Document> {
       find: this.ns.toString(),
       query: this.filter
     };
-
-    // TODO: figure out our story about inheriting BSON serialization options
-    this.bsonOptions = {
-      raw: options.raw ?? collection.s.raw ?? false,
-      promoteLongs: options.promoteLongs ?? collection.s.promoteLongs ?? true,
-      promoteValues: options.promoteValues ?? collection.s.promoteValues ?? true,
-      promoteBuffers: options.promoteBuffers ?? collection.s.promoteBuffers ?? false,
-      ignoreUndefined: options.ignoreUndefined ?? collection.s.ignoreUndefined ?? false
-    };
   }
 
   execute(server: Server, callback: Callback<Document>): void {

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -71,7 +71,7 @@ export class FindAndModifyOperation extends CommandOperation<FindAndModifyOption
     const query = this.query;
     const sort = formattedOrderClause(this.sort);
     const doc = this.doc;
-    let options = Object.assign({}, this.options, this.bsonOptions);
+    let options = { ...this.options, ...this.bsonOptions };
 
     // Create findAndModify command object
     const cmd: Document = {

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -71,7 +71,7 @@ export class FindAndModifyOperation extends CommandOperation<FindAndModifyOption
     const query = this.query;
     const sort = formattedOrderClause(this.sort);
     const doc = this.doc;
-    let options = this.options;
+    let options = Object.assign({}, this.options, this.bsonOptions);
 
     // Create findAndModify command object
     const cmd: Document = {

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -105,10 +105,6 @@ export class FindAndModifyOperation extends CommandOperation<FindAndModifyOption
       cmd.maxTimeMS = options.maxTimeMS;
     }
 
-    // Either use override on the function, or go back to default on either the collection
-    // level or db
-    options.serializeFunctions = options.serializeFunctions || coll.s.serializeFunctions;
-
     // No check on the documents
     options.checkKeys = false;
 

--- a/src/operations/find_one.ts
+++ b/src/operations/find_one.ts
@@ -1,6 +1,6 @@
 import { OperationBase } from './operation';
 import type { Callback } from '../utils';
-import type { Document } from '../bson';
+import { Document, inheritOrDefaultBSONSerializableOptions } from '../bson';
 import type { Collection } from '../collection';
 import type { FindOptions } from './find';
 import { MongoError } from '../error';
@@ -16,12 +16,15 @@ export class FindOneOperation extends OperationBase<FindOptions, Document> {
 
     this.collection = collection;
     this.query = query;
+
+    // Assign all bsonOptions to OperationBase obj, preferring command options over parent options
+    Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, collection.s));
   }
 
   execute(server: Server, callback: Callback<Document>): void {
     const coll = this.collection;
     const query = this.query;
-    const options = this.options;
+    const options = Object.assign({}, this.options, this.bsonOptions);
 
     try {
       const cursor = coll.find(query, options).limit(-1).batchSize(1);

--- a/src/operations/find_one.ts
+++ b/src/operations/find_one.ts
@@ -1,6 +1,6 @@
 import { OperationBase } from './operation';
 import type { Callback } from '../utils';
-import { Document, inheritOrDefaultBSONSerializableOptions } from '../bson';
+import { Document, inheritBSONOptions } from '../bson';
 import type { Collection } from '../collection';
 import type { FindOptions } from './find';
 import { MongoError } from '../error';
@@ -18,13 +18,13 @@ export class FindOneOperation extends OperationBase<FindOptions, Document> {
     this.query = query;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, collection.s));
+    Object.assign(this, inheritBSONOptions(options, collection.s));
   }
 
   execute(server: Server, callback: Callback<Document>): void {
     const coll = this.collection;
     const query = this.query;
-    const options = Object.assign({}, this.options, this.bsonOptions);
+    const options = { ...this.options, ...this.bsonOptions };
 
     try {
       const cursor = coll.find(query, options).limit(-1).batchSize(1);

--- a/src/operations/find_one.ts
+++ b/src/operations/find_one.ts
@@ -1,6 +1,6 @@
 import { OperationBase } from './operation';
 import type { Callback } from '../utils';
-import { Document, inheritBSONOptions } from '../bson';
+import { Document, resolveBSONOptions } from '../bson';
 import type { Collection } from '../collection';
 import type { FindOptions } from './find';
 import { MongoError } from '../error';
@@ -18,7 +18,7 @@ export class FindOneOperation extends OperationBase<FindOptions, Document> {
     this.query = query;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    this.bsonOptions = inheritBSONOptions(options, collection.s.options, true);
+    this.bsonOptions = resolveBSONOptions(options, collection);
   }
 
   execute(server: Server, callback: Callback<Document>): void {

--- a/src/operations/find_one.ts
+++ b/src/operations/find_one.ts
@@ -18,7 +18,7 @@ export class FindOneOperation extends OperationBase<FindOptions, Document> {
     this.query = query;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    Object.assign(this, inheritBSONOptions(options, collection.s));
+    Object.assign(this, inheritBSONOptions(options, collection.s.options, true));
   }
 
   execute(server: Server, callback: Callback<Document>): void {

--- a/src/operations/find_one.ts
+++ b/src/operations/find_one.ts
@@ -17,7 +17,7 @@ export class FindOneOperation extends OperationBase<FindOptions, Document> {
     this.collection = collection;
     this.query = query;
 
-    // Assign all bsonOptions to OperationBase obj, preferring command options over parent options
+    // Assign BSON serialize options to OperationBase, preferring options over collection options
     Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, collection.s));
   }
 

--- a/src/operations/find_one.ts
+++ b/src/operations/find_one.ts
@@ -18,7 +18,7 @@ export class FindOneOperation extends OperationBase<FindOptions, Document> {
     this.query = query;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    Object.assign(this, inheritBSONOptions(options, collection.s.options, true));
+    this.bsonOptions = inheritBSONOptions(options, collection.s.options, true);
   }
 
   execute(server: Server, callback: Callback<Document>): void {

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -65,7 +65,7 @@ export class InsertOneOperation extends CommandOperation<InsertOneOptions, Inser
   execute(server: Server, callback: Callback<InsertOneResult>): void {
     const coll = this.collection;
     const doc = this.doc;
-    const options = this.options;
+    const options = Object.assign({}, this.options, this.bsonOptions);
 
     if (Array.isArray(doc)) {
       return callback(

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -105,7 +105,6 @@ function insertDocuments(
 
   // If keep going set unordered
   if (finalOptions.keepGoing === true) finalOptions.ordered = false;
-  finalOptions.serializeFunctions = options.serializeFunctions || coll.s.serializeFunctions;
 
   docs = prepareDocs(coll, docs, options);
 

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -65,7 +65,7 @@ export class InsertOneOperation extends CommandOperation<InsertOneOptions, Inser
   execute(server: Server, callback: Callback<InsertOneResult>): void {
     const coll = this.collection;
     const doc = this.doc;
-    const options = Object.assign({}, this.options, this.bsonOptions);
+    const options = { ...this.options, ...this.bsonOptions };
 
     if (Array.isArray(doc)) {
       return callback(

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -32,7 +32,7 @@ export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertM
     this.docs = docs;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    Object.assign(this, inheritBSONOptions(options, collection.s.options, true));
+    this.bsonOptions = inheritBSONOptions(options, collection.s.options, true);
   }
 
   execute(server: Server, callback: Callback<InsertManyResult>): void {

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -4,7 +4,7 @@ import { MongoError } from '../error';
 import { prepareDocs } from './common_functions';
 import type { Callback } from '../utils';
 import type { Collection } from '../collection';
-import { ObjectId, Document, inheritOrDefaultBSONSerializableOptions } from '../bson';
+import { ObjectId, Document, inheritBSONOptions } from '../bson';
 import type { BulkWriteResult, BulkWriteOptions } from '../bulk/common';
 import type { Server } from '../sdam/server';
 
@@ -32,13 +32,13 @@ export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertM
     this.docs = docs;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, collection.s));
+    Object.assign(this, inheritBSONOptions(options, collection.s));
   }
 
   execute(server: Server, callback: Callback<InsertManyResult>): void {
     const coll = this.collection;
     let docs = this.docs;
-    const options = Object.assign({}, this.options, this.bsonOptions);
+    const options = { ...this.options, ...this.bsonOptions };
 
     if (!Array.isArray(docs)) {
       return callback(

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -46,9 +46,6 @@ export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertM
       );
     }
 
-    // If keep going set unordered
-    options['serializeFunctions'] = options['serializeFunctions'] || coll.s.serializeFunctions;
-
     docs = prepareDocs(coll, docs, options);
 
     // Generate the bulk write operations

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -31,7 +31,7 @@ export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertM
     this.collection = collection;
     this.docs = docs;
 
-    // Assign all bsonOptions to OperationBase obj, preferring command options over parent options
+    // Assign BSON serialize options to OperationBase, preferring options over collection options
     Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, collection.s));
   }
 

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -4,7 +4,7 @@ import { MongoError } from '../error';
 import { prepareDocs } from './common_functions';
 import type { Callback } from '../utils';
 import type { Collection } from '../collection';
-import { ObjectId, Document, inheritBSONOptions } from '../bson';
+import { ObjectId, Document, resolveBSONOptions } from '../bson';
 import type { BulkWriteResult, BulkWriteOptions } from '../bulk/common';
 import type { Server } from '../sdam/server';
 
@@ -32,7 +32,7 @@ export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertM
     this.docs = docs;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    this.bsonOptions = inheritBSONOptions(options, collection.s.options, true);
+    this.bsonOptions = resolveBSONOptions(options, collection);
   }
 
   execute(server: Server, callback: Callback<InsertManyResult>): void {

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -32,7 +32,7 @@ export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertM
     this.docs = docs;
 
     // Assign BSON serialize options to OperationBase, preferring options over collection options
-    Object.assign(this, inheritBSONOptions(options, collection.s));
+    Object.assign(this, inheritBSONOptions(options, collection.s.options, true));
   }
 
   execute(server: Server, callback: Callback<InsertManyResult>): void {

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -4,7 +4,7 @@ import { MongoError } from '../error';
 import { prepareDocs } from './common_functions';
 import type { Callback } from '../utils';
 import type { Collection } from '../collection';
-import type { ObjectId, Document } from '../bson';
+import { ObjectId, Document, inheritOrDefaultBSONSerializableOptions } from '../bson';
 import type { BulkWriteResult, BulkWriteOptions } from '../bulk/common';
 import type { Server } from '../sdam/server';
 
@@ -30,12 +30,15 @@ export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertM
 
     this.collection = collection;
     this.docs = docs;
+
+    // Assign all bsonOptions to OperationBase obj, preferring command options over parent options
+    Object.assign(this, inheritOrDefaultBSONSerializableOptions(options, collection.s));
   }
 
   execute(server: Server, callback: Callback<InsertManyResult>): void {
     const coll = this.collection;
     let docs = this.docs;
-    const options = this.options;
+    const options = Object.assign({}, this.options, this.bsonOptions);
 
     if (!Array.isArray(docs)) {
       return callback(

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -46,31 +46,11 @@ export abstract class OperationBase<
   fullResponse?: boolean;
 
   // BSON serialization options
-  fieldsAsRaw?: { [key: string]: boolean };
-  promoteValues?: boolean;
-  promoteBuffers?: boolean;
-  promoteLongs?: boolean;
-  serializeFunctions?: boolean;
-  ignoreUndefined?: boolean;
-  raw?: boolean;
+  bsonOptions?: BSONSerializeOptions;
 
   constructor(options: T = {} as T) {
     this.options = Object.assign({}, options);
     this.readPreference = ReadPreference.primary;
-  }
-
-  // BSON serialization options
-  get bsonOptions(): BSONSerializeOptions {
-    const bsonOptions: Document = {
-      promoteBuffers: this.promoteBuffers,
-      promoteValues: this.promoteValues,
-      promoteLongs: this.promoteLongs,
-      raw: this.raw,
-      ignoreUndefined: this.ignoreUndefined,
-      serializeFunctions: this.serializeFunctions,
-      fieldsAsRaw: this.fieldsAsRaw
-    };
-    return bsonOptions;
   }
 
   abstract execute(server: Server, callback: Callback<TResult>): void;

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -46,11 +46,11 @@ export abstract class OperationBase<
   fullResponse?: boolean;
 
   // BSON serialization options
-  // fieldsAsRaw?: { [key: string]: boolean };
+  fieldsAsRaw?: { [key: string]: boolean };
   promoteValues?: boolean;
   promoteBuffers?: boolean;
   promoteLongs?: boolean;
-  // serializeFunctions?: boolean;
+  serializeFunctions?: boolean;
   ignoreUndefined?: boolean;
   raw?: boolean;
 
@@ -60,14 +60,15 @@ export abstract class OperationBase<
   }
 
   // BSON serialization options
-  // Have omitted fieldsAsRaw and serializeFunctions because I am not sure if we want those used...
   get bsonOptions(): BSONSerializeOptions {
     const bsonOptions: Document = {
       promoteBuffers: this.promoteBuffers,
       promoteValues: this.promoteValues,
       promoteLongs: this.promoteLongs,
       raw: this.raw,
-      ignoreUndefined: this.ignoreUndefined
+      ignoreUndefined: this.ignoreUndefined,
+      serializeFunctions: this.serializeFunctions,
+      fieldsAsRaw: this.fieldsAsRaw
     };
     return bsonOptions;
   }

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -46,11 +46,30 @@ export abstract class OperationBase<
   fullResponse?: boolean;
 
   // BSON serialization options
-  bsonOptions?: BSONSerializeOptions;
+  // fieldsAsRaw?: { [key: string]: boolean };
+  promoteValues?: boolean;
+  promoteBuffers?: boolean;
+  promoteLongs?: boolean;
+  // serializeFunctions?: boolean;
+  ignoreUndefined?: boolean;
+  raw?: boolean;
 
   constructor(options: T = {} as T) {
     this.options = Object.assign({}, options);
     this.readPreference = ReadPreference.primary;
+  }
+
+  // BSON serialization options
+  // Have omitted fieldsAsRaw and serializeFunctions because I am not sure if we want those used...
+  get bsonOptions(): BSONSerializeOptions {
+    const bsonOptions: Document = {
+      promoteBuffers: this.promoteBuffers,
+      promoteValues: this.promoteValues,
+      promoteLongs: this.promoteLongs,
+      raw: this.raw,
+      ignoreUndefined: this.ignoreUndefined
+    };
+    return bsonOptions;
   }
 
   abstract execute(server: Server, callback: Callback<TResult>): void;

--- a/src/operations/replace_one.ts
+++ b/src/operations/replace_one.ts
@@ -50,7 +50,7 @@ export class ReplaceOneOperation extends CommandOperation<ReplaceOptions, Update
     const coll = this.collection;
     const filter = this.filter;
     const replacement = this.replacement;
-    const options = this.options;
+    const options = Object.assign({}, this.options, this.bsonOptions);
 
     // Set single document update
     options.multi = false;

--- a/src/operations/replace_one.ts
+++ b/src/operations/replace_one.ts
@@ -50,7 +50,7 @@ export class ReplaceOneOperation extends CommandOperation<ReplaceOptions, Update
     const coll = this.collection;
     const filter = this.filter;
     const replacement = this.replacement;
-    const options = Object.assign({}, this.options, this.bsonOptions);
+    const options = { ...this.options, ...this.bsonOptions };
 
     // Set single document update
     options.multi = false;

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -86,7 +86,7 @@ export class UpdateOneOperation extends CommandOperation<UpdateOptions, UpdateRe
     const coll = this.collection;
     const filter = this.filter;
     const update = this.update;
-    const options = Object.assign({}, this.options, this.bsonOptions);
+    const options = { ...this.options, ...this.bsonOptions };
 
     // Set single document update
     options.multi = false;
@@ -128,7 +128,7 @@ export class UpdateManyOperation extends CommandOperation<UpdateOptions, UpdateR
     const coll = this.collection;
     const filter = this.filter;
     const update = this.update;
-    const options = Object.assign({}, this.options, this.bsonOptions);
+    const options = { ...this.options, ...this.bsonOptions };
 
     // Set single document update
     options.multi = true;

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -86,7 +86,7 @@ export class UpdateOneOperation extends CommandOperation<UpdateOptions, UpdateRe
     const coll = this.collection;
     const filter = this.filter;
     const update = this.update;
-    const options = this.options;
+    const options = Object.assign({}, this.options, this.bsonOptions);
 
     // Set single document update
     options.multi = false;
@@ -128,7 +128,7 @@ export class UpdateManyOperation extends CommandOperation<UpdateOptions, UpdateR
     const coll = this.collection;
     const filter = this.filter;
     const update = this.update;
-    const options = this.options;
+    const options = Object.assign({}, this.options, this.bsonOptions);
 
     // Set single document update
     options.multi = true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -276,7 +276,7 @@ export function mergeOptionsAndWriteConcern(
 ): AnyOptions {
   // Mix in any allowed options
   for (let i = 0; i < keys.length; i++) {
-    if (!targetOptions[keys[i]] && sourceOptions[keys[i]] !== undefined) {
+    if (targetOptions[keys[i]] === undefined && sourceOptions[keys[i]] !== undefined) {
       targetOptions[keys[i]] = sourceOptions[keys[i]];
     }
   }

--- a/test/functional/ignore_undefined.test.js
+++ b/test/functional/ignore_undefined.test.js
@@ -150,39 +150,35 @@ describe('Ignore Undefined', function () {
     }
   });
 
-  it('Should correctly inherit ignore undefined field from db during insert', {
-    metadata: { requires: { topology: ['single'] } },
+  it('Should correctly inherit ignore undefined field from db during insert', function () {
+    const configuration = this.configuration;
+    const client = configuration.newClient(configuration.writeConcernMax(), {
+      poolSize: 1,
+      ignoreUndefined: false
+    });
 
-    test: function () {
-      const configuration = this.configuration;
-      const client = configuration.newClient(configuration.writeConcernMax(), {
-        poolSize: 1,
-        ignoreUndefined: false
-      });
+    return withClient.call(this, client, (client, done) => {
+      const db = client.db(configuration.db, { ignoreUndefined: true });
+      const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue3');
 
-      return withClient.call(this, client, (client, done) => {
-        const db = client.db(configuration.db, { ignoreUndefined: true });
-        const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue3');
+      // Ignore the undefined field
+      collection.insert({ a: 1, b: undefined }, configuration.writeConcernMax(), err => {
+        expect(err).to.not.exist;
 
-        // Ignore the undefined field
-        collection.insert({ a: 1, b: undefined }, configuration.writeConcernMax(), err => {
+        // Locate the doument
+        collection.findOne((err, item) => {
           expect(err).to.not.exist;
-
-          // Locate the doument
-          collection.findOne((err, item) => {
-            expect(err).to.not.exist;
-            expect(item).to.have.property('a', 1);
-            expect(item).to.not.have.property('b');
-            done();
-          });
+          expect(item).to.have.property('a', 1);
+          expect(item).to.not.have.property('b');
+          done();
         });
       });
-    }
+    });
   });
 
-  it('Should correctly inherit ignore undefined field from collection during insert', {
-    metadata: { requires: { topology: ['single'] } },
-    test: withClient(function (client, done) {
+  it(
+    'Should correctly inherit ignore undefined field from collection during insert',
+    withClient(function (client, done) {
       const db = client.db('shouldCorrectlyIgnoreUndefinedValue4', { ignoreUndefined: false });
       const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue4', {
         ignoreUndefined: true
@@ -201,11 +197,11 @@ describe('Ignore Undefined', function () {
         });
       });
     })
-  });
+  );
 
-  it('Should correctly inherit ignore undefined field from operation during insert', {
-    metadata: { requires: { topology: ['single'] } },
-    test: withClient(function (client, done) {
+  it(
+    'Should correctly inherit ignore undefined field from operation during insert',
+    withClient(function (client, done) {
       const db = client.db('shouldCorrectlyIgnoreUndefinedValue5');
       const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue5', {
         ignoreUndefined: false
@@ -224,11 +220,11 @@ describe('Ignore Undefined', function () {
         });
       });
     })
-  });
+  );
 
-  it('Should correctly inherit ignore undefined field from operation during findOneAndReplace', {
-    metadata: { requires: { topology: ['single'] } },
-    test: withClient(function (client, done) {
+  it(
+    'Should correctly inherit ignore undefined field from operation during findOneAndReplace',
+    withClient(function (client, done) {
       const db = client.db('shouldCorrectlyIgnoreUndefinedValue6');
       const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue6', {
         ignoreUndefined: false
@@ -251,11 +247,11 @@ describe('Ignore Undefined', function () {
         });
       });
     })
-  });
+  );
 
-  it('Should correctly ignore undefined field during bulk write', {
-    metadata: { requires: { topology: ['single'] } },
-    test: withClient(function (client, done) {
+  it(
+    'Should correctly ignore undefined field during bulk write',
+    withClient(function (client, done) {
       const db = client.db('shouldCorrectlyIgnoreUndefinedValue7');
       const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue7');
 
@@ -276,5 +272,5 @@ describe('Ignore Undefined', function () {
         }
       );
     })
-  });
+  );
 });

--- a/test/functional/ignore_undefined.test.js
+++ b/test/functional/ignore_undefined.test.js
@@ -170,8 +170,9 @@ describe('Ignore Undefined', function () {
 
           // Locate the doument
           collection.findOne((err, item) => {
+            expect(err).to.not.exist;
             expect(item).to.have.property('a', 1);
-            expect(item.b).to.be.undefined;
+            expect(item).to.not.have.property('b');
             done();
           });
         });
@@ -193,8 +194,9 @@ describe('Ignore Undefined', function () {
 
         // Locate the doument
         collection.findOne((err, item) => {
+          expect(err).to.not.exist;
           expect(item).to.have.property('a', 1);
-          expect(item.b).to.be.undefined;
+          expect(item).to.not.have.property('b');
           done();
         });
       });
@@ -217,7 +219,7 @@ describe('Ignore Undefined', function () {
         collection.findOne({}, (err, item) => {
           expect(err).to.not.exist;
           expect(item).to.have.property('a', 1);
-          expect(item.b).to.be.undefined;
+          expect(item).to.not.have.property('b');
           done();
         });
       });
@@ -241,8 +243,9 @@ describe('Ignore Undefined', function () {
 
           // Locate the doument
           collection.findOne((err, item) => {
+            expect(err).to.not.exist;
             expect(item).to.have.property('a', 1);
-            expect(item.b).to.be.undefined;
+            expect(item).to.not.have.property('b');
             done();
           });
         });
@@ -265,8 +268,9 @@ describe('Ignore Undefined', function () {
 
           // Locate the doument
           collection.findOne((err, item) => {
+            expect(err).to.not.exist;
             expect(item).to.have.property('a', 1);
-            expect(item.b).to.be.undefined;
+            expect(item).to.not.have.property('b');
             done();
           });
         }

--- a/test/functional/ignore_undefined.test.js
+++ b/test/functional/ignore_undefined.test.js
@@ -38,6 +38,75 @@ describe('Ignore Undefined', function () {
     }
   });
 
+  it('Should correctly inherit ignore undefined field from collection during insert', {
+    metadata: { requires: { topology: ['single'] } },
+
+    test: function (done) {
+      var configuration = this.configuration;
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1,
+        ignoreUndefined: false
+      });
+
+      client.connect(function (err, client) {
+        var db = client.db(configuration.db);
+        var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue', {
+          ignoreUndefined: true
+        });
+
+        // Ignore the undefined field
+        collection.insert({ a: 1, b: undefined }, configuration.writeConcernMax(), function (err) {
+          expect(err).to.not.exist;
+
+          // Locate the doument
+          collection.findOne(function (err, item) {
+            test.equal(1, item.a);
+            test.ok(item.b === undefined);
+            client.close(done);
+          });
+        });
+      });
+    }
+  });
+
+  it('Should correctly inherit ignore undefined field from operation during findOneAndReplace', {
+    metadata: { requires: { topology: ['single'] } },
+
+    test: function (done) {
+      var configuration = this.configuration;
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1,
+        ignoreUndefined: false
+      });
+
+      client.connect(function (err, client) {
+        var db = client.db(configuration.db);
+        var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue');
+
+        collection.insert({ a: 1, b: 2 }, configuration.writeConcernMax(), function (err) {
+          expect(err).to.not.exist;
+
+          // Replace the doument, ignoring undefined fields
+          collection.findOneAndReplace(
+            {},
+            { a: 1, b: undefined },
+            { ignoreUndefined: true },
+            function (err) {
+              expect(err).to.not.exist;
+
+              // Locate the doument
+              collection.findOne(function (err, item) {
+                test.equal(1, item.a);
+                test.ok(item.b === undefined);
+                client.close(done);
+              });
+            }
+          );
+        });
+      });
+    }
+  });
+
   it(
     'Should correctly connect using MongoClient and perform insert document ignoring undefined field',
     {

--- a/test/functional/ignore_undefined.test.js
+++ b/test/functional/ignore_undefined.test.js
@@ -153,16 +153,16 @@ describe('Ignore Undefined', function () {
   it('Should correctly inherit ignore undefined field from db during insert', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function (done) {
-      var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), {
+    test: function () {
+      const configuration = this.configuration;
+      const client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         ignoreUndefined: false
       });
 
-      client.connect(function (err, client) {
-        var db = client.db(configuration.db, { ignoreUndefined: true });
-        var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue3');
+      return withClient.call(this, client, (client, done) => {
+        const db = client.db(configuration.db, { ignoreUndefined: true });
+        const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue3');
 
         // Ignore the undefined field
         collection.insert({ a: 1, b: undefined }, configuration.writeConcernMax(), err => {
@@ -170,20 +170,20 @@ describe('Ignore Undefined', function () {
 
           // Locate the doument
           collection.findOne((err, item) => {
-            test.equal(1, item.a);
-            test.ok(item.b === undefined);
-            client.close(done);
+            expect(item).to.have.property('a', 1);
+            expect(item.b).to.be.undefined;
+            done();
           });
         });
       });
     }
   });
 
-  it(
-    'Should correctly inherit ignore undefined field from collection during insert',
-    withClient(function (client, done) {
-      var db = client.db('shouldCorrectlyIgnoreUndefinedValue4', { ignoreUndefined: false });
-      var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue4', {
+  it('Should correctly inherit ignore undefined field from collection during insert', {
+    metadata: { requires: { topology: ['single'] } },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldCorrectlyIgnoreUndefinedValue4', { ignoreUndefined: false });
+      const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue4', {
         ignoreUndefined: true
       });
 
@@ -193,19 +193,19 @@ describe('Ignore Undefined', function () {
 
         // Locate the doument
         collection.findOne((err, item) => {
-          test.equal(1, item.a);
-          test.ok(item.b === undefined);
+          expect(item).to.have.property('a', 1);
+          expect(item.b).to.be.undefined;
           done();
         });
       });
     })
-  );
+  });
 
-  it(
-    'Should correctly inherit ignore undefined field from operation during insert',
-    withClient(function (client, done) {
-      var db = client.db('shouldCorrectlyIgnoreUndefinedValue5');
-      var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue5', {
+  it('Should correctly inherit ignore undefined field from operation during insert', {
+    metadata: { requires: { topology: ['single'] } },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldCorrectlyIgnoreUndefinedValue5');
+      const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue5', {
         ignoreUndefined: false
       });
 
@@ -216,19 +216,19 @@ describe('Ignore Undefined', function () {
         // Locate the doument
         collection.findOne({}, (err, item) => {
           expect(err).to.not.exist;
-          test.equal(1, item.a);
-          test.ok(item.b === undefined);
+          expect(item).to.have.property('a', 1);
+          expect(item.b).to.be.undefined;
           done();
         });
       });
     })
-  );
+  });
 
-  it(
-    'Should correctly inherit ignore undefined field from operation during findOneAndReplace',
-    withClient(function (client, done) {
-      var db = client.db('shouldCorrectlyIgnoreUndefinedValue6');
-      var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue6', {
+  it('Should correctly inherit ignore undefined field from operation during findOneAndReplace', {
+    metadata: { requires: { topology: ['single'] } },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldCorrectlyIgnoreUndefinedValue6');
+      const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue6', {
         ignoreUndefined: false
       });
 
@@ -241,36 +241,36 @@ describe('Ignore Undefined', function () {
 
           // Locate the doument
           collection.findOne((err, item) => {
-            test.equal(1, item.a);
-            test.ok(item.b === undefined);
+            expect(item).to.have.property('a', 1);
+            expect(item.b).to.be.undefined;
             done();
           });
         });
       });
     })
-  );
+  });
 
-  it(
-    'Should correctly ignore undefined field during bulk write',
-    withClient(function (client, done) {
-      var db = client.db('shouldCorrectlyIgnoreUndefinedValue7');
-      var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue7');
+  it('Should correctly ignore undefined field during bulk write', {
+    metadata: { requires: { topology: ['single'] } },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldCorrectlyIgnoreUndefinedValue7');
+      const collection = db.collection('shouldCorrectlyIgnoreUndefinedValue7');
 
       // Ignore the undefined field
       collection.bulkWrite(
-        [{ insertOne: { a: 0, b: undefined } }],
+        [{ insertOne: { a: 1, b: undefined } }],
         { ignoreUndefined: true },
         err => {
           expect(err).to.not.exist;
 
           // Locate the doument
           collection.findOne((err, item) => {
-            test.equal(0, item.a);
-            test.ok(item.b === undefined);
+            expect(item).to.have.property('a', 1);
+            expect(item.b).to.be.undefined;
             done();
           });
         }
       );
     })
-  );
+  });
 });

--- a/test/functional/ignore_undefined.test.js
+++ b/test/functional/ignore_undefined.test.js
@@ -153,14 +153,14 @@ describe('Ignore Undefined', function () {
   it('Should correctly inherit ignore undefined field from db during insert', {
     metadata: { requires: { topology: ['single'] } },
 
-    test: function () {
+    test: function (done) {
       var configuration = this.configuration;
       var client = configuration.newClient(configuration.writeConcernMax(), {
         poolSize: 1,
         ignoreUndefined: false
       });
 
-      return withClient(client, (client, done) => {
+      client.connect(function (err, client) {
         var db = client.db(configuration.db, { ignoreUndefined: true });
         var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue3');
 

--- a/test/functional/ignore_undefined.test.js
+++ b/test/functional/ignore_undefined.test.js
@@ -38,75 +38,6 @@ describe('Ignore Undefined', function () {
     }
   });
 
-  it('Should correctly inherit ignore undefined field from collection during insert', {
-    metadata: { requires: { topology: ['single'] } },
-
-    test: function (done) {
-      var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), {
-        poolSize: 1,
-        ignoreUndefined: false
-      });
-
-      client.connect(function (err, client) {
-        var db = client.db(configuration.db);
-        var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue', {
-          ignoreUndefined: true
-        });
-
-        // Ignore the undefined field
-        collection.insert({ a: 1, b: undefined }, configuration.writeConcernMax(), function (err) {
-          expect(err).to.not.exist;
-
-          // Locate the doument
-          collection.findOne(function (err, item) {
-            test.equal(1, item.a);
-            test.ok(item.b === undefined);
-            client.close(done);
-          });
-        });
-      });
-    }
-  });
-
-  it('Should correctly inherit ignore undefined field from operation during findOneAndReplace', {
-    metadata: { requires: { topology: ['single'] } },
-
-    test: function (done) {
-      var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), {
-        poolSize: 1,
-        ignoreUndefined: false
-      });
-
-      client.connect(function (err, client) {
-        var db = client.db(configuration.db);
-        var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue');
-
-        collection.insert({ a: 1, b: 2 }, configuration.writeConcernMax(), function (err) {
-          expect(err).to.not.exist;
-
-          // Replace the doument, ignoring undefined fields
-          collection.findOneAndReplace(
-            {},
-            { a: 1, b: undefined },
-            { ignoreUndefined: true },
-            function (err) {
-              expect(err).to.not.exist;
-
-              // Locate the doument
-              collection.findOne(function (err, item) {
-                test.equal(1, item.a);
-                test.ok(item.b === undefined);
-                client.close(done);
-              });
-            }
-          );
-        });
-      });
-    }
-  });
-
   it(
     'Should correctly connect using MongoClient and perform insert document ignoring undefined field',
     {
@@ -211,6 +142,166 @@ describe('Ignore Undefined', function () {
                   });
                 }
               );
+            });
+          }
+        );
+      });
+    }
+  });
+
+  it('Should correctly inherit ignore undefined field from db during insert', {
+    metadata: { requires: { topology: ['single'] } },
+
+    test: function (done) {
+      var configuration = this.configuration;
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1,
+        ignoreUndefined: false
+      });
+
+      client.connect(function (err, client) {
+        var db = client.db(configuration.db, { ignoreUndefined: true });
+        var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue3');
+
+        // Ignore the undefined field
+        collection.insert({ a: 1, b: undefined }, configuration.writeConcernMax(), function (err) {
+          expect(err).to.not.exist;
+
+          // Locate the doument
+          collection.findOne(function (err, item) {
+            test.equal(1, item.a);
+            test.ok(item.b === undefined);
+            client.close(done);
+          });
+        });
+      });
+    }
+  });
+
+  it('Should correctly inherit ignore undefined field from collection during insert', {
+    metadata: { requires: { topology: ['single'] } },
+
+    test: function (done) {
+      var configuration = this.configuration;
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1
+      });
+
+      client.connect(function (err, client) {
+        var db = client.db(configuration.db, { ignoreUndefined: false });
+        var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue4', {
+          ignoreUndefined: true
+        });
+
+        // Ignore the undefined field
+        collection.insert({ a: 1, b: undefined }, configuration.writeConcernMax(), function (err) {
+          expect(err).to.not.exist;
+
+          // Locate the doument
+          collection.findOne(function (err, item) {
+            test.equal(1, item.a);
+            test.ok(item.b === undefined);
+            client.close(done);
+          });
+        });
+      });
+    }
+  });
+
+  it('Should correctly inherit ignore undefined field from operation during insert', {
+    metadata: { requires: { topology: ['single'] } },
+
+    test: function (done) {
+      var configuration = this.configuration;
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1
+      });
+
+      client.connect(function (err, client) {
+        var db = client.db(configuration.db);
+        var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue5', {
+          ignoreUndefined: false
+        });
+
+        // Ignore the undefined field
+        collection.insert({ a: 1, b: undefined }, { ignoreUndefined: true }, function (err) {
+          expect(err).to.not.exist;
+
+          // Locate the doument
+          collection.findOne({}, function (err, item) {
+            expect(err).to.not.exist;
+            test.equal(1, item.a);
+            test.ok(item.b === undefined);
+            client.close(done);
+          });
+        });
+      });
+    }
+  });
+
+  it('Should correctly inherit ignore undefined field from operation during findOneAndReplace', {
+    metadata: { requires: { topology: ['single'] } },
+
+    test: function (done) {
+      var configuration = this.configuration;
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1,
+        ignoreUndefined: false
+      });
+
+      client.connect(function (err, client) {
+        var db = client.db(configuration.db);
+        var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue6');
+
+        collection.insert({ a: 1, b: 2 }, configuration.writeConcernMax(), function (err) {
+          expect(err).to.not.exist;
+
+          // Replace the doument, ignoring undefined fields
+          collection.findOneAndReplace(
+            {},
+            { a: 1, b: undefined },
+            { ignoreUndefined: true },
+            function (err) {
+              expect(err).to.not.exist;
+
+              // Locate the doument
+              collection.findOne(function (err, item) {
+                test.equal(1, item.a);
+                test.ok(item.b === undefined);
+                client.close(done);
+              });
+            }
+          );
+        });
+      });
+    }
+  });
+
+  it('Should correctly ignore undefined field during bulk write', {
+    metadata: { requires: { topology: ['single'] } },
+
+    test: function (done) {
+      var configuration = this.configuration;
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1
+      });
+
+      client.connect(function (err, client) {
+        var db = client.db(configuration.db);
+        var collection = db.collection('shouldCorrectlyIgnoreUndefinedValue7');
+
+        // Ignore the undefined field
+        collection.bulkWrite(
+          [{ insertOne: { a: 0, b: undefined } }],
+          { ignoreUndefined: true },
+          function (err) {
+            expect(err).to.not.exist;
+
+            // Locate the doument
+            collection.findOne(function (err, item) {
+              test.equal(0, item.a);
+              test.ok(item.b === undefined);
+              client.close(done);
             });
           }
         );

--- a/test/functional/insert.test.js
+++ b/test/functional/insert.test.js
@@ -1903,8 +1903,6 @@ describe('Insert', function () {
   });
 
   it('shouldCorrectlyInheritPromoteLongFalseNativeBSONWithGetMore', {
-    // Add a tag that our runner can trigger on
-    // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },

--- a/test/functional/insert.test.js
+++ b/test/functional/insert.test.js
@@ -1909,61 +1909,58 @@ describe('Insert', function () {
       requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
     },
 
-    test: function () {
-      var configuration = this.configuration;
-
-      var client = configuration.newClient(configuration.writeConcernMax(), {
-        poolSize: 1,
+    test: withClient((client, done) => {
+      const db = client.db('shouldCorrectlyInheritPromoteLongFalseNativeBSONWithGetMore', {
         promoteLongs: true
       });
+      const collection = db.collection('test', { promoteLongs: false });
+      collection.insertMany(
+        [
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) },
+          { a: Long.fromNumber(10) }
+        ],
+        (err, doc) => {
+          expect(err).to.not.exist;
+          test.ok(doc);
 
-      return withClient(client, (client, done) => {
-        var db = client.db(configuration.db, { promoteLongs: false });
-        db.collection('shouldCorrectlyInheritPromoteLongFalseNativeBSONWithGetMore').insertMany(
-          [
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) },
-            { a: Long.fromNumber(10) }
-          ],
-          (err, doc) => {
-            expect(err).to.not.exist;
-            test.ok(doc);
+          collection
+            .find({})
+            .batchSize(2)
+            .toArray((err, docs) => {
+              expect(err).to.not.exist;
 
-            db.collection('shouldCorrectlyInheritPromoteLongFalseNativeBSONWithGetMore')
-              .find({})
-              .batchSize(2)
-              .toArray((err, docs) => {
-                expect(err).to.not.exist;
-                var doc = docs.pop();
-
-                test.ok(doc.a._bsontype === 'Long');
-                done();
+              docs.forEach((d, i) => {
+                expect(d.a, `Failed on the document at index ${i}`).to.not.be.a('number');
+                expect(d.a, `Failed on the document at index ${i}`).to.have.property('_bsontype');
+                expect(d.a._bsontype, `Failed on the document at index ${i}`).to.be.equal('Long');
               });
-          }
-        );
-      });
-    }
+              done();
+            });
+        }
+      );
+    })
   });
 
   it('shouldCorrectlyHonorPromoteLongTrueNativeBSON', {

--- a/test/functional/insert.test.js
+++ b/test/functional/insert.test.js
@@ -1917,7 +1917,7 @@ describe('Insert', function () {
         promoteLongs: true
       });
       client.connect(function (err, client) {
-        var db = client.db(configuration.db);
+        var db = client.db(configuration.db, { promoteLongs: false });
         db.collection('shouldCorrectlyInheritPromoteLongFalseNativeBSONWithGetMore').insertMany(
           [
             { a: Long.fromNumber(10) },
@@ -1950,7 +1950,7 @@ describe('Insert', function () {
             test.ok(doc);
 
             db.collection('shouldCorrectlyInheritPromoteLongFalseNativeBSONWithGetMore')
-              .find({}, { promoteLongs: false })
+              .find({})
               .batchSize(2)
               .toArray(function (err, docs) {
                 expect(err).to.not.exist;

--- a/test/functional/insert.test.js
+++ b/test/functional/insert.test.js
@@ -1902,6 +1902,69 @@ describe('Insert', function () {
     }
   });
 
+  it('shouldCorrectlyInheritPromoteLongFalseNativeBSONWithGetMore', {
+    // Add a tag that our runner can trigger on
+    // in this case we are setting that node needs to be higher than 0.10.X to run
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    test: function (done) {
+      var configuration = this.configuration;
+
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        poolSize: 1,
+        promoteLongs: true
+      });
+      client.connect(function (err, client) {
+        var db = client.db(configuration.db);
+        db.collection('shouldCorrectlyInheritPromoteLongFalseNativeBSONWithGetMore').insertMany(
+          [
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) },
+            { a: Long.fromNumber(10) }
+          ],
+          function (err, doc) {
+            expect(err).to.not.exist;
+            test.ok(doc);
+
+            db.collection('shouldCorrectlyInheritPromoteLongFalseNativeBSONWithGetMore')
+              .find({}, { promoteLongs: false })
+              .batchSize(2)
+              .toArray(function (err, docs) {
+                expect(err).to.not.exist;
+                var doc = docs.pop();
+
+                test.ok(doc.a._bsontype === 'Long');
+                client.close(done);
+              });
+          }
+        );
+      });
+    }
+  });
+
   it('shouldCorrectlyHonorPromoteLongTrueNativeBSON', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run

--- a/test/functional/mongo_client.test.js
+++ b/test/functional/mongo_client.test.js
@@ -57,8 +57,8 @@ describe('MongoClient', function () {
 
         test.equal(true, db.s.options.forceServerObjectId);
         test.equal(1, db.s.pkFactory.createPk());
-        test.equal(true, db.s.options.serializeFunctions);
-        test.equal(true, db.s.options.raw);
+        test.equal(true, db.bsonOptions.serializeFunctions);
+        test.equal(true, db.bsonOptions.raw);
         test.equal(10, db.s.options.numberOfRetries);
         test.equal(0, db.s.options.bufferMaxEntries);
 


### PR DESCRIPTION
## Description

**What changed?**
Previously, each operation in `collection.ts` needed to do the necessary logic to figure out which `BSONSerializationOptions` values to include in the options. Some operations omitted this logic completely, while others did it incorrectly. This change stores the `BSONSerializationOptions` as a new inheritable property on `MongoClient`, `Db`, `Collection`, and `OperationBase`, and makes it accessible via a new `bsonOptions` getter for each class. 

NODE-1561