### PR TITLE
fix: ingest WC as a simple object or number for w value

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -992,11 +992,18 @@ export const OPTIONS = {
             ...value
           }
         });
+      } else if (value === 'majority' || typeof value === 'number') {
+        return WriteConcern.fromOptions({
+          writeConcern: {
+            ...options.writeConcern,
+            w: value
+          }
+        });
       }
 
-      throw new MongoParseError(`WriteConcern must be an object, got ${JSON.stringify(value)}`);
+      throw new MongoParseError(`Invalid WriteConcern cannot parse: ${JSON.stringify(value)}`);
     }
-  } as OptionDescriptor,
+  },
   wtimeout: {
     deprecated: 'Please use wtimeoutMS instead',
     target: 'writeConcern',

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1003,7 +1003,7 @@ export const OPTIONS = {
 
       throw new MongoParseError(`Invalid WriteConcern cannot parse: ${JSON.stringify(value)}`);
     }
-  },
+  } as OptionDescriptor,
   wtimeout: {
     deprecated: 'Please use wtimeoutMS instead',
     target: 'writeConcern',

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -171,7 +171,9 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   /** Allow a driver to force a Single topology type with a connection string containing one host */
   directConnection?: boolean;
 
-  /** The write concern */
+  /* Write concern to be inherited by Db's and Collection's */
+  writeConcern: WriteConcern | W;
+  /** The write concern w value */
   w?: W;
   /** The write concern timeout */
   wtimeoutMS?: number;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -171,8 +171,6 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   /** Allow a driver to force a Single topology type with a connection string containing one host */
   directConnection?: boolean;
 
-  /* Write concern to be inherited by Db's and Collection's */
-  writeConcern: WriteConcern | W;
   /** The write concern w value */
   w?: W;
   /** The write concern timeout */

--- a/test/functional/write_concern.test.js
+++ b/test/functional/write_concern.test.js
@@ -69,9 +69,7 @@ describe('Write Concern', function () {
     });
   });
 
-  after(() => {
-    mock.cleanup();
-  });
+  after(() => mock.cleanup());
 
   it('should pipe writeConcern from client down to API call', function () {
     server.setMessageHandler(request => {


### PR DESCRIPTION
This reverts a change that now makes it possible to pass a
writeConcern option that maps directly to 'majority'
or a number for the w value

NODE-2836
