### PR TITLE
fix: correct typeof check in checkSupportedServer

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -41,7 +41,7 @@ function checkSupportedServer(ismaster: Document, options: ConnectionOptions) {
     ismaster.maxWireVersion >= MIN_SUPPORTED_WIRE_VERSION;
   const serverVersionLowEnough =
     ismaster &&
-    (typeof ismaster.maxWireVersion === 'number' || ismaster.maxWireVersion instanceof Int32) &&
+    (typeof ismaster.minWireVersion === 'number' || ismaster.minWireVersion instanceof Int32) &&
     ismaster.minWireVersion <= MAX_SUPPORTED_WIRE_VERSION;
 
   if (serverVersionHighEnough) {


### PR DESCRIPTION
This made it passed testing because if maxWireVersion is a number then so is min and the actual 'less than' comparison is correct.