### PR TITLE
chore: fix symbols & public / internal one-liners

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -56,7 +56,7 @@ export class Admin {
   s: AdminPrivate;
 
   /**
-   * Create a new Admin instance (INTERNAL TYPE, do not instantiate directly)
+   * Create a new Admin instance
    * @internal
    */
   constructor(db: Db) {

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -55,7 +55,10 @@ export class Admin {
   /** @internal */
   s: AdminPrivate;
 
-  /** @internal Create a new Admin instance (INTERNAL TYPE, do not instantiate directly) */
+  /**
+   * Create a new Admin instance (INTERNAL TYPE, do not instantiate directly)
+   * @internal
+   */
   constructor(db: Db) {
     this.s = { db };
   }

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -31,7 +31,10 @@ export interface Document {
 
 import type { SerializeOptions } from 'bson';
 
-/** @public BSON Serialization options. TODO: Remove me when types from BSON are updated */
+/**
+ * BSON Serialization options. TODO: Remove me when types from BSON are updated
+ * @public
+ */
 export interface BSONSerializeOptions extends SerializeOptions {
   /** Return document results as raw BSON buffers */
   fieldsAsRaw?: { [key: string]: boolean };

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -31,8 +31,9 @@ export interface Document {
 
 import type { SerializeOptions } from 'bson';
 
+// TODO: Remove me when types from BSON are updated
 /**
- * BSON Serialization options. TODO: Remove me when types from BSON are updated
+ * BSON Serialization options.
  * @public
  */
 export interface BSONSerializeOptions extends SerializeOptions {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -158,6 +158,7 @@ interface UpdateDescription {
   removedFields: string[];
 }
 
+/** @internal */
 export class ChangeStreamStream extends CursorStream {
   constructor(cursor: ChangeStreamCursor) {
     super(cursor);
@@ -465,7 +466,10 @@ export class ChangeStreamCursor extends Cursor<AggregateOperation, ChangeStreamC
   }
 }
 
-/** @internal Create a new change stream cursor based on self's configuration */
+/**
+ * Create a new change stream cursor based on self's configuration
+ * @internal
+ */
 function createChangeStreamCursor(
   self: ChangeStream,
   options: ChangeStreamOptions

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -127,7 +127,8 @@ export interface CloseOptions {
   force?: boolean;
 }
 
-/** @public NOTE: to be removed as part of NODE-2745 */
+// NOTE: to be removed as part of NODE-2745
+/** @public */
 export interface ConnectionPool {
   isConnected(): boolean;
   write(
@@ -137,7 +138,10 @@ export interface ConnectionPool {
   ): void;
 }
 
-/** @public A pool of connections which dynamically resizes, and emit events related to pool activity */
+/**
+ * A pool of connections which dynamically resizes, and emit events related to pool activity
+ * @public
+ */
 export class ConnectionPool extends EventEmitter {
   closed: boolean;
   options: Readonly<ConnectionPoolOptions>;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -172,7 +172,7 @@ export class Collection implements OperationParent {
   s: CollectionPrivate;
 
   /**
-   * Create a new Collection instance (INTERNAL TYPE, do not instantiate directly)
+   * Create a new Collection instance
    * @internal
    */
   constructor(db: Db, name: string, options?: CollectionOptions) {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -171,7 +171,10 @@ export class Collection implements OperationParent {
   /** @internal */
   s: CollectionPrivate;
 
-  /** @internal Create a new Collection instance (INTERNAL TYPE, do not instantiate directly) */
+  /**
+   * Create a new Collection instance (INTERNAL TYPE, do not instantiate directly)
+   * @internal
+   */
   constructor(db: Db, name: string, options?: CollectionOptions) {
     checkCollectionName(name);
     emitDeprecatedOptionWarning(options, ['promiseLibrary']);

--- a/src/cursor/cursor.ts
+++ b/src/cursor/cursor.ts
@@ -22,7 +22,10 @@ import type { ClientSession } from '../sessions';
 
 const kCursor = Symbol('cursor');
 
-/** @public Flags allowed for cursor */
+/**
+ * Flags allowed for cursor
+ * @public
+ */
 export const FLAGS = [
   'tailable',
   'oplogReplay',
@@ -47,7 +50,7 @@ export interface DocumentTransforms {
 }
 
 /** @internal */
-interface CursorPrivate {
+export interface CursorPrivate {
   /** Transforms functions */
   transforms?: DocumentTransforms;
   numberOfRetries: number;
@@ -60,7 +63,10 @@ interface CursorPrivate {
   readConcern?: ReadConcern;
 }
 
-/** @public Possible states for a cursor */
+/**
+ * Possible states for a cursor
+ * @public
+ */
 export enum CursorState {
   INIT = 0,
   OPEN = 1,
@@ -1647,7 +1653,10 @@ export function each(cursor: Cursor, callback: EachCallback): void {
   }
 }
 
-/** @internal Trampoline emptying the number of retrieved items without incurring a nextTick operation */
+/**
+ * Trampoline emptying the number of retrieved items without incurring a nextTick operation
+ * @internal
+ */
 function loop(cursor: Cursor, callback: Callback) {
   // No more items we are done
   if (cursor.bufferedCount() === 0) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,7 @@ export type {
 } from './bulk/common';
 export type {
   ChangeStream,
+  ChangeStreamStream,
   ChangeStreamOptions,
   ChangeStreamCursor,
   ResumeToken,
@@ -150,12 +151,14 @@ export type {
   CursorCloseOptions,
   DocumentTransforms,
   CursorStreamOptions,
+  CursorStream,
   CursorState,
   CursorOptions,
   FIELDS as CURSOR_FIELDS,
   FLAGS as CURSOR_FLAGS,
   CursorFlag,
-  EachCallback
+  EachCallback,
+  CursorPrivate
 } from './cursor/cursor';
 export type { DbPrivate, DbOptions } from './db';
 export type { AutoEncryptionOptions, AutoEncryptionLoggerLevels, AutoEncrypter } from './deps';

--- a/src/operations/distinct.ts
+++ b/src/operations/distinct.ts
@@ -8,7 +8,10 @@ import type { Collection } from '../collection';
 /** @public */
 export type DistinctOptions = CommandOperationOptions;
 
-/** @internal Return a list of distinct values for the given key across a collection. */
+/**
+ * Return a list of distinct values for the given key across a collection.
+ * @internal
+ */
 export class DistinctOperation extends CommandOperation<DistinctOptions, Document[]> {
   collection: Collection;
   /** Field of the document to find distinct values for. */

--- a/src/operations/map_reduce.ts
+++ b/src/operations/map_reduce.ts
@@ -63,7 +63,10 @@ interface MapReduceStats {
   timing?: number;
 }
 
-/** @internal Run Map Reduce across a collection. Be aware that the inline option for out will return an array of results not a collection. */
+/**
+ * Run Map Reduce across a collection. Be aware that the inline option for out will return an array of results not a collection.
+ * @internal
+ */
 export class MapReduceOperation extends CommandOperation<MapReduceOptions, Document | Document[]> {
   collection: Collection;
   /** The mapping function. */

--- a/src/operations/stats.ts
+++ b/src/operations/stats.ts
@@ -11,7 +11,10 @@ export interface CollStatsOptions extends CommandOperationOptions {
   scale?: number;
 }
 
-/** @internal Get all the collection statistics. */
+/**
+ * Get all the collection statistics.
+ * @internal
+ */
 export class CollStatsOperation extends CommandOperation<CollStatsOptions, Document> {
   collectionName: string;
 

--- a/src/sdam/common.ts
+++ b/src/sdam/common.ts
@@ -8,7 +8,10 @@ export const STATE_CLOSED = 'closed';
 export const STATE_CONNECTING = 'connecting';
 export const STATE_CONNECTED = 'connected';
 
-/** @public An enumeration of topology types we know about */
+/**
+ * An enumeration of topology types we know about
+ * @public
+ */
 export enum TopologyType {
   Single = 'Single',
   ReplicaSetNoPrimary = 'ReplicaSetNoPrimary',
@@ -17,7 +20,10 @@ export enum TopologyType {
   Unknown = 'Unknown'
 }
 
-/** @public An enumeration of server types we know about */
+/**
+ * An enumeration of server types we know about
+ * @public
+ */
 export enum ServerType {
   Standalone = 'Standalone',
   Mongos = 'Mongos',

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -16,7 +16,10 @@ export interface TopologyDescriptionOptions {
   localThresholdMS?: number;
 }
 
-/** @public Representation of a deployment of servers */
+/**
+ * Representation of a deployment of servers
+ * @public
+ */
 export class TopologyDescription {
   type: TopologyType;
   setName?: string;

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -42,7 +42,10 @@ const stateMachine = {
   ]
 };
 
-/** @public Configuration options for a transaction. */
+/**
+ * Configuration options for a transaction.
+ * @public
+ */
 export interface TransactionOptions extends CommandOperationOptions {
   /** A default read concern for commands in this transaction */
   readConcern?: ReadConcern;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,10 @@ import { resolve } from 'path';
 import type { Document } from './bson';
 import type { IndexSpecification, IndexDirection } from './operations/indexes';
 
-/** @public MongoDB Driver style callback */
+/**
+ * MongoDB Driver style callback
+ * @public
+ */
 export type Callback<T = any> = (error?: AnyError, result?: T) => void;
 /** @public */
 export type CallbackWithType<E = AnyError, T0 = any> = (error?: E, result?: T0) => void;
@@ -668,7 +671,10 @@ export function collectionNamespace(ns: string): string {
   return ns.split('.').slice(1).join('.');
 }
 
-/** @internal Synchronously Generate a UUIDv4 */
+/**
+ * Synchronously Generate a UUIDv4
+ * @internal
+ */
 export function uuidV4(): Buffer {
   const result = crypto.randomBytes(16);
   result[6] = (result[6] & 0x0f) | 0x40;
@@ -978,7 +984,10 @@ export interface InterruptableAsyncIntervalOptions {
   /** Whether the method should be called immediately when the interval is started  */
   immediate: boolean;
 
-  /* @internal only used for testing unreliable timer environments */
+  /**
+   * Only used for testing unreliable timer environments
+   * @internal
+   */
   clock: () => number;
 }
 


### PR DESCRIPTION
Fixes API Extractor warnings, and splits out `@public` and `@internal` one-liners, because while it's valid syntax, it's not the intended functionality, providing a string after a `@tag` becomes the "attribute" of that tag, and in these cases it's a `@description` which is the first string in the comment-doc.