### PR TITLE
chore: add the unified spec tests

### DIFF
--- a/test/spec/unified-test-format/Makefile
+++ b/test/spec/unified-test-format/Makefile
@@ -1,0 +1,24 @@
+SCHEMA=../schema-1.1.json
+
+.PHONY: all invalid valid-fail valid-pass versioned-api HAS_AJV
+
+all: invalid valid-fail valid-pass versioned-api
+
+invalid: HAS_AJV
+	@# Redirect stdout to hide expected validation errors
+	@ajv test -s $(SCHEMA) -d "invalid/*.yml" --invalid > /dev/null && echo "invalid/*.yml passed test"
+
+valid-fail: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "valid-fail/*.yml" --valid
+
+valid-pass: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "valid-pass/*.yml" --valid
+
+versioned-api: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../versioned-api/tests/*.yml" --valid
+
+HAS_AJV:
+	@if ! command -v ajv > /dev/null; then                \
+	    echo 'Error: need "npm install -g ajv-cli"' 1>&2; \
+	    exit 1;                                           \
+	fi

--- a/test/spec/unified-test-format/invalid/collectionData-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/collectionData-additionalProperties.json
@@ -1,0 +1,40 @@
+{
+  "description": "collectionData-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "databaseName": "foo",
+      "documents": [],
+      "foo": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionData-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/collectionData-additionalProperties.yml
@@ -1,0 +1,26 @@
+description: "collectionData-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: &database0Name "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: &collection0Name "foo"
+      foo: 0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+    foo: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionData-collectionName-required.json
+++ b/test/spec/unified-test-format/invalid/collectionData-collectionName-required.json
@@ -1,0 +1,38 @@
+{
+  "description": "collectionData-collectionName-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "foo",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionData-collectionName-required.yml
+++ b/test/spec/unified-test-format/invalid/collectionData-collectionName-required.yml
@@ -1,0 +1,24 @@
+description: "collectionData-collectionName-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: &database0Name "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: &collection0Name "foo"
+      foo: 0
+
+initialData:
+  - databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionData-collectionName-type.json
+++ b/test/spec/unified-test-format/invalid/collectionData-collectionName-type.json
@@ -1,0 +1,39 @@
+{
+  "description": "collectionData-collectionName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": 0,
+      "databaseName": "foo",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionData-collectionName-type.yml
+++ b/test/spec/unified-test-format/invalid/collectionData-collectionName-type.yml
@@ -1,0 +1,25 @@
+description: "collectionData-collectionName-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: &database0Name "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: &collection0Name "foo"
+      foo: 0
+
+initialData:
+  - collectionName: 0
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionData-databaseName-required.json
+++ b/test/spec/unified-test-format/invalid/collectionData-databaseName-required.json
@@ -1,0 +1,38 @@
+{
+  "description": "collectionData-databaseName-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionData-databaseName-required.yml
+++ b/test/spec/unified-test-format/invalid/collectionData-databaseName-required.yml
@@ -1,0 +1,24 @@
+description: "collectionData-databaseName-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: &database0Name "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: &collection0Name "foo"
+      foo: 0
+
+initialData:
+  - collectionName: *collection0Name
+    documents: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionData-databaseName-type.json
+++ b/test/spec/unified-test-format/invalid/collectionData-databaseName-type.json
@@ -1,0 +1,39 @@
+{
+  "description": "collectionData-databaseName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "databaseName": 0,
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionData-databaseName-type.yml
+++ b/test/spec/unified-test-format/invalid/collectionData-databaseName-type.yml
@@ -1,0 +1,25 @@
+description: "collectionData-databaseName-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: &database0Name "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: &collection0Name "foo"
+      foo: 0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: 0
+    documents: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionData-documents-items.json
+++ b/test/spec/unified-test-format/invalid/collectionData-documents-items.json
@@ -1,0 +1,41 @@
+{
+  "description": "collectionData-documents-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "databaseName": "foo",
+      "documents": [
+        0
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionData-documents-items.yml
+++ b/test/spec/unified-test-format/invalid/collectionData-documents-items.yml
@@ -1,0 +1,25 @@
+description: "collectionData-documents-items"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: &database0Name "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: &collection0Name "foo"
+      foo: 0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: [0]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionData-documents-required.json
+++ b/test/spec/unified-test-format/invalid/collectionData-documents-required.json
@@ -1,0 +1,38 @@
+{
+  "description": "collectionData-documents-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "databaseName": "foo"
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionData-documents-required.yml
+++ b/test/spec/unified-test-format/invalid/collectionData-documents-required.yml
@@ -1,0 +1,24 @@
+description: "collectionData-documents-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: &database0Name "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: &collection0Name "foo"
+      foo: 0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionData-documents-type.json
+++ b/test/spec/unified-test-format/invalid/collectionData-documents-type.json
@@ -1,0 +1,39 @@
+{
+  "description": "collectionData-documents-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "foo",
+      "databaseName": "foo",
+      "documents": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionData-documents-type.yml
+++ b/test/spec/unified-test-format/invalid/collectionData-documents-type.yml
@@ -1,0 +1,25 @@
+description: "collectionData-documents-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: &database0Name "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: &collection0Name "foo"
+      foo: 0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-additionalProperties.json
@@ -1,0 +1,27 @@
+{
+  "description": "collectionOrDatabaseOptions-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "databaseOptions": {
+          "foo": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-additionalProperties.yml
@@ -1,0 +1,17 @@
+description: "collectionOrDatabaseOptions-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+      databaseOptions:
+        foo: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-readConcern-type.json
+++ b/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-readConcern-type.json
@@ -1,0 +1,27 @@
+{
+  "description": "collectionOrDatabaseOptions-readConcern-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "databaseOptions": {
+          "readConcern": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-readConcern-type.yml
+++ b/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-readConcern-type.yml
@@ -1,0 +1,17 @@
+description: "collectionOrDatabaseOptions-readConcern-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+      databaseOptions:
+        readConcern: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-readPreference-type.json
+++ b/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-readPreference-type.json
@@ -1,0 +1,27 @@
+{
+  "description": "collectionOrDatabaseOptions-readPreference-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "databaseOptions": {
+          "readPreference": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-readPreference-type.yml
+++ b/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-readPreference-type.yml
@@ -1,0 +1,17 @@
+description: "collectionOrDatabaseOptions-readPreference-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+      databaseOptions:
+        readPreference: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-writeConcern-type.json
+++ b/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-writeConcern-type.json
@@ -1,0 +1,27 @@
+{
+  "description": "collectionOrDatabaseOptions-writeConcern-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "databaseOptions": {
+          "writeConcern": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-writeConcern-type.yml
+++ b/test/spec/unified-test-format/invalid/collectionOrDatabaseOptions-writeConcern-type.yml
@@ -1,0 +1,17 @@
+description: "collectionOrDatabaseOptions-writeConcern-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+      databaseOptions:
+        writeConcern: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/createEntities-items.json
+++ b/test/spec/unified-test-format/invalid/createEntities-items.json
@@ -1,0 +1,13 @@
+{
+  "description": "createEntities-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    0
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/createEntities-items.yml
+++ b/test/spec/unified-test-format/invalid/createEntities-items.yml
@@ -1,0 +1,9 @@
+description: "createEntities-items"
+
+schemaVersion: "1.0"
+
+createEntities: [0]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/createEntities-minItems.json
+++ b/test/spec/unified-test-format/invalid/createEntities-minItems.json
@@ -1,0 +1,11 @@
+{
+  "description": "createEntities-minItems",
+  "schemaVersion": "1.0",
+  "createEntities": [],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/createEntities-minItems.yml
+++ b/test/spec/unified-test-format/invalid/createEntities-minItems.yml
@@ -1,0 +1,9 @@
+description: "createEntities-minItems"
+
+schemaVersion: "1.0"
+
+createEntities: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/createEntities-type.json
+++ b/test/spec/unified-test-format/invalid/createEntities-type.json
@@ -1,0 +1,11 @@
+{
+  "description": "createEntities-type",
+  "schemaVersion": "1.0",
+  "createEntities": 0,
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/createEntities-type.yml
+++ b/test/spec/unified-test-format/invalid/createEntities-type.yml
@@ -1,0 +1,9 @@
+description: "createEntities-type"
+
+schemaVersion: "1.0"
+
+createEntities: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/description-required.json
+++ b/test/spec/unified-test-format/invalid/description-required.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/description-required.yml
+++ b/test/spec/unified-test-format/invalid/description-required.yml
@@ -1,0 +1,7 @@
+# description: "description-required"
+
+schemaVersion: "1.0"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/entity-additionalProperties.json
@@ -1,0 +1,15 @@
+{
+  "description": "entity-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "foo": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/entity-additionalProperties.yml
@@ -1,0 +1,10 @@
+description: "entity-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - foo: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-bucket-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/entity-bucket-additionalProperties.json
@@ -1,0 +1,31 @@
+{
+  "description": "entity-bucket-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-bucket-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/entity-bucket-additionalProperties.yml
@@ -1,0 +1,19 @@
+description: "entity-bucket-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - bucket:
+      id: &bucket0 "bucket0"
+      database: *database0
+      foo: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-bucket-bucketOptions-type.json
+++ b/test/spec/unified-test-format/invalid/entity-bucket-bucketOptions-type.json
@@ -1,0 +1,31 @@
+{
+  "description": "entity-bucket-bucketOptions-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0",
+        "bucketOptions": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-bucket-bucketOptions-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-bucket-bucketOptions-type.yml
@@ -1,0 +1,19 @@
+description: "entity-bucket-bucketOptions-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - bucket:
+      id: &bucket0 "bucket0"
+      database: *database0
+      bucketOptions: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-bucket-database-required.json
+++ b/test/spec/unified-test-format/invalid/entity-bucket-database-required.json
@@ -1,0 +1,29 @@
+{
+  "description": "entity-bucket-database-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-bucket-database-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-bucket-database-required.yml
@@ -1,0 +1,17 @@
+description: "entity-bucket-database-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - bucket:
+      id: &bucket0 "bucket0"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-bucket-database-type.json
+++ b/test/spec/unified-test-format/invalid/entity-bucket-database-type.json
@@ -1,0 +1,30 @@
+{
+  "description": "entity-bucket-database-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-bucket-database-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-bucket-database-type.yml
@@ -1,0 +1,18 @@
+description: "entity-bucket-database-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - bucket:
+      id: &bucket0 "bucket0"
+      database: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-bucket-id-required.json
+++ b/test/spec/unified-test-format/invalid/entity-bucket-id-required.json
@@ -1,0 +1,29 @@
+{
+  "description": "entity-bucket-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "database": "database0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-bucket-id-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-bucket-id-required.yml
@@ -1,0 +1,17 @@
+description: "entity-bucket-id-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - bucket:
+      database: *database0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-bucket-id-type.json
+++ b/test/spec/unified-test-format/invalid/entity-bucket-id-type.json
@@ -1,0 +1,30 @@
+{
+  "description": "entity-bucket-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "bucket": {
+        "id": 0,
+        "database": "database0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-bucket-id-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-bucket-id-type.yml
@@ -1,0 +1,18 @@
+description: "entity-bucket-id-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - bucket:
+      id: 0
+      database: *database0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/entity-client-additionalProperties.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-additionalProperties.yml
@@ -1,0 +1,12 @@
+description: "entity-client-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      foo: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-id-required.json
+++ b/test/spec/unified-test-format/invalid/entity-client-id-required.json
@@ -1,0 +1,15 @@
+{
+  "description": "entity-client-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {}
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-id-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-id-required.yml
@@ -1,0 +1,10 @@
+description: "entity-client-id-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client: {}
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-id-type.json
+++ b/test/spec/unified-test-format/invalid/entity-client-id-type.json
@@ -1,0 +1,17 @@
+{
+  "description": "entity-client-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-id-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-id-type.yml
@@ -1,0 +1,11 @@
+description: "entity-client-id-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-items.json
+++ b/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-items.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-ignoreCommandMonitoringEvents-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "ignoreCommandMonitoringEvents": [
+          0
+        ]
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-items.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-items.yml
@@ -1,0 +1,12 @@
+description: "entity-client-ignoreCommandMonitoringEvents-items"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      ignoreCommandMonitoringEvents: [0]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-minItems.json
+++ b/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-minItems.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-ignoreCommandMonitoringEvents-minItems",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "ignoreCommandMonitoringEvents": []
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-minItems.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-minItems.yml
@@ -1,0 +1,12 @@
+description: "entity-client-ignoreCommandMonitoringEvents-minItems"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      ignoreCommandMonitoringEvents: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-type.json
+++ b/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-ignoreCommandMonitoringEvents-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "ignoreCommandMonitoringEvents": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-ignoreCommandMonitoringEvents-type.yml
@@ -1,0 +1,12 @@
+description: "entity-client-ignoreCommandMonitoringEvents-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      ignoreCommandMonitoringEvents: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-observeEvents-enum.json
+++ b/test/spec/unified-test-format/invalid/entity-client-observeEvents-enum.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-observeEvents-enum",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "foo"
+        ]
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-observeEvents-enum.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-observeEvents-enum.yml
@@ -1,0 +1,12 @@
+description: "entity-client-observeEvents-enum"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      observeEvents: ["foo"]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-observeEvents-items.json
+++ b/test/spec/unified-test-format/invalid/entity-client-observeEvents-items.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-observeEvents-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          0
+        ]
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-observeEvents-items.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-observeEvents-items.yml
@@ -1,0 +1,12 @@
+description: "entity-client-observeEvents-items"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      observeEvents: [0]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-observeEvents-minItems.json
+++ b/test/spec/unified-test-format/invalid/entity-client-observeEvents-minItems.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-observeEvents-minItems",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": []
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-observeEvents-minItems.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-observeEvents-minItems.yml
@@ -1,0 +1,12 @@
+description: "entity-client-observeEvents-minItems"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      observeEvents: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-observeEvents-type.json
+++ b/test/spec/unified-test-format/invalid/entity-client-observeEvents-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-observeEvents-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-observeEvents-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-observeEvents-type.yml
@@ -1,0 +1,12 @@
+description: "entity-client-observeEvents-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      observeEvents: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-serverApi-deprecationErrors-type.json
+++ b/test/spec/unified-test-format/invalid/entity-client-serverApi-deprecationErrors-type.json
@@ -1,0 +1,21 @@
+{
+  "description": "entity-client-serverApi-version-type",
+  "schemaVersion": "1.1",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "serverApi": {
+          "version": "1",
+          "deprecationErrors": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-serverApi-deprecationErrors-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-serverApi-deprecationErrors-type.yml
@@ -1,0 +1,14 @@
+description: "entity-client-serverApi-version-type"
+
+schemaVersion: "1.1"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      serverApi:
+        version: "1"
+        deprecationErrors: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-serverApi-strict-type.json
+++ b/test/spec/unified-test-format/invalid/entity-client-serverApi-strict-type.json
@@ -1,0 +1,21 @@
+{
+  "description": "entity-client-serverApi-version-type",
+  "schemaVersion": "1.1",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "serverApi": {
+          "version": "1",
+          "strict": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-serverApi-strict-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-serverApi-strict-type.yml
@@ -1,0 +1,14 @@
+description: "entity-client-serverApi-version-type"
+
+schemaVersion: "1.1"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      serverApi:
+        version: "1"
+        strict: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-serverApi-type.json
+++ b/test/spec/unified-test-format/invalid/entity-client-serverApi-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-serverApi-type",
+  "schemaVersion": "1.1",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "serverApi": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-serverApi-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-serverApi-type.yml
@@ -1,0 +1,12 @@
+description: "entity-client-serverApi-type"
+
+schemaVersion: "1.1"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      serverApi: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-serverApi-version-required.json
+++ b/test/spec/unified-test-format/invalid/entity-client-serverApi-version-required.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-serverApi-version-required",
+  "schemaVersion": "1.1",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "serverApi": {}
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-serverApi-version-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-serverApi-version-required.yml
@@ -1,0 +1,12 @@
+description: "entity-client-serverApi-version-required"
+
+schemaVersion: "1.1"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      serverApi: {}
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-serverApi-version-type.json
+++ b/test/spec/unified-test-format/invalid/entity-client-serverApi-version-type.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-serverApi-version-type",
+  "schemaVersion": "1.1",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "serverApi": {
+          "version": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-serverApi-version-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-serverApi-version-type.yml
@@ -1,0 +1,13 @@
+description: "entity-client-serverApi-version-type"
+
+schemaVersion: "1.1"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      serverApi:
+        version: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-uriOptions-type.json
+++ b/test/spec/unified-test-format/invalid/entity-client-uriOptions-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-uriOptions-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "uriOptions": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-uriOptions-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-uriOptions-type.yml
@@ -1,0 +1,12 @@
+description: "entity-client-uriOptions-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      uriOptions: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-client-useMultipleMongoses-type.json
+++ b/test/spec/unified-test-format/invalid/entity-client-useMultipleMongoses-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-useMultipleMongoses-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-client-useMultipleMongoses-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-client-useMultipleMongoses-type.yml
@@ -1,0 +1,12 @@
+description: "entity-client-useMultipleMongoses-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      useMultipleMongoses: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-collection-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/entity-collection-additionalProperties.json
@@ -1,0 +1,32 @@
+{
+  "description": "entity-collection-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-collection-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/entity-collection-additionalProperties.yml
@@ -1,0 +1,20 @@
+description: "entity-collection-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: "foo"
+      foo: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-collection-collectionName-required.json
+++ b/test/spec/unified-test-format/invalid/entity-collection-collectionName-required.json
@@ -1,0 +1,30 @@
+{
+  "description": "entity-collection-collectionName-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-collection-collectionName-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-collection-collectionName-required.yml
@@ -1,0 +1,18 @@
+description: "entity-collection-collectionName-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-collection-collectionName-type.json
+++ b/test/spec/unified-test-format/invalid/entity-collection-collectionName-type.json
@@ -1,0 +1,31 @@
+{
+  "description": "entity-collection-collectionName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-collection-collectionName-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-collection-collectionName-type.yml
@@ -1,0 +1,19 @@
+description: "entity-collection-collectionName-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-collection-collectionOptions-type.json
+++ b/test/spec/unified-test-format/invalid/entity-collection-collectionOptions-type.json
@@ -1,0 +1,32 @@
+{
+  "description": "entity-collection-collectionOptions-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "foo",
+        "collectionOptions": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-collection-collectionOptions-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-collection-collectionOptions-type.yml
@@ -1,0 +1,20 @@
+description: "entity-collection-collectionOptions-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: *database0
+      collectionName: "foo"
+      collectionOptions: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-collection-database-required.json
+++ b/test/spec/unified-test-format/invalid/entity-collection-database-required.json
@@ -1,0 +1,30 @@
+{
+  "description": "entity-collection-database-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-collection-database-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-collection-database-required.yml
@@ -1,0 +1,18 @@
+description: "entity-collection-database-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - collection:
+      id: &collection0 "collection0"
+      collectionName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-collection-database-type.json
+++ b/test/spec/unified-test-format/invalid/entity-collection-database-type.json
@@ -1,0 +1,31 @@
+{
+  "description": "entity-collection-database-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": 0,
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-collection-database-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-collection-database-type.yml
@@ -1,0 +1,19 @@
+description: "entity-collection-database-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - collection:
+      id: &collection0 "collection0"
+      database: 0
+      collectionName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-collection-id-required.json
+++ b/test/spec/unified-test-format/invalid/entity-collection-id-required.json
@@ -1,0 +1,30 @@
+{
+  "description": "entity-collection-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "database": "database0",
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-collection-id-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-collection-id-required.yml
@@ -1,0 +1,18 @@
+description: "entity-collection-id-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - collection:
+      database: *database0
+      collectionName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-collection-id-type.json
+++ b/test/spec/unified-test-format/invalid/entity-collection-id-type.json
@@ -1,0 +1,31 @@
+{
+  "description": "entity-collection-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    },
+    {
+      "collection": {
+        "id": 0,
+        "database": "database0",
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-collection-id-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-collection-id-type.yml
@@ -1,0 +1,19 @@
+description: "entity-collection-id-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+  - collection:
+      id: 0
+      database: *database0
+      collectionName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-database-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/entity-database-additionalProperties.json
@@ -1,0 +1,25 @@
+{
+  "description": "entity-database-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-database-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/entity-database-additionalProperties.yml
@@ -1,0 +1,16 @@
+description: "entity-database-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+      foo: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-database-client-required.json
+++ b/test/spec/unified-test-format/invalid/entity-database-client-required.json
@@ -1,0 +1,23 @@
+{
+  "description": "entity-database-client-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-database-client-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-database-client-required.yml
@@ -1,0 +1,14 @@
+description: "entity-database-client-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      databaseName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-database-client-type.json
+++ b/test/spec/unified-test-format/invalid/entity-database-client-type.json
@@ -1,0 +1,24 @@
+{
+  "description": "entity-database-client-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": 0,
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-database-client-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-database-client-type.yml
@@ -1,0 +1,15 @@
+description: "entity-database-client-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: 0
+      databaseName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-database-databaseName-required.json
+++ b/test/spec/unified-test-format/invalid/entity-database-databaseName-required.json
@@ -1,0 +1,23 @@
+{
+  "description": "entity-database-databaseName-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-database-databaseName-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-database-databaseName-required.yml
@@ -1,0 +1,14 @@
+description: "entity-database-databaseName-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-database-databaseName-type.json
+++ b/test/spec/unified-test-format/invalid/entity-database-databaseName-type.json
@@ -1,0 +1,24 @@
+{
+  "description": "entity-database-databaseName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-database-databaseName-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-database-databaseName-type.yml
@@ -1,0 +1,15 @@
+description: "entity-database-databaseName-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-database-databaseOptions-type.json
+++ b/test/spec/unified-test-format/invalid/entity-database-databaseOptions-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "entity-database-databaseOptions-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo",
+        "databaseOptions": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-database-databaseOptions-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-database-databaseOptions-type.yml
@@ -1,0 +1,16 @@
+description: "entity-database-databaseOptions-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+      databaseOptions: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-database-id-required.json
+++ b/test/spec/unified-test-format/invalid/entity-database-id-required.json
@@ -1,0 +1,23 @@
+{
+  "description": "entity-database-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-database-id-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-database-id-required.yml
@@ -1,0 +1,14 @@
+description: "entity-database-id-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      client: *client0
+      databaseName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-database-id-type.json
+++ b/test/spec/unified-test-format/invalid/entity-database-id-type.json
@@ -1,0 +1,24 @@
+{
+  "description": "entity-database-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": 0,
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-database-id-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-database-id-type.yml
@@ -1,0 +1,15 @@
+description: "entity-database-id-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - database:
+      id: 0
+      client: *client0
+      databaseName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-maxProperties.json
+++ b/test/spec/unified-test-format/invalid/entity-maxProperties.json
@@ -1,0 +1,22 @@
+{
+  "description": "entity-maxProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      },
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-maxProperties.yml
+++ b/test/spec/unified-test-format/invalid/entity-maxProperties.yml
@@ -1,0 +1,15 @@
+description: "entity-maxProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+    database:
+      id: &database0 "database0"
+      client: *client0
+      databaseName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-minProperties.json
+++ b/test/spec/unified-test-format/invalid/entity-minProperties.json
@@ -1,0 +1,13 @@
+{
+  "description": "entity-minProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {}
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-minProperties.yml
+++ b/test/spec/unified-test-format/invalid/entity-minProperties.yml
@@ -1,0 +1,10 @@
+description: "entity-minProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - {}
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-session-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/entity-session-additionalProperties.json
@@ -1,0 +1,24 @@
+{
+  "description": "entity-session-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-session-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/entity-session-additionalProperties.yml
@@ -1,0 +1,15 @@
+description: "entity-session-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - session:
+      id: &session0 "session0"
+      client: *client0
+      foo: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-session-client-required.json
+++ b/test/spec/unified-test-format/invalid/entity-session-client-required.json
@@ -1,0 +1,22 @@
+{
+  "description": "entity-session-client-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-session-client-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-session-client-required.yml
@@ -1,0 +1,13 @@
+description: "entity-session-client-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - session:
+      id: &session0 "session0"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-session-client-type.json
+++ b/test/spec/unified-test-format/invalid/entity-session-client-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "entity-session-client-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-session-client-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-session-client-type.yml
@@ -1,0 +1,14 @@
+description: "entity-session-client-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - session:
+      id: &session0 "session0"
+      client: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-session-id-required.json
+++ b/test/spec/unified-test-format/invalid/entity-session-id-required.json
@@ -1,0 +1,22 @@
+{
+  "description": "entity-session-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-session-id-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-session-id-required.yml
@@ -1,0 +1,13 @@
+description: "entity-session-id-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - session:
+      client: *client0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-session-id-type.json
+++ b/test/spec/unified-test-format/invalid/entity-session-id-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "entity-session-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": 0,
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-session-id-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-session-id-type.yml
@@ -1,0 +1,14 @@
+description: "entity-session-id-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - session:
+      id: 0
+      client: *client0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-session-sessionOptions-type.json
+++ b/test/spec/unified-test-format/invalid/entity-session-sessionOptions-type.json
@@ -1,0 +1,24 @@
+{
+  "description": "entity-session-sessionOptions-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0",
+        "sessionOptions": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-session-sessionOptions-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-session-sessionOptions-type.yml
@@ -1,0 +1,15 @@
+description: "entity-session-sessionOptions-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+  - session:
+      id: &session0 "session0"
+      client: *client0
+      sessionOptions: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-stream-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/entity-stream-additionalProperties.json
@@ -1,0 +1,19 @@
+{
+  "description": "entity-stream-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "id": "stream0",
+        "hexBytes": "FF",
+        "foo": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-stream-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/entity-stream-additionalProperties.yml
@@ -1,0 +1,13 @@
+description: "entity-stream-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - stream:
+      id: &stream0 "stream0"
+      hexBytes: "FF"
+      foo: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-stream-hexBytes-pattern.json
+++ b/test/spec/unified-test-format/invalid/entity-stream-hexBytes-pattern.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-stream-hexBytes-pattern",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "id": "stream0",
+        "hexBytes": "FFF"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-stream-hexBytes-pattern.yml
+++ b/test/spec/unified-test-format/invalid/entity-stream-hexBytes-pattern.yml
@@ -1,0 +1,12 @@
+description: "entity-stream-hexBytes-pattern"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - stream:
+      id: &stream0 "stream0"
+      hexBytes: "FFF"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-stream-hexBytes-required.json
+++ b/test/spec/unified-test-format/invalid/entity-stream-hexBytes-required.json
@@ -1,0 +1,17 @@
+{
+  "description": "entity-stream-hexBytes-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "id": "stream0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-stream-hexBytes-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-stream-hexBytes-required.yml
@@ -1,0 +1,11 @@
+description: "entity-stream-hexBytes-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - stream:
+      id: &stream0 "stream0"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-stream-hexBytes-type.json
+++ b/test/spec/unified-test-format/invalid/entity-stream-hexBytes-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-stream-hexBytes-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "id": "stream0",
+        "hexBytes": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-stream-hexBytes-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-stream-hexBytes-type.yml
@@ -1,0 +1,12 @@
+description: "entity-stream-hexBytes-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - stream:
+      id: &stream0 "stream0"
+      hexBytes: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-stream-id-required.json
+++ b/test/spec/unified-test-format/invalid/entity-stream-id-required.json
@@ -1,0 +1,17 @@
+{
+  "description": "entity-stream-id-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "hexBytes": "FF"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-stream-id-required.yml
+++ b/test/spec/unified-test-format/invalid/entity-stream-id-required.yml
@@ -1,0 +1,11 @@
+description: "entity-stream-id-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - stream:
+      hexBytes: "FF"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/entity-stream-id-type.json
+++ b/test/spec/unified-test-format/invalid/entity-stream-id-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-stream-id-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "stream": {
+        "id": 0,
+        "hexBytes": "FF"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/entity-stream-id-type.yml
+++ b/test/spec/unified-test-format/invalid/entity-stream-id-type.yml
@@ -1,0 +1,12 @@
+description: "entity-stream-id-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - stream:
+      id: 0
+      hexBytes: "FF"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/expectedError-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/expectedError-additionalProperties.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "foo": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-additionalProperties.yml
@@ -1,0 +1,15 @@
+description: "expectedError-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          foo: 0

--- a/test/spec/unified-test-format/invalid/expectedError-errorCode-type.json
+++ b/test/spec/unified-test-format/invalid/expectedError-errorCode-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorCode-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorCode": "foo"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-errorCode-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-errorCode-type.yml
@@ -1,0 +1,15 @@
+description: "expectedError-errorCode-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          errorCode: "foo"

--- a/test/spec/unified-test-format/invalid/expectedError-errorCodeName-type.json
+++ b/test/spec/unified-test-format/invalid/expectedError-errorCodeName-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorCodeName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorCodeName": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-errorCodeName-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-errorCodeName-type.yml
@@ -1,0 +1,15 @@
+description: "expectedError-errorCodeName-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          errorCodeName: 0

--- a/test/spec/unified-test-format/invalid/expectedError-errorContains-type.json
+++ b/test/spec/unified-test-format/invalid/expectedError-errorContains-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorContains-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorContains": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-errorContains-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-errorContains-type.yml
@@ -1,0 +1,15 @@
+description: "expectedError-errorContains-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          errorContains: 0

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-items.json
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-items.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedError-errorLabelsContain-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsContain": [
+              0
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-items.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-items.yml
@@ -1,0 +1,15 @@
+description: "expectedError-errorLabelsContain-items"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          errorLabelsContain: [0]

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-minItems.json
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-minItems.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorLabelsContain-minItems",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsContain": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-minItems.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-minItems.yml
@@ -1,0 +1,15 @@
+description: "expectedError-errorLabelsContain-minItems"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          errorLabelsContain: []

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-type.json
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorLabelsContain-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsContain": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsContain-type.yml
@@ -1,0 +1,15 @@
+description: "expectedError-errorLabelsContain-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          errorLabelsContain: 0

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-items.json
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-items.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedError-errorLabelsOmit-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsOmit": [
+              0
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-items.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-items.yml
@@ -1,0 +1,15 @@
+description: "expectedError-errorLabelsOmit-items"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          errorLabelsOmit: [0]

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-minItems.json
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-minItems.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorLabelsOmit-minItems",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsOmit": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-minItems.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-minItems.yml
@@ -1,0 +1,15 @@
+description: "expectedError-errorLabelsOmit-minItems"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          errorLabelsOmit: []

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-type.json
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-errorLabelsOmit-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "errorLabelsOmit": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-errorLabelsOmit-type.yml
@@ -1,0 +1,15 @@
+description: "expectedError-errorLabelsOmit-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          errorLabelsOmit: 0

--- a/test/spec/unified-test-format/invalid/expectedError-isClientError-type.json
+++ b/test/spec/unified-test-format/invalid/expectedError-isClientError-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-isClientError-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "isClientError": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-isClientError-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-isClientError-type.yml
@@ -1,0 +1,15 @@
+description: "expectedError-isClientError-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          isClientError: 0

--- a/test/spec/unified-test-format/invalid/expectedError-isError-const.json
+++ b/test/spec/unified-test-format/invalid/expectedError-isError-const.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-isError-const",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "isError": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-isError-const.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-isError-const.yml
@@ -1,0 +1,15 @@
+description: "expectedError-isError-const"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          isError: false

--- a/test/spec/unified-test-format/invalid/expectedError-isError-type.json
+++ b/test/spec/unified-test-format/invalid/expectedError-isError-type.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedError-isError-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "isError": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-isError-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-isError-type.yml
@@ -1,0 +1,15 @@
+description: "expectedError-isError-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          isError: 0

--- a/test/spec/unified-test-format/invalid/expectedError-minProperties.json
+++ b/test/spec/unified-test-format/invalid/expectedError-minProperties.json
@@ -1,0 +1,23 @@
+{
+  "description": "expectedError-minProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {}
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedError-minProperties.yml
+++ b/test/spec/unified-test-format/invalid/expectedError-minProperties.yml
@@ -1,0 +1,14 @@
+description: "expectedError-minProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError: {}

--- a/test/spec/unified-test-format/invalid/expectedEvent-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/expectedEvent-additionalProperties.json
@@ -1,0 +1,32 @@
+{
+  "description": "expectedEvent-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "foo": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEvent-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/expectedEvent-additionalProperties.yml
@@ -1,0 +1,17 @@
+description: "expectedEvent-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events:
+              - foo: 0

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandFailedEvent-commandName-type.json
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandFailedEvent-commandName-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandFailedEvent-commandName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandFailedEvent": {
+                    "commandName": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandFailedEvent-commandName-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandFailedEvent-commandName-type.yml
@@ -1,0 +1,18 @@
+description: "expectedEvent-commandFailedEvent-commandName-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events:
+              - commandFailedEvent:
+                  commandName: 0

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-additionalProperties.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandStartedEvent-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandStartedEvent": {
+                    "foo": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-additionalProperties.yml
@@ -1,0 +1,18 @@
+description: "expectedEvent-commandStartedEvent-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events:
+              - commandStartedEvent:
+                  foo: 0

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-command-type.json
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-command-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandStartedEvent-command-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandStartedEvent": {
+                    "command": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-command-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-command-type.yml
@@ -1,0 +1,18 @@
+description: "expectedEvent-commandStartedEvent-command-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events:
+              - commandStartedEvent:
+                  command: 0

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-commandName-type.json
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-commandName-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandStartedEvent-commandName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandStartedEvent": {
+                    "commandName": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-commandName-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-commandName-type.yml
@@ -1,0 +1,18 @@
+description: "expectedEvent-commandStartedEvent-commandName-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events:
+              - commandStartedEvent:
+                  commandName: 0

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-databaseName-type.json
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-databaseName-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandStartedEvent-databaseName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandStartedEvent": {
+                    "databaseName": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-databaseName-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandStartedEvent-databaseName-type.yml
@@ -1,0 +1,18 @@
+description: "expectedEvent-commandStartedEvent-databaseName-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events:
+              - commandStartedEvent:
+                  databaseName: 0

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandSucceededEvent-commandName-type.json
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandSucceededEvent-commandName-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandSucceededEvent-commandName-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandSucceededEvent": {
+                    "commandName": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandSucceededEvent-commandName-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandSucceededEvent-commandName-type.yml
@@ -1,0 +1,18 @@
+description: "expectedEvent-commandSucceededEvent-commandName-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events:
+              - commandSucceededEvent:
+                  commandName: 0

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandSucceededEvent-reply-type.json
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandSucceededEvent-reply-type.json
@@ -1,0 +1,34 @@
+{
+  "description": "expectedEvent-commandSucceededEvent-reply-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandSucceededEvent": {
+                    "reply": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEvent-commandSucceededEvent-reply-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedEvent-commandSucceededEvent-reply-type.yml
@@ -1,0 +1,18 @@
+description: "expectedEvent-commandSucceededEvent-reply-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events:
+              - commandSucceededEvent:
+                  reply: 0

--- a/test/spec/unified-test-format/invalid/expectedEvent-maxProperties.json
+++ b/test/spec/unified-test-format/invalid/expectedEvent-maxProperties.json
@@ -1,0 +1,33 @@
+{
+  "description": "expectedEvent-maxProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {
+                  "commandStartedEvent": {},
+                  "commandSucceededEvent": {}
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEvent-maxProperties.yml
+++ b/test/spec/unified-test-format/invalid/expectedEvent-maxProperties.yml
@@ -1,0 +1,18 @@
+description: "expectedEvent-maxProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events:
+              - commandStartedEvent: {}
+                commandSucceededEvent: {}

--- a/test/spec/unified-test-format/invalid/expectedEvent-minProperties.json
+++ b/test/spec/unified-test-format/invalid/expectedEvent-minProperties.json
@@ -1,0 +1,30 @@
+{
+  "description": "expectedEvent-minProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                {}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEvent-minProperties.yml
+++ b/test/spec/unified-test-format/invalid/expectedEvent-minProperties.yml
@@ -1,0 +1,17 @@
+description: "expectedEvent-minProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events:
+              - {}

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-additionalProperties.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedEventsForClient-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [],
+              "foo": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-additionalProperties.yml
@@ -1,0 +1,17 @@
+description: "expectedEventsForClient-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events: []
+            foo: 0

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-client-required.json
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-client-required.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedEventsForClient-client-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "events": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-client-required.yml
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-client-required.yml
@@ -1,0 +1,15 @@
+description: "expectedEventsForClient-client-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - events: []

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-client-type.json
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-client-type.json
@@ -1,0 +1,28 @@
+{
+  "description": "expectedEventsForClient-client-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": 0,
+              "events": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-client-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-client-type.yml
@@ -1,0 +1,16 @@
+description: "expectedEventsForClient-client-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: 0
+            events: []

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-events-items.json
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-events-items.json
@@ -1,0 +1,30 @@
+{
+  "description": "expectedEventsForClient-events-items",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": [
+                0
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-events-items.yml
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-events-items.yml
@@ -1,0 +1,16 @@
+description: "expectedEventsForClient-events-items"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events: [0]

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-events-required.json
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-events-required.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedEventsForClient-events-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-events-required.yml
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-events-required.yml
@@ -1,0 +1,15 @@
+description: "expectedEventsForClient-events-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-events-type.json
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-events-type.json
@@ -1,0 +1,28 @@
+{
+  "description": "expectedEventsForClient-events-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": [
+            {
+              "client": "client0",
+              "events": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedEventsForClient-events-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedEventsForClient-events-type.yml
@@ -1,0 +1,16 @@
+description: "expectedEventsForClient-events-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents:
+          - client: *client0
+            events: 0

--- a/test/spec/unified-test-format/invalid/initialData-items.json
+++ b/test/spec/unified-test-format/invalid/initialData-items.json
@@ -1,0 +1,13 @@
+{
+  "description": "initialData-items",
+  "schemaVersion": "1.0",
+  "initialData": [
+    0
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/initialData-items.yml
+++ b/test/spec/unified-test-format/invalid/initialData-items.yml
@@ -1,0 +1,9 @@
+description: "initialData-items"
+
+schemaVersion: "1.0"
+
+initialData: [0]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/initialData-minItems.json
+++ b/test/spec/unified-test-format/invalid/initialData-minItems.json
@@ -1,0 +1,11 @@
+{
+  "description": "initialData-minItems",
+  "schemaVersion": "1.0",
+  "initialData": [],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/initialData-minItems.yml
+++ b/test/spec/unified-test-format/invalid/initialData-minItems.yml
@@ -1,0 +1,9 @@
+description: "initialData-minItems"
+
+schemaVersion: "1.0"
+
+initialData: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/initialData-type.json
+++ b/test/spec/unified-test-format/invalid/initialData-type.json
@@ -1,0 +1,11 @@
+{
+  "description": "initialData-type",
+  "schemaVersion": "1.0",
+  "initialData": 0,
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/initialData-type.yml
+++ b/test/spec/unified-test-format/invalid/initialData-type.yml
@@ -1,0 +1,9 @@
+description: "initialData-type"
+
+schemaVersion: "1.0"
+
+initialData: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/operation-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/operation-additionalProperties.json
@@ -1,0 +1,23 @@
+{
+  "description": "operation-additionalProperties",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "foo": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/operation-additionalProperties.yml
@@ -1,0 +1,14 @@
+description: "operation-additionalProperties"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        foo: 0

--- a/test/spec/unified-test-format/invalid/operation-arguments-type.json
+++ b/test/spec/unified-test-format/invalid/operation-arguments-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "operation-arguments-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "arguments": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-arguments-type.yml
+++ b/test/spec/unified-test-format/invalid/operation-arguments-type.yml
@@ -1,0 +1,14 @@
+description: "operation-arguments-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        arguments: 0

--- a/test/spec/unified-test-format/invalid/operation-expectError-conflicts_with_expectResult.json
+++ b/test/spec/unified-test-format/invalid/operation-expectError-conflicts_with_expectResult.json
@@ -1,0 +1,26 @@
+{
+  "description": "operation-expectError-conflicts_with_expectResult",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "isError": true
+          },
+          "expectResult": {}
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-expectError-conflicts_with_expectResult.yml
+++ b/test/spec/unified-test-format/invalid/operation-expectError-conflicts_with_expectResult.yml
@@ -1,0 +1,16 @@
+description: "operation-expectError-conflicts_with_expectResult"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          isError: true
+        expectResult: {}

--- a/test/spec/unified-test-format/invalid/operation-expectError-conflicts_with_saveResultAsEntity.json
+++ b/test/spec/unified-test-format/invalid/operation-expectError-conflicts_with_saveResultAsEntity.json
@@ -1,0 +1,26 @@
+{
+  "description": "operation-expectError-conflicts_with_saveResultAsEntity",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": {
+            "isError": true
+          },
+          "saveResultAsEntity": "foo"
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-expectError-conflicts_with_saveResultAsEntity.yml
+++ b/test/spec/unified-test-format/invalid/operation-expectError-conflicts_with_saveResultAsEntity.yml
@@ -1,0 +1,16 @@
+description: "operation-expectError-conflicts_with_saveResultAsEntity"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError:
+          isError: true
+        saveResultAsEntity: "foo"

--- a/test/spec/unified-test-format/invalid/operation-expectError-type.json
+++ b/test/spec/unified-test-format/invalid/operation-expectError-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "operation-expectError-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectError": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-expectError-type.yml
+++ b/test/spec/unified-test-format/invalid/operation-expectError-type.yml
@@ -1,0 +1,14 @@
+description: "operation-expectError-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectError: 0

--- a/test/spec/unified-test-format/invalid/operation-expectEvents-type.json
+++ b/test/spec/unified-test-format/invalid/operation-expectEvents-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "operation-expectEvents-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "expectEvents": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-expectEvents-type.yml
+++ b/test/spec/unified-test-format/invalid/operation-expectEvents-type.yml
@@ -1,0 +1,14 @@
+description: "operation-expectEvents-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        expectEvents: 0

--- a/test/spec/unified-test-format/invalid/operation-name-required.json
+++ b/test/spec/unified-test-format/invalid/operation-name-required.json
@@ -1,0 +1,21 @@
+{
+  "description": "operation-name-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "object": "client0"
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-name-required.yml
+++ b/test/spec/unified-test-format/invalid/operation-name-required.yml
@@ -1,0 +1,12 @@
+description: "operation-name-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - object: *client0

--- a/test/spec/unified-test-format/invalid/operation-name-type.json
+++ b/test/spec/unified-test-format/invalid/operation-name-type.json
@@ -1,0 +1,22 @@
+{
+  "description": "operation-name-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": 0,
+          "object": "client0"
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-name-type.yml
+++ b/test/spec/unified-test-format/invalid/operation-name-type.yml
@@ -1,0 +1,13 @@
+description: "operation-name-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: 0
+        object: *client0

--- a/test/spec/unified-test-format/invalid/operation-object-required.json
+++ b/test/spec/unified-test-format/invalid/operation-object-required.json
@@ -1,0 +1,21 @@
+{
+  "description": "operation-object-required",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo"
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-object-required.yml
+++ b/test/spec/unified-test-format/invalid/operation-object-required.yml
@@ -1,0 +1,12 @@
+description: "operation-object-required"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"

--- a/test/spec/unified-test-format/invalid/operation-object-type.json
+++ b/test/spec/unified-test-format/invalid/operation-object-type.json
@@ -1,0 +1,22 @@
+{
+  "description": "operation-object-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-object-type.yml
+++ b/test/spec/unified-test-format/invalid/operation-object-type.yml
@@ -1,0 +1,13 @@
+description: "operation-object-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: 0

--- a/test/spec/unified-test-format/invalid/operation-saveResultAsEntity-type.json
+++ b/test/spec/unified-test-format/invalid/operation-saveResultAsEntity-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "operation-saveResultAsEntity-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [
+        {
+          "name": "foo",
+          "object": "client0",
+          "saveResultAsEntity": 0
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/operation-saveResultAsEntity-type.yml
+++ b/test/spec/unified-test-format/invalid/operation-saveResultAsEntity-type.yml
@@ -1,0 +1,14 @@
+description: "operation-saveResultAsEntity-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations:
+      - name: "foo"
+        object: *client0
+        saveResultAsEntity: 0

--- a/test/spec/unified-test-format/invalid/runOnRequirement-additionalProperties.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-additionalProperties.json
@@ -1,0 +1,16 @@
+{
+  "description": "runOnRequirement-additionalProperties",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "foo": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirement-additionalProperties.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-additionalProperties.yml
@@ -1,0 +1,11 @@
+description: "runOnRequirement-additionalProperties"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    foo: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirement-maxServerVersion-pattern.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-maxServerVersion-pattern.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-maxServerVersion-pattern",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "maxServerVersion": "1.2.3.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirement-maxServerVersion-pattern.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-maxServerVersion-pattern.yml
@@ -1,0 +1,10 @@
+description: "runOnRequirement-maxServerVersion-pattern"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - maxServerVersion: "1.2.3.4"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirement-maxServerVersion-type.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-maxServerVersion-type.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-maxServerVersion-type",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "maxServerVersion": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirement-maxServerVersion-type.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-maxServerVersion-type.yml
@@ -1,0 +1,10 @@
+description: "runOnRequirement-maxServerVersion-type"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - maxServerVersion: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirement-minProperties.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-minProperties.json
@@ -1,0 +1,13 @@
+{
+  "description": "runOnRequirement-minProperties",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {}
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirement-minProperties.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-minProperties.yml
@@ -1,0 +1,10 @@
+description: "runOnRequirement-minProperties"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - {}
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirement-minServerVersion-pattern.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-minServerVersion-pattern.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-minServerVersion-pattern",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "1.2.3.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirement-minServerVersion-pattern.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-minServerVersion-pattern.yml
@@ -1,0 +1,10 @@
+description: "runOnRequirement-minServerVersion-pattern"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "1.2.3.4"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirement-minServerVersion-type.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-minServerVersion-type.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-minServerVersion-type",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirement-minServerVersion-type.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-minServerVersion-type.yml
@@ -1,0 +1,10 @@
+description: "runOnRequirement-minServerVersion-type"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirement-topologies-enum.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-topologies-enum.json
@@ -1,0 +1,17 @@
+{
+  "description": "runOnRequirement-topologies-enum",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "foo"
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirement-topologies-enum.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-topologies-enum.yml
@@ -1,0 +1,10 @@
+description: "runOnRequirement-topologies-enum"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - topologies: ["foo"]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirement-topologies-items.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-topologies-items.json
@@ -1,0 +1,17 @@
+{
+  "description": "runOnRequirement-topologies-items",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        0
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirement-topologies-items.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-topologies-items.yml
@@ -1,0 +1,10 @@
+description: "runOnRequirement-topologies-items"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - topologies: [0]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirement-topologies-minItems.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-topologies-minItems.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-topologies-minItems",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "topologies": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirement-topologies-minItems.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-topologies-minItems.yml
@@ -1,0 +1,10 @@
+description: "runOnRequirement-topologies-minItems"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - topologies: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirement-topologies-type.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-topologies-type.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-topologies-type",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "topologies": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirement-topologies-type.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirement-topologies-type.yml
@@ -1,0 +1,10 @@
+description: "runOnRequirement-topologies-type"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - topologies: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirements-items.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirements-items.json
@@ -1,0 +1,13 @@
+{
+  "description": "runOnRequirements-items",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    0
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirements-items.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirements-items.yml
@@ -1,0 +1,9 @@
+description: "runOnRequirements-items"
+
+schemaVersion: "1.0"
+
+runOnRequirements: [0]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirements-minItems.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirements-minItems.json
@@ -1,0 +1,11 @@
+{
+  "description": "runOnRequirements-minItems",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirements-minItems.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirements-minItems.yml
@@ -1,0 +1,9 @@
+description: "runOnRequirements-minItems"
+
+schemaVersion: "1.0"
+
+runOnRequirements: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/runOnRequirements-type.json
+++ b/test/spec/unified-test-format/invalid/runOnRequirements-type.json
@@ -1,0 +1,11 @@
+{
+  "description": "runOnRequirements-type",
+  "schemaVersion": "1.0",
+  "runOnRequirements": 0,
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/runOnRequirements-type.yml
+++ b/test/spec/unified-test-format/invalid/runOnRequirements-type.yml
@@ -1,0 +1,9 @@
+description: "runOnRequirements-type"
+
+schemaVersion: "1.0"
+
+runOnRequirements: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/schemaVersion-pattern.json
+++ b/test/spec/unified-test-format/invalid/schemaVersion-pattern.json
@@ -1,0 +1,10 @@
+{
+  "description": "schemaVersion-pattern",
+  "schemaVersion": "1.2.3.4",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/schemaVersion-pattern.yml
+++ b/test/spec/unified-test-format/invalid/schemaVersion-pattern.yml
@@ -1,0 +1,7 @@
+description: "schemaVersion-pattern"
+
+schemaVersion: "1.2.3.4"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/schemaVersion-required.json
+++ b/test/spec/unified-test-format/invalid/schemaVersion-required.json
@@ -1,0 +1,9 @@
+{
+  "description": "schemaVersion-required",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/schemaVersion-required.yml
+++ b/test/spec/unified-test-format/invalid/schemaVersion-required.yml
@@ -1,0 +1,5 @@
+description: "schemaVersion-required"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/invalid/schemaVersion-type.json
+++ b/test/spec/unified-test-format/invalid/schemaVersion-type.json
@@ -1,0 +1,10 @@
+{
+  "description": "schemaVersion-type",
+  "schemaVersion": 0,
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/schemaVersion-type.yml
+++ b/test/spec/unified-test-format/invalid/schemaVersion-type.yml
@@ -1,0 +1,7 @@
+description: "schemaVersion-type"
+
+schemaVersion: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/valid-fail/entity-bucket-database-undefined.json
+++ b/test/spec/unified-test-format/valid-fail/entity-bucket-database-undefined.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-bucket-database-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-fail/entity-bucket-database-undefined.yml
+++ b/test/spec/unified-test-format/valid-fail/entity-bucket-database-undefined.yml
@@ -1,0 +1,12 @@
+description: "entity-bucket-database-undefined"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - bucket:
+      id: &bucket0 "bucket0"
+      database: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/valid-fail/entity-client-apiVersion-unsupported.json
+++ b/test/spec/unified-test-format/valid-fail/entity-client-apiVersion-unsupported.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-apiVersion-unsupported",
+  "schemaVersion": "1.1",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "serverApi": {
+          "version": "server_will_never_support_this_api_version"
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-fail/entity-client-apiVersion-unsupported.yml
+++ b/test/spec/unified-test-format/valid-fail/entity-client-apiVersion-unsupported.yml
@@ -1,0 +1,13 @@
+description: "entity-client-apiVersion-unsupported"
+
+schemaVersion: "1.1"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      serverApi:
+        version: "server_will_never_support_this_api_version"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/valid-fail/entity-collection-database-undefined.json
+++ b/test/spec/unified-test-format/valid-fail/entity-collection-database-undefined.json
@@ -1,0 +1,19 @@
+{
+  "description": "entity-collection-database-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "foo",
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-fail/entity-collection-database-undefined.yml
+++ b/test/spec/unified-test-format/valid-fail/entity-collection-database-undefined.yml
@@ -1,0 +1,13 @@
+description: "entity-collection-database-undefined"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - collection:
+      id: &collection0 "collection0"
+      database: "foo"
+      collectionName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/valid-fail/entity-database-client-undefined.json
+++ b/test/spec/unified-test-format/valid-fail/entity-database-client-undefined.json
@@ -1,0 +1,19 @@
+{
+  "description": "entity-database-client-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "database": {
+        "id": "database0",
+        "client": "foo",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-fail/entity-database-client-undefined.yml
+++ b/test/spec/unified-test-format/valid-fail/entity-database-client-undefined.yml
@@ -1,0 +1,13 @@
+description: "entity-database-client-undefined"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - database:
+      id: &database0 "database0"
+      client: "foo"
+      databaseName: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/valid-fail/entity-session-client-undefined.json
+++ b/test/spec/unified-test-format/valid-fail/entity-session-client-undefined.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-session-client-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "session": {
+        "id": "session0",
+        "client": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-fail/entity-session-client-undefined.yml
+++ b/test/spec/unified-test-format/valid-fail/entity-session-client-undefined.yml
@@ -1,0 +1,12 @@
+description: "entity-session-client-undefined"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - session:
+      id: &session0 "session0"
+      client: "foo"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/valid-fail/returnDocument-enum-invalid.json
+++ b/test/spec/unified-test-format/valid-fail/returnDocument-enum-invalid.json
@@ -1,0 +1,66 @@
+{
+  "description": "returnDocument-enum-invalid",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "FindOneAndReplace returnDocument invalid enum value",
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "x": 111
+            },
+            "returnDocument": "invalid"
+          }
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndUpdate returnDocument invalid enum value",
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "invalid"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-fail/returnDocument-enum-invalid.yml
+++ b/test/spec/unified-test-format/valid-fail/returnDocument-enum-invalid.yml
@@ -1,0 +1,34 @@
+description: "returnDocument-enum-invalid"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+
+tests:
+  - description: "FindOneAndReplace returnDocument invalid enum value"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: { _id: 1, x: 111 }
+          returnDocument: invalid
+
+  - description: "FindOneAndUpdate returnDocument invalid enum value"
+    operations:
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $inc: { x : 1 }}
+          returnDocument: invalid

--- a/test/spec/unified-test-format/valid-fail/schemaVersion-unsupported.json
+++ b/test/spec/unified-test-format/valid-fail/schemaVersion-unsupported.json
@@ -1,0 +1,10 @@
+{
+  "description": "schemaVersion-unsupported",
+  "schemaVersion": "0.1",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-fail/schemaVersion-unsupported.yml
+++ b/test/spec/unified-test-format/valid-fail/schemaVersion-unsupported.yml
@@ -1,0 +1,7 @@
+description: "schemaVersion-unsupported"
+
+schemaVersion: "0.1"
+
+tests:
+  - description: "foo"
+    operations: []

--- a/test/spec/unified-test-format/valid-pass/poc-change-streams.json
+++ b/test/spec/unified-test-format/valid-pass/poc-change-streams.json
@@ -1,0 +1,414 @@
+{
+  "description": "poc-change-streams",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "getMore",
+          "killCursors"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database2",
+        "client": "client1",
+        "databaseName": "change-stream-tests-2"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection2",
+        "database": "database1",
+        "collectionName": "test2"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection3",
+        "database": "database2",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests",
+      "documents": []
+    },
+    {
+      "collectionName": "test2",
+      "databaseName": "change-stream-tests",
+      "documents": []
+    },
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests-2",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Executing a watch helper on a MongoClient results in notifications for changes to all collections in all databases in the cluster.",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.8.0",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "client0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection2",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection3",
+          "arguments": {
+            "document": {
+              "y": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "z": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test2"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests-2",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "y": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "z": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "cursor": {},
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "allChangesForCluster": true,
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test consecutive resume",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "getMore"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "batchSize": 1,
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "x": 2
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "x": 3
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 2
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "x": 3
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "cursor": {
+                    "batchSize": 1
+                  },
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "change-stream-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "cursor": {
+                    "batchSize": 1
+                  },
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        },
+                        "resumeAfter": {
+                          "$$exists": true
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "change-stream-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "cursor": {
+                    "batchSize": 1
+                  },
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": {
+                          "$$unsetOrMatches": "default"
+                        },
+                        "resumeAfter": {
+                          "$$exists": true
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "aggregate",
+                "databaseName": "change-stream-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/poc-change-streams.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-change-streams.yml
@@ -1,0 +1,220 @@
+description: "poc-change-streams"
+
+schemaVersion: "1.0"
+
+createEntities:
+  # Entities for creating changeStreams
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+      # Original tests do not observe getMore commands but only because event
+      # assertions ignore extra events. killCursors is explicitly ignored.
+      ignoreCommandMonitoringEvents: [ getMore, killCursors ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name change-stream-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  # Entities for executing insert operations
+  - client:
+      id: &client1 client1
+      useMultipleMongoses: false
+  - database:
+      id: &database1 database1
+      client: *client1
+      databaseName: &database1Name change-stream-tests
+  - database:
+      id: &database2 database2
+      client: *client1
+      databaseName: &database2Name change-stream-tests-2
+  - collection:
+      id: &collection1 collection1
+      database: *database1
+      collectionName: &collection1Name test
+  - collection:
+      id: &collection2 collection2
+      database: *database1
+      collectionName: &collection2Name test2
+  - collection:
+      id: &collection3 collection3
+      database: *database2
+      collectionName: &collection3Name test
+
+initialData:
+  - collectionName: *collection1Name
+    databaseName: *database1Name
+    documents: []
+  - collectionName: *collection2Name
+    databaseName: *database1Name
+    documents: []
+  - collectionName: *collection3Name
+    databaseName: *database2Name
+    documents: []
+
+tests:
+  - description: "Executing a watch helper on a MongoClient results in notifications for changes to all collections in all databases in the cluster."
+    runOnRequirements:
+      - minServerVersion: "3.8.0"
+        topologies: [ replicaset ]
+    operations:
+      - name: createChangeStream
+        object: *client0
+        arguments:
+          pipeline: []
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection2
+        arguments:
+          document: { x: 1 }
+      - name: insertOne
+        object: *collection3
+        arguments:
+          document: { y: 1 }
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: { z: 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1Name
+            coll: *collection2Name
+          fullDocument:
+            _id: { $$type: objectId }
+            x: 1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database2Name
+            coll: *collection3Name
+          fullDocument:
+            # Original tests did not include _id, but matching now only permits
+            # extra keys for root-level documents.
+            _id: { $$type: objectId }
+            y: 1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1Name
+            coll: *collection1Name
+          fullDocument:
+            _id: { $$type: objectId }
+            z: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: 1
+                cursor: {}
+                pipeline:
+                  - $changeStream:
+                      allChangesForCluster: true
+                      # Some drivers may send a default value for fullDocument
+                      # or omit it entirely (see: SPEC-1350).
+                      fullDocument: { $$unsetOrMatches: default }
+              commandName: aggregate
+              databaseName: admin
+
+  - description: "Test consecutive resume"
+    runOnRequirements:
+      - minServerVersion: "4.1.7"
+        topologies: [ replicaset ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+              failCommands: [ getMore ]
+              closeConnection: true
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          batchSize: 1
+          pipeline: []
+        saveResultAsEntity: *changeStream0
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: { x: 1 }
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: { x: 2 }
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: { x: 3 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1Name
+            coll: *collection1Name
+          fullDocument:
+            _id: { $$type: objectId }
+            x: 1
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1Name
+            coll: *collection1Name
+          fullDocument:
+            _id: { $$type: objectId }
+            x: 2
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: insert
+          ns:
+            db: *database1Name
+            coll: *collection1Name
+          fullDocument:
+            _id: { $$type: objectId }
+            x: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection1Name
+                cursor: { batchSize: 1 }
+                pipeline:
+                  - $changeStream:
+                      fullDocument: { $$unsetOrMatches: default }
+              commandName: aggregate
+              databaseName: *database1Name
+          # The original test only asserted the first command, since expected
+          # events were only an ordered subset. This file does ignore getMore
+          # commands but we must expect the subsequent aggregate commands, since
+          # each failed getMore will resume. While doing so we can also assert
+          # that those commands include a resume token.
+          - &resumingAggregate
+            commandStartedEvent:
+              command:
+                aggregate: *collection1Name
+                cursor: { batchSize: 1 }
+                pipeline:
+                  - $changeStream:
+                      fullDocument: { $$unsetOrMatches: default }
+                      resumeAfter: { $$exists: true }
+              commandName: aggregate
+              databaseName: *database0Name
+          - *resumingAggregate

--- a/test/spec/unified-test-format/valid-pass/poc-command-monitoring.json
+++ b/test/spec/unified-test-format/valid-pass/poc-command-monitoring.json
@@ -1,0 +1,222 @@
+{
+  "description": "poc-command-monitoring",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "command-monitoring-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "command-monitoring-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        },
+        {
+          "_id": 4,
+          "x": 44
+        },
+        {
+          "_id": 5,
+          "x": 55
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "A successful find event with a getmore and the server kills the cursor",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.1",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gte": 1
+              }
+            },
+            "sort": {
+              "_id": 1
+            },
+            "batchSize": 3,
+            "limit": 4
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": {
+                      "$gte": 1
+                    }
+                  },
+                  "sort": {
+                    "_id": 1
+                  },
+                  "batchSize": 3,
+                  "limit": 4
+                },
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "cursor": {
+                    "id": {
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
+                    },
+                    "ns": "command-monitoring-tests.test",
+                    "firstBatch": [
+                      {
+                        "_id": 1,
+                        "x": 11
+                      },
+                      {
+                        "_id": 2,
+                        "x": 22
+                      },
+                      {
+                        "_id": 3,
+                        "x": 33
+                      }
+                    ]
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "test",
+                  "batchSize": 1
+                },
+                "commandName": "getMore",
+                "databaseName": "command-monitoring-tests"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "cursor": {
+                    "id": 0,
+                    "ns": "command-monitoring-tests.test",
+                    "nextBatch": [
+                      {
+                        "_id": 4,
+                        "x": 44
+                      }
+                    ]
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A failed find event",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "$or": true
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/poc-command-monitoring.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-command-monitoring.yml
@@ -1,0 +1,101 @@
+description: "poc-command-monitoring"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+        - commandFailedEvent
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name command-monitoring-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+      - { _id: 4, x: 44 }
+      - { _id: 5, x: 55 }
+
+tests:
+  - description: "A successful find event with a getmore and the server kills the cursor"
+    runOnRequirements:
+      - minServerVersion: "3.1"
+        topologies: [ single, replicaset ]
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id: { $gte: 1 }}
+          sort: { _id: 1 }
+          batchSize: 3
+          limit: 4
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: { $gte : 1 } }
+                sort: { _id: 1 }
+                batchSize: 3
+                limit: 4
+              commandName: find
+              databaseName: *database0Name
+          - commandSucceededEvent:
+              reply:
+                ok: 1
+                cursor:
+                  id: { $$type: [ int, long ] }
+                  ns: &namespace command-monitoring-tests.test
+                  firstBatch:
+                    - { _id: 1, x: 11 }
+                    - { _id: 2, x: 22 }
+                    - { _id: 3, x: 33 }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+                batchSize: 1
+              commandName: getMore
+              databaseName: *database0Name
+          - commandSucceededEvent:
+              reply:
+                ok: 1
+                cursor:
+                  id: 0
+                  ns: *namespace
+                  nextBatch:
+                    - { _id: 4, x: 44 }
+              commandName: getMore
+
+  - description: "A failed find event"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { $or: true }
+        expectError: { isError: true }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { $or: true }
+              commandName: find
+              databaseName: *database0Name
+          - commandFailedEvent:
+              commandName: find

--- a/test/spec/unified-test-format/valid-pass/poc-crud.json
+++ b/test/spec/unified-test-format/valid-pass/poc-crud.json
@@ -1,0 +1,446 @@
+{
+  "description": "poc-crud",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client0",
+        "databaseName": "admin"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection2",
+        "database": "database0",
+        "collectionName": "coll2",
+        "collectionOptions": {
+          "readConcern": {
+            "level": "majority"
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        }
+      ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    },
+    {
+      "collectionName": "coll2",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    },
+    {
+      "collectionName": "aggregate_out",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite with mixed ordered operations",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 3,
+                    "x": 33
+                  }
+                }
+              },
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 2
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  }
+                }
+              },
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 4,
+                    "x": 44
+                  }
+                }
+              },
+              {
+                "deleteMany": {
+                  "filter": {
+                    "x": {
+                      "$nin": [
+                        24,
+                        34
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 4
+                  },
+                  "replacement": {
+                    "_id": 4,
+                    "x": 44
+                  },
+                  "upsert": true
+                }
+              }
+            ],
+            "ordered": true
+          },
+          "expectResult": {
+            "deletedCount": 2,
+            "insertedCount": 2,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 3,
+                "3": 4
+              }
+            },
+            "matchedCount": 3,
+            "modifiedCount": 3,
+            "upsertedCount": 1,
+            "upsertedIds": {
+              "5": 4
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 24
+            },
+            {
+              "_id": 3,
+              "x": 34
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertMany continue-on-error behavior with unordered (duplicate key in requests)",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection1",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 2,
+                "x": 22
+              },
+              {
+                "_id": 2,
+                "x": 22
+              },
+              {
+                "_id": 3,
+                "x": 33
+              }
+            ],
+            "ordered": false
+          },
+          "expectError": {
+            "expectResult": {
+              "deletedCount": 0,
+              "insertedCount": 2,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {}
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "ReplaceOne prohibits atomic modifiers",
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection1",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "$set": {
+                "x": 22
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "readConcern majority with out stage",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.1.0",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection2",
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "aggregate_out"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll2",
+                  "pipeline": [
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$out": "aggregate_out"
+                    }
+                  ],
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "aggregate_out",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $listLocalSessions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "database1",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "dummy": "dummy field"
+                }
+              },
+              {
+                "$project": {
+                  "_id": 0,
+                  "dummy": 1
+                }
+              }
+            ]
+          },
+          "expectResult": [
+            {
+              "dummy": "dummy field"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/poc-crud.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-crud.yml
@@ -1,0 +1,183 @@
+description: "poc-crud"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - database:
+      id: &database1 database1
+      client: *client0
+      databaseName: &database1Name admin
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+  - collection:
+      id: &collection1 collection1
+      database: *database0
+      collectionName: &collection1Name coll1
+  - collection:
+      id: &collection2 collection2
+      database: *database0
+      collectionName: &collection2Name coll2
+      collectionOptions:
+        readConcern: { level: majority }
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+  - collectionName: *collection1Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+  - collectionName: *collection2Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+  - collectionName: &out aggregate_out
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "BulkWrite with mixed ordered operations"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - insertOne:
+                document: { _id: 3, x: 33 }
+            - updateOne:
+                filter: { _id: 2 }
+                update: { $inc: { x: 1 } }
+            - updateMany:
+                filter: { _id: { $gt: 1 } }
+                update: { $inc: { x: 1 } }
+            - insertOne:
+                document: { _id: 4, x: 44 }
+            - deleteMany:
+                filter: { x: { $nin: [ 24, 34 ] } }
+            - replaceOne:
+                filter: { _id: 4 }
+                replacement: { _id: 4, x: 44 }
+                upsert: true
+          ordered: true
+        expectResult:
+          deletedCount: 2
+          insertedCount: 2
+          insertedIds: { $$unsetOrMatches: { 0: 3, 3: 4 } }
+          matchedCount: 3
+          modifiedCount: 3
+          upsertedCount: 1
+          upsertedIds: { 5: 4 }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - {_id: 2, x: 24 }
+          - {_id: 3, x: 34 }
+          - {_id: 4, x: 44 }
+
+  - description: "InsertMany continue-on-error behavior with unordered (duplicate key in requests)"
+    operations:
+      - name: insertMany
+        object: *collection1
+        arguments:
+          documents:
+            - { _id: 2, x: 22 }
+            - { _id: 2, x: 22 }
+            - { _id: 3, x: 33 }
+          ordered: false
+        expectError:
+          expectResult:
+            deletedCount: 0
+            insertedCount: 2
+            # Since the map of insertedIds is generated before execution it
+            # could indicate inserts that did not actually succeed. We omit
+            # this field rather than expect drivers to provide an accurate
+            # map filtered by write errors.
+            matchedCount: 0
+            modifiedCount: 0
+            upsertedCount: 0
+            upsertedIds: { }
+    outcome:
+      - collectionName: *collection1Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+
+  - description: "ReplaceOne prohibits atomic modifiers"
+    operations:
+      - name: replaceOne
+        object: *collection1
+        arguments:
+          filter: { _id: 1 }
+          replacement: { $set: { x: 22 }}
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *client0
+        events: []
+    outcome:
+      - collectionName: *collection1Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+
+  - description: "readConcern majority with out stage"
+    runOnRequirements:
+      - minServerVersion: "4.1.0"
+        topologies: [ replicaset, sharded-replicaset ]
+    operations:
+      - name: aggregate
+        object: *collection2
+        arguments:
+          pipeline: &pipeline
+            - $sort: { x : 1 }
+            - $match: { _id: { $gt: 1 } }
+            - $out: *out
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection2Name
+                pipeline: *pipeline
+                readConcern: { level: majority }
+              # The following two assertions were not in the original test
+              commandName: aggregate
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *out
+        databaseName: *database0Name
+        documents:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+
+  - description: "Aggregate with $listLocalSessions"
+    runOnRequirements:
+      - minServerVersion: "3.6.0"
+    operations:
+      - name: aggregate
+        object: *database1
+        arguments:
+          pipeline:
+            - $listLocalSessions: { }
+            - $limit: 1
+            - $addFields: { dummy: "dummy field"}
+            - $project: { _id: 0, dummy: 1}
+        expectResult:
+          - { dummy: "dummy field" }

--- a/test/spec/unified-test-format/valid-pass/poc-gridfs.json
+++ b/test/spec/unified-test-format/valid-pass/poc-gridfs.json
@@ -1,0 +1,301 @@
+{
+  "description": "poc-gridfs",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "gridfs-tests"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_files_collection",
+        "database": "database0",
+        "collectionName": "fs.files"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_chunks_collection",
+        "database": "database0",
+        "collectionName": "fs.chunks"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "fs.files",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "length": 10,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "md5": "57d83cd477bfb1ccd975ab33d827a92b",
+          "filename": "length-10",
+          "contentType": "application/octet-stream",
+          "aliases": [],
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "collectionName": "fs.chunks",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "ESIzRA==",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000006"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "n": 1,
+          "data": {
+            "$binary": {
+              "base64": "VWZ3iA==",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000007"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000005"
+          },
+          "n": 2,
+          "data": {
+            "$binary": {
+              "base64": "mao=",
+              "subType": "00"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Delete when length is 10",
+      "operations": [
+        {
+          "name": "delete",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000005"
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "fs.files",
+          "databaseName": "gridfs-tests",
+          "documents": []
+        },
+        {
+          "collectionName": "fs.chunks",
+          "databaseName": "gridfs-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Download when there are three chunks",
+      "operations": [
+        {
+          "name": "download",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000005"
+            }
+          },
+          "expectResult": {
+            "$$matchesHexBytes": "112233445566778899aa"
+          }
+        }
+      ]
+    },
+    {
+      "description": "Download when files entry does not exist",
+      "operations": [
+        {
+          "name": "download",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000000"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "Download when an intermediate chunk is missing",
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "bucket0_chunks_collection",
+          "arguments": {
+            "filter": {
+              "files_id": {
+                "$oid": "000000000000000000000005"
+              },
+              "n": 1
+            }
+          },
+          "expectResult": {
+            "deletedCount": 1
+          }
+        },
+        {
+          "name": "download",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000005"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "Upload when length is 5",
+      "operations": [
+        {
+          "name": "upload",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "filename",
+            "source": {
+              "$$hexBytes": "1122334455"
+            },
+            "chunkSizeBytes": 4
+          },
+          "expectResult": {
+            "$$type": "objectId"
+          },
+          "saveResultAsEntity": "oid0"
+        },
+        {
+          "name": "find",
+          "object": "bucket0_files_collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "uploadDate": -1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": {
+                "$$matchesEntity": "oid0"
+              },
+              "length": 5,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$$type": "date"
+              },
+              "md5": {
+                "$$unsetOrMatches": "283d4fea5dded59cf837d3047328f5af"
+              },
+              "filename": "filename"
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "bucket0_chunks_collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": {
+                  "$oid": "000000000000000000000007"
+                }
+              }
+            },
+            "sort": {
+              "n": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "files_id": {
+                "$$matchesEntity": "oid0"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "ESIzRA==",
+                  "subType": "00"
+                }
+              }
+            },
+            {
+              "_id": {
+                "$$type": "objectId"
+              },
+              "files_id": {
+                "$$matchesEntity": "oid0"
+              },
+              "n": 1,
+              "data": {
+                "$binary": {
+                  "base64": "VQ==",
+                  "subType": "00"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/poc-gridfs.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-gridfs.yml
@@ -1,0 +1,155 @@
+description: "poc-gridfs"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name gridfs-tests
+  - bucket:
+      id: &bucket0 bucket0
+      database: *database0
+  - collection:
+      id: &bucket0_files_collection bucket0_files_collection
+      database: *database0
+      collectionName: &bucket0_files_collectionName fs.files
+  - collection:
+      id: &bucket0_chunks_collection bucket0_chunks_collection
+      database: *database0
+      collectionName: &bucket0_chunks_collectionName fs.chunks
+
+initialData:
+  - collectionName: *bucket0_files_collectionName
+    databaseName: *database0Name
+    documents:
+      - _id: { $oid: "000000000000000000000005" }
+        length: 10
+        chunkSize: 4
+        uploadDate: { $date: "1970-01-01T00:00:00.000Z" }
+        md5: "57d83cd477bfb1ccd975ab33d827a92b"
+        filename: "length-10"
+        contentType: "application/octet-stream"
+        aliases: []
+        metadata: {}
+  - collectionName: *bucket0_chunks_collectionName
+    databaseName: *database0Name
+    documents:
+      - _id: { $oid: "000000000000000000000005" }
+        files_id: { $oid: "000000000000000000000005" }
+        n: 0
+        data: { $binary: { base64: "ESIzRA==", subType: "00" } } # hex: 11223344
+      - _id: { $oid: "000000000000000000000006" }
+        files_id: { $oid: "000000000000000000000005" }
+        n: 1
+        data: { $binary: { base64: "VWZ3iA==", subType: "00" } } # hex: 55667788
+      - _id: { $oid: "000000000000000000000007" }
+        files_id: { $oid: "000000000000000000000005" }
+        n: 2
+        data: { $binary: { base64: "mao=", subType: "00" } } # hex: 99aa
+
+tests:
+  # Changed from original test ("length is 8") to operate on same initialData
+  - description: "Delete when length is 10"
+    operations:
+      - name: delete
+        object: *bucket0
+        arguments:
+          id: { $oid: "000000000000000000000005" }
+    # Original test uses "assert.data" syntax to modify outcome collection for
+    # comparison. This can be accomplished using "outcome" directly.
+    outcome:
+      - collectionName: *bucket0_files_collectionName
+        databaseName: *database0Name
+        documents: []
+      - collectionName: *bucket0_chunks_collectionName
+        databaseName: *database0Name
+        documents: []
+
+  - description: "Download when there are three chunks"
+    operations:
+      # Original test uses "download" operation. We use an explicit operation
+      # that returns a stream and then assert the contents of that stream.
+      - name: download
+        object: *bucket0
+        arguments:
+          id: { $oid: "000000000000000000000005" }
+        expectResult: { $$matchesHexBytes: "112233445566778899aa" }
+
+  - description: "Download when files entry does not exist"
+    operations:
+      - name: download
+        object: *bucket0
+        arguments:
+          id: { $oid: "000000000000000000000000" }
+        # Original test expects "FileNotFound" error, which isn't specified
+        expectError: { isError: true }
+
+  - description: "Download when an intermediate chunk is missing"
+    operations:
+      # Original test uses "arrange" syntax to modify initialData. This can be
+      # accomplished as a delete operation on the chunks collection.
+      - name: deleteOne
+        object: *bucket0_chunks_collection
+        arguments:
+          filter:
+            files_id: { $oid: "000000000000000000000005" }
+            n: 1
+        expectResult:
+          deletedCount: 1
+      - name: download
+        object: *bucket0
+        arguments:
+          id: { $oid: "000000000000000000000005" }
+        # Original test expects "ChunkIsMissing" error, which isn't specified
+        expectError: { isError: true }
+
+  - description: "Upload when length is 5"
+    operations:
+      # Original test uses "upload" operation. We use an explicit operation
+      # that takes a stream, which has been created from the expected hex bytes.
+      - name: upload
+        object: *bucket0
+        arguments:
+          filename: filename
+          source: { $$hexBytes: "1122334455" }
+          chunkSizeBytes: 4
+        # Original test references the result directly in "assert.data". Here,
+        # we need to save the result as an entity, which we can later reference.
+        expectResult: { $$type: objectId }
+        saveResultAsEntity: &oid0 oid0
+      # "outcome" does not allow operators, but we can perform the assertions
+      # with separate find operations.
+      - name: find
+        object: *bucket0_files_collection
+        arguments:
+          filter: {}
+          sort: { uploadDate: -1 }
+          limit: 1
+        expectResult:
+          - _id: { $$matchesEntity: *oid0 }
+            length: 5
+            chunkSize: 4
+            uploadDate: { $$type: date }
+            # The md5 field is deprecated so some drivers do not calculate it when uploading files.
+            md5: { $$unsetOrMatches: "283d4fea5dded59cf837d3047328f5af" }
+            filename: filename
+      - name: find
+        object: *bucket0_chunks_collection
+        arguments:
+          # We cannot use the saved ObjectId when querying, but filtering by a
+          # non-zero timestamp will exclude initialData and sort can return the
+          # expected chunks in order.
+          filter: { _id: { $gt: { $oid: "000000000000000000000007" } } }
+          sort: { n: 1 }
+        expectResult:
+          - _id: { $$type: objectId }
+            files_id: { $$matchesEntity: *oid0 }
+            n: 0
+            data: { $binary: { base64: "ESIzRA==", subType: "00" } } # hex 11223344
+          - _id: { $$type: objectId }
+            files_id: { $$matchesEntity: *oid0 }
+            n: 1
+            data: { $binary: { base64: "VQ==", subType: "00" } } # hex 55

--- a/test/spec/unified-test-format/valid-pass/poc-retryable-reads.json
+++ b/test/spec/unified-test-format/valid-pass/poc-retryable-reads.json
@@ -1,0 +1,433 @@
+{
+  "description": "poc-retryable-reads",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "uriOptions": {
+          "retryReads": false
+        },
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-reads-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "retryable-reads-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "retryable-reads-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate succeeds after InterruptedAtShutdown",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "aggregate"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              }
+            ]
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Find succeeds on second attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 2
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "sort": {
+                    "_id": 1
+                  },
+                  "limit": 2
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "sort": {
+                    "_id": 1
+                  },
+                  "limit": 2
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Find fails on first attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection1",
+          "arguments": {
+            "filter": {}
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client1",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {}
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Find fails on second attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {}
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {}
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {}
+                },
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "ListDatabases succeeds on second attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "listDatabases"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "listDatabases",
+          "object": "client0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listDatabases": 1
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listDatabases": 1
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/poc-retryable-reads.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-retryable-reads.yml
@@ -1,0 +1,193 @@
+description: "poc-retryable-reads"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: [ single, replicaset ]
+  - minServerVersion: "4.1.7"
+    topologies: [ sharded ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - client:
+      id: &client1 client1
+      uriOptions: { retryReads: false }
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName retryable-reads-tests
+  - database:
+      id: &database1 database1
+      client: *client1
+      databaseName: *databaseName
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+  - collection:
+      id: &collection1 collection1
+      database: *database1
+      collectionName: *collectionName
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - {_id: 1, x: 11}
+      - {_id: 2, x: 22}
+      - {_id: 3, x: 33}
+
+tests:
+  - description: "Aggregate succeeds after InterruptedAtShutdown"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ aggregate ]
+              errorCode: 11600 # InterruptedAtShutdown
+      - name: aggregate
+        object: *collection0
+        arguments:
+          pipeline: &pipeline
+            - $match: { _id: { $gt: 1 } }
+            - $sort: { x: 1 }
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collectionName
+                pipeline: *pipeline
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                aggregate: *collectionName
+                pipeline: *pipeline
+              databaseName: *databaseName
+
+  - description: "Find succeeds on second attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ find ]
+              closeConnection: true
+      # Find options and expected result changed to use common initialData
+      - name: find
+        object: collection0
+        arguments:
+          filter: {}
+          sort: { _id: 1 }
+          limit: 2
+        expectResult:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+    expectEvents:
+      - client: *client0
+        events:
+          - &findAttempt
+            commandStartedEvent:
+              command:
+                find: *collectionName
+                filter: {}
+                sort: { _id: 1 }
+                limit: 2
+              databaseName: *databaseName
+          - *findAttempt
+
+  - description: "Find fails on first attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ find ]
+              closeConnection: true
+      - name: find
+        object: collection1 # client uses retryReads=false
+        arguments:
+          filter: {}
+          # Other arguments in the original test are not relevant
+        expectError: { isError: true }
+    expectEvents:
+      - client: *client1
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collectionName
+                filter: {}
+              databaseName: *databaseName
+
+  - description: "Find fails on second attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+              failCommands: [ find ]
+              closeConnection: true
+      - name: find
+        object: collection0
+        arguments:
+          filter: {}
+          # Other arguments in the original test are not relevant
+        expectError: { isError: true }
+    expectEvents:
+      - client: *client0
+        events:
+          - &findAttempt
+            commandStartedEvent:
+              command:
+                find: *collectionName
+                filter: {}
+              databaseName: *databaseName
+          - *findAttempt
+
+  - description: "ListDatabases succeeds on second attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ listDatabases ]
+              closeConnection: true
+      - name: listDatabases
+        object: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command: { listDatabases: 1 }
+          - commandStartedEvent:
+              command: { listDatabases: 1 }

--- a/test/spec/unified-test-format/valid-pass/poc-retryable-writes.json
+++ b/test/spec/unified-test-format/valid-pass/poc-retryable-writes.json
@@ -1,0 +1,485 @@
+{
+  "description": "poc-retryable-writes",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "uriOptions": {
+          "retryWrites": false
+        },
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-writes-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "retryable-writes-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "retryable-writes-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "FindOneAndUpdate is committed on first attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "onPrimaryTransactionalWrite",
+              "mode": {
+                "times": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndUpdate is not committed on first attempt",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "onPrimaryTransactionalWrite",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failBeforeCommitExceptionCode": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndUpdate is never committed",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "onPrimaryTransactionalWrite",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failBeforeCommitExceptionCode": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertMany succeeds after PrimarySteppedDown",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 189,
+                "errorLabels": [
+                  "RetryableWriteError"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3,
+                "x": 33
+              },
+              {
+                "_id": 4,
+                "x": 44
+              }
+            ],
+            "ordered": true
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedCount": {
+                "$$unsetOrMatches": 2
+              },
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 3,
+                  "1": 4
+                }
+              }
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertOne fails after connection failure when retryWrites option is false",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client1",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsOmit": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertOne fails after multiple retryable writeConcernErrors",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.7",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/poc-retryable-writes.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-retryable-writes.yml
@@ -1,0 +1,209 @@
+description: "poc-retryable-writes"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "3.6"
+    topologies: [ replicaset ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - client:
+      id: &client1 client1
+      uriOptions: { retryWrites: false }
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName retryable-writes-tests
+  - database:
+      id: &database1 database1
+      client: *client1
+      databaseName: *databaseName
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+  - collection:
+      id: &collection1 collection1
+      database: *database1
+      collectionName: *collectionName
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+
+tests:
+  - description: "FindOneAndUpdate is committed on first attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: onPrimaryTransactionalWrite
+            mode: { times: 1 }
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $inc: { x : 1 } }
+          returnDocument: Before
+        expectResult: { _id: 1, x: 11 }
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 12 }
+          - { _id: 2, x: 22 }
+
+  - description: "FindOneAndUpdate is not committed on first attempt"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: onPrimaryTransactionalWrite
+            mode: { times: 1 }
+            data: { failBeforeCommitExceptionCode: 1 }
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $inc: { x : 1 } }
+          returnDocument: Before
+        expectResult: { _id: 1, x: 11 }
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 12 }
+          - { _id: 2, x: 22 }
+
+  - description: "FindOneAndUpdate is never committed"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: onPrimaryTransactionalWrite
+            mode: { times: 2 }
+            data: { failBeforeCommitExceptionCode: 1 }
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $inc: { x : 1 } }
+          returnDocument: Before
+        expectError: { isError: true }
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+
+  - description: "InsertMany succeeds after PrimarySteppedDown"
+    runOnRequirements: &failCommand_requirements
+      - minServerVersion: "4.0"
+        topologies: [ replicaset ]
+      - minServerVersion: "4.1.7"
+        # Original test uses "sharded", but retryable writes requires a sharded
+        # cluster backed by replica sets
+        topologies: [ sharded-replicaset ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              errorCode: 189 # PrimarySteppedDown
+              errorLabels: [  RetryableWriteError ]
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents:
+            # Documents are modified from original test for "initialData"
+            - { _id: 3, x: 33 }
+            - { _id: 4, x: 44 }
+          ordered: true
+        expectResult:
+          { $$unsetOrMatches: { insertedCount: { $$unsetOrMatches: 2 } }, insertedIds: { $$unsetOrMatches: { 0: 3, 1: 4 } } }
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+
+  - description: "InsertOne fails after connection failure when retryWrites option is false"
+    runOnRequirements: *failCommand_requirements
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client1
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+                failCommands: [ insert ]
+                closeConnection: true
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          # If retryWrites is false, the driver should not add the
+          # RetryableWriteError label to the error.
+          errorLabelsOmit: [ RetryableWriteError ]
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+
+  - description: "InsertOne fails after multiple retryable writeConcernErrors"
+    runOnRequirements: *failCommand_requirements
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+              failCommands: [ insert ]
+              writeConcernError:
+                code: 91 # ShutdownInProgress
+                errmsg: "Replication is being shut down"
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          errorLabelsContain: [ RetryableWriteError ]
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }  # The write was still applied

--- a/test/spec/unified-test-format/valid-pass/poc-sessions.json
+++ b/test/spec/unified-test-format/valid-pass/poc-sessions.json
@@ -1,0 +1,466 @@
+{
+  "description": "poc-sessions",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6.0"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "session-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "session-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Server supports explicit sessions",
+      "operations": [
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server supports implicit sessions",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Dirty explicit session is discarded",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.8",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 3
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 2
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/poc-sessions.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-sessions.yml
@@ -1,0 +1,214 @@
+description: "poc-sessions"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "3.6.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name session-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  - session:
+      id: &session0 session0
+      client: *client0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "Server supports explicit sessions"
+    operations:
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: endSession
+        object: *session0
+      - &find_with_implicit_session
+        name: find
+        object: *collection0
+        arguments:
+          filter: { _id: -1 }
+        expectResult: []
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: [ { _id: 2 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$sessionLsid: *session0 }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+
+  - description: "Server supports implicit sessions"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - *find_with_implicit_session
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - { _id: 2 }
+                ordered: true
+                # Original test did not include any assertion, but we can use
+                # $$type to expect an arbitrary lsid document
+                lsid: { $$type: object }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$type: object }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+
+  - description: "Dirty explicit session is discarded"
+    # Original test specified retryWrites=true, but that is now the default.
+    # Retryable writes will require a sharded-replicaset, though.
+    runOnRequirements:
+      - minServerVersion: "4.0"
+        topologies: [ replicaset ]
+      - minServerVersion: "4.1.8"
+        topologies: [ sharded-replicaset ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              closeConnection: true
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 3 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 3 } } }
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: endSession
+        object: *session0
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          # ajv's YAML parser is unable to handle anchors on array elements, so
+          # we define an anchor on the commandStartedEvent object instead
+          - commandStartedEvent: &insert_attempt
+              command:
+                insert: *collection0Name
+                documents: 
+                  - { _id: 2 }
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent: *insert_attempt
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: 
+                  - { _id: 3 }
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 2
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$type: object }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+          - { _id: 3 }

--- a/test/spec/unified-test-format/valid-pass/poc-transactions-convenient-api.json
+++ b/test/spec/unified-test-format/valid-pass/poc-transactions-convenient-api.json
@@ -1,0 +1,505 @@
+{
+  "description": "poc-transactions-convenient-api",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        },
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "database": {
+        "id": "database1",
+        "client": "client1",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database1",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    },
+    {
+      "session": {
+        "id": "session1",
+        "client": "client1"
+      }
+    },
+    {
+      "session": {
+        "id": "session2",
+        "client": "client0",
+        "sessionOptions": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "majority"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "withTransaction and no transaction options set",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection0",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "withTransaction inherits transaction options from client",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session1",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection1",
+                "arguments": {
+                  "session": "session1",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client1",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session1"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session1"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "w": 1
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "withTransaction inherits transaction options from defaultTransactionOptions",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session2",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection0",
+                "arguments": {
+                  "session": "session2",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session2"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "level": "majority"
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session2"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "w": 1
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "withTransaction explicit transaction options",
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": [
+              {
+                "name": "insertOne",
+                "object": "collection0",
+                "arguments": {
+                  "session": "session0",
+                  "document": {
+                    "_id": 1
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ],
+            "readConcern": {
+              "level": "majority"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "level": "majority"
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "w": 1
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "startTransaction": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/poc-transactions-convenient-api.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-transactions-convenient-api.yml
@@ -1,0 +1,235 @@
+description: "poc-transactions-convenient-api"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: [ replicaset ]
+  - minServerVersion: "4.1.8"
+    topologies: [ sharded-replicaset ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+      observeEvents: [ commandStartedEvent ]
+  - client:
+      id: &client1 client1
+      uriOptions:
+        readConcernLevel: local
+        w: 1
+      useMultipleMongoses: true
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName transaction-tests
+  - database:
+      id: &database1 database1
+      client: *client1
+      databaseName: *databaseName
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName test
+  - collection:
+      id: &collection1 collection1
+      database: *database1
+      collectionName: *collectionName
+  - session:
+      id: &session0 session0
+      client: *client0
+  - session:
+      id: &session1 session1
+      client: *client1
+  - session:
+      id: &session2 session2
+      client: *client0
+      sessionOptions:
+        defaultTransactionOptions:
+          readConcern: { level: majority }
+          writeConcern: { w: 1 }
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents: []
+
+tests:
+  - description: "withTransaction and no transaction options set"
+    operations:
+      - name: withTransaction
+        object: *session0
+        arguments:
+          callback:
+            - name: insertOne
+              object: *collection0
+              arguments:
+                session: *session0
+                document: { _id: 1 }
+              expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } } }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 1 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                # omitted fields
+                readConcern: { $$exists: false }
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                autocommit: false
+                # omitted fields
+                readConcern: { $$exists: false }
+                startTransaction: { $$exists: false }
+                writeConcern: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+    outcome: &outcome
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1 }
+
+  - description: "withTransaction inherits transaction options from client"
+    operations:
+      - name: withTransaction
+        object: *session1
+        arguments:
+          callback:
+            - name: insertOne
+              object: *collection1
+              arguments:
+                session: *session1
+                document: { _id: 1 }
+              expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } } }
+    expectEvents:
+      - client: *client1
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 1 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session1 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                readConcern: { level: local }
+                # omitted fields
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session1 }
+                txnNumber: 1
+                autocommit: false
+                writeConcern: { w: 1 }
+                # omitted fields
+                readConcern: { $$exists: false }
+                startTransaction: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+    outcome: *outcome
+
+  - description: "withTransaction inherits transaction options from defaultTransactionOptions"
+    operations:
+      - name: withTransaction
+        object: *session2
+        arguments:
+          callback:
+            - name: insertOne
+              object: *collection0
+              arguments:
+                session: *session2
+                document: { _id: 1 }
+              expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } } }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 1 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session2 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                readConcern: { level: majority }
+                # omitted fields
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session2 }
+                txnNumber: 1
+                autocommit: false
+                writeConcern: { w: 1 }
+                # omitted fields
+                readConcern: { $$exists: false }
+                startTransaction: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+    outcome: *outcome
+
+  - description: "withTransaction explicit transaction options"
+    operations:
+      - name: withTransaction
+        object: *session0
+        arguments:
+          callback:
+            - name: insertOne
+              object: *collection0
+              arguments:
+                session: *session0
+                document: { _id: 1 }
+              expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } } }
+          readConcern: { level: majority }
+          writeConcern: { w: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 1 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                readConcern: { level: majority }
+                # omitted fields
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                autocommit: false
+                writeConcern: { w: 1 }
+                # omitted fields
+                readConcern: { $$exists: false }
+                startTransaction: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+    outcome: *outcome

--- a/test/spec/unified-test-format/valid-pass/poc-transactions-mongos-pin-auto.json
+++ b/test/spec/unified-test-format/valid-pass/poc-transactions-mongos-pin-auto.json
@@ -1,0 +1,409 @@
+{
+  "description": "poc-transactions-mongos-pin-auto",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "remain pinned after non-transient Interrupted error on insertOne",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 3
+              }
+            }
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 11601
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "expectError": {
+            "errorLabelsOmit": [
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
+            ],
+            "errorCodeName": "Interrupted"
+          }
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 4
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "recoveryToken": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "unpin after transient error within a transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 3
+              }
+            }
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 4
+                    }
+                  ],
+                  "ordered": true,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "abortTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "recoveryToken": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "abortTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/poc-transactions-mongos-pin-auto.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-transactions-mongos-pin-auto.yml
@@ -1,0 +1,169 @@
+description: "poc-transactions-mongos-pin-auto"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.1.8"
+    topologies: [ sharded-replicaset ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name transaction-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  - session:
+      id: &session0 session0
+      client: *client0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+      - { _id: 2 }
+
+tests:
+  - description: "remain pinned after non-transient Interrupted error on insertOne"
+    operations:
+      - &startTransaction
+        name: startTransaction
+        object: *session0
+      - &firstInsert
+        name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 3 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 3 } } }
+      - name: targetedFailPoint
+        object: testRunner
+        arguments:
+          session: *session0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              errorCode: 11601 # Interrupted
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 4 }
+        expectError:
+          errorLabelsOmit: [ TransientTransactionError, UnknownTransactionCommitResult ]
+          errorCodeName: Interrupted
+      - name: assertSessionPinned
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: commitTransaction
+        object: *session0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: &firstInsertEvent
+              command:
+                insert: *collection0Name
+                documents: [ { _id: 3 } ]
+                ordered: true
+                readConcern: { $$exists: false }
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent: &secondInsertEvent
+              command:
+                insert: *collection0Name
+                documents: [ { _id: 4 } ]
+                ordered: true
+                readConcern: { $$exists: false }
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+                # Original test expected any value, but we can assert an object
+                recoveryToken: { $$type: object }
+              commandName: commitTransaction
+              databaseName: admin
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+          - { _id: 3 }
+
+  - description: "unpin after transient error within a transaction"
+    operations:
+      - *startTransaction
+      - *firstInsert
+      - name: targetedFailPoint
+        object: testRunner
+        arguments:
+          session: *session0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              closeConnection: true
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 4 }
+        expectError:
+          errorLabelsContain: [ TransientTransactionError ]
+          errorLabelsOmit: [ UnknownTransactionCommitResult ]
+      - name: assertSessionUnpinned
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: abortTransaction
+        object: *session0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: *firstInsertEvent
+          - commandStartedEvent: *secondInsertEvent
+          - commandStartedEvent:
+              command:
+                abortTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+                # Original test expected any value, but we can assert an object
+                recoveryToken: { $$type: object }
+              commandName: abortTransaction
+              databaseName: admin
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }

--- a/test/spec/unified-test-format/valid-pass/poc-transactions.json
+++ b/test/spec/unified-test-format/valid-pass/poc-transactions.json
@@ -1,0 +1,322 @@
+{
+  "description": "poc-transactions",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Client side error in command starting transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": {
+                ".": "."
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        },
+        {
+          "name": "assertSessionTransactionState",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "state": "starting"
+          }
+        }
+      ]
+    },
+    {
+      "description": "explicitly create collection using create command",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.3.4",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "session": "session0",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test",
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "drop",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "create",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create index on a non-existing collection",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.3.4",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "name": "x_1",
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "assertIndexNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test",
+            "indexName": "x_1"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test",
+            "indexName": "x_1"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test",
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "drop",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "test",
+                  "indexes": [
+                    {
+                      "name": "x_1",
+                      "key": {
+                        "x": 1
+                      }
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "createIndexes",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/poc-transactions.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-transactions.yml
@@ -1,0 +1,170 @@
+description: "poc-transactions"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: [ replicaset ]
+  - minServerVersion: "4.1.8"
+    topologies: [ sharded-replicaset ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name transaction-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  - session:
+      id: &session0 session0
+      client: *client0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "Client side error in command starting transaction"
+    operations:
+      - name: startTransaction
+        object: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: { .: . } }
+        # Original test only asserted a generic error
+        expectError: { isClientError: true }
+      - name: assertSessionTransactionState
+        object: testRunner
+        arguments:
+          session: *session0
+          state: starting
+
+  - description: "explicitly create collection using create command"
+    runOnRequirements:
+      - minServerVersion: "4.3.4"
+        topologies: [ replicaset, sharded-replicaset ]
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: startTransaction
+        object: *session0
+      - name: createCollection
+        object: *database0
+        arguments:
+          session: *session0
+          collection: *collection0Name
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+      - name: commitTransaction
+        object: *session0
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+                writeConcern: { $$exists: false }
+              commandName: drop
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: create
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+
+  - description: "create index on a non-existing collection"
+    runOnRequirements:
+      - minServerVersion: "4.3.4"
+        topologies: [ replicaset, sharded-replicaset ]
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: startTransaction
+        object: *session0
+      - name: createIndex
+        object: *collection0
+        arguments:
+          session: *session0
+          name: &indexName "x_1"
+          keys: { x: 1 }
+      - name: assertIndexNotExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+          indexName: *indexName
+      - name: commitTransaction
+        object: *session0
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+          indexName: *indexName
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+                writeConcern: { $$exists: false }
+              commandName: drop
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                createIndexes: *collection0Name
+                indexes:
+                  - name: *indexName
+                    key: { x: 1 }
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: createIndexes
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin


### PR DESCRIPTION
Just ran the update-spec-test script to pull in the unified runner tests, figure we can do this on its own to reduce the file change count in the actual runner.