### PR TITLE
fix(topology): connect server only on next tick

### DIFF
--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -796,7 +796,7 @@ function createAndConnectServer(
     return server;
   }
 
-  server.connect();
+  process.nextTick(() => server.connect());
   return server;
 }
 


### PR DESCRIPTION
## Description
The PR defers connecting to a server until the next tick.

If the connection is triggered immediately, an infinite recursion might occur. This is caused for example by an invalid TLS client certificate (i.e. invalid content) that can be specified via the tlsClientCertificateFile option during MongoClient.connect.

The recursion occurs due to the order of operations in `connectServers` (https://github.com/mongodb/node-mongodb-native/blob/master/src/sdam/topology.ts#L824). The server is connected to before it is added to the internal known server descriptions. An invalid TLS certificate file however causes an immediate error in `server.connect()` (https://github.com/mongodb/node-mongodb-native/blob/master/src/sdam/topology.ts#L810). This error is caught and tried to react synchronously in an event listener which tries to access the known server descriptions - which have not been updated yet.

A simple reproduction of the stack overflow is the following:
```
const MongoClient = require('mongodb').MongoClient;

(async() => {
    try {
        const client = await MongoClient.connect('mongodb://localhost/?directConnection=true', {
            tlsCertificateKeyFile: './package.json'
        });
        console.log('that should not work.');
    } catch (e) {
        console.error(e);
    }
})();

```

**What changed?**
Connecting to a server is not triggered immediately in the `createAndConnectServer`
call but on next tick afterwards.

**Are there any files to ignore?**
_No._

NODE-2984