### PR TITLE
docs(mongo_client): indicate that ssl defaults to `true` for srv connection strings

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -77,7 +77,7 @@ const validOptions = require('./operations/connect').validOptions;
  * @param {string} url The connection URI string
  * @param {object} [options] Optional settings
  * @param {number} [options.poolSize=5] The maximum size of the individual server pool
- * @param {boolean} [options.ssl=false] Enable SSL connection. *deprecated* use `tls` variants
+ * @param {boolean} [options.ssl=false] Enable SSL connection. Defaults to `false` for `mongodb://` connection strings, and `true` for `mongodb+srv://` connection strings. *deprecated* use `tls` variants
  * @param {boolean} [options.sslValidate=false] Validate mongod server certificate against Certificate Authority
  * @param {buffer} [options.sslCA=undefined] SSL Certificate store binary buffer *deprecated* use `tls` variants
  * @param {buffer} [options.sslCert=undefined] SSL Certificate binary buffer *deprecated* use `tls` variants


### PR DESCRIPTION
Re: Automattic/mongoose#9511

## Description

If you're using `mongodb+srv://`, the `ssl` option is true by default, here's where it is set: https://github.com/mongodb/node-mongodb-native/blob/79df55383b5ba3f081b96513253e566793166199/lib/core/uri_parser.js#L78-L84 . I think it's worthwhile to document this.

**What changed?**

One line of documentation

**Are there any files to ignore?**

No