### PR TITLE
NODE-2815: alternative no generic parameter for options

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -104,7 +104,7 @@ export class Admin {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
     return this.command({ buildinfo: 1 }, options, callback as Callback<Document>);
   }
 
@@ -123,7 +123,7 @@ export class Admin {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
     return this.command({ buildinfo: 1 }, options, callback as Callback<Document>);
   }
 
@@ -142,7 +142,7 @@ export class Admin {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
     return this.command({ serverStatus: 1 }, options, callback as Callback<Document>);
   }
 
@@ -161,7 +161,7 @@ export class Admin {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
     return this.command({ ping: 1 }, options, callback as Callback<Document>);
   }
 
@@ -260,7 +260,7 @@ export class Admin {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     return executeOperation(
       getTopology(this.s.db),
@@ -284,7 +284,7 @@ export class Admin {
     callback?: Callback<ListDatabasesResult>
   ): Promise<ListDatabasesResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     return executeOperation(
       getTopology(this.s.db),
@@ -308,7 +308,7 @@ export class Admin {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
     return this.command({ replSetGetStatus: 1 }, options, callback as Callback<Document>);
   }
 }

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1212,7 +1212,7 @@ export abstract class BulkOperationBase {
   /** An internal helper method. Do not invoke directly. Will be going away in the future */
   execute(options?: BulkWriteOptions, callback?: Callback<BulkWriteResult>): Promise<void> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     if (this.s.executed) {
       return handleEarlyError(new MongoError('Batch cannot be re-executed'), callback);

--- a/src/cmap/commands.ts
+++ b/src/cmap/commands.ts
@@ -538,7 +538,7 @@ export class Response {
   parse(options: OpResponseOptions): void {
     // Don't parse again if not needed
     if (this.parsed) return;
-    options = options || {};
+    options = options ?? {};
 
     // Allow the return of raw documents instead of parsing
     const raw = options.raw || false;
@@ -666,7 +666,7 @@ export class Msg {
     }
 
     // Ensure empty options
-    this.options = options || {};
+    this.options = options ?? {};
 
     // Additional options
     this.requestId = options.requestId ? options.requestId : Msg.getRequestId();
@@ -806,7 +806,7 @@ export class BinMsg {
   parse(options: OpResponseOptions): void {
     // Don't parse again if not needed
     if (this.parsed) return;
-    options = options || {};
+    options = options ?? {};
 
     this.index = 4;
     // Allow the return of raw documents instead of parsing

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -397,7 +397,7 @@ function write(
     callback = options;
   }
 
-  options = options || {};
+  options = options ?? {};
   const operationDescription: OperationDescription = {
     requestId: command.requestId,
     cb: callback,

--- a/src/cmap/wire_protocol/get_more.ts
+++ b/src/cmap/wire_protocol/get_more.ts
@@ -21,7 +21,7 @@ export function getMore(
   options: GetMoreOptions,
   callback: Callback<Document>
 ): void {
-  options = options || {};
+  options = options ?? {};
 
   const fullResult = typeof options.fullResult === 'boolean' ? options.fullResult : false;
   const wireVersion = maxWireVersion(server);

--- a/src/cmap/wire_protocol/query.ts
+++ b/src/cmap/wire_protocol/query.ts
@@ -28,7 +28,7 @@ export function query(
   options: QueryOptions,
   callback: Callback
 ): void {
-  options = options || {};
+  options = options ?? {};
 
   const isExplain = typeof findCommand.$explain !== 'undefined';
   const readPreference = options.readPreference ?? ReadPreference.primary;

--- a/src/cmap/wire_protocol/write_command.ts
+++ b/src/cmap/wire_protocol/write_command.ts
@@ -41,7 +41,7 @@ export function writeCommand(
     options = {};
   }
 
-  options = options || {};
+  options = options ?? {};
   const ordered = typeof options.ordered === 'boolean' ? options.ordered : true;
   const writeConcern = options.writeConcern;
   let writeCommand: Document = {};

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -585,7 +585,7 @@ export class Collection implements OperationParent {
     callback?: Callback<boolean>
   ): Promise<boolean> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     return executeOperation(
       getTopology(this),
@@ -1089,7 +1089,7 @@ export class Collection implements OperationParent {
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     return executeOperation(getTopology(this), new CollStatsOperation(this, options), callback);
   }
@@ -1232,7 +1232,7 @@ export class Collection implements OperationParent {
   watch(pipeline?: Document[]): ChangeStream;
   watch(pipeline?: Document[], options?: ChangeStreamOptions): ChangeStream {
     pipeline = pipeline || [];
-    options = options || {};
+    options = options ?? {};
 
     // Allow optionally not specifying a pipeline
     if (!Array.isArray(pipeline)) {
@@ -1365,7 +1365,7 @@ export class Collection implements OperationParent {
     callback: Callback<Document>
   ): Promise<UpdateResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     return this.updateMany(selector, update, options, callback);
   }
@@ -1384,7 +1384,7 @@ export class Collection implements OperationParent {
     callback: Callback
   ): Promise<DeleteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     return this.deleteMany(selector, options, callback);
   }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -329,7 +329,7 @@ export abstract class AbstractCursor extends EventEmitter {
   close(options: CursorCloseOptions, callback: Callback): void;
   close(options?: CursorCloseOptions | Callback, callback?: Callback): Promise<void> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     const needsToEmitClosed = !this[kClosed];
     this[kClosed] = true;

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -120,7 +120,7 @@ export class FindCursor extends AbstractCursor {
     }
 
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     return executeOperation(
       this.topology,

--- a/src/db.ts
+++ b/src/db.ts
@@ -154,7 +154,7 @@ export class Db implements OperationParent {
    * @param options - Optional settings for Db construction
    */
   constructor(client: MongoClient, databaseName: string, options?: DbOptions) {
-    options = options || {};
+    options = options ?? {};
     emitDeprecatedOptionWarning(options, ['promiseLibrary']);
 
     // Filter the options
@@ -781,7 +781,7 @@ export class Db implements OperationParent {
   watch(pipeline?: Document[]): ChangeStream;
   watch(pipeline?: Document[], options?: ChangeStreamOptions): ChangeStream {
     pipeline = pipeline || [];
-    options = options || {};
+    options = options ?? {};
 
     // Allow optionally not specifying a pipeline
     if (!Array.isArray(pipeline)) {
@@ -887,7 +887,7 @@ export class Db implements OperationParent {
     callback?: Callback<Document[]>
   ): Promise<Document[]> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     const cursor = this.collection('system.profile').find({}, options);
     return callback ? cursor.toArray(callback) : cursor.toArray();

--- a/src/gridfs-stream/index.ts
+++ b/src/gridfs-stream/index.ts
@@ -142,7 +142,7 @@ export class GridFSBucket extends EventEmitter {
   /** Convenience wrapper around find on the files collection */
   find(filter: Document, options?: FindOptions): FindCursor {
     filter = filter || {};
-    options = options || {};
+    options = options ?? {};
     return this.s._filesCollection.find(filter, options);
   }
 

--- a/src/gridfs-stream/upload.ts
+++ b/src/gridfs-stream/upload.ts
@@ -83,7 +83,7 @@ export class GridFSBucketWriteStream extends Writable {
   constructor(bucket: GridFSBucket, filename: string, options?: GridFSBucketWriteStreamOptions) {
     super();
 
-    options = options || {};
+    options = options ?? {};
     this.bucket = bucket;
     this.chunks = bucket.s._chunksCollection;
     this.filename = filename;

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,7 +224,7 @@ export type {
   MapReduceOptions,
   FinalizeFunction
 } from './operations/map_reduce';
-export type { Hint, OperationOptions, OperationBase } from './operations/operation';
+export type { Hint, OperationOptions, AbstractOperation } from './operations/operation';
 export type { ProfilingLevelOptions } from './operations/profiling_level';
 export type { RemoveUserOptions } from './operations/remove_user';
 export type { RenameOptions } from './operations/rename';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -42,7 +42,7 @@ export class Logger {
    * @param options - Optional logging settings
    */
   constructor(className: string, options?: LoggerOptions) {
-    options = options || {};
+    options = options ?? {};
 
     // Current reference
     this.className = className;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -386,7 +386,7 @@ export class MongoClient extends EventEmitter implements OperationParent {
   db(dbName: string): Db;
   db(dbName: string, options: DbOptions & { returnNonCachedInstance?: boolean }): Db;
   db(dbName: string, options?: DbOptions & { returnNonCachedInstance?: boolean }): Db {
-    options = options || {};
+    options = options ?? {};
 
     // Default to db from connection string if not provided
     if (!dbName && this.s.options?.dbName) {
@@ -437,7 +437,7 @@ export class MongoClient extends EventEmitter implements OperationParent {
     callback?: Callback<MongoClient>
   ): Promise<MongoClient> | void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     // Create client
     const mongoClient = new MongoClient(url, options);
@@ -527,7 +527,7 @@ export class MongoClient extends EventEmitter implements OperationParent {
   watch(pipeline?: Document[]): ChangeStream;
   watch(pipeline?: Document[], options?: ChangeStreamOptions): ChangeStream {
     pipeline = pipeline || [];
-    options = options || {};
+    options = options ?? {};
 
     // Allow optionally not specifying a pipeline
     if (!Array.isArray(pipeline)) {

--- a/src/operations/add_user.ts
+++ b/src/operations/add_user.ts
@@ -6,6 +6,7 @@ import { Callback, getTopology } from '../utils';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Db } from '../db';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export interface AddUserOptions extends CommandOperationOptions {
@@ -18,7 +19,8 @@ export interface AddUserOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class AddUserOperation extends CommandOperation<AddUserOptions, Document> {
+export class AddUserOperation extends CommandOperation<Document> {
+  options: AddUserOptions;
   db: Db;
   username: string;
   password?: string;
@@ -35,9 +37,10 @@ export class AddUserOperation extends CommandOperation<AddUserOptions, Document>
     this.db = db;
     this.username = username;
     this.password = password;
+    this.options = options ?? {};
   }
 
-  execute(server: Server, callback: Callback<Document>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
     const db = this.db;
     const username = this.username;
     const password = this.password;
@@ -99,7 +102,7 @@ export class AddUserOperation extends CommandOperation<AddUserOptions, Document>
       command.pwd = userPassword;
     }
 
-    super.executeCommand(server, command, callback);
+    super.executeCommand(server, session, command, callback);
   }
 }
 

--- a/src/operations/count.ts
+++ b/src/operations/count.ts
@@ -4,6 +4,7 @@ import type { Callback, MongoDBNamespace } from '../utils';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export interface CountOptions extends CommandOperationOptions {
@@ -18,18 +19,20 @@ export interface CountOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class CountOperation extends CommandOperation<CountOptions, number> {
+export class CountOperation extends CommandOperation<number> {
+  options: CountOptions;
   collectionName?: string;
   query: Document;
 
   constructor(namespace: MongoDBNamespace, filter: Document, options: CountOptions) {
     super(({ s: { namespace: namespace } } as unknown) as Collection, options);
 
+    this.options = options;
     this.collectionName = namespace.collection;
     this.query = filter;
   }
 
-  execute(server: Server, callback: Callback<number>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<number>): void {
     const options = this.options;
     const cmd: Document = {
       count: this.collectionName,
@@ -52,7 +55,7 @@ export class CountOperation extends CommandOperation<CountOptions, number> {
       cmd.maxTimeMS = options.maxTimeMS;
     }
 
-    super.executeCommand(server, cmd, (err, result) => {
+    super.executeCommand(server, session, cmd, (err, result) => {
       callback(err, result ? result.n : 0);
     });
   }

--- a/src/operations/count_documents.ts
+++ b/src/operations/count_documents.ts
@@ -3,6 +3,7 @@ import type { Callback } from '../utils';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export interface CountDocumentsOptions extends AggregateOptions {
@@ -31,8 +32,8 @@ export class CountDocumentsOperation extends AggregateOperation<number> {
     super(collection, pipeline, options);
   }
 
-  execute(server: Server, callback: Callback<number>): void {
-    super.execute(server, (err, result) => {
+  execute(server: Server, session: ClientSession, callback: Callback<number>): void {
+    super.execute(server, session, (err, result) => {
       if (err || !result) {
         callback(err);
         return;

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -9,6 +9,7 @@ import type { PkFactory } from '../mongo_client';
 
 // eslint-disable-next-line
 import type { Collection } from '../collection';
+import type { ClientSession } from '../sessions';
 
 const ILLEGAL_COMMAND_FIELDS = new Set([
   'w',
@@ -64,20 +65,20 @@ export interface CreateCollectionOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class CreateCollectionOperation extends CommandOperation<
-  CreateCollectionOptions,
-  Collection
-> {
+export class CreateCollectionOperation extends CommandOperation<Collection> {
+  options: CreateCollectionOptions;
   db: Db;
   name: string;
 
   constructor(db: Db, name: string, options: CreateCollectionOptions = {}) {
     super(db, options);
+
+    this.options = options;
     this.db = db;
     this.name = name;
   }
 
-  execute(server: Server, callback: Callback<Collection>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<Collection>): void {
     const db = this.db;
     const name = this.name;
     const options = this.options;
@@ -103,7 +104,7 @@ export class CreateCollectionOperation extends CommandOperation<
     }
 
     // otherwise just execute the command
-    super.executeCommand(server, cmd, done);
+    super.executeCommand(server, session, cmd, done);
   }
 }
 

--- a/src/operations/distinct.ts
+++ b/src/operations/distinct.ts
@@ -5,6 +5,7 @@ import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
 import { MongoError } from '../error';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export type DistinctOptions = CommandOperationOptions;
@@ -13,7 +14,8 @@ export type DistinctOptions = CommandOperationOptions;
  * Return a list of distinct values for the given key across a collection.
  * @internal
  */
-export class DistinctOperation extends CommandOperation<DistinctOptions, Document[]> {
+export class DistinctOperation extends CommandOperation<Document[]> {
+  options: DistinctOptions;
   collection: Collection;
   /** Field of the document to find distinct values for. */
   key: string;
@@ -31,12 +33,13 @@ export class DistinctOperation extends CommandOperation<DistinctOptions, Documen
   constructor(collection: Collection, key: string, query: Document, options?: DistinctOptions) {
     super(collection, options);
 
+    this.options = options ?? {};
     this.collection = collection;
     this.key = key;
     this.query = query;
   }
 
-  execute(server: Server, callback: Callback<Document[]>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<Document[]>): void {
     const coll = this.collection;
     const key = this.key;
     const query = this.query;
@@ -69,7 +72,7 @@ export class DistinctOperation extends CommandOperation<DistinctOptions, Documen
       return;
     }
 
-    super.executeCommand(server, cmd, (err, result) => {
+    super.executeCommand(server, session, cmd, (err, result) => {
       if (err) {
         callback(err);
         return;

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -3,21 +3,24 @@ import { CommandOperation, CommandOperationOptions } from './command';
 import type { Callback } from '../utils';
 import type { Server } from '../sdam/server';
 import type { Db } from '../db';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export type DropCollectionOptions = CommandOperationOptions;
 
 /** @internal */
-export class DropCollectionOperation extends CommandOperation<DropCollectionOptions, boolean> {
+export class DropCollectionOperation extends CommandOperation<boolean> {
+  options: DropCollectionOptions;
   name: string;
 
   constructor(db: Db, name: string, options: DropCollectionOptions) {
     super(db, options);
+    this.options = options;
     this.name = name;
   }
 
-  execute(server: Server, callback: Callback<boolean>): void {
-    super.executeCommand(server, { drop: this.name }, (err, result) => {
+  execute(server: Server, session: ClientSession, callback: Callback<boolean>): void {
+    super.executeCommand(server, session, { drop: this.name }, (err, result) => {
       if (err) return callback(err);
       if (result.ok) return callback(undefined, true);
       callback(undefined, false);
@@ -29,9 +32,15 @@ export class DropCollectionOperation extends CommandOperation<DropCollectionOpti
 export type DropDatabaseOptions = CommandOperationOptions;
 
 /** @internal */
-export class DropDatabaseOperation extends CommandOperation<DropDatabaseOptions, boolean> {
-  execute(server: Server, callback: Callback<boolean>): void {
-    super.executeCommand(server, { dropDatabase: 1 }, (err, result) => {
+export class DropDatabaseOperation extends CommandOperation<boolean> {
+  options: DropDatabaseOptions;
+
+  constructor(db: Db, options: DropDatabaseOptions) {
+    super(db, options);
+    this.options = options;
+  }
+  execute(server: Server, session: ClientSession, callback: Callback<boolean>): void {
+    super.executeCommand(server, session, { dropDatabase: 1 }, (err, result) => {
       if (err) return callback(err);
       if (result.ok) return callback(undefined, true);
       callback(undefined, false);

--- a/src/operations/estimated_document_count.ts
+++ b/src/operations/estimated_document_count.ts
@@ -4,6 +4,7 @@ import type { Callback } from '../utils';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export interface EstimatedDocumentCountOptions extends CommandOperationOptions {
@@ -13,10 +14,8 @@ export interface EstimatedDocumentCountOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class EstimatedDocumentCountOperation extends CommandOperation<
-  EstimatedDocumentCountOptions,
-  number
-> {
+export class EstimatedDocumentCountOperation extends CommandOperation<number> {
+  options: EstimatedDocumentCountOptions;
   collectionName: string;
   query?: Document;
 
@@ -33,13 +32,14 @@ export class EstimatedDocumentCountOperation extends CommandOperation<
     }
 
     super(collection, options);
+    this.options = options;
     this.collectionName = collection.collectionName;
     if (query) {
       this.query = query;
     }
   }
 
-  execute(server: Server, callback: Callback<number>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<number>): void {
     const options = this.options;
     const cmd: Document = { count: this.collectionName };
 
@@ -59,7 +59,7 @@ export class EstimatedDocumentCountOperation extends CommandOperation<
       cmd.hint = options.hint;
     }
 
-    super.executeCommand(server, cmd, (err, response) => {
+    super.executeCommand(server, session, cmd, (err, response) => {
       if (err) {
         callback(err);
         return;

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -13,6 +13,7 @@ import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
 import { Sort, formatSort } from '../sort';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export interface FindAndModifyOptions extends CommandOperationOptions {
@@ -40,7 +41,8 @@ export interface FindAndModifyOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class FindAndModifyOperation extends CommandOperation<FindAndModifyOptions, Document> {
+export class FindAndModifyOperation extends CommandOperation<Document> {
+  options: FindAndModifyOptions;
   collection: Collection;
   query: Document;
   sort?: Sort;
@@ -54,6 +56,7 @@ export class FindAndModifyOperation extends CommandOperation<FindAndModifyOption
     options?: FindAndModifyOptions
   ) {
     super(collection, options);
+    this.options = options ?? {};
 
     // force primary read preference
     this.readPreference = ReadPreference.primary;
@@ -64,7 +67,7 @@ export class FindAndModifyOperation extends CommandOperation<FindAndModifyOption
     this.doc = doc;
   }
 
-  execute(server: Server, callback: Callback<Document>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
     const coll = this.collection;
     const query = this.query;
     const sort = formatSort(this.sort);
@@ -147,7 +150,7 @@ export class FindAndModifyOperation extends CommandOperation<FindAndModifyOption
     }
 
     // Execute the command
-    super.executeCommand(server, cmd, (err, result) => {
+    super.executeCommand(server, session, cmd, (err, result) => {
       if (err) return callback(err);
       return callback(undefined, result);
     });

--- a/src/operations/find_one.ts
+++ b/src/operations/find_one.ts
@@ -6,23 +6,26 @@ import { MongoError } from '../error';
 import type { Server } from '../sdam/server';
 import { CommandOperation } from './command';
 import { Aspect, defineAspects } from './operation';
+import type { ClientSession } from '../sessions';
 
 /** @internal */
-export class FindOneOperation extends CommandOperation<FindOptions, Document> {
+export class FindOneOperation extends CommandOperation<Document> {
+  options: FindOptions;
   collection: Collection;
   query: Document;
 
   constructor(collection: Collection, query: Document, options: FindOptions) {
     super(collection, options);
 
+    this.options = options;
     this.collection = collection;
     this.query = query;
   }
 
-  execute(server: Server, callback: Callback<Document>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
     const coll = this.collection;
     const query = this.query;
-    const options = { ...this.options, ...this.bsonOptions };
+    const options = { ...this.options, ...this.bsonOptions, session };
 
     try {
       const cursor = coll.find(query, options).limit(-1).batchSize(1);

--- a/src/operations/is_capped.ts
+++ b/src/operations/is_capped.ts
@@ -1,30 +1,37 @@
 import type { Callback } from '../utils';
 import type { Collection } from '../collection';
-import { OperationOptions, OperationBase } from './operation';
+import { OperationOptions, AbstractOperation } from './operation';
 import type { Server } from '../sdam/server';
-import { MongoError } from '..';
+import type { ClientSession } from '../sessions';
+import { MongoError } from '../error';
 
 /** @internal */
-export class IsCappedOperation extends OperationBase<OperationOptions, boolean> {
+export class IsCappedOperation extends AbstractOperation<boolean> {
+  options: OperationOptions;
   collection: Collection;
 
   constructor(collection: Collection, options: OperationOptions) {
     super(options);
+    this.options = options;
     this.collection = collection;
   }
 
-  execute(server: Server, callback: Callback<boolean>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<boolean>): void {
     const coll = this.collection;
-    const opts = this.options;
 
-    coll.s.db.listCollections({ name: coll.collectionName }, opts).toArray((err, collections) => {
-      if (err || !collections) return callback(err);
-      if (collections.length === 0) {
-        return callback(new MongoError(`collection ${coll.namespace} not found`));
-      }
+    coll.s.db
+      .listCollections(
+        { name: coll.collectionName },
+        { ...this.options, readPreference: this.readPreference, session }
+      )
+      .toArray((err, collections) => {
+        if (err || !collections) return callback(err);
+        if (collections.length === 0) {
+          return callback(new MongoError(`collection ${coll.namespace} not found`));
+        }
 
-      const collOptions = collections[0].options;
-      callback(undefined, !!(collOptions && collOptions.capped));
-    });
+        const collOptions = collections[0].options;
+        callback(undefined, !!(collOptions && collOptions.capped));
+      });
   }
 }

--- a/src/operations/list_collections.ts
+++ b/src/operations/list_collections.ts
@@ -20,7 +20,8 @@ export interface ListCollectionsOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class ListCollectionsOperation extends CommandOperation<ListCollectionsOptions, string[]> {
+export class ListCollectionsOperation extends CommandOperation<string[]> {
+  options: ListCollectionsOptions;
   db: Db;
   filter: Document;
   nameOnly: boolean;
@@ -29,6 +30,7 @@ export class ListCollectionsOperation extends CommandOperation<ListCollectionsOp
   constructor(db: Db, filter: Document, options?: ListCollectionsOptions) {
     super(db, options);
 
+    this.options = options ?? {};
     this.db = db;
     this.filter = filter;
     this.nameOnly = !!this.options.nameOnly;
@@ -38,7 +40,7 @@ export class ListCollectionsOperation extends CommandOperation<ListCollectionsOp
     }
   }
 
-  execute(server: Server, callback: Callback<string[]>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<string[]>): void {
     if (maxWireVersion(server) < LIST_COLLECTIONS_WIRE_VERSION) {
       let filter = this.filter;
       const databaseName = this.db.s.namespace.db;
@@ -98,7 +100,7 @@ export class ListCollectionsOperation extends CommandOperation<ListCollectionsOp
       nameOnly: this.nameOnly
     };
 
-    return super.executeCommand(server, command, callback);
+    return super.executeCommand(server, session, command, callback);
   }
 }
 

--- a/src/operations/list_databases.ts
+++ b/src/operations/list_databases.ts
@@ -4,6 +4,7 @@ import { MongoDBNamespace, Callback } from '../utils';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Db } from '../db';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export type ListDatabasesResult = string[] | Document[];
@@ -19,16 +20,16 @@ export interface ListDatabasesOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class ListDatabasesOperation extends CommandOperation<
-  ListDatabasesOptions,
-  ListDatabasesResult
-> {
+export class ListDatabasesOperation extends CommandOperation<ListDatabasesResult> {
+  options: ListDatabasesOptions;
+
   constructor(db: Db, options?: ListDatabasesOptions) {
     super(db, options);
+    this.options = options ?? {};
     this.ns = new MongoDBNamespace('admin', '$cmd');
   }
 
-  execute(server: Server, callback: Callback<ListDatabasesResult>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<ListDatabasesResult>): void {
     const cmd: Document = { listDatabases: 1 };
     if (this.options.nameOnly) {
       cmd.nameOnly = Number(cmd.nameOnly);
@@ -42,7 +43,7 @@ export class ListDatabasesOperation extends CommandOperation<
       cmd.authorizedDatabases = this.options.authorizedDatabases;
     }
 
-    super.executeCommand(server, cmd, callback);
+    super.executeCommand(server, session, cmd, callback);
   }
 }
 

--- a/src/operations/options_operation.ts
+++ b/src/operations/options_operation.ts
@@ -1,33 +1,39 @@
-import { OperationBase, OperationOptions } from './operation';
+import { AbstractOperation, OperationOptions } from './operation';
 import { MongoError } from '../error';
 import type { Callback } from '../utils';
 import type { Document } from '../bson';
 import type { Collection } from '../collection';
 import type { Server } from '../sdam/server';
+import type { ClientSession } from '../sessions';
 
 /** @internal */
-export class OptionsOperation extends OperationBase<OperationOptions, Document> {
+export class OptionsOperation extends AbstractOperation<Document> {
+  options: OperationOptions;
   collection: Collection;
 
   constructor(collection: Collection, options: OperationOptions) {
     super(options);
-
+    this.options = options;
     this.collection = collection;
   }
 
-  execute(server: Server, callback: Callback<Document>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
     const coll = this.collection;
-    const opts = this.options;
 
-    coll.s.db.listCollections({ name: coll.collectionName }, opts).toArray((err, collections) => {
-      if (err || !collections) return callback(err);
-      if (collections.length === 0) {
-        return callback(
-          MongoError.create({ message: `collection ${coll.namespace} not found`, driver: true })
-        );
-      }
+    coll.s.db
+      .listCollections(
+        { name: coll.collectionName },
+        { ...this.options, readPreference: this.readPreference, session }
+      )
+      .toArray((err, collections) => {
+        if (err || !collections) return callback(err);
+        if (collections.length === 0) {
+          return callback(
+            MongoError.create({ message: `collection ${coll.namespace} not found`, driver: true })
+          );
+        }
 
-      callback(err, collections[0].options || null);
-    });
+        callback(err, collections[0].options || null);
+      });
   }
 }

--- a/src/operations/profiling_level.ts
+++ b/src/operations/profiling_level.ts
@@ -2,18 +2,22 @@ import { CommandOperation, CommandOperationOptions } from './command';
 import type { Callback } from '../utils';
 import type { Server } from '../sdam/server';
 import type { Db } from '../db';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export type ProfilingLevelOptions = CommandOperationOptions;
 
 /** @internal */
-export class ProfilingLevelOperation extends CommandOperation<ProfilingLevelOptions, string> {
+export class ProfilingLevelOperation extends CommandOperation<string> {
+  options: ProfilingLevelOptions;
+
   constructor(db: Db, options: ProfilingLevelOptions) {
     super(db, options);
+    this.options = options;
   }
 
-  execute(server: Server, callback: Callback<string>): void {
-    super.executeCommand(server, { profile: -1 }, (err, doc) => {
+  execute(server: Server, session: ClientSession, callback: Callback<string>): void {
+    super.executeCommand(server, session, { profile: -1 }, (err, doc) => {
       if (err == null && doc.ok === 1) {
         const was = doc.was;
         if (was === 0) return callback(undefined, 'off');

--- a/src/operations/remove_user.ts
+++ b/src/operations/remove_user.ts
@@ -3,21 +3,24 @@ import { CommandOperation, CommandOperationOptions } from './command';
 import type { Callback } from '../utils';
 import type { Server } from '../sdam/server';
 import type { Db } from '../db';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export type RemoveUserOptions = CommandOperationOptions;
 
 /** @internal */
-export class RemoveUserOperation extends CommandOperation<RemoveUserOptions, boolean> {
+export class RemoveUserOperation extends CommandOperation<boolean> {
+  options: RemoveUserOptions;
   username: string;
 
   constructor(db: Db, username: string, options: RemoveUserOptions) {
     super(db, options);
+    this.options = options;
     this.username = username;
   }
 
-  execute(server: Server, callback: Callback<boolean>): void {
-    super.executeCommand(server, { dropUser: this.username }, err => {
+  execute(server: Server, session: ClientSession, callback: Callback<boolean>): void {
+    super.executeCommand(server, session, { dropUser: this.username }, err => {
       callback(err, err ? false : true);
     });
   }

--- a/src/operations/rename.ts
+++ b/src/operations/rename.ts
@@ -6,6 +6,7 @@ import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
 import type { CommandOperationOptions } from './command';
 import { MongoError } from '../error';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export interface RenameOptions extends CommandOperationOptions {
@@ -17,6 +18,7 @@ export interface RenameOptions extends CommandOperationOptions {
 
 /** @internal */
 export class RenameOperation extends RunAdminCommandOperation {
+  options: RenameOptions;
   collection: Collection;
   newName: string;
 
@@ -29,17 +31,18 @@ export class RenameOperation extends RunAdminCommandOperation {
     const toCollection = collection.s.namespace.withCollection(newName).toString();
     const dropTarget = typeof options.dropTarget === 'boolean' ? options.dropTarget : false;
     const cmd = { renameCollection: renameCollection, to: toCollection, dropTarget: dropTarget };
-    super(collection, cmd, options);
 
+    super(collection, cmd, options);
+    this.options = options;
     this.collection = collection;
     this.newName = newName;
   }
 
-  execute(server: Server, callback: Callback<Collection>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<Collection>): void {
     const Collection = loadCollection();
     const coll = this.collection;
 
-    super.execute(server, (err, doc) => {
+    super.execute(server, session, (err, doc) => {
       if (err) return callback(err);
       // We have an error
       if (doc.errmsg) {

--- a/src/operations/run_command.ts
+++ b/src/operations/run_command.ts
@@ -2,33 +2,30 @@ import { CommandOperation, CommandOperationOptions, OperationParent } from './co
 import { MongoDBNamespace, Callback } from '../utils';
 import type { Server } from '../sdam/server';
 import type { Document } from '../bson';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export type RunCommandOptions = CommandOperationOptions;
 
 /** @internal */
-export class RunCommandOperation<
-  T extends RunCommandOptions = RunCommandOptions,
-  TResult = Document
-> extends CommandOperation<T, TResult> {
+export class RunCommandOperation<T = Document> extends CommandOperation<T> {
+  options: RunCommandOptions;
   command: Document;
 
-  constructor(parent: OperationParent | undefined, command: Document, options?: T) {
+  constructor(parent: OperationParent | undefined, command: Document, options?: RunCommandOptions) {
     super(parent, options);
+    this.options = options ?? {};
     this.command = command;
   }
 
-  execute(server: Server, callback: Callback): void {
+  execute(server: Server, session: ClientSession, callback: Callback): void {
     const command = this.command;
-    this.executeCommand(server, command, callback);
+    this.executeCommand(server, session, command, callback);
   }
 }
 
-export class RunAdminCommandOperation<
-  T extends RunCommandOptions = RunCommandOptions,
-  TResult = Document
-> extends RunCommandOperation<T, TResult> {
-  constructor(parent: OperationParent | undefined, command: Document, options?: T) {
+export class RunAdminCommandOperation<T = Document> extends RunCommandOperation<T> {
+  constructor(parent: OperationParent | undefined, command: Document, options?: RunCommandOptions) {
     super(parent, command, options);
     this.ns = new MongoDBNamespace('admin');
   }

--- a/src/operations/set_profiling_level.ts
+++ b/src/operations/set_profiling_level.ts
@@ -2,6 +2,7 @@ import { CommandOperation, CommandOperationOptions } from './command';
 import type { Callback } from '../utils';
 import type { Server } from '../sdam/server';
 import type { Db } from '../db';
+import type { ClientSession } from '../sessions';
 const levelValues = new Set(['off', 'slow_only', 'all']);
 
 /** @public */
@@ -15,15 +16,14 @@ export enum ProfilingLevel {
 export type SetProfilingLevelOptions = CommandOperationOptions;
 
 /** @internal */
-export class SetProfilingLevelOperation extends CommandOperation<
-  SetProfilingLevelOptions,
-  ProfilingLevel
-> {
+export class SetProfilingLevelOperation extends CommandOperation<ProfilingLevel> {
+  options: SetProfilingLevelOptions;
   level: ProfilingLevel;
   profile: 0 | 1 | 2;
 
   constructor(db: Db, level: ProfilingLevel, options: SetProfilingLevelOptions) {
     super(db, options);
+    this.options = options;
     switch (level) {
       case ProfilingLevel.off:
         this.profile = 0;
@@ -42,14 +42,14 @@ export class SetProfilingLevelOperation extends CommandOperation<
     this.level = level;
   }
 
-  execute(server: Server, callback: Callback<ProfilingLevel>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<ProfilingLevel>): void {
     const level = this.level;
 
     if (!levelValues.has(level)) {
       return callback(new Error('Error: illegal profiling level value ' + level));
     }
 
-    super.executeCommand(server, { profile: this.profile }, (err, doc) => {
+    super.executeCommand(server, session, { profile: this.profile }, (err, doc) => {
       if (err == null && doc.ok === 1) return callback(undefined, level);
       return err != null ? callback(err) : callback(new Error('Error with profile command'));
     });

--- a/src/operations/stats.ts
+++ b/src/operations/stats.ts
@@ -4,6 +4,8 @@ import type { Callback } from '../utils';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
+import type { Db } from '../db';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export interface CollStatsOptions extends CommandOperationOptions {
@@ -15,7 +17,8 @@ export interface CollStatsOptions extends CommandOperationOptions {
  * Get all the collection statistics.
  * @internal
  */
-export class CollStatsOperation extends CommandOperation<CollStatsOptions, Document> {
+export class CollStatsOperation extends CommandOperation<Document> {
+  options: CollStatsOptions;
   collectionName: string;
 
   /**
@@ -26,16 +29,17 @@ export class CollStatsOperation extends CommandOperation<CollStatsOptions, Docum
    */
   constructor(collection: Collection, options?: CollStatsOptions) {
     super(collection, options);
+    this.options = options ?? {};
     this.collectionName = collection.collectionName;
   }
 
-  execute(server: Server, callback: Callback<Document>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
     const command: Document = { collStats: this.collectionName };
     if (this.options.scale != null) {
       command.scale = this.options.scale;
     }
 
-    super.executeCommand(server, command, callback);
+    super.executeCommand(server, session, command, callback);
   }
 }
 
@@ -46,14 +50,21 @@ export interface DbStatsOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class DbStatsOperation extends CommandOperation<DbStatsOptions, Document> {
-  execute(server: Server, callback: Callback<Document>): void {
+export class DbStatsOperation extends CommandOperation<Document> {
+  options: DbStatsOptions;
+
+  constructor(db: Db, options: DbStatsOptions) {
+    super(db, options);
+    this.options = options;
+  }
+
+  execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
     const command: Document = { dbStats: true };
     if (this.options.scale != null) {
       command.scale = this.options.scale;
     }
 
-    super.executeCommand(server, command, callback);
+    super.executeCommand(server, session, command, callback);
   }
 }
 

--- a/src/operations/validate_collection.ts
+++ b/src/operations/validate_collection.ts
@@ -3,6 +3,7 @@ import type { Callback } from '../utils';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Admin } from '../admin';
+import type { ClientSession } from '../sessions';
 
 /** @public */
 export interface ValidateCollectionOptions extends CommandOperationOptions {
@@ -11,10 +12,8 @@ export interface ValidateCollectionOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class ValidateCollectionOperation extends CommandOperation<
-  ValidateCollectionOptions,
-  Document
-> {
+export class ValidateCollectionOperation extends CommandOperation<Document> {
+  options: ValidateCollectionOptions;
   collectionName: string;
   command: Document;
 
@@ -29,14 +28,15 @@ export class ValidateCollectionOperation extends CommandOperation<
     }
 
     super(admin.s.db, options);
+    this.options = options;
     this.command = command;
     this.collectionName = collectionName;
   }
 
-  execute(server: Server, callback: Callback<Document>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
     const collectionName = this.collectionName;
 
-    super.executeCommand(server, this.command, (err, doc) => {
+    super.executeCommand(server, session, this.command, (err, doc) => {
       if (err != null) return callback(err);
 
       if (doc.ok === 0) return callback(new Error('Error with validate command'));

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -97,7 +97,7 @@ export class ReadPreference {
     this.tags = tags;
     this.hedge = options?.hedge;
 
-    options = options || {};
+    options = options ?? {};
     if (options.maxStalenessSeconds != null) {
       if (options.maxStalenessSeconds <= 0) {
         throw new TypeError('maxStalenessSeconds must be a positive integer');

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from 'events';
 import { Logger } from '../logger';
-import { ReadPreference } from '../read_preference';
 import { ConnectionPool, ConnectionPoolOptions } from '../cmap/connection_pool';
 import { CMAP_EVENT_NAMES } from '../cmap/events';
 import { ServerDescription, compareTopologyVersion } from './server_description';
@@ -256,18 +255,13 @@ export class Server extends EventEmitter {
     callback?: Callback<Document>
   ): void {
     if (typeof options === 'function') {
-      (callback = options), (options = {}), (options = options || {});
+      (callback = options), (options = {}), (options = options ?? {});
     }
 
     if (!callback) return;
     if (this.s.state === STATE_CLOSING || this.s.state === STATE_CLOSED) {
       callback(new MongoError('server is closed'));
       return;
-    }
-
-    const error = basicReadValidations(this, options);
-    if (error) {
-      return callback(error);
     }
 
     // Clone the options
@@ -440,18 +434,12 @@ function calculateRoundTripTime(oldRtt: number, duration: number): number {
   return alpha * duration + (1 - alpha) * oldRtt;
 }
 
-function basicReadValidations(server: Server, options?: CommandOptions) {
-  if (options?.readPreference && !(options.readPreference instanceof ReadPreference)) {
-    return new MongoError('readPreference must be an instance of ReadPreference');
-  }
-}
-
 function executeWriteOperation(
   args: { server: Server; op: string; ns: string; ops: Document[] | Document },
   options: WriteCommandOptions,
   callback: Callback
 ) {
-  options = options || {};
+  options = options ?? {};
 
   const { server, op, ns } = args;
   const ops = Array.isArray(args.ops) ? args.ops : [args.ops];

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -317,7 +317,7 @@ export class Topology extends EventEmitter {
   /** Initiate server connect */
   connect(options?: ConnectOptions, callback?: Callback): void {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
     if (this.s.state === STATE_CONNECTED) {
       if (typeof callback === 'function') {
         callback();
@@ -391,7 +391,7 @@ export class Topology extends EventEmitter {
       options = { force: options };
     }
 
-    options = options || {};
+    options = options ?? {};
     if (this.s.state === STATE_CLOSED || this.s.state === STATE_CLOSING) {
       if (typeof callback === 'function') {
         callback();
@@ -729,7 +729,7 @@ function destroyServer(
   options?: DestroyOptions,
   callback?: Callback
 ) {
-  options = options || {};
+  options = options ?? {};
   LOCAL_SERVER_EVENTS.forEach((event: string) => server.removeAllListeners(event));
 
   server.destroy(options, () => {

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -46,7 +46,7 @@ export class TopologyDescription {
     commonWireVersion?: number,
     options?: TopologyDescriptionOptions
   ) {
-    options = options || {};
+    options = options ?? {};
 
     // TODO: consider assigning all these values to a temporary value `s` which
     //       we use `Object.freeze` on, ensuring the internal state of this type

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -103,7 +103,7 @@ class ClientSession extends EventEmitter {
       throw new Error('ClientSession requires a ServerSessionPool');
     }
 
-    options = options || {};
+    options = options ?? {};
     clientOptions = clientOptions || {};
 
     this.topology = topology;
@@ -155,7 +155,7 @@ class ClientSession extends EventEmitter {
     callback?: Callback<void>
   ): void | Promise<void> {
     if (typeof options === 'function') (callback = options), (options = {});
-    options = options || {};
+    options = options ?? {};
 
     return maybePromise(callback, done => {
       if (this.hasEnded) {
@@ -795,16 +795,6 @@ function applySession(
     }
 
     return;
-  }
-
-  if (options) {
-    ReadPreference.translate(options);
-    const readPreference = options.readPreference as ReadPreference;
-    if (readPreference && !readPreference.equals(ReadPreference.primary)) {
-      return new MongoError(
-        `Read preference in a transaction must be primary, not: ${readPreference.mode}`
-      );
-    }
   }
 
   // `autocommit` must always be false to differentiate from retryable writes

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -70,7 +70,7 @@ export class Transaction {
 
   /** Create a transaction */
   constructor(options?: TransactionOptions) {
-    options = options || {};
+    options = options ?? {};
 
     this.state = TxnState.NO_TRANSACTION;
     this.options = {};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import type { Topology } from './sdam/topology';
 import type { EventEmitter } from 'events';
 import type { Db } from './db';
 import type { Collection } from './collection';
-import type { OperationOptions, OperationBase, Hint } from './operations/operation';
+import type { OperationOptions, Hint } from './operations/operation';
 import type { ClientSession } from './sessions';
 import { ReadConcern } from './read_concern';
 import type { Connection } from './cmap/connection';
@@ -230,7 +230,7 @@ export function filterOptions(options: AnyOptions, names: string[]): AnyOptions 
  * @param args - Arguments to apply the provided operation
  * @param options - Options that modify the behavior of the method
  */
-export function executeLegacyOperation<T extends OperationBase>(
+export function executeLegacyOperation<T>(
   topology: Topology,
   operation: (...args: any[]) => void | Promise<Document>,
   args: any[],
@@ -242,7 +242,7 @@ export function executeLegacyOperation<T extends OperationBase>(
     throw new TypeError('This method requires an array of arguments to apply');
   }
 
-  options = options || {};
+  options = options ?? {};
 
   let callback = args[args.length - 1];
 
@@ -350,7 +350,7 @@ export function applyWriteConcern<T extends HasWriteConcern>(
   sources: { db?: Db; collection?: Collection },
   options?: OperationOptions & WriteConcernOptions
 ): T {
-  options = options || {};
+  options = options ?? {};
   const db = sources.db;
   const coll = sources.collection;
 
@@ -887,7 +887,7 @@ export interface ClientMetadataOptions {
 const NODE_DRIVER_VERSION = require('../package.json').version;
 
 export function makeClientMetadata(options: ClientMetadataOptions): ClientMetadata {
-  options = options || {};
+  options = options ?? {};
 
   const metadata: ClientMetadata = {
     driver: {
@@ -1000,7 +1000,7 @@ export function makeInterruptableAsyncInterval(
   let lastWakeTime: number;
   let stopped = false;
 
-  options = options || {};
+  options = options ?? {};
   const interval = options.interval || 1000;
   const minInterval = options.minInterval || 500;
   const immediate = typeof options.immediate === 'boolean' ? options.immediate : false;

--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -3769,6 +3769,7 @@ describe('Operation Examples', function () {
 
             // Retrieve the number of documents from the collection
             collection.count(function (err, count) {
+              expect(err).to.not.exist;
               test.equal(1, count);
 
               // Rename the collection

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -113,8 +113,10 @@ describe('Sessions', function () {
 
           return client
             .withSession(testCase.operation(client))
-            .catch(() => expect(client.topology.s.sessionPool.sessions).to.have.length(1))
-            .then(() => expect(client.topology.s.sessionPool.sessions).to.have.length(1))
+            .then(
+              () => expect(client.topology.s.sessionPool.sessions).to.have.length(1),
+              () => expect(client.topology.s.sessionPool.sessions).to.have.length(1)
+            )
             .then(() => client.close())
             .then(() => {
               // verify that the `endSessions` command was sent


### PR DESCRIPTION
## Description
This is the most basic work required to remove the generic options type for the `OperationBase` type. The general rule of thumb was to add an `options` property to each subclass with a concrete type specific to that operation. Other work includes:
 - renamed `OperationBase` to `AbstractOperation` in keeping with the convention introduced in the `AbstractCursor` work
 - minor fixes uncovered when making options stricter (things like `readPreference` being stored on a copy of options in the base class)
