### PR TITLE
fix: revert BSON Map export removal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,8 @@ export {
   Timestamp,
   Decimal128,
   BSONRegExp,
-  BSONSymbol
+  BSONSymbol,
+  Map
 } from './bson';
 
 export {


### PR DESCRIPTION
Good news! Our mongosh early warning system works!
Looks like I dropped the Map export from BSON by mistake, here's the fix.