### PR TITLE
fix: revert use of setImmediate to process.nextTick

### DIFF
--- a/lib/cmap/connection_pool.js
+++ b/lib/cmap/connection_pool.js
@@ -233,7 +233,7 @@ class ConnectionPool extends EventEmitter {
     }
 
     this[kWaitQueue].push(waitQueueMember);
-    setImmediate(() => processWaitQueue(this));
+    process.nextTick(() => processWaitQueue(this));
   }
 
   /**
@@ -258,7 +258,7 @@ class ConnectionPool extends EventEmitter {
       destroyConnection(this, connection, reason);
     }
 
-    setImmediate(() => processWaitQueue(this));
+    process.nextTick(() => processWaitQueue(this));
   }
 
   /**
@@ -428,7 +428,7 @@ function createConnection(pool, callback) {
 
     // otherwise add it to the pool for later acquisition, and try to process the wait queue
     pool[kConnections].push(connection);
-    setImmediate(() => processWaitQueue(pool));
+    process.nextTick(() => processWaitQueue(pool));
   });
 }
 
@@ -439,7 +439,7 @@ function destroyConnection(pool, connection, reason) {
   pool[kPermits]++;
 
   // destroy the connection
-  setImmediate(() => connection.destroy());
+  process.nextTick(() => connection.destroy());
 }
 
 function processWaitQueue(pool) {


### PR DESCRIPTION
A performance regression was identified in switching the connection pool to using setImmediate instead of process.nextTick for wait
queue processing. This patch reverts that change.

NODE-2861
