### PR TITLE
Resolve inherited options

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,4 +1,4 @@
-import { emitDeprecatedOptionWarning } from './utils';
+import { emitDeprecatedOptionWarning, resolveInheritedOptions } from './utils';
 import { ReadPreference, ReadPreferenceLike } from './read_preference';
 import { deprecate } from 'util';
 import {
@@ -282,7 +282,7 @@ export class Collection implements OperationParent {
     callback?: Callback<InsertOneResult>
   ): Promise<InsertOneResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(this.s.topology, new InsertOneOperation(this, doc, options), callback);
   }
@@ -310,7 +310,7 @@ export class Collection implements OperationParent {
     callback?: Callback<InsertManyResult>
   ): Promise<InsertManyResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options ? Object.assign({}, options) : { ordered: true };
+    options = resolveInheritedOptions(this, options ?? { ordered: true });
 
     return executeOperation(
       this.s.topology,
@@ -366,7 +366,7 @@ export class Collection implements OperationParent {
     callback?: Callback<BulkWriteResult>
   ): Promise<BulkWriteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || { ordered: true };
+    options = resolveInheritedOptions(this, options ?? { ordered: true });
 
     if (!Array.isArray(operations)) {
       throw new MongoError('operations must be an array of documents');
@@ -403,7 +403,7 @@ export class Collection implements OperationParent {
     callback?: Callback<UpdateResult>
   ): Promise<UpdateResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options);
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -440,7 +440,7 @@ export class Collection implements OperationParent {
     callback?: Callback<UpdateResult>
   ): Promise<UpdateResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options);
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -473,7 +473,7 @@ export class Collection implements OperationParent {
     callback?: Callback<UpdateResult>
   ): Promise<UpdateResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options);
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -499,7 +499,7 @@ export class Collection implements OperationParent {
     callback?: Callback<DeleteResult>
   ): Promise<DeleteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options);
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -537,7 +537,7 @@ export class Collection implements OperationParent {
       options = {};
     }
 
-    options = Object.assign({}, options);
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -563,8 +563,8 @@ export class Collection implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
-
+    options = resolveInheritedOptions(this, options);
+    options.readPreference = ReadPreference.PRIMARY;
     return executeOperation(this.s.topology, new RenameOperation(this, newName, options), callback);
   }
 
@@ -618,7 +618,7 @@ export class Collection implements OperationParent {
       (callback = query as Callback<Document>), (query = {}), (options = {});
     if (typeof options === 'function') (callback = options), (options = {});
     query = query || {};
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(this.s.topology, new FindOneOperation(this, query, options), callback);
   }
@@ -639,6 +639,7 @@ export class Collection implements OperationParent {
       throw new TypeError('`options` parameter must not be function');
     }
 
+    options = resolveInheritedOptions(this, options);
     return new Cursor(
       this.s.topology,
       new FindOperation(this, this.s.namespace, filter, options),
@@ -661,7 +662,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(this.s.topology, new OptionsOperation(this, options), callback);
   }
@@ -681,7 +682,7 @@ export class Collection implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(this.s.topology, new IsCappedOperation(this, options), callback);
   }
@@ -729,7 +730,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -786,6 +787,7 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options ? Object.assign({}, options) : {};
     if (typeof options.maxTimeMS !== 'number') delete options.maxTimeMS;
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -811,7 +813,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     // Run only against primary
     options.readPreference = ReadPreference.primary;
@@ -838,7 +840,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options ? Object.assign({}, options) : {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(this.s.topology, new DropIndexesOperation(this, options), callback);
   }
@@ -849,6 +851,7 @@ export class Collection implements OperationParent {
    * @param options - Optional settings for the command
    */
   listIndexes(options?: ListIndexesOptions): CommandCursor {
+    options = resolveInheritedOptions(this, options);
     const cursor = new CommandCursor(
       this.s.topology,
       new ListIndexesOperation(this, options),
@@ -879,7 +882,7 @@ export class Collection implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -903,7 +906,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -927,7 +930,7 @@ export class Collection implements OperationParent {
     callback?: Callback<number>
   ): Promise<number> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -984,10 +987,10 @@ export class Collection implements OperationParent {
     }
 
     query = query || {};
-    options = options || {};
+    options = resolveInheritedOptions(this, options as CountDocumentsOptions);
     return executeOperation(
       this.s.topology,
-      new CountDocumentsOperation(this, query as Document, options as CountDocumentsOptions),
+      new CountDocumentsOperation(this, query as Document, options),
       callback
     );
   }
@@ -1026,10 +1029,10 @@ export class Collection implements OperationParent {
     }
 
     query = query || {};
-    options = options || {};
+    options = resolveInheritedOptions(this, options as DistinctOptions);
     return executeOperation(
       this.s.topology,
-      new DistinctOperation(this, key, query as Document, options as DistinctOptions),
+      new DistinctOperation(this, key, query as Document, options),
       callback
     );
   }
@@ -1049,7 +1052,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(this.s.topology, new IndexesOperation(this, options), callback);
   }
