### PR TITLE
fix: awaitable isMaster timeout must respect connectTimeoutMS

### DIFF
--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -217,7 +217,10 @@ function checkServer(monitor: Monitor, callback: Callback<Document>) {
         : { ismaster: true };
 
     const options = isAwaitable
-      ? { socketTimeout: connectTimeoutMS + maxAwaitTimeMS, exhaustAllowed: true }
+      ? {
+          socketTimeout: connectTimeoutMS ? connectTimeoutMS + maxAwaitTimeMS : 0,
+          exhaustAllowed: true
+        }
       : { socketTimeout: connectTimeoutMS };
 
     if (isAwaitable && monitor[kRTTPinger] == null) {


### PR DESCRIPTION
This PR ensures that awaitable isMaster handshakes respect an unlimited timeout (`connectionTimeoutMS=0`) as per the [SDAM specification section on socket timeouts](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-monitoring.rst#socket-timeout):

> Clients MUST use connectTimeoutMS as the timeout for the connection handshake. When connectTimeoutMS=0, the timeout is unlimited and MUST remain unlimited for awaitable isMaster replies. Otherwise, connectTimeoutMS is non-zero and clients MUST use connectTimeoutMS + heartbeatFrequencyMS as the timeout for awaitable isMaster replies.

NODE-2874

(port of #2627 for `4.0`)