### PR TITLE
fix: revert "fix: allow client connect after close (#2581)"

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -349,29 +349,19 @@ export class MongoClient extends EventEmitter implements OperationParent {
     const force = typeof forceOrCallback === 'boolean' ? forceOrCallback : false;
 
     return maybePromise(callback, cb => {
-      const completeClose = (err?: AnyError) => {
-        // clear out references to old topology
-        this.topology = undefined;
-        this.s.dbCache = new Map();
-        this.s.sessions = new Set();
-
-        cb(err);
-      };
-
       if (this.topology == null) {
-        completeClose();
-        return;
+        return cb();
       }
 
       const topology = this.topology;
       topology.close({ force }, err => {
         const autoEncrypter = topology.s.options.autoEncrypter;
         if (!autoEncrypter) {
-          completeClose(err);
+          cb(err);
           return;
         }
 
-        autoEncrypter.teardown(force, err2 => completeClose(err || err2));
+        autoEncrypter.teardown(force, err2 => cb(err || err2));
       });
     });
   }

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -197,11 +197,6 @@ export function connect(
     throw new Error('no callback function provided');
   }
 
-  // Has a connection already been established?
-  if (mongoClient.topology && mongoClient.topology.isConnected()) {
-    throw new MongoError(`'connect' cannot be called when already connected`);
-  }
-
   let didRequestAuthentication = false;
   const logger = new Logger('MongoClient', options);
 

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -2,7 +2,6 @@
 const test = require('./shared').assert,
   setupDatabase = require('./shared').setupDatabase,
   expect = require('chai').expect;
-const withClient = require('./shared').withClient;
 
 describe('Connection', function () {
   before(function () {
@@ -274,34 +273,4 @@ describe('Connection', function () {
       done();
     }
   });
-
-  it(
-    'should be able to connect again after close',
-    withClient(function (client, done) {
-      expect(client.isConnected()).to.be.true;
-
-      const collection = () => client.db('testReconnect').collection('test');
-      collection().insertOne({ a: 1 }, (err, result) => {
-        expect(err).to.not.exist;
-        expect(result).to.exist;
-
-        client.close(err => {
-          expect(err).to.not.exist;
-          expect(client.isConnected()).to.be.false;
-
-          client.connect(err => {
-            expect(err).to.not.exist;
-            expect(client.isConnected()).to.be.true;
-
-            collection().insertOne({ b: 2 }, (err, result) => {
-              expect(err).to.not.exist;
-              expect(result).to.exist;
-              expect(client.topology.isDestroyed()).to.be.false;
-              done();
-            });
-          });
-        });
-      });
-    })
-  );
 });

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -123,7 +123,7 @@ describe('Sessions', function () {
               // verify that the `endSessions` command was sent
               const lastCommand = test.commands.started[test.commands.started.length - 1];
               expect(lastCommand.commandName).to.equal('endSessions');
-              expect(client.topology).to.not.exist;
+              expect(client.topology.s.sessionPool.sessions).to.have.length(0);
             });
         });
       });
@@ -143,7 +143,7 @@ describe('Sessions', function () {
             // verify that the `endSessions` command was sent
             const lastCommand = test.commands.started[test.commands.started.length - 1];
             expect(lastCommand.commandName).to.equal('endSessions');
-            expect(client.topology).to.not.exist;
+            expect(client.topology.s.sessionPool.sessions).to.have.length(0);
           });
       });
     }


### PR DESCRIPTION
## Description

This reverts commit 1aecf964d79344acea4ff4387d2faf51b78cfe78. 

This approach for allowing a client to reconnect after being closed can cause session leaks, because old topologies (and sessions) may be stored on `Db`s/`Collection`s. This ticket can be revisited after NODE-2850.
