### PR TITLE
feat!: Integrate MongoOptions parser into driver

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 docs
 lib
+test/disabled

--- a/package-lock.json
+++ b/package-lock.json
@@ -566,6 +566,12 @@
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.0.tgz",
+      "integrity": "sha512-/Sge3BymXo4lKc31C8OINJgXLaw+7vL1/L1pGiBNpGrBiT8FQiaFpSYV0uhTaG4y78vcMBTMFsWaHDvuD+xGzQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.6.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/bl": "^2.1.0",
     "@types/bson": "^4.0.2",
     "@types/kerberos": "^1.1.0",
+    "@types/mocha": "^8.2.0",
     "@types/node": "^14.6.4",
     "@types/saslprep": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^3.10.0",

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -37,7 +37,7 @@ import type { SerializeOptions } from 'bson';
  * BSON Serialization options.
  * @public
  */
-export interface BSONSerializeOptions extends SerializeOptions {
+export interface BSONSerializeOptions extends Omit<SerializeOptions, 'index'> {
   /** Return document results as raw BSON buffers */
   fieldsAsRaw?: { [key: string]: boolean };
   /** Promotes BSON values to native types where possible, set to false to only receive wrapper types */

--- a/src/cmap/auth/defaultAuthProviders.ts
+++ b/src/cmap/auth/defaultAuthProviders.ts
@@ -21,20 +21,12 @@ export const AuthMechanism = {
 /** @public */
 export type AuthMechanismId = typeof AuthMechanism[keyof typeof AuthMechanism];
 
-export const AUTH_PROVIDERS = {
-  [AuthMechanism.MONGODB_AWS]: new MongoDBAWS(),
-  [AuthMechanism.MONGODB_CR]: new MongoCR(),
-  [AuthMechanism.MONGODB_GSSAPI]: new GSSAPI(),
-  [AuthMechanism.MONGODB_PLAIN]: new Plain(),
-  [AuthMechanism.MONGODB_SCRAM_SHA1]: new ScramSHA1(),
-  [AuthMechanism.MONGODB_SCRAM_SHA256]: new ScramSHA256(),
-  [AuthMechanism.MONGODB_X509]: new X509()
-};
-
-// TODO: We can make auth mechanism more functional since we pass around a context object
-// and we improve the the typing here to use the enum, the current issue is that the mechanism is
-// 'default' until resolved maybe we can do that resolution here and make the this strictly
-// AuthMechanism -> AuthProviders
-export function defaultAuthProviders(): Record<string, AuthProvider> {
-  return AUTH_PROVIDERS;
-}
+export const AUTH_PROVIDERS = new Map<AuthMechanismId | string, AuthProvider>([
+  [AuthMechanism.MONGODB_AWS, new MongoDBAWS()],
+  [AuthMechanism.MONGODB_CR, new MongoCR()],
+  [AuthMechanism.MONGODB_GSSAPI, new GSSAPI()],
+  [AuthMechanism.MONGODB_PLAIN, new Plain()],
+  [AuthMechanism.MONGODB_SCRAM_SHA1, new ScramSHA1()],
+  [AuthMechanism.MONGODB_SCRAM_SHA256, new ScramSHA256()],
+  [AuthMechanism.MONGODB_X509, new X509()]
+]);

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -60,16 +60,10 @@ export class GSSAPI extends AuthProvider {
   }
 }
 function makeKerberosClient(authContext: AuthContext, callback: Callback<KerberosClient>): void {
-  const { host, port } = authContext.options;
+  const { hostAddress } = authContext.options;
   const { credentials } = authContext;
-  if (!host || !port || !credentials) {
-    return callback(
-      new MongoError(
-        `Connection must specify: ${host ? 'host' : ''}, ${port ? 'port' : ''}, ${
-          credentials ? 'host' : 'credentials'
-        }.`
-      )
-    );
+  if (!hostAddress || typeof hostAddress.host !== 'string' || !credentials) {
+    return callback(new MongoError('Connection must have host and port and credentials defined.'));
   }
 
   if ('kModuleError' in Kerberos) {
@@ -83,7 +77,7 @@ function makeKerberosClient(authContext: AuthContext, callback: Callback<Kerbero
     'mongodb';
 
   performGssapiCanonicalizeHostName(
-    host,
+    hostAddress.host,
     mechanismProperties as MechanismProperties,
     (err?: Error | MongoError, host?: string) => {
       if (err) return callback(err);

--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -147,15 +147,15 @@ export class MongoCredentials {
   }
 
   static merge(
-    creds: MongoCredentials,
+    creds: MongoCredentials | undefined,
     options: Partial<MongoCredentialsOptions>
   ): MongoCredentials {
     return new MongoCredentials({
-      username: options.username ?? creds.username,
-      password: options.password ?? creds.password,
-      mechanism: options.mechanism ?? creds.mechanism,
-      mechanismProperties: options.mechanismProperties ?? creds.mechanismProperties,
-      source: options.source ?? creds.source ?? options.db
+      username: options.username ?? creds?.username ?? '',
+      password: options.password ?? creds?.password ?? '',
+      mechanism: options.mechanism ?? creds?.mechanism ?? AuthMechanism.MONGODB_DEFAULT,
+      mechanismProperties: options.mechanismProperties ?? creds?.mechanismProperties ?? {},
+      source: options.source ?? options.db ?? creds?.source ?? 'admin'
     });
   }
 }

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -45,7 +45,7 @@ export class MongoDBAWS extends AuthProvider {
 
     if (credentials.username == null) {
       makeTempCredentials(credentials, (err, tempCredentials) => {
-        if (err) return callback(err);
+        if (err || !tempCredentials) return callback(err);
 
         authContext.credentials = tempCredentials;
         this.auth(authContext, callback);

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -2,7 +2,7 @@ import * as net from 'net';
 import * as tls from 'tls';
 import { Connection, ConnectionOptions, CryptoConnection } from './connection';
 import { MongoError, MongoNetworkError, MongoNetworkTimeoutError, AnyError } from '../error';
-import { defaultAuthProviders, AuthMechanism } from './auth/defaultAuthProviders';
+import { AUTH_PROVIDERS, AuthMechanism } from './auth/defaultAuthProviders';
 import { AuthContext } from './auth/auth_provider';
 import { makeClientMetadata, ClientMetadata, Callback, CallbackWithType, ns } from '../utils';
 import {
@@ -12,46 +12,24 @@ import {
   MIN_SUPPORTED_SERVER_VERSION
 } from './wire_protocol/constants';
 import type { Document } from '../bson';
-import type { EventEmitter } from 'events';
 
 import type { Socket, SocketConnectOpts } from 'net';
 import type { TLSSocket, ConnectionOptions as TLSConnectionOpts } from 'tls';
+import { Int32 } from '../bson';
 
 /** @public */
 export type Stream = Socket | TLSSocket;
 
-const AUTH_PROVIDERS = defaultAuthProviders();
-
-export function connect(options: ConnectionOptions, callback: Callback<Connection>): void;
-export function connect(
-  options: ConnectionOptions,
-  cancellationToken: EventEmitter,
-  callback: Callback<Connection>
-): void;
-export function connect(
-  options: ConnectionOptions,
-  _cancellationToken: EventEmitter | Callback<Connection>,
-  _callback?: Callback<Connection>
-): void {
-  let cancellationToken = _cancellationToken as EventEmitter | undefined;
-  const callback = (_callback ?? _cancellationToken) as Callback<Connection>;
-  if ('function' === typeof cancellationToken) {
-    cancellationToken = undefined;
-  }
-
-  const family = options.family !== undefined ? options.family : 0;
-  let ConnectionType: typeof Connection =
-    options && options.connectionType ? options.connectionType : Connection;
-  if (options.autoEncrypter) {
-    ConnectionType = CryptoConnection;
-  }
-
-  makeConnection(family, options, cancellationToken, (err, socket) => {
+export function connect(options: ConnectionOptions, callback: Callback<Connection>): void {
+  makeConnection(options, (err, socket) => {
     if (err || !socket) {
-      callback(err);
-      return;
+      return callback(err);
     }
 
+    let ConnectionType = options.connectionType ?? Connection;
+    if (options.autoEncrypter) {
+      ConnectionType = CryptoConnection;
+    }
     performInitialHandshake(new ConnectionType(socket, options), options, callback);
   });
 }
@@ -59,24 +37,26 @@ export function connect(
 function checkSupportedServer(ismaster: Document, options: ConnectionOptions) {
   const serverVersionHighEnough =
     ismaster &&
-    typeof ismaster.maxWireVersion === 'number' &&
-    ismaster.maxWireVersion >= MIN_SUPPORTED_WIRE_VERSION;
+    (typeof ismaster.maxWireVersion === 'number' || ismaster.maxWireVersion instanceof Int32) &&
+    ismaster.maxWireVersion.valueOf() >= MIN_SUPPORTED_WIRE_VERSION;
   const serverVersionLowEnough =
     ismaster &&
-    typeof ismaster.minWireVersion === 'number' &&
-    ismaster.minWireVersion <= MAX_SUPPORTED_WIRE_VERSION;
+    (typeof ismaster.maxWireVersion === 'number' || ismaster.maxWireVersion instanceof Int32) &&
+    ismaster.minWireVersion.valueOf() <= MAX_SUPPORTED_WIRE_VERSION;
 
   if (serverVersionHighEnough) {
     if (serverVersionLowEnough) {
       return null;
     }
 
-    const message = `Server at ${options.host}:${options.port} reports minimum wire version ${ismaster.minWireVersion}, but this version of the Node.js Driver requires at most ${MAX_SUPPORTED_WIRE_VERSION} (MongoDB ${MAX_SUPPORTED_SERVER_VERSION})`;
+    const message = `Server at ${options.hostAddress} reports minimum wire version ${JSON.stringify(
+      ismaster.minWireVersion
+    )}, but this version of the Node.js Driver requires at most ${MAX_SUPPORTED_WIRE_VERSION} (MongoDB ${MAX_SUPPORTED_SERVER_VERSION})`;
     return new MongoError(message);
   }
 
-  const message = `Server at ${options.host}:${options.port} reports maximum wire version ${
-    ismaster.maxWireVersion || 0
+  const message = `Server at ${options.hostAddress} reports maximum wire version ${
+    JSON.stringify(ismaster.maxWireVersion) ?? 0
   }, but this version of the Node.js Driver requires at least ${MIN_SUPPORTED_WIRE_VERSION} (MongoDB ${MIN_SUPPORTED_SERVER_VERSION})`;
   return new MongoError(message);
 }
@@ -95,7 +75,10 @@ function performInitialHandshake(
 
   const credentials = options.credentials;
   if (credentials) {
-    if (!credentials.mechanism.match(/DEFAULT/i) && !AUTH_PROVIDERS[credentials.mechanism]) {
+    if (
+      !(credentials.mechanism === AuthMechanism.MONGODB_DEFAULT) &&
+      !AUTH_PROVIDERS.get(credentials.mechanism)
+    ) {
       callback(new MongoError(`authMechanism '${credentials.mechanism}' not supported`));
       return;
     }
@@ -108,9 +91,9 @@ function performInitialHandshake(
     }
 
     const handshakeOptions: Document = Object.assign({}, options);
-    if (options.connectTimeoutMS || options.connectionTimeout) {
+    if (typeof options.connectTimeoutMS === 'number') {
       // The handshake technically is a monitoring check, so its socket timeout should be connectTimeoutMS
-      handshakeOptions.socketTimeout = options.connectTimeoutMS || options.connectionTimeout;
+      handshakeOptions.socketTimeout = options.connectTimeoutMS;
     }
 
     const start = new Date().getTime();
@@ -142,7 +125,12 @@ function performInitialHandshake(
         authContext.response = response;
 
         const resolvedCredentials = credentials.resolveAuthMechanism(response);
-        const provider = AUTH_PROVIDERS[resolvedCredentials.mechanism];
+        const provider = AUTH_PROVIDERS.get(resolvedCredentials.mechanism);
+        if (!provider) {
+          return callback(
+            new MongoError(`No AuthProvider for ${resolvedCredentials.mechanism} defined.`)
+          );
+        }
         provider.auth(authContext, err => {
           if (err) return callback(err);
           callback(undefined, conn);
@@ -165,10 +153,9 @@ export interface HandshakeDocument extends Document {
 
 function prepareHandshakeDocument(authContext: AuthContext, callback: Callback<HandshakeDocument>) {
   const options = authContext.options;
-  const compressors =
-    options.compression && options.compression.compressors ? options.compression.compressors : [];
+  const compressors = options.compressors ? options.compressors : [];
 
-  const handshakeDoc = {
+  const handshakeDoc: HandshakeDocument = {
     ismaster: true,
     client: options.metadata || makeClientMetadata(options),
     compression: compressors
@@ -176,69 +163,87 @@ function prepareHandshakeDocument(authContext: AuthContext, callback: Callback<H
 
   const credentials = authContext.credentials;
   if (credentials) {
-    if (credentials.mechanism.match(/DEFAULT/i) && credentials.username) {
-      Object.assign(handshakeDoc, {
-        saslSupportedMechs: `${credentials.source}.${credentials.username}`
-      });
+    if (credentials.mechanism === AuthMechanism.MONGODB_DEFAULT && credentials.username) {
+      handshakeDoc.saslSupportedMechs = `${credentials.source}.${credentials.username}`;
 
-      let provider;
-      if ((provider = AUTH_PROVIDERS[AuthMechanism.MONGODB_SCRAM_SHA256])) {
+      const provider = AUTH_PROVIDERS.get(AuthMechanism.MONGODB_SCRAM_SHA256);
+      if (!provider) {
         // This auth mechanism is always present.
-        provider.prepare(handshakeDoc, authContext, callback);
-        return;
+        return callback(
+          new MongoError(`No AuthProvider for ${AuthMechanism.MONGODB_SCRAM_SHA256} defined.`)
+        );
       }
+      return provider.prepare(handshakeDoc, authContext, callback);
     }
-
-    const provider = AUTH_PROVIDERS[credentials.mechanism];
-    provider.prepare(handshakeDoc, authContext, callback);
-    return;
+    const provider = AUTH_PROVIDERS.get(credentials.mechanism);
+    if (!provider) {
+      return callback(new MongoError(`No AuthProvider for ${credentials.mechanism} defined.`));
+    }
+    return provider.prepare(handshakeDoc, authContext, callback);
   }
-
   callback(undefined, handshakeDoc);
 }
 
-const LEGAL_SSL_SOCKET_OPTIONS = [
-  'pfx',
-  'key',
-  'passphrase',
-  'cert',
-  'ca',
-  'ciphers',
+/** @public */
+export const LEGAL_TLS_SOCKET_OPTIONS = [
   'ALPNProtocols',
-  'servername',
-  'ecdhCurve',
-  'secureProtocol',
-  'secureContext',
-  'session',
-  'minDHSize',
+  'ca',
+  'cert',
+  'checkServerIdentity',
+  'ciphers',
   'crl',
-  'rejectUnauthorized'
+  'ecdhCurve',
+  'key',
+  'minDHSize',
+  'passphrase',
+  'pfx',
+  'rejectUnauthorized',
+  'secureContext',
+  'secureProtocol',
+  'servername',
+  'session'
 ] as const;
 
-function parseConnectOptions(family: number, options: ConnectionOptions): SocketConnectOpts {
-  const host = typeof options.host === 'string' ? options.host : 'localhost';
+/** @public */
+export const LEGAL_TCP_SOCKET_OPTIONS = [
+  'family',
+  'hints',
+  'localAddress',
+  'localPort',
+  'lookup'
+] as const;
 
-  if (host.indexOf('/') !== -1) {
-    // socket is a unix path
-    return { path: host };
+function parseConnectOptions(options: ConnectionOptions): SocketConnectOpts {
+  const hostAddress = options.hostAddress;
+  if (!hostAddress) throw new Error('HostAddress required');
+
+  const result: Partial<net.TcpNetConnectOpts & net.IpcNetConnectOpts> = {};
+  for (const name of LEGAL_TCP_SOCKET_OPTIONS) {
+    if (options[name] != null) {
+      (result as Document)[name] = options[name];
+    }
   }
 
-  const result = {
-    family,
-    host,
-    port: typeof options.port === 'number' ? options.port : 27017,
-    rejectUnauthorized: false
-  };
-
-  return result;
+  if (typeof hostAddress.socketPath === 'string') {
+    result.path = hostAddress.socketPath;
+    return result as net.IpcNetConnectOpts;
+  } else if (typeof hostAddress.host === 'string') {
+    result.host = hostAddress.host;
+    result.port = hostAddress.port;
+    return result as net.TcpNetConnectOpts;
+  } else {
+    // This should never happen since we set up HostAddresses
+    // But if we don't throw here the socket could hang until timeout
+    throw new Error(`Unexpected HostAddress ${JSON.stringify(hostAddress)}`);
+  }
 }
 
-function parseSslOptions(family: number, options: ConnectionOptions): TLSConnectionOpts {
-  const result: TLSConnectionOpts = parseConnectOptions(family, options);
+function parseSslOptions(options: ConnectionOptions): TLSConnectionOpts {
+  const result: TLSConnectionOpts = parseConnectOptions(options);
   // Merge in valid SSL options
-  for (const name of LEGAL_SSL_SOCKET_OPTIONS) {
-    if (options[name]) {
-      (result as { [k: string]: unknown })[name] = options[name];
+  for (const name of LEGAL_TLS_SOCKET_OPTIONS) {
+    if (options[name] != null) {
+      (result as Document)[name] = options[name];
     }
   }
 
@@ -263,30 +268,17 @@ const SOCKET_ERROR_EVENT_LIST = ['error', 'close', 'timeout', 'parseError'] as c
 type ErrorHandlerEventName = typeof SOCKET_ERROR_EVENT_LIST[number] | 'cancel';
 const SOCKET_ERROR_EVENTS = new Set(SOCKET_ERROR_EVENT_LIST);
 
-function makeConnection(
-  family: number,
-  options: ConnectionOptions,
-  cancellationToken: EventEmitter | undefined,
-  _callback: CallbackWithType<AnyError, Stream>
-) {
-  const useSsl = typeof options.ssl === 'boolean' ? options.ssl : false;
-  const keepAlive = typeof options.keepAlive === 'boolean' ? options.keepAlive : true;
-  let keepAliveInitialDelay =
-    typeof options.keepAliveInitialDelay === 'number' ? options.keepAliveInitialDelay : 120000;
-  const noDelay = typeof options.noDelay === 'boolean' ? options.noDelay : true;
-  const connectionTimeout =
-    typeof options.connectionTimeout === 'number'
-      ? options.connectionTimeout
-      : typeof options.connectTimeoutMS === 'number'
-      ? options.connectTimeoutMS
-      : 30000;
-  const socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 0;
-  const rejectUnauthorized =
-    typeof options.rejectUnauthorized === 'boolean' ? options.rejectUnauthorized : true;
-
-  if (keepAliveInitialDelay > socketTimeout) {
-    keepAliveInitialDelay = Math.round(socketTimeout / 2);
-  }
+function makeConnection(options: ConnectionOptions, _callback: CallbackWithType<AnyError, Stream>) {
+  const useTLS = options.tls ?? false;
+  const keepAlive = options.keepAlive ?? true;
+  const socketTimeout = options.socketTimeout ?? 0;
+  const noDelay = options.noDelay ?? true;
+  const connectionTimeout = options.connectTimeoutMS ?? 30000;
+  const rejectUnauthorized = options.rejectUnauthorized ?? true;
+  const keepAliveInitialDelay =
+    ((options.keepAliveInitialDelay ?? 120000) > socketTimeout
+      ? Math.round(socketTimeout / 2)
+      : options.keepAliveInitialDelay) ?? 120000;
 
   let socket: Stream;
   const callback: Callback<Stream> = function (err, ret) {
@@ -298,14 +290,14 @@ function makeConnection(
   };
 
   try {
-    if (useSsl) {
-      const tlsSocket = tls.connect(parseSslOptions(family, options));
+    if (useTLS) {
+      const tlsSocket = tls.connect(parseSslOptions(options));
       if (typeof tlsSocket.disableRenegotiation === 'function') {
         tlsSocket.disableRenegotiation();
       }
       socket = tlsSocket;
     } else {
-      socket = net.createConnection(parseConnectOptions(family, options));
+      socket = net.createConnection(parseConnectOptions(options));
     }
   } catch (err) {
     return callback(err);
@@ -315,13 +307,13 @@ function makeConnection(
   socket.setTimeout(connectionTimeout);
   socket.setNoDelay(noDelay);
 
-  const connectEvent = useSsl ? 'secureConnect' : 'connect';
+  const connectEvent = useTLS ? 'secureConnect' : 'connect';
   let cancellationHandler: (err: Error) => void;
   function errorHandler(eventName: ErrorHandlerEventName) {
     return (err: Error) => {
       SOCKET_ERROR_EVENTS.forEach(event => socket.removeAllListeners(event));
-      if (cancellationHandler && cancellationToken) {
-        cancellationToken.removeListener('cancel', cancellationHandler);
+      if (cancellationHandler && options.cancellationToken) {
+        options.cancellationToken.removeListener('cancel', cancellationHandler);
       }
 
       socket.removeListener(connectEvent, connectHandler);
@@ -331,8 +323,8 @@ function makeConnection(
 
   function connectHandler() {
     SOCKET_ERROR_EVENTS.forEach(event => socket.removeAllListeners(event));
-    if (cancellationHandler && cancellationToken) {
-      cancellationToken.removeListener('cancel', cancellationHandler);
+    if (cancellationHandler && options.cancellationToken) {
+      options.cancellationToken.removeListener('cancel', cancellationHandler);
     }
 
     if ('authorizationError' in socket) {
@@ -346,9 +338,9 @@ function makeConnection(
   }
 
   SOCKET_ERROR_EVENTS.forEach(event => socket.once(event, errorHandler(event)));
-  if (cancellationToken) {
+  if (options.cancellationToken) {
     cancellationHandler = errorHandler('cancel');
-    cancellationToken.once('cancel', cancellationHandler);
+    options.cancellationToken.once('cancel', cancellationHandler);
   }
 
   socket.once(connectEvent, connectHandler);

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -38,11 +38,11 @@ function checkSupportedServer(ismaster: Document, options: ConnectionOptions) {
   const serverVersionHighEnough =
     ismaster &&
     (typeof ismaster.maxWireVersion === 'number' || ismaster.maxWireVersion instanceof Int32) &&
-    ismaster.maxWireVersion.valueOf() >= MIN_SUPPORTED_WIRE_VERSION;
+    ismaster.maxWireVersion >= MIN_SUPPORTED_WIRE_VERSION;
   const serverVersionLowEnough =
     ismaster &&
     (typeof ismaster.maxWireVersion === 'number' || ismaster.maxWireVersion instanceof Int32) &&
-    ismaster.minWireVersion.valueOf() <= MAX_SUPPORTED_WIRE_VERSION;
+    ismaster.minWireVersion <= MAX_SUPPORTED_WIRE_VERSION;
 
   if (serverVersionHighEnough) {
     if (serverVersionLowEnough) {

--- a/src/cmap/events.ts
+++ b/src/cmap/events.ts
@@ -51,7 +51,7 @@ export class ConnectionPoolClosedEvent extends ConnectionPoolMonitoringEvent {
  */
 export class ConnectionCreatedEvent extends ConnectionPoolMonitoringEvent {
   /** A monotonically increasing, per-pool id for the newly created connection */
-  connectionId: number;
+  connectionId: number | '<monitor>';
 
   constructor(pool: ConnectionPool, connection: Connection) {
     super(pool);
@@ -65,7 +65,7 @@ export class ConnectionCreatedEvent extends ConnectionPoolMonitoringEvent {
  */
 export class ConnectionReadyEvent extends ConnectionPoolMonitoringEvent {
   /** The id of the connection */
-  connectionId: number;
+  connectionId: number | '<monitor>';
 
   constructor(pool: ConnectionPool, connection: Connection) {
     super(pool);
@@ -79,7 +79,7 @@ export class ConnectionReadyEvent extends ConnectionPoolMonitoringEvent {
  */
 export class ConnectionClosedEvent extends ConnectionPoolMonitoringEvent {
   /** The id of the connection */
-  connectionId: number;
+  connectionId: number | '<monitor>';
   /** The reason the connection was closed */
   reason: string;
 
@@ -117,7 +117,7 @@ export class ConnectionCheckOutFailedEvent extends ConnectionPoolMonitoringEvent
  */
 export class ConnectionCheckedOutEvent extends ConnectionPoolMonitoringEvent {
   /** The id of the connection */
-  connectionId: number;
+  connectionId: number | '<monitor>';
 
   constructor(pool: ConnectionPool, connection: Connection) {
     super(pool);
@@ -131,7 +131,7 @@ export class ConnectionCheckedOutEvent extends ConnectionPoolMonitoringEvent {
  */
 export class ConnectionCheckedInEvent extends ConnectionPoolMonitoringEvent {
   /** The id of the connection */
-  connectionId: number;
+  connectionId: number | '<monitor>';
 
   constructor(pool: ConnectionPool, connection: Connection) {
     super(pool);

--- a/src/cmap/stream_description.ts
+++ b/src/cmap/stream_description.ts
@@ -14,9 +14,7 @@ const RESPONSE_FIELDS = [
 
 /** @public */
 export interface StreamDescriptionOptions {
-  compression: {
-    compressors: CompressorName[];
-  };
+  compressors?: CompressorName[];
 }
 
 /** @public */
@@ -32,7 +30,7 @@ export class StreamDescription {
   compressor?: CompressorName;
   logicalSessionTimeoutMinutes?: number;
 
-  __nodejs_mock_server__ = false;
+  __nodejs_mock_server__?: boolean;
 
   zlibCompressionLevel?: number;
 
@@ -45,8 +43,8 @@ export class StreamDescription {
     this.maxMessageSizeBytes = 48000000;
     this.maxWriteBatchSize = 100000;
     this.compressors =
-      options && options.compression && Array.isArray(options.compression.compressors)
-        ? options.compression.compressors
+      options && options.compressors && Array.isArray(options.compressors)
+        ? options.compressors
         : [];
   }
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,4 +1,4 @@
-import { emitDeprecatedOptionWarning, resolveOptions } from './utils';
+import { DEFAULT_PK_FACTORY, resolveOptions } from './utils';
 import { ReadPreference, ReadPreferenceLike } from './read_preference';
 import { deprecate } from 'util';
 import {
@@ -9,7 +9,7 @@ import {
   Callback,
   getTopology
 } from './utils';
-import { ObjectId, Document, BSONSerializeOptions, resolveBSONOptions } from './bson';
+import { Document, BSONSerializeOptions, resolveBSONOptions } from './bson';
 import { MongoError } from './error';
 import { UnorderedBulkOperation } from './bulk/unordered';
 import { OrderedBulkOperation } from './bulk/ordered';
@@ -176,19 +176,13 @@ export class Collection {
    */
   constructor(db: Db, name: string, options?: CollectionOptions) {
     checkCollectionName(name);
-    emitDeprecatedOptionWarning(options, ['promiseLibrary']);
 
     // Internal state
     this.s = {
       db,
       options,
       namespace: new MongoDBNamespace(db.databaseName, name),
-      pkFactory: db.options?.pkFactory ?? {
-        createPk() {
-          // We prefer not to rely on ObjectId having a createPk method
-          return new ObjectId();
-        }
-      },
+      pkFactory: db.options?.pkFactory ?? DEFAULT_PK_FACTORY,
       readPreference: ReadPreference.fromOptions(options),
       bsonOptions: resolveBSONOptions(options, db),
       readConcern: ReadConcern.fromOptions(options),

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1,19 +1,24 @@
-import * as url from 'url';
-import * as qs from 'querystring';
 import * as dns from 'dns';
-import { URL } from 'url';
+import * as fs from 'fs';
+import { URL, URLSearchParams } from 'url';
 import { AuthMechanism } from './cmap/auth/defaultAuthProviders';
 import { ReadPreference, ReadPreferenceModeId } from './read_preference';
 import { ReadConcern, ReadConcernLevelId } from './read_concern';
 import { W, WriteConcern } from './write_concern';
 import { MongoParseError } from './error';
-import { AnyOptions, Callback, isRecord } from './utils';
-import type { ConnectionOptions } from './cmap/connection';
+import {
+  AnyOptions,
+  Callback,
+  DEFAULT_PK_FACTORY,
+  isRecord,
+  makeClientMetadata,
+  setDifference,
+  HostAddress
+} from './utils';
 import type { Document } from './bson';
-import type { CompressorName } from './cmap/wire_protocol/compression';
-import type {
+import {
   DriverInfo,
-  HostAddress,
+  MongoClient,
   MongoClientOptions,
   MongoOptions,
   PkFactory
@@ -21,13 +26,8 @@ import type {
 import { MongoCredentials } from './cmap/auth/mongo_credentials';
 import type { TagSet } from './sdam/server_description';
 import { Logger, LoggerLevel } from './logger';
-import { ObjectId } from 'bson';
-
-/**
- * The following regular expression validates a connection string and breaks the
- * provide string into the following capture groups: [protocol, username, password, hosts]
- */
-const HOSTS_RX = /(mongodb(?:\+srv|)):\/\/(?: (?:[^:]*) (?: : ([^@]*) )? @ )?([^/?]*)(?:\/|)(.*)/;
+import { PromiseProvider } from './promise_provider';
+import { createAutoEncrypter } from './operations/connect';
 
 /**
  * Determines whether a provided address matches the provided parent domain in order
@@ -51,28 +51,17 @@ function matchesParentDomain(srvAddress: string, parentDomain: string): boolean 
  * @param uri - The connection string to parse
  * @param options - Optional user provided connection string options
  */
-function parseSrvConnectionString(uri: string, options: any, callback: Callback) {
-  const result: AnyOptions = url.parse(uri, true);
-
-  if (options.directConnection) {
-    return callback(new MongoParseError('directConnection not supported with SRV URI'));
+export function resolveSRVRecord(options: MongoOptions, callback: Callback<HostAddress[]>): void {
+  if (typeof options.srvHost !== 'string') {
+    return callback(new MongoParseError('Cannot resolve empty srv string'));
   }
 
-  if (result.hostname.split('.').length < 3) {
+  if (options.srvHost.split('.').length < 3) {
     return callback(new MongoParseError('URI does not have hostname, domain name and tld'));
   }
 
-  result.domainLength = result.hostname.split('.').length;
-  if (result.pathname && result.pathname.match(',')) {
-    return callback(new MongoParseError('Invalid URI, cannot contain multiple hostnames'));
-  }
-
-  if (result.port) {
-    return callback(new MongoParseError(`Ports not accepted with '${PROTOCOL_MONGODB_SRV}' URIs`));
-  }
-
   // Resolve the SRV record and use the result as the list of hosts to connect to.
-  const lookupAddress = result.host;
+  const lookupAddress = options.srvHost;
   dns.resolveSrv(`_mongodb._tcp.${lookupAddress}`, (err, addresses) => {
     if (err) return callback(err);
 
@@ -80,428 +69,56 @@ function parseSrvConnectionString(uri: string, options: any, callback: Callback)
       return callback(new MongoParseError('No addresses found at host'));
     }
 
-    for (let i = 0; i < addresses.length; i++) {
-      if (!matchesParentDomain(addresses[i].name, result.hostname)) {
+    for (const { name } of addresses) {
+      if (!matchesParentDomain(name, lookupAddress)) {
         return callback(
           new MongoParseError('Server record does not share hostname with parent URI')
         );
       }
     }
 
-    // Convert the original URL to a non-SRV URL.
-    result.protocol = 'mongodb';
-    result.host = addresses.map((address: any) => `${address.name}:${address.port}`).join(',');
-
-    // Default to SSL true if it's not specified.
-    if (
-      !('ssl' in options) &&
-      (!result.search || !('ssl' in result.query) || result.query.ssl === null)
-    ) {
-      result.query.ssl = true;
-    }
+    const hostAddresses = addresses.map(r =>
+      HostAddress.fromString(`${r.name}:${r.port ?? 27017}`)
+    );
 
     // Resolve TXT record and add options from there if they exist.
-    dns.resolveTxt(lookupAddress, (err?: any, record?: any) => {
+    dns.resolveTxt(lookupAddress, (err, record) => {
       if (err) {
         if (err.code !== 'ENODATA' && err.code !== 'ENOTFOUND') {
           return callback(err);
         }
-        record = null;
-      }
-
-      if (record) {
+      } else {
         if (record.length > 1) {
           return callback(new MongoParseError('Multiple text records not allowed'));
         }
 
-        record = qs.parse(record[0].join(''));
-        if (Object.keys(record).some((key: any) => key !== 'authSource' && key !== 'replicaSet')) {
+        const txtRecordOptions = new URLSearchParams(record[0].join(''));
+        const txtRecordOptionKeys = [...txtRecordOptions.keys()];
+        if (txtRecordOptionKeys.some(key => key !== 'authSource' && key !== 'replicaSet')) {
           return callback(
             new MongoParseError('Text record must only set `authSource` or `replicaSet`')
           );
         }
 
-        result.query = Object.assign({}, record, result.query);
-      }
+        const source = txtRecordOptions.get('authSource') ?? undefined;
+        const replicaSet = txtRecordOptions.get('replicaSet') ?? undefined;
 
-      // Set completed options back into the URL object.
-      result.search = qs.stringify(result.query);
-
-      const finalString = url.format(result);
-      parseConnectionString(finalString, options, (err?: any, ret?: any) => {
-        if (err) {
-          callback(err);
-          return;
+        if (source === '' || replicaSet === '') {
+          return callback(new MongoParseError('Cannot have empty URI params in DNS TXT Record'));
         }
 
-        callback(undefined, Object.assign({}, ret, { srvHost: lookupAddress }));
-      });
+        if (!options.userSpecifiedAuthSource && source) {
+          options.credentials = MongoCredentials.merge(options.credentials, { source });
+        }
+
+        if (!options.userSpecifiedReplicaSet && replicaSet) {
+          options.replicaSet = replicaSet;
+        }
+      }
+
+      callback(undefined, hostAddresses);
     });
   });
-}
-
-/**
- * Parses a query string item according to the connection string spec
- *
- * @param key - The key for the parsed value
- * @param value - The value to parse
- */
-function parseQueryStringItemValue(key: string, value: any) {
-  if (Array.isArray(value)) {
-    // deduplicate and simplify arrays
-    value = value.filter((v: any, idx: any) => value.indexOf(v) === idx);
-    if (value.length === 1) value = value[0];
-  } else if (value.indexOf(':') > 0) {
-    value = value.split(',').reduce((result: any, pair: any) => {
-      const parts = pair.split(':');
-      result[parts[0]] = parseQueryStringItemValue(key, parts[1]);
-      return result;
-    }, {});
-  } else if (value.indexOf(',') > 0) {
-    value = value.split(',').map((v: any) => {
-      return parseQueryStringItemValue(key, v);
-    });
-  } else if (value.toLowerCase() === 'true' || value.toLowerCase() === 'false') {
-    value = value.toLowerCase() === 'true';
-  } else if (!Number.isNaN(value) && !STRING_OPTIONS.has(key)) {
-    const numericValue = parseFloat(value);
-    if (!Number.isNaN(numericValue)) {
-      value = parseFloat(value);
-    }
-  }
-
-  return value;
-}
-
-// Options that are known boolean types
-const BOOLEAN_OPTIONS = new Set([
-  'slaveok',
-  'slave_ok',
-  'sslvalidate',
-  'fsync',
-  'safe',
-  'retrywrites',
-  'j'
-]);
-
-// Known string options, only used to bypass Number coercion in `parseQueryStringItemValue`
-const STRING_OPTIONS = new Set(['authsource', 'replicaset']);
-
-// Supported text representations of auth mechanisms
-export const AUTH_MECHANISMS = new Set([...Object.values(AuthMechanism)]);
-
-// Lookup table used to translate normalized (lower-cased) forms of connection string
-// options to their expected camelCase version
-const CASE_TRANSLATION: any = {
-  replicaset: 'replicaSet',
-  connecttimeoutms: 'connectTimeoutMS',
-  sockettimeoutms: 'socketTimeoutMS',
-  maxpoolsize: 'maxPoolSize',
-  minpoolsize: 'minPoolSize',
-  maxidletimems: 'maxIdleTimeMS',
-  waitqueuemultiple: 'waitQueueMultiple',
-  waitqueuetimeoutms: 'waitQueueTimeoutMS',
-  wtimeoutms: 'wtimeoutMS',
-  readconcern: 'readConcern',
-  readconcernlevel: 'readConcernLevel',
-  readpreference: 'readPreference',
-  maxstalenessseconds: 'maxStalenessSeconds',
-  readpreferencetags: 'readPreferenceTags',
-  authsource: 'authSource',
-  authmechanism: 'authMechanism',
-  authmechanismproperties: 'authMechanismProperties',
-  gssapiservicename: 'gssapiServiceName',
-  localthresholdms: 'localThresholdMS',
-  serverselectiontimeoutms: 'serverSelectionTimeoutMS',
-  serverselectiontryonce: 'serverSelectionTryOnce',
-  heartbeatfrequencyms: 'heartbeatFrequencyMS',
-  retrywrites: 'retryWrites',
-  uuidrepresentation: 'uuidRepresentation',
-  zlibcompressionlevel: 'zlibCompressionLevel',
-  tlsallowinvalidcertificates: 'tlsAllowInvalidCertificates',
-  tlsallowinvalidhostnames: 'tlsAllowInvalidHostnames',
-  tlsinsecure: 'tlsInsecure',
-  tlsdisablecertificaterevocationcheck: 'tlsDisableCertificateRevocationCheck',
-  tlsdisableocspendpointcheck: 'tlsDisableOCSPEndpointCheck',
-  tlscafile: 'tlsCAFile',
-  tlscertificatekeyfile: 'tlsCertificateKeyFile',
-  tlscertificatekeyfilepassword: 'tlsCertificateKeyFilePassword',
-  wtimeout: 'wTimeoutMS',
-  j: 'journal',
-  directconnection: 'directConnection'
-};
-
-/**
- * Sets the value for `key`, allowing for any required translation
- *
- * @param obj - The object to set the key on
- * @param key - The key to set the value for
- * @param value - The value to set
- * @param options - The options used for option parsing
- */
-function applyConnectionStringOption(obj: any, key: string, value: any, options: any) {
-  // simple key translation
-  if (key === 'journal') {
-    key = 'j';
-  } else if (key === 'wtimeoutms') {
-    key = 'wtimeout';
-  }
-
-  // more complicated translation
-  if (BOOLEAN_OPTIONS.has(key)) {
-    value = value === 'true' || value === true;
-  } else if (key === 'appname') {
-    value = decodeURIComponent(value);
-  } else if (key === 'readconcernlevel') {
-    obj['readConcernLevel'] = value;
-    key = 'readconcern';
-    value = { level: value };
-  }
-
-  // simple validation
-  if (key === 'compressors') {
-    value = Array.isArray(value) ? value : [value];
-
-    if (!value.every((c: CompressorName) => c === 'snappy' || c === 'zlib')) {
-      throw new MongoParseError(
-        'Value for `compressors` must be at least one of: `snappy`, `zlib`'
-      );
-    }
-  }
-
-  if (key === 'authmechanism' && !AUTH_MECHANISMS.has(value)) {
-    throw new MongoParseError(
-      `Value for authMechanism must be one of: ${Array.from(AUTH_MECHANISMS).join(
-        ', '
-      )}, found: ${value}`
-    );
-  }
-
-  if (key === 'readpreference' && !ReadPreference.isValid(value)) {
-    throw new MongoParseError(
-      'Value for `readPreference` must be one of: `primary`, `primaryPreferred`, `secondary`, `secondaryPreferred`, `nearest`'
-    );
-  }
-
-  if (key === 'zlibcompressionlevel' && (value < -1 || value > 9)) {
-    throw new MongoParseError('zlibCompressionLevel must be an integer between -1 and 9');
-  }
-
-  // special cases
-  if (key === 'compressors' || key === 'zlibcompressionlevel') {
-    obj.compression = obj.compression || {};
-    obj = obj.compression;
-  }
-
-  if (key === 'authmechanismproperties') {
-    if (typeof value.SERVICE_NAME === 'string') obj.gssapiServiceName = value.SERVICE_NAME;
-    if (typeof value.SERVICE_REALM === 'string') obj.gssapiServiceRealm = value.SERVICE_REALM;
-    if (typeof value.CANONICALIZE_HOST_NAME !== 'undefined') {
-      obj.gssapiCanonicalizeHostName = value.CANONICALIZE_HOST_NAME;
-    }
-  }
-
-  if (key === 'readpreferencetags') {
-    value = Array.isArray(value) ? splitArrayOfMultipleReadPreferenceTags(value) : [value];
-  }
-
-  // set the actual value
-  if (options.caseTranslate && CASE_TRANSLATION[key]) {
-    obj[CASE_TRANSLATION[key]] = value;
-    return;
-  }
-
-  obj[key] = value;
-}
-
-const USERNAME_REQUIRED_MECHANISMS = new Set([
-  'GSSAPI',
-  'MONGODB-CR',
-  'PLAIN',
-  'SCRAM-SHA-1',
-  'SCRAM-SHA-256'
-]);
-
-function splitArrayOfMultipleReadPreferenceTags(value: any) {
-  const parsedTags: any = [];
-
-  for (let i = 0; i < value.length; i++) {
-    parsedTags[i] = {};
-    value[i].split(',').forEach((individualTag: any) => {
-      const splitTag = individualTag.split(':');
-      parsedTags[i][splitTag[0]] = splitTag[1];
-    });
-  }
-
-  return parsedTags;
-}
-
-/**
- * Modifies the parsed connection string object taking into account expectations we
- * have for authentication-related options.
- *
- * @param parsed - The parsed connection string result
- * @returns The parsed connection string result possibly modified for auth expectations
- */
-function applyAuthExpectations(parsed: any) {
-  if (parsed.options == null) {
-    return;
-  }
-
-  const options = parsed.options;
-  const authSource = options.authsource || options.authSource;
-  if (authSource != null) {
-    parsed.auth = Object.assign({}, parsed.auth, { db: authSource });
-  }
-
-  const authMechanism = options.authmechanism || options.authMechanism;
-  if (authMechanism != null) {
-    if (
-      USERNAME_REQUIRED_MECHANISMS.has(authMechanism) &&
-      (!parsed.auth || parsed.auth.username == null)
-    ) {
-      throw new MongoParseError(`Username required for mechanism \`${authMechanism}\``);
-    }
-
-    if (authMechanism === 'GSSAPI') {
-      if (authSource != null && authSource !== '$external') {
-        throw new MongoParseError(
-          `Invalid source \`${authSource}\` for mechanism \`${authMechanism}\` specified.`
-        );
-      }
-
-      parsed.auth = Object.assign({}, parsed.auth, { db: '$external' });
-    }
-
-    if (authMechanism === 'MONGODB-AWS') {
-      if (authSource != null && authSource !== '$external') {
-        throw new MongoParseError(
-          `Invalid source \`${authSource}\` for mechanism \`${authMechanism}\` specified.`
-        );
-      }
-
-      parsed.auth = Object.assign({}, parsed.auth, { db: '$external' });
-    }
-
-    if (authMechanism === 'MONGODB-X509') {
-      if (parsed.auth && parsed.auth.password != null) {
-        throw new MongoParseError(`Password not allowed for mechanism \`${authMechanism}\``);
-      }
-
-      if (authSource != null && authSource !== '$external') {
-        throw new MongoParseError(
-          `Invalid source \`${authSource}\` for mechanism \`${authMechanism}\` specified.`
-        );
-      }
-
-      parsed.auth = Object.assign({}, parsed.auth, { db: '$external' });
-    }
-
-    if (authMechanism === 'PLAIN') {
-      if (parsed.auth && parsed.auth.db == null) {
-        parsed.auth = Object.assign({}, parsed.auth, { db: '$external' });
-      }
-    }
-  }
-
-  // default to `admin` if nothing else was resolved
-  if (parsed.auth && parsed.auth.db == null) {
-    parsed.auth = Object.assign({}, parsed.auth, { db: 'admin' });
-  }
-
-  return parsed;
-}
-
-/**
- * Parses a query string according the connection string spec.
- *
- * @param query - The query string to parse
- * @param options - The options used for options parsing
- * @returns The parsed query string as an object
- */
-function parseQueryString(query: string, options?: AnyOptions): Document {
-  const result = {} as any;
-  const parsedQueryString = qs.parse(query);
-
-  checkTLSQueryString(parsedQueryString);
-
-  for (const key in parsedQueryString) {
-    const value = parsedQueryString[key];
-    if (value === '' || value == null) {
-      throw new MongoParseError('Incomplete key value pair for option');
-    }
-
-    const normalizedKey = key.toLowerCase();
-    const parsedValue = parseQueryStringItemValue(normalizedKey, value);
-    applyConnectionStringOption(result, normalizedKey, parsedValue, options);
-  }
-
-  // special cases for known deprecated options
-  if (result.wtimeout && result.wtimeoutms) {
-    delete result.wtimeout;
-    console.warn('Unsupported option `wtimeout` specified');
-  }
-
-  return Object.keys(result).length ? result : null;
-}
-
-/// Adds support for modern `tls` variants of out `ssl` options
-function translateTLSOptions(queryString: any) {
-  if (queryString.tls) {
-    queryString.ssl = queryString.tls;
-  }
-
-  if (queryString.tlsInsecure) {
-    queryString.checkServerIdentity = false;
-    queryString.sslValidate = false;
-  } else {
-    Object.assign(queryString, {
-      checkServerIdentity: queryString.tlsAllowInvalidHostnames ? false : true,
-      sslValidate: queryString.tlsAllowInvalidCertificates ? false : true
-    });
-  }
-
-  if (queryString.tlsCAFile) {
-    queryString.ssl = true;
-    queryString.sslCA = queryString.tlsCAFile;
-  }
-
-  if (queryString.tlsCertificateKeyFile) {
-    queryString.ssl = true;
-    if (queryString.tlsCertificateFile) {
-      queryString.sslCert = queryString.tlsCertificateFile;
-      queryString.sslKey = queryString.tlsCertificateKeyFile;
-    } else {
-      queryString.sslKey = queryString.tlsCertificateKeyFile;
-      queryString.sslCert = queryString.tlsCertificateKeyFile;
-    }
-  }
-
-  if (queryString.tlsCertificateKeyFilePassword) {
-    queryString.ssl = true;
-    queryString.sslPass = queryString.tlsCertificateKeyFilePassword;
-  }
-
-  return queryString;
-}
-
-/**
- * Checks a query string for invalid tls options according to the URI options spec.
- *
- * @param queryString - The parsed query string
- * @throws MongoParseError if tls and ssl options contain conflicts
- */
-function checkTLSQueryString(queryString: any) {
-  const queryStringKeys = Object.keys(queryString);
-
-  const tlsValue = assertTlsOptionsAreEqual('tls', queryString, queryStringKeys);
-  const sslValue = assertTlsOptionsAreEqual('ssl', queryString, queryStringKeys);
-
-  if (tlsValue != null && sslValue != null) {
-    if (tlsValue !== sslValue) {
-      throw new MongoParseError('All values of `tls` and `ssl` must be the same.');
-    }
-  }
 }
 
 /**
@@ -526,240 +143,12 @@ export function checkTLSOptions(options: AnyOptions): void {
   check('tlsDisableCertificateRevocationCheck', 'tlsDisableOCSPEndpointCheck');
 }
 
-/**
- * Checks a query string to ensure all tls/ssl options are the same.
- *
- * @param optionName - The key (tls or ssl) to check
- * @param queryString - The parsed query string
- * @param queryStringKeys - list of keys in the query string
- * @throws MongoParseError
- * @returns The value of the tls/ssl option
- */
-function assertTlsOptionsAreEqual(optionName: string, queryString: any, queryStringKeys: any) {
-  const queryStringHasTLSOption = queryStringKeys.indexOf(optionName) !== -1;
-
-  let optionValue;
-  if (Array.isArray(queryString[optionName])) {
-    optionValue = queryString[optionName][0];
-  } else {
-    optionValue = queryString[optionName];
-  }
-
-  if (queryStringHasTLSOption) {
-    if (Array.isArray(queryString[optionName])) {
-      const firstValue = queryString[optionName][0];
-      queryString[optionName].forEach((tlsValue: any) => {
-        if (tlsValue !== firstValue) {
-          throw new MongoParseError(`All values of ${optionName} must be the same.`);
-        }
-      });
-    }
-  }
-
-  return optionValue;
-}
-
-const PROTOCOL_MONGODB = 'mongodb';
-const PROTOCOL_MONGODB_SRV = 'mongodb+srv';
-const SUPPORTED_PROTOCOLS = [PROTOCOL_MONGODB, PROTOCOL_MONGODB_SRV];
-
-interface ParseConnectionStringOptions extends Partial<ConnectionOptions> {
-  /** Whether the parser should translate options back into camelCase after normalization */
-  caseTranslate?: boolean;
-}
-
-/** Parses a MongoDB connection string */
-export function parseConnectionString(uri: string, callback: Callback): void;
-export function parseConnectionString(
-  uri: string,
-  options: ParseConnectionStringOptions,
-  callback: Callback
-): void;
-export function parseConnectionString(
-  uri: string,
-  options?: ParseConnectionStringOptions | Callback,
-  _callback?: Callback
-): void {
-  let callback = _callback as Callback;
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-  options = { caseTranslate: true, ...options };
-
-  // Check for bad uris before we parse
-  try {
-    url.parse(uri);
-  } catch (e) {
-    return callback(new MongoParseError('URI malformed, cannot be parsed'));
-  }
-
-  const cap = uri.match(HOSTS_RX);
-  if (!cap) {
-    return callback(new MongoParseError('Invalid connection string'));
-  }
-
-  const protocol = cap[1];
-  if (SUPPORTED_PROTOCOLS.indexOf(protocol) === -1) {
-    return callback(new MongoParseError('Invalid protocol provided'));
-  }
-
-  const dbAndQuery = cap[4].split('?');
-  const db = dbAndQuery.length > 0 ? dbAndQuery[0] : null;
-  const query = dbAndQuery.length > 1 ? dbAndQuery[1] : '';
-
-  let parsedOptions;
-  try {
-    // this just parses the query string NOT the connection options object
-    parsedOptions = parseQueryString(query, options);
-    // this merges the options object with the query string object above
-    parsedOptions = Object.assign({}, parsedOptions, options);
-    checkTLSOptions(parsedOptions);
-  } catch (parseError) {
-    return callback(parseError);
-  }
-
-  parsedOptions = Object.assign({}, parsedOptions, options);
-
-  if (protocol === PROTOCOL_MONGODB_SRV) {
-    return parseSrvConnectionString(uri, parsedOptions, callback);
-  }
-
-  const auth: any = {
-    username: null,
-    password: null,
-    db: db && db !== '' ? qs.unescape(db) : null
-  };
-  if (parsedOptions.auth) {
-    // maintain support for legacy options passed into `MongoClient`
-    if (parsedOptions.auth.username) auth.username = parsedOptions.auth.username;
-    if (parsedOptions.auth.user) auth.username = parsedOptions.auth.user;
-    if (parsedOptions.auth.password) auth.password = parsedOptions.auth.password;
-  } else {
-    if (parsedOptions.username) auth.username = parsedOptions.username;
-    if (parsedOptions.user) auth.username = parsedOptions.user;
-    if (parsedOptions.password) auth.password = parsedOptions.password;
-  }
-
-  if (cap[4].split('?')[0].indexOf('@') !== -1) {
-    return callback(new MongoParseError('Unescaped slash in userinfo section'));
-  }
-
-  const authorityParts: any = cap[3].split('@');
-  if (authorityParts.length > 2) {
-    return callback(new MongoParseError('Unescaped at-sign in authority section'));
-  }
-
-  if (authorityParts[0] == null || authorityParts[0] === '') {
-    return callback(new MongoParseError('No username provided in authority section'));
-  }
-
-  if (authorityParts.length > 1) {
-    const authParts = authorityParts.shift().split(':');
-    if (authParts.length > 2) {
-      return callback(new MongoParseError('Unescaped colon in authority section'));
-    }
-
-    if (authParts[0] === '') {
-      return callback(new MongoParseError('Invalid empty username provided'));
-    }
-
-    if (!auth.username) auth.username = qs.unescape(authParts[0]);
-    if (!auth.password) auth.password = authParts[1] ? qs.unescape(authParts[1]) : null;
-  }
-
-  let hostParsingError = null;
-  const hosts = authorityParts
-    .shift()
-    .split(',')
-    .map((host: any) => {
-      const parsedHost: any = url.parse(`mongodb://${host}`);
-      if (parsedHost.path === '/:') {
-        hostParsingError = new MongoParseError('Double colon in host identifier');
-        return null;
-      }
-
-      // heuristically determine if we're working with a domain socket
-      if (host.match(/\.sock/)) {
-        parsedHost.hostname = qs.unescape(host);
-        parsedHost.port = null;
-      }
-
-      if (Number.isNaN(parsedHost.port)) {
-        hostParsingError = new MongoParseError('Invalid port (non-numeric string)');
-        return;
-      }
-
-      const result = {
-        host: parsedHost.hostname,
-        port: parsedHost.port ? parseInt(parsedHost.port) : 27017
-      };
-
-      if (result.port === 0) {
-        hostParsingError = new MongoParseError('Invalid port (zero) with hostname');
-        return;
-      }
-
-      if (result.port > 65535) {
-        hostParsingError = new MongoParseError('Invalid port (larger than 65535) with hostname');
-        return;
-      }
-
-      if (result.port < 0) {
-        hostParsingError = new MongoParseError('Invalid port (negative number)');
-        return;
-      }
-
-      return result;
-    })
-    .filter((host: any) => !!host);
-
-  if (hostParsingError) {
-    return callback(hostParsingError);
-  }
-
-  if (hosts.length === 0 || hosts[0].host === '' || hosts[0].host === null) {
-    return callback(new MongoParseError('No hostname or hostnames provided in connection string'));
-  }
-
-  const directConnection = !!parsedOptions.directConnection;
-  if (directConnection && hosts.length !== 1) {
-    // If the option is set to true, the driver MUST validate that there is exactly one host given
-    // in the host list in the URI, and fail client creation otherwise.
-    return callback(new MongoParseError('directConnection option requires exactly one host'));
-  }
-
-  const result = {
-    hosts: hosts,
-    auth: auth.db || auth.username ? auth : null,
-    options: Object.keys(parsedOptions).length ? parsedOptions : {}
-  } as any;
-
-  if (result.auth && result.auth.db) {
-    result.defaultDatabase = result.auth.db;
-  } else {
-    result.defaultDatabase = 'test';
-  }
-
-  // support modern `tls` variants to SSL options
-  result.options = translateTLSOptions(result.options);
-
-  try {
-    applyAuthExpectations(result);
-  } catch (authError) {
-    return callback(authError);
-  }
-
-  callback(undefined, result);
-}
-
-// NEW PARSER WORK...
-
 const HOSTS_REGEX = new RegExp(
   String.raw`(?<protocol>mongodb(?:\+srv|)):\/\/(?:(?<username>[^:]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^\/?@]+)(?<rest>.*)`
 );
 
-function parseURI(uri: string): { srv: boolean; url: URL; hosts: string[] } {
+/** @internal */
+export function parseURI(uri: string): { isSRV: boolean; url: URL; hosts: string[] } {
   const match = uri.match(HOSTS_REGEX);
   if (!match) {
     throw new MongoParseError(`Invalid connection string ${uri}`);
@@ -798,19 +187,19 @@ function parseURI(uri: string): { srv: boolean; url: URL; hosts: string[] } {
   if (typeof username === 'string') authString += username;
   if (typeof password === 'string') authString += `:${password}`;
 
-  const srv = protocol.includes('srv');
+  const isSRV = protocol.includes('srv');
   const hostList = hosts.split(',');
   const url = new URL(`${protocol.toLowerCase()}://${authString}@dummyHostname${rest}`);
 
-  if (srv && hostList.length !== 1) {
+  if (isSRV && hostList.length !== 1) {
     throw new MongoParseError('mongodb+srv URI cannot have multiple service names');
   }
-  if (srv && hostList[0].includes(':')) {
+  if (isSRV && hostList[0].includes(':')) {
     throw new MongoParseError('mongodb+srv URI cannot have port number');
   }
 
   return {
-    srv,
+    isSRV,
     url,
     hosts: hosts.split(',')
   };
@@ -846,17 +235,24 @@ function toRecord(value: string): Record<string, any> {
   const keyValuePairs = value.split(',');
   for (const keyValue of keyValuePairs) {
     const [key, value] = keyValue.split(':');
-    record[key] = value;
+    if (typeof value === 'undefined') {
+      throw new MongoParseError('Cannot have undefined values in key value pairs');
+    }
+    try {
+      // try to get a boolean
+      record[key] = getBoolean('', value);
+    } catch {
+      try {
+        // try to get a number
+        record[key] = getInt('', value);
+      } catch {
+        // keep value as a string
+        record[key] = value;
+      }
+    }
   }
   return record;
 }
-
-const DEFAULT_PK_FACTORY = {
-  createPk(): ObjectId {
-    // We prefer not to rely on ObjectId having a createPk method
-    return new ObjectId();
-  }
-};
 
 class CaseInsensitiveMap extends Map<string, any> {
   constructor(entries: Array<[string, any]> = []) {
@@ -871,33 +267,52 @@ class CaseInsensitiveMap extends Map<string, any> {
   set(k: string, v: any) {
     return super.set(k.toLowerCase(), v);
   }
+  delete(k: string): boolean {
+    return super.delete(k.toLowerCase());
+  }
 }
 
 export function parseOptions(
   uri: string,
+  mongoClient: MongoClient | MongoClientOptions | undefined = undefined,
   options: MongoClientOptions = {}
-): Readonly<MongoOptions> {
-  const { url, hosts, srv } = parseURI(uri);
+): MongoOptions {
+  if (typeof mongoClient !== 'undefined' && !(mongoClient instanceof MongoClient)) {
+    options = mongoClient;
+    mongoClient = undefined;
+  }
 
-  // TODO(NODE-2704): Move back to test/tools/runner/config.js
-  options = { ...options };
-  Reflect.deleteProperty(options, 'host');
-  Reflect.deleteProperty(options, 'port');
+  const { url, hosts, isSRV } = parseURI(uri);
 
   const mongoOptions = Object.create(null);
-  mongoOptions.hosts = srv ? [{ host: hosts[0], type: 'srv' }] : hosts.map(toHostArray);
-  mongoOptions.srv = srv;
-  mongoOptions.dbName = decodeURIComponent(
-    url.pathname[0] === '/' ? url.pathname.slice(1) : url.pathname
-  );
-  mongoOptions.credentials = new MongoCredentials({
-    ...mongoOptions.credentials,
-    source: mongoOptions.dbName,
-    username: typeof url.username === 'string' ? decodeURIComponent(url.username) : undefined,
-    password: typeof url.password === 'string' ? decodeURIComponent(url.password) : undefined
-  });
+  mongoOptions.hosts = isSRV ? [] : hosts.map(HostAddress.fromString);
+  if (isSRV) {
+    // SRV Record is resolved upon connecting
+    mongoOptions.srvHost = hosts[0];
+    options.tls = true;
+  }
 
   const urlOptions = new CaseInsensitiveMap();
+
+  if (url.pathname !== '/' && url.pathname !== '') {
+    const dbName = decodeURIComponent(
+      url.pathname[0] === '/' ? url.pathname.slice(1) : url.pathname
+    );
+    urlOptions.set('dbName', [dbName]);
+  }
+
+  if (url.username !== '') {
+    const auth: Document = {
+      username: decodeURIComponent(url.username)
+    };
+
+    if (typeof url.password === 'string') {
+      auth.password = decodeURIComponent(url.password);
+    }
+
+    urlOptions.set('auth', [auth]);
+  }
+
   for (const key of url.searchParams.keys()) {
     const values = [...url.searchParams.getAll(key)];
 
@@ -905,9 +320,12 @@ export function parseOptions(
       throw new MongoParseError('URI cannot contain options with no value');
     }
 
-    if (urlOptions.has(key)) {
-      urlOptions.get(key)?.push(...values);
-    } else {
+    if (key.toLowerCase() === 'authsource' && urlOptions.has('authSource')) {
+      // If authSource is an explicit key in the urlOptions we need to remove the implicit dbName
+      urlOptions.delete('authSource');
+    }
+
+    if (!urlOptions.has(key)) {
       urlOptions.set(key, values);
     }
   }
@@ -942,16 +360,82 @@ export function parseOptions(
     allOptions.set(key, values);
   }
 
+  const unsupportedOptions = setDifference(
+    allKeys,
+    Array.from(Object.keys(OPTIONS)).map(s => s.toLowerCase())
+  );
+  if (unsupportedOptions.size !== 0) {
+    throw new MongoParseError(
+      `options ${Array.from(unsupportedOptions).join(', ')} are not supported`
+    );
+  }
+
   for (const [key, descriptor] of Object.entries(OPTIONS)) {
     const values = allOptions.get(key);
     if (!values || values.length === 0) continue;
     setOption(mongoOptions, key, descriptor, values);
   }
 
-  mongoOptions.credentials?.validate();
-  checkTLSOptions(mongoOptions);
+  if (mongoOptions.credentials) {
+    const gssapiOrX509 =
+      mongoOptions.credentials.mechanism === AuthMechanism.MONGODB_GSSAPI ||
+      mongoOptions.credentials.mechanism === AuthMechanism.MONGODB_X509;
 
-  return Object.freeze(mongoOptions) as Readonly<MongoOptions>;
+    if (
+      gssapiOrX509 &&
+      allOptions.has('authSource') &&
+      mongoOptions.credentials.source !== '$external'
+    ) {
+      // If authSource was explicitly given and its incorrect, we error
+      throw new MongoParseError(
+        `${mongoOptions.credentials} can only have authSource set to '$external'`
+      );
+    }
+
+    if (!gssapiOrX509 && mongoOptions.dbName) {
+      // inherit the dbName unless GSSAPI or X509, then silently ignore dbName
+      mongoOptions.credentials = MongoCredentials.merge(mongoOptions.credentials, {
+        source: mongoOptions.dbName
+      });
+    }
+
+    mongoOptions.credentials.validate();
+  }
+
+  if (!mongoOptions.dbName) {
+    // dbName default is applied here because of the credential validation above
+    mongoOptions.dbName = 'test';
+  }
+
+  if (allOptions.has('tls')) {
+    if (new Set(allOptions.get('tls')?.map(getBoolean)).size !== 1) {
+      throw new MongoParseError('All values of tls must be the same.');
+    }
+  }
+
+  if (allOptions.has('ssl')) {
+    if (new Set(allOptions.get('ssl')?.map(getBoolean)).size !== 1) {
+      throw new MongoParseError('All values of ssl must be the same.');
+    }
+  }
+
+  checkTLSOptions(mongoOptions);
+  if (mongoClient && options.autoEncryption) {
+    mongoOptions.autoEncrypter = createAutoEncrypter(mongoClient);
+  }
+  if (options.promiseLibrary) PromiseProvider.set(options.promiseLibrary);
+
+  if (mongoOptions.directConnection && typeof mongoOptions.srvHost === 'string') {
+    throw new MongoParseError('directConnection not supported with SRV URI');
+  }
+
+  // Potential SRV Overrides
+  mongoOptions.userSpecifiedAuthSource =
+    objectOptions.has('authSource') || urlOptions.has('authSource');
+  mongoOptions.userSpecifiedReplicaSet =
+    objectOptions.has('replicaSet') || urlOptions.has('replicaSet');
+
+  return mongoOptions;
 }
 
 function setOption(
@@ -964,7 +448,8 @@ function setOption(
   const name = target ?? key;
 
   if (deprecated) {
-    console.warn(`${key} is a deprecated option`);
+    const deprecatedMsg = typeof deprecated === 'string' ? `: ${deprecated}` : '';
+    console.warn(`${key} is a deprecated option${deprecatedMsg}`);
   }
 
   switch (type) {
@@ -985,7 +470,7 @@ function setOption(
       break;
     case 'record':
       if (!isRecord(values[0])) {
-        throw new TypeError(`${name} must be an object`);
+        throw new MongoParseError(`${name} must be an object`);
       }
       mongoOptions[name] = values[0];
       break;
@@ -1003,44 +488,12 @@ function setOption(
   }
 }
 
-function toHostArray(hostString: string) {
-  const parsedHost = new URL(`mongodb://${hostString.split(' ').join('%20')}`);
-
-  let socketPath;
-  if (hostString.endsWith('.sock')) {
-    // heuristically determine if we're working with a domain socket
-    socketPath = decodeURIComponent(hostString);
-  }
-
-  let ipv6SanitizedHostName;
-  if (parsedHost.hostname.startsWith('[') && parsedHost.hostname.endsWith(']')) {
-    ipv6SanitizedHostName = parsedHost.hostname.substring(1, parsedHost.hostname.length - 1);
-  }
-
-  const result: HostAddress = socketPath
-    ? {
-        host: socketPath,
-        type: 'unix'
-      }
-    : {
-        host: decodeURIComponent(ipv6SanitizedHostName ?? parsedHost.hostname),
-        port: parsedHost.port ? parseInt(parsedHost.port) : 27017,
-        type: 'tcp'
-      };
-
-  if (result.type === 'tcp' && result.port === 0) {
-    throw new MongoParseError('Invalid port (zero) with hostname');
-  }
-
-  return result;
-}
-
 interface OptionDescriptor {
   target?: string;
   type?: 'boolean' | 'int' | 'uint' | 'record' | 'string' | 'any';
   default?: any;
 
-  deprecated?: boolean;
+  deprecated?: boolean | string;
   /**
    * @param name - the original option name
    * @param options - the options so far for resolution
@@ -1051,16 +504,18 @@ interface OptionDescriptor {
 
 export const OPTIONS = {
   appName: {
-    target: 'driverInfo',
+    target: 'metadata',
     transform({ options, values: [value] }): DriverInfo {
-      return { ...options.driverInfo, name: String(value) };
+      return makeClientMetadata({ ...options.driverInfo, appName: String(value) });
     }
   },
   auth: {
     target: 'credentials',
     transform({ name, options, values: [value] }): MongoCredentials {
       if (!isRecord(value, ['username', 'password'] as const)) {
-        throw new TypeError(`${name} must be an object with 'username' and 'password' properties`);
+        throw new MongoParseError(
+          `${name} must be an object with 'username' and 'password' properties`
+        );
       }
       return MongoCredentials.merge(options.credentials, {
         username: value.username,
@@ -1074,19 +529,20 @@ export const OPTIONS = {
       const mechanisms = Object.values(AuthMechanism);
       const [mechanism] = mechanisms.filter(m => m.match(RegExp(String.raw`\b${value}\b`, 'i')));
       if (!mechanism) {
-        throw new TypeError(`authMechanism one of ${mechanisms}, got ${value}`);
+        throw new MongoParseError(`authMechanism one of ${mechanisms}, got ${value}`);
       }
-      let source = options.credentials.source; // some mechanisms have '$external' as the Auth Source
+      let source = options.credentials?.source;
       if (
         mechanism === AuthMechanism.MONGODB_PLAIN ||
         mechanism === AuthMechanism.MONGODB_GSSAPI ||
         mechanism === AuthMechanism.MONGODB_AWS ||
         mechanism === AuthMechanism.MONGODB_X509
       ) {
+        // some mechanisms have '$external' as the Auth Source
         source = '$external';
       }
 
-      let password: string | undefined = options.credentials.password;
+      let password = options.credentials?.password;
       if (mechanism === AuthMechanism.MONGODB_X509 && password === '') {
         password = undefined;
       }
@@ -1104,7 +560,7 @@ export const OPTIONS = {
         value = toRecord(value);
       }
       if (!isRecord(value)) {
-        throw new TypeError('AuthMechanismProperties must be an object');
+        throw new MongoParseError('AuthMechanismProperties must be an object');
       }
       return MongoCredentials.merge(options.credentials, { mechanismProperties: value });
     }
@@ -1112,7 +568,8 @@ export const OPTIONS = {
   authSource: {
     target: 'credentials',
     transform({ options, values: [value] }): MongoCredentials {
-      return MongoCredentials.merge(options.credentials, { source: String(value) });
+      const source = String(value);
+      return MongoCredentials.merge(options.credentials, { source });
     }
   },
   autoEncryption: {
@@ -1127,23 +584,8 @@ export const OPTIONS = {
       values: [value]
     }): boolean | ((hostname: string, cert: Document) => Error | undefined) {
       if (typeof value !== 'boolean' && typeof value !== 'function')
-        throw new TypeError('check server identity must be a boolean or custom function');
+        throw new MongoParseError('check server identity must be a boolean or custom function');
       return value as boolean | ((hostname: string, cert: Document) => Error | undefined);
-    }
-  },
-  compression: {
-    default: 'none',
-    target: 'compressors',
-    transform({ values }) {
-      const compressionList = new Set();
-      for (const c of values) {
-        if (['none', 'snappy', 'zlib'].includes(String(c))) {
-          compressionList.add(String(c));
-        } else {
-          throw new TypeError(`${c} is not a valid compression mechanism`);
-        }
-      }
-      return [...compressionList];
     }
   },
   compressors: {
@@ -1156,7 +598,7 @@ export const OPTIONS = {
           if (['none', 'snappy', 'zlib'].includes(String(c))) {
             compressionList.add(String(c));
           } else {
-            throw new TypeError(`${c} is not a valid compression mechanism`);
+            throw new MongoParseError(`${c} is not a valid compression mechanism`);
           }
         }
       }
@@ -1168,7 +610,6 @@ export const OPTIONS = {
     type: 'uint'
   },
   dbName: {
-    default: 'test',
     type: 'string'
   },
   directConnection: {
@@ -1176,8 +617,15 @@ export const OPTIONS = {
     type: 'boolean'
   },
   driverInfo: {
-    default: {},
-    type: 'record'
+    target: 'metadata',
+    default: makeClientMetadata(),
+    transform({ options, values: [value] }) {
+      if (!isRecord(value)) throw new MongoParseError('DriverInfo must be an object');
+      return makeClientMetadata({
+        driverInfo: value,
+        appName: options.metadata?.application?.name
+      });
+    }
   },
   family: {
     transform({ name, values: [value] }): 4 | 6 {
@@ -1185,7 +633,7 @@ export const OPTIONS = {
       if (transformValue === 4 || transformValue === 6) {
         return transformValue;
       }
-      throw new TypeError(`Option 'family' must be 4 or 6 got ${transformValue}.`);
+      throw new MongoParseError(`Option 'family' must be 4 or 6 got ${transformValue}.`);
     }
   },
   fieldsAsRaw: {
@@ -1196,6 +644,7 @@ export const OPTIONS = {
     type: 'boolean'
   },
   fsync: {
+    deprecated: 'Please use journal instead',
     target: 'writeConcern',
     transform({ name, options, values: [value] }): WriteConcern {
       const wc = WriteConcern.fromOptions({
@@ -1204,10 +653,10 @@ export const OPTIONS = {
           fsync: getBoolean(name, value)
         }
       });
-      if (!wc) throw new TypeError(`Unable to make a writeConcern from fsync=${value}`);
+      if (!wc) throw new MongoParseError(`Unable to make a writeConcern from fsync=${value}`);
       return wc;
     }
-  },
+  } as OptionDescriptor,
   heartbeatFrequencyMS: {
     default: 10000,
     type: 'uint'
@@ -1216,6 +665,7 @@ export const OPTIONS = {
     type: 'boolean'
   },
   j: {
+    deprecated: 'Please use journal instead',
     target: 'writeConcern',
     transform({ name, options, values: [value] }): WriteConcern {
       const wc = WriteConcern.fromOptions({
@@ -1224,10 +674,10 @@ export const OPTIONS = {
           journal: getBoolean(name, value)
         }
       });
-      if (!wc) throw new TypeError(`Unable to make a writeConcern from journal=${value}`);
+      if (!wc) throw new MongoParseError(`Unable to make a writeConcern from journal=${value}`);
       return wc;
     }
-  },
+  } as OptionDescriptor,
   journal: {
     target: 'writeConcern',
     transform({ name, options, values: [value] }): WriteConcern {
@@ -1237,7 +687,7 @@ export const OPTIONS = {
           journal: getBoolean(name, value)
         }
       });
-      if (!wc) throw new TypeError(`Unable to make a writeConcern from journal=${value}`);
+      if (!wc) throw new MongoParseError(`Unable to make a writeConcern from journal=${value}`);
       return wc;
     }
   },
@@ -1250,7 +700,7 @@ export const OPTIONS = {
     type: 'uint'
   },
   localThresholdMS: {
-    default: 0,
+    default: 15,
     type: 'uint'
   },
   logger: {
@@ -1279,7 +729,17 @@ export const OPTIONS = {
     type: 'uint'
   },
   maxStalenessSeconds: {
-    type: 'uint'
+    target: 'readPreference',
+    transform({ name, options, values: [value] }) {
+      const maxStalenessSeconds = getUint(name, value);
+      if (options.readPreference) {
+        return ReadPreference.fromOptions({
+          readPreference: { ...options.readPreference, maxStalenessSeconds }
+        });
+      } else {
+        return new ReadPreference('secondary', undefined, { maxStalenessSeconds });
+      }
+    }
   },
   minInternalBufferSize: {
     type: 'uint'
@@ -1289,6 +749,7 @@ export const OPTIONS = {
     type: 'uint'
   },
   minHeartbeatFrequencyMS: {
+    default: 500,
     type: 'uint'
   },
   monitorCommands: {
@@ -1305,38 +766,19 @@ export const OPTIONS = {
     default: true,
     type: 'boolean'
   },
-  numberOfRetries: {
-    default: 5,
-    type: 'int'
-  },
-  password: {
-    target: 'credentials',
-    transform({ values: [password], options }) {
-      if (typeof password !== 'string') {
-        throw new TypeError('pass must be a string');
-      }
-      return MongoCredentials.merge(options.credentials, { password });
-    }
-  },
   pkFactory: {
     default: DEFAULT_PK_FACTORY,
-    target: 'createPk',
     transform({ values: [value] }): PkFactory {
       if (isRecord(value, ['createPk'] as const) && typeof value.createPk === 'function') {
         return value as PkFactory;
       }
-      throw new TypeError(
+      throw new MongoParseError(
         `Option pkFactory must be an object with a createPk function, got ${value}`
       );
     }
   },
-  platform: {
-    target: 'driverInfo',
-    transform({ values: [value], options }) {
-      return { ...options.driverInfo, platform: String(value) };
-    }
-  } as OptionDescriptor,
   promiseLibrary: {
+    deprecated: true,
     type: 'any'
   },
   promoteBuffers: {
@@ -1400,21 +842,27 @@ export const OPTIONS = {
     }
   },
   readPreferenceTags: {
-    transform({ values }) {
-      const tags: TagSet = Object.create(null);
+    target: 'readPreference',
+    transform({ values, options }) {
+      const readPreferenceTags = [];
       for (const tag of values) {
+        const readPreferenceTag: TagSet = Object.create(null);
         if (typeof tag === 'string') {
           for (const [k, v] of Object.entries(toRecord(tag))) {
-            tags[k] = v;
+            readPreferenceTag[k] = v;
           }
         }
         if (isRecord(tag)) {
           for (const [k, v] of Object.entries(tag)) {
-            tags[k] = v;
+            readPreferenceTag[k] = v;
           }
         }
+        readPreferenceTags.push(readPreferenceTag);
       }
-      return tags;
+      return ReadPreference.fromOptions({
+        readPreference: options.readPreference,
+        readPreferenceTags
+      });
     }
   },
   replicaSet: {
@@ -1448,23 +896,28 @@ export const OPTIONS = {
     type: 'boolean'
   },
   sslCA: {
-    deprecated: true,
     target: 'ca',
-    type: 'any'
+    transform({ values: [value] }) {
+      return fs.readFileSync(String(value), { encoding: 'ascii' });
+    }
   },
   sslCRL: {
     target: 'crl',
-    type: 'any'
+    transform({ values: [value] }) {
+      return fs.readFileSync(String(value), { encoding: 'ascii' });
+    }
   },
   sslCert: {
-    deprecated: true,
     target: 'cert',
-    type: 'any'
+    transform({ values: [value] }) {
+      return fs.readFileSync(String(value), { encoding: 'ascii' });
+    }
   },
   sslKey: {
-    deprecated: true,
     target: 'key',
-    type: 'any'
+    transform({ values: [value] }) {
+      return fs.readFileSync(String(value), { encoding: 'ascii' });
+    }
   },
   sslPass: {
     deprecated: true,
@@ -1486,38 +939,43 @@ export const OPTIONS = {
   },
   tlsCAFile: {
     target: 'ca',
-    type: 'any'
+    transform({ values: [value] }) {
+      return fs.readFileSync(String(value), { encoding: 'ascii' });
+    }
   },
   tlsCertificateFile: {
     target: 'cert',
-    type: 'any'
+    transform({ values: [value] }) {
+      return fs.readFileSync(String(value), { encoding: 'ascii' });
+    }
   },
   tlsCertificateKeyFile: {
     target: 'key',
-    type: 'any'
+    transform({ values: [value] }) {
+      return fs.readFileSync(String(value), { encoding: 'ascii' });
+    }
   },
   tlsCertificateKeyFilePassword: {
     target: 'passphrase',
     type: 'any'
   },
   tlsInsecure: {
-    type: 'boolean'
+    transform({ name, options, values: [value] }) {
+      const tlsInsecure = getBoolean(name, value);
+      if (tlsInsecure) {
+        options.checkServerIdentity = undefined;
+        options.rejectUnauthorized = false;
+      } else {
+        options.checkServerIdentity = options.tlsAllowInvalidHostnames ? undefined : (true as any);
+        options.rejectUnauthorized = options.tlsAllowInvalidCertificates ? false : true;
+      }
+      return tlsInsecure;
+    }
   },
   useRecoveryToken: {
+    default: true,
     type: 'boolean'
   },
-  username: {
-    target: 'credentials',
-    transform({ values: [value], options }) {
-      return MongoCredentials.merge(options.credentials, { username: String(value) });
-    }
-  },
-  version: {
-    target: 'driverInfo',
-    transform({ values: [value], options }) {
-      return { ...options.driverInfo, version: String(value) };
-    }
-  } as OptionDescriptor,
   w: {
     target: 'writeConcern',
     transform({ values: [value], options }) {
@@ -1542,8 +1000,9 @@ export const OPTIONS = {
 
       throw new MongoParseError(`WriteConcern must be an object, got ${JSON.stringify(value)}`);
     }
-  },
+  } as OptionDescriptor,
   wtimeout: {
+    deprecated: 'Please use wtimeoutMS instead',
     target: 'writeConcern',
     transform({ values: [value], options }) {
       const wc = WriteConcern.fromOptions({
@@ -1555,7 +1014,7 @@ export const OPTIONS = {
       if (wc) return wc;
       throw new MongoParseError(`Cannot make WriteConcern from wtimeout`);
     }
-  },
+  } as OptionDescriptor,
   wtimeoutMS: {
     target: 'writeConcern',
     transform({ values: [value], options }) {
@@ -1572,5 +1031,33 @@ export const OPTIONS = {
   zlibCompressionLevel: {
     default: 0,
     type: 'int'
-  }
+  },
+  // Custom types for modifying core behavior
+  connectionType: { type: 'any' },
+  srvPoller: { type: 'any' },
+  /// Accepted NodeJS Options
+  minDHSize: { type: 'any' },
+  pskCallback: { type: 'any' },
+  secureContext: { type: 'any' },
+  enableTrace: { type: 'any' },
+  requestCert: { type: 'any' },
+  rejectUnauthorized: { type: 'any' },
+  ALPNProtocols: { type: 'any' },
+  SNICallback: { type: 'any' },
+  session: { type: 'any' },
+  requestOCSP: { type: 'any' },
+  localAddress: { type: 'any' },
+  localPort: { type: 'any' },
+  hints: { type: 'any' },
+  lookup: { type: 'any' },
+  ca: { type: 'any' },
+  cert: { type: 'any' },
+  ciphers: { type: 'any' },
+  crl: { type: 'any' },
+  ecdhCurve: { type: 'any' },
+  key: { type: 'any' },
+  passphrase: { type: 'any' },
+  pfx: { type: 'any' },
+  secureProtocol: { type: 'any' },
+  index: { type: 'any' }
 } as Record<keyof MongoClientOptions, OptionDescriptor>;

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -392,8 +392,9 @@ export function parseOptions(
       );
     }
 
-    if (!gssapiOrX509 && mongoOptions.dbName) {
+    if (!gssapiOrX509 && mongoOptions.dbName && !allOptions.has('authSource')) {
       // inherit the dbName unless GSSAPI or X509, then silently ignore dbName
+      // and there was no specific authSource given
       mongoOptions.credentials = MongoCredentials.merge(mongoOptions.credentials, {
         source: mongoOptions.dbName
       });

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -298,7 +298,9 @@ export function parseOptions(
     const dbName = decodeURIComponent(
       url.pathname[0] === '/' ? url.pathname.slice(1) : url.pathname
     );
-    urlOptions.set('dbName', [dbName]);
+    if (dbName) {
+      urlOptions.set('dbName', [dbName]);
+    }
   }
 
   if (url.username !== '') {

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -334,18 +334,12 @@ export function parseOptions(
 
   const objectOptions = new CaseInsensitiveMap(Object.entries(options));
 
-  const defaultOptions = new CaseInsensitiveMap(
-    Object.entries(OPTIONS)
-      .filter(([, descriptor]) => typeof descriptor.default !== 'undefined')
-      .map(([k, d]) => [k, d.default])
-  );
-
   const allOptions = new CaseInsensitiveMap();
 
   const allKeys = new Set<string>([
     ...urlOptions.keys(),
     ...objectOptions.keys(),
-    ...defaultOptions.keys()
+    ...DEFAULT_OPTIONS.keys()
   ]);
 
   for (const key of allKeys) {
@@ -356,8 +350,8 @@ export function parseOptions(
     if (objectOptions.has(key)) {
       values.push(objectOptions.get(key));
     }
-    if (defaultOptions.has(key)) {
-      values.push(defaultOptions.get(key));
+    if (DEFAULT_OPTIONS.has(key)) {
+      values.push(DEFAULT_OPTIONS.get(key));
     }
     allOptions.set(key, values);
   }
@@ -895,7 +889,6 @@ export const OPTIONS = {
   },
   ssl: {
     target: 'tls',
-    deprecated: true,
     type: 'boolean'
   },
   sslCA: {
@@ -1038,7 +1031,7 @@ export const OPTIONS = {
   // Custom types for modifying core behavior
   connectionType: { type: 'any' },
   srvPoller: { type: 'any' },
-  /// Accepted NodeJS Options
+  // Accepted NodeJS Options
   minDHSize: { type: 'any' },
   pskCallback: { type: 'any' },
   secureContext: { type: 'any' },
@@ -1064,3 +1057,9 @@ export const OPTIONS = {
   secureProtocol: { type: 'any' },
   index: { type: 'any' }
 } as Record<keyof MongoClientOptions, OptionDescriptor>;
+
+export const DEFAULT_OPTIONS = new CaseInsensitiveMap(
+  Object.entries(OPTIONS)
+    .filter(([, descriptor]) => typeof descriptor.default !== 'undefined')
+    .map(([k, d]) => [k, d.default])
+);

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -1,4 +1,4 @@
-import { Callback, maybePromise, MongoDBNamespace } from '../utils';
+import { Callback, maybePromise, MongoDBNamespace, ns } from '../utils';
 import { Long, Document, BSONSerializeOptions, pluckBSONSerializeOptions } from '../bson';
 import { ClientSession } from '../sessions';
 import { MongoError } from '../error';
@@ -637,7 +637,7 @@ function next(
               : response.cursor.id;
 
           if (response.cursor.ns) {
-            cursor[kNamespace] = MongoDBNamespace.fromString(response.cursor.ns);
+            cursor[kNamespace] = ns(response.cursor.ns);
           }
 
           cursor[kDocuments] = response.cursor.firstBatch;

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export type {
   OpGetMoreOptions,
   OpQueryOptions
 } from './cmap/commands';
-export type { Stream } from './cmap/connect';
+export type { Stream, LEGAL_TLS_SOCKET_OPTIONS, LEGAL_TCP_SOCKET_OPTIONS } from './cmap/connect';
 export type {
   Connection,
   ConnectionOptions,
@@ -173,13 +173,15 @@ export type {
   MongoClientOptions,
   WithSessionCallback,
   PkFactory,
-  MongoURIOptions,
   LogLevel,
   LogLevelId,
   Auth,
   DriverInfo,
   MongoOptions,
-  HostAddress
+  SupportedNodeConnectionOptions,
+  SupportedTLSConnectionOptions,
+  SupportedTLSSocketOptions,
+  SupportedSocketOptions
 } from './mongo_client';
 export type { AddUserOptions } from './operations/add_user';
 export type {
@@ -277,8 +279,7 @@ export type {
   ServerCapabilities,
   ConnectOptions,
   SelectServerOptions,
-  ServerSelectionCallback,
-  ServerAddress
+  ServerSelectionCallback
 } from './sdam/topology';
 export type { TopologyDescription, TopologyDescriptionOptions } from './sdam/topology_description';
 export type {
@@ -296,7 +297,8 @@ export type {
   ClientMetadataOptions,
   MongoDBNamespace,
   InterruptibleAsyncInterval,
-  BufferPool
+  BufferPool,
+  HostAddress
 } from './utils';
 export type { WriteConcern, W, WriteConcernOptions, WriteConcernSettings } from './write_concern';
 export type { ExecutionResult } from './operations/execute_operation';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,7 +10,7 @@ let level: LoggerLevel;
 const pid = process.pid;
 
 // current logger
-let currentLogger: LoggerFunction;
+let currentLogger: LoggerFunction = console.warn;
 
 /** @public */
 export enum LoggerLevel {
@@ -48,7 +48,7 @@ export class Logger {
     this.className = className;
 
     // Current logger
-    if (options.logger) {
+    if (!(options.logger instanceof Logger) && typeof options.logger === 'function') {
       currentLogger = options.logger;
     } else if (currentLogger == null) {
       currentLogger = console.log;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -50,8 +50,6 @@ export class Logger {
     // Current logger
     if (!(options.logger instanceof Logger) && typeof options.logger === 'function') {
       currentLogger = options.logger;
-    } else if (currentLogger == null) {
-      currentLogger = console.log;
     }
 
     // Set level of logging, default is error

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -1,151 +1,13 @@
-import * as fs from 'fs';
-import { Logger } from '../logger';
-import { ReadPreference } from '../read_preference';
-import { MongoError, AnyError } from '../error';
-import { ServerAddress, Topology, TopologyOptions } from '../sdam/topology';
-import { AUTH_MECHANISMS, parseConnectionString } from '../connection_string';
-import { ReadConcern } from '../read_concern';
+import { MongoError } from '../error';
+import { Topology } from '../sdam/topology';
+import { resolveSRVRecord } from '../connection_string';
 import { emitDeprecationWarning, Callback } from '../utils';
 import { CMAP_EVENT_NAMES } from '../cmap/events';
-import { MongoCredentials } from '../cmap/auth/mongo_credentials';
 import * as BSON from '../bson';
-import type { Document } from '../bson';
-import type { MongoClient } from '../mongo_client';
-import { ConnectionOptions, Connection } from '../cmap/connection';
-import { AuthMechanism, AuthMechanismId } from '../cmap/auth/defaultAuthProviders';
+import type { MongoClient, MongoOptions } from '../mongo_client';
+import { Connection } from '../cmap/connection';
 import { Server } from '../sdam/server';
-import { WRITE_CONCERN_KEYS } from '../write_concern';
-
-const validOptionNames = [
-  'poolSize',
-  'ssl',
-  'sslValidate',
-  'sslCA',
-  'sslCert',
-  'sslKey',
-  'sslPass',
-  'sslCRL',
-  'autoReconnect',
-  'noDelay',
-  'keepAlive',
-  'keepAliveInitialDelay',
-  'connectTimeoutMS',
-  'family',
-  'socketTimeoutMS',
-  'reconnectTries',
-  'reconnectInterval',
-  'ha',
-  'haInterval',
-  'replicaSet',
-  'secondaryAcceptableLatencyMS',
-  'acceptableLatencyMS',
-  'connectWithNoPrimary',
-  'authSource',
-  'writeConcern',
-  'forceServerObjectId',
-  'serializeFunctions',
-  'ignoreUndefined',
-  'raw',
-  'readPreference',
-  'pkFactory',
-  'promiseLibrary',
-  'readConcern',
-  'maxStalenessSeconds',
-  'loggerLevel',
-  'logger',
-  'promoteValues',
-  'promoteBuffers',
-  'promoteLongs',
-  'domainsEnabled',
-  'checkServerIdentity',
-  'validateOptions',
-  'appname',
-  'auth',
-  'user',
-  'username',
-  'host',
-  'password',
-  'authMechanism',
-  'compression',
-  'readPreferenceTags',
-  'numberOfRetries',
-  'auto_reconnect',
-  'minSize',
-  'monitorCommands',
-  'retryWrites',
-  'retryReads',
-  'useNewUrlParser',
-  'serverSelectionTimeoutMS',
-  'useRecoveryToken',
-  'autoEncryption',
-  'driverInfo',
-  'tls',
-  'tlsInsecure',
-  'tlsAllowInvalidCertificates',
-  'tlsAllowInvalidHostnames',
-  'tlsDisableCertificateRevocationCheck',
-  'tlsDisableOCSPEndpointCheck',
-  'tlsCAFile',
-  'tlsCertificateFile',
-  'tlsCertificateKeyFile',
-  'tlsCertificateKeyFilePassword',
-  'minHeartbeatFrequencyMS',
-  'heartbeatFrequencyMS',
-  'directConnection',
-  'appName',
-
-  // CMAP options
-  'maxPoolSize',
-  'minPoolSize',
-  'maxIdleTimeMS',
-  'waitQueueTimeoutMS'
-];
-
-const ignoreOptionNames = ['native_parser'];
-const legacyOptionNames = ['server', 'replset', 'replSet', 'mongos', 'db'];
-
-interface MongoClientOptions extends TopologyOptions, Omit<ConnectionOptions, 'host'> {
-  tls: boolean;
-  servers: string | ServerAddress[];
-  autoEncryption: null;
-  validateOptions: boolean;
-  readPreference?: ReadPreference;
-
-  sslCA: string | Buffer;
-  sslKey: string | Buffer;
-  sslCert: string | Buffer;
-}
-
-// Validate options object
-export function validOptions(options?: MongoClientOptions): void | MongoError {
-  const _validOptions = validOptionNames.concat(legacyOptionNames);
-
-  for (const name in options) {
-    if (ignoreOptionNames.indexOf(name) !== -1) {
-      continue;
-    }
-
-    if (_validOptions.indexOf(name) === -1) {
-      if (options.validateOptions) {
-        return new MongoError(`option ${name} is not supported`);
-      } else {
-        console.warn(`the options [${name}] is not supported`);
-      }
-    }
-
-    if (legacyOptionNames.indexOf(name) !== -1) {
-      console.warn(
-        `the server/replset/mongos/db options are deprecated, ` +
-          `all their options are supported at the top level of the options object [${validOptionNames}]`
-      );
-    }
-  }
-}
-
-const LEGACY_OPTIONS_MAP = validOptionNames.reduce((obj, name: string) => {
-  obj[name.toLowerCase()] = name;
-  return obj;
-}, {} as { [key: string]: string });
+import type { AutoEncrypter } from '../deps';
 
 function addListeners(mongoClient: MongoClient, topology: Topology) {
   topology.on('authenticated', createListener(mongoClient, 'authenticated'));
@@ -159,28 +21,11 @@ function addListeners(mongoClient: MongoClient, topology: Topology) {
   topology.on('reconnect', createListener(mongoClient, 'reconnect'));
 }
 
-function resolveTLSOptions(options: MongoClientOptions) {
-  if (!options.tls) {
-    return;
-  }
-
-  const keyFileOptionNames = ['sslCA', 'sslKey', 'sslCert'] as const;
-  for (const optionName of keyFileOptionNames) {
-    if (options[optionName]) {
-      options[optionName] = fs.readFileSync(options[optionName]);
-    }
-  }
-}
-
 export function connect(
   mongoClient: MongoClient,
-  url: string,
-  options: ConnectionOptions,
+  options: MongoOptions,
   callback: Callback<MongoClient>
 ): void {
-  options = Object.assign({}, options);
-
-  // If callback is null throw an exception
   if (!callback) {
     throw new Error('no callback function provided');
   }
@@ -190,59 +35,9 @@ export function connect(
     return callback(undefined, mongoClient);
   }
 
-  let didRequestAuthentication = false;
-  const logger = new Logger('MongoClient', options);
-
-  parseConnectionString(url, options, (err, connectionStringOptions) => {
-    // Do not attempt to connect if parsing error
-    if (err) return callback(err);
-
-    // Flatten
-    const urlOptions = transformUrlOptions(connectionStringOptions);
-
-    // Parse the string
-    const finalOptions = createUnifiedOptions(urlOptions, options);
-
-    // Check if we have connection and socket timeout set
-    if (finalOptions.socketTimeoutMS == null) finalOptions.socketTimeoutMS = 0;
-    if (finalOptions.connectTimeoutMS == null) finalOptions.connectTimeoutMS = 10000;
-    if (finalOptions.retryWrites == null) finalOptions.retryWrites = true;
-    if (finalOptions.useRecoveryToken == null) finalOptions.useRecoveryToken = true;
-    if (finalOptions.readPreference == null) finalOptions.readPreference = 'primary';
-
-    if (finalOptions.db_options && finalOptions.db_options.auth) {
-      delete finalOptions.db_options.auth;
-    }
-
-    // resolve tls options if needed
-    resolveTLSOptions(finalOptions);
-
-    // Store the merged options object
-    mongoClient.s.options = finalOptions;
-
-    // Failure modes
-    if (urlOptions.servers.length === 0) {
-      return callback(new Error('connection string must contain at least one seed host'));
-    }
-
-    if (finalOptions.auth && !finalOptions.credentials) {
-      try {
-        didRequestAuthentication = true;
-        finalOptions.credentials = generateCredentials(
-          mongoClient,
-          finalOptions.auth.user,
-          finalOptions.auth.password,
-          finalOptions
-        );
-      } catch (err) {
-        return callback(err);
-      }
-    }
-
-    return createTopology(mongoClient, finalOptions, connectCallback);
-  });
-
-  function connectCallback(err?: AnyError, topology?: MongoClient) {
+  const didRequestAuthentication = false;
+  const logger = mongoClient.logger;
+  const connectCallback: Callback = err => {
     const warningMessage =
       'seed list contains no mongos proxies, replicaset connections requires ' +
       'the parameter replicaSet to be supplied in the URI or options object, ' +
@@ -260,9 +55,21 @@ export function connect(
       mongoClient.emit('authenticated', null, true);
     }
 
-    // Return the error and db instance
-    callback(err, topology);
+    callback(err, mongoClient);
+  };
+
+  if (typeof options.srvHost === 'string') {
+    return resolveSRVRecord(options, (err, hosts) => {
+      if (err || !hosts) return callback(err);
+      for (const [index, host] of hosts.entries()) {
+        options.hosts[index] = host;
+      }
+
+      return createTopology(mongoClient, options, connectCallback);
+    });
   }
+
+  return createTopology(mongoClient, options, connectCallback);
 }
 
 export type ListenerFunction<V1 = unknown, V2 = unknown> = (v1: V1, v2: V2) => boolean;
@@ -302,49 +109,50 @@ function registerDeprecatedEventNotifiers(client: MongoClient) {
   });
 }
 
-function createTopology(mongoClient: MongoClient, options: MongoClientOptions, callback: Callback) {
-  // Set default options
-  translateOptions(options);
-
-  // determine CSFLE support
-  if (options.autoEncryption != null) {
-    let AutoEncrypter;
-    try {
-      require.resolve('mongodb-client-encryption');
-    } catch (err) {
-      callback(
-        new MongoError(
-          'Auto-encryption requested, but the module is not installed. ' +
-            'Please add `mongodb-client-encryption` as a dependency of your project'
-        )
-      );
-      return;
-    }
-
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const mongodbClientEncryption = require('mongodb-client-encryption');
-      if (typeof mongodbClientEncryption.extension !== 'function') {
-        callback(
-          new MongoError(
-            'loaded version of `mongodb-client-encryption` does not have property `extension`. ' +
-              'Please make sure you are loading the correct version of `mongodb-client-encryption`'
-          )
-        );
-      }
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      AutoEncrypter = mongodbClientEncryption.extension(require('../../lib/index')).AutoEncrypter;
-    } catch (err) {
-      callback(err);
-      return;
-    }
-
-    const mongoCryptOptions = Object.assign({ bson: BSON }, options.autoEncryption);
-    options.autoEncrypter = new AutoEncrypter(mongoClient, mongoCryptOptions);
+/**
+ * If AutoEncryption is requested, handles the optional dependency logic and passing through options
+ * returns undefined if CSFLE is not enabled.
+ * @throws if optional 'mongodb-client-encryption' dependency missing
+ */
+export function createAutoEncrypter(client: MongoClient): AutoEncrypter | undefined {
+  if (!client.options.autoEncryption) {
+    return;
+  }
+  try {
+    require.resolve('mongodb-client-encryption');
+  } catch (err) {
+    throw new MongoError(
+      'Auto-encryption requested, but the module is not installed. ' +
+        'Please add `mongodb-client-encryption` as a dependency of your project'
+    );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mongodbClientEncryption = require('mongodb-client-encryption');
+  if (typeof mongodbClientEncryption.extension !== 'function') {
+    throw new MongoError(
+      'loaded version of `mongodb-client-encryption` does not have property `extension`. ' +
+        'Please make sure you are loading the correct version of `mongodb-client-encryption`'
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { AutoEncrypterClass } = mongodbClientEncryption.extension(require('../../lib/index'));
+
+  const mongoCryptOptions = Object.assign({ bson: BSON }, client.options.autoEncryption);
+  return new AutoEncrypterClass(client, mongoCryptOptions);
+}
+
+function createTopology(
+  mongoClient: MongoClient,
+  options: MongoOptions,
+  callback: Callback<Topology>
+) {
   // Create the topology
-  const topology = new Topology(options.servers, options);
+  const topology = new Topology(options.hosts, options);
+  // Events can be emitted before initialization is complete so we have to
+  // save the reference to the topology on the client ASAP if the event handlers need to access it
+  mongoClient.topology = topology;
+
   registerDeprecatedEventNotifiers(mongoClient);
 
   // Add listeners
@@ -353,12 +161,9 @@ function createTopology(mongoClient: MongoClient, options: MongoClientOptions, c
   // Propagate the events to the client
   relayEvents(mongoClient, topology);
 
-  // Assign the topology
-  mongoClient.topology = topology;
-
   // initialize CSFLE if requested
-  if (options.autoEncrypter) {
-    options.autoEncrypter.init(err => {
+  if (mongoClient.autoEncrypter) {
+    mongoClient.autoEncrypter.init(err => {
       if (err) {
         callback(err);
         return;
@@ -388,93 +193,6 @@ function createTopology(mongoClient: MongoClient, options: MongoClientOptions, c
     callback(undefined, topology);
     return;
   });
-}
-
-function createUnifiedOptions(finalOptions: any, options: any) {
-  const childOptions = [
-    'mongos',
-    'server',
-    'db',
-    'replset',
-    'db_options',
-    'server_options',
-    'rs_options',
-    'mongos_options'
-  ];
-  const noMerge = ['readconcern', 'compression', 'autoencryption'];
-
-  for (const name in options) {
-    if (name === 'writeConcern') {
-      finalOptions[name] = { ...finalOptions[name], ...options[name] };
-    } else if (noMerge.indexOf(name.toLowerCase()) !== -1) {
-      finalOptions[name] = options[name];
-    } else if (childOptions.indexOf(name.toLowerCase()) !== -1) {
-      finalOptions = mergeOptions(finalOptions, options[name], false);
-    } else {
-      if (
-        options[name] &&
-        typeof options[name] === 'object' &&
-        !Buffer.isBuffer(options[name]) &&
-        !Array.isArray(options[name])
-      ) {
-        finalOptions = mergeOptions(finalOptions, options[name], true);
-      } else {
-        finalOptions[name] = options[name];
-      }
-    }
-  }
-
-  return finalOptions;
-}
-
-export interface GenerateCredentialsOptions {
-  authSource: string;
-  authdb: string;
-  dbName: string;
-  authMechanism: AuthMechanismId;
-  authMechanismProperties: Document;
-}
-
-function generateCredentials(
-  client: MongoClient,
-  username: string,
-  password: string,
-  options: GenerateCredentialsOptions
-) {
-  options = Object.assign({}, options);
-
-  // the default db to authenticate against is 'self'
-  // if authenticate is called from a retry context, it may be another one, like admin
-  const source = options.authSource || options.authdb || options.dbName;
-
-  // authMechanism
-  const authMechanismRaw = options.authMechanism || AuthMechanism.MONGODB_DEFAULT;
-  const mechanism = authMechanismRaw.toUpperCase() as AuthMechanismId;
-  const mechanismProperties = options.authMechanismProperties;
-
-  if (!AUTH_MECHANISMS.has(mechanism)) {
-    throw new MongoError(`authentication mechanism ${mechanism} not supported`);
-  }
-
-  return new MongoCredentials({
-    mechanism,
-    mechanismProperties,
-    source,
-    username,
-    password
-  });
-}
-
-function mergeOptions<T, S>(target: T, source: S, flatten: boolean): S & T {
-  for (const name in source) {
-    if (source[name] && typeof source[name] === 'object' && flatten) {
-      target = mergeOptions(target, source[name], flatten);
-    } else {
-      target = Object.assign(target, { [name]: source[name] });
-    }
-  }
-
-  return target as S & T;
 }
 
 function relayEvents(mongoClient: MongoClient, topology: Topology) {
@@ -507,107 +225,4 @@ function relayEvents(mongoClient: MongoClient, topology: Topology) {
       mongoClient.emit(event, object1, object2);
     });
   });
-}
-
-function transformUrlOptions(connStrOptions: any) {
-  const connStrOpts = Object.assign({ servers: connStrOptions.hosts }, connStrOptions.options);
-  for (const name in connStrOpts) {
-    const camelCaseName = LEGACY_OPTIONS_MAP[name];
-    if (camelCaseName) {
-      connStrOpts[camelCaseName] = connStrOpts[name];
-    }
-  }
-
-  const hasUsername = connStrOptions.auth && connStrOptions.auth.username;
-  const hasAuthMechanism = connStrOptions.options && connStrOptions.options.authMechanism;
-  if (hasUsername || hasAuthMechanism) {
-    connStrOpts.auth = Object.assign({}, connStrOptions.auth);
-    if (connStrOpts.auth.db) {
-      connStrOpts.authSource = connStrOpts.authSource || connStrOpts.auth.db;
-    }
-
-    if (connStrOpts.auth.username) {
-      connStrOpts.auth.user = connStrOpts.auth.username;
-    }
-  }
-
-  if (connStrOptions.defaultDatabase) {
-    connStrOpts.dbName = connStrOptions.defaultDatabase;
-  }
-
-  if (connStrOpts.maxPoolSize) {
-    connStrOpts.poolSize = connStrOpts.maxPoolSize;
-  }
-
-  if (connStrOpts.readConcernLevel) {
-    connStrOpts.readConcern = new ReadConcern(connStrOpts.readConcernLevel);
-  }
-
-  if (connStrOpts.wTimeoutMS) {
-    connStrOpts.wtimeout = connStrOpts.wTimeoutMS;
-    connStrOpts.wTimeoutMS = undefined;
-  }
-
-  if (connStrOptions.srvHost) {
-    connStrOpts.srvHost = connStrOptions.srvHost;
-  }
-
-  // Any write concern options from the URL will be top-level, so we manually
-  // move them options under `object.writeConcern`
-  for (const key of WRITE_CONCERN_KEYS) {
-    if (connStrOpts[key] !== undefined) {
-      if (connStrOpts.writeConcern === undefined) connStrOpts.writeConcern = {};
-      connStrOpts.writeConcern[key] = connStrOpts[key];
-      connStrOpts[key] = undefined;
-    }
-  }
-
-  return connStrOpts;
-}
-
-function translateOptions(options: any) {
-  // If we have a readPreference passed in by the db options
-  if (typeof options.readPreference === 'string' || typeof options.read_preference === 'string') {
-    options.readPreference = new ReadPreference(options.readPreference || options.read_preference);
-  }
-
-  // Do we have readPreference tags, add them
-  if (options.readPreference && (options.readPreferenceTags || options.read_preference_tags)) {
-    options.readPreference.tags = options.readPreferenceTags || options.read_preference_tags;
-  }
-
-  // Do we have maxStalenessSeconds
-  if (options.maxStalenessSeconds) {
-    options.readPreference.maxStalenessSeconds = options.maxStalenessSeconds;
-  }
-
-  // Set the socket and connection timeouts
-  if (options.socketTimeoutMS == null) options.socketTimeoutMS = 0;
-  if (options.connectTimeoutMS == null) options.connectTimeoutMS = 10000;
-
-  const translations = {
-    // SSL translation options
-    sslCA: 'ca',
-    sslCRL: 'crl',
-    sslValidate: 'rejectUnauthorized',
-    sslKey: 'key',
-    sslCert: 'cert',
-    sslPass: 'passphrase',
-    // SocketTimeout translation options
-    socketTimeoutMS: 'socketTimeout',
-    connectTimeoutMS: 'connectionTimeout',
-    // Replicaset options
-    replicaSet: 'setName',
-    rs_name: 'setName',
-    secondaryAcceptableLatencyMS: 'acceptableLatency',
-    connectWithNoPrimary: 'secondaryOnlyConnectionAllowed',
-    // Mongos options
-    acceptableLatencyMS: 'localThresholdMS'
-  } as { [key: string]: string };
-
-  for (const name in options) {
-    if (translations[name]) {
-      options[translations[name]] = options[name];
-    }
-  }
 }

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -155,11 +155,19 @@ export class ReadPreference {
     } else if (!(readPreference instanceof ReadPreference) && typeof readPreference === 'object') {
       const mode = readPreference.mode || readPreference.preference;
       if (mode && typeof mode === 'string') {
-        return new ReadPreference(mode as ReadPreferenceModeId, readPreference.tags, {
-          maxStalenessSeconds: readPreference.maxStalenessSeconds,
-          hedge: options.hedge
-        });
+        return new ReadPreference(
+          mode as ReadPreferenceModeId,
+          readPreference.tags ?? readPreferenceTags,
+          {
+            maxStalenessSeconds: readPreference.maxStalenessSeconds,
+            hedge: options.hedge
+          }
+        );
       }
+    }
+
+    if (readPreferenceTags) {
+      readPreference.tags = readPreferenceTags;
     }
 
     return readPreference as ReadPreference;

--- a/src/sdam/common.ts
+++ b/src/sdam/common.ts
@@ -36,16 +36,6 @@ export enum ServerType {
   Unknown = 'Unknown'
 }
 
-export const TOPOLOGY_DEFAULTS = {
-  localThresholdMS: 15,
-  serverSelectionTimeoutMS: 30000,
-  heartbeatFrequencyMS: 10000,
-  minHeartbeatFrequencyMS: 500,
-
-  // TODO: remove in v4
-  useRecoveryToken: true
-};
-
 /** @internal */
 export type TimerQueue = Set<NodeJS.Timeout>;
 

--- a/src/sdam/srv_polling.ts
+++ b/src/sdam/srv_polling.ts
@@ -1,6 +1,7 @@
 import * as dns from 'dns';
 import { Logger, LoggerOptions } from '../logger';
 import { EventEmitter } from 'events';
+import { HostAddress } from '../utils';
 
 /**
  * Determines whether a provided address matches the provided parent domain in order
@@ -27,8 +28,13 @@ export class SrvPollingEvent {
     this.srvRecords = srvRecords;
   }
 
-  addresses(): Set<string> {
-    return new Set(this.srvRecords.map((record: dns.SrvRecord) => `${record.name}:${record.port}`));
+  addresses(): Map<string, HostAddress> {
+    return new Map(
+      this.srvRecords.map(record => {
+        const host = new HostAddress(`${record.name}:${record.port}`);
+        return [host.toString(), host];
+      })
+    );
   }
 }
 

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -19,10 +19,9 @@ import {
   relayEvents,
   makeStateMachine,
   eachAsync,
-  makeClientMetadata,
-  emitDeprecatedOptionWarning,
   ClientMetadata,
   Callback,
+  HostAddress,
   ns
 } from '../utils';
 import {
@@ -36,8 +35,7 @@ import {
   STATE_CLOSED,
   STATE_CLOSING,
   STATE_CONNECTING,
-  STATE_CONNECTED,
-  TOPOLOGY_DEFAULTS
+  STATE_CONNECTED
 } from './common';
 import {
   ServerOpeningEvent,
@@ -51,7 +49,6 @@ import type { Document, BSONSerializeOptions } from '../bson';
 import type { MongoCredentials } from '../cmap/auth/mongo_credentials';
 import type { Transaction } from '../transactions';
 import type { CloseOptions } from '../cmap/connection_pool';
-import type { LoggerOptions } from '../logger';
 import { DestroyOptions, Connection } from '../cmap/connection';
 import type { MongoClientOptions } from '../mongo_client';
 
@@ -103,7 +100,7 @@ export interface TopologyPrivate {
   /** passed in options */
   options: TopologyOptions;
   /** initial seedlist of servers to connect to */
-  seedlist: ServerAddress[];
+  seedlist: HostAddress[];
   /** initial state */
   state: string;
   /** the topology description */
@@ -129,25 +126,12 @@ export interface TopologyPrivate {
 }
 
 /** @public */
-export interface ServerAddress {
-  host: string;
-  port: number;
-  domain_socket?: string;
-}
-
-/** @public */
-export interface TopologyOptions extends ServerOptions, BSONSerializeOptions, LoggerOptions {
-  reconnect: boolean;
-  retryWrites?: boolean;
-  retryReads?: boolean;
-  host: string;
-  port?: number;
-  credentials?: MongoCredentials;
+export interface TopologyOptions extends BSONSerializeOptions, ServerOptions {
+  hosts: HostAddress[];
+  retryWrites: boolean;
+  retryReads: boolean;
   /** How long to block for server selection before throwing an error */
   serverSelectionTimeoutMS: number;
-  /** The frequency with which topology updates are scheduled */
-  heartbeatFrequencyMS: number;
-  minHeartbeatFrequencyMS: number;
   /** The name of the replica set to connect to */
   replicaSet?: string;
   srvHost?: string;
@@ -206,38 +190,24 @@ export class Topology extends EventEmitter {
   static readonly CONNECT = 'connect' as const;
 
   /**
-   * @param seedlist - a string list, or array of ServerAddress instances to connect to
+   * @param seedlist - a list of HostAddress instances to connect to
    */
-  constructor(seedlist: string | ServerAddress[], options?: TopologyOptions) {
+  constructor(seedlist: string | HostAddress | HostAddress[], options: TopologyOptions) {
     super();
-    emitDeprecatedOptionWarning(options, ['promiseLibrary']);
 
-    seedlist = seedlist || [];
     if (typeof seedlist === 'string') {
-      seedlist = parseStringSeedlist(seedlist);
+      seedlist = [HostAddress.fromString(seedlist)];
     } else if (!Array.isArray(seedlist)) {
       seedlist = [seedlist];
     }
 
-    options = Object.assign({}, TOPOLOGY_DEFAULTS, options);
-    options = Object.freeze(
-      Object.assign(options, {
-        metadata: makeClientMetadata(options),
-        compression: { compressors: makeCompressionInfo(options) }
-      })
-    );
-
     const topologyType = topologyTypeFromOptions(options);
     const topologyId = globalTopologyCounter++;
-    const serverDescriptions = seedlist.reduce(
-      (result: Map<string, ServerDescription>, seed: ServerAddress) => {
-        if (seed.domain_socket) seed.host = seed.domain_socket;
-        const address = seed.port ? `${seed.host}:${seed.port}` : `${seed.host}:27017`;
-        result.set(address, new ServerDescription(address));
-        return result;
-      },
-      new Map<string, ServerDescription>()
-    );
+
+    const serverDescriptions = new Map();
+    for (const hostAddress of seedlist) {
+      serverDescriptions.set(hostAddress.toString(), new ServerDescription(hostAddress));
+    }
 
     this[kWaitQueue] = new Denque();
     this.s = {
@@ -345,8 +315,7 @@ export class Topology extends EventEmitter {
     // connect all known servers, then attempt server selection to connect
     connectServers(this, Array.from(this.s.description.servers.values()));
 
-    ReadPreference.translate(options);
-    const readPreference = options.readPreference || ReadPreference.primary;
+    const readPreference = options.readPreference ?? ReadPreference.primary;
     this.selectServer(readPreferenceServerSelector(readPreference), options, (err, server) => {
       if (err) {
         this.close();
@@ -746,25 +715,13 @@ function destroyServer(
   });
 }
 
-/**
- * Parses a basic seedlist in string form
- *
- * @param seedlist - The seedlist to parse
- */
-function parseStringSeedlist(seedlist: string): ServerAddress[] {
-  return seedlist.split(',').map((seed: string) => ({
-    host: seed.split(':')[0],
-    port: parseInt(seed.split(':')[1], 10) || 27017
-  }));
-}
-
 /** Predicts the TopologyType from options */
-function topologyTypeFromOptions(options: TopologyOptions) {
-  if (options.directConnection) {
+function topologyTypeFromOptions(options?: TopologyOptions) {
+  if (options?.directConnection) {
     return TopologyType.Single;
   }
 
-  if (options.replicaSet) {
+  if (options?.replicaSet) {
     return TopologyType.ReplicaSetNoPrimary;
   }
 
@@ -965,23 +922,12 @@ function processWaitQueue(topology: Topology) {
 
   if (topology[kWaitQueue].length > 0) {
     // ensure all server monitors attempt monitoring soon
-    topology.s.servers.forEach((server: Server) => process.nextTick(() => server.requestCheck()));
-  }
-}
-
-function makeCompressionInfo(options: TopologyOptions) {
-  if (!options.compression || !options.compression.compressors) {
-    return [];
-  }
-
-  // Check that all supplied compressors are valid
-  options.compression.compressors.forEach((compressor: string) => {
-    if (compressor !== 'snappy' && compressor !== 'zlib') {
-      throw new Error('compressors must be at least one of snappy or zlib');
+    for (const [, server] of topology.s.servers) {
+      process.nextTick(function scheduleServerCheck() {
+        return server.requestCheck();
+      });
     }
-  });
-
-  return options.compression.compressors;
+  }
 }
 
 /** @public */

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -51,8 +51,8 @@ export class TopologyDescription {
     // TODO: consider assigning all these values to a temporary value `s` which
     //       we use `Object.freeze` on, ensuring the internal state of this type
     //       is immutable.
-    this.type = topologyType || TopologyType.Unknown;
-    this.servers = serverDescriptions || new Map();
+    this.type = topologyType ?? TopologyType.Unknown;
+    this.servers = serverDescriptions ?? new Map();
     this.stale = false;
     this.compatible = true;
     this.heartbeatFrequencyMS = options.heartbeatFrequencyMS ?? 0;
@@ -127,8 +127,8 @@ export class TopologyDescription {
       return this;
     }
 
-    for (const address of newAddresses) {
-      serverDescriptions.set(address, new ServerDescription(address));
+    for (const [address, host] of newAddresses) {
+      serverDescriptions.set(address, new ServerDescription(host));
     }
 
     return new TopologyDescription(
@@ -217,15 +217,16 @@ export class TopologyDescription {
           maxElectionId
         );
 
-        (topologyType = result[0]),
-          (setName = result[1]),
-          (maxSetVersion = result[2]),
-          (maxElectionId = result[3]);
+        topologyType = result[0];
+        setName = result[1];
+        maxSetVersion = result[2];
+        maxElectionId = result[3];
       } else if (
         [ServerType.RSSecondary, ServerType.RSArbiter, ServerType.RSOther].indexOf(serverType) >= 0
       ) {
         const result = updateRsNoPrimaryFromMember(serverDescriptions, serverDescription, setName);
-        (topologyType = result[0]), (setName = result[1]);
+        topologyType = result[0];
+        setName = result[1];
       }
     }
 
@@ -242,10 +243,10 @@ export class TopologyDescription {
           maxElectionId
         );
 
-        (topologyType = result[0]),
-          (setName = result[1]),
-          (maxSetVersion = result[2]),
-          (maxElectionId = result[3]);
+        topologyType = result[0];
+        setName = result[1];
+        maxSetVersion = result[2];
+        maxElectionId = result[3];
       } else if (
         [ServerType.RSSecondary, ServerType.RSArbiter, ServerType.RSOther].indexOf(serverType) >= 0
       ) {
@@ -400,7 +401,7 @@ function updateRsFromPrimary(
   });
 
   // Remove hosts not in the response.
-  const currentAddresses = Array.from(serverDescriptions.keys()) as string[];
+  const currentAddresses = Array.from(serverDescriptions.keys());
   const responseAddresses = serverDescription.allHosts;
   currentAddresses
     .filter((addr: string) => responseAddresses.indexOf(addr) === -1)

--- a/src/write_concern.ts
+++ b/src/write_concern.ts
@@ -12,13 +12,15 @@ export interface WriteConcernSettings {
   /** The write concern */
   w?: W;
   /** The write concern timeout */
-  wtimeout?: number;
-  /** The write concern timeout */
   wtimeoutMS?: number;
   /** The journal write concern */
-  j?: boolean;
-  /** The journal write concern */
   journal?: boolean;
+
+  // legacy options
+  /** The journal write concern */
+  j?: boolean;
+  /** The write concern timeout */
+  wtimeout?: number;
   /** The file sync write concern */
   fsync?: boolean | 1;
 }
@@ -70,13 +72,19 @@ export class WriteConcern {
 
   /** Construct a WriteConcern given an options object. */
   static fromOptions(
-    options?: WriteConcernOptions | WriteConcern,
+    options?: WriteConcernOptions | WriteConcern | W,
     inherit?: WriteConcernOptions | WriteConcern
   ): WriteConcern | undefined {
     if (typeof options === 'undefined') return undefined;
     inherit = inherit ?? {};
-    const opts: WriteConcern | WriteConcernSettings | undefined =
-      options instanceof WriteConcern ? options : options.writeConcern;
+    let opts;
+    if (typeof options === 'string' || typeof options === 'number') {
+      opts = { w: options };
+    } else if (options instanceof WriteConcern) {
+      opts = options;
+    } else {
+      opts = options.writeConcern;
+    }
     const parentOpts: WriteConcern | WriteConcernSettings | undefined =
       inherit instanceof WriteConcern ? inherit : inherit.writeConcern;
 

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -30,7 +30,7 @@
     "jsdoc/valid-types": "off",
 
     // Since we use ts-node we should always require the TS code
-    "no-restricted-modules": ["error", { "patterns": ["**/../lib/**"] }],
+    "no-restricted-modules": ["error", { "patterns": ["**/../lib/**", "mongodb-mock-server"] }],
 
     "no-console": "off",
     "eqeqeq": ["error", "always", { "null": "ignore" }],

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -30,7 +30,7 @@ describe('APM', function () {
         instrumentation.on('succeeded', filterForCommands('insert', succeeded));
 
         let client = this.configuration.newClient(
-          { w: 1 },
+          { writeConcern: { w: 1 } },
           { maxPoolSize: 1, monitorCommands: true }
         );
 
@@ -52,7 +52,7 @@ describe('APM', function () {
             started = [];
             succeeded = [];
             client = this.configuration.newClient(
-              { w: 1 },
+              { writeConcern: { w: 1 } },
               { maxPoolSize: 1, monitorCommands: true }
             );
 
@@ -124,7 +124,7 @@ describe('APM', function () {
       const started = [];
       const succeeded = [];
       const client = this.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -153,7 +153,7 @@ describe('APM', function () {
       const succeeded = [];
       const self = this;
       const client = this.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -183,33 +183,36 @@ describe('APM', function () {
       const started = [];
       const succeeded = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
       client.on('commandStarted', filterForCommands('listCollections', started));
       client.on('commandSucceeded', filterForCommands('listCollections', succeeded));
 
-      return client.connect().then(client => {
-        const db = client.db(self.configuration.db);
+      return client
+        .connect()
+        .then(client => {
+          const db = client.db(self.configuration.db);
 
-        return db
-          .collection('apm_test_list_collections')
-          .insertOne({ a: 1 }, self.configuration.writeConcernMax())
-          .then(r => {
-            expect(r).property('insertedId').to.exist;
-            return db.listCollections({}, { readPreference: ReadPreference.PRIMARY }).toArray();
-          })
-          .then(() =>
-            db.listCollections({}, { readPreference: ReadPreference.SECONDARY }).toArray()
-          )
-          .then(() => {
-            expect(started).to.have.lengthOf(2);
-            expect(started[0]).property('address').to.not.equal(started[1].address);
+          return db
+            .collection('apm_test_list_collections')
+            .insertOne({ a: 1 }, self.configuration.writeConcernMax())
+            .then(r => {
+              expect(r).property('insertedId').to.exist;
+              return db.listCollections({}, { readPreference: ReadPreference.primary }).toArray();
+            })
+            .then(() =>
+              db.listCollections({}, { readPreference: ReadPreference.secondary }).toArray()
+            )
+            .then(() => {
+              expect(started).to.have.lengthOf(2);
+              expect(started[0]).property('address').to.not.equal(started[1].address);
 
-            return client.close();
-          });
-      });
+              return client.close();
+            });
+        })
+        .catch(err => expect(err).to.not.exist);
     }
   });
 
@@ -221,7 +224,7 @@ describe('APM', function () {
       const started = [];
       const succeeded = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -301,7 +304,7 @@ describe('APM', function () {
         // });
 
         const client = self.configuration.newClient(
-          { w: 1 },
+          { writeConcern: { w: 1 } },
           { maxPoolSize: 1, monitorCommands: true }
         );
 
@@ -337,7 +340,7 @@ describe('APM', function () {
       const succeeded = [];
       const failed = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -411,7 +414,7 @@ describe('APM', function () {
       const succeeded = [];
       const failed = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -469,7 +472,7 @@ describe('APM', function () {
       const started = [];
       const succeeded = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -511,7 +514,7 @@ describe('APM', function () {
       const succeeded = [];
       const failed = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -561,7 +564,7 @@ describe('APM', function () {
       const succeeded = [];
       const failed = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -593,7 +596,7 @@ describe('APM', function () {
       const started = [];
       const succeeded = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -628,7 +631,7 @@ describe('APM', function () {
       const started = [];
       const succeeded = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -663,7 +666,7 @@ describe('APM', function () {
       const started = [];
       const succeeded = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -693,7 +696,7 @@ describe('APM', function () {
     test: function () {
       const self = this;
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -743,7 +746,7 @@ describe('APM', function () {
       for (let i = 0; i < 2500; i++) docs.push({ a: i });
 
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 
@@ -789,7 +792,7 @@ describe('APM', function () {
       const started = [];
       const succeeded = [];
       const client = self.configuration.newClient(
-        { w: 1 },
+        { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
 

--- a/test/functional/buffering_proxy.test.js
+++ b/test/functional/buffering_proxy.test.js
@@ -1,7 +1,7 @@
 'use strict';
 var test = require('./shared').assert;
 var co = require('co');
-var mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 const { ReadPreference, ObjectId } = require('../../src');
 const { expect } = require('chai');
 

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -1201,7 +1201,7 @@ describe('Bulk', function () {
         batch.insert({ a: 1 });
         batch.insert({ a: 2 });
 
-        batch.execute({ writeConcern: { w: 2, wtimeout: 1000 } }, function (err) {
+        batch.execute({ writeConcern: { w: 2, wtimeoutMS: 1000 } }, function (err) {
           test.ok(err != null);
           test.ok(err.code != null);
           test.ok(err.errmsg != null);
@@ -1303,7 +1303,7 @@ describe('Bulk', function () {
         batch.insert({ a: 1 });
         batch.insert({ a: 2 });
 
-        batch.execute({ writeConcern: { w: 2, wtimeout: 1000 } }, function (err) {
+        batch.execute({ writeConcern: { w: 2, wtimeoutMS: 1000 } }, function (err) {
           test.ok(err != null);
           test.ok(err.code != null);
           test.ok(err.errmsg != null);

--- a/test/functional/cmap/connection.test.js
+++ b/test/functional/cmap/connection.test.js
@@ -4,7 +4,7 @@ const { Connection } = require('../../../src/cmap/connection');
 const { connect } = require('../../../src/cmap/connect');
 const { expect } = require('chai');
 const { setupDatabase } = require('../../functional/shared');
-const { ns } = require('../../../src/utils');
+const { ns, HostAddress } = require('../../../src/utils');
 
 describe('Connection - functional/cmap', function () {
   before(function () {
@@ -55,18 +55,19 @@ describe('Connection - functional/cmap', function () {
     });
   });
 
-  it('should support socket timeouts', {
+  it.skip('should support socket timeouts', {
+    // FIXME: NODE-2941
     metadata: {
       requires: {
         os: '!win32' // NODE-2941: 240.0.0.1 doesnt work for windows
       }
     },
     test: function (done) {
-      const connectOptions = Object.assign({
-        host: '240.0.0.1',
+      const connectOptions = {
+        hostAddress: new HostAddress('240.0.0.1'),
         connectionType: Connection,
         connectionTimeout: 500
-      });
+      };
 
       connect(connectOptions, err => {
         expect(err).to.exist;

--- a/test/functional/collations.test.js
+++ b/test/functional/collations.test.js
@@ -1,6 +1,6 @@
 'use strict';
 const setupDatabase = require('./shared').setupDatabase;
-const mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 const expect = require('chai').expect;
 const { Long, Code } = require('../../src');
 

--- a/test/functional/collection.test.js
+++ b/test/functional/collection.test.js
@@ -3,7 +3,7 @@ const setupDatabase = require('./shared').setupDatabase;
 const chai = require('chai');
 const expect = chai.expect;
 const sinonChai = require('sinon-chai');
-const mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 chai.use(sinonChai);
 
 describe('Collection', function () {

--- a/test/functional/command_write_concern.test.js
+++ b/test/functional/command_write_concern.test.js
@@ -1,10 +1,10 @@
 'use strict';
 const co = require('co');
-const mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 const expect = require('chai').expect;
 const { ObjectId, Code } = require('../../src');
 
-const TEST_OPTIONS = { writeConcern: { w: 2, wtimeout: 1000 } };
+const TEST_OPTIONS = { writeConcern: { w: 2, wtimeoutMS: 1000 } };
 
 class WriteConcernTest {
   constructor(configuration) {
@@ -110,7 +110,10 @@ function writeConcernTest(command, testFn) {
     t.run(command, (client, db) =>
       testFn.call(this, db, Object.assign({}, TEST_OPTIONS), err => {
         expect(err).to.not.exist;
-        expect(TEST_OPTIONS.writeConcern).to.deep.equal(t.commandResult.writeConcern);
+        expect({
+          w: TEST_OPTIONS.writeConcern.w,
+          wtimeout: TEST_OPTIONS.writeConcern.wtimeoutMS
+        }).to.deep.equal(t.commandResult.writeConcern);
         client.close(done);
       })
     );

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -1899,7 +1899,7 @@ describe('Cursor', function () {
 
           let closeCount = 0;
           const docs = Array.from({ length: 100 }).map(() => ({ a: 1 }));
-          collection.insertMany(docs, { w: 'majority', wtimeout: 5000 }, err => {
+          collection.insertMany(docs, { w: 'majority', wtimeoutMS: 5000 }, err => {
             expect(err).to.not.exist;
 
             const cursor = collection.find({}, { tailable: true, awaitData: true });

--- a/test/functional/custom_pk.test.js
+++ b/test/functional/custom_pk.test.js
@@ -25,7 +25,7 @@ describe('Custom PK', function () {
 
       var client = configuration.newClient(
         {
-          w: 1,
+          writeConcern: { w: 1 },
           maxPoolSize: 1
         },
         {

--- a/test/functional/find_and_modify.test.js
+++ b/test/functional/find_and_modify.test.js
@@ -216,8 +216,8 @@ describe('Find and Modify', function () {
       const configuration = this.configuration;
       const client = configuration.newClient({ readPreference: 'secondary' }, { maxPoolSize: 1 });
       client.connect((err, client) => {
-        const db = client.db(configuration.db);
         expect(err).to.not.exist;
+        const db = client.db(configuration.db);
 
         const collection = db.collection('findAndModifyTEST');
         // Execute findOneAndUpdate

--- a/test/functional/max_staleness.test.js
+++ b/test/functional/max_staleness.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const { Long } = require('bson');
 const { expect } = require('chai');
-const mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 const { ReadPreference } = require('../../src');
 
 const test = {};

--- a/test/functional/mongo_client.test.js
+++ b/test/functional/mongo_client.test.js
@@ -25,7 +25,7 @@ describe('MongoClient', function () {
       const client = configuration.newClient(
         {},
         {
-          writeConcern: { w: 1, wtimeout: 1000, fsync: true, j: true },
+          writeConcern: { w: 1, wtimeoutMS: 1000, fsync: true, j: true },
           readPreference: 'nearest',
           readPreferenceTags: { loc: 'ny' },
           forceServerObjectId: true,
@@ -35,8 +35,7 @@ describe('MongoClient', function () {
             }
           },
           serializeFunctions: true,
-          raw: true,
-          numberOfRetries: 10
+          raw: true
         }
       );
 
@@ -49,13 +48,12 @@ describe('MongoClient', function () {
         test.equal(true, db.writeConcern.j);
 
         test.equal('nearest', db.s.readPreference.mode);
-        test.deepEqual({ loc: 'ny' }, db.s.readPreference.tags);
+        test.deepEqual([{ loc: 'ny' }], db.s.readPreference.tags);
 
         test.equal(true, db.s.options.forceServerObjectId);
         test.equal(1, db.s.pkFactory.createPk());
         test.equal(true, db.bsonOptions.serializeFunctions);
         test.equal(true, db.bsonOptions.raw);
-        test.equal(10, db.s.options.numberOfRetries);
 
         client.close(done);
       });

--- a/test/functional/mongo_client_options.test.js
+++ b/test/functional/mongo_client_options.test.js
@@ -25,11 +25,29 @@ describe('MongoClient Options', function () {
         function (err, client) {
           expect(err)
             .property('message')
-            .to.match(/option notlegal is not supported/);
+            .to.match(/options notlegal, validateoptions are not supported/);
           expect(client).to.not.exist;
           done();
         }
       );
+    }
+  });
+
+  it('should error on unexpected options (promise)', {
+    metadata: { requires: { topology: 'single' } },
+
+    test() {
+      MongoClient.connect(this.configuration.url(), {
+        maxPoolSize: 4,
+        notlegal: {},
+        validateOptions: true
+      })
+        .then(() => expect().fail())
+        .catch(err => {
+          expect(err)
+            .property('message')
+            .to.match(/options notlegal, validateoptions are not supported/);
+        });
     }
   });
 

--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -4153,14 +4153,9 @@ describe('Operation Examples', function () {
       var configuration = this.configuration;
 
       // Replica configuration
-      var client = new Topology(
-        [
-          { host: configuration.host, port: configuration.port },
-          { host: configuration.host, port: configuration.port + 1 },
-          { host: configuration.host, port: configuration.port + 2 }
-        ],
-        { replicaSet: configuration.replicasetName }
-      );
+      var client = new Topology(configuration.options.hostAddresses, {
+        replicaSet: configuration.replicasetName
+      });
 
       client.connect(function (err, client) {
         expect(err).to.not.exist;

--- a/test/functional/replicaset_mock.test.js
+++ b/test/functional/replicaset_mock.test.js
@@ -1,6 +1,6 @@
 'use strict';
 const { expect } = require('chai');
-const mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 const { ObjectId } = require('bson');
 const { Logger } = require('../../src/logger');
 

--- a/test/functional/saslprep.test.js
+++ b/test/functional/saslprep.test.js
@@ -66,10 +66,7 @@ describe('SASLPrep', function () {
     { username: '\u2168', password: 'IV' },
     { username: '\u2168', password: 'I\u00ADV' },
     { username: '\u2168', password: '\u2163' }
-  ].forEach(user => {
-    const username = user.username;
-    const password = user.password;
-
+  ].forEach(({ username, password }) => {
     it(`should be able to login with username "${username}" and password "${password}"`, {
       metadata: {
         requires: {
@@ -79,8 +76,7 @@ describe('SASLPrep', function () {
       },
       test: function () {
         const options = {
-          username: username,
-          password: password,
+          auth: { username, password },
           authSource: 'admin',
           authMechanism: 'SCRAM-SHA-256'
         };

--- a/test/functional/spec-runner/context.js
+++ b/test/functional/spec-runner/context.js
@@ -70,7 +70,7 @@ class TestRunnerContext {
       resolveConnectionString(config, { useMultipleMongoses: true }, this)
     );
     if (config.topologyType === 'Sharded') {
-      this.failPointClients = config.options.hosts.map(proxy =>
+      this.failPointClients = config.options.hostAddresses.map(proxy =>
         config.newClient(`mongodb://${proxy.host}:${proxy.port}/`)
       );
     }

--- a/test/functional/spec-runner/context.js
+++ b/test/functional/spec-runner/context.js
@@ -65,9 +65,10 @@ class TestRunnerContext {
       : fn(this.sharedClient);
   }
 
-  setup(config) {
+  setup(config, options) {
     this.sharedClient = config.newClient(
-      resolveConnectionString(config, { useMultipleMongoses: true }, this)
+      resolveConnectionString(config, { useMultipleMongoses: true }, this),
+      options
     );
     if (config.topologyType === 'Sharded') {
       this.failPointClients = config.options.hostAddresses.map(proxy =>

--- a/test/functional/spec-runner/context.js
+++ b/test/functional/spec-runner/context.js
@@ -34,7 +34,7 @@ class TestRunnerContext {
     const defaults = {
       password: undefined,
       user: undefined,
-      authSource: 'admin',
+      authSource: undefined,
       useSessions: true,
       skipPrepareDatabase: false
     };
@@ -67,10 +67,9 @@ class TestRunnerContext {
       : fn(this.sharedClient);
   }
 
-  setup(config, options) {
+  setup(config) {
     this.sharedClient = config.newClient(
-      resolveConnectionString(config, { useMultipleMongoses: true }, this),
-      options
+      resolveConnectionString(config, { useMultipleMongoses: true }, this)
     );
     if (config.topologyType === 'Sharded') {
       this.failPointClients = config.options.hostAddresses.map(proxy =>

--- a/test/functional/spec-runner/context.js
+++ b/test/functional/spec-runner/context.js
@@ -34,6 +34,7 @@ class TestRunnerContext {
     const defaults = {
       password: undefined,
       user: undefined,
+      authSource: 'admin',
       useSessions: true,
       skipPrepareDatabase: false
     };
@@ -42,6 +43,7 @@ class TestRunnerContext {
     this.useSessions = opts.useSessions;
     this.user = opts.user;
     this.password = opts.password;
+    this.authSource = opts.authSource;
     this.sharedClient = null;
     this.failPointClients = [];
     this.appliedFailPoints = [];

--- a/test/functional/spec-runner/utils.js
+++ b/test/functional/spec-runner/utils.js
@@ -5,10 +5,11 @@ function resolveConnectionString(configuration, spec, context) {
   const useMultipleMongoses = spec && !!spec.useMultipleMongoses;
   const user = context && context.user;
   const password = context && context.password;
+  const authSource = context && context.authSource;
   const connectionString =
     isShardedEnvironment && !useMultipleMongoses
-      ? `mongodb://${configuration.host}:${configuration.port}/${configuration.db}?directConnection=false`
-      : configuration.url(user, password);
+      ? `mongodb://${configuration.host}:${configuration.port}/${configuration.db}?directConnection=false&authSource=${authSource}`
+      : configuration.url(user, password, { authSource });
   return connectionString;
 }
 

--- a/test/functional/spec-runner/utils.js
+++ b/test/functional/spec-runner/utils.js
@@ -8,7 +8,9 @@ function resolveConnectionString(configuration, spec, context) {
   const authSource = context && context.authSource;
   const connectionString =
     isShardedEnvironment && !useMultipleMongoses
-      ? `mongodb://${configuration.host}:${configuration.port}/${configuration.db}?directConnection=false&authSource=${authSource}`
+      ? `mongodb://${configuration.host}:${configuration.port}/${
+          configuration.db
+        }?directConnection=false${authSource ? '&authSource=${authSource}' : ''}`
       : configuration.url(user, password, { authSource });
   return connectionString;
 }

--- a/test/functional/transactions.test.js
+++ b/test/functional/transactions.test.js
@@ -129,7 +129,7 @@ describe('Transactions', function () {
   describe('withTransaction', function () {
     let session, sessionPool;
     beforeEach(() => {
-      const topology = new Topology('localhost:27017');
+      const topology = new Topology('localhost:27017', {});
       sessionPool = topology.s.sessionPool;
       session = new ClientSession(topology, sessionPool);
     });

--- a/test/functional/transactions.test.js
+++ b/test/functional/transactions.test.js
@@ -129,7 +129,7 @@ describe('Transactions', function () {
   describe('withTransaction', function () {
     let session, sessionPool;
     beforeEach(() => {
-      const topology = new Topology('localhost:27017', {});
+      const topology = new Topology('localhost:27017');
       sessionPool = topology.s.sessionPool;
       session = new ClientSession(topology, sessionPool);
     });

--- a/test/functional/uri.test.js
+++ b/test/functional/uri.test.js
@@ -116,7 +116,7 @@ describe('URI', function () {
       client.connect((err, client) => {
         expect(err).to.not.exist;
         expect(client).to.exist;
-        expect(client.s.options.replicaSet).to.exist.and.equal(config.replicasetName);
+        expect(client.options.replicaSet).to.exist.and.equal(config.replicasetName);
         client.close(done);
       });
     }

--- a/test/functional/view.test.js
+++ b/test/functional/view.test.js
@@ -1,6 +1,6 @@
 'use strict';
 var expect = require('chai').expect,
-  mock = require('mongodb-mock-server'),
+  mock = require('../tools/mock'),
   co = require('co');
 const { Long } = require('../../src');
 

--- a/test/manual/data_lake.test.js
+++ b/test/manual/data_lake.test.js
@@ -12,14 +12,15 @@ describe('Atlas Data Lake', function () {
       skipPrepareDatabase: true,
       useSessions: false,
       user: 'mhuser',
-      password: 'pencil'
+      password: 'pencil',
+      authSource: 'admin'
     });
 
     let testSuites = gatherTestSuites(path.resolve(__dirname, '../spec/atlas-data-lake-testing'));
 
     after(() => testContext.teardown());
     before(function () {
-      return testContext.setup(this.configuration, { authSource: 'admin' });
+      return testContext.setup(this.configuration);
     });
 
     generateTopologyTests(testSuites, testContext);

--- a/test/manual/data_lake.test.js
+++ b/test/manual/data_lake.test.js
@@ -19,7 +19,7 @@ describe('Atlas Data Lake', function () {
 
     after(() => testContext.teardown());
     before(function () {
-      return testContext.setup(this.configuration);
+      return testContext.setup(this.configuration, { authSource: 'admin' });
     });
 
     generateTopologyTests(testSuites, testContext);

--- a/test/tools/mock.js
+++ b/test/tools/mock.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const {
+  createServer: superCreateServer,
+  cleanup,
+  DEFAULT_ISMASTER,
+  DEFAULT_ISMASTER_36
+  // eslint-disable-next-line no-restricted-modules
+} = require('mongodb-mock-server');
+const { HostAddress } = require('../../src/utils');
+
+/**
+ * @callback GetHostAddress
+ * @returns {import('../../src/mongo_client').HostAddress}
+ */
+
+/**
+ * @callback GetAddress
+ * @returns {({host: string, port: number})}
+ */
+
+/**
+ * @callback GetURI
+ * @returns {string}
+ */
+
+/**
+ * @typedef {Object} MockServer
+ * @property {Function} onRead - todo
+ * @property {string} host - todo
+ * @property {number} port - todo
+ * @property {import('net').Server | import('tls').Server} server - todo
+ * @property {boolean} tlsEnabled - todo
+ * @property {any} messages - todo
+ * @property {any} state - todo
+ * @property {number} connections - todo
+ * @property {any[]} sockets - todo
+ * @property {object} messageHandlers - todo
+ * // methods
+ * @property {GetHostAddress} hostAddress - the HostAddress type
+ * @property {GetAddress} address - the address as a string
+ * @property {GetURI} uri - the connection string
+ * @property {Function} destroy - todo
+ * @property {Function} start - todo
+ * @property {Function} receive - todo
+ * @property {Function} setMessageHandler - todo
+ * @property {Function} addMessageHandler - todo
+ */
+
+/**
+ * Make a mock mongodb server.
+ *
+ * @param {number} port - port number
+ * @param {string} host - address
+ * @param {object} options - options
+ * @returns {Promise<MockServer>}
+ */
+function createServer(port, host, options) {
+  const willBeServer = superCreateServer(port, host, options);
+  willBeServer.then(s => {
+    s.hostAddress = () => {
+      const address = s.address();
+      return new HostAddress(`${address.host}:${address.port}`);
+    };
+    return s;
+  });
+  return willBeServer;
+}
+
+module.exports = {
+  createServer,
+  cleanup,
+  DEFAULT_ISMASTER,
+  DEFAULT_ISMASTER_36
+};

--- a/test/tools/runner/config.js
+++ b/test/tools/runner/config.js
@@ -229,6 +229,10 @@ class TestConfiguration {
           )
         });
       }
+
+      if (options.authSource) {
+        query.authSource = options.authSource;
+      }
     }
 
     if (multipleHosts) {

--- a/test/tools/runner/config.js
+++ b/test/tools/runner/config.js
@@ -181,11 +181,7 @@ class TestConfiguration {
       //       the host entry. This will eventually be solved by autodetection.
       if (this.topologyType === TopologyType.Sharded) {
         const firstHost = this.options.hostAddresses[0];
-        if (firstHost.type === 'tcp') {
-          multipleHosts = `${firstHost.host}:${firstHost.port},${firstHost.host}:${firstHost.port}`;
-        } else {
-          multipleHosts = `${firstHost.host},${firstHost.host}`;
-        }
+        multipleHosts = `${firstHost.host}:${firstHost.port}`;
       } else {
         multipleHosts = this.options.hostAddresses
           .reduce((built, host) => {

--- a/test/tools/runner/index.js
+++ b/test/tools/runner/index.js
@@ -3,10 +3,9 @@
 const path = require('path');
 const fs = require('fs');
 const { MongoClient } = require('../../../src');
-const TestConfiguration = require('./config');
-const { parseConnectionString } = require('../../../src/connection_string');
+const { TestConfiguration } = require('./config');
 const { eachAsync } = require('../../../src/utils');
-const mock = require('mongodb-mock-server');
+const mock = require('../mock');
 const wtfnode = require('wtfnode');
 
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017';
@@ -78,16 +77,8 @@ before(function (_done) {
 
       // replace this when mocha supports dynamic skipping with `afterEach`
       filterOutTests(this._runnable.parent);
-
-      parseConnectionString(MONGODB_URI, (err, parsedURI) => {
-        if (err) {
-          done(err);
-          return;
-        }
-
-        this.configuration = new TestConfiguration(parsedURI, context);
-        done();
-      });
+      this.configuration = new TestConfiguration(MONGODB_URI, context);
+      done();
     });
   });
 });

--- a/test/tools/runner/plugins/client_leak_checker.js
+++ b/test/tools/runner/plugins/client_leak_checker.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const TestConfiguration = require('../config');
+const { TestConfiguration } = require('../config');
 const chalk = require('chalk');
 
 let activeClients = [];

--- a/test/unit/bulk_write.test.js
+++ b/test/unit/bulk_write.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 
 describe('Bulk Writes', function () {
   const test = {};

--- a/test/unit/bypass_validation.test.js
+++ b/test/unit/bypass_validation.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 
 describe('bypass document validation', function () {
   const test = {};

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 
 describe('Client (unit)', function () {
   let server;

--- a/test/unit/cmap/connection.test.js
+++ b/test/unit/cmap/connection.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 const { connect } = require('../../../src/cmap/connect');
 const { Connection } = require('../../../src/cmap/connection');
 const { expect } = require('chai');
@@ -21,7 +21,7 @@ describe('Connection - unit/cmap', function () {
       // blackhole all other requests
     });
 
-    connect(Object.assign({ connectionType: Connection }, server.address()), (err, conn) => {
+    connect({ connectionType: Connection, hostAddress: server.hostAddress() }, (err, conn) => {
       expect(err).to.not.exist;
       expect(conn).to.exist;
 
@@ -44,7 +44,7 @@ describe('Connection - unit/cmap', function () {
       // blackhole all other requests
     });
 
-    connect(Object.assign({ connectionType: Connection }, server.address()), (err, conn) => {
+    connect({ connectionType: Connection, hostAddress: server.hostAddress() }, (err, conn) => {
       expect(err).to.not.exist;
       expect(conn).to.exist;
 

--- a/test/unit/cmap/connection_pool.test.js
+++ b/test/unit/cmap/connection_pool.test.js
@@ -5,7 +5,7 @@ const { loadSpecTests } = require('../../spec');
 const { ConnectionPool } = require('../../../src/cmap/connection_pool');
 const { WaitQueueTimeoutError } = require('../../../src/cmap/errors');
 const { EventEmitter } = require('events');
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 const cmapEvents = require('../../../src/cmap/events');
 const sinon = require('sinon');
 const { expect } = require('chai');
@@ -52,7 +52,7 @@ describe('Connection Pool', function () {
       }
     });
 
-    const pool = new ConnectionPool(Object.assign({ maxPoolSize: 1 }, server.address()));
+    const pool = new ConnectionPool({ maxPoolSize: 1, hostAddress: server.hostAddress() });
 
     const events = [];
     pool.on('connectionClosed', event => events.push(event));
@@ -93,9 +93,11 @@ describe('Connection Pool', function () {
       }
     });
 
-    const pool = new ConnectionPool(
-      Object.assign({ maxPoolSize: 1, socketTimeout: 200 }, server.address())
-    );
+    const pool = new ConnectionPool({
+      maxPoolSize: 1,
+      socketTimeout: 200,
+      hostAddress: server.hostAddress()
+    });
 
     pool.withConnection(
       (err, conn, cb) => {
@@ -119,9 +121,11 @@ describe('Connection Pool', function () {
       }
     });
 
-    const pool = new ConnectionPool(
-      Object.assign({ maxPoolSize: 1, waitQueueTimeoutMS: 200 }, server.address())
-    );
+    const pool = new ConnectionPool({
+      maxPoolSize: 1,
+      waitQueueTimeoutMS: 200,
+      hostAddress: server.hostAddress()
+    });
 
     pool.checkOut((err, conn) => {
       expect(err).to.not.exist;
@@ -153,7 +157,7 @@ describe('Connection Pool', function () {
         }
       });
 
-      const pool = new ConnectionPool(Object.assign({}, server.address()));
+      const pool = new ConnectionPool({ hostAddress: server.hostAddress() });
       const callback = (err, result) => {
         expect(err).to.not.exist;
         expect(result).to.exist;
@@ -178,7 +182,10 @@ describe('Connection Pool', function () {
         }
       });
 
-      const pool = new ConnectionPool(Object.assign({ waitQueueTimeoutMS: 200 }, server.address()));
+      const pool = new ConnectionPool({
+        waitQueueTimeoutMS: 200,
+        hostAddress: server.hostAddress()
+      });
 
       const callback = err => {
         expect(err).to.exist;
@@ -201,7 +208,7 @@ describe('Connection Pool', function () {
         }
       });
 
-      const pool = new ConnectionPool(Object.assign({}, server.address()));
+      const pool = new ConnectionPool({ hostAddress: server.hostAddress() });
       const callback = (err, result) => {
         expect(err).to.exist;
         expect(result).to.not.exist;
@@ -223,7 +230,7 @@ describe('Connection Pool', function () {
         }
       });
 
-      const pool = new ConnectionPool(Object.assign({ maxPoolSize: 1 }, server.address()));
+      const pool = new ConnectionPool({ maxPoolSize: 1, hostAddress: server.hostAddress() });
 
       const events = [];
       pool.on('connectionCheckedOut', event => events.push(event));
@@ -252,7 +259,7 @@ describe('Connection Pool', function () {
     let pool = undefined;
 
     function createPool(options) {
-      options = Object.assign({}, options, {}, server.address());
+      options = Object.assign({}, options, { hostAddress: server.hostAddress() });
       pool = new ConnectionPool(options);
       ALL_POOL_EVENTS.forEach(ev => {
         pool.on(ev, x => {

--- a/test/unit/core/common.js
+++ b/test/unit/core/common.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 const { ObjectId, Timestamp, Binary } = require('bson');
 
 class ReplSetFixture {

--- a/test/unit/core/mongodb_srv.test.js
+++ b/test/unit/core/mongodb_srv.test.js
@@ -1,16 +1,14 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-const parseConnectionString = require('../../../src/connection_string').parseConnectionString;
+const { parseOptions, resolveSRVRecord } = require('../../../src/connection_string');
 const expect = require('chai').expect;
 
 describe('mongodb+srv', function () {
-  it('should parse a default database', function (done) {
-    parseConnectionString('mongodb+srv://test1.test.build.10gen.cc/somedb', (err, result) => {
-      expect(err).to.not.exist;
-      expect(result.auth.db).to.eql('somedb');
-      done();
-    });
+  it('should parse a default database', function () {
+    const options = parseOptions('mongodb+srv://test1.test.build.10gen.cc/somedb');
+    expect(options.dbName).to.equal('somedb');
+    expect(options.srvHost).to.equal('test1.test.build.10gen.cc');
   });
 
   describe('spec tests', function () {
@@ -29,27 +27,45 @@ describe('mongodb+srv', function () {
       it(test[1].comment, {
         metadata: { requires: { topology: ['single'] } },
         test: function (done) {
-          parseConnectionString(test[1].uri, (err, result) => {
+          try {
+            const options = parseOptions(test[1].uri);
+            resolveSRVRecord(options, (err, result) => {
+              if (test[1].error) {
+                expect(err).to.exist;
+                expect(result).to.not.exist;
+              } else {
+                expect(err).to.not.exist;
+                expect(result).to.exist;
+                // Implicit SRV options must be set.
+                expect(options.directConnection).to.be.false;
+                expect(options.tls).to.be.true;
+                const testOptions = test[1].options;
+                if (testOptions && testOptions.replicaSet) {
+                  expect(options).to.have.property('replicaSet', testOptions.replicaSet);
+                }
+                if (testOptions && testOptions.authSource) {
+                  expect(options).to.have.property('credentials');
+                  expect(options.credentials.source).to.equal(testOptions.authSource);
+                }
+                if (
+                  test[1].parsed_options &&
+                  test[1].parsed_options.user &&
+                  test[1].parsed_options.password
+                ) {
+                  expect(options.credentials.username).to.equal(test[1].parsed_options.user);
+                  expect(options.credentials.password).to.equal(test[1].parsed_options.password);
+                }
+              }
+              done();
+            });
+          } catch (error) {
             if (test[1].error) {
-              expect(err).to.exist;
-              expect(result).to.not.exist;
+              expect(error).to.exist;
+              done();
             } else {
-              expect(err).to.not.exist;
-              expect(result).to.exist;
-              if (test[1].options) {
-                expect(result).property('options').to.matchMongoSpec(test[1].options);
-              }
-              if (
-                test[1].parsed_options &&
-                test[1].parsed_options.user &&
-                test[1].parsed_options.password
-              ) {
-                expect(result.auth.username).to.equal(test[1].parsed_options.user);
-                expect(result.auth.password).to.equal(test[1].parsed_options.password);
-              }
+              throw error;
             }
-            done();
-          });
+          }
         }
       });
     });

--- a/test/unit/core/response_test.js.test.js
+++ b/test/unit/core/response_test.js.test.js
@@ -2,7 +2,7 @@
 
 const expect = require('chai').expect;
 const { MongoError } = require('../../../src/error');
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 const { Topology } = require('../../../src/sdam/topology');
 const { Long } = require('bson');
 const { MongoDBNamespace } = require('../../../src/utils');
@@ -24,7 +24,7 @@ describe('Response', function () {
         errmsg: 'Cursor not found (namespace: "liveearth.entityEvents", id: 2018648316188432590).'
       };
 
-      const client = new Topology(test.server.address());
+      const client = new Topology(test.server.hostAddress(), {});
 
       test.server.setMessageHandler(request => {
         const doc = request.document;

--- a/test/unit/core/response_test.js.test.js
+++ b/test/unit/core/response_test.js.test.js
@@ -24,7 +24,7 @@ describe('Response', function () {
         errmsg: 'Cursor not found (namespace: "liveearth.entityEvents", id: 2018648316188432590).'
       };
 
-      const client = new Topology(test.server.hostAddress(), {});
+      const client = new Topology(test.server.hostAddress());
 
       test.server.setMessageHandler(request => {
         const doc = request.document;

--- a/test/unit/core/scram_iterations.test.js
+++ b/test/unit/core/scram_iterations.test.js
@@ -1,16 +1,16 @@
 'use strict';
 
 const { expect } = require('chai');
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 const { Topology } = require('../../../src/sdam/topology');
 const { MongoCredentials } = require('../../../src/cmap/auth/mongo_credentials');
 
 describe('SCRAM Iterations Tests', function () {
-  const test = {};
+  let server;
 
   beforeEach(() => {
     return mock.createServer().then(mockServer => {
-      test.server = mockServer;
+      server = mockServer;
     });
   });
 
@@ -21,7 +21,7 @@ describe('SCRAM Iterations Tests', function () {
       'r=IE+xNFeOcslsupAA+zkDVzHd5HfwoRuP7Wi8S4py+erf8PcNm7XIdXQyT52Nj3+M,s=AzomrlMs99A7oFxDLpgFvVb+CSvdyXuNagoWVw==,i=4000';
 
     const credentials = new MongoCredentials({
-      mechanism: 'default',
+      mechanism: 'DEFAULT',
       source: 'db',
       username: 'user',
       password: 'pencil'
@@ -32,7 +32,7 @@ describe('SCRAM Iterations Tests', function () {
       return _done(e);
     };
 
-    test.server.setMessageHandler(request => {
+    server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
         return request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
@@ -47,7 +47,7 @@ describe('SCRAM Iterations Tests', function () {
       }
     });
 
-    const client = new Topology(test.server.uri(), { credentials });
+    const client = new Topology(server.hostAddress(), { credentials });
     client.on('error', err => {
       let testErr;
       try {
@@ -67,7 +67,7 @@ describe('SCRAM Iterations Tests', function () {
 
   it('should error if server digest is invalid', function (_done) {
     const credentials = new MongoCredentials({
-      mechanism: 'default',
+      mechanism: 'DEFAULT',
       source: 'db',
       username: 'user',
       password: 'pencil'
@@ -78,7 +78,7 @@ describe('SCRAM Iterations Tests', function () {
       return _done(e);
     };
 
-    test.server.setMessageHandler(request => {
+    server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
         return request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
@@ -99,7 +99,7 @@ describe('SCRAM Iterations Tests', function () {
       }
     });
 
-    const client = new Topology(test.server.uri(), { credentials });
+    const client = new Topology(server.hostAddress(), { credentials });
     client.on('error', err => {
       expect(err).to.not.be.null;
       expect(err)
@@ -114,7 +114,7 @@ describe('SCRAM Iterations Tests', function () {
 
   it('should properly handle network errors on `saslContinue`', function (_done) {
     const credentials = new MongoCredentials({
-      mechanism: 'default',
+      mechanism: 'DEFAULT',
       source: 'db',
       username: 'user',
       password: 'pencil'
@@ -125,7 +125,7 @@ describe('SCRAM Iterations Tests', function () {
       return _done(e);
     };
 
-    test.server.setMessageHandler(request => {
+    server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
         return request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
@@ -142,7 +142,7 @@ describe('SCRAM Iterations Tests', function () {
       }
     });
 
-    const client = new Topology(test.server.uri(), { credentials });
+    const client = new Topology(server.hostAddress(), { credentials });
     client.on('error', err => {
       expect(err).to.not.be.null;
       expect(err)

--- a/test/unit/core/sessions.test.js
+++ b/test/unit/core/sessions.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 const { expect } = require('chai');
 const { genClusterTime, sessionCleanupHandler } = require('./common');
 const { Topology } = require('../../../src/sdam/topology');
@@ -30,7 +30,7 @@ describe('Sessions - unit/core', function () {
     it('should default to `null` for `clusterTime`', {
       metadata: { requires: { topology: 'single' } },
       test: function (done) {
-        const client = new Topology('localhost:27017');
+        const client = new Topology('localhost:27017', {});
         const sessionPool = client.s.sessionPool;
         const session = new ClientSession(client, sessionPool);
         done = sessionCleanupHandler(session, sessionPool, done);
@@ -44,7 +44,7 @@ describe('Sessions - unit/core', function () {
       metadata: { requires: { topology: 'single' } },
       test: function (done) {
         const clusterTime = genClusterTime(Date.now());
-        const client = new Topology('localhost:27017');
+        const client = new Topology('localhost:27017', {});
         const sessionPool = client.s.sessionPool;
         const session = new ClientSession(client, sessionPool, { initialClusterTime: clusterTime });
         done = sessionCleanupHandler(session, sessionPool, done);
@@ -57,7 +57,7 @@ describe('Sessions - unit/core', function () {
 
   describe('ServerSessionPool', function () {
     afterEach(() => {
-      test.client.destroy();
+      test.client.close();
       return mock.cleanup();
     });
 
@@ -76,7 +76,7 @@ describe('Sessions - unit/core', function () {
           });
         })
         .then(() => {
-          test.client = new Topology(test.server.address());
+          test.client = new Topology(test.server.hostAddress(), {});
 
           return new Promise((resolve, reject) => {
             test.client.once('error', reject);

--- a/test/unit/core/sessions.test.js
+++ b/test/unit/core/sessions.test.js
@@ -44,7 +44,7 @@ describe('Sessions - unit/core', function () {
       metadata: { requires: { topology: 'single' } },
       test: function (done) {
         const clusterTime = genClusterTime(Date.now());
-        const client = new Topology('localhost:27017', {});
+        const client = new Topology('localhost:27017');
         const sessionPool = client.s.sessionPool;
         const session = new ClientSession(client, sessionPool, { initialClusterTime: clusterTime });
         done = sessionCleanupHandler(session, sessionPool, done);
@@ -76,7 +76,7 @@ describe('Sessions - unit/core', function () {
           });
         })
         .then(() => {
-          test.client = new Topology(test.server.hostAddress(), {});
+          test.client = new Topology(test.server.hostAddress());
 
           return new Promise((resolve, reject) => {
             test.client.once('error', reject);

--- a/test/unit/core/write_concern_error.test.js
+++ b/test/unit/core/write_concern_error.test.js
@@ -1,6 +1,6 @@
 'use strict';
 const { Topology } = require('../../../src/sdam/topology');
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 const { ReplSetFixture } = require('./common');
 const { MongoWriteConcernError } = require('../../../src/error');
 const { expect } = require('chai');
@@ -12,7 +12,7 @@ describe('WriteConcernError', function () {
     createUser: 'foo2',
     pwd: 'pwd',
     roles: ['read'],
-    writeConcern: { w: 'majority', wtimeout: 1 }
+    writeConcern: { w: 'majority', wtimeoutMS: 1 }
   };
 
   const RAW_USER_WRITE_CONCERN_ERROR = {
@@ -56,7 +56,7 @@ describe('WriteConcernError', function () {
   function makeAndConnectReplSet(cb) {
     let invoked = false;
     const replSet = new Topology(
-      [test.primaryServer.address(), test.firstSecondaryServer.address()],
+      [test.primaryServer.hostAddress(), test.firstSecondaryServer.hostAddress()],
       { replicaSet: 'rs' }
     );
 

--- a/test/unit/create_index_error.test.js
+++ b/test/unit/create_index_error.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 
 describe('CreateIndexError', function () {
   const test = {};

--- a/test/unit/db_list_collections.test.js
+++ b/test/unit/db_list_collections.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const mock = require('mongodb-mock-server');
+const mock = require('../tools/mock');
 const expect = require('chai').expect;
 
 describe('db.listCollections', function () {

--- a/test/unit/mongo_client_options.test.js
+++ b/test/unit/mongo_client_options.test.js
@@ -289,6 +289,15 @@ describe('MongoOptions', function () {
     expect(options.credentials).to.be.an.instanceof(MongoCredentials);
     expect(options.credentials.username).to.equal('USERNAME');
     expect(options.credentials.password).to.equal('PASSWORD');
+    expect(options.credentials.source).to.equal('admin');
+  });
+
+  it('supports Credentials option in url with db', function () {
+    const options = parseOptions('mongodb://USERNAME:PASSWORD@localhost/foo');
+    expect(options.credentials).to.be.an.instanceof(MongoCredentials);
+    expect(options.credentials.username).to.equal('USERNAME');
+    expect(options.credentials.password).to.equal('PASSWORD');
+    expect(options.credentials.source).to.equal('foo');
   });
 
   it('supports Credentials option in auth object plain', function () {

--- a/test/unit/mongo_client_options.test.js
+++ b/test/unit/mongo_client_options.test.js
@@ -26,7 +26,7 @@ describe('MongoOptions', function () {
     expect(options.prototype).to.not.exist;
   });
 
-  it('tls renames', function () {
+  it('should rename tls options correctly', function () {
     const filename = `${os.tmpdir()}/tmp.pem`;
     fs.closeSync(fs.openSync(filename, 'w'));
     const options = parseOptions('mongodb://localhost:27017/?ssl=true', {
@@ -124,19 +124,12 @@ describe('MongoOptions', function () {
     servername: 'some tls option',
     socketTimeoutMS: 3,
     ssl: true,
-    // sslCA: 'ca',
-    // sslCert: 'cert',
-    // sslCRL: 'crl',
-    // sslKey: 'key',
     sslPass: 'pass',
     sslValidate: true,
     tls: false,
     tlsAllowInvalidCertificates: true,
     tlsAllowInvalidHostnames: true,
-    // tlsCAFile: 'tls-ca',
-    // tlsCertificateKeyFile: 'tls-key',
     tlsCertificateKeyFilePassword: 'tls-pass',
-    // tlsInsecure: true,
     w: 'majority',
     waitQueueTimeoutMS: 3,
     writeConcern: new WriteConcern(2),
@@ -183,12 +176,7 @@ describe('MongoOptions', function () {
       'tls=true',
       'tlsAllowInvalidCertificates=true',
       'tlsAllowInvalidHostnames=true',
-      // 'tlsCAFile=CA_FILE',
-      // 'tlsCertificateKeyFile=KEY_FILE',
       'tlsCertificateKeyFilePassword=PASSWORD',
-      // 'tlsDisableCertificateRevocationCheck=true', // not implemented
-      // 'tlsDisableOCSPEndpointCheck=true', // not implemented
-      // 'tlsInsecure=true',
       'w=majority',
       'waitQueueTimeoutMS=2',
       'wTimeoutMS=2',

--- a/test/unit/optional_require.test.js
+++ b/test/unit/optional_require.test.js
@@ -7,6 +7,7 @@ const { compress } = require('../../src/cmap/wire_protocol/compression');
 const { GSSAPI } = require('../../src/cmap/auth/gssapi');
 const { AuthContext } = require('../../src/cmap/auth/auth_provider');
 const { MongoDBAWS } = require('../../src/cmap/auth/mongodb_aws');
+const { HostAddress } = require('../../src/utils');
 
 function moduleExistsSync(moduleName) {
   return existsSync(resolve(__dirname, `../../node_modules/${moduleName}`));
@@ -41,10 +42,13 @@ describe('optionalRequire', function () {
         return this.skip();
       }
       const gssapi = new GSSAPI();
-      gssapi.auth(new AuthContext(null, true, { host: true, port: true }), error => {
-        expect(error).to.exist;
-        expect(error.message).includes('not found');
-      });
+      gssapi.auth(
+        new AuthContext(null, true, { hostAddress: new HostAddress('a'), credentials: true }),
+        error => {
+          expect(error).to.exist;
+          expect(error.message).includes('not found');
+        }
+      );
     });
   });
 

--- a/test/unit/sdam/monitoring.test.js
+++ b/test/unit/sdam/monitoring.test.js
@@ -1,5 +1,5 @@
 'use strict';
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 const { ServerType } = require('../../../src/sdam/common');
 const { Topology } = require('../../../src/sdam/topology');
 const { Monitor } = require('../../../src/sdam/monitor');
@@ -8,7 +8,7 @@ const { ServerDescription } = require('../../../src/sdam/server_description');
 
 class MockServer {
   constructor(options) {
-    this.s = {};
+    this.s = { pool: { generation: 1 } };
     this.description = new ServerDescription(`${options.host}:${options.port}`);
     this.description.type = ServerType.Unknown;
   }
@@ -33,7 +33,7 @@ describe('monitoring', function () {
     });
 
     // set `heartbeatFrequencyMS` to 250ms to force a quick monitoring check, and wait 500ms to validate below
-    const topology = new Topology(mockServer.uri(), { heartbeatFrequencyMS: 250 });
+    const topology = new Topology(mockServer.hostAddress(), { heartbeatFrequencyMS: 250 });
     topology.connect(err => {
       expect(err).to.not.exist;
 
@@ -74,7 +74,7 @@ describe('monitoring', function () {
       acceptConnections = true;
     }, 250);
 
-    const topology = new Topology(mockServer.uri());
+    const topology = new Topology(mockServer.hostAddress(), {});
     topology.connect(err => {
       expect(err).to.not.exist;
       expect(topology).property('description').property('servers').to.have.length(1);
@@ -181,7 +181,7 @@ describe('monitoring', function () {
       });
 
       const server = new MockServer(mockServer.address());
-      server.description = new ServerDescription(server.description.address);
+      server.description = new ServerDescription(server.description.hostAddress);
       const monitor = new Monitor(server, {
         heartbeatFrequencyMS: 250,
         minHeartbeatFrequencyMS: 50

--- a/test/unit/sdam/server_description.test.js
+++ b/test/unit/sdam/server_description.test.js
@@ -43,7 +43,7 @@ describe('ServerDescription', function () {
   });
 
   it('should sensibly parse an ipv6 address', function () {
-    const description = new ServerDescription('abcd:f::abcd:abcd:abcd:abcd:27017');
+    const description = new ServerDescription('[ABCD:f::abcd:abcd:abcd:abcd]:27017');
     expect(description.host).to.equal('abcd:f::abcd:abcd:abcd:abcd');
     expect(description.port).to.equal(27017);
   });

--- a/test/unit/sdam/server_selection/select_servers.test.js
+++ b/test/unit/sdam/server_selection/select_servers.test.js
@@ -15,7 +15,7 @@ describe('selectServer', function () {
   });
 
   it('should schedule monitoring if no suitable server is found', function (done) {
-    const topology = new Topology('someserver:27019');
+    const topology = new Topology('someserver:27019', {});
     const requestCheck = this.sinon.stub(Server.prototype, 'requestCheck');
 
     // satisfy the initial connect, then restore the original method
@@ -48,7 +48,7 @@ describe('selectServer', function () {
   });
 
   it('should disallow selection when the topology is explicitly closed', function (done) {
-    const topology = new Topology('someserver:27019');
+    const topology = new Topology('someserver:27019', {});
     this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
       this.s.state = 'connected';
       this.emit('connect');
@@ -65,7 +65,7 @@ describe('selectServer', function () {
 
   describe('waitQueue', function () {
     it('should process all wait queue members, including selection with errors', function (done) {
-      const topology = new Topology('someserver:27019');
+      const topology = new Topology('someserver:27019', {});
       const selectServer = this.sinon
         .stub(Topology.prototype, 'selectServer')
         .callsFake(function (selector, options, callback) {

--- a/test/unit/sdam/server_selection/select_servers.test.js
+++ b/test/unit/sdam/server_selection/select_servers.test.js
@@ -15,7 +15,7 @@ describe('selectServer', function () {
   });
 
   it('should schedule monitoring if no suitable server is found', function (done) {
-    const topology = new Topology('someserver:27019', {});
+    const topology = new Topology('someserver:27019');
     const requestCheck = this.sinon.stub(Server.prototype, 'requestCheck');
 
     // satisfy the initial connect, then restore the original method
@@ -48,7 +48,7 @@ describe('selectServer', function () {
   });
 
   it('should disallow selection when the topology is explicitly closed', function (done) {
-    const topology = new Topology('someserver:27019', {});
+    const topology = new Topology('someserver:27019');
     this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
       this.s.state = 'connected';
       this.emit('connect');
@@ -65,7 +65,7 @@ describe('selectServer', function () {
 
   describe('waitQueue', function () {
     it('should process all wait queue members, including selection with errors', function (done) {
-      const topology = new Topology('someserver:27019', {});
+      const topology = new Topology('someserver:27019');
       const selectServer = this.sinon
         .stub(Topology.prototype, 'selectServer')
         .callsFake(function (selector, options, callback) {

--- a/test/unit/sdam/server_selection/spec.test.js
+++ b/test/unit/sdam/server_selection/spec.test.js
@@ -142,24 +142,6 @@ describe('Max Staleness (spec)', function () {
   });
 });
 
-function normalizeSeed(seed) {
-  let host = seed;
-  let port = 27017;
-
-  // is this a host + port combo?
-  if (seed.indexOf(':') !== -1) {
-    host = seed.split(':')[0];
-    port = parseInt(seed.split(':')[1], 10);
-  }
-
-  // support IPv6
-  if (host.startsWith('[')) {
-    host = host.slice(1, host.length - 1);
-  }
-
-  return { host, port };
-}
-
 function serverDescriptionFromDefinition(definition, hosts) {
   hosts = hosts || [];
 
@@ -223,7 +205,7 @@ function executeServerSelectionTest(testDefinition, options, testDone) {
   const topologyDescription = testDefinition.topology_description;
   const seedData = topologyDescription.servers.reduce(
     (result, seed) => {
-      result.seedlist.push(normalizeSeed(seed.address));
+      result.seedlist.push(seed.address);
       result.hosts.push(seed.address);
       return result;
     },

--- a/test/unit/sdam/srv_polling.test.js
+++ b/test/unit/sdam/srv_polling.test.js
@@ -10,7 +10,8 @@ const dns = require('dns');
 const EventEmitter = require('events').EventEmitter;
 const chai = require('chai');
 const sinon = require('sinon');
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
+const { HostAddress } = require('../../../src/utils');
 
 const expect = chai.expect;
 chai.use(require('sinon-chai'));
@@ -242,7 +243,12 @@ describe('Mongos SRV Polling', function () {
     it('should not make an srv poller if there is no srv host', function () {
       const srvPoller = new FakeSrvPoller({ srvHost: SRV_HOST });
 
-      const topology = new Topology(['localhost:27017,localhost:27018'], { srvPoller });
+      const topology = new Topology(
+        ['localhost:27017', 'localhost:27018'].map(HostAddress.fromString),
+        {
+          srvPoller
+        }
+      );
 
       expect(topology).to.not.have.property('srvPoller');
     });
@@ -250,10 +256,13 @@ describe('Mongos SRV Polling', function () {
     it('should make an srvPoller if there is an srvHost', function () {
       const srvPoller = new FakeSrvPoller({ srvHost: SRV_HOST });
 
-      const topology = new Topology(['localhost:27017,localhost:27018'], {
-        srvHost: SRV_HOST,
-        srvPoller
-      });
+      const topology = new Topology(
+        ['localhost:27017', 'localhost:27018'].map(HostAddress.fromString),
+        {
+          srvHost: SRV_HOST,
+          srvPoller
+        }
+      );
 
       expect(topology.s).to.have.property('srvPoller').that.equals(srvPoller);
     });
@@ -262,10 +271,13 @@ describe('Mongos SRV Polling', function () {
       const srvPoller = new FakeSrvPoller({ srvHost: SRV_HOST });
       sinon.stub(srvPoller, 'start');
 
-      const topology = new Topology(['localhost:27017,localhost:27018'], {
-        srvHost: SRV_HOST,
-        srvPoller
-      });
+      const topology = new Topology(
+        ['localhost:27017', 'localhost:27018'].map(HostAddress.fromString),
+        {
+          srvHost: SRV_HOST,
+          srvPoller
+        }
+      );
 
       const topologyDescriptions = [
         new TopologyDescription(TopologyType.Unknown),
@@ -331,7 +343,9 @@ describe('Mongos SRV Polling', function () {
         });
 
         const srvPoller = new FakeSrvPoller({ srvHost: SRV_HOST });
-        const seedlist = recordSets[0].map(record => `${record.name}:${record.port}`).join(',');
+        const seedlist = recordSets[0].map(record =>
+          HostAddress.fromString(`${record.name}:${record.port}`)
+        );
 
         context.topology = new Topology(seedlist, { srvPoller, srvHost: SRV_HOST });
         const topology = context.topology;

--- a/test/unit/sdam/srv_polling.test.js
+++ b/test/unit/sdam/srv_polling.test.js
@@ -243,12 +243,9 @@ describe('Mongos SRV Polling', function () {
     it('should not make an srv poller if there is no srv host', function () {
       const srvPoller = new FakeSrvPoller({ srvHost: SRV_HOST });
 
-      const topology = new Topology(
-        ['localhost:27017', 'localhost:27018'].map(HostAddress.fromString),
-        {
-          srvPoller
-        }
-      );
+      const topology = new Topology(['localhost:27017', 'localhost:27018'], {
+        srvPoller
+      });
 
       expect(topology).to.not.have.property('srvPoller');
     });
@@ -256,13 +253,10 @@ describe('Mongos SRV Polling', function () {
     it('should make an srvPoller if there is an srvHost', function () {
       const srvPoller = new FakeSrvPoller({ srvHost: SRV_HOST });
 
-      const topology = new Topology(
-        ['localhost:27017', 'localhost:27018'].map(HostAddress.fromString),
-        {
-          srvHost: SRV_HOST,
-          srvPoller
-        }
-      );
+      const topology = new Topology(['localhost:27017', 'localhost:27018'], {
+        srvHost: SRV_HOST,
+        srvPoller
+      });
 
       expect(topology.s).to.have.property('srvPoller').that.equals(srvPoller);
     });
@@ -271,13 +265,10 @@ describe('Mongos SRV Polling', function () {
       const srvPoller = new FakeSrvPoller({ srvHost: SRV_HOST });
       sinon.stub(srvPoller, 'start');
 
-      const topology = new Topology(
-        ['localhost:27017', 'localhost:27018'].map(HostAddress.fromString),
-        {
-          srvHost: SRV_HOST,
-          srvPoller
-        }
-      );
+      const topology = new Topology(['localhost:27017', 'localhost:27018'], {
+        srvHost: SRV_HOST,
+        srvPoller
+      });
 
       const topologyDescriptions = [
         new TopologyDescription(TopologyType.Unknown),

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 const { expect } = require('chai');
 const sinon = require('sinon');
 const { Topology } = require('../../../src/sdam/topology');
 const { Server } = require('../../../src/sdam/server');
 const { ServerDescription } = require('../../../src/sdam/server_description');
-const { ns } = require('../../../src/utils');
+const { ns, HostAddress, makeClientMetadata } = require('../../../src/utils');
 
 describe('Topology (unit)', function () {
   describe('client metadata', function () {
@@ -22,7 +22,9 @@ describe('Topology (unit)', function () {
         var server = new Topology(
           [{ host: this.configuration.host, port: this.configuration.port }],
           {
-            appname: 'My application name'
+            metadata: makeClientMetadata({
+              appName: 'My application name'
+            })
           }
         );
 
@@ -85,7 +87,7 @@ describe('Topology (unit)', function () {
     });
 
     it('should check for sessions if connected to a single server and has no known servers', function (done) {
-      const topology = new Topology('someserver:27019');
+      const topology = new Topology('someserver:27019', {});
       this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
         this.s.state = 'connected';
         this.emit('connect');
@@ -98,7 +100,7 @@ describe('Topology (unit)', function () {
     });
 
     it('should not check for sessions if connected to a single server', function (done) {
-      const topology = new Topology('someserver:27019');
+      const topology = new Topology('someserver:27019', {});
       this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
         this.s.state = 'connected';
         this.emit('connect');
@@ -118,7 +120,10 @@ describe('Topology (unit)', function () {
     });
 
     it('should check for sessions if there are no data-bearing nodes', function (done) {
-      const topology = new Topology('mongos:27019,mongos:27018,mongos:27017');
+      const topology = new Topology(
+        ['mongos:27019', 'mongos:27018', 'mongos:27017'].map(HostAddress.fromString),
+        {}
+      );
       this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
         this.s.state = 'connected';
         this.emit('connect');
@@ -156,7 +161,7 @@ describe('Topology (unit)', function () {
         }
       });
 
-      const topology = new Topology(mockServer.uri());
+      const topology = new Topology(mockServer.hostAddress(), {});
       topology.connect(err => {
         expect(err).to.not.exist;
 
@@ -192,7 +197,7 @@ describe('Topology (unit)', function () {
         }
       });
 
-      const topology = new Topology(mockServer.uri());
+      const topology = new Topology(mockServer.hostAddress(), {});
       topology.connect(err => {
         expect(err).to.not.exist;
 
@@ -229,7 +234,7 @@ describe('Topology (unit)', function () {
         }
       });
 
-      const topology = new Topology(mockServer.uri());
+      const topology = new Topology(mockServer.hostAddress(), {});
       topology.connect(err => {
         expect(err).to.not.exist;
 
@@ -266,7 +271,7 @@ describe('Topology (unit)', function () {
         }
       });
 
-      const topology = new Topology(mockServer.uri());
+      const topology = new Topology(mockServer.hostAddress(), {});
       topology.connect(err => {
         expect(err).to.not.exist;
 

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const { Topology } = require('../../../src/sdam/topology');
 const { Server } = require('../../../src/sdam/server');
 const { ServerDescription } = require('../../../src/sdam/server_description');
-const { ns, HostAddress, makeClientMetadata } = require('../../../src/utils');
+const { ns, makeClientMetadata } = require('../../../src/utils');
 
 describe('Topology (unit)', function () {
   describe('client metadata', function () {
@@ -19,14 +19,11 @@ describe('Topology (unit)', function () {
 
       test: function (done) {
         // Attempt to connect
-        var server = new Topology(
-          [{ host: this.configuration.host, port: this.configuration.port }],
-          {
-            metadata: makeClientMetadata({
-              appName: 'My application name'
-            })
-          }
-        );
+        var server = new Topology([`${this.configuration.host}:${this.configuration.port}`], {
+          metadata: makeClientMetadata({
+            appName: 'My application name'
+          })
+        });
 
         expect(server.clientMetadata.application.name).to.equal('My application name');
         done();
@@ -87,7 +84,7 @@ describe('Topology (unit)', function () {
     });
 
     it('should check for sessions if connected to a single server and has no known servers', function (done) {
-      const topology = new Topology('someserver:27019', {});
+      const topology = new Topology('someserver:27019');
       this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
         this.s.state = 'connected';
         this.emit('connect');
@@ -100,7 +97,7 @@ describe('Topology (unit)', function () {
     });
 
     it('should not check for sessions if connected to a single server', function (done) {
-      const topology = new Topology('someserver:27019', {});
+      const topology = new Topology('someserver:27019');
       this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
         this.s.state = 'connected';
         this.emit('connect');
@@ -120,10 +117,7 @@ describe('Topology (unit)', function () {
     });
 
     it('should check for sessions if there are no data-bearing nodes', function (done) {
-      const topology = new Topology(
-        ['mongos:27019', 'mongos:27018', 'mongos:27017'].map(HostAddress.fromString),
-        {}
-      );
+      const topology = new Topology(['mongos:27019', 'mongos:27018', 'mongos:27017'], {});
       this.sinon.stub(Server.prototype, 'connect').callsFake(function () {
         this.s.state = 'connected';
         this.emit('connect');
@@ -161,7 +155,7 @@ describe('Topology (unit)', function () {
         }
       });
 
-      const topology = new Topology(mockServer.hostAddress(), {});
+      const topology = new Topology(mockServer.hostAddress());
       topology.connect(err => {
         expect(err).to.not.exist;
 
@@ -197,7 +191,7 @@ describe('Topology (unit)', function () {
         }
       });
 
-      const topology = new Topology(mockServer.hostAddress(), {});
+      const topology = new Topology(mockServer.hostAddress());
       topology.connect(err => {
         expect(err).to.not.exist;
 
@@ -234,7 +228,7 @@ describe('Topology (unit)', function () {
         }
       });
 
-      const topology = new Topology(mockServer.hostAddress(), {});
+      const topology = new Topology(mockServer.hostAddress());
       topology.connect(err => {
         expect(err).to.not.exist;
 
@@ -271,7 +265,7 @@ describe('Topology (unit)', function () {
         }
       });
 
-      const topology = new Topology(mockServer.hostAddress(), {});
+      const topology = new Topology(mockServer.hostAddress());
       topology.connect(err => {
         expect(err).to.not.exist;
 

--- a/test/unit/sessions/client.test.js
+++ b/test/unit/sessions/client.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 
 const test = {};
 describe('Sessions - client/unit', function () {

--- a/test/unit/sessions/collection.test.js
+++ b/test/unit/sessions/collection.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const { Timestamp } = require('bson');
 const { expect } = require('chai');
-const mock = require('mongodb-mock-server');
+const mock = require('../../tools/mock');
 
 const test = {};
 describe('Sessions - unit/sessions', function () {


### PR DESCRIPTION
MongoOptions introduce a well typed HostAddress type that tracks
the correct shape of a host's address depending on its type.
The MongoClientOptions type inherit from node's TLS and Socket options
and use our allow list of options to maintain a connection between the
types and programmatic processing of options. The hierarchy of options
from MongoClient > Topology > Server > ConnectionPool > Connection have
been corrected and clarified for responsibilities.

NODE-2704