### PR TITLE
feat: add explain support for cursor commands 

### DIFF
--- a/src/cmap/wire_protocol/query.ts
+++ b/src/cmap/wire_protocol/query.ts
@@ -27,7 +27,7 @@ export function query(
     return callback(new MongoError(`command ${JSON.stringify(cmd)} does not return a cursor`));
   }
 
-  if (shouldUseLegacyQuery(server, options)) {
+  if (maxWireVersion(server) < 4) {
     const query = prepareLegacyFindQuery(server, ns, cmd, options);
     const queryOptions = applyCommonQueryOptions(
       {},
@@ -67,13 +67,6 @@ export function query(
   );
 
   command(server, ns, findCmd, commandOptions, callback);
-}
-
-// Typically, a legacy find query is used for wire versions prior to 4. However, for explain with
-// find on wire versions between 3 and 4, we can't use a legacy find command.
-function shouldUseLegacyQuery(server: Server, options: FindOptions): boolean {
-  const wireVersion = maxWireVersion(server);
-  return wireVersion <= 3 || (wireVersion < 4 && options.explain === undefined);
 }
 
 function prepareFindCommand(server: Server, ns: string, cmd: Document) {

--- a/src/cmap/wire_protocol/query.ts
+++ b/src/cmap/wire_protocol/query.ts
@@ -1,12 +1,13 @@
 import { command, CommandOptions } from './command';
 import { Query } from '../commands';
 import { MongoError } from '../../error';
-import { maxWireVersion, collectionNamespace, Callback } from '../../utils';
+import { maxWireVersion, collectionNamespace, Callback, decorateWithExplain } from '../../utils';
 import { getReadPreference, isSharded, applyCommonQueryOptions } from './shared';
 import { Document, pluckBSONSerializeOptions } from '../../bson';
 import type { Server } from '../../sdam/server';
 import type { ReadPreferenceLike } from '../../read_preference';
 import type { FindOptions } from '../../operations/find';
+import { Explain } from '../../explain';
 
 /** @internal */
 export interface QueryOptions extends CommandOptions {
@@ -26,7 +27,7 @@ export function query(
     return callback(new MongoError(`command ${JSON.stringify(cmd)} does not return a cursor`));
   }
 
-  if (maxWireVersion(server) < 4) {
+  if (shouldUseLegacyQuery(server, options)) {
     const query = prepareLegacyFindQuery(server, ns, cmd, options);
     const queryOptions = applyCommonQueryOptions(
       {},
@@ -43,7 +44,14 @@ export function query(
   }
 
   const readPreference = getReadPreference(cmd, options);
-  const findCmd = prepareFindCommand(server, ns, cmd);
+  let findCmd = prepareFindCommand(server, ns, cmd);
+
+  // If we have explain, we need to rewrite the find command
+  // to wrap it in the explain command
+  const explain = Explain.fromOptions(options);
+  if (explain) {
+    findCmd = decorateWithExplain(findCmd, explain);
+  }
 
   // NOTE: This actually modifies the passed in cmd, and our code _depends_ on this
   //       side-effect. Change this ASAP
@@ -61,8 +69,15 @@ export function query(
   command(server, ns, findCmd, commandOptions, callback);
 }
 
+// Typically, a legacy find query is used for wire versions prior to 4. However, for explain with
+// find on wire versions between 3 and 4, we can't use a legacy find command.
+function shouldUseLegacyQuery(server: Server, options: FindOptions): boolean {
+  const wireVersion = maxWireVersion(server);
+  return wireVersion <= 3 || (wireVersion < 4 && options.explain === undefined);
+}
+
 function prepareFindCommand(server: Server, ns: string, cmd: Document) {
-  let findCmd: Document = {
+  const findCmd: Document = {
     find: collectionNamespace(ns)
   };
 
@@ -146,14 +161,6 @@ function prepareFindCommand(server: Server, ns: string, cmd: Document) {
   if (cmd.collation) findCmd.collation = cmd.collation;
   if (cmd.readConcern) findCmd.readConcern = cmd.readConcern;
 
-  // If we have explain, we need to rewrite the find command
-  // to wrap it in the explain command
-  if (cmd.explain) {
-    findCmd = {
-      explain: findCmd
-    };
-  }
-
   return findCmd;
 }
 
@@ -195,7 +202,7 @@ function prepareLegacyFindQuery(
   if (typeof cmd.showDiskLoc !== 'undefined') findCmd['$showDiskLoc'] = cmd.showDiskLoc;
   if (cmd.comment) findCmd['$comment'] = cmd.comment;
   if (cmd.maxTimeMS) findCmd['$maxTimeMS'] = cmd.maxTimeMS;
-  if (cmd.explain) {
+  if (options.explain !== undefined) {
     // nToReturn must be 0 (match all) or negative (match N and close cursor)
     // nToReturn > 0 will give explain results equivalent to limit(0)
     numberToReturn = -Math.abs(cmd.limit || 0);

--- a/src/explain.ts
+++ b/src/explain.ts
@@ -9,8 +9,9 @@ export const ExplainVerbosity = {
 } as const;
 
 /**
- * For backwards compatibility, true is interpreted as
- * "allPlansExecution" and false as "queryPlanner".
+ * For backwards compatibility, true is interpreted as "allPlansExecution"
+ * and false as "queryPlanner". Prior to server version 3.6, aggregate()
+ * ignores the verbosity parameter and executes in "queryPlanner".
  * @public
  */
 export type ExplainVerbosityLike = keyof typeof ExplainVerbosity | boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,7 @@ export type {
 export type { DbPrivate, DbOptions } from './db';
 export type { AutoEncryptionOptions, AutoEncryptionLoggerLevels, AutoEncrypter } from './deps';
 export type { AnyError, ErrorDescription } from './error';
-export type { ExplainOptions, ExplainVerbosity, ExplainVerbosityLike } from './explain';
+export type { Explain, ExplainOptions, ExplainVerbosity, ExplainVerbosityLike } from './explain';
 export type {
   GridFSBucketReadStream,
   GridFSBucketReadStreamOptions,

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -65,10 +65,8 @@ export class AggregateOperation<T = Document> extends CommandOperation<Aggregate
       this.readPreference = ReadPreference.primary;
     }
 
-    if (options?.explain && (this.readConcern || this.writeConcern)) {
-      throw new MongoError(
-        '"explain" cannot be used on an aggregate call with readConcern/writeConcern'
-      );
+    if (options?.explain && this.writeConcern) {
+      throw new MongoError('"explain" cannot be used on an aggregate call with writeConcern');
     }
 
     if (options?.cursor != null && typeof options.cursor !== 'object') {
@@ -111,10 +109,6 @@ export class AggregateOperation<T = Document> extends CommandOperation<Aggregate
       command.hint = options.hint;
     }
 
-    if (options.explain) {
-      command.explain = options.explain;
-    }
-
     command.cursor = options.cursor || {};
     if (options.batchSize && !this.hasWriteStage) {
       command.cursor.batchSize = options.batchSize;
@@ -124,4 +118,4 @@ export class AggregateOperation<T = Document> extends CommandOperation<Aggregate
   }
 }
 
-defineAspects(AggregateOperation, [Aspect.READ_OPERATION, Aspect.RETRYABLE]);
+defineAspects(AggregateOperation, [Aspect.READ_OPERATION, Aspect.RETRYABLE, Aspect.EXPLAINABLE]);

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -65,7 +65,7 @@ export class AggregateOperation<T = Document> extends CommandOperation<Aggregate
       this.readPreference = ReadPreference.primary;
     }
 
-    if (options?.explain && this.writeConcern) {
+    if (this.explain && this.writeConcern) {
       throw new MongoError('"explain" cannot be used on an aggregate call with writeConcern');
     }
 

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -145,7 +145,12 @@ export abstract class CommandOperation<
     }
 
     if (this.hasAspect(Aspect.EXPLAINABLE) && this.explain) {
-      cmd = decorateWithExplain(cmd, this.explain);
+      if (serverWireVersion < 6 && cmd.aggregate) {
+        // Prior to 3.6, with aggregate, verbosity is ignored, and we must pass in "explain: true"
+        cmd.explain = true;
+      } else {
+        cmd = decorateWithExplain(cmd, this.explain);
+      }
     }
 
     server.command(

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -212,6 +212,11 @@ export class FindOperation extends CommandOperation<FindOptions, Document> {
       findCommand.allowDiskUse = options.allowDiskUse;
     }
 
+    if (this.explain) {
+      // TODO: For now, we need to manually ensure explain is in the options. This will change after cursor refactor.
+      this.options.explain = this.explain.verbosity;
+    }
+
     // TODO: use `MongoDBNamespace` through and through
     server.query(
       this.ns.toString(),
@@ -222,4 +227,4 @@ export class FindOperation extends CommandOperation<FindOptions, Document> {
   }
 }
 
-defineAspects(FindOperation, [Aspect.READ_OPERATION, Aspect.RETRYABLE]);
+defineAspects(FindOperation, [Aspect.READ_OPERATION, Aspect.RETRYABLE, Aspect.EXPLAINABLE]);

--- a/src/operations/find_one.ts
+++ b/src/operations/find_one.ts
@@ -5,6 +5,7 @@ import type { FindOptions } from './find';
 import { MongoError } from '../error';
 import type { Server } from '../sdam/server';
 import { CommandOperation } from './command';
+import { Aspect, defineAspects } from './operation';
 
 /** @internal */
 export class FindOneOperation extends CommandOperation<FindOptions, Document> {
@@ -36,3 +37,5 @@ export class FindOneOperation extends CommandOperation<FindOptions, Document> {
     }
   }
 }
+
+defineAspects(FindOneOperation, [Aspect.EXPLAINABLE]);

--- a/test/functional/aggregation.test.js
+++ b/test/functional/aggregation.test.js
@@ -386,12 +386,7 @@ describe('Aggregation', function () {
    * @example-class Collection
    * @example-method aggregate
    */
-  it.skip('should correctly return a cursor and call explain', {
-    // TODO NODE-2853: This had to be skipped during NODE-2852; un-skip while re-implementing
-    // cursor explain
-
-    // Add a tag that our runner can trigger on
-    // in this case we are setting that node needs to be higher than 0.10.X to run
+  it('should correctly return a cursor and call explain', {
     metadata: {
       requires: {
         mongodb: '>2.5.3',
@@ -461,7 +456,7 @@ describe('Aggregation', function () {
           cursor.explain(function (err, result) {
             expect(err).to.not.exist;
             expect(result.stages).to.have.lengthOf.at.least(1);
-            expect(result.stages[0]).to.have.key('$cursor');
+            expect(result.stages[0]).to.have.property('$cursor');
 
             client.close(done);
           });
@@ -928,7 +923,7 @@ describe('Aggregation', function () {
     }
   });
 
-  it('should fail if you try to use explain flag with readConcern/writeConcern', {
+  it('should fail if you try to use explain flag with writeConcern', {
     metadata: {
       requires: {
         mongodb: '>3.6.0',
@@ -938,12 +933,9 @@ describe('Aggregation', function () {
 
     test: function (done) {
       var databaseName = this.configuration.db;
-      var client = this.configuration.newClient(this.configuration.writeConcernMax(), {
-        poolSize: 1
-      });
+      var client = this.configuration.newClient({ poolSize: 1 });
 
       const testCases = [
-        { readConcern: { level: 'local' } },
         { writeConcern: { j: true } },
         { readConcern: { level: 'local' }, writeConcern: { j: true } }
       ];

--- a/test/functional/explain.test.js
+++ b/test/functional/explain.test.js
@@ -458,4 +458,307 @@ describe('Explain', function () {
       });
     })
   });
+
+  it('should honor boolean explain with find', {
+    metadata: {
+      requires: {
+        mongodb: '>=3.0'
+      }
+    },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldHonorBooleanExplainWithFind');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection.find({ a: 1 }, { explain: true }).toArray((err, docs) => {
+          expect(err).to.not.exist;
+          const explanation = docs[0];
+          expect(explanation).to.exist;
+          expect(explanation).property('queryPlanner').to.exist;
+          done();
+        });
+      });
+    })
+  });
+
+  it('should honor string explain with find', {
+    metadata: {
+      requires: {
+        mongodb: '>=3.0'
+      }
+    },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldHonorStringExplainWithFind');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection.find({ a: 1 }, { explain: 'executionStats' }).toArray((err, docs) => {
+          expect(err).to.not.exist;
+          const explanation = docs[0];
+          expect(explanation).to.exist;
+          expect(explanation).property('queryPlanner').to.exist;
+          expect(explanation).property('executionStats').to.exist;
+          done();
+        });
+      });
+    })
+  });
+
+  it('should honor boolean explain with findOne', {
+    metadata: {
+      requires: {
+        mongodb: '>=3.0'
+      }
+    },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldHonorBooleanExplainWithFindOne');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection.findOne({ a: 1 }, { explain: true }, (err, explanation) => {
+          expect(err).to.not.exist;
+          expect(explanation).to.exist;
+          expect(explanation).property('queryPlanner').to.exist;
+          done();
+        });
+      });
+    })
+  });
+
+  it('should honor string explain with findOne', {
+    metadata: {
+      requires: {
+        mongodb: '>=3.0'
+      }
+    },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldHonorStringExplainWithFindOne');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection.findOne({ a: 1 }, { explain: 'executionStats' }, (err, explanation) => {
+          expect(err).to.not.exist;
+          expect(explanation).to.exist;
+          expect(explanation).property('queryPlanner').to.exist;
+          expect(explanation).property('executionStats').to.exist;
+          done();
+        });
+      });
+    })
+  });
+
+  it('should honor boolean explain specified on cursor with find', {
+    metadata: {
+      requires: {
+        mongodb: '>=3.0'
+      }
+    },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldHonorBooleanExplainSpecifiedOnCursor');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection.find({ a: 1 }).explain(false, (err, explanation) => {
+          expect(err).to.not.exist;
+          expect(explanation).to.exist;
+          expect(explanation).property('queryPlanner').to.exist;
+          done();
+        });
+      });
+    })
+  });
+
+  it('should honor string explain specified on cursor with find', {
+    metadata: {
+      requires: {
+        mongodb: '>=3.0'
+      }
+    },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldHonorStringExplainSpecifiedOnCursor');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection.find({ a: 1 }).explain('allPlansExecution', (err, explanation) => {
+          expect(err).to.not.exist;
+          expect(explanation).to.exist;
+          expect(explanation).property('queryPlanner').to.exist;
+          expect(explanation).property('executionStats').to.exist;
+          done();
+        });
+      });
+    })
+  });
+
+  it('should honor legacy explain with find', {
+    metadata: {
+      requires: {
+        mongodb: '<3.0'
+      }
+    },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldHonorLegacyExplainWithFind');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection.find({ a: 1 }).explain((err, result) => {
+          expect(err).to.not.exist;
+          expect(result).to.have.property('allPlans');
+          done();
+        });
+      });
+    })
+  });
+
+  it(
+    'should honor boolean explain with aggregate',
+    withClient(function (client, done) {
+      const db = client.db('shouldHonorBooleanExplainWithAggregate');
+      const collection = db.collection('test');
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection
+          .aggregate([{ $project: { a: 1 } }, { $group: { _id: '$a' } }], { explain: true })
+          .toArray((err, docs) => {
+            expect(err).to.not.exist;
+            const result = docs[0];
+            expect(result).to.have.property('stages');
+            expect(result.stages).to.have.lengthOf.at.least(1);
+            expect(result.stages[0]).to.have.property('$cursor');
+            done();
+          });
+      });
+    })
+  );
+
+  it('should honor string explain with aggregate', {
+    metadata: {
+      requires: {
+        mongodb: '>=3.6.0'
+      }
+    },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldHonorStringExplainWithAggregate');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection
+          .aggregate([{ $project: { a: 1 } }, { $group: { _id: '$a' } }], {
+            explain: 'executionStats'
+          })
+          .toArray((err, docs) => {
+            expect(err).to.not.exist;
+            const result = docs[0];
+            expect(result).to.have.property('stages');
+            expect(result.stages).to.have.lengthOf.at.least(1);
+            expect(result.stages[0]).to.have.property('$cursor');
+            expect(result.stages[0].$cursor).to.have.property('queryPlanner');
+            expect(result.stages[0].$cursor).to.have.property('executionStats');
+            done();
+          });
+      });
+    })
+  });
+
+  it(
+    'should honor boolean explain specified on cursor with aggregate',
+    withClient(function (client, done) {
+      const db = client.db('shouldHonorBooleanExplainSpecifiedOnCursor');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection
+          .aggregate([{ $project: { a: 1 } }, { $group: { _id: '$a' } }])
+          .explain(false, (err, result) => {
+            expect(err).to.not.exist;
+            expect(result).to.have.property('stages');
+            expect(result.stages).to.have.lengthOf.at.least(1);
+            expect(result.stages[0]).to.have.property('$cursor');
+            done();
+          });
+      });
+    })
+  );
+
+  it('should honor string explain specified on cursor with aggregate', {
+    metadata: {
+      requires: {
+        mongodb: '>=3.6'
+      }
+    },
+    test: withClient(function (client, done) {
+      const db = client.db('shouldHonorStringExplainSpecifiedOnCursor');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection
+          .aggregate([{ $project: { a: 1 } }, { $group: { _id: '$a' } }])
+          .explain('allPlansExecution', (err, result) => {
+            expect(err).to.not.exist;
+            expect(result).to.exist;
+            expect(result).to.have.property('stages');
+            expect(result.stages).to.have.lengthOf.at.least(1);
+            expect(result.stages[0]).to.have.property('$cursor');
+            expect(result.stages[0].$cursor).to.have.property('queryPlanner');
+            expect(result.stages[0].$cursor).to.have.property('executionStats');
+            done();
+          });
+      });
+    })
+  });
+
+  it(
+    'should honor legacy explain with aggregate',
+    withClient(function (client, done) {
+      const db = client.db('shouldHonorLegacyExplainWithAggregate');
+      const collection = db.collection('test');
+
+      collection.insertOne({ a: 1 }, (err, res) => {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+
+        collection
+          .aggregate([{ $project: { a: 1 } }, { $group: { _id: '$a' } }])
+          .explain((err, result) => {
+            expect(err).to.not.exist;
+            expect(result).to.have.property('stages');
+            expect(result.stages).to.have.lengthOf.at.least(1);
+            expect(result.stages[0]).to.have.property('$cursor');
+            done();
+          });
+      });
+    })
+  );
 });


### PR DESCRIPTION
This PR implements explain functionality for `findOne`, `find`, and `aggregate`. 

These operations can be explained via the `explain` option introduced in #2599 or with the `explain` method on cursors, which now takes an optional `verbosity` parameter (defaults to `true` for backwards compatibility).
