### PR TITLE
feat: add `withReadConcern` builder to AbstractCursor

### DIFF
--- a/docs/reference/content/tutorials/crud.md
+++ b/docs/reference/content/tutorials/crud.md
@@ -699,7 +699,8 @@ collection.find({}).max(10)                                    // Set the cursor
 collection.find({}).maxTimeMS(1000)                            // Set the cursor maxTimeMS
 collection.find({}).min(100)                                   // Set the cursor min
 collection.find({}).returnKey(10)                              // Set the cursor returnKey
-collection.find({}).setReadPreference(ReadPreference.PRIMARY)  // Set the cursor readPreference
+collection.find({}).withReadPreference(ReadPreference.PRIMARY) // Set the cursor readPreference
+collection.find({}).withReadConcern('majority')                // Set the cursor readConcern
 collection.find({}).showRecordId(true)                         // Set the cursor showRecordId
 collection.find({}).sort([['a', 1]])                           // Sets the sort order of the cursor query
 collection.find({}).hint('a_1')                                // Set the cursor hint

--- a/src/gridfs-stream/download.ts
+++ b/src/gridfs-stream/download.ts
@@ -349,7 +349,7 @@ function init(stream: GridFSBucketReadStream): void {
     stream.s.cursor = stream.s.chunks.find(filter).sort({ n: 1 });
 
     if (stream.s.readPreference) {
-      stream.s.cursor.setReadPreference(stream.s.readPreference);
+      stream.s.cursor.withReadPreference(stream.s.readPreference);
     }
 
     stream.s.expectedEnd = Math.ceil(doc.length / doc.chunkSize);

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -173,8 +173,8 @@ export class FindOperation extends CommandOperation<FindOptions, Document> {
       findCommand.maxTimeMS = options.maxTimeMS;
     }
 
-    if (this.readConcern && (!this.session || !this.session.inTransaction())) {
-      findCommand.readConcern = this.readConcern;
+    if (this.readConcern) {
+      findCommand.readConcern = this.readConcern.toJSON();
     }
 
     if (options.max) {

--- a/src/read_concern.ts
+++ b/src/read_concern.ts
@@ -1,3 +1,5 @@
+import type { Document } from './bson';
+
 /** @public */
 export enum ReadConcernLevel {
   local = 'local',
@@ -77,5 +79,9 @@ export class ReadConcern {
 
   static get SNAPSHOT(): string {
     return ReadConcernLevel.snapshot;
+  }
+
+  toJSON(): Document {
+    return { level: this.level };
   }
 }

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -373,7 +373,7 @@ describe('APM', function () {
               .batchSize(2)
               .comment('some comment')
               .maxTimeMS(5000)
-              .setReadPreference(ReadPreference.PRIMARY)
+              .withReadPreference(ReadPreference.PRIMARY)
               .addCursorFlag('noCursorTimeout', true)
               .toArray();
           })
@@ -445,7 +445,7 @@ describe('APM', function () {
               .batchSize(2)
               .comment('some comment')
               .maxTimeMS(5000)
-              .setReadPreference(ReadPreference.PRIMARY)
+              .withReadPreference(ReadPreference.PRIMARY)
               .addCursorFlag('noCursorTimeout', true)
               .toArray();
           })

--- a/test/functional/buffering_proxy.test.js
+++ b/test/functional/buffering_proxy.test.js
@@ -217,7 +217,7 @@ describe.skip('Buffering Proxy', function () {
 
               db.collection('test')
                 .find({})
-                .setReadPreference(new ReadPreference(ReadPreference.SECONDARY))
+                .withReadPreference(new ReadPreference(ReadPreference.SECONDARY))
                 .toArray(function (err) {
                   expect(err).to.not.exist;
                   results.push('find');
@@ -439,7 +439,7 @@ describe.skip('Buffering Proxy', function () {
 
               db.collection('test')
                 .find({})
-                .setReadPreference(new ReadPreference(ReadPreference.SECONDARY))
+                .withReadPreference(new ReadPreference(ReadPreference.SECONDARY))
                 .toArray(function (err) {
                   expect(err).to.not.exist;
                   results.push('find');

--- a/test/functional/max_staleness.test.js
+++ b/test/functional/max_staleness.test.js
@@ -166,7 +166,7 @@ describe('Max Staleness', function () {
         // Get a db with a new readPreference
         db.collection('test')
           .find({})
-          .setReadPreference(readPreference)
+          .withReadPreference(readPreference)
           .toArray(function (err) {
             expect(err).to.not.exist;
             expect(test.checkCommand).to.eql({

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -478,7 +478,7 @@ describe('ReadPreference', function () {
       })
     });
 
-    it('should set hedge using [.setReadPreference & empty hedge] ', {
+    it('should set hedge using [.withReadPreference & empty hedge] ', {
       metadata: { requires: { mongodb: '>=3.6.0' } },
       test: withMonitoredClient(['find'], function (client, events, done) {
         const rp = new ReadPreference(ReadPreference.SECONDARY, null, { hedge: {} });
@@ -486,7 +486,7 @@ describe('ReadPreference', function () {
           .db(this.configuration.db)
           .collection('test')
           .find({})
-          .setReadPreference(rp)
+          .withReadPreference(rp)
           .toArray(err => {
             expect(err).to.not.exist;
             const expected = { mode: ReadPreference.SECONDARY, hedge: {} };
@@ -496,7 +496,7 @@ describe('ReadPreference', function () {
       })
     });
 
-    it('should set hedge using [.setReadPreference & enabled hedge] ', {
+    it('should set hedge using [.withReadPreference & enabled hedge] ', {
       metadata: { requires: { mongodb: '>=3.6.0' } },
       test: withMonitoredClient(['find'], function (client, events, done) {
         const rp = new ReadPreference(ReadPreference.SECONDARY, null, { hedge: { enabled: true } });
@@ -504,7 +504,7 @@ describe('ReadPreference', function () {
           .db(this.configuration.db)
           .collection('test')
           .find({})
-          .setReadPreference(rp)
+          .withReadPreference(rp)
           .toArray(err => {
             expect(err).to.not.exist;
             const expected = { mode: ReadPreference.SECONDARY, hedge: { enabled: true } };
@@ -514,7 +514,7 @@ describe('ReadPreference', function () {
       })
     });
 
-    it('should set hedge using [.setReadPreference & disabled hedge] ', {
+    it('should set hedge using [.withReadPreference & disabled hedge] ', {
       metadata: { requires: { mongodb: '>=3.6.0' } },
       test: withMonitoredClient(['find'], function (client, events, done) {
         const rp = new ReadPreference(ReadPreference.SECONDARY, null, {
@@ -524,7 +524,7 @@ describe('ReadPreference', function () {
           .db(this.configuration.db)
           .collection('test')
           .find({})
-          .setReadPreference(rp)
+          .withReadPreference(rp)
           .toArray(err => {
             expect(err).to.not.exist;
             const expected = { mode: ReadPreference.SECONDARY, hedge: { enabled: false } };
@@ -534,7 +534,7 @@ describe('ReadPreference', function () {
       })
     });
 
-    it('should set hedge using [.setReadPreference & undefined hedge] ', {
+    it('should set hedge using [.withReadPreference & undefined hedge] ', {
       metadata: { requires: { mongodb: '>=3.6.0' } },
       test: withMonitoredClient(['find'], function (client, events, done) {
         const rp = new ReadPreference(ReadPreference.SECONDARY, null);
@@ -542,7 +542,7 @@ describe('ReadPreference', function () {
           .db(this.configuration.db)
           .collection('test')
           .find({})
-          .setReadPreference(rp)
+          .withReadPreference(rp)
           .toArray(err => {
             expect(err).to.not.exist;
             const expected = { mode: ReadPreference.SECONDARY };


### PR DESCRIPTION
This patch adds a builder method to add a read concern to a cursor similar to the existing method to build with a ReadPreference. It also changes `setReadPreference` to `withReadPreference` so the two follow a common convention.

NODE-2806