### PR TITLE
feat: expose package version on MongoClient

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -11,7 +11,8 @@ import {
   resolveOptions,
   ClientMetadata,
   ns,
-  HostAddress
+  HostAddress,
+  NODE_DRIVER_VERSION
 } from './utils';
 import { deprecate } from 'util';
 import { connect } from './operations/connect';
@@ -579,6 +580,11 @@ export class MongoClient extends EventEmitter {
     if (typeof options === 'function') (callback = options), (options = {});
     if (typeof callback === 'function') callback(undefined, true);
   }, 'Multiple authentication is prohibited on a connected client, please only authenticate once per MongoClient');
+
+  /** Provides the version of the 'mongodb' package. */
+  static get version(): string {
+    return NODE_DRIVER_VERSION;
+  }
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -889,8 +889,9 @@ export interface ClientMetadataOptions {
   appName?: string;
 }
 
+/** @internal */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const NODE_DRIVER_VERSION = require('../package.json').version;
+export const NODE_DRIVER_VERSION = require('../package.json').version;
 
 export function makeClientMetadata(options?: ClientMetadataOptions): ClientMetadata {
   options = options ?? {};

--- a/test/functional/mongo_client.test.js
+++ b/test/functional/mongo_client.test.js
@@ -170,6 +170,27 @@ describe('MongoClient', function () {
     }
   });
 
+  it('Should provide the same package version in metadata and on the MongoClient class', {
+    metadata: {
+      requires: {
+        topology: ['single', 'replicaset', 'sharded']
+      }
+    },
+
+    test: function (done) {
+      var configuration = this.configuration;
+      var url = configuration.url();
+
+      const client = configuration.newClient(url, { appname: 'hello world' });
+      client.connect(err => {
+        expect(err).to.not.exist;
+        test.equal(client.topology.clientMetadata.driver.version, client.constructor.version);
+
+        client.close(done);
+      });
+    }
+  });
+
   it('Should correctly pass through socketTimeoutMS and connectTimeoutMS', {
     metadata: {
       requires: {


### PR DESCRIPTION
## Description

Provide the current package version statically. The idea here is to use this to solve NODE-3043, by allowing mongodb-client-encryption to pass the correct options for a specific driver version.

If this is merged, I’ll make the corresponding change in the libmongocrypt repository. If you think that this is not a good approach, that’s very much okay and you can just go ahead and close this in that case.