### PR TITLE
refactor!: CreateIndexOp returns string, CreateIndexesOp returns array

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1210,7 +1210,10 @@ export abstract class BulkOperationBase {
   }
 
   /** An internal helper method. Do not invoke directly. Will be going away in the future */
-  execute(options?: BulkWriteOptions, callback?: Callback<BulkWriteResult>): Promise<void> | void {
+  execute(
+    options?: BulkWriteOptions,
+    callback?: Callback<BulkWriteResult>
+  ): Promise<BulkWriteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options ?? {};
 
@@ -1292,7 +1295,7 @@ Object.defineProperty(BulkOperationBase.prototype, 'length', {
 function handleEarlyError(
   err?: AnyError,
   callback?: Callback<BulkWriteResult>
-): Promise<void> | void {
+): Promise<BulkWriteResult> | void {
   const Promise = PromiseProvider.get();
   if (typeof callback === 'function') {
     callback(err);

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -727,19 +727,19 @@ export class Collection implements OperationParent {
    * await collection.createIndex(['j', ['k', -1], { l: '2d' }])
    * ```
    */
-  createIndex(indexSpec: IndexSpecification): Promise<Document>;
-  createIndex(indexSpec: IndexSpecification, callback: Callback<Document>): void;
-  createIndex(indexSpec: IndexSpecification, options: CreateIndexesOptions): Promise<Document>;
+  createIndex(indexSpec: IndexSpecification): Promise<string>;
+  createIndex(indexSpec: IndexSpecification, callback: Callback<string>): void;
+  createIndex(indexSpec: IndexSpecification, options: CreateIndexesOptions): Promise<string>;
   createIndex(
     indexSpec: IndexSpecification,
     options: CreateIndexesOptions,
-    callback: Callback<Document>
+    callback: Callback<string>
   ): void;
   createIndex(
     indexSpec: IndexSpecification,
-    options?: CreateIndexesOptions | Callback<Document>,
-    callback?: Callback<Document>
-  ): Promise<Document> | void {
+    options?: CreateIndexesOptions | Callback<string>,
+    callback?: Callback<string>
+  ): Promise<string> | void {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
@@ -781,19 +781,19 @@ export class Collection implements OperationParent {
    * ]);
    * ```
    */
-  createIndexes(indexSpecs: IndexDescription[]): Promise<Document>;
-  createIndexes(indexSpecs: IndexDescription[], callback: Callback<Document>): void;
-  createIndexes(indexSpecs: IndexDescription[], options: CreateIndexesOptions): Promise<Document>;
+  createIndexes(indexSpecs: IndexDescription[]): Promise<string[]>;
+  createIndexes(indexSpecs: IndexDescription[], callback: Callback<string[]>): void;
+  createIndexes(indexSpecs: IndexDescription[], options: CreateIndexesOptions): Promise<string[]>;
   createIndexes(
     indexSpecs: IndexDescription[],
     options: CreateIndexesOptions,
-    callback: Callback<Document>
+    callback: Callback<string[]>
   ): void;
   createIndexes(
     indexSpecs: IndexDescription[],
-    options?: CreateIndexesOptions | Callback<Document>,
-    callback?: Callback<Document>
-  ): Promise<Document> | void {
+    options?: CreateIndexesOptions | Callback<string[]>,
+    callback?: Callback<string[]>
+  ): Promise<string[]> | void {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options ? Object.assign({}, options) : {};
     if (typeof options.maxTimeMS !== 'number') delete options.maxTimeMS;

--- a/src/db.ts
+++ b/src/db.ts
@@ -581,25 +581,25 @@ export class Db implements OperationParent {
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
-  createIndex(name: string, indexSpec: IndexSpecification): Promise<Document>;
-  createIndex(name: string, indexSpec: IndexSpecification, callback?: Callback<Document>): void;
+  createIndex(name: string, indexSpec: IndexSpecification): Promise<string>;
+  createIndex(name: string, indexSpec: IndexSpecification, callback?: Callback<string>): void;
   createIndex(
     name: string,
     indexSpec: IndexSpecification,
     options: CreateIndexesOptions
-  ): Promise<Document>;
+  ): Promise<string>;
   createIndex(
     name: string,
     indexSpec: IndexSpecification,
     options: CreateIndexesOptions,
-    callback: Callback<Document>
+    callback: Callback<string>
   ): void;
   createIndex(
     name: string,
     indexSpec: IndexSpecification,
-    options?: CreateIndexesOptions | Callback<Document>,
-    callback?: Callback<Document>
-  ): Promise<Document> | void {
+    options?: CreateIndexesOptions | Callback<string>,
+    callback?: Callback<string>
+  ): Promise<string> | void {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -150,7 +150,9 @@ export class IndexesOperation extends AbstractOperation<Document> {
 }
 
 /** @internal */
-export class CreateIndexesOperation<T = string[]> extends CommandOperation<T> {
+export class CreateIndexesOperation<
+  T extends string | string[] = string[]
+> extends CommandOperation<T> {
   options: CreateIndexesOptions;
   collectionName: string;
   indexes: IndexDescription[];
@@ -169,7 +171,7 @@ export class CreateIndexesOperation<T = string[]> extends CommandOperation<T> {
     this.indexes = indexes;
   }
 
-  execute(server: Server, session: ClientSession, callback: Callback<any>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<T>): void {
     const options = this.options;
     const indexes = this.indexes;
 
@@ -221,8 +223,8 @@ export class CreateIndexesOperation<T = string[]> extends CommandOperation<T> {
         return;
       }
 
-      const indexNames = indexes.map(index => index.name);
-      callback(undefined, indexNames);
+      const indexNames = indexes.map(index => index.name || '');
+      callback(undefined, indexNames as T);
     });
   }
 }
@@ -245,7 +247,7 @@ export class CreateIndexOperation extends CreateIndexesOperation<string> {
   }
   execute(server: Server, session: ClientSession, callback: Callback<string>): void {
     super.execute(server, session, (err, indexNames) => {
-      if (err) return callback(err);
+      if (err || !indexNames) return callback(err);
       return callback(undefined, indexNames[0]);
     });
   }

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -221,8 +221,8 @@ export class CreateIndexesOperation<T = string[]> extends CommandOperation<T> {
         return;
       }
 
-      const names = indexes.map(index => index.name);
-      callback(undefined, names);
+      const indexNames = indexes.map(index => index.name);
+      callback(undefined, indexNames);
     });
   }
 }
@@ -244,9 +244,9 @@ export class CreateIndexOperation extends CreateIndexesOperation<string> {
     super(parent, collectionName, [makeIndexSpec(indexSpec, options)], options);
   }
   execute(server: Server, session: ClientSession, callback: Callback<string>): void {
-    super.execute(server, session, (err, result) => {
+    super.execute(server, session, (err, indexNames) => {
       if (err) return callback(err);
-      return callback(undefined, result[0]);
+      return callback(undefined, indexNames[0]);
     });
   }
 }


### PR DESCRIPTION
`CreateIndexesOperation` was returning the name of the created index
instead of the result from the server because of the logic ensuring
`CreateIndexOperation` has that behavior.

This PR makes `CreateIndexesOperation` return an *array of index names*
(breaking change), while `CreateIndexOperation` continues to return a
single index name string. This makes the behavior consistent with other
official drivers.

Users in need of the raw result from the server should use `db.command`.

NODE-2602