### PR TITLE
refactor!: conform CRUD result types to specification

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -161,6 +161,8 @@ export class Batch {
 export class BulkWriteResult {
   result: BulkResult;
 
+  /** Indicates whether this write result was acknowledged. If not, then all other members of this result will be undefined */
+  // acknowledged: Boolean;
   /** Number of documents inserted. */
   insertedCount: number;
   /** Number of documents matched for update. */

--- a/src/gridfs-stream/index.ts
+++ b/src/gridfs-stream/index.ts
@@ -239,9 +239,11 @@ function _rename(
     if (error) {
       return callback(error);
     }
-    if (!res?.result.n) {
+
+    if (!res?.matchedCount) {
       return callback(new MongoError(`File with id ${id} not found`));
     }
+
     return callback();
   });
 }

--- a/src/operations/common_functions.ts
+++ b/src/operations/common_functions.ts
@@ -14,7 +14,6 @@ import type { ReadPreference } from '../read_preference';
 import type { Collection } from '../collection';
 import type { UpdateOptions } from './update';
 import type { WriteCommandOptions } from '../cmap/wire_protocol/write_command';
-import type { DeleteOptions } from './delete';
 
 /** @internal */
 export interface IndexInformationOptions {
@@ -102,89 +101,6 @@ export function prepareDocs(
 
     return doc;
   });
-}
-
-export function removeDocuments(server: Server, coll: Collection, callback?: Callback): void;
-export function removeDocuments(
-  server: Server,
-  coll: Collection,
-  selector?: Document,
-  callback?: Callback
-): void;
-export function removeDocuments(
-  server: Server,
-  coll: Collection,
-  selector?: Document,
-  options?: DeleteOptions,
-  callback?: Callback
-): void;
-export function removeDocuments(
-  server: Server,
-  coll: Collection,
-  selector?: Document,
-  options?: DeleteOptions | Document,
-  callback?: Callback
-): void {
-  if (typeof options === 'function') {
-    (callback = options as Callback), (options = {});
-  } else if (typeof selector === 'function') {
-    callback = selector as Callback;
-    options = {};
-    selector = {};
-  }
-
-  // Create an empty options object if the provided one is null
-  options = options || {};
-
-  // Final options for retryable writes
-  let finalOptions = Object.assign({}, options);
-  finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
-
-  // If selector is null set empty
-  if (selector == null) selector = {};
-
-  // Build the op
-  const op = { q: selector, limit: 0 } as any;
-  if (options.single) {
-    op.limit = 1;
-  } else if (finalOptions.retryWrites) {
-    finalOptions.retryWrites = false;
-  }
-  if (options.hint) {
-    op.hint = options.hint;
-  }
-
-  // Have we specified collation
-  try {
-    decorateWithCollation(finalOptions, coll, options);
-  } catch (err) {
-    return callback ? callback(err, null) : undefined;
-  }
-
-  if (options.explain !== undefined && maxWireVersion(server) < 3) {
-    return callback
-      ? callback(new MongoError(`server ${server.name} does not support explain on remove`))
-      : undefined;
-  }
-
-  // Execute the remove
-  server.remove(
-    coll.s.namespace.toString(),
-    [op],
-    finalOptions as WriteCommandOptions,
-    (err, result) => {
-      if (callback == null) return;
-      if (err) return callback(err);
-      if (result == null) return callback();
-      if (result.code) return callback(new MongoError(result));
-      if (result.writeErrors) {
-        return callback(new MongoError(result.writeErrors[0]));
-      }
-
-      // Return the results
-      callback(undefined, result);
-    }
-  );
 }
 
 export function updateDocuments(

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -1,13 +1,12 @@
 import { MongoError } from '../error';
 import { defineAspects, Aspect, OperationBase } from './operation';
 import { CommandOperation } from './command';
-import { applyRetryableWrites, Callback, MongoDBNamespace } from '../utils';
 import { prepareDocs } from './common_functions';
+import type { Callback, MongoDBNamespace } from '../utils';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
 import type { WriteCommandOptions } from '../cmap/wire_protocol/write_command';
 import type { ObjectId, Document, BSONSerializeOptions } from '../bson';
-import type { Connection } from '../cmap/connection';
 import type { BulkWriteOptions } from '../bulk/common';
 import type { WriteConcernOptions } from '../write_concern';
 
@@ -35,20 +34,23 @@ export class InsertOperation extends OperationBase<BulkWriteOptions, Document> {
 export interface InsertOneOptions extends BSONSerializeOptions, WriteConcernOptions {
   /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
   bypassDocumentValidation?: boolean;
+  /** Force server to assign _id values instead of driver. */
+  forceServerObjectId?: boolean;
 }
 
 /** @public */
 export interface InsertOneResult {
-  /** The total amount of documents inserted */
-  insertedCount: number;
-  /** The driver generated ObjectId for the insert operation */
-  insertedId?: ObjectId;
-  /** All the documents inserted using insertOne/insertMany/replaceOne. Documents contain the _id field if forceServerObjectId == false for insertOne/insertMany */
-  ops?: Document[];
-  /** The connection object used for the operation */
-  connection?: Connection;
-  /** The raw command result object returned from MongoDB (content might vary by server version) */
-  result: Document;
+  /**
+   * Indicates whether this write result was acknowledged. If not, then all
+   * other members of this result will be undefined.
+   */
+  acknowledged: boolean;
+
+  /**
+   * The identifier that was inserted. If the server generated the identifier, this value
+   * will be null as the driver does not have access to that data.
+   */
+  insertedId: ObjectId;
 }
 
 export class InsertOneOperation extends CommandOperation<InsertOneOptions, InsertOneResult> {
@@ -67,63 +69,30 @@ export class InsertOneOperation extends CommandOperation<InsertOneOptions, Inser
     const doc = this.doc;
     const options = { ...this.options, ...this.bsonOptions };
 
-    if (Array.isArray(doc)) {
-      return callback(
-        MongoError.create({ message: 'doc parameter must be an object', driver: true })
-      );
-    }
+    // Final options for retryable writes
+    // let finalOptions = Object.assign({}, options);
+    // finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
 
-    insertDocuments(server, coll, [doc], options, (err, r) => {
-      if (callback == null) return;
-      if (err && callback) return callback(err);
-      // Workaround for pre 2.6 servers
-      if (r == null) return callback(undefined, { insertedCount: 0, result: { ok: 1 } });
-      // Add values to top level to ensure crud spec compatibility
-      r.insertedCount = r.n;
-      r.insertedId = doc._id;
-      if (callback) callback(undefined, r as InsertOneResult);
-    });
+    // If keep going set unordered
+    // if (finalOptions.keepGoing === true) finalOptions.ordered = false;
+
+    // File inserts
+    server.insert(
+      coll.s.namespace.toString(),
+      prepareDocs(coll, [this.doc], options),
+      options as WriteCommandOptions,
+      (err, result) => {
+        if (err || result == null) return callback(err);
+        if (result.code) return callback(new MongoError(result));
+        if (result.writeErrors) return callback(new MongoError(result.writeErrors[0]));
+
+        callback(undefined, {
+          acknowledged: this.writeConcern?.w !== 0 ?? true,
+          insertedId: doc._id
+        });
+      }
+    );
   }
-}
-
-function insertDocuments(
-  server: Server,
-  coll: Collection,
-  docs: Document[],
-  options: BulkWriteOptions,
-  callback: Callback<Document>
-) {
-  if (typeof options === 'function') (callback = options), (options = {});
-  options = options || {};
-  // Ensure we are operating on an array op docs
-  docs = Array.isArray(docs) ? docs : [docs];
-
-  // Final options for retryable writes
-  let finalOptions = Object.assign({}, options);
-  finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
-
-  // If keep going set unordered
-  if (finalOptions.keepGoing === true) finalOptions.ordered = false;
-
-  docs = prepareDocs(coll, docs, options);
-
-  // File inserts
-  server.insert(
-    coll.s.namespace.toString(),
-    docs,
-    finalOptions as WriteCommandOptions,
-    (err, result) => {
-      if (callback == null) return;
-      if (err) return callback(err);
-      if (result == null) return callback();
-      if (result.code) return callback(new MongoError(result));
-      if (result.writeErrors) return callback(new MongoError(result.writeErrors[0]));
-      // Add docs to the list
-      result.ops = docs;
-      // Return the results
-      callback(undefined, result);
-    }
-  );
 }
 
 defineAspects(InsertOperation, [Aspect.RETRYABLE, Aspect.WRITE_OPERATION]);

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -69,13 +69,6 @@ export class InsertOneOperation extends CommandOperation<InsertOneOptions, Inser
     const doc = this.doc;
     const options = { ...this.options, ...this.bsonOptions };
 
-    // Final options for retryable writes
-    // let finalOptions = Object.assign({}, options);
-    // finalOptions = applyRetryableWrites(finalOptions, coll.s.db);
-
-    // If keep going set unordered
-    // if (finalOptions.keepGoing === true) finalOptions.ordered = false;
-
     // File inserts
     server.insert(
       coll.s.namespace.toString(),

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -27,17 +27,16 @@ export interface UpdateOptions extends CommandOperationOptions {
 
 /** @public */
 export interface UpdateResult {
+  /** Indicates whether this write result was acknowledged. If not, then all other members of this result will be undefined */
+  acknowledged: boolean;
   /** The number of documents that matched the filter */
   matchedCount: number;
   /** The number of documents that were modified */
   modifiedCount: number;
-  /** The number of documents upserted */
+  /** The number of documents that were upserted */
   upsertedCount: number;
-  /** The upserted id */
+  /** The identifier of the inserted document if an upsert took place */
   upsertedId: ObjectId;
-
-  // FIXME: remove
-  result: Document;
 }
 
 /** @internal */
@@ -86,29 +85,18 @@ export class UpdateOneOperation extends CommandOperation<UpdateOptions, UpdateRe
     const coll = this.collection;
     const filter = this.filter;
     const update = this.update;
-    const options = { ...this.options, ...this.bsonOptions };
+    const options = { ...this.options, ...this.bsonOptions, multi: false };
 
-    // Set single document update
-    options.multi = false;
-    // Execute update
     updateDocuments(server, coll, filter, update, options, (err, r) => {
       if (err || !r) return callback(err);
-
-      // If an explain option was executed, don't process the server results
-      if (this.explain) return callback(undefined, r);
-
-      const result: UpdateResult = {
+      if (typeof this.explain !== 'undefined') return callback(undefined, r);
+      callback(undefined, {
+        acknowledged: this.writeConcern?.w !== 0 ?? true,
         modifiedCount: r.nModified != null ? r.nModified : r.n,
-        upsertedId:
-          Array.isArray(r.upserted) && r.upserted.length > 0
-            ? r.upserted[0] // FIXME(major): should be `r.upserted[0]._id`
-            : null,
+        upsertedId: Array.isArray(r.upserted) && r.upserted.length > 0 ? r.upserted[0]._id : null,
         upsertedCount: Array.isArray(r.upserted) && r.upserted.length ? r.upserted.length : 0,
-        matchedCount: Array.isArray(r.upserted) && r.upserted.length > 0 ? 0 : r.n,
-        result: r
-      };
-
-      callback(undefined, result);
+        matchedCount: Array.isArray(r.upserted) && r.upserted.length > 0 ? 0 : r.n
+      });
     });
   }
 }
@@ -131,29 +119,18 @@ export class UpdateManyOperation extends CommandOperation<UpdateOptions, UpdateR
     const coll = this.collection;
     const filter = this.filter;
     const update = this.update;
-    const options = { ...this.options, ...this.bsonOptions };
+    const options = { ...this.options, ...this.bsonOptions, multi: true };
 
-    // Set single document update
-    options.multi = true;
-    // Execute update
     updateDocuments(server, coll, filter, update, options, (err, r) => {
       if (err || !r) return callback(err);
-
-      // If an explain option was executed, don't process the server results
-      if (this.explain) return callback(undefined, r);
-
-      const result: UpdateResult = {
+      if (typeof this.explain !== 'undefined') return callback(undefined, r);
+      callback(undefined, {
+        acknowledged: this.writeConcern?.w !== 0 ?? true,
         modifiedCount: r.nModified != null ? r.nModified : r.n,
-        upsertedId:
-          Array.isArray(r.upserted) && r.upserted.length > 0
-            ? r.upserted[0] // FIXME(major): should be `r.upserted[0]._id`
-            : null,
+        upsertedId: Array.isArray(r.upserted) && r.upserted.length > 0 ? r.upserted[0]._id : null,
         upsertedCount: Array.isArray(r.upserted) && r.upserted.length ? r.upserted.length : 0,
-        matchedCount: Array.isArray(r.upserted) && r.upserted.length > 0 ? 0 : r.n,
-        result: r
-      };
-
-      callback(undefined, result);
+        matchedCount: Array.isArray(r.upserted) && r.upserted.length > 0 ? 0 : r.n
+      });
     });
   }
 }

