### PR TITLE
feat(ci): add mongosh integration testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -137,6 +137,14 @@ functions:
         script: |
           ${PREPARE_SHELL}
           bash ${PROJECT_DIRECTORY}/.evergreen/run-checks.sh
+  run mongosh integration tests:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        script: |
+          ${PREPARE_SHELL}
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-mongosh-integration-tests.sh
   cleanup:
     - command: shell.exec
       params:
@@ -1132,6 +1140,15 @@ tasks:
         vars:
           NODE_LTS_NAME: erbium
       - func: run checks
+  - name: run-mongosh-integration-tests
+    tags:
+      - run-mongosh-integration-tests
+    exec_timeout_secs: 3600
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_NAME: fermium
+      - func: run mongosh integration tests
 buildvariants:
   - name: macos-1014-dubnium
     display_name: macOS 10.14 Node Dubnium
@@ -1359,6 +1376,11 @@ buildvariants:
     run_on: rhel70
     tasks:
       - run-checks
+  - name: mongosh_integration_tests
+    display_name: mongosh integration tests
+    run_on: ubuntu1804-test
+    tasks:
+      - run-mongosh-integration-tests
   - name: ubuntu1804-test-mongodb-aws
     display_name: MONGODB-AWS Auth test
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -159,6 +159,15 @@ functions:
           ${PREPARE_SHELL}
           bash ${PROJECT_DIRECTORY}/.evergreen/run-checks.sh
 
+  "run mongosh integration tests":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-mongosh-integration-tests.sh
+
   "cleanup":
     - command: shell.exec
       params:
@@ -253,7 +262,7 @@ functions:
         script: |
           MONGODB_URI='${plain_auth_mongodb_uri}' NODE_LTS_NAME='${NODE_LTS_NAME}' \
           bash ${PROJECT_DIRECTORY}/.evergreen/run-ldap-tests.sh
-  
+
   "run data lake tests":
       - command: shell.exec
         type: test
@@ -262,7 +271,7 @@ functions:
           script: |
             MONGODB_URI='mongodb://mhuser:pencil@localhost' NODE_LTS_NAME='${NODE_LTS_NAME}' \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-data-lake-tests.sh
-  
+
   "run tls tests":
     - command: shell.exec
       type: test

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -484,8 +484,30 @@ BUILD_VARIANTS.push({
   tasks: ['run-checks']
 });
 
-// special case for MONGODB-AWS authentication
+// singleton build variant for mongosh integration tests
+SINGLETON_TASKS.push({
+  name: 'run-mongosh-integration-tests',
+  tags: ['run-mongosh-integration-tests'],
+  exec_timeout_secs: 3600,
+  commands: [
+    {
+      func: 'install dependencies',
+      vars: {
+        NODE_LTS_NAME: 'fermium'
+      }
+    },
+    { func: 'run mongosh integration tests' }
+  ]
+});
 
+BUILD_VARIANTS.push({
+  name: 'mongosh_integration_tests',
+  display_name: 'mongosh integration tests',
+  run_on: 'ubuntu1804-test',
+  tasks: ['run-mongosh-integration-tests']
+});
+
+// special case for MONGODB-AWS authentication
 BUILD_VARIANTS.push({
   name: 'ubuntu1804-test-mongodb-aws',
   display_name: 'MONGODB-AWS Auth test',

--- a/.evergreen/run-mongosh-integration-tests.sh
+++ b/.evergreen/run-mongosh-integration-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o errexit  # Exit the script with error if any of the commands fail
+set -o xtrace   # Write all commands first to stderr
+
+export PROJECT_DIRECTORY="$(pwd)"
+NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
+export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+npm pack | tee npm-pack.log
+export TARBALL_FILENAME="$(tail -n1 npm-pack.log)"
+cd /tmp
+git clone --depth=10 https://github.com/mongodb-js/mongosh.git
+cd mongosh
+export REPLACE_PACKAGE="mongodb:${PROJECT_DIRECTORY}/${TARBALL_FILENAME}"
+npm run test-nodedriver


### PR DESCRIPTION
This is part of NODE-2940 (it doesn’t address Compass integration, because I don’t know what that would even look like given the many, many packages that make up Compass).

--- 

Add a mongosh integration test task to evergreen. This currently passes CI, but could fail if more breaking changes are being added. I’m doing my best to keep up with all driver changes, but we still have to adjust our code on a regular basis to changes being made to the master branch here – if you want to avoid this task failing occasionally, you can of course wait until the actual 4.0 release (or until all planned breaking changes are done).