### PR TITLE
fix: apply bson options for bulk operations

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -572,7 +572,7 @@ function executeCommands(
 
   const finalOptions = Object.assign(
     { ordered: bulkOperation.isOrdered },
-    bulkOperation.s.bsonOptions,
+    bulkOperation.bsonOptions,
     options
   );
   if (bulkOperation.s.writeConcern != null) {
@@ -1162,6 +1162,10 @@ export abstract class BulkOperationBase {
     throw TypeError(
       'bulkWrite only supports insertOne, insertMany, updateOne, updateMany, removeOne, removeMany, deleteOne, deleteMany'
     );
+  }
+
+  get bsonOptions(): BSONSerializeOptions {
+    return this.s.bsonOptions;
   }
 
   /** An internal helper method. Do not invoke directly. Will be going away in the future */

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1285,24 +1285,12 @@ export class Collection implements OperationParent {
 
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
-    options = options || {};
-    // Give function's options precedence over session options.
-    if (options.ignoreUndefined == null) {
-      options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
-    }
-
-    return new UnorderedBulkOperation(this, options);
+    return new UnorderedBulkOperation(this, options || {});
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
-    options = options || {};
-    // Give function's options precedence over session's options.
-    if (options.ignoreUndefined == null) {
-      options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
-    }
-
-    return new OrderedBulkOperation(this, options);
+    return new OrderedBulkOperation(this, options || {});
   }
 
   /** Get the db scoped logger */

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1285,12 +1285,12 @@ export class Collection implements OperationParent {
 
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
-    return new UnorderedBulkOperation(this, options || {});
+    return new UnorderedBulkOperation(this, options ?? {});
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
-    return new OrderedBulkOperation(this, options || {});
+    return new OrderedBulkOperation(this, options ?? {});
   }
 
   /** Get the db scoped logger */

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -1,11 +1,8 @@
 'use strict';
-const { withClient } = require('./shared');
-const test = require('./shared').assert,
-  setupDatabase = require('./shared').setupDatabase,
-  expect = require('chai').expect;
-
-const MongoError = require('../../src/error').MongoError;
-const ignoreNsNotFound = require('./shared').ignoreNsNotFound;
+const { withClient, setupDatabase, ignoreNsNotFound } = require('./shared');
+const test = require('./shared').assert;
+const { expect } = require('chai');
+const { MongoError } = require('../../src/error');
 const { Long } = require('../../src');
 
 describe('Bulk', function () {

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -1,10 +1,12 @@
 'use strict';
+const { withClient } = require('./shared');
 const test = require('./shared').assert,
   setupDatabase = require('./shared').setupDatabase,
   expect = require('chai').expect;
 
 const MongoError = require('../../src/error').MongoError;
 const ignoreNsNotFound = require('./shared').ignoreNsNotFound;
+const { Long } = require('../../src');
 
 describe('Bulk', function () {
   before(function () {
@@ -157,6 +159,108 @@ describe('Bulk', function () {
       });
     }
   });
+
+  it('should inherit promote long false from db during unordered bulk operation', function () {
+    const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
+      promoteLongs: true
+    });
+
+    return withClient.call(this, client, (client, done) => {
+      const db = client.db('shouldInheritPromoteLongFalseFromDb1', { promoteLongs: false });
+      const coll = db.collection('test');
+
+      const batch = coll.initializeUnorderedBulkOp();
+      batch.insert({ a: Long.fromNumber(10) });
+      batch.execute((err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+
+        coll.findOne((err, item) => {
+          expect(err).to.not.exist;
+          expect(item.a).to.not.be.a('number');
+          expect(item.a).to.have.property('_bsontype');
+          expect(item.a._bsontype).to.be.equal('Long');
+
+          done();
+        });
+      });
+    });
+  });
+
+  it(
+    'should inherit promote long false from collection during unordered bulk operation',
+    withClient(function (client, done) {
+      const db = client.db('shouldInheritPromoteLongFalseFromColl1', { promoteLongs: true });
+      const coll = db.collection('test', { promoteLongs: false });
+
+      const batch = coll.initializeUnorderedBulkOp();
+      batch.insert({ a: Long.fromNumber(10) });
+      batch.execute((err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+
+        coll.findOne((err, item) => {
+          expect(err).to.not.exist;
+          expect(item.a).to.not.be.a('number');
+          expect(item.a).to.have.property('_bsontype');
+          expect(item.a._bsontype).to.be.equal('Long');
+
+          done();
+        });
+      });
+    })
+  );
+
+  it('should inherit promote long false from db during ordered bulk operation', function () {
+    const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
+      promoteLongs: true
+    });
+
+    return withClient.call(this, client, (client, done) => {
+      const db = client.db('shouldInheritPromoteLongFalseFromDb2', { promoteLongs: false });
+      const coll = db.collection('test');
+
+      const batch = coll.initializeOrderedBulkOp();
+      batch.insert({ a: Long.fromNumber(10) });
+      batch.execute((err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+
+        coll.findOne((err, item) => {
+          expect(err).to.not.exist;
+          expect(item.a).to.not.be.a('number');
+          expect(item.a).to.have.property('_bsontype');
+          expect(item.a._bsontype).to.be.equal('Long');
+
+          done();
+        });
+      });
+    });
+  });
+
+  it(
+    'should inherit promote long false from collection during ordered bulk operation',
+    withClient(function (client, done) {
+      const db = client.db('shouldInheritPromoteLongFalseFromColl2', { promoteLongs: true });
+      const coll = db.collection('test', { promoteLongs: false });
+
+      const batch = coll.initializeOrderedBulkOp();
+      batch.insert({ a: Long.fromNumber(10) });
+      batch.execute((err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+
+        coll.findOne((err, item) => {
+          expect(err).to.not.exist;
+          expect(item.a).to.not.be.a('number');
+          expect(item.a).to.have.property('_bsontype');
+          expect(item.a._bsontype).to.be.equal('Long');
+
+          done();
+        });
+      });
+    })
+  );
 
   it('should correctly handle ordered multiple batch api write command errors', {
     metadata: {


### PR DESCRIPTION
This change extends the work from #2589 to bulk operations. The changes involved for `BulkOperationBase` parallel those for `OperationBase`: a new `bsonOptions` field was added (in `s`, so it's at the same level as `options`) with values inherited from the collection parent, it is exposed with a `bsonOptions` getter, and it is included in the options before any `executeOperation` is called.

NODE-1561