### PR TITLE
refactor: consolidate options inheritance logic 

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1309,13 +1309,11 @@ export class Collection implements OperationParent {
 
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
-    options = options || {};
     return new UnorderedBulkOperation(this, options ?? {});
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
-    options = options || {};
     return new OrderedBulkOperation(this, options ?? {});
   }
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,4 +1,4 @@
-import { emitDeprecatedOptionWarning } from './utils';
+import { emitDeprecatedOptionWarning, resolveInheritedOptions } from './utils';
 import { ReadPreference, ReadPreferenceLike } from './read_preference';
 import { deprecate } from 'util';
 import {
@@ -280,7 +280,7 @@ export class Collection implements OperationParent {
     callback?: Callback<InsertOneResult>
   ): Promise<InsertOneResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -312,7 +312,7 @@ export class Collection implements OperationParent {
     callback?: Callback<InsertManyResult>
   ): Promise<InsertManyResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options ? Object.assign({}, options) : { ordered: true };
+    options = resolveInheritedOptions(this, options ?? { ordered: true });
 
     return executeOperation(
       getTopology(this),
@@ -368,7 +368,7 @@ export class Collection implements OperationParent {
     callback?: Callback<BulkWriteResult>
   ): Promise<BulkWriteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || { ordered: true };
+    options = resolveInheritedOptions(this, options ?? { ordered: true });
 
     if (!Array.isArray(operations)) {
       throw new MongoError('operations must be an array of documents');
@@ -405,7 +405,7 @@ export class Collection implements OperationParent {
     callback?: Callback<UpdateResult>
   ): Promise<UpdateResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options);
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -442,7 +442,7 @@ export class Collection implements OperationParent {
     callback?: Callback<UpdateResult>
   ): Promise<UpdateResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options);
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -475,7 +475,7 @@ export class Collection implements OperationParent {
     callback?: Callback<UpdateResult>
   ): Promise<UpdateResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options);
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -501,7 +501,7 @@ export class Collection implements OperationParent {
     callback?: Callback<DeleteResult>
   ): Promise<DeleteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options);
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -539,7 +539,7 @@ export class Collection implements OperationParent {
       options = {};
     }
 
-    options = Object.assign({}, options);
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -565,8 +565,8 @@ export class Collection implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
-
+    options = resolveInheritedOptions(this, options);
+    options.readPreference = ReadPreference.PRIMARY;
     return executeOperation(
       getTopology(this),
       new RenameOperation(this, newName, options),
@@ -624,7 +624,7 @@ export class Collection implements OperationParent {
       (callback = query as Callback<Document>), (query = {}), (options = {});
     if (typeof options === 'function') (callback = options), (options = {});
     query = query || {};
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -649,6 +649,7 @@ export class Collection implements OperationParent {
       throw new TypeError('`options` parameter must not be function');
     }
 
+    options = resolveInheritedOptions(this, options);
     return new Cursor(
       getTopology(this),
       new FindOperation(this, this.s.namespace, filter, options),
@@ -671,7 +672,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(getTopology(this), new OptionsOperation(this, options), callback);
   }
@@ -691,7 +692,7 @@ export class Collection implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(getTopology(this), new IsCappedOperation(this, options), callback);
   }
@@ -739,7 +740,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -796,6 +797,7 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options ? Object.assign({}, options) : {};
     if (typeof options.maxTimeMS !== 'number') delete options.maxTimeMS;
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -821,7 +823,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     // Run only against primary
     options.readPreference = ReadPreference.primary;
@@ -848,7 +850,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options ? Object.assign({}, options) : {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(getTopology(this), new DropIndexesOperation(this, options), callback);
   }
@@ -859,6 +861,7 @@ export class Collection implements OperationParent {
    * @param options - Optional settings for the command
    */
   listIndexes(options?: ListIndexesOptions): CommandCursor {
+    options = resolveInheritedOptions(this, options);
     const cursor = new CommandCursor(
       getTopology(this),
       new ListIndexesOperation(this, options),
@@ -889,7 +892,7 @@ export class Collection implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -913,7 +916,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -937,7 +940,7 @@ export class Collection implements OperationParent {
     callback?: Callback<number>
   ): Promise<number> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -994,10 +997,10 @@ export class Collection implements OperationParent {
     }
 
     query = query || {};
-    options = options || {};
+    options = resolveInheritedOptions(this, options as CountDocumentsOptions);
     return executeOperation(
       getTopology(this),
-      new CountDocumentsOperation(this, query as Document, options as CountDocumentsOptions),
+      new CountDocumentsOperation(this, query as Document, options),
       callback
     );
   }
@@ -1036,10 +1039,10 @@ export class Collection implements OperationParent {
     }
 
     query = query || {};
-    options = options || {};
+    options = resolveInheritedOptions(this, options as DistinctOptions);
     return executeOperation(
       getTopology(this),
-      new DistinctOperation(this, key, query as Document, options as DistinctOptions),
+      new DistinctOperation(this, key, query as Document, options),
       callback
     );
   }
@@ -1059,7 +1062,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(getTopology(this), new IndexesOperation(this, options), callback);
   }
@@ -1105,7 +1108,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -1142,7 +1145,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -1179,7 +1182,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -1205,8 +1208,7 @@ export class Collection implements OperationParent {
       throw new TypeError('`options` parameter must not be function');
     }
 
-    options = options || {};
-
+    options = resolveInheritedOptions(this, options);
     return new AggregationCursor(
       getTopology(this),
       new AggregateOperation(this, pipeline, options),
@@ -1290,6 +1292,8 @@ export class Collection implements OperationParent {
       options.finalize = options.finalize.toString();
     }
 
+    options = resolveInheritedOptions(this, options);
+
     return executeOperation(
       getTopology(this),
       new MapReduceOperation(this, map, reduce, options),
@@ -1299,12 +1303,14 @@ export class Collection implements OperationParent {
 
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
-    return new UnorderedBulkOperation(this, options ?? {});
+    options = resolveInheritedOptions(this, options);
+    return new UnorderedBulkOperation(this, options);
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
-    return new OrderedBulkOperation(this, options ?? {});
+    options = resolveInheritedOptions(this, options);
+    return new OrderedBulkOperation(this, options);
   }
 
   /** Get the db scoped logger */
@@ -1396,7 +1402,7 @@ export class Collection implements OperationParent {
     callback: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -1436,7 +1442,7 @@ export class Collection implements OperationParent {
     }
 
     query = query || {};
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
     return executeOperation(
       getTopology(this),
       new EstimatedDocumentCountOperation(this, query, options),
@@ -1483,6 +1489,7 @@ export class Collection implements OperationParent {
       options = {};
     }
 
+    options = resolveInheritedOptions(this, options);
     // Add the remove option
     options.remove = true;
 
@@ -1600,7 +1607,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     // Force read preference primary
     options.readPreference = ReadPreference.primary;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,4 +1,4 @@
-import { emitDeprecatedOptionWarning, resolveInheritedOptions } from './utils';
+import { emitDeprecatedOptionWarning, resolveOptions } from './utils';
 import { ReadPreference, ReadPreferenceLike } from './read_preference';
 import { deprecate } from 'util';
 import {
@@ -280,11 +280,10 @@ export class Collection implements OperationParent {
     callback?: Callback<InsertOneResult>
   ): Promise<InsertOneResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new InsertOneOperation(this, doc, options),
+      new InsertOneOperation(this, doc, resolveOptions(this, options)),
       callback
     );
   }
@@ -405,11 +404,10 @@ export class Collection implements OperationParent {
     callback?: Callback<UpdateResult>
   ): Promise<UpdateResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new UpdateOneOperation(this, filter, update, options),
+      new UpdateOneOperation(this, filter, update, resolveOptions(this, options)),
       callback
     );
   }
@@ -442,11 +440,10 @@ export class Collection implements OperationParent {
     callback?: Callback<UpdateResult>
   ): Promise<UpdateResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new ReplaceOneOperation(this, filter, replacement, options),
+      new ReplaceOneOperation(this, filter, replacement, resolveOptions(this, options)),
       callback
     );
   }
