### PR TITLE
test: restrict destroy test to node v8 and up

### DIFF
--- a/test/functional/gridfs_stream.test.js
+++ b/test/functional/gridfs_stream.test.js
@@ -100,7 +100,7 @@ describe('GridFS Stream', function() {
   });
 
   it('destroy publishes provided error', {
-    metadata: { requires: { topology: ['single'] } },
+    metadata: { requires: { topology: ['single'], node: '>=8' } },
     test: function(done) {
       var configuration = this.configuration;
       var GridFSBucket = configuration.require.GridFSBucket;


### PR DESCRIPTION
Note: [writable.destroy](https://nodejs.org/api/stream.html#stream_writable_destroy_error) was added in node v8.0.0

NODE-3065