### PR TITLE
fix(operations): avoid hardcoding `checkKeys` for insert operations

### DIFF
--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -18,7 +18,7 @@ export class InsertOperation extends CommandOperation<Document> {
 
   constructor(ns: MongoDBNamespace, documents: Document[], options: BulkWriteOptions) {
     super(undefined, options);
-    this.options = { ...options };
+    this.options = { ...options, checkKeys: options.checkKeys ?? true };
     this.ns = ns;
     this.documents = documents;
   }

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -18,7 +18,7 @@ export class InsertOperation extends CommandOperation<Document> {
 
   constructor(ns: MongoDBNamespace, documents: Document[], options: BulkWriteOptions) {
     super(undefined, options);
-    this.options = { ...options, checkKeys: true };
+    this.options = { ...options };
     this.ns = ns;
     this.documents = documents;
   }

--- a/test/functional/collection.test.js
+++ b/test/functional/collection.test.js
@@ -269,6 +269,16 @@ describe('Collection', function () {
       });
     });
 
+    it('should permit insert of dot and dollar keys if requested', function () {
+      const collection = db.collection('test_invalid_key_names');
+      return Promise.all([
+        collection.insertOne({ hel$lo: 0 }, { checkKeys: false }),
+        collection.insertOne({ hello: { $hello: 0 } }, { checkKeys: false }), // embedded document can have a leading dollar
+        collection.insertOne({ 'hel.lo': 0 }, { checkKeys: false }),
+        collection.drop()
+      ]);
+    });
+
     it('should fail due to illegal listCollections', function (done) {
       db.collection(5, err => {
         expect(err.message).to.equal('collection name must be a String');


### PR DESCRIPTION
## Description

**What changed?**

It looks like all insert operations hardcode `checkKeys: true`. I'm not sure if this change was intentional, I tracked the change to this commit: https://github.com/mongodb/node-mongodb-native/commit/07fd317afa91851cfa0065e664f1b5a88ec96fa9 . If this change was intentional, it would make sense to make a note in the changelog.

**Are there any files to ignore?**

Nope