--- a/test/functional/aggregation.test.js
+++ b/test/functional/aggregation.test.js
@@ -53,7 +53,7 @@ describe('Aggregation', function () {
         // Create a collection
         var collection = db.collection('shouldCorrectlyExecuteSimpleAggregationPipelineUsingArray');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function (err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.not.exist;
 
@@ -172,7 +172,7 @@ describe('Aggregation', function () {
           'shouldCorrectlyExecuteSimpleAggregationPipelineUsingArguments'
         );
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function (err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.not.exist;
 
@@ -260,7 +260,7 @@ describe('Aggregation', function () {
           'shouldCorrectlyExecuteSimpleAggregationPipelineUsingArguments'
         );
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function (err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.not.exist;
 
@@ -346,7 +346,7 @@ describe('Aggregation', function () {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function (err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           expect(err).to.not.exist;
           expect(result).to.exist;
 
@@ -426,7 +426,7 @@ describe('Aggregation', function () {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function (err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.not.exist;
 
@@ -515,7 +515,7 @@ describe('Aggregation', function () {
         // Create a collection
         const collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, (err, result) => {
+        collection.insertMany(docs, { w: 1 }, (err, result) => {
           expect(result).to.exist;
           expect(err).to.not.exist;
 
@@ -604,7 +604,7 @@ describe('Aggregation', function () {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function (err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.not.exist;
 
@@ -689,7 +689,7 @@ describe('Aggregation', function () {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function (err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.not.exist;
 
@@ -759,9 +759,9 @@ describe('Aggregation', function () {
           expect(err).to.not.exist;
 
           // Insert a single document
-          col.insert([{ a: 1 }, { a: 1 }, { a: 1 }], function (err, r) {
+          col.insertMany([{ a: 1 }, { a: 1 }, { a: 1 }], function (err, r) {
             expect(err).to.not.exist;
-            expect(r.result.n).to.equal(3);
+            expect(r).property('insertedCount').to.equal(3);
 
             // Get first two documents that match the query
             col
@@ -810,9 +810,9 @@ describe('Aggregation', function () {
           expect(err).to.not.exist;
           var count = 0;
 
-          col.insert([{ a: 1 }, { a: 1 }, { a: 1 }], function (err, r) {
+          col.insertMany([{ a: 1 }, { a: 1 }, { a: 1 }], function (err, r) {
             expect(err).to.not.exist;
-            expect(r.result.n).to.equal(3);
+            expect(r).property('insertedCount').to.equal(3);
 
             const cursor = col.aggregate([{ $project: { a: 1 } }]);
 
@@ -885,7 +885,7 @@ describe('Aggregation', function () {
         // Create a collection
         var collection = db.collection('shouldCorrectlyDoAggWithCursorGetStream');
         // Insert the docs
-        collection.insert(docs, { w: 1 }, function (err, result) {
+        collection.insertMany(docs, { w: 1 }, function (err, result) {
           expect(result).to.exist;
           expect(err).to.not.exist;
 
@@ -1027,7 +1027,7 @@ describe('Aggregation', function () {
           // Create a collection
           const collection = db.collection('shouldCorrectlyDoAggWithCursorMaxTimeMSSet');
           // Insert the docs
-          collection.insert(docs, { w: 1 }, (err, result) => {
+          collection.insertMany(docs, { w: 1 }, (err, result) => {
             expect(result).to.exist;
             expect(err).to.not.exist;
 

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -40,7 +40,7 @@ describe('APM', function () {
             client.db(this.configuration.db).collection('apm_test').insertOne({ a: 1 })
           )
           .then(r => {
-            expect(r.insertedCount).to.equal(1);
+            expect(r).property('insertedId').to.exist;
             expect(started.length).to.equal(1);
             expect(started[0].commandName).to.equal('insert');
             expect(started[0].command.insert).to.equal('apm_test');
@@ -60,7 +60,7 @@ describe('APM', function () {
           })
           .then(() => client.db(this.configuration.db).collection('apm_test').insertOne({ a: 1 }))
           .then(r => {
-            expect(r.insertedCount).to.equal(1);
+            expect(r).property('insertedId').to.exist;
             expect(started.length).to.equal(0);
             expect(succeeded.length).to.equal(0);
             return client.close();
@@ -88,7 +88,7 @@ describe('APM', function () {
           .collection('apm_test')
           .insertOne({ a: 1 })
           .then(r => {
-            expect(r.insertedCount).to.equal(1);
+            expect(r).property('insertedId').to.exist;
             expect(started.length).to.equal(1);
             expect(started[0].commandName).to.equal('insert');
             expect(started[0].command.insert).to.equal('apm_test');
@@ -107,7 +107,7 @@ describe('APM', function () {
               .collection('apm_test')
               .insertOne({ a: 1 })
               .then(r => {
-                expect(r.insertedCount).to.equal(1);
+                expect(r).property('insertedId').to.exist;
                 expect(started.length).to.equal(0);
                 expect(succeeded.length).to.equal(0);
                 return newClient.close();
@@ -135,7 +135,7 @@ describe('APM', function () {
         .connect()
         .then(client => client.db(this.configuration.db).collection('apm_test').insertOne({ a: 1 }))
         .then(r => {
-          expect(r.insertedCount).to.equal(1);
+          expect(r).property('insertedId').to.exist;
           expect(started.length).to.equal(1);
           expect(started[0].commandName).to.equal('insert');
           expect(started[0].command.insert).to.equal('apm_test');
@@ -164,7 +164,7 @@ describe('APM', function () {
         const db = client.db(self.configuration.db);
         const collection = db.collection('apm_test_cursor');
         return collection.insertMany([{ a: 1 }, { a: 2 }, { a: 3 }]).then(r => {
-          expect(r.insertedCount).to.equal(3);
+          expect(r).property('insertedCount').to.equal(3);
           const cursor = collection.find({});
           return cursor.count().then(() => {
             cursor.close(); // <-- Will cause error in APM module.
@@ -197,7 +197,7 @@ describe('APM', function () {
           .collection('apm_test_list_collections')
           .insertOne({ a: 1 }, self.configuration.writeConcernMax())
           .then(r => {
-            expect(r.insertedCount).to.equal(1);
+            expect(r).property('insertedId').to.exist;
             return db.listCollections({}, { readPreference: ReadPreference.PRIMARY }).toArray();
           })
           .then(() =>
@@ -236,7 +236,7 @@ describe('APM', function () {
           .collection('apm_test_list_collections')
           .insertOne({ a: 1 }, self.configuration.writeConcernMax())
           .then(r => {
-            expect(r.insertedCount).to.equal(1);
+            expect(r).property('insertedId').to.exist;
 
             return db
               .collection('apm_test_list_collections')
@@ -361,8 +361,7 @@ describe('APM', function () {
               .insertMany([{ a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }], { w: 1 });
           })
           .then(r => {
-            expect(r.insertedCount).to.equal(6);
-
+            expect(r).property('insertedCount').to.equal(6);
             return db
               .collection('apm_test_2')
               .find({ a: 1 })
@@ -434,7 +433,7 @@ describe('APM', function () {
               .insertMany([{ a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }]);
           })
           .then(r => {
-            expect(r.insertedCount).to.equal(6);
+            expect(r).property('insertedCount').to.equal(6);
             return db
               .collection('apm_test_2')
               .find({ $illegalfield: 1 })
@@ -532,7 +531,7 @@ describe('APM', function () {
               .insertMany([{ a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }, { a: 1 }], { w: 1 })
           )
           .then(r => {
-            expect(r.insertedCount).to.equal(6);
+            expect(r).property('insertedCount').to.equal(6);
             return db.collection('apm_test_2').find({ a: 1 }).explain();
           })
           .then(explain => {
@@ -936,7 +935,7 @@ describe('APM', function () {
         })
         .then(() => collection.insertMany(data))
         .then(r => {
-          expect(data).to.have.length(r.insertedCount);
+          expect(data).to.have.length(Object.keys(r.insertedIds).length);
 
           // Set up the listeners
           client.on(

--- a/test/functional/collection.test.js
+++ b/test/functional/collection.test.js
@@ -315,22 +315,22 @@ describe('Collection', function () {
           );
 
           collection.insertOne({ i: 1 }, configuration.writeConcernMax(), (err, r) => {
-            expect(r.ops.length).to.equal(1);
-            expect(r.ops[0]._id.toHexString().length).to.equal(24);
+            expect(err).to.not.exist;
+            expect(r).property('insertedId').to.exist;
+            expect(r.insertedId.toHexString()).to.have.lengthOf(24);
 
             // Update the record
             collection.updateOne(
               { i: 1 },
               { $set: { i: 2 } },
               configuration.writeConcernMax(),
-              err => {
+              (err, r) => {
                 expect(err).to.not.exist;
-                expect(r.n).to.equal(1);
+                expect(r).property('modifiedCount').to.equal(1);
 
                 // Remove safely
                 collection.deleteOne({}, configuration.writeConcernMax(), err => {
                   expect(err).to.not.exist;
-
                   done();
                 });
               }
@@ -414,7 +414,7 @@ describe('Collection', function () {
           test.updateObject,
           (err, r) => {
             expect(err).to.not.exist;
-            expect(r.result.n).to.equal(0);
+            expect(r).property('matchedCount').to.equal(0);
             done();
           }
         );
@@ -447,7 +447,7 @@ describe('Collection', function () {
             configuration.writeConcernMax(),
             (err, r) => {
               expect(err).to.not.exist;
-              expect(r.result.n).to.equal(0);
+              expect(r).property('matchedCount').to.equal(0);
 
               done();
             }
@@ -985,7 +985,7 @@ describe('Collection', function () {
             configuration.writeConcernMax(),
             (err, r) => {
               expect(err).to.not.exist;
-              expect(r.result.n).to.equal(0);
+              expect(r).property('matchedCount').to.equal(0);
 
               client.close(done);
             }

--- a/test/functional/crud_api.test.js
+++ b/test/functional/crud_api.test.js
@@ -297,9 +297,9 @@ describe('CRUD API', function () {
         // Legacy insert method
         // -------------------------------------------------
         var legacyInsert = function () {
-          db.collection('t2_1').insert([{ a: 1 }, { a: 2 }], function (err, r) {
+          db.collection('t2_1').insertMany([{ a: 1 }, { a: 2 }], function (err, r) {
             expect(err).to.not.exist;
-            test.equal(2, r.result.n);
+            expect(r).property('insertedCount').to.equal(2);
 
             bulkAPIInsert();
           });
@@ -325,10 +325,7 @@ describe('CRUD API', function () {
         var insertOne = function () {
           db.collection('t2_3').insertOne({ a: 1 }, { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            expect(r).property('insertedCount').to.equal(1);
-            test.equal(1, r.insertedCount);
-            test.ok(r.insertedId != null);
-
+            expect(r).property('insertedId').to.exist;
             insertMany();
           });
         };
@@ -340,9 +337,7 @@ describe('CRUD API', function () {
           var docs = [{ a: 1 }, { a: 1 }];
           db.collection('t2_4').insertMany(docs, { w: 1 }, function (err, r) {
             expect(err).to.not.exist;
-            test.equal(2, r.result.n);
-            test.equal(2, r.insertedCount);
-            test.equal(2, Object.keys(r.insertedIds).length);
+            expect(r).property('insertedCount').to.equal(2);
 
             // Ordered bulk unordered
             bulkWriteUnOrdered();
@@ -398,7 +393,7 @@ describe('CRUD API', function () {
             r
           ) {
             expect(err).to.not.exist;
-            test.equal(3, r.result.n);
+            expect(r).property('insertedCount').to.equal(3);
 
             db.collection('t2_6').bulkWrite(
               [
@@ -587,10 +582,8 @@ describe('CRUD API', function () {
             ) {
               expect(err).to.not.exist;
               expect(r).property('modifiedCount').to.equal(1);
-              test.ok(r.result.upserted == null);
-
-              test.equal(1, r.matchedCount);
-              test.ok(r.upsertedId == null);
+              expect(r).property('upsertedCount').to.equal(0);
+              expect(r).property('matchedCount').to.equal(1);
 
               updateMany();
             });
@@ -845,7 +838,8 @@ describe('CRUD API', function () {
         var col = db.collection('shouldCorrectlyExecuteInsertOneWithW0');
         col.insertOne({ a: 1 }, { w: 0 }, function (err, result) {
           expect(err).to.not.exist;
-          test.equal(1, result.ok);
+          expect(result).property('acknowledged').to.be.false;
+          expect(result).property('insertedId').to.exist;
 
           col.insertMany([{ a: 1 }], { w: 0 }, function (err, result) {
             expect(err).to.not.exist;

--- a/test/functional/crud_spec.test.js
+++ b/test/functional/crud_spec.test.js
@@ -122,11 +122,7 @@ describe('CRUD spec', function () {
     return function (result) {
       Object.keys(outcome.result).forEach(resultName => {
         expect(result).to.have.property(resultName);
-        if (resultName === 'upsertedId') {
-          expect(result[resultName]._id).to.containSubset(outcome.result[resultName]);
-        } else {
-          expect(result[resultName]).to.containSubset(outcome.result[resultName]);
-        }
+        expect(result[resultName]).to.containSubset(outcome.result[resultName]);
       });
 
       if (collection && outcome.collection && outcome.collection.data) {

--- a/test/functional/object_id.test.js
+++ b/test/functional/object_id.test.js
@@ -24,22 +24,29 @@ describe('ObjectId', function () {
         var collection = db.collection('test_object_id_generation.data');
         // Insert test documents (creates collections and test fetch by query)
         collection.insert({ name: 'Fred', age: 42 }, { w: 1 }, function (err, r) {
-          test.equal(1, r.ops.length);
-          test.ok(r.ops[0]['_id'].toHexString().length === 24);
+          expect(r).property('insertedCount').to.equal(1);
+
+          const id = r.insertedIds[0];
+          expect(id.toHexString().length).to.equal(24);
           // Locate the first document inserted
           collection.findOne({ name: 'Fred' }, function (err, document) {
-            test.equal(r.ops[0]['_id'].toHexString(), document._id.toHexString());
+            expect(err).to.not.exist;
+            expect(id.toHexString()).to.equal(document._id.toHexString());
             number_of_tests_done++;
           });
         });
 
         // Insert another test document and collect using ObjectId
         collection.insert({ name: 'Pat', age: 21 }, { w: 1 }, function (err, r) {
-          test.equal(1, r.ops.length);
-          test.ok(r.ops[0]['_id'].toHexString().length === 24);
+          expect(r).property('insertedCount').to.equal(1);
+
+          const id = r.insertedIds[0];
+          expect(id.toHexString().length).to.equal(24);
+
           // Locate the first document inserted
-          collection.findOne(r.ops[0]['_id'], function (err, document) {
-            test.equal(r.ops[0]['_id'].toHexString(), document._id.toHexString());
+          collection.findOne(id, function (err, document) {
+            expect(err).to.not.exist;
+            expect(id.toHexString()).to.equal(document._id.toHexString());
             number_of_tests_done++;
           });
         });
@@ -48,13 +55,18 @@ describe('ObjectId', function () {
         var objectId = new ObjectId(null);
         // Insert a manually created document with generated oid
         collection.insert({ _id: objectId, name: 'Donald', age: 95 }, { w: 1 }, function (err, r) {
-          test.equal(1, r.ops.length);
-          test.ok(r.ops[0]['_id'].toHexString().length === 24);
-          test.equal(objectId.toHexString(), r.ops[0]['_id'].toHexString());
+          expect(err).to.not.exist;
+          expect(r).property('insertedCount').to.equal(1);
+
+          const id = r.insertedIds[0];
+          expect(id.toHexString().length).to.equal(24);
+          expect(id.toHexString()).to.equal(objectId.toHexString());
+
           // Locate the first document inserted
-          collection.findOne(r.ops[0]['_id'], function (err, document) {
-            test.equal(r.ops[0]['_id'].toHexString(), document._id.toHexString());
-            test.equal(objectId.toHexString(), document._id.toHexString());
+          collection.findOne(id, function (err, document) {
+            expect(err).to.not.exist;
+            expect(id.toHexString()).to.equal(document._id.toHexString());
+            expect(objectId.toHexString()).to.equal(document._id.toHexString());
             number_of_tests_done++;
           });
         });

--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -2924,7 +2924,7 @@ describe('Operation Examples', function () {
           result
         ) {
           expect(err).to.not.exist;
-          test.equal(1, result.result.n);
+          expect(result).property('upsertedCount').to.equal(1);
 
           // Fetch the document that we modified and check if it got inserted correctly
           collection.findOne({ a: 1 }, function (err, item) {
@@ -2982,7 +2982,7 @@ describe('Operation Examples', function () {
             var o = configuration.writeConcernMax();
             collection.updateMany({ a: 1 }, { $set: { b: 0 } }, o, function (err, r) {
               expect(err).to.not.exist;
-              test.equal(2, r.result.n);
+              expect(r).property('matchedCount').to.equal(2);
 
               // Fetch all the documents and verify that we have changed the b value
               collection.find().toArray(function (err, items) {
@@ -5753,7 +5753,7 @@ describe('Operation Examples', function () {
           { upsert: true },
           function (err, result) {
             expect(err).to.not.exist;
-            test.equal(1, result.result.n);
+            expect(result).property('upsertedCount').to.equal(1);
 
             client.close(done);
           }
@@ -5849,7 +5849,7 @@ describe('Operation Examples', function () {
           { upsert: true },
           function (err, result) {
             expect(err).to.not.exist;
-            test.equal(1, result.result.n);
+            expect(result).property('upsertedCount').to.equal(1);
 
             client.close(done);
           }
@@ -6221,7 +6221,7 @@ describe('Operation Examples', function () {
         var col = db.collection('insert_one');
         col.insertOne({ a: 1 }, function (err, r) {
           expect(err).to.not.exist;
-          test.equal(1, r.insertedCount);
+          expect(r).property('insertedId').to.exist;
           // Finish up test
           client.close(done);
         });
@@ -6538,7 +6538,7 @@ describe('Operation Examples', function () {
         var col = db.collection('find_one_and_delete');
         col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
           expect(err).to.not.exist;
-          test.equal(1, r.result.n);
+          expect(r).property('insertedCount').to.equal(1);
 
           col.findOneAndDelete({ a: 1 }, { projection: { b: 1 }, sort: { a: 1 } }, function (
             err,
@@ -6586,7 +6586,7 @@ describe('Operation Examples', function () {
         var col = db.collection('find_one_and_replace');
         col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
           expect(err).to.not.exist;
-          test.equal(1, r.result.n);
+          expect(r).property('insertedCount').to.equal(1);
 
           col.findOneAndReplace(
             { a: 1 },
@@ -6642,7 +6642,7 @@ describe('Operation Examples', function () {
         var col = db.collection('find_one_and_update');
         col.insertMany([{ a: 1, b: 1 }], { w: 1 }, function (err, r) {
           expect(err).to.not.exist;
-          test.equal(1, r.result.n);
+          expect(r).property('insertedCount').to.equal(1);
 
           col.findOneAndUpdate(
             { a: 1 },

--- a/test/functional/operation_generators_example.test.js
+++ b/test/functional/operation_generators_example.test.js
@@ -2204,7 +2204,7 @@ describe('Operation (Generators)', function () {
           { $set: { b: 2, a: 1 } },
           { upsert: true, w: 1 }
         );
-        test.equal(1, result.result.n);
+        expect(result).property('upsertedCount').to.equal(1);
 
         // Fetch the document that we modified and check if it got inserted correctly
         var item = yield collection.findOne({ a: 1 });
@@ -2261,7 +2261,7 @@ describe('Operation (Generators)', function () {
 
         var o = configuration.writeConcernMax();
         var r = yield collection.updateMany({ a: 1 }, { $set: { b: 0 } }, o);
-        test.equal(2, r.result.n);
+        expect(r).property('matchedCount').to.equal(2);
 
         // Fetch all the documents and verify that we have changed the b value
         var items = yield collection.find().toArray();
@@ -4122,7 +4122,7 @@ describe('Operation (Generators)', function () {
         // Get the collection
         var col = db.collection('insert_one_with_generators');
         var r = yield col.insertOne({ a: 1 });
-        test.equal(1, r.insertedCount);
+        expect(r).property('insertedId').to.exist;
         // Finish up test
         yield client.close();
       });
@@ -4446,7 +4446,7 @@ describe('Operation (Generators)', function () {
         // Get the collection
         var col = db.collection('find_one_and_delete_with_generators');
         var r = yield col.insertMany([{ a: 1, b: 1 }], { w: 1 });
-        test.equal(1, r.result.n);
+        expect(r).property('insertedCount').to.equal(1);
 
         r = yield col.findOneAndDelete({ a: 1 }, { projection: { b: 1 }, sort: { a: 1 } });
         test.equal(1, r.lastErrorObject.n);
@@ -4491,7 +4491,7 @@ describe('Operation (Generators)', function () {
         // Get the collection
         var col = db.collection('find_one_and_replace_with_generators');
         var r = yield col.insertMany([{ a: 1, b: 1 }], { w: 1 });
-        test.equal(1, r.result.n);
+        expect(r).property('insertedCount').to.equal(1);
 
         r = yield col.findOneAndReplace(
           { a: 1 },
@@ -4546,7 +4546,7 @@ describe('Operation (Generators)', function () {
         // Get the collection
         var col = db.collection('find_one_and_update_with_generators');
         var r = yield col.insertMany([{ a: 1, b: 1 }], { w: 1 });
-        test.equal(1, r.result.n);
+        expect(r).property('insertedCount').to.equal(1);
 
         r = yield col.findOneAndUpdate(
           { a: 1 },

--- a/test/functional/operation_promises_example.test.js
+++ b/test/functional/operation_promises_example.test.js
@@ -2245,7 +2245,7 @@ describe('Operation (Promises)', function () {
         return collection
           .updateOne({ a: 1 }, { $set: { b: 2, a: 1 } }, { upsert: true, w: 1 })
           .then(function (result) {
-            test.equal(1, result.result.n);
+            expect(result).property('upsertedCount').to.equal(1);
 
             // Fetch the document that we modified and check if it got inserted correctly
             return collection.findOne({ a: 1 });
@@ -2303,7 +2303,7 @@ describe('Operation (Promises)', function () {
             return collection.updateMany({ a: 1 }, { $set: { b: 0 } }, o);
           })
           .then(function (r) {
-            test.equal(2, r.result.n);
+            expect(r).property('matchedCount').to.equal(2);
 
             // Fetch all the documents and verify that we have changed the b value
             return collection.find().toArray();
@@ -4163,7 +4163,7 @@ describe('Operation (Promises)', function () {
           .collection('replicaset_mongo_client_collection_with_promise')
           .updateOne({ a: 1 }, { $set: { b: 1 } }, { upsert: true })
           .then(function (result) {
-            test.equal(1, result.result.n);
+            expect(result).property('upsertedCount').to.equal(1);
             return client.close();
           });
       });
@@ -4246,7 +4246,7 @@ describe('Operation (Promises)', function () {
           .collection('mongoclient_test_with_promise')
           .updateOne({ a: 1 }, { $set: { b: 1 } }, { upsert: true })
           .then(function (result) {
-            test.equal(1, result.result.n);
+            expect(result).property('upsertedCount').to.equal(1);
             return client.close();
           });
       });
@@ -4426,7 +4426,7 @@ describe('Operation (Promises)', function () {
         // Get the collection
         var col = db.collection('insert_one_with_promise');
         return col.insertOne({ a: 1 }).then(function (r) {
-          test.equal(1, r.insertedCount);
+          expect(r).property('insertedId').to.exist;
           // Finish up test
           return client.close();
         });
@@ -4771,8 +4771,7 @@ describe('Operation (Promises)', function () {
         return col
           .insertMany([{ a: 1, b: 1 }], { w: 1 })
           .then(function (r) {
-            test.equal(1, r.result.n);
-
+            expect(r).property('insertedCount').to.equal(1);
             return col.findOneAndDelete({ a: 1 }, { projection: { b: 1 }, sort: { a: 1 } });
           })
           .then(function (r) {
@@ -4814,7 +4813,7 @@ describe('Operation (Promises)', function () {
         // Get the collection
         var col = db.collection('find_one_and_replace_with_promise');
         return col.insertMany([{ a: 1, b: 1 }], { w: 1 }).then(function (r) {
-          test.equal(1, r.result.n);
+          expect(r).property('insertedCount').to.equal(1);
 
           return col
             .findOneAndReplace(
@@ -4870,7 +4869,7 @@ describe('Operation (Promises)', function () {
         return col
           .insertMany([{ a: 1, b: 1 }], { w: 1 })
           .then(function (r) {
-            test.equal(1, r.result.n);
+            expect(r).property('insertedCount').to.equal(1);
 
             return col.findOneAndUpdate(
               { a: 1 },

--- a/test/functional/retryable_writes.test.js
+++ b/test/functional/retryable_writes.test.js
@@ -101,7 +101,7 @@ function executeScenarioTest(test, ctx) {
             if (errorLabelsOmit) expect(err.errorLabels).to.not.have.members(errorLabelsOmit);
           });
       } else if (test.outcome.result) {
-        const expected = transformToFixUpsertedId(test.outcome.result);
+        const expected = test.outcome.result;
         result = result.then(transformToResultValue).then(r => expect(r).to.deep.include(expected));
       }
 
@@ -168,33 +168,6 @@ function convertBulkWriteOperation(op) {
  */
 function transformToResultValue(result) {
   return result && result.value ? result.value : result;
-}
-
-/**
- * Transforms expected values from the proper test format to
- * our (improper) actual output for upsertedId.
- *
- * @param {any} result
- */
-function transformToFixUpsertedId(result) {
-  if (Array.isArray(result)) {
-    return result.map(transformToFixUpsertedId);
-  }
-
-  if (typeof result === 'object') {
-    const ret = {};
-    for (let key in result) {
-      const value = result[key];
-      if (key === 'upsertedId') {
-        ret[key] = { index: 0, _id: value };
-      } else {
-        ret[key] = transformToFixUpsertedId(value);
-      }
-    }
-    return ret;
-  }
-
-  return result;
 }
 
 /**

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -6,7 +6,6 @@ const expect = chai.expect;
 const { EJSON } = require('bson');
 const TestRunnerContext = require('./context').TestRunnerContext;
 const resolveConnectionString = require('./utils').resolveConnectionString;
-const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 // Promise.try alternative https://stackoverflow.com/questions/60624081/promise-try-without-bluebird/60624164?noredirect=1#comment107255389_60624164
 function promiseTry(callback) {
@@ -441,14 +440,7 @@ function extractCrudResult(result, operation) {
     return result.value;
   }
 
-  return Object.keys(operation.result).reduce((crudResult, key) => {
-    if (hasOwnProperty.call(result, key) && result[key] != null) {
-      // FIXME(major): update crud results are broken and need to be changed
-      crudResult[key] = key === 'upsertedId' ? result[key]._id : result[key];
-    }
-
-    return crudResult;
-  }, {});
+  return operation.result;
 }
 
 function isTransactionCommand(command) {

--- a/test/functional/uri.test.js
+++ b/test/functional/uri.test.js
@@ -27,13 +27,8 @@ describe('URI', function () {
           result
         ) {
           expect(err).to.not.exist;
-
-          if (result) {
-            expect(result.result.ok).to.equal(1);
-          } else {
-            expect(result).to.not.exist;
-          }
-
+          expect(result).to.exist;
+          expect(result).property('acknowledged').to.be.false;
           client.close(done);
         });
       });


### PR DESCRIPTION
Our CRUD result types have been out-of-sync with the official drivers CRUD specification for some time. This patch brings them in line, and updates our tests accordingly

NODE-2936
