### PR TITLE
fix: move kerberos client setup from prepare to auth

### DIFF
--- a/lib/core/auth/gssapi.js
+++ b/lib/core/auth/gssapi.js
@@ -16,7 +16,7 @@ class GSSAPI extends AuthProvider {
     function externalCommand(command, cb) {
       return connection.command('$external.$cmd', command, cb);
     }
-    getClient(authContext, (err, client) => {
+    makeKerberosClient(authContext, (err, client) => {
       if (err) return callback(err);
       if (client == null) return callback(new MongoError('gssapi client missing'));
       client.step('', (err, payload) => {
@@ -52,7 +52,7 @@ class GSSAPI extends AuthProvider {
 }
 module.exports = GSSAPI;
 
-function getClient(authContext, callback) {
+function makeKerberosClient(authContext, callback) {
   const host = authContext.options.host;
   const port = authContext.options.port;
   const credentials = authContext.credentials;

--- a/lib/core/auth/gssapi.js
+++ b/lib/core/auth/gssapi.js
@@ -5,88 +5,44 @@ const AuthProvider = require('./auth_provider').AuthProvider;
 const retrieveKerberos = require('../utils').retrieveKerberos;
 const MongoError = require('../error').MongoError;
 
-const kGssapiClient = Symbol('GSSAPI_CLIENT');
 let kerberos;
 
 class GSSAPI extends AuthProvider {
-  prepare(handshakeDoc, authContext, callback) {
-    const host = authContext.options.host;
-    const port = authContext.options.port;
-    const credentials = authContext.credentials;
-    if (!host || !port || !credentials) {
-      return callback(
-        new MongoError(
-          `Connection must specify: ${host ? 'host' : ''}, ${port ? 'port' : ''}, ${
-            credentials ? 'host' : 'credentials'
-          }.`
-        )
-      );
-    }
-    if (kerberos == null) {
-      try {
-        kerberos = retrieveKerberos();
-      } catch (e) {
-        return callback(e);
-      }
-    }
-    const username = credentials.username;
-    const password = credentials.password;
-    const mechanismProperties = credentials.mechanismProperties;
-    const serviceName =
-      mechanismProperties['gssapiservicename'] ||
-      mechanismProperties['gssapiServiceName'] ||
-      'mongodb';
-    performGssapiCanonicalizeHostName(host, mechanismProperties, (err, host) => {
-      if (err) return callback(err);
-      const initOptions = {};
-      if (password != null) {
-        Object.assign(initOptions, { user: username, password: password });
-      }
-      kerberos.initializeClient(
-        `${serviceName}${process.platform === 'win32' ? '/' : '@'}${host}`,
-        initOptions,
-        (err, client) => {
-          if (err) return callback(new MongoError(err));
-          if (client == null) return callback();
-          this[kGssapiClient] = client;
-          callback(undefined, handshakeDoc);
-        }
-      );
-    });
-  }
   auth(authContext, callback) {
     const connection = authContext.connection;
     const credentials = authContext.credentials;
     if (credentials == null) return callback(new MongoError('credentials required'));
     const username = credentials.username;
-    const client = this[kGssapiClient];
-    if (client == null) return callback(new MongoError('gssapi client missing'));
     function externalCommand(command, cb) {
       return connection.command('$external.$cmd', command, cb);
     }
-    client.step('', (err, payload) => {
+    getClient(authContext, (err, client) => {
       if (err) return callback(err);
-      externalCommand(saslStart(payload), (err, response) => {
-        const result = response.result;
+      if (client == null) return callback(new MongoError('gssapi client missing'));
+      client.step('', (err, payload) => {
         if (err) return callback(err);
-        negotiate(client, 10, result.payload, (err, payload) => {
+        externalCommand(saslStart(payload), (err, response) => {
           if (err) return callback(err);
-          externalCommand(saslContinue(payload, result.conversationId), (err, response) => {
-            const result = response.result;
+          const result = response.result;
+          negotiate(client, 10, result.payload, (err, payload) => {
             if (err) return callback(err);
-            finalize(client, username, result.payload, (err, payload) => {
+            externalCommand(saslContinue(payload, result.conversationId), (err, response) => {
               if (err) return callback(err);
-              externalCommand(
-                {
-                  saslContinue: 1,
-                  conversationId: result.conversationId,
-                  payload
-                },
-                (err, result) => {
-                  if (err) return callback(err);
-                  callback(undefined, result);
-                }
-              );
+              const result = response.result;
+              finalize(client, username, result.payload, (err, payload) => {
+                if (err) return callback(err);
+                externalCommand(
+                  {
+                    saslContinue: 1,
+                    conversationId: result.conversationId,
+                    payload
+                  },
+                  (err, result) => {
+                    if (err) return callback(err);
+                    callback(undefined, result);
+                  }
+                );
+              });
             });
           });
         });
@@ -95,6 +51,50 @@ class GSSAPI extends AuthProvider {
   }
 }
 module.exports = GSSAPI;
+
+function getClient(authContext, callback) {
+  const host = authContext.options.host;
+  const port = authContext.options.port;
+  const credentials = authContext.credentials;
+  if (!host || !port || !credentials) {
+    return callback(
+      new MongoError(
+        `Connection must specify: ${host ? 'host' : ''}, ${port ? 'port' : ''}, ${
+          credentials ? 'host' : 'credentials'
+        }.`
+      )
+    );
+  }
+  if (kerberos == null) {
+    try {
+      kerberos = retrieveKerberos();
+    } catch (e) {
+      return callback(e);
+    }
+  }
+  const username = credentials.username;
+  const password = credentials.password;
+  const mechanismProperties = credentials.mechanismProperties;
+  const serviceName =
+    mechanismProperties['gssapiservicename'] ||
+    mechanismProperties['gssapiServiceName'] ||
+    'mongodb';
+  performGssapiCanonicalizeHostName(host, mechanismProperties, (err, host) => {
+    if (err) return callback(err);
+    const initOptions = {};
+    if (password != null) {
+      Object.assign(initOptions, { user: username, password: password });
+    }
+    kerberos.initializeClient(
+      `${serviceName}${process.platform === 'win32' ? '/' : '@'}${host}`,
+      initOptions,
+      (err, client) => {
+        if (err) return callback(new MongoError(err));
+        callback(null, client);
+      }
+    );
+  });
+}
 
 function saslStart(payload) {
   return {


### PR DESCRIPTION
## Description

This PR fixes a bug in Kerberos authentication by moving the Kerberos
client initialization from the `AuthProvider.prepare` override into a
local `getClient` function.

NODE-2859

**What changed?**

**Are there any files to ignore?**
