### PR TITLE
refactor: Remove generic options parameter from OperationBase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6483,6 +6483,12 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "spec-xunit-file": {
+      "version": "0.0.1-3",
+      "resolved": "https://registry.npmjs.org/spec-xunit-file/-/spec-xunit-file-0.0.1-3.tgz",
+      "integrity": "sha1-hVpmq4w4LrMWXfkoqB0HSQKdI4Y=",
+      "dev": true
+    },
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -1,7 +1,7 @@
 import { Aspect, OperationBase, OperationOptions } from './operation';
 import { ReadConcern } from '../read_concern';
 import { WriteConcern, WriteConcernOptions } from '../write_concern';
-import { maxWireVersion, MongoDBNamespace, Callback } from '../utils';
+import { maxWireVersion, MongoDBNamespace, Callback, deepFreeze } from '../utils';
 import { ReadPreference, ReadPreferenceLike } from '../read_preference';
 import { commandSupportsReadConcern } from '../sessions';
 import { MongoError } from '../error';
@@ -35,9 +35,14 @@ export interface CommandOperationOptions extends OperationOptions, WriteConcernO
   noResponse?: boolean;
 }
 
+export interface OperationParentPrivate extends BSONSerializeOptions {
+  options?: BSONSerializeOptions;
+  namespace: MongoDBNamespace;
+}
+
 /** @internal */
 export interface OperationParent {
-  s: { namespace: MongoDBNamespace };
+  s: OperationParentPrivate;
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
   readPreference?: ReadPreference;
@@ -54,9 +59,29 @@ export abstract class CommandOperation<
   readPreference: ReadPreference;
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
-  explain: boolean;
   fullResponse?: boolean;
   logger?: Logger;
+
+  protected collation;
+  protected maxTimeMS;
+  protected comment;
+  protected retryWrites;
+  protected noResponse;
+
+  get builtOptions(): Readonly<CommandOperationOptions> {
+    return deepFreeze({
+      ...super.builtOptions,
+      collation: this.collation,
+      maxTimeMS: this.maxTimeMS,
+      comment: this.comment,
+      retryWrites: this.retryWrites,
+      noResponse: this.noResponse,
+      fullResponse: this.fullResponse
+      // Override with proper type
+      // writeConcern: this.writeConcern,
+      // readConcern: this.readConcern
+    });
+  }
 
   constructor(parent?: OperationParent, options?: T) {
     super(options);
@@ -76,16 +101,29 @@ export abstract class CommandOperation<
     const propertyProvider = this.hasAspect(Aspect.NO_INHERIT_OPTIONS) ? undefined : parent;
     this.readPreference = this.hasAspect(Aspect.WRITE_OPERATION)
       ? ReadPreference.primary
-      : ReadPreference.resolve(propertyProvider, this.options);
-    this.readConcern = resolveReadConcern(propertyProvider, this.options);
-    this.writeConcern = resolveWriteConcern(propertyProvider, this.options);
+      : ReadPreference.resolve(propertyProvider, options);
+    this.readConcern = resolveReadConcern(propertyProvider, options);
+    this.writeConcern = resolveWriteConcern(propertyProvider, options);
     this.explain = false;
     this.fullResponse =
       options && typeof options.fullResponse === 'boolean' ? options.fullResponse : false;
 
+    // if (this.writeConcern && this.writeConcern.w === 0) {
+    //   if (this.session && this.session.explicit) {
+    //     throw new MongoError('Cannot have explicit session with unacknowledged writes');
+    //   }
+    //   return;
+    // }
+
     // TODO: A lot of our code depends on having the read preference in the options. This should
     //       go away, but also requires massive test rewrites.
     this.options.readPreference = this.readPreference;
+
+    this.collation = options?.collation;
+    this.maxTimeMS = options?.maxTimeMS;
+    this.comment = options?.comment;
+    this.retryWrites = options?.retryWrites;
+    this.noResponse = options?.noResponse;
 
     // TODO(NODE-2056): make logger another "inheritable" property
     if (parent && parent.logger) {
@@ -102,7 +140,6 @@ export abstract class CommandOperation<
     // TODO: consider making this a non-enumerable property
     this.server = server;
 
-    const options = { ...this.options, ...this.bsonOptions };
     const serverWireVersion = maxWireVersion(server);
     const inTransaction = this.session && this.session.inTransaction();
 
@@ -110,7 +147,7 @@ export abstract class CommandOperation<
       Object.assign(cmd, { readConcern: this.readConcern });
     }
 
-    if (options.collation && serverWireVersion < SUPPORTS_WRITE_CONCERN_AND_COLLATION) {
+    if (this.builtOptions.collation && serverWireVersion < SUPPORTS_WRITE_CONCERN_AND_COLLATION) {
       callback(
         new MongoError(
           `Server ${server.name}, which reports wire version ${serverWireVersion}, does not support collation`
@@ -124,17 +161,17 @@ export abstract class CommandOperation<
         Object.assign(cmd, { writeConcern: this.writeConcern });
       }
 
-      if (options.collation && typeof options.collation === 'object') {
-        Object.assign(cmd, { collation: options.collation });
+      if (this.builtOptions.collation && typeof this.builtOptions.collation === 'object') {
+        Object.assign(cmd, { collation: this.builtOptions.collation });
       }
     }
 
-    if (typeof options.maxTimeMS === 'number') {
-      cmd.maxTimeMS = options.maxTimeMS;
+    if (typeof this.builtOptions.maxTimeMS === 'number') {
+      cmd.maxTimeMS = this.builtOptions.maxTimeMS;
     }
 
-    if (typeof options.comment === 'string') {
-      cmd.comment = options.comment;
+    if (typeof this.builtOptions.comment === 'string') {
+      cmd.comment = this.builtOptions.comment;
     }
 
     if (this.logger && this.logger.isDebug()) {
@@ -144,7 +181,7 @@ export abstract class CommandOperation<
     server.command(
       this.ns.toString(),
       cmd,
-      { fullResult: !!this.fullResponse, ...this.options },
+      { fullResult: !!this.fullResponse, ...this.builtOptions },
       callback
     );
   }

--- a/src/operations/common_functions.ts
+++ b/src/operations/common_functions.ts
@@ -8,19 +8,16 @@ import {
 } from '../utils';
 import type { Document } from '../bson';
 import type { Db } from '../db';
-import type { ClientSession } from '../sessions';
 import type { Server } from '../sdam/server';
-import type { ReadPreference } from '../read_preference';
 import type { Collection } from '../collection';
 import type { UpdateOptions } from './update';
 import type { WriteCommandOptions } from '../cmap/wire_protocol/write_command';
 import type { DeleteOptions } from './delete';
+import type { OperationOptions } from './operation';
 
 /** @internal */
-export interface IndexInformationOptions {
+export interface IndexInformationOptions extends OperationOptions {
   full?: boolean;
-  readPreference?: ReadPreference;
-  session?: ClientSession;
 }
 /**
  * Retrieves this collections index info.
@@ -28,25 +25,12 @@ export interface IndexInformationOptions {
  * @param db - The Db instance on which to retrieve the index info.
  * @param name - The name of the collection.
  */
-export function indexInformation(db: Db, name: string, callback: Callback): void;
 export function indexInformation(
   db: Db,
   name: string,
   options: IndexInformationOptions,
-  callback?: Callback
-): void;
-export function indexInformation(
-  db: Db,
-  name: string,
-  _optionsOrCallback: IndexInformationOptions | Callback,
-  _callback?: Callback
+  callback: Callback
 ): void {
-  let options = _optionsOrCallback as IndexInformationOptions;
-  let callback = _callback as Callback;
-  if ('function' === typeof _optionsOrCallback) {
-    callback = _optionsOrCallback as Callback;
-    options = {};
-  }
   // If we specified full information
   const full = options.full == null ? false : options.full;
 
@@ -104,26 +88,12 @@ export function prepareDocs(
   });
 }
 
-export function removeDocuments(server: Server, coll: Collection, callback?: Callback): void;
 export function removeDocuments(
   server: Server,
   coll: Collection,
-  selector?: Document,
-  callback?: Callback
-): void;
-export function removeDocuments(
-  server: Server,
-  coll: Collection,
-  selector?: Document,
-  options?: DeleteOptions,
-  callback?: Callback
-): void;
-export function removeDocuments(
-  server: Server,
-  coll: Collection,
-  selector?: Document,
-  options?: DeleteOptions | Document,
-  callback?: Callback
+  selector: Document,
+  options: DeleteOptions,
+  callback: Callback
 ): void {
   if (typeof options === 'function') {
     (callback = options as Callback), (options = {});
@@ -187,31 +157,9 @@ export function updateDocuments(
   coll: Collection,
   selector: Document,
   document: Document,
-  callback: Callback
-): void;
-export function updateDocuments(
-  server: Server,
-  coll: Collection,
-  selector: Document,
-  document: Document,
   options: UpdateOptions,
   callback: Callback
-): void;
-export function updateDocuments(
-  server: Server,
-  coll: Collection,
-  selector: Document,
-  document: Document,
-  _options: UpdateOptions | Callback,
-  _callback?: Callback
 ): void {
-  let options = _options as UpdateOptions;
-  let callback = _callback as Callback;
-  if ('function' === typeof options) {
-    callback = options;
-    options = {};
-  }
-
   // If we are not providing a selector or document throw
   if (selector == null || typeof selector !== 'object')
     return callback(new TypeError('selector must be a valid JavaScript object'));

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -126,11 +126,17 @@ function makeIndexSpec(indexSpec: IndexSpecification, options: any): IndexDescri
 /** @internal */
 export class IndexesOperation extends OperationBase<IndexInformationOptions, Document> {
   collection: Collection;
+  protected full;
+
+  getOptions(): Readonly<IndexInformationOptions> {
+    return deepFreeze({ ...super.getOptions(), full: this.full });
+  }
 
   constructor(collection: Collection, options: IndexInformationOptions) {
     super(options);
 
     this.collection = collection;
+    this.full = options.full;
   }
 
   execute(server: Server, callback: Callback<Document>): void {
@@ -147,9 +153,9 @@ export class CreateIndexesOperation extends CommandOperation<CreateIndexesOption
   onlyReturnNameOfCreatedIndex?: boolean;
   indexes: IndexDescription[];
 
-  get builtOptions(): Readonly<CreateIndexesOptions> {
+  getOptions(): Readonly<CreateIndexesOptions> {
     return deepFreeze({
-      ...super.builtOptions,
+      ...super.getOptions(),
       // collation is set on each index, it should not be defined at the root
       collation: undefined
     });
@@ -171,7 +177,7 @@ export class CreateIndexesOperation extends CommandOperation<CreateIndexesOption
   }
 
   execute(server: Server, callback: Callback<Document>): void {
-    const options = this.builtOptions;
+    const options = this.getOptions();
     const indexes = this.indexes;
 
     const serverWireVersion = maxWireVersion(server);

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -23,9 +23,9 @@ export class InsertOperation extends OperationBase<BulkWriteOptions, Document> {
   protected ordered;
   protected forceServerObjectId;
 
-  get builtOptions(): BulkWriteOptions {
+  getOptions(): BulkWriteOptions {
     return deepFreeze({
-      ...super.builtOptions,
+      ...super.getOptions(),
       bypassDocumentValidation: this.bypassDocumentValidation,
       ordered: this.ordered,
       forceServerObjectId: this.forceServerObjectId
@@ -43,7 +43,7 @@ export class InsertOperation extends OperationBase<BulkWriteOptions, Document> {
   }
 
   execute(server: Server, callback: Callback<Document>): void {
-    server.insert(this.ns.toString(), this.operations, this.builtOptions as any, callback);
+    server.insert(this.ns.toString(), this.operations, this.getOptions() as any, callback);
   }
 }
 
@@ -72,9 +72,9 @@ export class InsertOneOperation extends CommandOperation<InsertOneOptions, Inser
   doc: Document;
   protected bypassDocumentValidation;
 
-  get builtOptions(): InsertOneOptions {
+  getOptions(): InsertOneOptions {
     return deepFreeze({
-      ...super.builtOptions,
+      ...super.getOptions(),
       bypassDocumentValidation: this.bypassDocumentValidation
     });
   }
@@ -95,7 +95,7 @@ export class InsertOneOperation extends CommandOperation<InsertOneOptions, Inser
       return callback(new MongoError('doc parameter must be an object'));
     }
 
-    insertDocuments(server, coll, [doc], this.builtOptions, (err, r) => {
+    insertDocuments(server, coll, [doc], this.getOptions(), (err, r) => {
       if (callback == null) return;
       if (err && callback) return callback(err);
       // Workaround for pre 2.6 servers

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -49,7 +49,7 @@ export abstract class OperationBase<
   // BSON serialization options
   bsonOptions?: BSONSerializeOptions;
 
-  get builtOptions(): Readonly<OperationOptions> {
+  getOptions(): Readonly<OperationOptions> {
     return deepFreeze({
       ...this.options, // Should go away when options aren't generic params anymore.
       ...this.bsonOptions,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import type { EventEmitter } from 'events';
 import type { Db } from './db';
 import type { Collection } from './collection';
 import type { OperationOptions, OperationBase, Hint } from './operations/operation';
-import type { ClientSession } from './sessions';
+import { ClientSession } from './sessions';
 import type { ReadConcern } from './read_concern';
 import type { Connection } from './cmap/connection';
 import { readFileSync } from 'fs';
@@ -1126,8 +1126,8 @@ export function deepFreeze<O extends Record<string, any>>(object: O): Readonly<O
   for (const name of propNames) {
     const value = object[name];
 
-    if (name === 'session') continue;
-    if (ArrayBuffer.isView(value)) continue;
+    if (value instanceof ClientSession) continue; // Sessions have circular references
+    if (ArrayBuffer.isView(value)) continue; // Typed arrays that have nonzero size can't be frozen
 
     if (value && typeof value === 'object' && !Object.isFrozen(value)) {
       deepFreeze(value);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1116,3 +1116,23 @@ export function hasAtomicOperators(doc: Document | Document[]): boolean {
   const keys = Object.keys(doc);
   return keys.length > 0 && keys[0][0] === '$';
 }
+
+export function deepFreeze<O extends Record<string, any>>(object: O): Readonly<O> {
+  // Retrieve the property names defined on object
+  const propNames = Object.getOwnPropertyNames(object);
+
+  // Freeze properties before freezing self
+
+  for (const name of propNames) {
+    const value = object[name];
+
+    if (name === 'session') continue;
+    if (ArrayBuffer.isView(value)) continue;
+
+    if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+      deepFreeze(value);
+    }
+  }
+
+  return Object.freeze(object);
+}


### PR DESCRIPTION
Add a `builtOptions` getter that inherits options from the parent class.

NODE-2815

### Description

In order to make tracing options sensible I went with this idea of inheriting the super class's `builtOptions` which are frozen. I'll put this small start in review to get some feedback going on how we like this methodology and I can start expanding this to other operations. 

Some of the bsonOptions work is duplicated in here to get the code to work, but I will pull that in from master when its there.

Look out for a parallel PR to this that works on removing executeLegacyOperation.