@@ -475,11 +472,10 @@ export class Collection implements OperationParent {
     callback?: Callback<UpdateResult>
   ): Promise<UpdateResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new UpdateManyOperation(this, filter, update, options),
+      new UpdateManyOperation(this, filter, update, resolveOptions(this, options)),
       callback
     );
   }
@@ -501,11 +497,10 @@ export class Collection implements OperationParent {
     callback?: Callback<DeleteResult>
   ): Promise<DeleteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new DeleteOneOperation(this, filter, options),
+      new DeleteOneOperation(this, filter, resolveOptions(this, options)),
       callback
     );
   }
@@ -539,11 +534,9 @@ export class Collection implements OperationParent {
       options = {};
     }
 
-    options = resolveInheritedOptions(this, options);
-
     return executeOperation(
       getTopology(this),
-      new DeleteManyOperation(this, filter, options),
+      new DeleteManyOperation(this, filter, resolveOptions(this, options)),
       callback
     );
   }
@@ -567,10 +560,9 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
 
     // Intentionally, we do not inherit options from parent for this operation.
-    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
     return executeOperation(
       getTopology(this),
-      new RenameOperation(this, newName, options),
+      new RenameOperation(this, newName, { ...options, readPreference: ReadPreference.PRIMARY }),
       callback
     );
   }
@@ -625,11 +617,10 @@ export class Collection implements OperationParent {
       (callback = query as Callback<Document>), (query = {}), (options = {});
     if (typeof options === 'function') (callback = options), (options = {});
     query = query || {};
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new FindOneOperation(this, query, options),
+      new FindOneOperation(this, query, resolveOptions(this, options)),
       callback
     );
   }
@@ -650,7 +641,7 @@ export class Collection implements OperationParent {
       throw new TypeError('`options` parameter must not be function');
     }
 
-    options = resolveInheritedOptions(this, options);
+    options = resolveOptions(this, options);
     return new Cursor(
       getTopology(this),
       new FindOperation(this, this.s.namespace, filter, options),
@@ -673,9 +664,12 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
-    return executeOperation(getTopology(this), new OptionsOperation(this, options), callback);
+    return executeOperation(
+      getTopology(this),
+      new OptionsOperation(this, resolveOptions(this, options)),
+      callback
+    );
   }
 
   /**
@@ -693,9 +687,12 @@ export class Collection implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
-    return executeOperation(getTopology(this), new IsCappedOperation(this, options), callback);
+    return executeOperation(
+      getTopology(this),
+      new IsCappedOperation(this, resolveOptions(this, options)),
+      callback
+    );
   }
 
   /**
@@ -741,11 +738,10 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new CreateIndexOperation(this, this.collectionName, indexSpec, options),
+      new CreateIndexOperation(this, this.collectionName, indexSpec, resolveOptions(this, options)),
       callback
     );
   }
@@ -798,11 +794,15 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options ? Object.assign({}, options) : {};
     if (typeof options.maxTimeMS !== 'number') delete options.maxTimeMS;
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new CreateIndexesOperation(this, this.collectionName, indexSpecs, options),
+      new CreateIndexesOperation(
+        this,
+        this.collectionName,
+        indexSpecs,
+        resolveOptions(this, options)
+      ),
       callback
     );
   }
@@ -824,7 +824,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
+    options = resolveOptions(this, options);
 
     // Run only against primary
     options.readPreference = ReadPreference.primary;
@@ -851,9 +851,12 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
-    return executeOperation(getTopology(this), new DropIndexesOperation(this, options), callback);
+    return executeOperation(
+      getTopology(this),
+      new DropIndexesOperation(this, resolveOptions(this, options)),
+      callback
+    );
   }
 
   /**
@@ -862,7 +865,7 @@ export class Collection implements OperationParent {
    * @param options - Optional settings for the command
    */
   listIndexes(options?: ListIndexesOptions): CommandCursor {
-    options = resolveInheritedOptions(this, options);
+    options = resolveOptions(this, options);
     const cursor = new CommandCursor(
       getTopology(this),
       new ListIndexesOperation(this, options),
@@ -893,11 +896,10 @@ export class Collection implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new IndexExistsOperation(this, indexes, options),
+      new IndexExistsOperation(this, indexes, resolveOptions(this, options)),
       callback
     );
   }
@@ -917,11 +919,10 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new IndexInformationOperation(this.s.db, this.collectionName, options),
+      new IndexInformationOperation(this.s.db, this.collectionName, resolveOptions(this, options)),
       callback
     );
   }
@@ -941,11 +942,10 @@ export class Collection implements OperationParent {
     callback?: Callback<number>
   ): Promise<number> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new EstimatedDocumentCountOperation(this, options),
+      new EstimatedDocumentCountOperation(this, resolveOptions(this, options)),
       callback
     );
   }
@@ -998,10 +998,13 @@ export class Collection implements OperationParent {
     }
 
     query = query || {};
-    options = resolveInheritedOptions(this, options as CountDocumentsOptions);
     return executeOperation(
       getTopology(this),
-      new CountDocumentsOperation(this, query as Document, options),
+      new CountDocumentsOperation(
+        this,
+        query as Document,
+        resolveOptions(this, options as CountDocumentsOptions)
+      ),
       callback
     );
   }
@@ -1040,10 +1043,14 @@ export class Collection implements OperationParent {
     }
 
     query = query || {};
-    options = resolveInheritedOptions(this, options as DistinctOptions);
     return executeOperation(
       getTopology(this),
-      new DistinctOperation(this, key, query as Document, options),
+      new DistinctOperation(
+        this,
+        key,
+        query as Document,
+        resolveOptions(this, options as DistinctOptions)
+      ),
       callback
     );
   }
