### PR TITLE
chore(ci): continuous matrix integration [3.3]

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -132,12 +132,17 @@ functions:
           NODE_LTS_NAME='${NODE_LTS_NAME}' ATLAS_REPL='${atlas_repl}' ATLAS_SHRD='${atlas_shrd}'
           ATLAS_FREE='${atlas_free}' ATLAS_TLS11='${atlas_tls11}' ATLAS_TLS12='${atlas_tls12}' bash
           ${PROJECT_DIRECTORY}/.evergreen/run-atlas-tests.sh
+  upload test results:
+    - command: attach.xunit_results
+      params:
+        file: src/xunit.xml
 pre:
   - func: fetch source
   - func: prepare resources
   - func: fix absolute paths
   - func: make files executable
 post:
+  - func: upload test results
   - func: cleanup
 tasks:
   - name: test-latest-server

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -165,6 +165,10 @@ functions:
           # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
           NODE_LTS_NAME='${NODE_LTS_NAME}' ATLAS_REPL='${atlas_repl}' ATLAS_SHRD='${atlas_shrd}' ATLAS_FREE='${atlas_free}' ATLAS_TLS11='${atlas_tls11}' ATLAS_TLS12='${atlas_tls12}' bash ${PROJECT_DIRECTORY}/.evergreen/run-atlas-tests.sh
 
+  "upload test results":
+    - command: attach.xunit_results
+      params:
+        file: src/xunit.xml
 pre:
   - func: "fetch source"
   - func: "prepare resources"
@@ -173,4 +177,5 @@ pre:
   - func: "make files executable"
 
 post:
+  - func: "upload test results"
   - func: "cleanup"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -2,35 +2,103 @@
 # set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
+NVM_WINDOWS_URL="https://github.com/coreybutler/nvm-windows/releases/download/1.1.7/nvm-noinstall.zip"
+NVM_URL="https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh"
+
 NODE_LTS_NAME=${NODE_LTS_NAME:-carbon}
+MSVS_VERSION=${MSVS_VERSION:-2017}
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 NPM_CACHE_DIR="${NODE_ARTIFACTS_PATH}/npm"
 NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
 
 # this needs to be explicitly exported for the nvm install below
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+export XDG_CONFIG_HOME=${NODE_ARTIFACTS_PATH}
 
 # create node artifacts path if needed
 mkdir -p ${NODE_ARTIFACTS_PATH}
 mkdir -p ${NPM_CACHE_DIR}
 mkdir -p "${NPM_TMP_DIR}"
 
-# install Node.js
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
-[ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
-nvm install --lts=${NODE_LTS_NAME}
+case $NODE_LTS_NAME in
+  "argon")
+    VERSION=4
+    ;;
+  "boron")
+    VERSION=6
+    ;;
+  "carbon")
+    VERSION=8
+    ;;
+  "dubnium")
+    VERSION=10
+    ;;
+  "erbium")
+    VERSION=12
+    ;;
+  "fermium")
+    VERSION=14
+    ;;
+  *)
+    echo "Unsupported Node LTS version $1"
+    exit 1
+    ;;
+esac
+NODE_VERSION=$(curl --retry 8 --retry-delay 5  --max-time 50 -s -o- \
+  https://nodejs.org/download/release/latest-v${VERSION}.x/SHASUMS256.txt \
+| head -n 1 | awk '{print $2};' | cut -d- -f2)
+export NODE_VERSION=${NODE_VERSION:1}
 
