### PR TITLE
chore(ci): continuous matrix integration [3.6]

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -113,7 +113,8 @@ functions:
           fi
 
           AUTH=${AUTH} SSL=${SSL} UNIFIED=${UNIFIED} MONGODB_URI="${MONGODB_URI}" \
-          NODE_VERSION=${NODE_VERSION} SKIP_DEPS=1 bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          NODE_VERSION=${NODE_VERSION} SKIP_DEPS=1 NO_EXIT=1 \
+            bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
   run checks:
     - command: shell.exec
       type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -113,7 +113,7 @@ functions:
           fi
 
           AUTH=${AUTH} SSL=${SSL} UNIFIED=${UNIFIED} MONGODB_URI="${MONGODB_URI}" \
-          NODE_VERSION=${NODE_VERSION} bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          NODE_VERSION=${NODE_VERSION} SKIP_DEPS=1 bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
   run checks:
     - command: shell.exec
       type: test
@@ -1672,11 +1672,11 @@ buildvariants:
       NODE_LTS_NAME: argon
       CLIENT_ENCRYPTION: true
     tasks: *ref_2
-  - name: windows-64-vs2013-erbium
-    display_name: Windows (VS2013) Node Erbium
+  - name: windows-64-vs2013-carbon
+    display_name: Windows (VS2013) Node Carbon
     run_on: windows-64-vs2013-large
     expansions:
-      NODE_LTS_NAME: erbium
+      NODE_LTS_NAME: carbon
       MSVS_VERSION: 2013
     tasks: &ref_3
       - test-4.2-server
@@ -1721,20 +1721,6 @@ buildvariants:
       - test-2.6-server-unified
       - test-2.6-replica_set-unified
       - test-2.6-sharded_cluster-unified
-  - name: windows-64-vs2013-dubnium
-    display_name: Windows (VS2013) Node Dubnium
-    run_on: windows-64-vs2013-large
-    expansions:
-      NODE_LTS_NAME: dubnium
-      MSVS_VERSION: 2013
-    tasks: *ref_3
-  - name: windows-64-vs2013-carbon
-    display_name: Windows (VS2013) Node Carbon
-    run_on: windows-64-vs2013-large
-    expansions:
-      NODE_LTS_NAME: carbon
-      MSVS_VERSION: 2013
-    tasks: *ref_3
   - name: windows-64-vs2013-boron
     display_name: Windows (VS2013) Node Boron
     run_on: windows-64-vs2013-large

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -132,7 +132,8 @@ functions:
           fi
 
           AUTH=${AUTH} SSL=${SSL} UNIFIED=${UNIFIED} MONGODB_URI="${MONGODB_URI}" \
-          NODE_VERSION=${NODE_VERSION} SKIP_DEPS=1 bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          NODE_VERSION=${NODE_VERSION} SKIP_DEPS=1 NO_EXIT=1 \
+            bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "run checks":
     - command: shell.exec

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -132,7 +132,7 @@ functions:
           fi
 
           AUTH=${AUTH} SSL=${SSL} UNIFIED=${UNIFIED} MONGODB_URI="${MONGODB_URI}" \
