### PR TITLE
chore: capture more informative stack trace in session leak checker

### DIFF
--- a/test/tools/runner/plugins/session_leak_checker.js
+++ b/test/tools/runner/plugins/session_leak_checker.js
@@ -14,11 +14,11 @@ function getSessionLeakMetadata(currentTest) {
 
 const kTrace = Symbol('trace');
 function dumpSessionInfo(which, sessions) {
-  console.log(which);
+  console.warn(which);
   sessions.forEach(session => {
-    console.log(` >> ${JSON.stringify(session.id)}`);
+    console.warn(` >> ${JSON.stringify(session.id)}`);
     if (session[kTrace]) {
-      console.log(session[kTrace]);
+      console.warn(session[kTrace]);
     }
   });
 }

--- a/test/tools/runner/plugins/session_leak_checker.js
+++ b/test/tools/runner/plugins/session_leak_checker.js
@@ -12,11 +12,14 @@ function getSessionLeakMetadata(currentTest) {
   return (currentTest.metadata && currentTest.metadata.sessions) || {};
 }
 
+const kTrace = Symbol('trace');
 function dumpSessionInfo(which, sessions) {
   console.log(which);
   sessions.forEach(session => {
     console.log(` >> ${JSON.stringify(session.id)}`);
-    console.log(session.trace);
+    if (session[kTrace]) {
+      console.log(session[kTrace]);
+    }
   });
 }
 
@@ -32,10 +35,31 @@ beforeEach('Session Leak Before Each - setup session tracking', function () {
     return;
   }
 
+  const _startSession = Topology.prototype.startSession;
+  sandbox.stub(Topology.prototype, 'startSession').callsFake(function () {
+    const session = _startSession.apply(this, arguments);
+    const stackTrace = new Error().stack;
+    const result = new Proxy(session, {
+      get: function (target, prop) {
+        if (prop === 'serverSession') {
+          const serverSession = target[prop];
+          if (serverSession[kTrace] == null) {
+            serverSession[kTrace] = stackTrace;
+          }
+
+          return serverSession;
+        }
+
+        return Reflect.get(...arguments);
+      }
+    });
+
+    return result;
+  });
+
   const _acquire = ServerSessionPool.prototype.acquire;
   sandbox.stub(ServerSessionPool.prototype, 'acquire').callsFake(function () {
     const session = _acquire.apply(this, arguments);
-    session.trace = new Error().stack;
     activeSessions.add(session);
     return session;
   });


### PR DESCRIPTION
Since we migrated to acquiring a server session lazily the stack traces for the sesson leak checker haven't been very helpful. This patch records the trace from the call to `Topology#startSession` in order to provide a more high quality trace.

NODE-2880
