### PR TITLE
fix: Compatibility with mongodb-client-encryption

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -278,7 +278,16 @@ export class Collection {
     options?: InsertOneOptions | Callback<InsertOneResult>,
     callback?: Callback<InsertOneResult>
   ): Promise<InsertOneResult> | void {
-    if (typeof options === 'function') (callback = options), (options = {});
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    // CSFLE passes in { w: 'majority' } to ensure the lib works in both 3.x and 4.x
+    // we support that option style here only
+    if (options && Reflect.get(options, 'w')) {
+      options.writeConcern = WriteConcern.fromOptions(Reflect.get(options, 'w'));
+    }
 
     return executeOperation(
       getTopology(this),

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -418,7 +418,7 @@ export function parseOptions(
 
   checkTLSOptions(mongoOptions);
   if (mongoClient && options.autoEncryption) {
-    mongoOptions.autoEncrypter = createAutoEncrypter(mongoClient, options);
+    mongoOptions.autoEncrypter = createAutoEncrypter(mongoClient, mongoOptions);
   }
   if (options.promiseLibrary) PromiseProvider.set(options.promiseLibrary);
 
@@ -1062,7 +1062,10 @@ export const OPTIONS = {
   passphrase: { type: 'any' },
   pfx: { type: 'any' },
   secureProtocol: { type: 'any' },
-  index: { type: 'any' }
+  index: { type: 'any' },
+  // Legacy Options, these are unused but left here to avoid errors with CSFLE lib
+  useNewUrlParser: { type: 'boolean' } as OptionDescriptor,
+  useUnifiedTopology: { type: 'boolean' } as OptionDescriptor
 } as Record<keyof MongoClientOptions, OptionDescriptor>;
 
 export const DEFAULT_OPTIONS = new CaseInsensitiveMap(

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -4,7 +4,7 @@ import { resolveSRVRecord } from '../connection_string';
 import { emitDeprecationWarning, Callback } from '../utils';
 import { CMAP_EVENT_NAMES } from '../cmap/events';
 import * as BSON from '../bson';
-import type { MongoClient, MongoOptions, MongoClientOptions } from '../mongo_client';
+import type { MongoClient, MongoOptions } from '../mongo_client';
 import { Connection } from '../cmap/connection';
 import { Server } from '../sdam/server';
 import type { AutoEncrypter } from '../deps';
@@ -116,7 +116,7 @@ function registerDeprecatedEventNotifiers(client: MongoClient) {
  */
 export function createAutoEncrypter(
   client: MongoClient,
-  options: MongoClientOptions
+  options: MongoOptions
 ): AutoEncrypter | undefined {
   if (!options.autoEncryption) {
     return;

--- a/test/tools/runner/config.js
+++ b/test/tools/runner/config.js
@@ -185,7 +185,7 @@ class TestConfiguration {
       } else {
         multipleHosts = this.options.hostAddresses
           .reduce((built, host) => {
-            built.push(host.type === 'tcp' ? `${host.host}:${host.port}` : host.host);
+            built.push(typeof host.port === 'number' ? `${host.host}:${host.port}` : host.host);
             return built;
           }, [])
           .join(',');


### PR DESCRIPTION
Permits legacy options being used by mongodb-client-encryption's
use of the MongoClient constructor. Permits legacy WC option style in
insertOne.

NODE-3006

[CSFLE Tests Patch](https://spruce.mongodb.com/task/mongo_node_driver_ubuntu_18.04_erbium_test_4.2_replica_set_patch_25ef87026bca935b00d30ad943ddd28784f801e8_600b33953627e07e4a808b81_21_01_22_20_20_38/tests?execution=0&page=0&testname=Client_Side_Encryption)
