### PR TITLE
fix: add optional peer dependencies (yarn2/pnpm)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,26 @@
     "snappy": "^6.3.4",
     "bson-ext": "^2.0.0"
   },
+  "peerDependenciesMeta": {
+    "kerberos": {
+      "optional": true
+    },
+    "mongodb-client-encryption": {
+      "optional": true
+    },
+    "mongodb-extjson": {
+      "optional": true
+    },
+    "snappy": {
+      "optional": true
+    },
+    "bson-ext": {
+      "optional": true
+    },
+    "aws4": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "bl": "^2.2.1",
     "bson": "^1.1.4",


### PR DESCRIPTION
## Description

It appears that `aws4` was being required without being listed as a dependency. This results in errors when using strict package managers such as Yarn 2 (berry) and pnpm.

~~Additionally, it seems a non-standard way of requiring optional modules was being used.~~

All recent package managers support optional peer dependencies using the `peerDependenciesMeta` field:

npm as of: https://github.com/npm/cli/pull/224
Yarn 1: https://classic.yarnpkg.com/en/docs/package-json#toc-peerdependenciesmeta
Yarn 2: https://yarnpkg.com/configuration/manifest/#peerDependenciesMeta
pnpm: https://pnpm.js.org/en/package_json#peerdependenciesmeta

**What changed?**

~~Removed `require_optional` dependency and used standard optional peer dependency definitions.~~

Added `aws4` as an optional peer dependency. See:
https://yarnpkg.com/advanced/rulebook/#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies

**Are there any files to ignore?**

No