### PR TITLE
test: restrict geoSearch tests to mongodb <= 4.4

### DIFF
--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -1754,7 +1754,7 @@ describe('Operation Examples', function() {
    * @ignore
    */
   it('shouldCorrectlyPerformSimpleGeoHaystackSearchCommand', {
-    metadata: { requires: { topology: ['single', 'replicaset'] } },
+    metadata: { requires: { mongodb: '<=4.4', topology: ['single', 'replicaset'] } },
 
     // The actual test we wish to run
     test: function(done) {

--- a/test/functional/operation_generators_example.test.js
+++ b/test/functional/operation_generators_example.test.js
@@ -1093,7 +1093,7 @@ describe('Operation (Generators)', function() {
    * @ignore
    */
   it('shouldCorrectlyPerformSimpleGeoHaystackSearchCommandWithGenerators', {
-    metadata: { requires: { generators: true, topology: ['single'] } },
+    metadata: { requires: { mongodb: '<=4.4', generators: true, topology: ['single'] } },
 
     // The actual test we wish to run
     test: function() {

--- a/test/functional/operation_promises_example.test.js
+++ b/test/functional/operation_promises_example.test.js
@@ -1120,7 +1120,7 @@ describe('Operation (Promises)', function() {
    * @ignore
    */
   it('shouldCorrectlyPerformSimpleGeoHaystackSearchCommandWithPromises', {
-    metadata: { requires: { topology: ['single', 'replicaset'] } },
+    metadata: { requires: { mongodb: '<=4.4', topology: ['single', 'replicaset'] } },
 
     // The actual test we wish to run
     test: function() {

--- a/test/functional/readconcern.test.js
+++ b/test/functional/readconcern.test.js
@@ -59,9 +59,12 @@ describe('ReadConcern', function() {
   ];
 
   tests.forEach(test => {
+    const metadata = { requires: { topology: 'replicaset', mongodb: '>= 3.2' } };
+    if (test.commandName === 'geoSearch') {
+      metadata.requires.mongodb += ' <=4.4';
+    }
     it(test.description, {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2' } },
-
+      metadata,
       test: function(done) {
         const started = [];
         const succeeded = [];


### PR DESCRIPTION
## Description

This PR restricts `geoHaystack`/`geoSearch` tests to mongodb `<=4.4`, which was overlooked in NODE-2546.

**What changed?**

**Are there any files to ignore?**
