### PR TITLE
chore(ci): fix mongosh integration

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -144,6 +144,7 @@ functions:
         working_dir: src
         script: |
           ${PREPARE_SHELL}
+          export DISTRO_ID=${distro_id}
           bash ${PROJECT_DIRECTORY}/.evergreen/run-mongosh-integration-tests.sh
   cleanup:
     - command: shell.exec

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -166,6 +166,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
+          export DISTRO_ID=${distro_id}
           bash ${PROJECT_DIRECTORY}/.evergreen/run-mongosh-integration-tests.sh
 
   "cleanup":


### PR DESCRIPTION
After https://github.com/mongodb-js/mongosh/commit/be303719f53726ed3cb55fe0087d3a49645e6488
we are temporarily relying on the `DISTRO_ID` evergreen expansion to
figure out which mongod server package to download.

Sorry for causing trouble!
