### PR TITLE
fix: allow client connect after close

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -588,7 +588,6 @@ function processNewChange(
 }
 
 function processError(changeStream: ChangeStream, error: AnyError, callback?: Callback) {
-  const topology = getTopology(changeStream.parent);
   const cursor = changeStream.cursor;
 
   // If the change stream has been closed explicitly, do not process error.
@@ -618,6 +617,7 @@ function processError(changeStream: ChangeStream, error: AnyError, callback?: Ca
     // close internal cursor, ignore errors
     cursor.close();
 
+    const topology = getTopology(changeStream.parent);
     waitForTopologyConnected(topology, { readPreference: cursor.readPreference }, err => {
       // if the topology can't reconnect, close the stream
       if (err) return unresumableError(err);

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -362,7 +362,10 @@ export class MongoClient extends EventEmitter implements OperationParent {
         return cb();
       }
 
+      // clear out references to old topology
       const topology = this.topology;
+      this.topology = undefined;
+
       topology.close({ force }, err => {
         const autoEncrypter = topology.s.options.autoEncrypter;
         if (!autoEncrypter) {

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -197,6 +197,11 @@ export function connect(
     throw new Error('no callback function provided');
   }
 
+  // Has a connection already been established?
+  if (mongoClient.topology && mongoClient.topology.isConnected()) {
+    throw new MongoError(`'connect' cannot be called when already connected`);
+  }
+
   let didRequestAuthentication = false;
   const logger = new Logger('MongoClient', options);
 

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -199,7 +199,7 @@ export function connect(
 
   // Has a connection already been established?
   if (mongoClient.topology && mongoClient.topology.isConnected()) {
-    throw new MongoError(`'connect' cannot be called when already connected`);
+    return callback(new MongoError('MongoClient is already connected'));
   }
 
   let didRequestAuthentication = false;

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -197,9 +197,9 @@ export function connect(
     throw new Error('no callback function provided');
   }
 
-  // Has a connection already been established?
+  // If a connection already been established, we can terminate early
   if (mongoClient.topology && mongoClient.topology.isConnected()) {
-    return callback(new MongoError('MongoClient is already connected'));
+    return callback(undefined, mongoClient);
   }
 
   let didRequestAuthentication = false;

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -273,58 +273,58 @@ describe('Connection', function () {
       done();
     }
   });
-});
 
-it(
-  'should be able to connect again after close',
-  withClient(function (client, done) {
-    expect(client.isConnected()).to.be.true;
+  it(
+    'should be able to connect again after close',
+    withClient(function (client, done) {
+      expect(client.isConnected()).to.be.true;
 
-    const collection = client.db('shouldConnectAfterClose').collection('test');
-    collection.insertOne({ a: 1, b: 2 }, (err, result) => {
-      expect(err).to.not.exist;
-      expect(result).to.exist;
-
-      client.close(err => {
+      const collection = client.db('shouldConnectAfterClose').collection('test');
+      collection.insertOne({ a: 1, b: 2 }, (err, result) => {
         expect(err).to.not.exist;
-        expect(client.isConnected()).to.be.false;
+        expect(result).to.exist;
 
-        client.connect(err => {
+        client.close(err => {
           expect(err).to.not.exist;
-          expect(client.isConnected()).to.be.true;
+          expect(client.isConnected()).to.be.false;
 
-          collection.findOne({ a: 1 }, (err, result) => {
+          client.connect(err => {
             expect(err).to.not.exist;
-            expect(result).to.exist;
-            expect(result).to.have.property('a', 1);
-            expect(result).to.have.property('b', 2);
-            expect(client.topology.isDestroyed()).to.be.false;
-            done();
+            expect(client.isConnected()).to.be.true;
+
+            collection.findOne({ a: 1 }, (err, result) => {
+              expect(err).to.not.exist;
+              expect(result).to.exist;
+              expect(result).to.have.property('a', 1);
+              expect(result).to.have.property('b', 2);
+              expect(client.topology.isDestroyed()).to.be.false;
+              done();
+            });
           });
         });
       });
-    });
-  })
-);
+    })
+  );
 
-it(
-  'should correctly fail on retry when client has been closed',
-  withClient(function (client, done) {
-    expect(client.isConnected()).to.be.true;
-    const collection = client.db('shouldCorrectlyFailOnRetry').collection('test');
-    collection.insertOne({ a: 1 }, (err, result) => {
-      expect(err).to.not.exist;
-      expect(result).to.exist;
-
-      client.close(true, function (err) {
+  it(
+    'should correctly fail on retry when client has been closed',
+    withClient(function (client, done) {
+      expect(client.isConnected()).to.be.true;
+      const collection = client.db('shouldCorrectlyFailOnRetry').collection('test');
+      collection.insertOne({ a: 1 }, (err, result) => {
         expect(err).to.not.exist;
-        expect(client.isConnected()).to.be.false;
+        expect(result).to.exist;
 
-        expect(() => {
-          collection.insertOne({ a: 2 });
-        }).to.throw(/must be connected/);
-        done();
+        client.close(true, function (err) {
+          expect(err).to.not.exist;
+          expect(client.isConnected()).to.be.false;
+
+          expect(() => {
+            collection.insertOne({ a: 2 });
+          }).to.throw(/must be connected/);
+          done();
+        });
       });
-    });
-  })
-);
+    })
+  );
+});

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -1,6 +1,6 @@
 'use strict';
+const { withClient, setupDatabase } = require('./shared');
 const test = require('./shared').assert,
-  setupDatabase = require('./shared').setupDatabase,
   expect = require('chai').expect;
 
 describe('Connection', function () {
@@ -274,3 +274,55 @@ describe('Connection', function () {
     }
   });
 });
+
+it(
+  'should be able to connect again after close',
+  withClient(function (client, done) {
+    expect(client.isConnected()).to.be.true;
+
+    const collection = client.db('testReconnect').collection('test');
+    collection.insertOne({ a: 1 }, (err, result) => {
+      expect(err).to.not.exist;
+      expect(result).to.exist;
+
+      client.close(err => {
+        expect(err).to.not.exist;
+        expect(client.isConnected()).to.be.false;
+
+        client.connect(err => {
+          expect(err).to.not.exist;
+          expect(client.isConnected()).to.be.true;
+
+          collection.insertOne({ b: 2 }, (err, result) => {
+            expect(err).to.not.exist;
+            expect(result).to.exist;
+            expect(client.topology.isDestroyed()).to.be.false;
+            done();
+          });
+        });
+      });
+    });
+  })
+);
+
+it(
+  'should correctly fail on retry when client has been closed',
+  withClient(function (client, done) {
+    expect(client.isConnected()).to.be.true;
+    const collection = client.db('shouldCorrectlyFailOnRetry').collection('test');
+    collection.insertOne({ a: 1 }, (err, result) => {
+      expect(err).to.not.exist;
+      expect(result).to.exist;
+
+      client.close(true, function (err) {
+        expect(err).to.not.exist;
+        expect(client.isConnected()).to.be.false;
+
+        expect(() => {
+          collection.insertOne({ a: 2 });
+        }).to.throw(/must be connected/);
+        done();
+      });
+    });
+  })
+);

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const { withClient, setupDatabase } = require('./shared');
-const test = require('./shared').assert,
-  expect = require('chai').expect;
+const test = require('./shared').assert;
+const { expect } = require('chai');
 
 describe('Connection', function () {
   before(function () {
@@ -280,8 +280,8 @@ it(
   withClient(function (client, done) {
     expect(client.isConnected()).to.be.true;
 
-    const collection = client.db('testReconnect').collection('test');
-    collection.insertOne({ a: 1 }, (err, result) => {
+    const collection = client.db('shouldConnectAfterClose').collection('test');
+    collection.insertOne({ a: 1, b: 2 }, (err, result) => {
       expect(err).to.not.exist;
       expect(result).to.exist;
 
@@ -293,9 +293,11 @@ it(
           expect(err).to.not.exist;
           expect(client.isConnected()).to.be.true;
 
-          collection.insertOne({ b: 2 }, (err, result) => {
+          collection.findOne({ a: 1 }, (err, result) => {
             expect(err).to.not.exist;
             expect(result).to.exist;
+            expect(result).to.have.property('a', 1);
+            expect(result).to.have.property('b', 2);
             expect(client.topology.isDestroyed()).to.be.false;
             done();
           });

--- a/test/functional/find.test.js
+++ b/test/functional/find.test.js
@@ -2637,7 +2637,8 @@ describe('Find', function () {
         expect(err).to.not.exist;
 
         let selectedServer;
-        const selectServerStub = sinon.stub(client.topology, 'selectServer').callsFake(function () {
+        const topology = client.topology;
+        const selectServerStub = sinon.stub(topology, 'selectServer').callsFake(function () {
           const args = Array.prototype.slice.call(arguments);
           const originalCallback = args.pop();
           args.push((err, server) => {
@@ -2645,7 +2646,7 @@ describe('Find', function () {
             originalCallback(err, server);
           });
 
-          return client.topology.selectServer.wrappedMethod.apply(this, args);
+          return topology.selectServer.wrappedMethod.apply(this, args);
         });
 
         const collection = client.db().collection('test_read_preference');

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -123,7 +123,7 @@ describe('Sessions', function () {
               // verify that the `endSessions` command was sent
               const lastCommand = test.commands.started[test.commands.started.length - 1];
               expect(lastCommand.commandName).to.equal('endSessions');
-              expect(client.topology.s.sessionPool.sessions).to.have.length(0);
+              expect(client.topology).to.not.exist;
             });
         });
       });
@@ -143,7 +143,7 @@ describe('Sessions', function () {
             // verify that the `endSessions` command was sent
             const lastCommand = test.commands.started[test.commands.started.length - 1];
             expect(lastCommand.commandName).to.equal('endSessions');
-            expect(client.topology.s.sessionPool.sessions).to.have.length(0);
+            expect(client.topology).to.not.exist;
           });
       });
     }


### PR DESCRIPTION
This reinstates the work from #2581 now that NODE-2850 is complete. 

During `close` of a `MongoClient`, we remove the `topology`. Then, when a client is reconnected, a new topology is created and added to the client. First, this means references to `Db`s and `Collection`s can be re-used after the reconnect, since they will pull the new topology from the client. Also, when an operation requiring a topology is performed on a closed client, an error is thrown. 

After this, the work of figuring out how to re-connect a topology is one of the last steps towards having a single, immutable topology associated with a `MongoClient`. As in #2581, I skipped this work for now, since the refactor required to re-connect topologies may be too much work for this ticket.

NODE-2544