### PR TITLE
chore: add shell flag to prepare script

### DIFF
--- a/etc/prepare.js
+++ b/etc/prepare.js
@@ -1,9 +1,10 @@
 #! /usr/bin/env node
 var cp = require('child_process');
 var fs = require('fs');
+var os = require('os');
 
 if (fs.existsSync('src')) {
-  cp.spawn('npm', ['run', 'build:dts'], { stdio: 'inherit' });
+  cp.spawn('npm', ['run', 'build:dts'], { stdio: 'inherit', shell: os.platform() === 'win32' });
 } else {
   if (!fs.existsSync('lib')) {
     console.warn('MongoDB: No compiled javascript present, the driver is not installed correctly.');


### PR DESCRIPTION
This should fix the script failing to run on windows.

I had added this flag in earlier work when we wanted a more complex prepare script but we abandoned that, however we should still keep this flag to fix windows use cases.