-# setup npm cache in a local directory
-cat <<EOT > .npmrc
+# output node version to expansions file for use in subsequent scripts
+cat <<EOT > deps-expansion.yml
+  NODE_VERSION: "$NODE_VERSION"
+EOT
+
+# install Node.js on Windows
+if [[ "$OS" == "Windows_NT" ]]; then
+  # Delete pre-existing node to avoid version conflicts
+  rm -rf "/cygdrive/c/Program Files/nodejs"
+
+  export NVM_HOME=`cygpath -w "$NVM_DIR"`
+  export NVM_SYMLINK=`cygpath -w "$NODE_ARTIFACTS_PATH/bin"`
+  export NVM_ARTIFACTS_PATH=`cygpath -w "$NODE_ARTIFACTS_PATH/bin"`
+  export PATH=`cygpath $NVM_SYMLINK`:`cygpath $NVM_HOME`:$PATH
+
+  curl -L $NVM_WINDOWS_URL -o nvm.zip
+  unzip -d $NVM_DIR nvm.zip
+  rm nvm.zip
+
+  chmod 777 $NVM_DIR
+  chmod -R a+rx $NVM_DIR
+
+  cat <<EOT > $NVM_DIR/settings.txt
+root: $NVM_HOME
+path: $NVM_SYMLINK
+EOT
+  nvm install $NODE_VERSION
+  nvm use $NODE_VERSION
+  which node || echo "node not found, PATH=$PATH"
+  which npm || echo "npm not found, PATH=$PATH"
+  npm config set msvs_version ${MSVS_VERSION}
+  npm config set scripts-prepend-node-path true
+
+# install Node.js on Linux/MacOS
+else
+  curl -o- $NVM_URL | bash
+  [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
+  nvm install --no-progress $NODE_VERSION
+
+  # setup npm cache in a local directory
+  cat <<EOT > .npmrc
 devdir=${NPM_CACHE_DIR}/.node-gyp
 init-module=${NPM_CACHE_DIR}/.npm-init.js
 cache=${NPM_CACHE_DIR}
 tmp=${NPM_TMP_DIR}
 registry=https://registry.npmjs.org
 EOT
+fi
 
 # NOTE: registry was overridden to not use artifactory, remove the `registry` line when
 #       BUILD-6774 is resolved.
 
-# install node dependencies
-npm install
+npm install --unsafe-perm

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -10,11 +10,15 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       MARCH                   Machine Architecture. Defaults to lowercase uname -m
 #       TEST_NPM_SCRIPT         Script to npm run. Defaults to "test-nolint"
 #       SKIP_DEPS               Skip installing dependencies
+#       NO_EXIT                 Exit early from tests that leak resources
 
 AUTH=${AUTH:-noauth}
 UNIFIED=${UNIFIED:-}
 MONGODB_URI=${MONGODB_URI:-}
 TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-test-nolint}
+if [[ -z "${NO_EXIT}" ]]; then
+  TEST_NPM_SCRIPT="$TEST_NPM_SCRIPT -- --exit"
+fi
 
 # ssl setup
 SSL=${SSL:-nossl}

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -8,17 +8,47 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       UNIFIED                 Set to enable the Unified SDAM topology for the node driver
 #       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
 #       MARCH                   Machine Architecture. Defaults to lowercase uname -m
+#       TEST_NPM_SCRIPT         Script to npm run. Defaults to "test-nolint"
+#       SKIP_DEPS               Skip installing dependencies
 
 AUTH=${AUTH:-noauth}
-SSL=${SSL:-nossl}
 UNIFIED=${UNIFIED:-}
 MONGODB_URI=${MONGODB_URI:-}
+TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-test-nolint}
+
+# ssl setup
+SSL=${SSL:-nossl}
+if [ "$SSL" != "nossl" ]; then
+   export SSL_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
+   export SSL_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
+fi
 
 # run tests
 echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"
 
 export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
-NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
-export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-MONGODB_UNIFIED_TOPOLOGY=${UNIFIED} MONGODB_URI=${MONGODB_URI} npm test
+
+if [[ -z "${SKIP_DEPS}" ]]; then
+  source "${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
+else
+  NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
+  export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+  if [[ "$OS" == "Windows_NT" ]]; then
+    export NVM_HOME=`cygpath -m -a "$NVM_DIR"`
+    export NVM_SYMLINK=`cygpath -m -a "$NODE_ARTIFACTS_PATH/bin"`
+    export NVM_ARTIFACTS_PATH=`cygpath -m -a "$NODE_ARTIFACTS_PATH/bin"`
+    export PATH=`cygpath $NVM_SYMLINK`:`cygpath $NVM_HOME`:$PATH
+  else
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  fi
+fi
+
+# only run FLE tets on hosts we explicitly choose to test on
+if [[ -z "${CLIENT_ENCRYPTION}" ]]; then
+  unset AWS_ACCESS_KEY_ID;
+  unset AWS_SECRET_ACCESS_KEY;
+else
+  npm install mongodb-client-encryption
+fi
+
+MONGODB_UNIFIED_TOPOLOGY=${UNIFIED} MONGODB_URI=${MONGODB_URI} npm run ${TEST_NPM_SCRIPT}

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ manual_tests/
 docs/build
 docs/Makefile
 
