### PR TITLE
NODE-3008: Dont pass session to cloned cursor

### DIFF
--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -1,6 +1,7 @@
 import { AggregateOperation, AggregateOptions } from '../operations/aggregate';
 import { AbstractCursor, assertUninitialized } from './abstract_cursor';
 import { executeOperation, ExecutionResult } from '../operations/execute_operation';
+import { mergeOptions } from '../utils';
 import type { Document } from '../bson';
 import type { Sort } from '../sort';
 import type { Topology } from '../sdam/topology';
@@ -52,9 +53,9 @@ export class AggregationCursor extends AbstractCursor {
   }
 
   clone(): AggregationCursor {
+    const clonedOptions = mergeOptions({}, this[kOptions]);
     return new AggregationCursor(this[kParent], this.topology, this.namespace, this[kPipeline], {
-      ...this[kOptions],
-      ...this.cursorOptions
+      ...clonedOptions
     });
   }
 

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -4,6 +4,7 @@ import type { ExplainVerbosityLike } from '../explain';
 import { CountOperation, CountOptions } from '../operations/count';
 import { executeOperation, ExecutionResult } from '../operations/execute_operation';
 import { FindOperation, FindOptions } from '../operations/find';
+import { mergeOptions } from '../utils';
 import type { Hint } from '../operations/operation';
 import type { CollationOptions } from '../operations/command';
 import type { Topology } from '../sdam/topology';
@@ -52,9 +53,9 @@ export class FindCursor extends AbstractCursor {
   }
 
   clone(): FindCursor {
+    const clonedOptions = mergeOptions({}, this[kBuiltOptions]);
     return new FindCursor(this.topology, this.namespace, this[kFilter], {
-      ...this[kBuiltOptions],
-      ...this.cursorOptions
+      ...clonedOptions
     });
   }
 


### PR DESCRIPTION
Removed session from options when cloning the `FindCursor` and `AggregationCursor`
