### PR TITLE
fix(cursor): don't use other operation's session for cloned cursor operation (NODE-3008)

### DIFF
--- a/lib/core/cursor.js
+++ b/lib/core/cursor.js
@@ -11,6 +11,7 @@ const executeOperation = require('../operations/execute_operation');
 const Readable = require('stream').Readable;
 const SUPPORTS = require('../utils').SUPPORTS;
 const MongoDBNamespace = require('../utils').MongoDBNamespace;
+const mergeOptions = require('../utils').mergeOptions;
 const OperationBase = require('../operations/operation').OperationBase;
 
 const BSON = retrieveBSON();
@@ -207,7 +208,9 @@ class CoreCursor extends Readable {
    * @return {Cursor}
    */
   clone() {
-    return this.topology.cursor(this.ns, this.cmd, this.options);
+    const clonedOptions = mergeOptions({}, this.options);
+    delete clonedOptions.session;
+    return this.topology.cursor(this.ns, this.cmd, clonedOptions);
   }
 
   /**


### PR DESCRIPTION
Fixes NODE-3008.

## Description

Please refer to NODE-3008 for more details.

I can try to write a test for this bug if someone give me a hint on an example of such tests.

Also we should check if this should be ported to v4.x