### PR TITLE
fix: restore auto direct connection behavior

### DIFF
--- a/lib/core/uri_parser.js
+++ b/lib/core/uri_parser.js
@@ -687,6 +687,15 @@ function parseConnectionString(uri, options, callback) {
     return callback(new MongoParseError('directConnection option requires exactly one host'));
   }
 
+  // NOTE: this behavior will go away in v4.0, we will always auto discover there
+  if (
+    parsedOptions.directConnection == null &&
+    hosts.length === 1 &&
+    parsedOptions.replicaSet == null
+  ) {
+    parsedOptions.directConnection = true;
+  }
+
   const result = {
     hosts: hosts,
     auth: auth.db || auth.username ? auth : null,

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -1687,9 +1687,10 @@ describe('Bulk', function() {
           );
         }
       })
-      .finally(() => {
-        return client.close();
-      });
+      .then(
+        () => client.close(),
+        () => client.close()
+      );
   });
 
   it('should respect toBSON conversion when checking for atomic operators', function() {
@@ -1721,8 +1722,9 @@ describe('Bulk', function() {
           expect.fail(); // shouldn't throw any error
         }
       })
-      .finally(() => {
-        return client.close();
-      });
+      .then(
+        () => client.close(),
+        () => client.close()
+      );
   });
 });

--- a/test/functional/mongo_client_options.test.js
+++ b/test/functional/mongo_client_options.test.js
@@ -168,6 +168,20 @@ describe('MongoClient Options', function() {
     }
   });
 
+  it('should directConnect when no replicaSet name is specified', {
+    metadata: { requires: { topology: 'replicaset' } },
+    test: function(done) {
+      // strip the replicaSet parameter from the url if present
+      const urlNoReplicaSet = this.configuration.url().replace(/([&?])replicaSet=.+?[&$]/, '$1');
+      const client = this.configuration.newClient(urlNoReplicaSet);
+      client.connect(err => {
+        expect(err).to.not.exist;
+        expect(client.s.options.directConnection).to.be.true;
+        client.close(done);
+      });
+    }
+  });
+
   /**
    * @ignore
    */

--- a/test/functional/mongo_client_options.test.js
+++ b/test/functional/mongo_client_options.test.js
@@ -171,8 +171,12 @@ describe('MongoClient Options', function() {
   it('should directConnect when no replicaSet name is specified', {
     metadata: { requires: { topology: 'replicaset' } },
     test: function(done) {
-      // strip the replicaSet parameter from the url if present
-      const urlNoReplicaSet = this.configuration.url().replace(/([&?])replicaSet=.+?[&$]/, '$1');
+      const urlNoReplicaSet = this.configuration
+        .url()
+        // strip the replicaSet parameter from the url if present
+        .replace(/([&?])replicaSet=.+?[&$]/, '$1')
+        // reduce down to a single host if multiple are provided
+        .replace(new RegExp('(^mongodb://[^,]+)[^/]+'), '$1');
       const client = this.configuration.newClient(urlNoReplicaSet);
       client.connect(err => {
         expect(err).to.not.exist;

--- a/test/functional/sharding_connection.test.js
+++ b/test/functional/sharding_connection.test.js
@@ -13,7 +13,12 @@ describe('Sharding (Connection)', function() {
   it('Should use sharded topology', {
     metadata: { requires: { topology: 'sharded' } },
     test: function() {
-      const client = this.configuration.newClient({}, { useUnifiedTopology: true });
+      const client = this.configuration.newClient(
+        {},
+        // note: auto-discovery will be the default behavior in 4.0,
+        // for now we must supply directConnection: false
+        { useUnifiedTopology: true, directConnection: false }
+      );
       return withClient(client, (client, done) => {
         expect(client).to.exist;
         expect(client)


### PR DESCRIPTION
## Description

We removed automatic direct connection for the unified topology in the `3.6.3` release of the driver. This change was preparatory for the `4.0` version of the driver, where we'll always perform automatic discovery. This PR restores automatic direct connection when connecting to a single host without a specified `replicaSet` and without `directConnection: false`. 

In #2557 this was justified because `useUnifiedTopology: true` is an opt-in feature, but we've had a number of users file tickets about this change, and it's probably more appropriate to delay it until the major release of the driver, along with a call-out/explanation in the migration guide, rather than putting it in a patch release. That said, I'm open to closing this PR if we decide the original reasoning was appropriate.

NODE-2966

**What changed?**

**Are there any files to ignore?**
