### PR TITLE
fix: tests using lib prohibited

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -29,6 +29,9 @@
     "jsdoc/require-returns-type": "off",
     "jsdoc/valid-types": "off",
 
+    // Since we use ts-node we should always require the TS code
+    "no-restricted-modules": ["error", { "patterns": ["**/../lib/**"] }],
+
     "no-console": "off",
     "eqeqeq": ["error", "always", { "null": "ignore" }],
     "strict": ["error", "global"],

--- a/test/functional/sharding_connection.test.js
+++ b/test/functional/sharding_connection.test.js
@@ -1,9 +1,8 @@
 'use strict';
 
-const withClient = require('./shared').withClient;
-const setupDatabase = require('./shared').setupDatabase;
-const expect = require('chai').expect;
-const TopologyType = require('../../lib/sdam/common').TopologyType;
+const { withClient, setupDatabase } = require('./shared');
+const { expect } = require('chai');
+const { TopologyType } = require('../../src/sdam/common');
 
 describe('Sharding (Connection)', function () {
   before(function () {


### PR DESCRIPTION
One of our tests was using lib which stops the tests from running if you have a clean repo, this little fix changes the import and adds a linter rule to catch this for us going forward.
