### PR TITLE
docs: aggregation cursor wrong param for unwind

### DIFF
--- a/lib/aggregation_cursor.js
+++ b/lib/aggregation_cursor.js
@@ -202,7 +202,7 @@ class AggregationCursor extends Cursor {
   /**
    * Add a unwind stage to the aggregation pipeline
    * @method
-   * @param {number} field The unwind field name.
+   * @param {(string|object)} field The unwind field name or stage document.
    * @return {AggregationCursor}
    */
   unwind(field) {


### PR DESCRIPTION
## Description
Related Issue [NODE-2895](https://jira.mongodb.org/browse/NODE-2895)

**What changed?**
param change from number to string or object

**Are there any files to ignore?**