+# xunit test output for CI
+xunit.xml
+
 # Directory for dbs
 db
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,5 @@
+Server Version: 5.0
+- BSON field 'listCollections.collation' is an unknown field.
+
+Server Version: 4.4
+- $where no longer supports deprecated BSON type CodeWScope

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official [MongoDB](https://www.mongodb.com/) driver for Node.js. Provides a 
 | what          | where                                          |
 |---------------|------------------------------------------------|
 | documentation | http://mongodb.github.io/node-mongodb-native  |
-| api-doc        | http://mongodb.github.io/node-mongodb-native/3.1/api  |
+| api-doc        | http://mongodb.github.io/node-mongodb-native/3.3/api  |
 | source        | https://github.com/mongodb/node-mongodb-native |
 | mongodb       | http://www.mongodb.org                        |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2045,6 +2045,147 @@
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
+        "bl": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+          "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "buffer-alloc": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+          "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+          "requires": {
+            "buffer-alloc-unsafe": "^1.1.0",
+            "buffer-fill": "^1.0.0"
+          }
+        },
+        "buffer-alloc-unsafe": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+        },
+        "buffer-fill": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+          "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+        },
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+          "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+        },
+        "end-of-stream": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "expand-template": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+          "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+        },
+        "file-uri-to-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+        },
+        "fs-constants": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "github-from-package": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+          "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+        },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -2064,6 +2205,237 @@
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
+        "has-unicode": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "nan": {
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+        },
+        "napi-build-utils": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+          "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+        },
+        "node-abi": {
+          "version": "2.19.1",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
+          "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+          "requires": {
+            "semver": "^5.4.1"
+          }
+        },
+        "noop-logger": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+          "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+        },
+        "prebuild-install": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.0.tgz",
+          "integrity": "sha512-aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==",
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "os-homedir": "^1.0.1",
+            "pump": "^2.0.1",
+            "rc": "^1.2.7",
+            "simple-get": "^2.7.0",
+            "tar-fs": "^1.13.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "rc": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "signal-exit": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+        },
+        "simple-concat": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+          "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+        },
+        "simple-get": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+          "requires": {
+            "decompress-response": "^3.3.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -2072,6 +2444,83 @@
           "requires": {
             "has-flag": "^1.0.0"
           }
+        },
+        "tar-fs": {
+          "version": "1.16.3",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+          "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+          "requires": {
+            "chownr": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pump": "^1.0.0",
+            "tar-stream": "^1.1.2"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+              "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "tar-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+          "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+          "requires": {
+            "bl": "^1.0.0",
+            "buffer-alloc": "^1.2.0",
+            "end-of-stream": "^1.0.0",
+            "fs-constants": "^1.0.0",
+            "readable-stream": "^2.3.0",
+            "to-buffer": "^1.1.1",
+            "xtend": "^4.0.0"
+          }
+        },
+        "to-buffer": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+          "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "which-pm-runs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+          "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "xtend": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         }
       }
     },
