### PR TITLE
feat: Deprecate top-level write concern option keys 

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -166,10 +166,10 @@ Admin.prototype.ping = function(options, callback) {
  * @param {string} username The username.
  * @param {string} password The password.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
+ * @param {boolean} [options.fsync=false] **Deprecated** Specify a file sync write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {object} [options.customData] Custom data associated with the user (only Mongodb 2.6 or higher)
  * @param {object[]} [options.roles] Roles associated with the created user (only Mongodb 2.6 or higher)
@@ -204,10 +204,10 @@ Admin.prototype.addUser = function(username, password, options, callback) {
  * @method
  * @param {string} username The username.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
+ * @param {boolean} [options.fsync=false] **Deprecated** Specify a file sync write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Admin~resultCallback} [callback] The command result callback

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -166,10 +166,11 @@ Admin.prototype.ping = function(options, callback) {
  * @param {string} username The username.
  * @param {string} password The password.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {boolean} [options.fsync=false] Specify a file sync write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {object} [options.customData] Custom data associated with the user (only Mongodb 2.6 or higher)
  * @param {object[]} [options.roles] Roles associated with the created user (only Mongodb 2.6 or higher)
  * @param {ClientSession} [options.session] optional session to use for this operation
@@ -203,10 +204,11 @@ Admin.prototype.addUser = function(username, password, options, callback) {
  * @method
  * @param {string} username The username.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {boolean} [options.fsync=false] Specify a file sync write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Admin~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -1125,10 +1125,10 @@ class BulkOperationBase {
    * @method
    * @param {WriteConcern} [_writeConcern] Optional write concern. Can also be specified through options.
    * @param {object} [options] Optional settings.
-   * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
-   * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
-   * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
-   * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+   * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+   * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+   * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
+   * @param {boolean} [options.fsync=false] **Deprecated** Specify a file sync write concern. Use writeConcern instead.
    * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
    * @param {BulkOperationBase~resultCallback} [callback] A callback that will be invoked when bulkWrite finishes/errors
    * @throws {MongoError} Throws error if the bulk object has already been executed

--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -1125,10 +1125,11 @@ class BulkOperationBase {
    * @method
    * @param {WriteConcern} [_writeConcern] Optional write concern. Can also be specified through options.
    * @param {object} [options] Optional settings.
-   * @param {(number|string)} [options.w] The write concern.
-   * @param {number} [options.wtimeout] The write concern timeout.
-   * @param {boolean} [options.j=false] Specify a journal write concern.
-   * @param {boolean} [options.fsync=false] Specify a file sync write concern.
+   * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+   * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+   * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+   * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+   * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
    * @param {BulkOperationBase~resultCallback} [callback] A callback that will be invoked when bulkWrite finishes/errors
    * @throws {MongoError} Throws error if the bulk object has already been executed
    * @throws {MongoError} Throws error if the bulk object does not have any operations

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -492,9 +492,10 @@ Collection.prototype.find = deprecateOptions(
  * @param {object} [options] Optional settings.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=true] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -528,9 +529,10 @@ Collection.prototype.insertOne = function(doc, options, callback) {
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {boolean} [options.ordered=true] If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=true] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -595,9 +597,10 @@ Collection.prototype.insertMany = function(docs, options, callback) {
  * @param {boolean} [options.ordered=true] Execute write operation in ordered or unordered fashion.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {object[]} [options.arrayFilters] Determines which array elements to modify for update operation in MongoDB 3.6 or higher.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -676,9 +679,10 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
  * @method
  * @param {(object|object[])} docs Documents to insert.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
@@ -733,9 +737,10 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {boolean} [options.upsert=false] When true, creates a new document if no document matches the query..
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -770,9 +775,10 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {boolean} [options.upsert=false] When true, creates a new document if no document matches the query.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -808,9 +814,10 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {boolean} [options.upsert=false] When true, creates a new document if no document matches the query..
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -841,9 +848,10 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
  * @param {object} selector The selector for the update operation.
  * @param {object} update The update operations to be applied to the documents
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.upsert=false] Update operation is an upsert.
  * @param {boolean} [options.multi=false] Update one/all documents with operation.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
@@ -897,9 +905,10 @@ Collection.prototype.update = deprecate(function(selector, update, options, call
  * @param {object} filter The Filter used to select the document to remove
  * @param {object} [options] Optional settings.
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -931,9 +940,10 @@ Collection.prototype.removeOne = Collection.prototype.deleteOne;
  * @param {object} filter The Filter used to select the documents to remove
  * @param {object} [options] Optional settings.
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -965,9 +975,10 @@ Collection.prototype.removeMany = Collection.prototype.deleteMany;
  * @param {object} selector The selector for the update operation.
  * @param {object} [options] Optional settings.
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.single=false] Removes the first document found.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~writeOpCallback} [callback] The command result callback
@@ -998,9 +1009,10 @@ Collection.prototype.remove = deprecate(function(selector, options, callback) {
  * @method
  * @param {object} doc Document to save
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~writeOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -1122,10 +1134,10 @@ Collection.prototype.rename = function(newName, options, callback) {
  *
  * @method
  * @param {object} [options] Optional settings.
- * @param {WriteConcern} [options.writeConcern] A full WriteConcern object
- * @param {(number|string)} [options.w] The write concern
- * @param {number} [options.wtimeout] The write concern timeout
- * @param {boolean} [options.j] The journal write concern
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
@@ -1184,9 +1196,10 @@ Collection.prototype.isCapped = function(options, callback) {
  * @method
  * @param {(string|array|object)} fieldOrSpec Defines the index.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.unique=false] Creates an unique index.
  * @param {boolean} [options.sparse=false] Creates a sparse index.
  * @param {boolean} [options.background=false] Creates the index in the background, yielding whenever possible.
@@ -1297,9 +1310,10 @@ Collection.prototype.createIndexes = function(indexSpecs, options, callback) {
  * @method
  * @param {string} indexName Name of the index to drop.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {number} [options.maxTimeMS] Number of milliseconds to wait before aborting the query.
  * @param {Collection~resultCallback} [callback] The command result callback
@@ -1395,9 +1409,10 @@ Collection.prototype.listIndexes = function(options) {
  * @deprecated use createIndexes instead
  * @param {(string|object)} fieldOrSpec Defines the index.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.unique=false] Creates an unique index.
  * @param {boolean} [options.sparse=false] Creates a sparse index.
  * @param {boolean} [options.background=false] Creates the index in the background, yielding whenever possible.
@@ -1748,9 +1763,10 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
  * @param {array} sort If multiple docs match, choose the first one in the specified sort order as the object to manipulate.
  * @param {object} doc The fields/vals to be updated.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.remove=false] Set to true to remove the object before returning.
  * @param {boolean} [options.upsert=false] Perform an upsert operation.
  * @param {boolean} [options.new=false] Set to true if you want to return the modified object rather than the original. Ignored for remove.
@@ -1798,9 +1814,10 @@ function _findAndModify(query, sort, doc, options, callback) {
  * @param {object} query Query object to locate the object to modify.
  * @param {array} sort If multiple docs match, choose the first one in the specified sort order as the object to manipulate.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -2124,9 +2141,10 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
  *
  * @method
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {UnorderedBulkOperation}
@@ -2147,9 +2165,10 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
  *
  * @method
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {OrderedBulkOperation} callback The command result callback

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -492,9 +492,9 @@ Collection.prototype.find = deprecateOptions(
  * @param {object} [options] Optional settings.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=true] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
@@ -529,9 +529,9 @@ Collection.prototype.insertOne = function(doc, options, callback) {
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {boolean} [options.ordered=true] If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=true] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
@@ -597,9 +597,9 @@ Collection.prototype.insertMany = function(docs, options, callback) {
  * @param {boolean} [options.ordered=true] Execute write operation in ordered or unordered fashion.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
  * @param {object[]} [options.arrayFilters] Determines which array elements to modify for update operation in MongoDB 3.6 or higher.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
@@ -679,9 +679,9 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
  * @method
  * @param {(object|object[])} docs Documents to insert.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
@@ -737,9 +737,9 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {boolean} [options.upsert=false] When true, creates a new document if no document matches the query..
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
@@ -775,9 +775,9 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {boolean} [options.upsert=false] When true, creates a new document if no document matches the query.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
@@ -814,9 +814,9 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
  * @param {object} [options.hint] An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.
  * @param {boolean} [options.upsert=false] When true, creates a new document if no document matches the query..
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
@@ -848,9 +848,9 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
  * @param {object} selector The selector for the update operation.
  * @param {object} update The update operations to be applied to the documents
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.upsert=false] Update operation is an upsert.
  * @param {boolean} [options.multi=false] Update one/all documents with operation.
@@ -905,9 +905,9 @@ Collection.prototype.update = deprecate(function(selector, update, options, call
  * @param {object} filter The Filter used to select the document to remove
  * @param {object} [options] Optional settings.
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
@@ -940,9 +940,9 @@ Collection.prototype.removeOne = Collection.prototype.deleteOne;
  * @param {object} filter The Filter used to select the documents to remove
  * @param {object} [options] Optional settings.
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
@@ -975,9 +975,9 @@ Collection.prototype.removeMany = Collection.prototype.deleteMany;
  * @param {object} selector The selector for the update operation.
  * @param {object} [options] Optional settings.
  * @param {object} [options.collation] Specify collation (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.single=false] Removes the first document found.
  * @param {ClientSession} [options.session] optional session to use for this operation
@@ -1009,9 +1009,9 @@ Collection.prototype.remove = deprecate(function(selector, options, callback) {
  * @method
  * @param {object} doc Document to save
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~writeOpCallback} [callback] The command result callback
@@ -1134,9 +1134,9 @@ Collection.prototype.rename = function(newName, options, callback) {
  *
  * @method
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The results callback
@@ -1196,9 +1196,9 @@ Collection.prototype.isCapped = function(options, callback) {
  * @method
  * @param {(string|array|object)} fieldOrSpec Defines the index.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.unique=false] Creates an unique index.
  * @param {boolean} [options.sparse=false] Creates a sparse index.
@@ -1310,9 +1310,9 @@ Collection.prototype.createIndexes = function(indexSpecs, options, callback) {
  * @method
  * @param {string} indexName Name of the index to drop.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {number} [options.maxTimeMS] Number of milliseconds to wait before aborting the query.
@@ -1409,9 +1409,9 @@ Collection.prototype.listIndexes = function(options) {
  * @deprecated use createIndexes instead
  * @param {(string|object)} fieldOrSpec Defines the index.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.unique=false] Creates an unique index.
  * @param {boolean} [options.sparse=false] Creates a sparse index.
@@ -1763,9 +1763,9 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
  * @param {array} sort If multiple docs match, choose the first one in the specified sort order as the object to manipulate.
  * @param {object} doc The fields/vals to be updated.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.remove=false] Set to true to remove the object before returning.
  * @param {boolean} [options.upsert=false] Perform an upsert operation.
@@ -1814,9 +1814,9 @@ function _findAndModify(query, sort, doc, options, callback) {
  * @param {object} query Query object to locate the object to modify.
  * @param {array} sort If multiple docs match, choose the first one in the specified sort order as the object to manipulate.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The command result callback
@@ -2141,9 +2141,9 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
  *
  * @method
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
@@ -2165,9 +2165,9 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
  *
  * @method
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -495,7 +495,7 @@ Collection.prototype.find = deprecateOptions(
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=true] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -532,7 +532,7 @@ Collection.prototype.insertOne = function(doc, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=true] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -600,7 +600,7 @@ Collection.prototype.insertMany = function(docs, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -682,7 +682,7 @@ Collection.prototype.bulkWrite = function(operations, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
@@ -740,7 +740,7 @@ Collection.prototype.insert = deprecate(function(docs, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -778,7 +778,7 @@ Collection.prototype.updateOne = function(filter, update, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -817,7 +817,7 @@ Collection.prototype.replaceOne = function(filter, doc, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -851,7 +851,7 @@ Collection.prototype.updateMany = function(filter, update, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.upsert=false] Update operation is an upsert.
  * @param {boolean} [options.multi=false] Update one/all documents with operation.
  * @param {boolean} [options.bypassDocumentValidation=false] Allow driver to bypass schema validation in MongoDB 3.2 or higher.
@@ -908,7 +908,7 @@ Collection.prototype.update = deprecate(function(selector, update, options, call
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -943,7 +943,7 @@ Collection.prototype.removeOne = Collection.prototype.deleteOne;
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.checkKeys=false] If true, will throw if bson documents start with `$` or include a `.` in any key value
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -978,7 +978,7 @@ Collection.prototype.removeMany = Collection.prototype.deleteMany;
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.single=false] Removes the first document found.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~writeOpCallback} [callback] The command result callback
@@ -1012,7 +1012,7 @@ Collection.prototype.remove = deprecate(function(selector, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~writeOpCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -1199,7 +1199,7 @@ Collection.prototype.isCapped = function(options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.unique=false] Creates an unique index.
  * @param {boolean} [options.sparse=false] Creates a sparse index.
  * @param {boolean} [options.background=false] Creates the index in the background, yielding whenever possible.
@@ -1313,7 +1313,7 @@ Collection.prototype.createIndexes = function(indexSpecs, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {number} [options.maxTimeMS] Number of milliseconds to wait before aborting the query.
  * @param {Collection~resultCallback} [callback] The command result callback
@@ -1412,7 +1412,7 @@ Collection.prototype.listIndexes = function(options) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.unique=false] Creates an unique index.
  * @param {boolean} [options.sparse=false] Creates a sparse index.
  * @param {boolean} [options.background=false] Creates the index in the background, yielding whenever possible.
@@ -1766,7 +1766,7 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.remove=false] Set to true to remove the object before returning.
  * @param {boolean} [options.upsert=false] Perform an upsert operation.
  * @param {boolean} [options.new=false] Set to true if you want to return the modified object rather than the original. Ignored for remove.
@@ -1817,7 +1817,7 @@ function _findAndModify(query, sort, doc, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Collection~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed
@@ -2144,7 +2144,7 @@ Collection.prototype.mapReduce = function(map, reduce, options, callback) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @return {UnorderedBulkOperation}
@@ -2168,7 +2168,7 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
  * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
  * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
  * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {object} [options.writeConcern] Specify write concern settings.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {OrderedBulkOperation} callback The command result callback

--- a/lib/db.js
+++ b/lib/db.js
@@ -72,6 +72,7 @@ const legalOptionNames = [
   'wtimeout',
   'fsync',
   'j',
+  'writeConcern',
   'readPreference',
   'readPreferenceTags',
   'native_parser',

--- a/lib/db.js
+++ b/lib/db.js
@@ -106,9 +106,9 @@ const legalOptionNames = [
  * @param {(Server|ReplSet|Mongos)} topology The server topology for the database.
  * @param {object} [options] Optional settings.
  * @param {string} [options.authSource] If the database authentication is dependent on another databaseName.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
@@ -401,9 +401,9 @@ const collectionKeys = [
  * @method
  * @param {string} name the collection name we wish to access.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.raw=false] Return document results as raw BSON buffers.
  * @param {object} [options.pkFactory] A primary key factory object for generation of custom _id keys.
@@ -496,9 +496,9 @@ Db.prototype.collection = function(name, options, callback) {
  * @method
  * @param {string} name the collection name we wish to access.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.raw=false] Return document results as raw BSON buffers.
  * @param {object} [options.pkFactory] A primary key factory object for generation of custom _id keys.
@@ -655,9 +655,9 @@ Db.prototype.renameCollection = function(fromCollection, toCollection, options, 
  * @method
  * @param {string} name Name of collection to drop
  * @param {Object} [options] Optional settings
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Db~resultCallback} [callback] The results callback
@@ -738,9 +738,9 @@ Db.prototype.executeDbAdminCommand = function(selector, options, callback) {
  * @param {string} name Name of the collection to create the index on.
  * @param {(string|object)} fieldOrSpec Defines the index.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.unique=false] Creates an unique index.
  * @param {boolean} [options.sparse=false] Creates a sparse index.
@@ -773,9 +773,9 @@ Db.prototype.createIndex = function(name, fieldOrSpec, options, callback) {
  * @param {string} name The index name
  * @param {(string|object)} fieldOrSpec Defines the index.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.unique=false] Creates an unique index.
  * @param {boolean} [options.sparse=false] Creates a sparse index.
@@ -814,9 +814,9 @@ Db.prototype.addChild = function(db) {
  * @param {string} username The username.
  * @param {string} password The password.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {object} [options.customData] Custom data associated with the user (only Mongodb 2.6 or higher)
  * @param {object[]} [options.roles] Roles associated with the created user (only Mongodb 2.6 or higher)
@@ -844,9 +844,9 @@ Db.prototype.addUser = function(username, password, options, callback) {
  * @method
  * @param {string} username The username.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Db~resultCallback} [callback] The command result callback

--- a/lib/db.js
+++ b/lib/db.js
@@ -106,9 +106,10 @@ const legalOptionNames = [
  * @param {(Server|ReplSet|Mongos)} topology The server topology for the database.
  * @param {object} [options] Optional settings.
  * @param {string} [options.authSource] If the database authentication is dependent on another databaseName.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver.
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
@@ -400,9 +401,10 @@ const collectionKeys = [
  * @method
  * @param {string} name the collection name we wish to access.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.raw=false] Return document results as raw BSON buffers.
  * @param {object} [options.pkFactory] A primary key factory object for generation of custom _id keys.
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
@@ -494,9 +496,10 @@ Db.prototype.collection = function(name, options, callback) {
  * @method
  * @param {string} name the collection name we wish to access.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.raw=false] Return document results as raw BSON buffers.
  * @param {object} [options.pkFactory] A primary key factory object for generation of custom _id keys.
  * @param {(ReadPreference|string)} [options.readPreference] The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST).
@@ -522,7 +525,7 @@ Db.prototype.collection = function(name, options, callback) {
 Db.prototype.createCollection = deprecateOptions(
   {
     name: 'Db.createCollection',
-    deprecatedOptions: ['autoIndexId', 'strict'],
+    deprecatedOptions: ['autoIndexId', 'strict', 'w', 'wtimeout', 'j'],
     optionsIndex: 1
   },
   function(name, options, callback) {
@@ -652,10 +655,10 @@ Db.prototype.renameCollection = function(fromCollection, toCollection, options, 
  * @method
  * @param {string} name Name of collection to drop
  * @param {Object} [options] Optional settings
- * @param {WriteConcern} [options.writeConcern] A full WriteConcern object
- * @param {(number|string)} [options.w] The write concern
- * @param {number} [options.wtimeout] The write concern timeout
- * @param {boolean} [options.j] The journal write concern
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Db~resultCallback} [callback] The results callback
  * @return {Promise} returns Promise if no callback passed
@@ -735,9 +738,10 @@ Db.prototype.executeDbAdminCommand = function(selector, options, callback) {
  * @param {string} name Name of the collection to create the index on.
  * @param {(string|object)} fieldOrSpec Defines the index.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.unique=false] Creates an unique index.
  * @param {boolean} [options.sparse=false] Creates a sparse index.
  * @param {boolean} [options.background=false] Creates the index in the background, yielding whenever possible.
@@ -769,9 +773,10 @@ Db.prototype.createIndex = function(name, fieldOrSpec, options, callback) {
  * @param {string} name The index name
  * @param {(string|object)} fieldOrSpec Defines the index.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.unique=false] Creates an unique index.
  * @param {boolean} [options.sparse=false] Creates a sparse index.
  * @param {boolean} [options.background=false] Creates the index in the background, yielding whenever possible.
@@ -809,9 +814,10 @@ Db.prototype.addChild = function(db) {
  * @param {string} username The username.
  * @param {string} password The password.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {object} [options.customData] Custom data associated with the user (only Mongodb 2.6 or higher)
  * @param {object[]} [options.roles] Roles associated with the created user (only Mongodb 2.6 or higher)
  * @param {ClientSession} [options.session] optional session to use for this operation
@@ -838,9 +844,10 @@ Db.prototype.addUser = function(username, password, options, callback) {
  * @method
  * @param {string} username The username.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {Db~resultCallback} [callback] The command result callback
  * @return {Promise} returns Promise if no callback passed

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -22,9 +22,9 @@ module.exports = GridFSBucketWriteStream;
  * @param {object} [options] Optional settings.
  * @param {string|number|object} [options.id] Custom file id for the GridFS file.
  * @param {number} [options.chunkSizeBytes] The chunk size to use, in bytes
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.disableMD5=false] If true, disables adding an md5 field to file data
  * @fires GridFSBucketWriteStream#error

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -22,9 +22,10 @@ module.exports = GridFSBucketWriteStream;
  * @param {object} [options] Optional settings.
  * @param {string|number|object} [options.id] Custom file id for the GridFS file.
  * @param {number} [options.chunkSizeBytes] The chunk size to use, in bytes
- * @param {number} [options.w] The write concern
- * @param {number} [options.wtimeout] The write concern timeout
- * @param {number} [options.j] The journal write concern
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.disableMD5=false] If true, disables adding an md5 field to file data
  * @fires GridFSBucketWriteStream#error
  * @fires GridFSBucketWriteStream#finish

--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -73,10 +73,11 @@ const deprecationFn = deprecate(() => {},
  * @param {string} [filename] optional filename for this file, no unique constrain on the field
  * @param {string} mode set the mode for this file.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] The write concern.
- * @param {number} [options.wtimeout] The write concern timeout.
- * @param {boolean} [options.j=false] Specify a journal write concern.
- * @param {boolean} [options.fsync=false] Specify a file sync write concern.
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {string} [options.root] Root collection to use. Defaults to **{GridStore.DEFAULT_ROOT_COLLECTION}**.
  * @param {string} [options.content_type] MIME type of the file. Defaults to **{GridStore.DEFAULT_CONTENT_TYPE}**.
  * @param {number} [options.chunk_size=261120] Size for the chunk. Defaults to **{Chunk.DEFAULT_CHUNK_SIZE}**.
@@ -1572,12 +1573,13 @@ var _writeNormal = function(self, data, close, options, callback) {
  * @ignore
  */
 var _setWriteConcernHash = function(options) {
+  const baseOptions = Object.assign(options, options.writeConcern);
   var finalOptions = {};
-  if (options.w != null) finalOptions.w = options.w;
-  if (options.journal === true) finalOptions.j = options.journal;
-  if (options.j === true) finalOptions.j = options.j;
-  if (options.fsync === true) finalOptions.fsync = options.fsync;
-  if (options.wtimeout != null) finalOptions.wtimeout = options.wtimeout;
+  if (baseOptions.w != null) finalOptions.w = baseOptions.w;
+  if (baseOptions.journal === true) finalOptions.j = baseOptions.journal;
+  if (baseOptions.j === true) finalOptions.j = baseOptions.j;
+  if (baseOptions.fsync === true) finalOptions.fsync = baseOptions.fsync;
+  if (baseOptions.wtimeout != null) finalOptions.wtimeout = baseOptions.wtimeout;
   return finalOptions;
 };
 
@@ -1591,6 +1593,7 @@ var _getWriteConcern = function(self, options) {
 
   // Local options verification
   if (
+    options.writeConcern != null ||
     options.w != null ||
     typeof options.j === 'boolean' ||
     typeof options.journal === 'boolean' ||
@@ -1602,6 +1605,7 @@ var _getWriteConcern = function(self, options) {
   } else if (typeof options.safe === 'boolean') {
     finalOptions = { w: options.safe ? 1 : 0 };
   } else if (
+    self.options.writeConcern != null ||
     self.options.w != null ||
     typeof self.options.j === 'boolean' ||
     typeof self.options.journal === 'boolean' ||

--- a/lib/gridfs/grid_store.js
+++ b/lib/gridfs/grid_store.js
@@ -73,10 +73,10 @@ const deprecationFn = deprecate(() => {},
  * @param {string} [filename] optional filename for this file, no unique constrain on the field
  * @param {string} mode set the mode for this file.
  * @param {object} [options] Optional settings.
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
+ * @param {boolean} [options.fsync=false] **Deprecated** Specify a file sync write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {string} [options.root] Root collection to use. Defaults to **{GridStore.DEFAULT_ROOT_COLLECTION}**.
  * @param {string} [options.content_type] MIME type of the file. Defaults to **{GridStore.DEFAULT_CONTENT_TYPE}**.

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -109,10 +109,10 @@ const validOptions = require('./operations/connect').validOptions;
  * @param {number} [options.acceptableLatencyMS=15] Cutoff latency point in MS for Mongos proxies selection
  * @param {boolean} [options.connectWithNoPrimary=false] Sets if the driver should connect even if no primary is available
  * @param {string} [options.authSource=undefined] Define the database to authenticate against
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
+ * @param {boolean} [options.fsync=false] **Deprecated** Specify a file sync write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object
@@ -385,10 +385,10 @@ MongoClient.prototype.isConnected = function(options) {
  * @param {number} [options.acceptableLatencyMS=15] Cutoff latency point in MS for Mongos proxies selection
  * @param {boolean} [options.connectWithNoPrimary=false] Sets if the driver should connect even if no primary is available
  * @param {string} [options.authSource=undefined] Define the database to authenticate against
- * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
- * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
- * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
- * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+ * @param {(number|string)} [options.w] **Deprecated** The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] **Deprecated** The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] **Deprecated** Specify a journal write concern. Use writeConcern instead.
+ * @param {boolean} [options.fsync=false] **Deprecated** Specify a file sync write concern. Use writeConcern instead.
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -109,9 +109,11 @@ const validOptions = require('./operations/connect').validOptions;
  * @param {number} [options.acceptableLatencyMS=15] Cutoff latency point in MS for Mongos proxies selection
  * @param {boolean} [options.connectWithNoPrimary=false] Sets if the driver should connect even if no primary is available
  * @param {string} [options.authSource=undefined] Define the database to authenticate against
- * @param {(number|string)} [options.w] The write concern
- * @param {number} [options.wtimeout] The write concern timeout
- * @param {boolean} [options.j=false] Specify a journal write concern
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields
@@ -135,7 +137,6 @@ const validOptions = require('./operations/connect').validOptions;
  * @param {string} [options.auth.password=undefined] The password for auth
  * @param {string} [options.authMechanism] An authentication mechanism to use for connection authentication, see the {@link https://docs.mongodb.com/manual/reference/connection-string/#urioption.authMechanism|authMechanism} reference for supported options.
  * @param {object} [options.compression] Type of compression to use: snappy or zlib
- * @param {boolean} [options.fsync=false] Specify a file sync write concern
  * @param {array} [options.readPreferenceTags] Read preference tags
  * @param {number} [options.numberOfRetries=5] The number of retries for a tailable cursor
  * @param {boolean} [options.auto_reconnect=true] Enable auto reconnecting for single server instances
@@ -384,9 +385,11 @@ MongoClient.prototype.isConnected = function(options) {
  * @param {number} [options.acceptableLatencyMS=15] Cutoff latency point in MS for Mongos proxies selection
  * @param {boolean} [options.connectWithNoPrimary=false] Sets if the driver should connect even if no primary is available
  * @param {string} [options.authSource=undefined] Define the database to authenticate against
- * @param {(number|string)} [options.w] The write concern
- * @param {number} [options.wtimeout] The write concern timeout
- * @param {boolean} [options.j=false] Specify a journal write concern
+ * @param {(number|string)} [options.w] DEPRECATED: The write concern. Use writeConcern instead.
+ * @param {number} [options.wtimeout] DEPRECATED: The write concern timeout. Use writeConcern instead.
+ * @param {boolean} [options.j=false] DEPRECATED: Specify a journal write concern. Use writeConcern instead.
+ * @param {boolean} [options.fsync=false] DEPRECATED: Specify a file sync write concern. Use writeConcern instead.
+ * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {boolean} [options.forceServerObjectId=false] Force server to assign _id values instead of driver
  * @param {boolean} [options.serializeFunctions=false] Serialize functions on any object
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields
@@ -410,7 +413,6 @@ MongoClient.prototype.isConnected = function(options) {
  * @param {string} [options.auth.password=undefined] The password for auth
  * @param {string} [options.authMechanism] An authentication mechanism to use for connection authentication, see the {@link https://docs.mongodb.com/manual/reference/connection-string/#urioption.authMechanism|authMechanism} reference for supported options.
  * @param {object} [options.compression] Type of compression to use: snappy or zlib
- * @param {boolean} [options.fsync=false] Specify a file sync write concern
  * @param {array} [options.readPreferenceTags] Read preference tags
  * @param {number} [options.numberOfRetries=5] The number of retries for a tailable cursor
  * @param {boolean} [options.auto_reconnect=true] Enable auto reconnecting for single server instances

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -647,11 +647,7 @@ function createUnifiedOptions(finalOptions, options) {
   // This way, `fromOptions` will warn once if `options` is using deprecated write concern options
   const optionsWriteConcern = WriteConcern.fromOptions(options);
   if (optionsWriteConcern) {
-    finalOptions.writeConcern = Object.assign(
-      {},
-      finalOptions.writeConcern,
-      WriteConcern.fromOptions(options)
-    );
+    finalOptions.writeConcern = Object.assign({}, finalOptions.writeConcern, optionsWriteConcern);
   }
 
   return finalOptions;
@@ -779,11 +775,6 @@ function transformUrlOptions(_object) {
   if (object.wTimeoutMS) {
     object.wtimeout = object.wTimeoutMS;
     object.wTimeoutMS = undefined;
-  }
-
-  if (object.journal) {
-    object.j = object.journal;
-    object.journal = undefined;
   }
 
   if (_object.srvHost) {

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -14,6 +14,7 @@ const Server = require('../topologies/server');
 const ServerSessionPool = require('../core').Sessions.ServerSessionPool;
 const emitDeprecationWarning = require('../utils').emitDeprecationWarning;
 const fs = require('fs');
+const WriteConcern = require('../write_concern');
 const BSON = require('../core/connection/utils').retrieveBSON();
 const CMAP_EVENT_NAMES = require('../cmap/events').CMAP_EVENT_NAMES;
 
@@ -105,6 +106,7 @@ const validOptionNames = [
   'w',
   'wtimeout',
   'j',
+  'writeConcern',
   'forceServerObjectId',
   'serializeFunctions',
   'ignoreUndefined',
@@ -300,9 +302,9 @@ function connect(mongoClient, url, options, callback) {
       delete _finalOptions.db_options.auth;
     }
 
-    // `journal` should be translated to `j` for the driver
     if (_finalOptions.journal != null) {
-      _finalOptions.j = _finalOptions.journal;
+      if (_finalOptions.writeConcern == null) _finalOptions.writeConcern = {};
+      _finalOptions.writeConcern.j = _finalOptions.journal;
       _finalOptions.journal = undefined;
     }
 
@@ -616,9 +618,12 @@ function createUnifiedOptions(finalOptions, options) {
     'mongos_options'
   ];
   const noMerge = ['readconcern', 'compression', 'autoencryption'];
+  const skip = ['w', 'wtimeout', 'j', 'fsync', 'writeConcern'];
 
   for (const name in options) {
-    if (noMerge.indexOf(name.toLowerCase()) !== -1) {
+    if (skip.indexOf(name.toLowerCase()) !== -1) {
+      continue;
+    } else if (noMerge.indexOf(name.toLowerCase()) !== -1) {
       finalOptions[name] = options[name];
     } else if (childOptions.indexOf(name.toLowerCase()) !== -1) {
       finalOptions = mergeOptions(finalOptions, options[name], false);
@@ -634,6 +639,18 @@ function createUnifiedOptions(finalOptions, options) {
         finalOptions[name] = options[name];
       }
     }
+  }
+
+  // Handle write concern keys separately, since `options` may have the keys at the top level or
+  // under `options.writeConcern`. The final merged keys will be under `finalOptions.writeConcern`.
+  // `fromOptions` will warn if `options` is using deprecated write concern options
+  const optionsWriteConcern = WriteConcern.fromOptions(options);
+  if (optionsWriteConcern) {
+    finalOptions.writeConcern = Object.assign(
+      {},
+      finalOptions.writeConcern,
+      WriteConcern.fromOptions(options)
+    );
   }
 
   return finalOptions;
@@ -760,10 +777,27 @@ function transformUrlOptions(_object) {
 
   if (object.wTimeoutMS) {
     object.wtimeout = object.wTimeoutMS;
+    object.wTimeoutMS = undefined;
+  }
+
+  if (object.journal) {
+    object.j = object.journal;
+    object.journal = undefined;
   }
 
   if (_object.srvHost) {
     object.srvHost = _object.srvHost;
+  }
+
+  // Any write concern options from the URL will be top-level, so we manually
+  // move them options under `object.writeConcern`
+  const wcKeys = ['w', 'wtimeout', 'j', 'fsync'];
+  for (const key of wcKeys) {
+    if (object[key] !== undefined) {
+      if (object.writeConcern === undefined) object.writeConcern = {};
+      object.writeConcern[key] = object[key];
+      object[key] = undefined;
+    }
   }
 
   return object;

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -302,6 +302,7 @@ function connect(mongoClient, url, options, callback) {
       delete _finalOptions.db_options.auth;
     }
 
+    // `journal` should be translated to `j` for the driver
     if (_finalOptions.journal != null) {
       if (_finalOptions.writeConcern == null) _finalOptions.writeConcern = {};
       _finalOptions.writeConcern.j = _finalOptions.journal;
@@ -643,7 +644,7 @@ function createUnifiedOptions(finalOptions, options) {
 
   // Handle write concern keys separately, since `options` may have the keys at the top level or
   // under `options.writeConcern`. The final merged keys will be under `finalOptions.writeConcern`.
-  // `fromOptions` will warn if `options` is using deprecated write concern options
+  // This way, `fromOptions` will warn once if `options` is using deprecated write concern options
   const optionsWriteConcern = WriteConcern.fromOptions(options);
   if (optionsWriteConcern) {
     finalOptions.writeConcern = Object.assign(
@@ -790,7 +791,7 @@ function transformUrlOptions(_object) {
   }
 
   // Any write concern options from the URL will be top-level, so we manually
-  // move them options under `object.writeConcern`
+  // move them options under `object.writeConcern` to avoid warnings later
   const wcKeys = ['w', 'wtimeout', 'j', 'fsync'];
   for (const key of wcKeys) {
     if (object[key] !== undefined) {

--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -302,13 +302,6 @@ function connect(mongoClient, url, options, callback) {
       delete _finalOptions.db_options.auth;
     }
 
-    // `journal` should be translated to `j` for the driver
-    if (_finalOptions.journal != null) {
-      if (_finalOptions.writeConcern == null) _finalOptions.writeConcern = {};
-      _finalOptions.writeConcern.j = _finalOptions.journal;
-      _finalOptions.journal = undefined;
-    }
-
     // resolve tls options if needed
     resolveTLSOptions(_finalOptions);
 
@@ -619,7 +612,7 @@ function createUnifiedOptions(finalOptions, options) {
     'mongos_options'
   ];
   const noMerge = ['readconcern', 'compression', 'autoencryption'];
-  const skip = ['w', 'wtimeout', 'j', 'fsync', 'writeConcern'];
+  const skip = ['w', 'wtimeout', 'j', 'journal', 'fsync', 'writeConcern'];
 
   for (const name in options) {
     if (skip.indexOf(name.toLowerCase()) !== -1) {
@@ -783,7 +776,7 @@ function transformUrlOptions(_object) {
 
   // Any write concern options from the URL will be top-level, so we manually
   // move them options under `object.writeConcern` to avoid warnings later
-  const wcKeys = ['w', 'wtimeout', 'j', 'fsync'];
+  const wcKeys = ['w', 'wtimeout', 'j', 'journal', 'fsync'];
   for (const key of wcKeys) {
     if (object[key] !== undefined) {
       if (object.writeConcern === undefined) object.writeConcern = {};

--- a/lib/write_concern.js
+++ b/lib/write_concern.js
@@ -42,6 +42,7 @@ class WriteConcern {
    * @param {number} [options.wtimeout] **Deprecated** Use `options.writeConcern` instead
    * @param {boolean} [options.j] **Deprecated** Use `options.writeConcern` instead
    * @param {boolean} [options.fsync] **Deprecated** Use `options.writeConcern` instead
+   * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
    * @return {WriteConcern}
    */
   static fromOptions(options) {

--- a/lib/write_concern.js
+++ b/lib/write_concern.js
@@ -69,6 +69,9 @@ class WriteConcern {
       );
     }
 
+    console.warn(
+      `Top-level use of w, wtimeout, j, and fsync is deprecated. Use writeConcern instead.`
+    );
     return new WriteConcern(options.w, options.wtimeout, options.j, options.fsync);
   }
 }

--- a/lib/write_concern.js
+++ b/lib/write_concern.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const kWriteConcernKeys = new Set(['w', 'wtimeout', 'j', 'fsync']);
+const kWriteConcernKeys = new Set(['w', 'wtimeout', 'j', 'journal', 'fsync']);
 
 /**
  * The **WriteConcern** class is a class that represents a MongoDB WriteConcern.
@@ -52,6 +52,7 @@ class WriteConcern {
         options.w == null &&
         options.wtimeout == null &&
         options.j == null &&
+        options.journal == null &&
         options.fsync == null)
     ) {
       return;
@@ -69,7 +70,7 @@ class WriteConcern {
       return new WriteConcern(
         options.writeConcern.w,
         options.writeConcern.wtimeout,
-        options.writeConcern.j,
+        options.writeConcern.j || options.writeConcern.journal,
         options.writeConcern.fsync
       );
     }
@@ -77,7 +78,12 @@ class WriteConcern {
     console.warn(
       `Top-level use of w, wtimeout, j, and fsync is deprecated. Use writeConcern instead.`
     );
-    return new WriteConcern(options.w, options.wtimeout, options.j, options.fsync);
+    return new WriteConcern(
+      options.w,
+      options.wtimeout,
+      options.j || options.journal,
+      options.fsync
+    );
   }
 }
 

--- a/lib/write_concern.js
+++ b/lib/write_concern.js
@@ -37,7 +37,11 @@ class WriteConcern {
   /**
    * Construct a WriteConcern given an options object.
    *
-   * @param {object} options The options object from which to extract the write concern.
+   * @param {object} [options] The options object from which to extract the write concern.
+   * @param {(number|string)} [options.w] **Deprecated** Use `options.writeConcern` instead
+   * @param {number} [options.wtimeout] **Deprecated** Use `options.writeConcern` instead
+   * @param {boolean} [options.j] **Deprecated** Use `options.writeConcern` instead
+   * @param {boolean} [options.fsync] **Deprecated** Use `options.writeConcern` instead
    * @return {WriteConcern}
    */
   static fromOptions(options) {

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -760,7 +760,7 @@ describe('Bulk', function() {
           batch.insert({ b: 1 });
 
           // Execute the operations
-          batch.execute(self.configuration.writeConcernMax(), function(err, result) {
+          batch.execute(self.configuration.writeConcernMax().writeConcern, function(err, result) {
             expect(err).to.exist;
             expect(result).to.not.exist;
 
@@ -812,7 +812,7 @@ describe('Bulk', function() {
           batch.insert({ a: 1 });
 
           // Execute the operations
-          batch.execute(configuration.writeConcernMax(), (err, result) => {
+          batch.execute(configuration.writeConcernMax().writeConcern, (err, result) => {
             expect(err).to.exist;
             expect(result).to.not.exist;
 
@@ -872,7 +872,7 @@ describe('Bulk', function() {
             batch.insert({ b: 1 });
 
             // Execute the operations
-            batch.execute(self.configuration.writeConcernMax(), function(err, result) {
+            batch.execute(self.configuration.writeConcernMax().writeConcern, function(err, result) {
               expect(err).to.exist;
               expect(result).to.not.exist;
 
@@ -928,7 +928,7 @@ describe('Bulk', function() {
           .updateOne({ $set: { b: 2 } });
 
         // Execute the operations
-        batch.execute(self.configuration.writeConcernMax(), function(err, result) {
+        batch.execute(self.configuration.writeConcernMax().writeConcern, function(err, result) {
           // Check state of result
           test.equal(1, result.nUpserted);
           test.equal(0, result.nInserted);

--- a/test/functional/write_concern.test.js
+++ b/test/functional/write_concern.test.js
@@ -24,9 +24,8 @@ describe('Write Concern', function() {
   // TODO: once `read-write-concern/connection-string` spec tests are implemented these can likely be removed
   describe('test journal connection string option', function() {
     function journalOptionTest(client, events, done) {
-      expect(client).to.have.nested.property('s.options');
-      const clientOptions = client.s.options;
-      expect(clientOptions).to.containSubset({ writeConcern: { j: true } });
+      expect(client).to.have.nested.property('s.options.writeConcern');
+      expect(client.s.options.writeConcern).to.satisfy(wc => wc.j || wc.journal);
       client
         .db('test')
         .collection('test')

--- a/test/functional/write_concern.test.js
+++ b/test/functional/write_concern.test.js
@@ -26,7 +26,7 @@ describe('Write Concern', function() {
     function journalOptionTest(client, events, done) {
       expect(client).to.have.nested.property('s.options');
       const clientOptions = client.s.options;
-      expect(clientOptions).to.containSubset({ j: true });
+      expect(clientOptions).to.containSubset({ writeConcern: { j: true } });
       client
         .db('test')
         .collection('test')

--- a/test/tools/runner/config.js
+++ b/test/tools/runner/config.js
@@ -108,6 +108,12 @@ class NativeConfiguration {
       Object.assign(dbOptions, { replicaSet: this.options.replicaSet, auto_reconnect: false });
     }
 
+    // Flatten any options nested under `writeConcern` before we make the connection string
+    if (dbOptions.writeConcern) {
+      Object.assign(dbOptions, dbOptions.writeConcern);
+      delete dbOptions.writeConcern;
+    }
+
     const urlOptions = {
       protocol: 'mongodb',
       slashes: true,
@@ -224,10 +230,10 @@ class NativeConfiguration {
 
   writeConcernMax() {
     if (this.topologyType !== TopologyType.Single) {
-      return { w: 'majority', wtimeout: 30000 };
+      return { writeConcern: { w: 'majority', wtimeout: 30000 } };
     }
 
-    return { w: 1 };
+    return { writeConcern: { w: 1 } };
   }
 
   // Accessors and methods Client-Side Encryption


### PR DESCRIPTION
This PR is mostly documentation changes to indicate that keys `w`, `j`, `wtimeout` and `fsync` are deprecated. 

Code changes include:
- `WriteConcern.fromOptions` now warns when the options contain the top-level keys and _not_ the `writeConcern` key.
- During client creation, when creating options from a URL, the write concern options are moved under the `writeConcern` key, so that warnings are not logged later. Options passed directly to the client are also moved under the `writeConcern` key, but only after `WriteConcern.fromOptions` is called, ensuring at least one warning is logged.
- GridFS now includes `options.writeConcern`, if it exists, when getting the write concern. 

Tests now spit out a _ton_ of warns because the vast majority of tests which pass write concern options to client/operations use the top level keys.