### PR TITLE
fix(write_concern): avoid throwing error when `options` is null

### DIFF
--- a/src/write_concern.ts
+++ b/src/write_concern.ts
@@ -75,7 +75,7 @@ export class WriteConcern {
     options?: WriteConcernOptions | WriteConcern | W,
     inherit?: WriteConcernOptions | WriteConcern
   ): WriteConcern | undefined {
-    if (typeof options === 'undefined') return undefined;
+    if (options == null) return undefined;
     inherit = inherit ?? {};
     let opts;
     if (typeof options === 'string' || typeof options === 'number') {


### PR DESCRIPTION
## Description

**What changed?**

If you call `createCollection()` with `null` for options, you get a "Cannot read property 'writeConcern' of null" error. Not a problem in TypeScript because technically this function doesn't accept `null` as a parameter, but might be worth fixing in case JS developers run into it.

**Are there any files to ignore?**
