### PR TITLE
chore: change pass to password in Auth interface #2921

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -43,7 +43,7 @@ export interface Auth {
   /** The username for auth */
   user?: string;
   /** The password for auth */
-  pass?: string;
+  password?: string;
 }
 
 /** @public */


### PR DESCRIPTION
Updated the Auth interface to include 'password' instead of 'pass'. I could not find any tests that depended on this, but let me know if anything else should be changed.
