### PR TITLE
refactor: consolidate options inheritance for bulk ops

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -21,7 +21,6 @@ import type { Topology } from '../sdam/topology';
 import type { CommandOperationOptions } from '../operations/command';
 import type { CollationOptions } from '../cmap/wire_protocol/write_command';
 import type { Hint } from '../operations/operation';
-import { ReadPreference } from '../read_preference';
 
 // Error codes
 const WRITE_CONCERN_ERROR = 64;

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -2,14 +2,14 @@ import { PromiseProvider } from '../promise_provider';
 import { Long, ObjectId, Document, BSONSerializeOptions, resolveBSONOptions } from '../bson';
 import { MongoError, MongoWriteConcernError, AnyError } from '../error';
 import {
-  applyWriteConcern,
   applyRetryableWrites,
   executeLegacyOperation,
   hasAtomicOperators,
   Callback,
   MongoDBNamespace,
   maxWireVersion,
-  getTopology
+  getTopology,
+  resolveOptions
 } from '../utils';
 import { executeOperation } from '../operations/execute_operation';
 import { InsertOperation } from '../operations/insert';
@@ -571,14 +571,10 @@ function executeCommands(
     executeCommands(bulkOperation, options, callback);
   }
 
-  const finalOptions = Object.assign(
-    { ordered: bulkOperation.isOrdered },
-    bulkOperation.bsonOptions,
-    options
-  );
-  if (bulkOperation.s.writeConcern != null) {
-    finalOptions.writeConcern = bulkOperation.s.writeConcern;
-  }
+  const finalOptions = resolveOptions(bulkOperation, {
+    ordered: bulkOperation.isOrdered,
+    ...options
+  });
 
   if (finalOptions.bypassDocumentValidation !== true) {
     delete finalOptions.bypassDocumentValidation;
@@ -935,10 +931,9 @@ export abstract class BulkOperationBase {
     //   + 1 bytes for null terminator
     const maxKeySize = (maxWriteBatchSize - 1).toString(10).length + 2;
 
-    // Final options for retryable writes and write concern
+    // Final options for retryable writes
     let finalOptions = Object.assign({}, options);
     finalOptions = applyRetryableWrites(finalOptions, collection.s.db);
-    finalOptions = applyWriteConcern(finalOptions, { collection: collection }, options);
 
     // Final results
     const bulkResult: BulkResult = {
@@ -983,7 +978,7 @@ export abstract class BulkOperationBase {
       // Options
       options: finalOptions,
       // BSON options
-      bsonOptions: resolveBSONOptions(options, collection),
+      bsonOptions: resolveBSONOptions(options),
       // Current operation
       currentOp,
       // Executed
@@ -1167,6 +1162,10 @@ export abstract class BulkOperationBase {
 
   get bsonOptions(): BSONSerializeOptions {
     return this.s.bsonOptions;
+  }
+
+  get writeConcern(): WriteConcern | undefined {
+    return this.s.writeConcern;
   }
 
   /** An internal helper method. Do not invoke directly. Will be going away in the future */

--- a/src/cmap/wire_protocol/write_command.ts
+++ b/src/cmap/wire_protocol/write_command.ts
@@ -4,6 +4,7 @@ import { command, CommandOptions } from './command';
 import type { Server } from '../../sdam/server';
 import type { Document, BSONSerializeOptions } from '../../bson';
 import type { WriteConcern } from '../../write_concern';
+import { ReadPreference } from '../../read_preference';
 
 /** @public */
 export interface CollationOptions {
@@ -62,6 +63,12 @@ export function writeCommand(
 
   if (options.bypassDocumentValidation === true) {
     writeCommand.bypassDocumentValidation = options.bypassDocumentValidation;
+  }
+
+  // A read preference may be present in the options, inherited from a transaction or parent.
+  // For write commands, we need to ensure it is ReadPreference.primary, so we override it here.
+  if (options.readPreference) {
+    options.readPreference = ReadPreference.primary;
   }
 
   const commandOptions = Object.assign(

--- a/src/cmap/wire_protocol/write_command.ts
+++ b/src/cmap/wire_protocol/write_command.ts
@@ -4,7 +4,6 @@ import { command, CommandOptions } from './command';
 import type { Server } from '../../sdam/server';
 import type { Document, BSONSerializeOptions } from '../../bson';
 import type { WriteConcern } from '../../write_concern';
-import { ReadPreference } from '../../read_preference';
 
 /** @public */
 export interface CollationOptions {
@@ -63,12 +62,6 @@ export function writeCommand(
 
   if (options.bypassDocumentValidation === true) {
     writeCommand.bypassDocumentValidation = options.bypassDocumentValidation;
-  }
-
-  // A read preference may be present in the options, inherited from a transaction or parent.
-  // For write commands, we need to ensure it is ReadPreference.primary, so we override it here.
-  if (options.readPreference) {
-    options.readPreference = ReadPreference.primary;
   }
 
   const commandOptions = Object.assign(

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -315,7 +315,7 @@ export class Collection implements OperationParent {
 
     return executeOperation(
       getTopology(this),
-      new InsertManyOperation(this, docs, options),
+      new InsertManyOperation(this, docs, resolveOptions(this, options)),
       callback
     );
   }
@@ -375,7 +375,7 @@ export class Collection implements OperationParent {
 
     return executeOperation(
       getTopology(this),
-      new BulkWriteOperation(this, operations, options),
+      new BulkWriteOperation(this, operations, resolveOptions(this, options)),
       callback
     );
   }
@@ -1312,12 +1312,12 @@ export class Collection implements OperationParent {
 
   /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): any {
-    return new UnorderedBulkOperation(this, options ?? {});
+    return new UnorderedBulkOperation(this, resolveOptions(this, options));
   }
 
   /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
   initializeOrderedBulkOp(options?: BulkWriteOptions): any {
-    return new OrderedBulkOperation(this, options ?? {});
+    return new OrderedBulkOperation(this, resolveOptions(this, options));
   }
 
   /** Get the db scoped logger */

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -1,4 +1,4 @@
-import { applyRetryableWrites, applyWriteConcern, Callback } from '../utils';
+import { applyRetryableWrites, Callback } from '../utils';
 import { OperationBase } from './operation';
 import { resolveBSONOptions } from '../bson';
 import { WriteConcern } from '../write_concern';
@@ -26,8 +26,8 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
     this.collection = collection;
     this.operations = operations;
 
-    // Assign BSON serialize options to OperationBase, preferring options over collection options
-    this.bsonOptions = resolveBSONOptions(options, collection);
+    // Pull the BSON serialize options from the already-resolved options
+    this.bsonOptions = resolveBSONOptions(options);
   }
 
   execute(server: Server, callback: Callback<BulkWriteResult>): void {
@@ -50,11 +50,8 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
       return callback(err);
     }
 
-    // Final options for retryable writes and write concern
     let finalOptions = Object.assign({}, options);
     finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
-    finalOptions = applyWriteConcern(finalOptions, { db: coll.s.db, collection: coll }, options);
-
     const writeCon = WriteConcern.fromOptions(finalOptions);
 
     // Execute the bulk

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -1,6 +1,5 @@
 import { applyRetryableWrites, Callback } from '../utils';
 import { OperationBase } from './operation';
-import { resolveBSONOptions } from '../bson';
 import { WriteConcern } from '../write_concern';
 import type { Collection } from '../collection';
 import type {
@@ -25,9 +24,6 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
 
     this.collection = collection;
     this.operations = operations;
-
-    // Pull the BSON serialize options from the already-resolved options
-    this.bsonOptions = resolveBSONOptions(options);
   }
 
   execute(server: Server, callback: Callback<BulkWriteResult>): void {

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -1,6 +1,5 @@
 import { applyRetryableWrites, Callback } from '../utils';
-import { OperationBase } from './operation';
-import { WriteConcern } from '../write_concern';
+import { Aspect, defineAspects, OperationBase } from './operation';
 import type { Collection } from '../collection';
 import type {
   BulkOperationBase,
@@ -48,10 +47,9 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
 
     let finalOptions = Object.assign({}, options);
     finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
-    const writeCon = WriteConcern.fromOptions(finalOptions);
 
     // Execute the bulk
-    bulk.execute(writeCon, finalOptions, (err, r) => {
+    bulk.execute(finalOptions, (err, r) => {
       // We have connection level error
       if (!r && err) {
         return callback(err);
@@ -62,3 +60,5 @@ export class BulkWriteOperation extends OperationBase<BulkWriteOptions, BulkWrit
     });
   }
 }
+
+defineAspects(BulkWriteOperation, [Aspect.WRITE_OPERATION]);

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -7,7 +7,7 @@ import { commandSupportsReadConcern } from '../sessions';
 import { MongoError } from '../error';
 import type { Logger } from '../logger';
 import type { Server } from '../sdam/server';
-import { BSONSerializeOptions, Document, resolveBSONOptions } from '../bson';
+import type { BSONSerializeOptions, Document } from '../bson';
 import type { CollationOptions } from '../cmap/wire_protocol/write_command';
 import type { ReadConcernLike } from './../read_concern';
 
@@ -78,7 +78,6 @@ export abstract class CommandOperation<
       : ReadPreference.fromOptions(options) ?? ReadPreference.primary;
     this.readConcern = ReadConcern.fromOptions(options);
     this.writeConcern = WriteConcern.fromOptions(options);
-    this.bsonOptions = resolveBSONOptions(options);
 
     this.explain = false;
     this.fullResponse =

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -2,7 +2,7 @@ import { Aspect, OperationBase, OperationOptions } from './operation';
 import { ReadConcern } from '../read_concern';
 import { WriteConcern, WriteConcernOptions } from '../write_concern';
 import { maxWireVersion, MongoDBNamespace, Callback } from '../utils';
-import { ReadPreference, ReadPreferenceLike } from '../read_preference';
+import type { ReadPreference } from '../read_preference';
 import { commandSupportsReadConcern } from '../sessions';
 import { MongoError } from '../error';
 import type { Logger } from '../logger';
@@ -19,8 +19,6 @@ export interface CommandOperationOptions extends OperationOptions, WriteConcernO
   fullResponse?: boolean;
   /** Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported) */
   readConcern?: ReadConcernLike;
-  /** The preferred read preference (ReadPreference.primary, ReadPreference.primary_preferred, ReadPreference.secondary, ReadPreference.secondary_preferred, ReadPreference.nearest). */
-  readPreference?: ReadPreferenceLike;
   /** Collation */
   collation?: CollationOptions;
   maxTimeMS?: number;
@@ -51,7 +49,6 @@ export abstract class CommandOperation<
   TResult = Document
 > extends OperationBase<T> {
   ns: MongoDBNamespace;
-  readPreference: ReadPreference;
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
   explain: boolean;
@@ -73,19 +70,12 @@ export abstract class CommandOperation<
         : new MongoDBNamespace('admin', '$cmd');
     }
 
-    this.readPreference = this.hasAspect(Aspect.WRITE_OPERATION)
-      ? ReadPreference.primary
-      : ReadPreference.fromOptions(options) ?? ReadPreference.primary;
     this.readConcern = ReadConcern.fromOptions(options);
     this.writeConcern = WriteConcern.fromOptions(options);
 
     this.explain = false;
     this.fullResponse =
       options && typeof options.fullResponse === 'boolean' ? options.fullResponse : false;
-
-    // TODO: A lot of our code depends on having the read preference in the options. This should
-    //       go away, but also requires massive test rewrites.
-    this.options.readPreference = this.readPreference;
 
     // TODO(NODE-2056): make logger another "inheritable" property
     if (parent && parent.logger) {

--- a/src/operations/common_functions.ts
+++ b/src/operations/common_functions.ts
@@ -215,12 +215,6 @@ export function updateDocuments(
   let finalOptions = Object.assign({}, options);
   finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
 
-  // Do we return the actual result document
-  // Either use override on the function, or go back to default on either the collection
-  // level or db
-  finalOptions.serializeFunctions =
-    options.serializeFunctions || coll.bsonOptions.serializeFunctions;
-
   // Execute the operation
   const op: Document = { q: selector, u: document };
   op.upsert = options.upsert !== void 0 ? !!options.upsert : false;

--- a/src/operations/common_functions.ts
+++ b/src/operations/common_functions.ts
@@ -1,11 +1,5 @@
 import { MongoError } from '../error';
-import {
-  applyRetryableWrites,
-  applyWriteConcern,
-  decorateWithCollation,
-  Callback,
-  getTopology
-} from '../utils';
+import { applyRetryableWrites, decorateWithCollation, Callback, getTopology } from '../utils';
 import type { Document } from '../bson';
 import type { Db } from '../db';
 import type { ClientSession } from '../sessions';
@@ -136,10 +130,9 @@ export function removeDocuments(
   // Create an empty options object if the provided one is null
   options = options || {};
 
-  // Final options for retryable writes and write concern
+  // Final options for retryable writes
   let finalOptions = Object.assign({}, options);
   finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
-  finalOptions = applyWriteConcern(finalOptions, { db: coll.s.db, collection: coll }, options);
 
   // If selector is null set empty
   if (selector == null) selector = {};
@@ -218,10 +211,9 @@ export function updateDocuments(
   if (document == null || typeof document !== 'object')
     return callback(new TypeError('document must be a valid JavaScript object'));
 
-  // Final options for retryable writes and write concern
+  // Final options for retryable writes
   let finalOptions = Object.assign({}, options);
   finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
-  finalOptions = applyWriteConcern(finalOptions, { db: coll.s.db, collection: coll }, options);
 
   // Do we return the actual result document
   // Either use override on the function, or go back to default on either the collection

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -3,7 +3,6 @@ import {
   maxWireVersion,
   applyRetryableWrites,
   decorateWithCollation,
-  applyWriteConcern,
   hasAtomicOperators,
   Callback
 } from '../utils';
@@ -107,9 +106,8 @@ export class FindAndModifyOperation extends CommandOperation<FindAndModifyOption
     // No check on the documents
     options.checkKeys = false;
 
-    // Final options for retryable writes and write concern
+    // Final options for retryable writes
     options = applyRetryableWrites(options, coll.s.db);
-    options = applyWriteConcern(options, { db: coll.s.db, collection: coll }, options);
 
     // Decorate the findAndModify command with the write Concern
     if (options.writeConcern) {

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -1,7 +1,7 @@
 import { MongoError } from '../error';
 import { defineAspects, Aspect, OperationBase } from './operation';
 import { CommandOperation } from './command';
-import { applyRetryableWrites, applyWriteConcern, Callback, MongoDBNamespace } from '../utils';
+import { applyRetryableWrites, Callback, MongoDBNamespace } from '../utils';
 import { prepareDocs } from './common_functions';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
@@ -98,10 +98,9 @@ function insertDocuments(
   // Ensure we are operating on an array op docs
   docs = Array.isArray(docs) ? docs : [docs];
 
-  // Final options for retryable writes and write concern
+  // Final options for retryable writes
   let finalOptions = Object.assign({}, options);
   finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
-  finalOptions = applyWriteConcern(finalOptions, { db: coll.s.db, collection: coll }, options);
 
   // If keep going set unordered
   if (finalOptions.keepGoing === true) finalOptions.ordered = false;

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -31,8 +31,8 @@ export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertM
     this.collection = collection;
     this.docs = docs;
 
-    // Assign BSON serialize options to OperationBase, preferring options over collection options
-    this.bsonOptions = resolveBSONOptions(options, collection);
+    // Pull the BSON serialize options from the already-resolved options
+    this.bsonOptions = resolveBSONOptions(options);
   }
 
   execute(server: Server, callback: Callback<InsertManyResult>): void {

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -4,7 +4,7 @@ import { MongoError } from '../error';
 import { prepareDocs } from './common_functions';
 import type { Callback } from '../utils';
 import type { Collection } from '../collection';
-import { ObjectId, Document, resolveBSONOptions } from '../bson';
+import type { ObjectId, Document } from '../bson';
 import type { BulkWriteResult, BulkWriteOptions } from '../bulk/common';
 import type { Server } from '../sdam/server';
 
@@ -30,9 +30,6 @@ export class InsertManyOperation extends OperationBase<BulkWriteOptions, InsertM
 
     this.collection = collection;
     this.docs = docs;
-
-    // Pull the BSON serialize options from the already-resolved options
-    this.bsonOptions = resolveBSONOptions(options);
   }
 
   execute(server: Server, callback: Callback<InsertManyResult>): void {

--- a/src/operations/insert_many.ts
+++ b/src/operations/insert_many.ts
@@ -1,4 +1,4 @@
-import { OperationBase } from './operation';
+import { Aspect, defineAspects, OperationBase } from './operation';
 import { BulkWriteOperation } from './bulk_write';
 import { MongoError } from '../error';
 import { prepareDocs } from './common_functions';
@@ -70,3 +70,5 @@ function mapInsertManyResults(docs: Document[], r: BulkWriteResult): InsertManyR
 
   return finalResult;
 }
+
+defineAspects(InsertManyOperation, [Aspect.WRITE_OPERATION]);

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -1,6 +1,6 @@
 import { ReadPreference } from '../read_preference';
 import type { ClientSession } from '../sessions';
-import type { Document, BSONSerializeOptions } from '../bson';
+import { Document, BSONSerializeOptions, resolveBSONOptions } from '../bson';
 import type { MongoDBNamespace, Callback } from '../utils';
 import type { Server } from '../sdam/server';
 
@@ -50,6 +50,9 @@ export abstract class OperationBase<
   constructor(options: T = {} as T) {
     this.options = Object.assign({}, options);
     this.readPreference = ReadPreference.primary;
+
+    // Pull the BSON serialize options from the already-resolved options
+    this.bsonOptions = resolveBSONOptions(options);
   }
 
   abstract execute(server: Server, callback: Callback<TResult>): void;

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -1,4 +1,4 @@
-import { ReadPreference } from '../read_preference';
+import { ReadPreference, ReadPreferenceLike } from '../read_preference';
 import type { ClientSession } from '../sessions';
 import { Document, BSONSerializeOptions, resolveBSONOptions } from '../bson';
 import type { MongoDBNamespace, Callback } from '../utils';
@@ -24,6 +24,9 @@ export interface OperationOptions extends BSONSerializeOptions {
 
   explain?: boolean;
   willRetryWrites?: boolean;
+
+  /** The preferred read preference (ReadPreference.primary, ReadPreference.primary_preferred, ReadPreference.secondary, ReadPreference.secondary_preferred, ReadPreference.nearest). */
+  readPreference?: ReadPreferenceLike;
 }
 
 /**
@@ -49,7 +52,13 @@ export abstract class OperationBase<
 
   constructor(options: T = {} as T) {
     this.options = Object.assign({}, options);
-    this.readPreference = ReadPreference.primary;
+
+    this.readPreference = this.hasAspect(Aspect.WRITE_OPERATION)
+      ? ReadPreference.primary
+      : ReadPreference.fromOptions(options) ?? ReadPreference.primary;
+    // TODO: A lot of our code depends on having the read preference in the options. This should
+    //       go away, but also requires massive test rewrites.
+    this.options.readPreference = this.readPreference;
 
     // Pull the BSON serialize options from the already-resolved options
     this.bsonOptions = resolveBSONOptions(options);


### PR DESCRIPTION
This PR extends the work from #2614 to bulk operations. Now, bulk ops use `resolveOptions` to inherit options from the parent. Also, since no bson options or read preference resolving needs to be done in subclasses of `OperationBase`, assigning the `bsonOptions` and `readPreference` properties now occurs in the `OperationBase` constructor.

The changes to `find_and_modify.ts`, `insert.ts`, and `common_functions.ts` should have been done in the last PR :(

NODE-2870