### PR TITLE
fix: prevent bulk operations from being executed multiple times

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1201,14 +1201,13 @@ export abstract class BulkOperationBase {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options || {};
 
+    if (this.s.executed) {
+      return handleEarlyError(new MongoError('Batch cannot be re-executed'), callback);
+    }
+
     const writeConcern = WriteConcern.fromOptions(options);
     if (writeConcern) {
       this.s.writeConcern = writeConcern;
-    }
-
-    if (this.s.executed) {
-      const executedError = new MongoError('batch cannot be re-executed');
-      return handleEarlyError(executedError, callback);
     }
 
     // If we have current batch
@@ -1225,6 +1224,7 @@ export abstract class BulkOperationBase {
       return handleEarlyError(emptyBatchError, callback);
     }
 
+    this.s.executed = true;
     return executeLegacyOperation(this.s.topology, executeCommands, [this, options, callback]);
   }
 

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -1759,4 +1759,22 @@ describe('Bulk', function () {
       });
     })
   );
+
+  it(
+    'should throw an error if bulk execute is called more than once',
+    withClientV2(function (client, done) {
+      const bulk = client.db().collection('coll').initializeUnorderedBulkOp();
+      bulk.insert({});
+
+      bulk.execute((err, result) => {
+        expect(err).to.not.exist;
+        expect(result).to.exist;
+
+        bulk.execute(err => {
+          expect(err).to.match(/Batch cannot be re-executed/);
+          done();
+        });
+      });
+    })
+  );
 });


### PR DESCRIPTION
This spec compliant behavior was lost through refactoring in recent years. We now prevent users from calling execute multiple times on a bulk operation.

NODE-2926
