### PR TITLE
chore(ci): fix aws auth tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -67,8 +67,8 @@ functions:
         script: >
           ${PREPARE_SHELL}
 
-          git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
-
+          git clone --branch DRIVERS-1462/aws-auth-upgrade-boto3 --single-branch \
+            git://github.com/emadum/drivers-evergreen-tools.git $DRIVERS_TOOLS
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" >
           $MONGO_ORCHESTRATION_HOME/orchestration.config
   bootstrap mongo-orchestration:
@@ -259,6 +259,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+          . ./activate_venv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_regular_aws.js
     - command: shell.exec
       type: test
@@ -287,6 +288,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+          . ./activate_venv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_assume_role.js
     - command: shell.exec
       type: test
@@ -319,6 +321,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+          . ./activate_venv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_ec2.js
     - command: shell.exec
       type: test
@@ -391,6 +394,7 @@ functions:
           EOF
 
           cat setup.js
+          . ./activate_venv.sh
           mongo --nodb setup.js aws_e2e_ecs.js
   run-ocsp-test:
     - command: shell.exec
@@ -1350,7 +1354,6 @@ tasks:
           ORCHESTRATION_FILE: auth-aws.json
           TOPOLOGY: server
       - func: add aws auth variables to file
-      - func: upgrade boto3 aws library for python
       - func: run aws auth test with regular aws credentials
       - func: run aws auth test with assume role credentials
       - func: run aws auth test with aws EC2 credentials
@@ -1367,7 +1370,6 @@ tasks:
           ORCHESTRATION_FILE: auth-aws.json
           TOPOLOGY: server
       - func: add aws auth variables to file
-      - func: upgrade boto3 aws library for python
       - func: run aws auth test with regular aws credentials
       - func: run aws auth test with assume role credentials
       - func: run aws auth test with aws EC2 credentials

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -243,6 +243,14 @@ functions:
               "iam_auth_ec2_instance_profile" : "${iam_auth_ec2_instance_profile}"
           }
           EOF
+  upgrade boto3 aws library for python:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        silent: true
+        script: |
+          pip install --upgrade boto3
   run aws auth test with regular aws credentials:
     - command: shell.exec
       type: test
@@ -1342,6 +1350,7 @@ tasks:
           ORCHESTRATION_FILE: auth-aws.json
           TOPOLOGY: server
       - func: add aws auth variables to file
+      - func: upgrade boto3 aws library for python
       - func: run aws auth test with regular aws credentials
       - func: run aws auth test with assume role credentials
       - func: run aws auth test with aws EC2 credentials
@@ -1358,6 +1367,7 @@ tasks:
           ORCHESTRATION_FILE: auth-aws.json
           TOPOLOGY: server
       - func: add aws auth variables to file
+      - func: upgrade boto3 aws library for python
       - func: run aws auth test with regular aws credentials
       - func: run aws auth test with assume role credentials
       - func: run aws auth test with aws EC2 credentials

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -243,14 +243,6 @@ functions:
               "iam_auth_ec2_instance_profile" : "${iam_auth_ec2_instance_profile}"
           }
           EOF
-  upgrade boto3 aws library for python:
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        silent: true
-        script: |
-          pip install --upgrade boto3
   run aws auth test with regular aws credentials:
     - command: shell.exec
       type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -67,8 +67,8 @@ functions:
         script: >
           ${PREPARE_SHELL}
 
-          git clone --branch DRIVERS-1462/aws-auth-upgrade-boto3 --single-branch \
-            git://github.com/emadum/drivers-evergreen-tools.git $DRIVERS_TOOLS
+          git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" >
           $MONGO_ORCHESTRATION_HOME/orchestration.config
   bootstrap mongo-orchestration:

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -85,8 +85,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          git clone --branch DRIVERS-1462/aws-auth-upgrade-boto3 --single-branch \
-            git://github.com/emadum/drivers-evergreen-tools.git $DRIVERS_TOOLS
+          git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 
   "bootstrap mongo-orchestration":

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -85,7 +85,8 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+          git clone --branch DRIVERS-1462/aws-auth-upgrade-boto3 --single-branch \
+            git://github.com/emadum/drivers-evergreen-tools.git $DRIVERS_TOOLS
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 
   "bootstrap mongo-orchestration":
@@ -291,6 +292,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+          . ./activate_venv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_regular_aws.js
     - command: shell.exec
       type: test
@@ -320,6 +322,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+          . ./activate_venv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_assume_role.js
     - command: shell.exec
       type: test
@@ -353,6 +356,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+          . ./activate_venv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_ec2.js
     - command: shell.exec
       type: test
@@ -428,6 +432,7 @@ functions:
           EOF
 
           cat setup.js
+          . ./activate_venv.sh
           mongo --nodb setup.js aws_e2e_ecs.js
 
   "run-ocsp-test":

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -275,15 +275,6 @@ functions:
           }
           EOF
 
-  "upgrade boto3 aws library for python":
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: "src"
-        silent: true
-        script: |
-          pip install --upgrade boto3
-
   "run aws auth test with regular aws credentials":
     - command: shell.exec
       type: test

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -274,6 +274,15 @@ functions:
           }
           EOF
 
+  "upgrade boto3 aws library for python":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        silent: true
+        script: |
+          pip install --upgrade boto3
+
   "run aws auth test with regular aws credentials":
     - command: shell.exec
       type: test

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -303,7 +303,6 @@ AWS_AUTH_VERSIONS.forEach(VERSION => {
         }
       },
       { func: 'add aws auth variables to file' },
-      { func: 'upgrade boto3 aws library for python' },
       { func: 'run aws auth test with regular aws credentials' },
       { func: 'run aws auth test with assume role credentials' },
       { func: 'run aws auth test with aws EC2 credentials' },

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -303,6 +303,7 @@ AWS_AUTH_VERSIONS.forEach(VERSION => {
         }
       },
       { func: 'add aws auth variables to file' },
+      { func: 'upgrade boto3 aws library for python' },
       { func: 'run aws auth test with regular aws credentials' },
       { func: 'run aws auth test with assume role credentials' },
       { func: 'run aws auth test with aws EC2 credentials' },

--- a/.evergreen/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/run-mongodb-aws-ecs-test.sh
@@ -16,5 +16,5 @@ export NVM_DIR="${PROJECT_DIRECTORY}/node-artifacts/nvm"
 set -x
 
 # run the tests
-npm install aws4 
+npm install aws4
 MONGODB_URI=$MONGODB_URI MONGODB_UNIFIED_TOPOLOGY=1 npx mocha test/functional/mongodb_aws.test.js


### PR DESCRIPTION
## Description

Upgrades the `boto3` python dependency used in the AWS auth tests by means of the newly added `activate_venv.sh` script.

NODE-3056

**What changed?**

**Are there any files to ignore?**