@@ -1063,9 +1070,12 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
-    return executeOperation(getTopology(this), new IndexesOperation(this, options), callback);
+    return executeOperation(
+      getTopology(this),
+      new IndexesOperation(this, resolveOptions(this, options)),
+      callback
+    );
   }
 
   /**
@@ -1109,11 +1119,10 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new FindOneAndDeleteOperation(this, filter, options),
+      new FindOneAndDeleteOperation(this, filter, resolveOptions(this, options)),
       callback
     );
   }
@@ -1146,11 +1155,10 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new FindOneAndReplaceOperation(this, filter, replacement, options),
+      new FindOneAndReplaceOperation(this, filter, replacement, resolveOptions(this, options)),
       callback
     );
   }
@@ -1183,11 +1191,10 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new FindOneAndUpdateOperation(this, filter, update, options),
+      new FindOneAndUpdateOperation(this, filter, update, resolveOptions(this, options)),
       callback
     );
   }
@@ -1209,7 +1216,7 @@ export class Collection implements OperationParent {
       throw new TypeError('`options` parameter must not be function');
     }
 
-    options = resolveInheritedOptions(this, options);
+    options = resolveOptions(this, options);
     return new AggregationCursor(
       getTopology(this),
       new AggregateOperation(this, pipeline, options),
@@ -1293,11 +1300,9 @@ export class Collection implements OperationParent {
       options.finalize = options.finalize.toString();
     }
 
-    options = resolveInheritedOptions(this, options);
-
     return executeOperation(
       getTopology(this),
-      new MapReduceOperation(this, map, reduce, options),
+      new MapReduceOperation(this, map, reduce, resolveOptions(this, options)),
       callback
     );
   }
@@ -1403,11 +1408,15 @@ export class Collection implements OperationParent {
     callback: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new EnsureIndexOperation(this.s.db, this.collectionName, fieldOrSpec, options),
+      new EnsureIndexOperation(
+        this.s.db,
+        this.collectionName,
+        fieldOrSpec,
+        resolveOptions(this, options)
+      ),
       callback
     );
   }
@@ -1443,10 +1452,9 @@ export class Collection implements OperationParent {
     }
 
     query = query || {};
-    options = resolveInheritedOptions(this, options);
     return executeOperation(
       getTopology(this),
-      new EstimatedDocumentCountOperation(this, query, options),
+      new EstimatedDocumentCountOperation(this, query, resolveOptions(this, options)),
       callback
     );
   }
@@ -1490,7 +1498,7 @@ export class Collection implements OperationParent {
       options = {};
     }
 
-    options = resolveInheritedOptions(this, options);
+    options = resolveOptions(this, options);
     // Add the remove option
     options.remove = true;
 
@@ -1554,7 +1562,7 @@ export class Collection implements OperationParent {
     // Set up the command as default
     command = command == null ? true : command;
 
-    options = resolveInheritedOptions(this, options);
+    options = resolveOptions(this, options);
 
     if (command == null) {
       return executeOperation(
@@ -1610,7 +1618,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
+    options = resolveOptions(this, options);
 
     // Force read preference primary
     options.readPreference = ReadPreference.primary;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -368,7 +368,7 @@ export class Collection implements OperationParent {
     callback?: Callback<BulkWriteResult>
   ): Promise<BulkWriteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options ?? { ordered: true });
+    options = options || { ordered: true };
 
     if (!Array.isArray(operations)) {
       throw new MongoError('operations must be an array of documents');
@@ -1305,14 +1305,24 @@ export class Collection implements OperationParent {
 
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
-    options = resolveInheritedOptions(this, options);
-    return new UnorderedBulkOperation(this, options);
+    options = options || {};
+    // Give function's options precedence over session options.
+    if (options.ignoreUndefined == null) {
+      options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
+    }
+
+    return new UnorderedBulkOperation(this, options ?? {});
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
-    options = resolveInheritedOptions(this, options);
-    return new OrderedBulkOperation(this, options);
+    options = options || {};
+    // Give function's options precedence over session options.
+    if (options.ignoreUndefined == null) {
+      options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
+    }
+
+    return new OrderedBulkOperation(this, options ?? {});
   }
 
   /** Get the db scoped logger */

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -565,7 +565,9 @@ export class Collection implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
+
+    // Intentionally, we do not inherit options from parent for this operation.
+    options = options || {};
     options.readPreference = ReadPreference.PRIMARY;
     return executeOperation(
       getTopology(this),

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -312,7 +312,7 @@ export class Collection implements OperationParent {
     callback?: Callback<InsertManyResult>
   ): Promise<InsertManyResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ? Object.assign({}, options) : { ordered: true };
 
     return executeOperation(
       getTopology(this),
@@ -1305,22 +1305,12 @@ export class Collection implements OperationParent {
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
     options = options || {};
-    // Give function's options precedence over session options.
-    if (options.ignoreUndefined == null) {
-      options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
-    }
-
     return new UnorderedBulkOperation(this, options ?? {});
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
     options = options || {};
-    // Give function's options precedence over session's options.
-    if (options.ignoreUndefined == null) {
-      options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
-    }
-
     return new OrderedBulkOperation(this, options ?? {});
   }
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -567,8 +567,7 @@ export class Collection implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
 
     // Intentionally, we do not inherit options from parent for this operation.
-    options = options || {};
-    options.readPreference = ReadPreference.PRIMARY;
+    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
     return executeOperation(
       getTopology(this),
       new RenameOperation(this, newName, options),
@@ -1317,7 +1316,7 @@ export class Collection implements OperationParent {
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
     options = options || {};
-    // Give function's options precedence over session options.
+    // Give function's options precedence over session's options.
     if (options.ignoreUndefined == null) {
       options.ignoreUndefined = this.bsonOptions.ignoreUndefined;
     }

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1536,7 +1536,7 @@ export class Collection implements OperationParent {
     let reduce = args.length ? args.shift() : undefined;
     let finalize = args.length ? args.shift() : undefined;
     let command = args.length ? args.shift() : undefined;
-    const options = args.length ? args.shift() || {} : {};
+    let options = args.length ? args.shift() || {} : {};
 
     // Make sure we are backward compatible
     if (!(typeof finalize === 'function')) {
@@ -1563,6 +1563,8 @@ export class Collection implements OperationParent {
 
     // Set up the command as default
     command = command == null ? true : command;
+
+    options = resolveInheritedOptions(this, options);
 
     if (command == null) {
       return executeOperation(

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -544,6 +544,9 @@ export class Collection implements OperationParent {
   /**
    * Rename the collection.
    *
+   * @remarks
+   * This operation does not inherit options from the Db or MongoClient.
+   *
    * @param newName - New name of of the collection.
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -312,7 +312,7 @@ export class Collection implements OperationParent {
     callback?: Callback<InsertManyResult>
   ): Promise<InsertManyResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options ?? { ordered: true });
+    options = options || {};
 
     return executeOperation(
       getTopology(this),

--- a/src/db.ts
+++ b/src/db.ts
@@ -459,8 +459,7 @@ export class Db implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
 
     // Intentionally, we do not inherit options from parent for this operation.
-    options = options || {};
-    options.readPreference = ReadPreference.PRIMARY;
+    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
 
     // Add return new collection
     options.new_collection = true;

--- a/src/db.ts
+++ b/src/db.ts
@@ -266,6 +266,9 @@ export class Db implements OperationParent {
   /**
    * Execute a command
    *
+   * @remarks
+   * This command does not inherit options from the MongoClient.
+   *
    * @param command - The command to run
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
@@ -428,6 +431,9 @@ export class Db implements OperationParent {
   /**
    * Rename a collection.
    *
+   * @remarks
+   * This operation does not inherit options from the MongoClient.
+   *
    * @param fromCollection - Name of current collection to rename
    * @param toCollection - New name of of the collection
    * @param options - Optional settings for the command
@@ -544,6 +550,9 @@ export class Db implements OperationParent {
 
   /**
    * Runs a command on the database as admin.
+   *
+   * @remarks
+   * This command does not inherit options from the MongoClient.
    *
    * @param command - The command to run
    * @param options - Optional settings for the command

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,5 @@
 import { deprecate } from 'util';
-import { emitDeprecatedOptionWarning, Callback } from './utils';
+import { emitDeprecatedOptionWarning, Callback, resolveInheritedOptions } from './utils';
 import { loadAdmin } from './dynamic_loaders';
 import { AggregationCursor, CommandCursor } from './cursor';
 import { ObjectId, Code, Document, BSONSerializeOptions, resolveBSONOptions } from './bson';
@@ -254,8 +254,7 @@ export class Db implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
-    options.readConcern = ReadConcern.fromOptions(options) ?? this.readConcern;
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -281,7 +280,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -312,7 +311,7 @@ export class Db implements OperationParent {
     const cursor = new AggregationCursor(
       getTopology(this),
       new AggregateOperation(this, pipeline, options),
-      options
+      resolveInheritedOptions(this, options)
     );
 
     return cursor;
@@ -414,8 +413,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
-
+    options = resolveInheritedOptions(this, options);
     return executeOperation(getTopology(this), new DbStatsOperation(this, options), callback);
   }
 
@@ -432,7 +430,7 @@ export class Db implements OperationParent {
     return new CommandCursor(
       getTopology(this),
       new ListCollectionsOperation(this, filter, options),
-      options
+      resolveInheritedOptions(this, options)
     );
   }
 
@@ -468,7 +466,8 @@ export class Db implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
+    options = resolveInheritedOptions(this, options);
+    options.readPreference = ReadPreference.PRIMARY;
 
     // Add return new collection
     options.new_collection = true;
@@ -497,7 +496,7 @@ export class Db implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -521,7 +520,7 @@ export class Db implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(getTopology(this), new DropDatabaseOperation(this, options), callback);
   }
@@ -541,7 +540,7 @@ export class Db implements OperationParent {
     callback?: Callback<Collection[]>
   ): Promise<Collection[]> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(getTopology(this), new CollectionsOperation(this, options), callback);
   }
@@ -567,7 +566,7 @@ export class Db implements OperationParent {
     callback?: Callback<void>
   ): Promise<void> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -604,7 +603,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options ? Object.assign({}, options) : {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -652,7 +651,7 @@ export class Db implements OperationParent {
       if (typeof options === 'function') (callback = options), (options = {});
     }
 
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
     return executeOperation(
       getTopology(this),
       new AddUserOperation(this, username, password, options),
@@ -677,7 +676,7 @@ export class Db implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -710,7 +709,7 @@ export class Db implements OperationParent {
     callback?: Callback<ProfilingLevel>
   ): Promise<ProfilingLevel> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -734,7 +733,7 @@ export class Db implements OperationParent {
     callback?: Callback<string>
   ): Promise<string> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -764,7 +763,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -835,7 +834,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
@@ -873,7 +872,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),

--- a/src/db.ts
+++ b/src/db.ts
@@ -284,7 +284,7 @@ export class Db implements OperationParent {
     // Intentionally, we do not inherit options from parent for this operation.
     return executeOperation(
       getTopology(this),
-      new RunCommandOperation(this, command, options || {}),
+      new RunCommandOperation(this, command, options ?? {}),
       callback
     );
   }
@@ -567,7 +567,7 @@ export class Db implements OperationParent {
     // Intentionally, we do not inherit options from parent for this operation.
     return executeOperation(
       getTopology(this),
-      new RunAdminCommandOperation(this, command, options || {}),
+      new RunAdminCommandOperation(this, command, options ?? {}),
       callback
     );
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -281,7 +281,9 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
+
+    // Intentionally, we do not inherit options from parent for this operation.
+    options = options || {};
 
     return executeOperation(
       getTopology(this),
@@ -455,7 +457,9 @@ export class Db implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
+
+    // Intentionally, we do not inherit options from parent for this operation.
+    options = options || {};
     options.readPreference = ReadPreference.PRIMARY;
 
     // Add return new collection
@@ -555,7 +559,9 @@ export class Db implements OperationParent {
     callback?: Callback<void>
   ): Promise<void> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
+
+    // Intentionally, we do not inherit options from parent for this operation.
+    options = options || {};
 
     return executeOperation(
       getTopology(this),

--- a/src/db.ts
+++ b/src/db.ts
@@ -2,7 +2,7 @@ import { deprecate } from 'util';
 import {
   emitDeprecatedOptionWarning,
   Callback,
-  resolveInheritedOptions,
+  resolveOptions,
   filterOptions,
   deprecateOptions,
   MongoDBNamespace,
@@ -255,11 +255,10 @@ export class Db implements OperationParent {
     callback?: Callback<Collection>
   ): Promise<Collection> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new CreateCollectionOperation(this, name, options),
+      new CreateCollectionOperation(this, name, resolveOptions(this, options)),
       callback
     );
   }
@@ -283,11 +282,9 @@ export class Db implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
 
     // Intentionally, we do not inherit options from parent for this operation.
-    options = options || {};
-
     return executeOperation(
       getTopology(this),
-      new RunCommandOperation(this, command, options),
+      new RunCommandOperation(this, command, options || {}),
       callback
     );
   }
@@ -309,7 +306,7 @@ export class Db implements OperationParent {
       throw new TypeError('`options` parameter must not be function');
     }
 
-    options = resolveInheritedOptions(this, options);
+    options = resolveOptions(this, options);
     const cursor = new AggregationCursor(
       getTopology(this),
       new AggregateOperation(this, pipeline, options),
@@ -342,7 +339,7 @@ export class Db implements OperationParent {
     callback?: Callback<Collection>
   ): Collection | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    const finalOptions = resolveInheritedOptions(this, options);
+    const finalOptions = resolveOptions(this, options);
 
     // Execute
     if (!finalOptions.strict) {
@@ -404,8 +401,11 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
-    return executeOperation(getTopology(this), new DbStatsOperation(this, options), callback);
+    return executeOperation(
+      getTopology(this),
+      new DbStatsOperation(this, resolveOptions(this, options)),
+      callback
+    );
   }
 
   /**
@@ -416,7 +416,7 @@ export class Db implements OperationParent {
    */
   listCollections(filter?: Document, options?: ListCollectionsOptions): CommandCursor {
     filter = filter || {};
-    options = resolveInheritedOptions(this, options);
+    options = resolveOptions(this, options);
 
     return new CommandCursor(
       getTopology(this),
@@ -459,7 +459,7 @@ export class Db implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
 
     // Intentionally, we do not inherit options from parent for this operation.
-    options = Object.assign({}, options, { readPreference: ReadPreference.PRIMARY });
+    options = { ...options, readPreference: ReadPreference.PRIMARY };
 
     // Add return new collection
     options.new_collection = true;
@@ -488,11 +488,10 @@ export class Db implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new DropCollectionOperation(this, name, options),
+      new DropCollectionOperation(this, name, resolveOptions(this, options)),
       callback
     );
   }
@@ -512,9 +511,12 @@ export class Db implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
-    return executeOperation(getTopology(this), new DropDatabaseOperation(this, options), callback);
+    return executeOperation(
+      getTopology(this),
+      new DropDatabaseOperation(this, resolveOptions(this, options)),
+      callback
+    );
   }
 
   /**
@@ -532,9 +534,12 @@ export class Db implements OperationParent {
     callback?: Callback<Collection[]>
   ): Promise<Collection[]> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
-    return executeOperation(getTopology(this), new CollectionsOperation(this, options), callback);
+    return executeOperation(
+      getTopology(this),
+      new CollectionsOperation(this, resolveOptions(this, options)),
+      callback
+    );
   }
 
   /**
@@ -560,11 +565,9 @@ export class Db implements OperationParent {
     if (typeof options === 'function') (callback = options), (options = {});
 
     // Intentionally, we do not inherit options from parent for this operation.
-    options = options || {};
-
     return executeOperation(
       getTopology(this),
-      new RunAdminCommandOperation(this, command, options),
+      new RunAdminCommandOperation(this, command, options || {}),
       callback
     );
   }
@@ -597,11 +600,10 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new CreateIndexOperation(this, name, indexSpec, options),
+      new CreateIndexOperation(this, name, indexSpec, resolveOptions(this, options)),
       callback
     );
   }
@@ -645,10 +647,9 @@ export class Db implements OperationParent {
       if (typeof options === 'function') (callback = options), (options = {});
     }
 
-    options = resolveInheritedOptions(this, options);
     return executeOperation(
       getTopology(this),
-      new AddUserOperation(this, username, password, options),
+      new AddUserOperation(this, username, password, resolveOptions(this, options)),
       callback
     );
   }
@@ -670,11 +671,10 @@ export class Db implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new RemoveUserOperation(this, username, options),
+      new RemoveUserOperation(this, username, resolveOptions(this, options)),
       callback
     );
   }
@@ -703,11 +703,10 @@ export class Db implements OperationParent {
     callback?: Callback<ProfilingLevel>
   ): Promise<ProfilingLevel> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new SetProfilingLevelOperation(this, level, options),
+      new SetProfilingLevelOperation(this, level, resolveOptions(this, options)),
       callback
     );
   }
@@ -727,11 +726,10 @@ export class Db implements OperationParent {
     callback?: Callback<string>
   ): Promise<string> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new ProfilingLevelOperation(this, options),
+      new ProfilingLevelOperation(this, resolveOptions(this, options)),
       callback
     );
   }
@@ -757,11 +755,10 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new IndexInformationOperation(this, name, options),
+      new IndexInformationOperation(this, name, resolveOptions(this, options)),
       callback
     );
   }
@@ -828,11 +825,10 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new EvalOperation(this, code, parameters, options),
+      new EvalOperation(this, code, parameters, resolveOptions(this, options)),
       callback
     );
   }
@@ -866,11 +862,10 @@ export class Db implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = resolveInheritedOptions(this, options);
 
     return executeOperation(
       getTopology(this),
-      new EnsureIndexOperation(this, name, fieldOrSpec, options),
+      new EnsureIndexOperation(this, name, fieldOrSpec, resolveOptions(this, options)),
       callback
     );
   }

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -73,7 +73,6 @@ export abstract class CommandOperation<
         : new MongoDBNamespace('admin', '$cmd');
     }
 
-    // todo what about this.hasAspect(Aspect.NO_INHERIT_OPTIONS)
     const readPref = ReadPreference.fromOptions(options);
     this.readPreference =
       this.hasAspect(Aspect.WRITE_OPERATION) || readPref === undefined

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -73,10 +73,9 @@ export abstract class CommandOperation<
         : new MongoDBNamespace('admin', '$cmd');
     }
 
-    const readPref = ReadPreference.fromOptions(options) ?? ReadPreference.primary;
     this.readPreference = this.hasAspect(Aspect.WRITE_OPERATION)
       ? ReadPreference.primary
-      : readPref;
+      : ReadPreference.fromOptions(options) ?? ReadPreference.primary;
     this.readConcern = ReadConcern.fromOptions(options);
     this.writeConcern = WriteConcern.fromOptions(options);
     this.bsonOptions = resolveBSONOptions(options);

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -73,14 +73,14 @@ export abstract class CommandOperation<
         : new MongoDBNamespace('admin', '$cmd');
     }
 
-    const readPref = ReadPreference.fromOptions(options);
-    this.readPreference =
-      this.hasAspect(Aspect.WRITE_OPERATION) || readPref === undefined
-        ? ReadPreference.primary
-        : readPref;
+    const readPref = ReadPreference.fromOptions(options) ?? ReadPreference.primary;
+    this.readPreference = this.hasAspect(Aspect.WRITE_OPERATION)
+      ? ReadPreference.primary
+      : readPref;
     this.readConcern = ReadConcern.fromOptions(options);
     this.writeConcern = WriteConcern.fromOptions(options);
     this.bsonOptions = resolveBSONOptions(options);
+
     this.explain = false;
     this.fullResponse =
       options && typeof options.fullResponse === 'boolean' ? options.fullResponse : false;

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -73,12 +73,15 @@ export abstract class CommandOperation<
         : new MongoDBNamespace('admin', '$cmd');
     }
 
-    const propertyProvider = this.hasAspect(Aspect.NO_INHERIT_OPTIONS) ? undefined : parent;
-    this.readPreference = this.hasAspect(Aspect.WRITE_OPERATION)
-      ? ReadPreference.primary
-      : ReadPreference.resolve(propertyProvider, this.options);
-    this.readConcern = resolveReadConcern(propertyProvider, this.options);
-    this.writeConcern = resolveWriteConcern(propertyProvider, this.options);
+    // todo what about this.hasAspect(Aspect.NO_INHERIT_OPTIONS)
+    const readPref = ReadPreference.fromOptions(options);
+    this.readPreference =
+      this.hasAspect(Aspect.WRITE_OPERATION) || readPref === undefined
+        ? ReadPreference.primary
+        : readPref;
+    this.readConcern = ReadConcern.fromOptions(options);
+    this.writeConcern = WriteConcern.fromOptions(options);
+    this.bsonOptions = resolveBSONOptions(options);
     this.explain = false;
     this.fullResponse =
       options && typeof options.fullResponse === 'boolean' ? options.fullResponse : false;
@@ -91,9 +94,6 @@ export abstract class CommandOperation<
     if (parent && parent.logger) {
       this.logger = parent.logger;
     }
-
-    // Assign BSON serialize options to OperationBase, preferring options over parent options.
-    this.bsonOptions = resolveBSONOptions(options, parent);
   }
 
   abstract execute(server: Server, callback: Callback<TResult>): void;
@@ -148,12 +148,4 @@ export abstract class CommandOperation<
       callback
     );
   }
-}
-
-function resolveWriteConcern(parent: OperationParent | undefined, options: any) {
-  return WriteConcern.fromOptions(options) || parent?.writeConcern;
-}
-
-function resolveReadConcern(parent: OperationParent | undefined, options: any) {
-  return ReadConcern.fromOptions(options) || parent?.readConcern;
 }

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -16,7 +16,6 @@ const ILLEGAL_COMMAND_FIELDS = new Set([
   'j',
   'fsync',
   'autoIndexId',
-  'serializeFunctions',
   'pkFactory',
   'raw',
   'readPreference',

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -22,7 +22,14 @@ const ILLEGAL_COMMAND_FIELDS = new Set([
   'readPreference',
   'session',
   'readConcern',
-  'writeConcern'
+  'writeConcern',
+  'raw',
+  'fieldsAsRaw',
+  'promoteLongs',
+  'promoteValues',
+  'promoteBuffers',
+  'serializeFunctions',
+  'ignoreUndefined'
 ]);
 
 /** @public */

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -1,5 +1,4 @@
 import { Aspect, defineAspects, Hint } from './operation';
-import { ReadPreference } from '../read_preference';
 import { maxWireVersion, MongoDBNamespace, Callback, normalizeHintField } from '../utils';
 import { MongoError } from '../error';
 import type { Document } from '../bson';
@@ -64,7 +63,6 @@ const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
 export class FindOperation extends CommandOperation<FindOptions, Document> {
   cmd: Document;
   filter: Document;
-  readPreference: ReadPreference;
 
   hint?: Hint;
 
@@ -76,7 +74,6 @@ export class FindOperation extends CommandOperation<FindOptions, Document> {
   ) {
     super(collection, options);
     this.ns = ns;
-    this.readPreference = ReadPreference.resolve(collection, this.options);
 
     if (typeof filter !== 'object' || Array.isArray(filter)) {
       throw new MongoError('Query filter must be a plain object or ObjectId');

--- a/src/operations/map_reduce.ts
+++ b/src/operations/map_reduce.ts
@@ -17,6 +17,7 @@ import type { ObjectId } from '../bson';
 
 const exclusionList = [
   'readPreference',
+  'readConcern',
   'session',
   'bypassDocumentValidation',
   'w',

--- a/src/operations/map_reduce.ts
+++ b/src/operations/map_reduce.ts
@@ -128,13 +128,9 @@ export class MapReduceOperation extends CommandOperation<MapReduceOptions, Docum
 
     options = Object.assign({}, options);
 
-    // Ensure we have the right read preference inheritance
-    options.readPreference = ReadPreference.resolve(coll, options);
-
     // If we have a read preference and inline is not set as output fail hard
     if (
-      options.readPreference &&
-      options.readPreference.mode === ReadPreferenceMode.primary &&
+      this.readPreference.mode === ReadPreferenceMode.primary &&
       options.out &&
       (options.out as any).inline !== 1 &&
       options.out !== 'inline'

--- a/src/operations/map_reduce.ts
+++ b/src/operations/map_reduce.ts
@@ -23,6 +23,13 @@ const exclusionList = [
   'wtimeout',
   'j',
   'writeConcern',
+  'raw',
+  'fieldsAsRaw',
+  'promoteLongs',
+  'promoteValues',
+  'promoteBuffers',
+  'serializeFunctions',
+  'ignoreUndefined',
   'scope' // this option is reformatted thus exclude the original
 ];
 

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -7,8 +7,7 @@ import type { Server } from '../sdam/server';
 export const Aspect = {
   READ_OPERATION: Symbol('READ_OPERATION'),
   WRITE_OPERATION: Symbol('WRITE_OPERATION'),
-  RETRYABLE: Symbol('RETRYABLE'),
-  NO_INHERIT_OPTIONS: Symbol('NO_INHERIT_OPTIONS')
+  RETRYABLE: Symbol('RETRYABLE')
 } as const;
 
 /** @public */

--- a/src/operations/run_command.ts
+++ b/src/operations/run_command.ts
@@ -1,5 +1,4 @@
 import { CommandOperation, CommandOperationOptions, OperationParent } from './command';
-import { defineAspects, Aspect } from './operation';
 import { MongoDBNamespace, Callback } from '../utils';
 import type { Server } from '../sdam/server';
 import type { Document } from '../bson';
@@ -34,6 +33,3 @@ export class RunAdminCommandOperation<
     this.ns = new MongoDBNamespace('admin');
   }
 }
-
-defineAspects(RunCommandOperation, [Aspect.NO_INHERIT_OPTIONS]);
-defineAspects(RunAdminCommandOperation, [Aspect.NO_INHERIT_OPTIONS]);

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -164,35 +164,35 @@ export class ReadPreference {
     return readPreference as ReadPreference;
   }
 
-  /**
-   * Resolves a read preference based on well-defined inheritance rules. This method will not only
-   * determine the read preference (if there is one), but will also ensure the returned value is a
-   * properly constructed instance of `ReadPreference`.
-   *
-   * @param parent - The parent of the operation on which to determine the read preference, used for determining the inherited read preference.
-   * @param options - The options passed into the method, potentially containing a read preference
-   */
-  static resolve(parent?: OperationParent, options?: ReadPreferenceFromOptions): ReadPreference {
-    options = options || {};
-    const session = options.session;
+  // /**
+  //  * Resolves a read preference based on well-defined inheritance rules. This method will not only
+  //  * determine the read preference (if there is one), but will also ensure the returned value is a
+  //  * properly constructed instance of `ReadPreference`.
+  //  *
+  //  * @param parent - The parent of the operation on which to determine the read preference, used for determining the inherited read preference.
+  //  * @param options - The options passed into the method, potentially containing a read preference
+  //  */
+  // static resolve(parent?: OperationParent, options?: ReadPreferenceFromOptions): ReadPreference {
+  //   options = options || {};
+  //   const session = options.session;
 
-    const inheritedReadPreference = parent?.readPreference;
+  //   const inheritedReadPreference = parent?.readPreference;
 
-    let readPreference: ReadPreference = ReadPreference.primary;
-    if (options.readPreference) {
-      const readPrefFromOptions = ReadPreference.fromOptions(options);
-      readPreference = readPrefFromOptions ? readPrefFromOptions : readPreference;
-    } else if (session && session.inTransaction() && session.transaction.options.readPreference) {
-      // The transaction’s read preference MUST override all other user configurable read preferences.
-      readPreference = session.transaction.options.readPreference;
-    } else if (inheritedReadPreference != null) {
-      readPreference = inheritedReadPreference;
-    }
+  //   let readPreference: ReadPreference = ReadPreference.primary;
+  //   if (options.readPreference) {
+  //     const readPrefFromOptions = ReadPreference.fromOptions(options);
+  //     readPreference = readPrefFromOptions ? readPrefFromOptions : readPreference;
+  //   } else if (session && session.inTransaction() && session.transaction.options.readPreference) {
+  //     // The transaction’s read preference MUST override all other user configurable read preferences.
+  //     readPreference = session.transaction.options.readPreference;
+  //   } else if (inheritedReadPreference != null) {
+  //     readPreference = inheritedReadPreference;
+  //   }
 
-    return typeof readPreference === 'string'
-      ? new ReadPreference(readPreference as ReadPreferenceMode)
-      : readPreference;
-  }
+  //   return typeof readPreference === 'string'
+  //     ? new ReadPreference(readPreference as ReadPreferenceMode)
+  //     : readPreference;
+  // }
 
   /**
    * Replaces options.readPreference with a ReadPreference instance

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -163,36 +163,6 @@ export class ReadPreference {
     return readPreference as ReadPreference;
   }
 
-  // /**
-  //  * Resolves a read preference based on well-defined inheritance rules. This method will not only
-  //  * determine the read preference (if there is one), but will also ensure the returned value is a
-  //  * properly constructed instance of `ReadPreference`.
-  //  *
-  //  * @param parent - The parent of the operation on which to determine the read preference, used for determining the inherited read preference.
-  //  * @param options - The options passed into the method, potentially containing a read preference
-  //  */
-  // static resolve(parent?: OperationParent, options?: ReadPreferenceFromOptions): ReadPreference {
-  //   options = options || {};
-  //   const session = options.session;
-
-  //   const inheritedReadPreference = parent?.readPreference;
-
-  //   let readPreference: ReadPreference = ReadPreference.primary;
-  //   if (options.readPreference) {
-  //     const readPrefFromOptions = ReadPreference.fromOptions(options);
-  //     readPreference = readPrefFromOptions ? readPrefFromOptions : readPreference;
-  //   } else if (session && session.inTransaction() && session.transaction.options.readPreference) {
-  //     // The transaction’s read preference MUST override all other user configurable read preferences.
-  //     readPreference = session.transaction.options.readPreference;
-  //   } else if (inheritedReadPreference != null) {
-  //     readPreference = inheritedReadPreference;
-  //   }
-
-  //   return typeof readPreference === 'string'
-  //     ? new ReadPreference(readPreference as ReadPreferenceMode)
-  //     : readPreference;
-  // }
-
   /**
    * Replaces options.readPreference with a ReadPreference instance
    */

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -141,7 +141,8 @@ export class ReadPreference {
    */
   static fromOptions(options?: ReadPreferenceFromOptions): ReadPreference | undefined {
     if (!options) return;
-    const readPreference = options.readPreference;
+    const readPreference =
+      options.readPreference ?? options.session?.transaction.options.readPreference;
     const readPreferenceTags = options.readPreferenceTags;
 
     if (readPreference == null) {

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -1,5 +1,4 @@
 import type { TagSet } from './sdam/server_description';
-import type { OperationParent } from './operations/command';
 import type { Document } from './bson';
 import type { ClientSession } from './sessions';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1087,12 +1087,9 @@ function resolveWriteConcern(
   options: any
 ): WriteConcern | undefined {
   const session = options.session;
-  if (
-    session &&
-    session.inTransaction() &&
-    session.transaction.options.writeConcern !== 'undefined'
-  ) {
-    return session.transaction.options.writeConcern;
+  if (session && session.inTransaction()) {
+    // Users cannot pass a writeConcern to operations in a transaction
+    return;
   }
   return WriteConcern.fromOptions(options) || parent?.writeConcern;
 }
@@ -1102,12 +1099,9 @@ function resolveReadConcern(
   options: any
 ): ReadConcern | undefined {
   const session = options.session;
-  if (
-    session &&
-    session.inTransaction() &&
-    session.transaction.options.readConcern !== 'undefined'
-  ) {
-    return session.transaction.options.readConcern;
+  if (session && session.inTransaction()) {
+    // Users cannot pass a readConcern to operations in a transaction
+    return;
   }
   return ReadConcern.fromOptions(options) || parent?.readConcern;
 }
@@ -1116,15 +1110,7 @@ function resolveReadPreference(
   parent: OperationParent | undefined,
   options: any
 ): ReadPreference | undefined {
-  const session = options.session;
-  if (
-    session &&
-    session.inTransaction() &&
-    session.transaction.options.readPreference !== 'undefined'
-  ) {
-    return session.transaction.options.readPreference;
-  }
-  return ReadPreference.fromOptions(options) || parent?.readPreference;
+  return ReadPreference.fromOptions(options) ?? parent?.readPreference;
 }
 
 /** @internal Prioritizes options from transaction, then from options, then from parent */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import * as os from 'os';
 import * as crypto from 'crypto';
 import { PromiseProvider } from './promise_provider';
 import { MongoError, AnyError } from './error';
-import { WriteConcern, WriteConcernOptions, W, writeConcernKeys } from './write_concern';
+import { WriteConcern, WriteConcernOptions, W } from './write_concern';
 import type { Server } from './sdam/server';
 import type { Topology } from './sdam/topology';
 import type { EventEmitter } from 'events';
@@ -215,42 +215,44 @@ export function filterOptions(options: AnyOptions, names: string[]): AnyOptions 
   return filterOptions;
 }
 
-/** @internal */
-export function mergeOptionsAndWriteConcern(
-  targetOptions: AnyOptions,
-  sourceOptions: AnyOptions,
-  keys: string[],
-  mergeWriteConcern: boolean
-): AnyOptions {
-  // Mix in any allowed options
-  for (let i = 0; i < keys.length; i++) {
-    if (targetOptions[keys[i]] === undefined && sourceOptions[keys[i]] !== undefined) {
-      targetOptions[keys[i]] = sourceOptions[keys[i]];
-    }
-  }
+// /** @internal */
+// export function mergeOptionsAndWriteConcern(
+//   targetOptions: AnyOptions,
+//   sourceOptions: AnyOptions,
+//   keys: string[]
+// ): AnyOptions {
+//   // Mix in any allowed options
+//   for (let i = 0; i < keys.length; i++) {
+//     if (targetOptions[keys[i]] === undefined && sourceOptions[keys[i]] !== undefined) {
+//       targetOptions[keys[i]] = sourceOptions[keys[i]];
+//     }
+//   }
 
-  // No merging of write concern
-  if (!mergeWriteConcern) return targetOptions;
+//   // todo could do this with an object.assign and then pluck the keys, except this doesn't work w mergeWriteconcern
+//   // but we always set that to true so we're good!
 
-  // Found no write Concern options
-  let found = false;
-  for (let i = 0; i < writeConcernKeys.length; i++) {
-    if (targetOptions[writeConcernKeys[i]]) {
-      found = true;
-      break;
-    }
-  }
+//   // Found no write Concern options
+//   let found = false;
+//   for (let i = 0; i < writeConcernKeys.length; i++) {
+//     if (targetOptions[writeConcernKeys[i]]) {
+//       found = true;
+//       break;
+//     }
+//   }
 
-  if (!found) {
-    for (let i = 0; i < writeConcernKeys.length; i++) {
-      if (sourceOptions[writeConcernKeys[i]]) {
-        targetOptions[writeConcernKeys[i]] = sourceOptions[writeConcernKeys[i]];
-      }
-    }
-  }
+//   // merge write concern keys iff none are found
+//   if (!found) {
+//     for (let i = 0; i < writeConcernKeys.length; i++) {
+//       if (sourceOptions[writeConcernKeys[i]]) {
+//         targetOptions[writeConcernKeys[i]] = sourceOptions[writeConcernKeys[i]];
+//       }
+//     }
+//   }
 
-  return targetOptions;
-}
+//   results = resolveInheritedOptions(this, options);
+
+//   return targetOptions;
+// }
 
 /**
  * Executes the given operation with provided arguments.
@@ -1164,7 +1166,7 @@ function resolveReadPreference(
   return ReadPreference.fromOptions(options) || parent?.readPreference;
 }
 
-/** @internal   Prioritizes options from transaction, then from options, then from parent */
+/** @internal Prioritizes options from transaction, then from options, then from parent */
 export function resolveInheritedOptions<T extends CommandOperationOptions>(
   parent: OperationParent | undefined,
   options?: T

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1091,10 +1091,10 @@ export function resolveOptions<T extends CommandOperationOptions>(
   parent: OperationParent | undefined,
   options?: T
 ): T {
-  const result: T = Object.assign({}, options);
-  const session = options?.session;
+  const result: T = Object.assign({}, options, resolveBSONOptions(options, parent));
 
   // Users cannot pass a readConcern/writeConcern to operations in a transaction
+  const session = options?.session;
   if (!session?.inTransaction()) {
     const readConcern = ReadConcern.fromOptions(options) ?? parent?.readConcern;
     if (readConcern) {
@@ -1112,7 +1112,5 @@ export function resolveOptions<T extends CommandOperationOptions>(
     result.readPreference = readPreference;
   }
 
-  const bsonOptions = resolveBSONOptions(result, parent);
-
-  return { ...result, ...bsonOptions };
+  return result;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,45 +215,6 @@ export function filterOptions(options: AnyOptions, names: string[]): AnyOptions 
   return filterOptions;
 }
 
-// /** @internal */
-// export function mergeOptionsAndWriteConcern(
-//   targetOptions: AnyOptions,
-//   sourceOptions: AnyOptions,
-//   keys: string[]
-// ): AnyOptions {
-//   // Mix in any allowed options
-//   for (let i = 0; i < keys.length; i++) {
-//     if (targetOptions[keys[i]] === undefined && sourceOptions[keys[i]] !== undefined) {
-//       targetOptions[keys[i]] = sourceOptions[keys[i]];
-//     }
-//   }
-
-//   // todo could do this with an object.assign and then pluck the keys, except this doesn't work w mergeWriteconcern
-//   // but we always set that to true so we're good!
-
-//   // Found no write Concern options
-//   let found = false;
-//   for (let i = 0; i < writeConcernKeys.length; i++) {
-//     if (targetOptions[writeConcernKeys[i]]) {
-//       found = true;
-//       break;
-//     }
-//   }
-
-//   // merge write concern keys iff none are found
-//   if (!found) {
-//     for (let i = 0; i < writeConcernKeys.length; i++) {
-//       if (sourceOptions[writeConcernKeys[i]]) {
-//         targetOptions[writeConcernKeys[i]] = sourceOptions[writeConcernKeys[i]];
-//       }
-//     }
-//   }
-
-//   results = resolveInheritedOptions(this, options);
-
-//   return targetOptions;
-// }
-
 /**
  * Executes the given operation with provided arguments.
  *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1087,7 +1087,7 @@ export function hasAtomicOperators(doc: Document | Document[]): boolean {
  * then values from parent.
  * @internal
  */
-export function resolveInheritedOptions<T extends CommandOperationOptions>(
+export function resolveOptions<T extends CommandOperationOptions>(
   parent: OperationParent | undefined,
   options?: T
 ): T {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1189,9 +1189,6 @@ export function resolveInheritedOptions<T extends CommandOperationOptions>(
   }
 
   const bsonOptions = resolveBSONOptions(result, parent);
-  Object.assign(result, bsonOptions);
 
-  // todo: are there others?
-
-  return result;
+  return { ...result, ...bsonOptions };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1082,57 +1082,34 @@ export function hasAtomicOperators(doc: Document | Document[]): boolean {
   return keys.length > 0 && keys[0][0] === '$';
 }
 
-function resolveWriteConcern(
-  parent: OperationParent | undefined,
-  options: any
-): WriteConcern | undefined {
-  const session = options.session;
-  if (session && session.inTransaction()) {
-    // Users cannot pass a writeConcern to operations in a transaction
-    return;
-  }
-  return WriteConcern.fromOptions(options) || parent?.writeConcern;
-}
-
-function resolveReadConcern(
-  parent: OperationParent | undefined,
-  options: any
-): ReadConcern | undefined {
-  const session = options.session;
-  if (session && session.inTransaction()) {
-    // Users cannot pass a readConcern to operations in a transaction
-    return;
-  }
-  return ReadConcern.fromOptions(options) || parent?.readConcern;
-}
-
-function resolveReadPreference(
-  parent: OperationParent | undefined,
-  options: any
-): ReadPreference | undefined {
-  return ReadPreference.fromOptions(options) ?? parent?.readPreference;
-}
-
-/** @internal Prioritizes options from transaction, then from options, then from parent */
+/**
+ * Merge inherited properties from parent into options, prioritizing values from options,
+ * then values from parent.
+ * @internal
+ */
 export function resolveInheritedOptions<T extends CommandOperationOptions>(
   parent: OperationParent | undefined,
   options?: T
 ): T {
   const result: T = Object.assign({}, options);
+  const session = options?.session;
 
-  const readPreference = resolveReadPreference(parent, result);
+  // Users cannot pass a readConcern/writeConcern to operations in a transaction
+  if (!session?.inTransaction()) {
+    const readConcern = ReadConcern.fromOptions(options) ?? parent?.readConcern;
+    if (readConcern) {
+      result.readConcern = readConcern;
+    }
+
+    const writeConcern = WriteConcern.fromOptions(options) ?? parent?.writeConcern;
+    if (writeConcern) {
+      result.writeConcern = writeConcern;
+    }
+  }
+
+  const readPreference = ReadPreference.fromOptions(options) ?? parent?.readPreference;
   if (readPreference) {
     result.readPreference = readPreference;
-  }
-
-  const readConcern = resolveReadConcern(parent, result);
-  if (readConcern) {
-    result.readConcern = readConcern;
-  }
-
-  const writeConcern = resolveWriteConcern(parent, result);
-  if (writeConcern) {
-    result.writeConcern = writeConcern;
   }
 
   const bsonOptions = resolveBSONOptions(result, parent);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,14 +10,16 @@ import type { Db } from './db';
 import type { Collection } from './collection';
 import type { OperationOptions, OperationBase, Hint } from './operations/operation';
 import type { ClientSession } from './sessions';
-import type { ReadConcern } from './read_concern';
+import { ReadConcern } from './read_concern';
 import type { Connection } from './cmap/connection';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import type { Document } from './bson';
+import { Document, resolveBSONOptions } from './bson';
 import type { IndexSpecification, IndexDirection } from './operations/indexes';
 import type { MongoClient } from './mongo_client';
 import type { Cursor } from './cursor/cursor';
+import type { CommandOperationOptions, OperationParent } from './operations/command';
+import { ReadPreference } from './read_preference';
 
 /**
  * MongoDB Driver style callback
@@ -1115,4 +1117,79 @@ export function hasAtomicOperators(doc: Document | Document[]): boolean {
 
   const keys = Object.keys(doc);
   return keys.length > 0 && keys[0][0] === '$';
+}
+
+function resolveWriteConcern(
+  parent: OperationParent | undefined,
+  options: any
+): WriteConcern | undefined {
+  const session = options.session;
+  if (
+    session &&
+    session.inTransaction() &&
+    session.transaction.options.writeConcern !== 'undefined'
+  ) {
+    return session.transaction.options.writeConcern;
+  }
+  return WriteConcern.fromOptions(options) || parent?.writeConcern;
+}
+
+function resolveReadConcern(
+  parent: OperationParent | undefined,
+  options: any
+): ReadConcern | undefined {
+  const session = options.session;
+  if (
+    session &&
+    session.inTransaction() &&
+    session.transaction.options.readConcern !== 'undefined'
+  ) {
+    return session.transaction.options.readConcern;
+  }
+  return ReadConcern.fromOptions(options) || parent?.readConcern;
+}
+
+function resolveReadPreference(
+  parent: OperationParent | undefined,
+  options: any
+): ReadPreference | undefined {
+  const session = options.session;
+  if (
+    session &&
+    session.inTransaction() &&
+    session.transaction.options.readPreference !== 'undefined'
+  ) {
+    return session.transaction.options.readPreference;
+  }
+  return ReadPreference.fromOptions(options) || parent?.readPreference;
+}
+
+/** @internal   Prioritizes options from transaction, then from options, then from parent */
+export function resolveInheritedOptions<T extends CommandOperationOptions>(
+  parent: OperationParent | undefined,
+  options?: T
+): T {
+  const result: T = Object.assign({}, options);
+
+  const readPreference = resolveReadPreference(parent, result);
+  if (readPreference) {
+    result.readPreference = readPreference;
+  }
+
+  const readConcern = resolveReadConcern(parent, result);
+  if (readConcern) {
+    result.readConcern = readConcern;
+  }
+
+  const writeConcern = resolveWriteConcern(parent, result);
+  if (writeConcern) {
+    result.writeConcern = writeConcern;
+  }
+
+  const bsonOptions = resolveBSONOptions(result, parent);
+  Object.assign(result, bsonOptions);
+
+  // todo: are there others?
+
+  return result;
 }


### PR DESCRIPTION
This PR introduces a new helper `resolveOptions` which includes the logic for inheriting some options from a parent. NOTE: It only merges in inherited properties (read/write concern, read preference, and bson options) from the parent, and does not add to or modify any other properties of options. 

Options are resolved before a command is constructed. This means the options passed to `CommandOperation` are already properly inherited, and inheritance is no longer needed in the `CommandOperation` constructor. So, we can get rid of the `NO_INHERIT_OPTIONS` aspect and simply not call `resolveOptions` before those commands. Similarly, the `ReadPreference.resolve()` function is no longer needed.

There is also a change to `ReadPreference.fromOptions()`, where if the options don't have a `readPreference` property and a session is present on the options, we attempt to get the read preference from the session. This might have been intended all along, since the type of the options passed to this function, `ReadPreferenceFromOptions`, already had an optional `session` property. 

NODE-2870