@@ -3497,6 +3946,12 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
+    "spec-xunit-file": {
+      "version": "0.0.1-3",
+      "resolved": "https://registry.npmjs.org/spec-xunit-file/-/spec-xunit-file-0.0.1-3.tgz",
+      "integrity": "sha1-hVpmq4w4LrMWXfkoqB0HSQKdI4Y=",
       "dev": true
     },
     "split": {

--- a/package.json
+++ b/package.json
@@ -49,10 +49,11 @@
     "sinon": "^4.3.0",
     "sinon-chai": "^3.2.0",
     "snappy": "^6.1.2",
+    "spec-xunit-file": "0.0.1-3",
     "standard-version": "^4.4.0",
-    "yargs": "^14.2.0",
     "worker-farm": "^1.5.0",
-    "wtfnode": "^0.8.0"
+    "wtfnode": "^0.8.0",
+    "yargs": "^14.2.0"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/test/core/functional/rs_mocks/add_remove_tests.js
+++ b/test/core/functional/rs_mocks/add_remove_tests.js
@@ -387,6 +387,7 @@ describe('ReplSet Add Remove (mocks)', function() {
   it('Successfully remove and re-add secondary server to the set', {
     metadata: {
       requires: {
+        os: '!win32',
         generators: true,
         topology: 'single'
       }

--- a/test/core/functional/rs_mocks/connection_tests.js
+++ b/test/core/functional/rs_mocks/connection_tests.js
@@ -267,7 +267,8 @@ describe('ReplSet Connection Tests (mocks)', function() {
     metadata: {
       requires: {
         generators: true,
-        topology: 'single'
+        topology: 'single',
+        os: '!win32' // test fails erroneously on windows, skip for matrix testing
       }
     },
 
@@ -375,7 +376,8 @@ describe('ReplSet Connection Tests (mocks)', function() {
     metadata: {
       requires: {
         generators: true,
-        topology: 'single'
+        topology: 'single',
+        os: '!win32' // test fails erroneously on windows, skip for matrix testing
       }
     },
 

--- a/test/functional/collations_tests.js
+++ b/test/functional/collations_tests.js
@@ -825,7 +825,9 @@ describe('Collation', function() {
   });
 
   it('Should correctly create collection with collation', {
-    metadata: { requires: { topology: 'single', mongodb: '>=3.3.12' } },
+    metadata: { requires: { topology: 'single', mongodb: '>=3.3.12 <=4.4' } },
+    // skipped on mongodb > 4.4 because of server error:
+    //   BSON field 'listCollections.collation' is an unknown field.
 
     test: function() {
       const configuration = this.configuration;

--- a/test/functional/connection_tests.js
+++ b/test/functional/connection_tests.js
@@ -12,7 +12,7 @@ describe('Connection', function() {
    * @ignore
    */
   it('should correctly start monitoring for single server connection', {
-    metadata: { requires: { topology: 'single' } },
+    metadata: { requires: { topology: 'single', os: '!win32' } },
 
     // The actual test we wish to run
     test: function(done) {
@@ -36,7 +36,7 @@ describe('Connection', function() {
    * @ignore
    */
   it('should correctly disable monitoring for single server connection', {
-    metadata: { requires: { topology: 'single' } },
+    metadata: { requires: { topology: 'single', os: '!win32' } },
 
     // The actual test we wish to run
     test: function(done) {
@@ -64,7 +64,7 @@ describe('Connection', function() {
    * @ignore
    */
   it('should correctly connect to server using domain socket', {
-    metadata: { requires: { topology: 'single' } },
+    metadata: { requires: { topology: 'single', os: '!win32' } },
 
     // The actual test we wish to run
     test: function(done) {
@@ -162,7 +162,7 @@ describe('Connection', function() {
    * @ignore
    */
   it('should connect to server using domain socket with undefined port', {
-    metadata: { requires: { topology: 'single' } },
+    metadata: { requires: { topology: 'single', os: '!win32' } },
 
     // The actual test we wish to run
     test: function(done) {

--- a/test/functional/cursor_tests.js
+++ b/test/functional/cursor_tests.js
@@ -2,6 +2,8 @@
 const test = require('./shared').assert;
 const setupDatabase = require('./shared').setupDatabase;
 const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const expect = require('chai').expect;
 const Long = require('bson').Long;
 const sinon = require('sinon');
@@ -2234,8 +2236,8 @@ describe('Cursor', function() {
           collection.insert(docs, configuration.writeConcernMax(), function(err) {
             test.equal(null, err);
 
-            var filename = '/tmp/_nodemongodbnative_stream_out.txt',
-              out = fs.createWriteStream(filename);
+            var filename = path.join(os.tmpdir(), '_nodemongodbnative_stream_out.txt');
+            var out = fs.createWriteStream(filename);
 
             // hack so we don't need to create a stream filter just to
             // stringify the objects (otherwise the created file would

--- a/test/functional/db_tests.js
+++ b/test/functional/db_tests.js
@@ -313,7 +313,7 @@ describe('Db', function() {
    */
   it('shouldCorrectlyForceReindexOnCollection', {
     metadata: {
-      requires: { topology: ['single', 'replicaset'] }
+      requires: { topology: ['single'] }
     },
 
     // The actual test we wish to run

--- a/test/functional/find_tests.js
+++ b/test/functional/find_tests.js
@@ -516,9 +516,7 @@ describe('Find', function() {
    * @ignore
    */
   it('shouldCorrectlyPerformFindByWhere', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
+    metadata: { requires: { mongodb: '<4.4' } },
 
     // The actual test we wish to run
     test: function(done) {

--- a/test/functional/gridfs_tests.js
+++ b/test/functional/gridfs_tests.js
@@ -1734,7 +1734,7 @@ describe('GridFS', function() {
   /**
    * @ignore
    */
-  it('shouldWriteFileWithMongofilesAndReadWithNodeJS', {
+  it.skip('shouldWriteFileWithMongofilesAndReadWithNodeJS', {
     metadata: { requires: { topology: 'single' } },
 
     // The actual test we wish to run

--- a/test/functional/index_tests.js
+++ b/test/functional/index_tests.js
@@ -1263,24 +1263,20 @@ describe('Indexes', function() {
         var db = client.db(configuration.db);
         var collection = db.collection('messed_up_options');
 
-        collection.ensureIndex(
-          { 'a.one': 1, 'a.two': 1 },
-          { name: 'n1', partialFilterExpression: { 'a.two': { $exists: true } } },
-          function(err) {
-            test.equal(null, err);
+        collection.ensureIndex({ 'a.one': 1, 'a.two': 1 }, { name: 'n1', sparse: false }, function(
+          err
+        ) {
+          test.equal(null, err);
 
-            collection.ensureIndex(
-              { 'a.one': 1, 'a.two': 1 },
-              { name: 'n2', partialFilterExpression: { 'a.too': { $exists: true } } },
-              function(err) {
-                test.ok(err);
-                test.equal(85, err.code);
+          collection.ensureIndex({ 'a.one': 1, 'a.two': 1 }, { name: 'n2', sparse: true }, function(
+            err
+          ) {
+            test.ok(err);
+            test.equal(85, err.code);
 
-                client.close(done);
-              }
-            );
-          }
-        );
+            client.close(done);
+          });
+        });
       });
     }
   });

--- a/test/functional/mapreduce_tests.js
+++ b/test/functional/mapreduce_tests.js
@@ -364,44 +364,52 @@ describe('MapReduce', function() {
       var client = configuration.newClient(configuration.writeConcernMax(), { poolSize: 1 });
       client.connect(function(err, client) {
         var db = client.db(configuration.db);
+        const outDb = client.db('outputCollectionDb');
 
         // Create a test collection
         db.createCollection('test_map_reduce_functions', function(err, collection) {
-          // Insert some documents to perform map reduce over
-          collection.insert(
-            [{ user_id: 1 }, { user_id: 2 }],
-            configuration.writeConcernMax(),
-            function(err) {
-              test.equal(null, err);
-              // Map function
-              var map = function() {
-                emit(this.user_id, 1); // eslint-disable-line
-              };
-              // Reduce function
-              var reduce = function() {
-                return 1;
-              };
+          test.equal(null, err);
+          // create the output collection
+          outDb.createCollection('test_map_reduce_functions_temp', err => {
+            test.equal(null, err);
+            // Insert some documents to perform map reduce over
+            collection.insert(
+              [{ user_id: 1 }, { user_id: 2 }],
+              configuration.writeConcernMax(),
+              function(err) {
+                test.equal(null, err);
+                // Map function
+                var map = function() {
+                  emit(this.user_id, 1); // eslint-disable-line
+                };
+                // Reduce function
+                var reduce = function() {
+                  return 1;
+                };
 
-              // Perform the map reduce
-              collection.mapReduce(
-                map,
-                reduce,
-                { out: { replace: 'tempCollection', db: 'outputCollectionDb' } },
-                function(err, collection) {
-                  // Mapreduce returns the temporary collection with the results
-                  collection.findOne({ _id: 1 }, function(err, result) {
-                    test.equal(1, result.value);
-
-                    collection.findOne({ _id: 2 }, function(err, result) {
+                // Perform the map reduce
+                collection.mapReduce(
+                  map,
+                  reduce,
+                  { out: { replace: 'test_map_reduce_functions_temp', db: 'outputCollectionDb' } },
+                  function(err, collection) {
+                    // Mapreduce returns the temporary collection with the results
+                    collection.findOne({ _id: 1 }, function(err, result) {
+                      test.equal(null, err);
                       test.equal(1, result.value);
 
-                      client.close(done);
+                      collection.findOne({ _id: 2 }, function(err, result) {
+                        test.equal(null, err);
+                        test.equal(1, result.value);
+
+                        client.close(done);
+                      });
                     });
-                  });
-                }
-              );
-            }
-          );
+                  }
+                );
+              }
+            );
+          });
         });
       });
     }

--- a/test/functional/mongo_client_tests.js
+++ b/test/functional/mongo_client_tests.js
@@ -484,7 +484,7 @@ describe('MongoClient', function() {
   });
 
   it('should correctly connect to mongodb using domain socket', {
-    metadata: { requires: { topology: ['single'] } },
+    metadata: { requires: { topology: ['single'], os: '!win32' } },
 
     // The actual test we wish to run
     test: function(done) {

--- a/test/functional/operation_example_tests.js
+++ b/test/functional/operation_example_tests.js
@@ -1721,7 +1721,7 @@ describe('Operation Examples', function() {
    * @ignore
    */
   it('shouldCorrectlyPerformSimpleGeoHaystackSearchCommand', {
-    metadata: { requires: { topology: ['single', 'replicaset'] } },
+    metadata: { requires: { mongodb: '<=4.4', topology: ['single', 'replicaset'] } },
 
     // The actual test we wish to run
     test: function(done) {
@@ -2791,7 +2791,7 @@ describe('Operation Examples', function() {
    */
   it('shouldCorrectlyIndexAndForceReindexOnCollection', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'ssl', 'heap', 'wiredtiger'] }
+      requires: { topology: ['single'] }
     },
 
     // The actual test we wish to run

--- a/test/functional/operation_generators_example_tests.js
+++ b/test/functional/operation_generators_example_tests.js
@@ -1065,7 +1065,7 @@ describe('Operation (Generators)', function() {
    * @ignore
    */
   it('shouldCorrectlyPerformSimpleGeoHaystackSearchCommandWithGenerators', {
-    metadata: { requires: { generators: true, topology: ['single'] } },
+    metadata: { requires: { mongodb: '<=4.4', generators: true, topology: ['single'] } },
 
     // The actual test we wish to run
     test: function() {

--- a/test/functional/operation_promises_example_tests.js
+++ b/test/functional/operation_promises_example_tests.js
@@ -1086,7 +1086,7 @@ describe('Operation (Promises)', function() {
    * @ignore
    */
   it('shouldCorrectlyPerformSimpleGeoHaystackSearchCommandWithPromises', {
-    metadata: { requires: { topology: ['single', 'replicaset'] } },
+    metadata: { requires: { mongodb: '<=4.4', topology: ['single', 'replicaset'] } },
 
     // The actual test we wish to run
     test: function() {

--- a/test/functional/readconcern_tests.js
+++ b/test/functional/readconcern_tests.js
@@ -44,7 +44,8 @@ describe('ReadConcern', function() {
     {
       description: 'Should set majority readConcern geoSearch command',
       commandName: 'geoSearch',
-      readConcern: { level: 'majority' }
+      readConcern: { level: 'majority' },
+      serverVersion: '>=3.2 <=4.4'
     },
     {
       description: 'Should set local readConcern at collection level',
@@ -60,8 +61,7 @@ describe('ReadConcern', function() {
 
   tests.forEach(test => {
     it(test.description, {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>= 3.2' } },
-
+      metadata: { requires: { topology: 'replicaset', mongodb: test.serverVersion || '>= 3.2' } },
       test: function(done) {
         const started = [];
         const succeeded = [];

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,4 +2,5 @@
   --timeout 60000
   --file test/runner
   --ui test/runner/metadata_ui.js
-
+  --reporter spec-xunit-file
+  --colors


### PR DESCRIPTION
The Continuous Matrix Testing project requires updates to some driver versions which are no longer maintained.

This PR for the `3.3` branch allows testing the Node driver released to support MongoDB 4.2.

port of #2667

[patch build](https://spruce.mongodb.com/version/5fe10b073066155bd25aa86e/tasks?page=0&taskName=4.2-era-driver)

- enables xunit reporting
- fixes testing on windows
- adds `COMPATIBILITY.md` and skips incompatible tests

NODE-2914