### PR TITLE
fix(operations): make every CollationOptions property optional except `locale`

### DIFF
--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -16,13 +16,14 @@ const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
 /** @public */
 export interface CollationOptions {
   locale: string;
-  caseLevel: boolean;
-  caseFirst: string;
-  strength: number;
-  numericOrdering: boolean;
-  alternate: string;
-  maxVariable: string;
-  backwards: boolean;
+  caseLevel?: boolean;
+  caseFirst?: string;
+  strength?: number;
+  numericOrdering?: boolean;
+  alternate?: string;
+  maxVariable?: string;
+  backwards?: boolean;
+  normalization?: boolean;
 }
 
 /** @public */


### PR DESCRIPTION
## Description

**What changed?**

Came up when working on https://github.com/Automattic/mongoose/pull/9855: according to the [server collation docs](https://docs.mongodb.com/manual/reference/collation/), every collation property except `locale` is optional.

**Are there any files to ignore?**

Nope