@@ -1095,7 +1098,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -1132,7 +1135,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -1169,7 +1172,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -1195,7 +1198,7 @@ export class Collection implements OperationParent {
       throw new TypeError('`options` parameter must not be function');
     }
 
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
     return new AggregationCursor(
       this.s.topology,
       new AggregateOperation(this, pipeline, options),
@@ -1279,6 +1282,8 @@ export class Collection implements OperationParent {
       options.finalize = options.finalize.toString();
     }
 
+    options = resolveInheritedOptions(this, options);
+
     return executeOperation(
       this.s.topology,
       new MapReduceOperation(this, map, reduce, options),
@@ -1288,12 +1293,14 @@ export class Collection implements OperationParent {
 
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
-    return new UnorderedBulkOperation(this, options ?? {});
+    options = resolveInheritedOptions(this, options);
+    return new UnorderedBulkOperation(this, options);
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
-    return new OrderedBulkOperation(this, options ?? {});
+    options = resolveInheritedOptions(this, options);
+    return new OrderedBulkOperation(this, options);
   }
 
   /** Get the db scoped logger */
@@ -1385,7 +1392,7 @@ export class Collection implements OperationParent {
     callback: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -1425,7 +1432,7 @@ export class Collection implements OperationParent {
     }
 
     query = query || {};
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
     return executeOperation(
       this.s.topology,
       new EstimatedDocumentCountOperation(this, query, options),
@@ -1472,6 +1479,7 @@ export class Collection implements OperationParent {
       options = {};
     }
 
+    options = resolveInheritedOptions(this, options);
     // Add the remove option
     options.remove = true;
 
@@ -1589,7 +1597,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     // Force read preference primary
     options.readPreference = ReadPreference.primary;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1526,7 +1526,7 @@ export class Collection implements OperationParent {
     let reduce = args.length ? args.shift() : undefined;
     let finalize = args.length ? args.shift() : undefined;
     let command = args.length ? args.shift() : undefined;
-    const options = args.length ? args.shift() || {} : {};
+    let options = args.length ? args.shift() || {} : {};
 
     // Make sure we are backward compatible
     if (!(typeof finalize === 'function')) {
@@ -1553,6 +1553,8 @@ export class Collection implements OperationParent {
 
     // Set up the command as default
     command = command == null ? true : command;
+
+    options = resolveInheritedOptions(this, options);
 
     if (command == null) {
       return executeOperation(

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -366,7 +366,7 @@ export class Collection implements OperationParent {
     callback?: Callback<BulkWriteResult>
   ): Promise<BulkWriteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options ?? { ordered: true });
+    options = options || { ordered: true };
 
     if (!Array.isArray(operations)) {
       throw new MongoError('operations must be an array of documents');
@@ -1295,14 +1295,24 @@ export class Collection implements OperationParent {
 
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
-    options = resolveInheritedOptions(this, options);
-    return new UnorderedBulkOperation(this, options);
+    options = options || {};
+    // Give function's options precedence over session options.
+    if (options.ignoreUndefined == null) {
+      options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
+    }
+
+    return new UnorderedBulkOperation(this, options ?? {});
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
-    options = resolveInheritedOptions(this, options);
-    return new OrderedBulkOperation(this, options);
+    options = options || {};
+    // Give function's options precedence over session options.
+    if (options.ignoreUndefined == null) {
+      options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
+    }
+
+    return new OrderedBulkOperation(this, options ?? {});
   }
 
   /** Get the db scoped logger */

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -563,7 +563,9 @@ export class Collection implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
+
+    // Intentionally, we do not inherit options from parent for this operation.
+    options = options || {};
     options.readPreference = ReadPreference.PRIMARY;
     return executeOperation(this.s.topology, new RenameOperation(this, newName, options), callback);
   }

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -310,7 +310,7 @@ export class Collection implements OperationParent {
     callback?: Callback<InsertManyResult>
   ): Promise<InsertManyResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options ?? { ordered: true });
+    options = options || {};
 
     return executeOperation(
       this.s.topology,

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -310,7 +310,7 @@ export class Collection implements OperationParent {
     callback?: Callback<InsertManyResult>
   ): Promise<InsertManyResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ? Object.assign({}, options) : { ordered: true };
 
     return executeOperation(
       this.s.topology,
@@ -1295,22 +1295,12 @@ export class Collection implements OperationParent {
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
     options = options || {};
-    // Give function's options precedence over session options.
-    if (options.ignoreUndefined == null) {
-      options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
-    }
-
     return new UnorderedBulkOperation(this, options ?? {});
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
     options = options || {};
-    // Give function's options precedence over session's options.
-    if (options.ignoreUndefined == null) {
-      options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
-    }
-
     return new OrderedBulkOperation(this, options ?? {});
   }
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -565,8 +565,7 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
 
     // Intentionally, we do not inherit options from parent for this operation.
-    options = options || {};
-    options.readPreference = ReadPreference.PRIMARY;
+    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
     return executeOperation(this.s.topology, new RenameOperation(this, newName, options), callback);
   }
 
@@ -1307,7 +1306,7 @@ export class Collection implements OperationParent {
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
     options = options || {};
-    // Give function's options precedence over session options.
+    // Give function's options precedence over session's options.
     if (options.ignoreUndefined == null) {
       options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
     }

--- a/src/db.ts
+++ b/src/db.ts
@@ -11,12 +11,7 @@ import * as CONSTANTS from './constants';
 import { WriteConcern, WriteConcernOptions } from './write_concern';
 import { ReadConcern } from './read_concern';
 import { Logger, LoggerOptions } from './logger';
-import {
-  filterOptions,
-  mergeOptionsAndWriteConcern,
-  deprecateOptions,
-  MongoDBNamespace
-} from './utils';
+import { filterOptions, deprecateOptions, MongoDBNamespace } from './utils';
 import { AggregateOperation, AggregateOptions } from './operations/aggregate';
 import { AddUserOperation, AddUserOptions } from './operations/add_user';
 import { CollectionsOperation } from './operations/collections';
@@ -308,11 +303,11 @@ export class Db implements OperationParent {
       throw new TypeError('`options` parameter must not be function');
     }
 
-    options = options || {};
+    resolveInheritedOptions(this, options);
     const cursor = new AggregationCursor(
       this.s.topology,
       new AggregateOperation(this, pipeline, options),
-      resolveInheritedOptions(this, options)
+      options
     );
 
     return cursor;
@@ -341,21 +336,10 @@ export class Db implements OperationParent {
     callback?: Callback<Collection>
   ): Collection | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options);
-
-    // If we have not set a collection level readConcern set the db level one
-    options.readConcern = ReadConcern.fromOptions(options) ?? this.readConcern;
-
-    // Merge in all needed options and ensure correct writeConcern merging from db level
-    const finalOptions = mergeOptionsAndWriteConcern(
-      options,
-      this.s.options ?? {},
-      collectionKeys,
-      true
-    ) as CollectionOptions;
+    const finalOptions = resolveInheritedOptions(this, options);
 
     // Execute
-    if (finalOptions == null || !finalOptions.strict) {
+    if (!finalOptions.strict) {
       try {
         const collection = new Collection(this, name, finalOptions);
         if (callback) callback(undefined, collection);
@@ -426,12 +410,12 @@ export class Db implements OperationParent {
    */
   listCollections(filter?: Document, options?: ListCollectionsOptions): CommandCursor {
     filter = filter || {};
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return new CommandCursor(
       this.s.topology,
       new ListCollectionsOperation(this, filter, options),
-      resolveInheritedOptions(this, options)
+      options
     );
   }
 
@@ -900,18 +884,6 @@ export class Db implements OperationParent {
     return callback ? cursor.toArray(callback) : cursor.toArray();
   }
 }
-
-const collectionKeys = [
-  'pkFactory',
-  'readPreference',
-  'serializeFunctions',
-  'strict',
-  'readConcern',
-  'ignoreUndefined',
-  'promoteValues',
-  'promoteBuffers',
-  'promoteLongs'
-];
 
 Db.prototype.createCollection = deprecateOptions(
   {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,5 @@
 import { deprecate } from 'util';
-import { emitDeprecatedOptionWarning, Callback } from './utils';
+import { emitDeprecatedOptionWarning, Callback, resolveInheritedOptions } from './utils';
 import { loadAdmin } from './dynamic_loaders';
 import { AggregationCursor, CommandCursor } from './cursor';
 import { ObjectId, Code, Document, BSONSerializeOptions, resolveBSONOptions } from './bson';
@@ -256,8 +256,7 @@ export class Db implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
-    options.readConcern = ReadConcern.fromOptions(options) ?? this.readConcern;
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -283,7 +282,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -313,7 +312,7 @@ export class Db implements OperationParent {
     const cursor = new AggregationCursor(
       this.s.topology,
       new AggregateOperation(this, pipeline, options),
-      options
+      resolveInheritedOptions(this, options)
     );
 
     return cursor;
@@ -415,8 +414,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
-
+    options = resolveInheritedOptions(this, options);
     return executeOperation(this.s.topology, new DbStatsOperation(this, options), callback);
   }
 
@@ -433,7 +431,7 @@ export class Db implements OperationParent {
     return new CommandCursor(
       this.s.topology,
       new ListCollectionsOperation(this, filter, options),
-      options
+      resolveInheritedOptions(this, options)
     );
   }
 
@@ -469,7 +467,8 @@ export class Db implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
+    options = resolveInheritedOptions(this, options);
+    options.readPreference = ReadPreference.PRIMARY;
 
     // Add return new collection
     options.new_collection = true;
@@ -498,7 +497,7 @@ export class Db implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -522,7 +521,7 @@ export class Db implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(this.s.topology, new DropDatabaseOperation(this, options), callback);
   }
@@ -542,7 +541,7 @@ export class Db implements OperationParent {
     callback?: Callback<Collection[]>
   ): Promise<Collection[]> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(this.s.topology, new CollectionsOperation(this, options), callback);
   }
@@ -568,7 +567,7 @@ export class Db implements OperationParent {
     callback?: Callback<void>
   ): Promise<void> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -605,7 +604,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options ? Object.assign({}, options) : {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -653,7 +652,7 @@ export class Db implements OperationParent {
       if (typeof options === 'function') (callback = options), (options = {});
     }
 
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
     return executeOperation(
       this.s.topology,
       new AddUserOperation(this, username, password, options),
@@ -678,7 +677,7 @@ export class Db implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -711,7 +710,7 @@ export class Db implements OperationParent {
     callback?: Callback<ProfilingLevel>
   ): Promise<ProfilingLevel> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -735,7 +734,7 @@ export class Db implements OperationParent {
     callback?: Callback<string>
   ): Promise<string> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(this.s.topology, new ProfilingLevelOperation(this, options), callback);
   }
@@ -761,7 +760,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -832,7 +831,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,
@@ -870,7 +869,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       this.s.topology,

--- a/src/db.ts
+++ b/src/db.ts
@@ -277,7 +277,9 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
+
+    // Intentionally, we do not inherit options from parent for this operation.
+    options = options || {};
 
     return executeOperation(
       this.s.topology,
@@ -451,7 +453,9 @@ export class Db implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
+
+    // Intentionally, we do not inherit options from parent for this operation.
+    options = options || {};
     options.readPreference = ReadPreference.PRIMARY;
 
     // Add return new collection
@@ -551,7 +555,9 @@ export class Db implements OperationParent {
     callback?: Callback<void>
   ): Promise<void> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
+
+    // Intentionally, we do not inherit options from parent for this operation.
+    options = options || {};
 
     return executeOperation(
       this.s.topology,

--- a/src/db.ts
+++ b/src/db.ts
@@ -455,8 +455,7 @@ export class Db implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
 
     // Intentionally, we do not inherit options from parent for this operation.
-    options = options || {};
-    options.readPreference = ReadPreference.PRIMARY;
+    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
 
     // Add return new collection
     options.new_collection = true;

--- a/src/db.ts
+++ b/src/db.ts
@@ -305,7 +305,7 @@ export class Db implements OperationParent {
       throw new TypeError('`options` parameter must not be function');
     }
 
-    resolveInheritedOptions(this, options);
+    options = resolveInheritedOptions(this, options);
     const cursor = new AggregationCursor(
       this.s.topology,
       new AggregateOperation(this, pipeline, options),

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,12 @@
 import { deprecate } from 'util';
-import { emitDeprecatedOptionWarning, Callback, resolveInheritedOptions } from './utils';
+import {
+  emitDeprecatedOptionWarning,
+  Callback,
+  resolveInheritedOptions,
+  filterOptions,
+  deprecateOptions,
+  MongoDBNamespace
+} from './utils';
 import { loadAdmin } from './dynamic_loaders';
 import { AggregationCursor, CommandCursor } from './cursor';
 import { ObjectId, Code, Document, BSONSerializeOptions, resolveBSONOptions } from './bson';
@@ -11,7 +18,6 @@ import * as CONSTANTS from './constants';
 import { WriteConcern, WriteConcernOptions } from './write_concern';
 import { ReadConcern } from './read_concern';
 import { Logger, LoggerOptions } from './logger';
-import { filterOptions, deprecateOptions, MongoDBNamespace } from './utils';
 import { AggregateOperation, AggregateOptions } from './operations/aggregate';
 import { AddUserOperation, AddUserOptions } from './operations/add_user';
 import { CollectionsOperation } from './operations/collections';

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -73,7 +73,6 @@ export abstract class CommandOperation<
         : new MongoDBNamespace('admin', '$cmd');
     }
 
-    // todo what about this.hasAspect(Aspect.NO_INHERIT_OPTIONS)
     const readPref = ReadPreference.fromOptions(options);
     this.readPreference =
       this.hasAspect(Aspect.WRITE_OPERATION) || readPref === undefined

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -73,12 +73,15 @@ export abstract class CommandOperation<
         : new MongoDBNamespace('admin', '$cmd');
     }
 
-    const propertyProvider = this.hasAspect(Aspect.NO_INHERIT_OPTIONS) ? undefined : parent;
-    this.readPreference = this.hasAspect(Aspect.WRITE_OPERATION)
-      ? ReadPreference.primary
-      : ReadPreference.resolve(propertyProvider, this.options);
-    this.readConcern = resolveReadConcern(propertyProvider, this.options);
-    this.writeConcern = resolveWriteConcern(propertyProvider, this.options);
+    // todo what about this.hasAspect(Aspect.NO_INHERIT_OPTIONS)
+    const readPref = ReadPreference.fromOptions(options);
+    this.readPreference =
+      this.hasAspect(Aspect.WRITE_OPERATION) || readPref === undefined
+        ? ReadPreference.primary
+        : readPref;
+    this.readConcern = ReadConcern.fromOptions(options);
+    this.writeConcern = WriteConcern.fromOptions(options);
+    this.bsonOptions = resolveBSONOptions(options);
     this.explain = false;
     this.fullResponse =
       options && typeof options.fullResponse === 'boolean' ? options.fullResponse : false;
@@ -91,9 +94,6 @@ export abstract class CommandOperation<
     if (parent && parent.logger) {
       this.logger = parent.logger;
     }
-
-    // Assign BSON serialize options to OperationBase, preferring options over parent options.
-    this.bsonOptions = resolveBSONOptions(options, parent);
   }
 
   abstract execute(server: Server, callback: Callback<TResult>): void;
@@ -148,12 +148,4 @@ export abstract class CommandOperation<
       callback
     );
   }
-}
-
-function resolveWriteConcern(parent: OperationParent | undefined, options: any) {
-  return WriteConcern.fromOptions(options) || parent?.writeConcern;
-}
-
-function resolveReadConcern(parent: OperationParent | undefined, options: any) {
-  return ReadConcern.fromOptions(options) || parent?.readConcern;
 }

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -16,7 +16,6 @@ const ILLEGAL_COMMAND_FIELDS = new Set([
   'j',
   'fsync',
   'autoIndexId',
-  'serializeFunctions',
   'pkFactory',
   'raw',
   'readPreference',

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -22,7 +22,14 @@ const ILLEGAL_COMMAND_FIELDS = new Set([
   'readPreference',
   'session',
   'readConcern',
-  'writeConcern'
+  'writeConcern',
+  'raw',
+  'fieldsAsRaw',
+  'promoteLongs',
+  'promoteValues',
+  'promoteBuffers',
+  'serializeFunctions',
+  'ignoreUndefined'
 ]);
 
 /** @public */

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -1,5 +1,4 @@
 import { Aspect, defineAspects, Hint } from './operation';
-import { ReadPreference } from '../read_preference';
 import { maxWireVersion, MongoDBNamespace, Callback, normalizeHintField } from '../utils';
 import { MongoError } from '../error';
 import type { Document } from '../bson';
@@ -64,7 +63,6 @@ const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
 export class FindOperation extends CommandOperation<FindOptions, Document> {
   cmd: Document;
   filter: Document;
-  readPreference: ReadPreference;
 
   hint?: Hint;
 
@@ -76,7 +74,6 @@ export class FindOperation extends CommandOperation<FindOptions, Document> {
   ) {
     super(collection, options);
     this.ns = ns;
-    this.readPreference = ReadPreference.resolve(collection, this.options);
 
     if (typeof filter !== 'object' || Array.isArray(filter)) {
       throw new MongoError('Query filter must be a plain object or ObjectId');

--- a/src/operations/map_reduce.ts
+++ b/src/operations/map_reduce.ts
@@ -17,6 +17,7 @@ import type { ObjectId } from '../bson';
 
 const exclusionList = [
   'readPreference',
+  'readConcern',
   'session',
   'bypassDocumentValidation',
   'w',

--- a/src/operations/map_reduce.ts
+++ b/src/operations/map_reduce.ts
@@ -128,13 +128,9 @@ export class MapReduceOperation extends CommandOperation<MapReduceOptions, Docum
 
     options = Object.assign({}, options);
 
-    // Ensure we have the right read preference inheritance
-    options.readPreference = ReadPreference.resolve(coll, options);
-
     // If we have a read preference and inline is not set as output fail hard
     if (
-      options.readPreference &&
-      options.readPreference.mode === ReadPreferenceMode.primary &&
+      this.readPreference.mode === ReadPreferenceMode.primary &&
       options.out &&
       (options.out as any).inline !== 1 &&
       options.out !== 'inline'

--- a/src/operations/map_reduce.ts
+++ b/src/operations/map_reduce.ts
@@ -23,6 +23,13 @@ const exclusionList = [
   'wtimeout',
   'j',
   'writeConcern',
+  'raw',
+  'fieldsAsRaw',
+  'promoteLongs',
+  'promoteValues',
+  'promoteBuffers',
+  'serializeFunctions',
+  'ignoreUndefined',
   'scope' // this option is reformatted thus exclude the original
 ];
 

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -7,8 +7,7 @@ import type { Server } from '../sdam/server';
 export const Aspect = {
   READ_OPERATION: Symbol('READ_OPERATION'),
   WRITE_OPERATION: Symbol('WRITE_OPERATION'),
-  RETRYABLE: Symbol('RETRYABLE'),
-  NO_INHERIT_OPTIONS: Symbol('NO_INHERIT_OPTIONS')
+  RETRYABLE: Symbol('RETRYABLE')
 } as const;
 
 /** @public */

--- a/src/operations/run_command.ts
+++ b/src/operations/run_command.ts
@@ -1,5 +1,4 @@
 import { CommandOperation, CommandOperationOptions, OperationParent } from './command';
-import { defineAspects, Aspect } from './operation';
 import { MongoDBNamespace, Callback } from '../utils';
 import type { Server } from '../sdam/server';
 import type { Document } from '../bson';
@@ -34,6 +33,3 @@ export class RunAdminCommandOperation<
     this.ns = new MongoDBNamespace('admin');
   }
 }
-
-defineAspects(RunCommandOperation, [Aspect.NO_INHERIT_OPTIONS]);
-defineAspects(RunAdminCommandOperation, [Aspect.NO_INHERIT_OPTIONS]);

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -164,35 +164,35 @@ export class ReadPreference {
     return readPreference as ReadPreference;
   }
 
-  /**
-   * Resolves a read preference based on well-defined inheritance rules. This method will not only
-   * determine the read preference (if there is one), but will also ensure the returned value is a
-   * properly constructed instance of `ReadPreference`.
-   *
-   * @param parent - The parent of the operation on which to determine the read preference, used for determining the inherited read preference.
-   * @param options - The options passed into the method, potentially containing a read preference
-   */
-  static resolve(parent?: OperationParent, options?: ReadPreferenceFromOptions): ReadPreference {
-    options = options || {};
-    const session = options.session;
+  // /**
+  //  * Resolves a read preference based on well-defined inheritance rules. This method will not only
+  //  * determine the read preference (if there is one), but will also ensure the returned value is a
+  //  * properly constructed instance of `ReadPreference`.
+  //  *
+  //  * @param parent - The parent of the operation on which to determine the read preference, used for determining the inherited read preference.
+  //  * @param options - The options passed into the method, potentially containing a read preference
+  //  */
+  // static resolve(parent?: OperationParent, options?: ReadPreferenceFromOptions): ReadPreference {
+  //   options = options || {};
+  //   const session = options.session;
 
-    const inheritedReadPreference = parent?.readPreference;
+  //   const inheritedReadPreference = parent?.readPreference;
 
-    let readPreference: ReadPreference = ReadPreference.primary;
-    if (options.readPreference) {
-      const readPrefFromOptions = ReadPreference.fromOptions(options);
-      readPreference = readPrefFromOptions ? readPrefFromOptions : readPreference;
-    } else if (session && session.inTransaction() && session.transaction.options.readPreference) {
-      // The transaction’s read preference MUST override all other user configurable read preferences.
-      readPreference = session.transaction.options.readPreference;
-    } else if (inheritedReadPreference != null) {
-      readPreference = inheritedReadPreference;
-    }
+  //   let readPreference: ReadPreference = ReadPreference.primary;
+  //   if (options.readPreference) {
+  //     const readPrefFromOptions = ReadPreference.fromOptions(options);
+  //     readPreference = readPrefFromOptions ? readPrefFromOptions : readPreference;
+  //   } else if (session && session.inTransaction() && session.transaction.options.readPreference) {
+  //     // The transaction’s read preference MUST override all other user configurable read preferences.
+  //     readPreference = session.transaction.options.readPreference;
+  //   } else if (inheritedReadPreference != null) {
+  //     readPreference = inheritedReadPreference;
+  //   }
 
-    return typeof readPreference === 'string'
-      ? new ReadPreference(readPreference as ReadPreferenceMode)
-      : readPreference;
-  }
+  //   return typeof readPreference === 'string'
+  //     ? new ReadPreference(readPreference as ReadPreferenceMode)
+  //     : readPreference;
+  // }
 
   /**
    * Replaces options.readPreference with a ReadPreference instance

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -163,36 +163,6 @@ export class ReadPreference {
     return readPreference as ReadPreference;
   }
 
-  // /**
-  //  * Resolves a read preference based on well-defined inheritance rules. This method will not only
-  //  * determine the read preference (if there is one), but will also ensure the returned value is a
-  //  * properly constructed instance of `ReadPreference`.
-  //  *
-  //  * @param parent - The parent of the operation on which to determine the read preference, used for determining the inherited read preference.
-  //  * @param options - The options passed into the method, potentially containing a read preference
-  //  */
-  // static resolve(parent?: OperationParent, options?: ReadPreferenceFromOptions): ReadPreference {
-  //   options = options || {};
-  //   const session = options.session;
-
-  //   const inheritedReadPreference = parent?.readPreference;
-
-  //   let readPreference: ReadPreference = ReadPreference.primary;
-  //   if (options.readPreference) {
-  //     const readPrefFromOptions = ReadPreference.fromOptions(options);
-  //     readPreference = readPrefFromOptions ? readPrefFromOptions : readPreference;
-  //   } else if (session && session.inTransaction() && session.transaction.options.readPreference) {
-  //     // The transaction’s read preference MUST override all other user configurable read preferences.
-  //     readPreference = session.transaction.options.readPreference;
-  //   } else if (inheritedReadPreference != null) {
-  //     readPreference = inheritedReadPreference;
-  //   }
-
-  //   return typeof readPreference === 'string'
-  //     ? new ReadPreference(readPreference as ReadPreferenceMode)
-  //     : readPreference;
-  // }
-
   /**
    * Replaces options.readPreference with a ReadPreference instance
    */

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -141,7 +141,8 @@ export class ReadPreference {
    */
   static fromOptions(options?: ReadPreferenceFromOptions): ReadPreference | undefined {
     if (!options) return;
-    const readPreference = options.readPreference;
+    const readPreference =
+      options.readPreference ?? options.session?.transaction.options.readPreference;
     const readPreferenceTags = options.readPreferenceTags;
 
     if (readPreference == null) {

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -1,5 +1,4 @@
 import type { TagSet } from './sdam/server_description';
-import type { OperationParent } from './operations/command';
 import type { Document } from './bson';
 import type { ClientSession } from './sessions';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1181,9 +1181,6 @@ export function resolveInheritedOptions<T extends CommandOperationOptions>(
   }
 
   const bsonOptions = resolveBSONOptions(result, parent);
-  Object.assign(result, bsonOptions);
 
-  // todo: are there others?
-
-  return result;
+  return { ...result, ...bsonOptions };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1079,12 +1079,9 @@ function resolveWriteConcern(
   options: any
 ): WriteConcern | undefined {
   const session = options.session;
-  if (
-    session &&
-    session.inTransaction() &&
-    session.transaction.options.writeConcern !== 'undefined'
-  ) {
-    return session.transaction.options.writeConcern;
+  if (session && session.inTransaction()) {
+    // Users cannot pass a writeConcern to operations in a transaction
+    return;
   }
   return WriteConcern.fromOptions(options) || parent?.writeConcern;
 }
@@ -1094,12 +1091,9 @@ function resolveReadConcern(
   options: any
 ): ReadConcern | undefined {
   const session = options.session;
-  if (
-    session &&
-    session.inTransaction() &&
-    session.transaction.options.readConcern !== 'undefined'
-  ) {
-    return session.transaction.options.readConcern;
+  if (session && session.inTransaction()) {
+    // Users cannot pass a readConcern to operations in a transaction
+    return;
   }
   return ReadConcern.fromOptions(options) || parent?.readConcern;
 }
@@ -1108,15 +1102,7 @@ function resolveReadPreference(
   parent: OperationParent | undefined,
   options: any
 ): ReadPreference | undefined {
-  const session = options.session;
-  if (
-    session &&
-    session.inTransaction() &&
-    session.transaction.options.readPreference !== 'undefined'
-  ) {
-    return session.transaction.options.readPreference;
-  }
-  return ReadPreference.fromOptions(options) || parent?.readPreference;
+  return ReadPreference.fromOptions(options) ?? parent?.readPreference;
 }
 
 /** @internal Prioritizes options from transaction, then from options, then from parent */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import * as os from 'os';
 import * as crypto from 'crypto';
 import { PromiseProvider } from './promise_provider';
 import { MongoError, AnyError } from './error';
-import { WriteConcern, WriteConcernOptions, W, writeConcernKeys } from './write_concern';
+import { WriteConcern, WriteConcernOptions, W } from './write_concern';
 import type { Server } from './sdam/server';
 import type { Topology } from './sdam/topology';
 import type { EventEmitter } from 'events';
@@ -213,42 +213,44 @@ export function filterOptions(options: AnyOptions, names: string[]): AnyOptions 
   return filterOptions;
 }
 
-/** @internal */
-export function mergeOptionsAndWriteConcern(
-  targetOptions: AnyOptions,
-  sourceOptions: AnyOptions,
-  keys: string[],
-  mergeWriteConcern: boolean
-): AnyOptions {
-  // Mix in any allowed options
-  for (let i = 0; i < keys.length; i++) {
-    if (targetOptions[keys[i]] === undefined && sourceOptions[keys[i]] !== undefined) {
-      targetOptions[keys[i]] = sourceOptions[keys[i]];
-    }
-  }
+// /** @internal */
+// export function mergeOptionsAndWriteConcern(
+//   targetOptions: AnyOptions,
+//   sourceOptions: AnyOptions,
+//   keys: string[]
+// ): AnyOptions {
+//   // Mix in any allowed options
+//   for (let i = 0; i < keys.length; i++) {
+//     if (targetOptions[keys[i]] === undefined && sourceOptions[keys[i]] !== undefined) {
+//       targetOptions[keys[i]] = sourceOptions[keys[i]];
+//     }
+//   }
 
-  // No merging of write concern
-  if (!mergeWriteConcern) return targetOptions;
+//   // todo could do this with an object.assign and then pluck the keys, except this doesn't work w mergeWriteconcern
+//   // but we always set that to true so we're good!
 
-  // Found no write Concern options
-  let found = false;
-  for (let i = 0; i < writeConcernKeys.length; i++) {
-    if (targetOptions[writeConcernKeys[i]]) {
-      found = true;
-      break;
-    }
-  }
+//   // Found no write Concern options
+//   let found = false;
+//   for (let i = 0; i < writeConcernKeys.length; i++) {
+//     if (targetOptions[writeConcernKeys[i]]) {
+//       found = true;
+//       break;
+//     }
+//   }
 
-  if (!found) {
-    for (let i = 0; i < writeConcernKeys.length; i++) {
-      if (sourceOptions[writeConcernKeys[i]]) {
-        targetOptions[writeConcernKeys[i]] = sourceOptions[writeConcernKeys[i]];
-      }
-    }
-  }
+//   // merge write concern keys iff none are found
+//   if (!found) {
+//     for (let i = 0; i < writeConcernKeys.length; i++) {
+//       if (sourceOptions[writeConcernKeys[i]]) {
+//         targetOptions[writeConcernKeys[i]] = sourceOptions[writeConcernKeys[i]];
+//       }
+//     }
+//   }
 
-  return targetOptions;
-}
+//   results = resolveInheritedOptions(this, options);
+
+//   return targetOptions;
+// }
 
 /**
  * Executes the given operation with provided arguments.
@@ -1156,7 +1158,7 @@ function resolveReadPreference(
   return ReadPreference.fromOptions(options) || parent?.readPreference;
 }
 
-/** @internal   Prioritizes options from transaction, then from options, then from parent */
+/** @internal Prioritizes options from transaction, then from options, then from parent */
 export function resolveInheritedOptions<T extends CommandOperationOptions>(
   parent: OperationParent | undefined,
   options?: T

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -213,45 +213,6 @@ export function filterOptions(options: AnyOptions, names: string[]): AnyOptions 
   return filterOptions;
 }
 
-// /** @internal */
-// export function mergeOptionsAndWriteConcern(
-//   targetOptions: AnyOptions,
-//   sourceOptions: AnyOptions,
-//   keys: string[]
-// ): AnyOptions {
-//   // Mix in any allowed options
-//   for (let i = 0; i < keys.length; i++) {
-//     if (targetOptions[keys[i]] === undefined && sourceOptions[keys[i]] !== undefined) {
-//       targetOptions[keys[i]] = sourceOptions[keys[i]];
-//     }
-//   }
-
-//   // todo could do this with an object.assign and then pluck the keys, except this doesn't work w mergeWriteconcern
-//   // but we always set that to true so we're good!
-
-//   // Found no write Concern options
-//   let found = false;
-//   for (let i = 0; i < writeConcernKeys.length; i++) {
-//     if (targetOptions[writeConcernKeys[i]]) {
-//       found = true;
-//       break;
-//     }
-//   }
-
-//   // merge write concern keys iff none are found
-//   if (!found) {
-//     for (let i = 0; i < writeConcernKeys.length; i++) {
-//       if (sourceOptions[writeConcernKeys[i]]) {
-//         targetOptions[writeConcernKeys[i]] = sourceOptions[writeConcernKeys[i]];
-//       }
-//     }
-//   }
-
-//   results = resolveInheritedOptions(this, options);
-
-//   return targetOptions;
-// }
-
 /**
  * Executes the given operation with provided arguments.
  *


### PR DESCRIPTION
This PR introduces a new helper `resolveInheritedOptions` which includes the logic for inheriting some options from a parent. NOTE: It only merges in inherited properties (read/write concern, read preference, and bson options) from the parent, and does not add to or modify any other properties of options. 

Options are resolved before a command is constructed. This means the options passed to `CommandOperation` are already properly inherited, and inheritance is no longer needed in in the `CommandOperation` constructor. So, we can get rid of the `NO_INHERIT_OPTIONS` aspect and simple not call `resolveInheritedOptions` before those commands. Similarly, the `ReadPreference.resolve()` function is no longer needed.

There is also a change to `ReadPreference.fromOptions()`, where if the options don't have a `readPreference` property and a session is present on the options, we attempt to get the read preference from the session. This might have been intended all along, since the type of the options passed to this function, `ReadPreferenceFromOptions`, already had an optional `session` property. 