### PR TITLE
HELP-21340: Adding Tests For Max BSON Size Batching

### DIFF
--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -1648,12 +1648,9 @@ describe('Bulk', function () {
       })
       .then(() => {
         const coll = db.collection('doesnt_matter');
-
-        coll.insertMany(documents, { ordered: true }, err => {
-          client.close(() => {
-            done(err);
-          });
-        });
+        coll.insertMany(documents, { ordered: true })
+      .then(() => {
+        client.close(done);
       });
   });
 
@@ -1677,12 +1674,9 @@ describe('Bulk', function () {
       })
       .then(() => {
         const coll = db.collection('doesnt_matter');
-
-        coll.insertMany(documents, { ordered: false }, err => {
-          client.close(() => {
-            done(err);
-          });
-        });
+        coll.insertMany(documents, { ordered: false })
+      .then(() => {
+        client.close(done);
       });
   });
 

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -1628,7 +1628,7 @@ describe('Bulk', function () {
       });
   });
 
-  it('properly accounts for bson size in bytes in bulk ordered inserts', function (done) {
+  it('properly accounts for bson size in bytes in bulk ordered inserts', function () {
     const client = this.configuration.newClient();
     const size = MAX_BSON_SIZE / 2;
     const largeString = crypto.randomBytes(size - 100).toString('hex');
@@ -1636,9 +1636,8 @@ describe('Bulk', function () {
 
     let db;
 
-    client
+    return client
       .connect()
-      // NOTE: Hack to get around unrelated strange error in bulkWrites for right now.
       .then(() => {
         db = client.db(this.configuration.db);
         return db.dropCollection('doesnt_matter').catch(() => {});
@@ -1648,13 +1647,14 @@ describe('Bulk', function () {
       })
       .then(() => {
         const coll = db.collection('doesnt_matter');
-        coll.insertMany(documents, { ordered: true })
+        coll.insertMany(documents, { ordered: true });
+      })
       .then(() => {
-        client.close(done);
+        client.close();
       });
   });
 
-  it('properly accounts for bson size in bytes in bulk unordered inserts', function (done) {
+  it('properly accounts for bson size in bytes in bulk unordered inserts', function () {
     const client = this.configuration.newClient();
     const size = MAX_BSON_SIZE / 2;
     const largeString = crypto.randomBytes(size - 100).toString('hex');
@@ -1662,9 +1662,8 @@ describe('Bulk', function () {
 
     let db;
 
-    client
+    return client
       .connect()
-      // NOTE: Hack to get around unrelated strange error in bulkWrites for right now.
       .then(() => {
         db = client.db(this.configuration.db);
         return db.dropCollection('doesnt_matter').catch(() => {});
@@ -1674,9 +1673,10 @@ describe('Bulk', function () {
       })
       .then(() => {
         const coll = db.collection('doesnt_matter');
-        coll.insertMany(documents, { ordered: false })
+        coll.insertMany(documents, { ordered: false });
+      })
       .then(() => {
-        client.close(done);
+        client.close();
       });
   });
 

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -1649,9 +1649,7 @@ describe('Bulk', function () {
         const coll = db.collection('doesnt_matter');
         coll.insertMany(documents, { ordered: true });
       })
-      .then(() => {
-        client.close();
-      });
+      .finally(() => client.close());
   });
 
   it('properly accounts for bson size in bytes in bulk unordered inserts', function () {
@@ -1675,9 +1673,7 @@ describe('Bulk', function () {
         const coll = db.collection('doesnt_matter');
         coll.insertMany(documents, { ordered: false });
       })
-      .then(() => {
-        client.close();
-      });
+      .finally(() => client.close());
   });
 
   function testPropagationOfBulkWriteError(bulk) {

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -9,9 +9,12 @@ const {
 const test = require('./shared').assert;
 const { MongoError } = require('../../src/error');
 const { Long } = require('../../src');
+const crypto = require('crypto');
 const chai = require('chai');
 const expect = chai.expect;
 chai.use(require('chai-subset'));
+
+const MAX_BSON_SIZE = 16777216;
 
 describe('Bulk', function () {
   before(function () {
@@ -1618,6 +1621,64 @@ describe('Bulk', function () {
         const coll = db.collection('doesnt_matter');
 
         coll.insertMany(documents, { ordered: true }, err => {
+          client.close(() => {
+            done(err);
+          });
+        });
+      });
+  });
+
+  it('properly accounts for bson size in bytes in bulk ordered inserts', function (done) {
+    const client = this.configuration.newClient();
+    const size = MAX_BSON_SIZE / 2;
+    const largeString = crypto.randomBytes(size - 100).toString('hex');
+    const documents = [{ s: largeString }, { s: largeString }];
+
+    let db;
+
+    client
+      .connect()
+      // NOTE: Hack to get around unrelated strange error in bulkWrites for right now.
+      .then(() => {
+        db = client.db(this.configuration.db);
+        return db.dropCollection('doesnt_matter').catch(() => {});
+      })
+      .then(() => {
+        return db.createCollection('doesnt_matter');
+      })
+      .then(() => {
+        const coll = db.collection('doesnt_matter');
+
+        coll.insertMany(documents, { ordered: true }, err => {
+          client.close(() => {
+            done(err);
+          });
+        });
+      });
+  });
+
+  it('properly accounts for bson size in bytes in bulk unordered inserts', function (done) {
+    const client = this.configuration.newClient();
+    const size = MAX_BSON_SIZE / 2;
+    const largeString = crypto.randomBytes(size - 100).toString('hex');
+    const documents = [{ s: largeString }, { s: largeString }];
+
+    let db;
+
+    client
+      .connect()
+      // NOTE: Hack to get around unrelated strange error in bulkWrites for right now.
+      .then(() => {
+        db = client.db(this.configuration.db);
+        return db.dropCollection('doesnt_matter').catch(() => {});
+      })
+      .then(() => {
+        return db.createCollection('doesnt_matter');
+      })
+      .then(() => {
+        const coll = db.collection('doesnt_matter');
+
+        coll.insertMany(documents, { ordered: false }, err => {
           client.close(() => {
             done(err);
           });


### PR DESCRIPTION
## Description

This adds tests to ensure ordered and unordered bulk operations respect the max bson size and split into batches. The previous tests were only testing splitting in to batches based on the number of documents in the batch.

**What changed?**

Added 2 tests in `bulk.test.js`.
