### PR TITLE
feat: reintroduce clone and rewind for cursors

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -425,6 +425,12 @@ export class ChangeStreamCursor extends AbstractCursor {
     }
   }
 
+  clone(): ChangeStreamCursor {
+    return new ChangeStreamCursor(this.topology, this.namespace, this.pipeline, {
+      ...this.cursorOptions
+    });
+  }
+
   _initialize(session: ClientSession, callback: Callback<ExecutionResult>): void {
     const aggregateOperation = new AggregateOperation(
       { s: { namespace: this.namespace } },

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -508,6 +508,11 @@ export abstract class AbstractCursor extends EventEmitter {
     }
   }
 
+  /**
+   * Returns a new uninitialized copy of this cursor, with options matching those that have been set on the current instance
+   */
+  abstract clone(): AbstractCursor;
+
   /* @internal */
   abstract _initialize(
     session: ClientSession | undefined,

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -48,6 +48,13 @@ export class AggregationCursor extends AbstractCursor {
     return this[kPipeline];
   }
 
+  clone(): AggregationCursor {
+    return new AggregationCursor(this[kParent], this.topology, this.namespace, this[kPipeline], {
+      ...this[kOptions],
+      ...this.cursorOptions
+    });
+  }
+
   /** @internal */
   _initialize(session: ClientSession | undefined, callback: Callback<ExecutionResult>): void {
     const aggregateOperation = new AggregateOperation(this[kParent], this[kPipeline], {

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -49,6 +49,13 @@ export class FindCursor extends AbstractCursor {
     }
   }
 
+  clone(): FindCursor {
+    return new FindCursor(this.topology, this.namespace, this[kFilter], {
+      ...this[kBuiltOptions],
+      ...this.cursorOptions
+    });
+  }
+
   /** @internal */
   _initialize(session: ClientSession | undefined, callback: Callback<ExecutionResult>): void {
     const findOperation = new FindOperation(undefined, this.namespace, this[kFilter], {

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -369,6 +369,13 @@ export class ListIndexesCursor extends AbstractCursor {
     this.options = options;
   }
 
+  clone(): ListIndexesCursor {
+    return new ListIndexesCursor(this.parent, {
+      ...this.options,
+      ...this.cursorOptions
+    });
+  }
+
   /** @internal */
   _initialize(session: ClientSession | undefined, callback: Callback<ExecutionResult>): void {
     const operation = new ListIndexesOperation(this.parent, {

--- a/src/operations/list_collections.ts
+++ b/src/operations/list_collections.ts
@@ -115,6 +115,13 @@ export class ListCollectionsCursor extends AbstractCursor {
     this.options = options;
   }
 
+  clone(): ListCollectionsCursor {
+    return new ListCollectionsCursor(this.parent, this.filter, {
+      ...this.options,
+      ...this.cursorOptions
+    });
+  }
+
   _initialize(session: ClientSession | undefined, callback: Callback<ExecutionResult>): void {
     const operation = new ListCollectionsOperation(this.parent, this.filter, {
       ...this.cursorOptions,

--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -4908,8 +4908,7 @@ describe('Operation Examples', function () {
    * @example-class Cursor
    * @example-method rewind
    */
-  // NOTE: unclear whether we should continue to support `rewind`
-  it.skip('Should correctly rewind and restart cursor', {
+  it('Should correctly rewind and restart cursor', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run
     metadata: {


### PR DESCRIPTION
## Description
These two commits add back support for cloning and rewinding cursors.

**What changed?**
The changes should be fairly straightforward, but I wanted to call out a few design decisions:
~- I had originally intended `clone` to be an abstract method on `AbstractCursor`, forcing us to implement it for all possible cursor subclasses. This would have unfortunately required us to make `AbstractCursor` generic over the subclass types, since the following signature results in type ambiguity at the point of implementation in the subclass: `abstract clone(): this`~

- Therefore, `clone` is implemented by hand in `AbstractCursor` subclasses. I only implemented it for `FindCursor` and `AggregateCursor` because it's likely that's where legacy users have actually used this feature.

- There is a correction in the `rewind` implementation regarding sessions. When a session is started as part of cursor initialization I had originally marked this as an `explicit: true` start, however, this is clearly an implicit session the driver is creating in the absence of an explicitly provided one. 

**Are there any files to ignore?**
none