-          NODE_VERSION=${NODE_VERSION} bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          NODE_VERSION=${NODE_VERSION} SKIP_DEPS=1 bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "run checks":
     - command: shell.exec

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -45,7 +45,8 @@ const OPERATING_SYSTEMS = [
     display_name: 'Windows (VS2013)',
     run_on: 'windows-64-vs2013-large',
     msvsVersion: 2013,
-    mongoVersion: '<4.4'
+    mongoVersion: '<4.4',
+    nodeVersions: ['carbon', 'boron', 'argon']
   },
   {
     name: 'windows-64-vs2015',

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -86,7 +86,7 @@ EOT
 else
   curl -o- $NVM_URL | bash
   [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
-  nvm install --no-progress --lts=${NODE_LTS_NAME}
+  nvm install --no-progress $NODE_VERSION
 
   # setup npm cache in a local directory
   cat <<EOT > .npmrc
@@ -101,10 +101,4 @@ fi
 # NOTE: registry was overridden to not use artifactory, remove the `registry` line when
 #       BUILD-6774 is resolved.
 
-# install node dependencies
-if [[ "$SKIP_INSTALL" == "1" ]]; then
-  echo "Skipping npm install"
-else
-  echo "Running npm install"
-  npm install --unsafe-perm
-fi
+npm install --unsafe-perm

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -o xtrace   # Write all commands first to stderr
+set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported/used environment variables:
@@ -8,11 +8,13 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       UNIFIED                 Set to enable the Unified SDAM topology for the node driver
 #       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
 #       MARCH                   Machine Architecture. Defaults to lowercase uname -m
+#       TEST_NPM_SCRIPT         Script to npm run. Defaults to "test-nolint"
+#       SKIP_DEPS               Skip installing dependencies
 
 AUTH=${AUTH:-noauth}
 UNIFIED=${UNIFIED:-}
 MONGODB_URI=${MONGODB_URI:-}
-TEST_NPM_SCRIPT="test-nolint"
+TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-test-nolint}
 
 # ssl setup
 SSL=${SSL:-nossl}
@@ -25,18 +27,21 @@ fi
 echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"
 
 export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
-NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
-export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
-if [[ "$OS" == "Windows_NT" ]]; then
-  export NVM_HOME=`cygpath -m -a "$NVM_DIR"`
-  export NVM_SYMLINK=`cygpath -m -a "$NODE_ARTIFACTS_PATH/bin"`
-  export NVM_ARTIFACTS_PATH=`cygpath -m -a "$NODE_ARTIFACTS_PATH/bin"`
-  export PATH=`cygpath $NVM_SYMLINK`:`cygpath $NVM_HOME`:$PATH
-  echo "updated path on windows PATH=$PATH"
+
+if [[ -z "${SKIP_DEPS}" ]]; then
+  source "${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
 else
-  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
+  export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+  if [[ "$OS" == "Windows_NT" ]]; then
+    export NVM_HOME=`cygpath -m -a "$NVM_DIR"`
+    export NVM_SYMLINK=`cygpath -m -a "$NODE_ARTIFACTS_PATH/bin"`
+    export NVM_ARTIFACTS_PATH=`cygpath -m -a "$NODE_ARTIFACTS_PATH/bin"`
+    export PATH=`cygpath $NVM_SYMLINK`:`cygpath $NVM_HOME`:$PATH
+  else
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  fi
 fi
-echo "initializing NVM, NVM_DIR=$NVM_DIR"
 
 # only run FLE tets on hosts we explicitly choose to test on
 if [[ -z "${CLIENT_ENCRYPTION}" ]]; then

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o xtrace   # Write all commands first to stderr
+# set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported/used environment variables:
@@ -10,17 +10,21 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       MARCH                   Machine Architecture. Defaults to lowercase uname -m
 #       TEST_NPM_SCRIPT         Script to npm run. Defaults to "test-nolint"
 #       SKIP_DEPS               Skip installing dependencies
+#       NO_EXIT                 Don't exit early from tests that leak resources
 
 AUTH=${AUTH:-noauth}
-UNIFIED=${UNIFIED:-}
+UNIFIED=${UNIFIED:-0}
 MONGODB_URI=${MONGODB_URI:-}
 TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-test-nolint}
+if [[ -z "${NO_EXIT}" ]]; then
+  TEST_NPM_SCRIPT="$TEST_NPM_SCRIPT -- --exit"
+fi
 
 # ssl setup
 SSL=${SSL:-nossl}
 if [ "$SSL" != "nossl" ]; then
-   export SSL_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
-   export SSL_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
+  export SSL_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
+  export SSL_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
 fi
 
 # run tests


### PR DESCRIPTION
The Continuous Matrix Testing project requires a number of changes to our test infrastructure.

This PR:
- prevents testing node versions after carbon on vs2013, which they don't support 
- fixes a flaky change stream test which could sometimes produce invalid JSON and then attempt to parse it 
- adds `SKIP_DEPS` flag to `run-tests.sh` 
    - if this flag is missing, automatically run `install-dependencies.sh` (for matrix tests)
    - adds `SKIP_DEPS=1` to `run tests` Evergreen function, preserving old behavior
- adds `NO_EXIT` flag to `run-tests.sh`
    - if this flag is missing, automatically exit early from test runs that leak resources (for matrix tests)
    - adds `NO_EXIT=1` to `run tests` Evergreen function, preserving old behavior

NODE-2914