### PR TITLE
fix: use require instead of readFileSync for driver.version (#2937)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -885,9 +885,7 @@ export interface ClientMetadataOptions {
   appname?: string;
 }
 
-const NODE_DRIVER_VERSION = JSON.parse(
-  readFileSync(resolve(__dirname, '..', 'package.json'), { encoding: 'utf-8' })
-).version;
+const NODE_DRIVER_VERSION = require('../package.json').version;
 
 export function makeClientMetadata(options: ClientMetadataOptions): ClientMetadata {
   options = options || {};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,8 +12,6 @@ import type { OperationOptions, OperationBase, Hint } from './operations/operati
 import type { ClientSession } from './sessions';
 import { ReadConcern } from './read_concern';
 import type { Connection } from './cmap/connection';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
 import { Document, resolveBSONOptions } from './bson';
 import type { IndexSpecification, IndexDirection } from './operations/indexes';
 import type { Explain } from './explain';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -885,6 +885,7 @@ export interface ClientMetadataOptions {
   appname?: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const NODE_DRIVER_VERSION = require('../package.json').version;
 
 export function makeClientMetadata(options: ClientMetadataOptions): ClientMetadata {


### PR DESCRIPTION
This is the solution mongosh is currently using in my fork of the driver. I don't know if you want to use this directly or some other solution. For more details see NODE-2937