### PR TITLE
fix: enumerate function override call signatures

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -263,9 +263,9 @@ export class Connection extends EventEmitter {
   }
 
   destroy(): void;
-  destroy(callback?: Callback): void;
-  destroy(options?: DestroyOptions): void;
-  destroy(options?: DestroyOptions, callback?: Callback): void;
+  destroy(callback: Callback): void;
+  destroy(options: DestroyOptions): void;
+  destroy(options: DestroyOptions, callback: Callback): void;
   destroy(options?: DestroyOptions | Callback, callback?: Callback): void {
     if (typeof options === 'function') {
       callback = options;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1242,8 +1242,6 @@ export class Collection {
    * @param pipeline - An array of {@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/|aggregation pipeline stages} through which to pass change stream documents. This allows for filtering (using $match) and manipulating the change stream documents.
    * @param options - Optional settings for the command
    */
-  watch(): ChangeStream;
-  watch(pipeline?: Document[]): ChangeStream;
   watch(pipeline?: Document[], options?: ChangeStreamOptions): ChangeStream {
     pipeline = pipeline || [];
     options = options ?? {};

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -77,7 +77,7 @@ export class AggregationCursor extends AbstractCursor {
   /** Execute the explain for the cursor */
   explain(): Promise<Document>;
   explain(callback: Callback): void;
-  explain(verbosity?: ExplainVerbosityLike): Promise<Document>;
+  explain(verbosity: ExplainVerbosityLike): Promise<Document>;
   explain(
     verbosity?: ExplainVerbosityLike | Callback,
     callback?: Callback<Document>

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -346,7 +346,7 @@ export class MongoClient extends EventEmitter {
    * @see docs.mongodb.org/manual/reference/connection-string/
    */
   connect(): Promise<MongoClient>;
-  connect(callback?: Callback<MongoClient>): void;
+  connect(callback: Callback<MongoClient>): void;
   connect(callback?: Callback<MongoClient>): Promise<MongoClient> | void {
     if (callback && typeof callback !== 'function') {
       throw new TypeError('`connect` only accepts a callback');
@@ -457,7 +457,11 @@ export class MongoClient extends EventEmitter {
       // Create client
       const mongoClient = new MongoClient(url, options);
       // Execute the connect method
-      return mongoClient.connect(callback);
+      if (callback) {
+        return mongoClient.connect(callback);
+      } else {
+        return mongoClient.connect();
+      }
     } catch (error) {
       if (callback) return callback(error);
       else return PromiseProvider.get().reject(error);


### PR DESCRIPTION
Function overrides now declare each possible form
of the call signature, including the actual call signature

NODE-2934