### PR TITLE
fix: honor ignoreUndefined on findAndModify commands

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1688,6 +1688,12 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
 
+  // Add ignoreUndefined
+  if (this.s.options.ignoreUndefined) {
+    options = Object.assign({}, options);
+    options.ignoreUndefined = this.s.options.ignoreUndefined;
+  }
+
   return executeOperation(
     this.s.topology,
     new FindOneAndDeleteOperation(this, filter, options),
@@ -1721,6 +1727,12 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
 Collection.prototype.findOneAndReplace = function(filter, replacement, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
+
+  // Add ignoreUndefined
+  if (this.s.options.ignoreUndefined) {
+    options = Object.assign({}, options);
+    options.ignoreUndefined = this.s.options.ignoreUndefined;
+  }
 
   return executeOperation(
     this.s.topology,
@@ -1756,6 +1768,12 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
 Collection.prototype.findOneAndUpdate = function(filter, update, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = options || {};
+
+  // Add ignoreUndefined
+  if (this.s.options.ignoreUndefined) {
+    options = Object.assign({}, options);
+    options.ignoreUndefined = this.s.options.ignoreUndefined;
+  }
 
   return executeOperation(
     this.s.topology,


### PR DESCRIPTION
Honors the `ignoreUndefined` option for find-and-modify commands.

Note: this option doesn't seem to have any effect for `findOneAndDelete`
operations, but support was added because it is listed as a valid option.

NODE-2945