### PR TITLE
test: more Unified runner operations

### DIFF
--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -144,9 +144,9 @@ describe('Connection - functional', function () {
     metadata: { requires: { topology: 'single' } },
 
     test: function (done) {
-      var configuration = this.configuration;
-      var user = 'testConnectGoodAuth',
-        password = 'password';
+      const configuration = this.configuration;
+      const username = 'testConnectGoodAuth';
+      const password = 'password';
 
       const setupClient = configuration.newClient();
 
@@ -155,14 +155,14 @@ describe('Connection - functional', function () {
         expect(err).to.not.exist;
         var db = client.db(configuration.db);
 
-        db.addUser(user, password, function (err) {
+        db.addUser(username, password, function (err) {
           expect(err).to.not.exist;
           client.close(restOfTest);
         });
       });
 
       function restOfTest() {
-        const testClient = configuration.newClient(configuration.url(user, password));
+        const testClient = configuration.newClient(configuration.url({ username, password }));
         testClient.connect(
           connectionTester(configuration, 'testConnectGoodAuth', function (client) {
             client.close(done);
@@ -176,7 +176,7 @@ describe('Connection - functional', function () {
     metadata: { requires: { topology: 'single' } },
 
     test: function (done) {
-      var configuration = this.configuration;
+      const configuration = this.configuration;
       const username = 'testConnectGoodAuthAsOption';
       const password = 'password';
 
@@ -211,7 +211,9 @@ describe('Connection - functional', function () {
 
     test: function (done) {
       var configuration = this.configuration;
-      const client = configuration.newClient(configuration.url('slithy', 'toves'));
+      const client = configuration.newClient(
+        configuration.url({ username: 'slithy', password: 'toves' })
+      );
       client.connect(function (err, client) {
         expect(err).to.exist;
         expect(client).to.not.exist;

--- a/test/functional/spec-runner/utils.js
+++ b/test/functional/spec-runner/utils.js
@@ -3,7 +3,7 @@
 function resolveConnectionString(configuration, spec, context) {
   const isShardedEnvironment = configuration.topologyType === 'Sharded';
   const useMultipleMongoses = spec && !!spec.useMultipleMongoses;
-  const user = context && context.user;
+  const username = context && context.user;
   const password = context && context.password;
   const authSource = context && context.authSource;
   const connectionString =
@@ -11,7 +11,7 @@ function resolveConnectionString(configuration, spec, context) {
       ? `mongodb://${configuration.host}:${configuration.port}/${
           configuration.db
         }?directConnection=false${authSource ? '&authSource=${authSource}' : ''}`
-      : configuration.url(user, password, { authSource });
+      : configuration.url({ username, password, authSource });
   return connectionString;
 }
 

--- a/test/functional/unified-spec-runner/entities.ts
+++ b/test/functional/unified-spec-runner/entities.ts
@@ -1,4 +1,7 @@
 import { MongoClient, Db, Collection, GridFSBucket, Document } from '../../../src/index';
+import { ReadConcern } from '../../../src/read_concern';
+import { WriteConcern } from '../../../src/write_concern';
+import { ReadPreference } from '../../../src/read_preference';
 import { ClientSession } from '../../../src/sessions';
 import { ChangeStream } from '../../../src/change_stream';
 import type { ClientEntity, EntityDescription } from './schema';
@@ -10,9 +13,14 @@ import type {
 import { patchCollectionOptions, patchDbOptions } from './unified-utils';
 import { TestConfiguration } from './unified.test';
 import { expect } from 'chai';
+import { parseURI } from '../../../src/connection_string';
 
 interface UnifiedChangeStream extends ChangeStream {
   eventCollector: InstanceType<typeof import('../../tools/utils')['EventCollector']>;
+}
+
+interface UnifiedClientSession extends ClientSession {
+  client: UnifiedMongoClient;
 }
 
 export type CommandEvent = CommandStartedEvent | CommandSucceededEvent | CommandFailedEvent;
@@ -85,7 +93,7 @@ export type Entity =
   | UnifiedMongoClient
   | Db
   | Collection
-  | ClientSession
+  | UnifiedClientSession
   | UnifiedChangeStream
   | GridFSBucket
   | Document; // Results from operations
@@ -112,7 +120,7 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
   mapOf(type: 'client'): EntitiesMap<UnifiedMongoClient>;
   mapOf(type: 'db'): EntitiesMap<Db>;
   mapOf(type: 'collection'): EntitiesMap<Collection>;
-  mapOf(type: 'session'): EntitiesMap<ClientSession>;
+  mapOf(type: 'session'): EntitiesMap<UnifiedClientSession>;
   mapOf(type: 'bucket'): EntitiesMap<GridFSBucket>;
   mapOf(type: 'stream'): EntitiesMap<UnifiedChangeStream>;
   mapOf(type: EntityTypeId): EntitiesMap<Entity> {
@@ -126,13 +134,13 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
   getEntity(type: 'client', key: string, assertExists?: boolean): UnifiedMongoClient;
   getEntity(type: 'db', key: string, assertExists?: boolean): Db;
   getEntity(type: 'collection', key: string, assertExists?: boolean): Collection;
-  getEntity(type: 'session', key: string, assertExists?: boolean): ClientSession;
+  getEntity(type: 'session', key: string, assertExists?: boolean): UnifiedClientSession;
   getEntity(type: 'bucket', key: string, assertExists?: boolean): GridFSBucket;
   getEntity(type: 'stream', key: string, assertExists?: boolean): UnifiedChangeStream;
   getEntity(type: EntityTypeId, key: string, assertExists = true): Entity {
     const entity = this.get(key);
     if (!entity) {
-      if (assertExists) throw new Error(`Entity ${key} does not exist`);
+      if (assertExists) throw new Error(`Entity '${key}' does not exist`);
       return;
     }
     const ctor = ENTITY_CTORS.get(type);
@@ -163,7 +171,17 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
     const map = new EntitiesMap();
     for (const entity of entities ?? []) {
       if ('client' in entity) {
-        const client = new UnifiedMongoClient(config.url(), entity.client);
+        let uri = config.url();
+        const { hosts, url } = parseURI(uri);
+
+        if (entity.client.useMultipleMongoses) {
+          expect(hosts).to.have.length.greaterThan(1);
+        } else if (entity.client.useMultipleMongoses === false) {
+          url.host = hosts[0];
+          uri = url.toString();
+        }
+
+        const client = new UnifiedMongoClient(uri, entity.client);
         await client.connect();
         map.set(entity.client.id, client);
       } else if ('database' in entity) {
@@ -181,11 +199,60 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
         );
         map.set(entity.collection.id, collection);
       } else if ('session' in entity) {
-        map.set(entity.session.id, null);
+        const client = map.getEntity('client', entity.session.client);
+
+        const options = Object.create(null);
+
+        if (entity.session.sessionOptions?.causalConsistency) {
+          options.causalConsistency = entity.session.sessionOptions?.causalConsistency;
+        }
+
+        if (entity.session.sessionOptions?.defaultTransactionOptions) {
+          options.defaultTransactionOptions = Object.create(null);
+          const defaultOptions = entity.session.sessionOptions.defaultTransactionOptions;
+          if (defaultOptions.readConcern) {
+            options.defaultTransactionOptions.readConcern = ReadConcern.fromOptions(
+              defaultOptions.readConcern
+            );
+          }
+          if (defaultOptions.writeConcern) {
+            options.defaultTransactionOptions.writeConcern = WriteConcern.fromOptions(
+              defaultOptions
+            );
+          }
+          if (defaultOptions.readPreference) {
+            options.defaultTransactionOptions.readPreference = ReadPreference.fromOptions(
+              defaultOptions.readPreference
+            );
+          }
+          if (typeof defaultOptions.maxCommitTimeMS === 'number') {
+            options.defaultTransactionOptions.maxCommitTimeMS = defaultOptions.maxCommitTimeMS;
+          }
+        }
+
+        const session = client.startSession(options) as UnifiedClientSession;
+        // targetedFailPoint operations need to access the client the session came from
+        session.client = client;
+
+        map.set(entity.session.id, session);
       } else if ('bucket' in entity) {
-        map.set(entity.bucket.id, null);
+        const db = map.getEntity('db', entity.bucket.database);
+
+        const options = Object.create(null);
+
+        if (entity.bucket.bucketOptions?.bucketName) {
+          options.bucketName = entity.bucket.bucketOptions?.bucketName;
+        }
+        if (entity.bucket.bucketOptions?.chunkSizeBytes) {
+          options.chunkSizeBytes = entity.bucket.bucketOptions?.chunkSizeBytes;
+        }
+        if (entity.bucket.bucketOptions?.readPreference) {
+          options.readPreference = entity.bucket.bucketOptions?.readPreference;
+        }
+
+        map.set(entity.bucket.id, new GridFSBucket(db, options));
       } else if ('stream' in entity) {
-        map.set(entity.stream.id, null);
+        throw new Error(`Unsupported Entity ${JSON.stringify(entity)}`);
       } else {
         throw new Error(`Unsupported Entity ${JSON.stringify(entity)}`);
       }

--- a/test/functional/unified-spec-runner/entities.ts
+++ b/test/functional/unified-spec-runner/entities.ts
@@ -13,7 +13,6 @@ import type {
 import { patchCollectionOptions, patchDbOptions } from './unified-utils';
 import { TestConfiguration } from './unified.test';
 import { expect } from 'chai';
-import { parseURI } from '../../../src/connection_string';
 
 interface UnifiedChangeStream extends ChangeStream {
   eventCollector: InstanceType<typeof import('../../tools/utils')['EventCollector']>;

--- a/test/functional/unified-spec-runner/entities.ts
+++ b/test/functional/unified-spec-runner/entities.ts
@@ -11,8 +11,8 @@ import type {
   CommandSucceededEvent
 } from '../../../src/cmap/events';
 import { patchCollectionOptions, patchDbOptions } from './unified-utils';
-import { TestConfiguration } from './unified.test';
 import { expect } from 'chai';
+import { TestConfiguration } from './runner';
 
 interface UnifiedChangeStream extends ChangeStream {
   eventCollector: InstanceType<typeof import('../../tools/utils')['EventCollector']>;

--- a/test/functional/unified-spec-runner/entities.ts
+++ b/test/functional/unified-spec-runner/entities.ts
@@ -171,16 +171,7 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
     const map = new EntitiesMap();
     for (const entity of entities ?? []) {
       if ('client' in entity) {
-        let uri = config.url();
-        const { hosts, url } = parseURI(uri);
-
-        if (entity.client.useMultipleMongoses) {
-          expect(hosts).to.have.length.greaterThan(1);
-        } else if (entity.client.useMultipleMongoses === false) {
-          url.host = hosts[0];
-          uri = url.toString();
-        }
-
+        const uri = config.url({ useMultipleMongoses: entity.client.useMultipleMongoses });
         const client = new UnifiedMongoClient(uri, entity.client);
         await client.connect();
         map.set(entity.client.id, client);

--- a/test/functional/unified-spec-runner/match.ts
+++ b/test/functional/unified-spec-runner/match.ts
@@ -257,7 +257,7 @@ export function expectErrorCheck(
     return;
   }
 
-  if (expected.errorContains) {
+  if (expected.errorContains != null) {
     expect(error.message).to.include(expected.errorContains);
   }
 
@@ -267,15 +267,15 @@ export function expectErrorCheck(
     return;
   }
 
-  if (expected.errorCode) {
+  if (expected.errorCode != null) {
     expect(error).to.have.property('code', expected.errorCode);
   }
 
-  if (expected.errorCodeName) {
+  if (expected.errorCodeName != null) {
     expect(error).to.have.property('codeName', expected.errorCodeName);
   }
 
-  if (expected.errorLabelsContain) {
+  if (expected.errorLabelsContain != null) {
     for (const errorLabel of expected.errorLabelsContain) {
       expect(
         error.hasErrorLabel(errorLabel),
@@ -284,7 +284,7 @@ export function expectErrorCheck(
     }
   }
 
-  if (expected.errorLabelsOmit) {
+  if (expected.errorLabelsOmit != null) {
     for (const errorLabel of expected.errorLabelsOmit) {
       expect(
         error.hasErrorLabel(errorLabel),
@@ -293,7 +293,7 @@ export function expectErrorCheck(
     }
   }
 
-  if (expected.expectResult) {
+  if (expected.expectResult != null) {
     resultCheck(error, expected.expectResult, entities);
   }
 }

--- a/test/functional/unified-spec-runner/match.ts
+++ b/test/functional/unified-spec-runner/match.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { isDeepStrictEqual } from 'util';
 import { Binary, Document, Long, ObjectId, MongoError } from '../../../src';
 import {
   CommandFailedEvent,
@@ -107,61 +106,55 @@ TYPE_MAP.set(
   actual => (typeof actual === 'number' && Number.isInteger(actual)) || Long.isLong(actual)
 );
 
-export function expectResultCheck(
+export function resultCheck(
   actual: Document,
   expected: Document | number | string | boolean,
   entities: EntitiesMap,
   path: string[] = [],
   depth = 0
-): boolean {
-  const ok = resultCheck(actual, expected, entities, path, depth);
-  if (ok === false) {
-    const pathString = path.join('');
-    const expectedJSON = JSON.stringify(expected, undefined, 2);
-    const actualJSON = JSON.stringify(actual, undefined, 2);
-    expect.fail(`Unable to match ${expectedJSON} to ${actualJSON} at ${pathString}`);
-  }
-  return ok;
-}
-
-export function resultCheck(
-  actual: Document,
-  expected: Document | number | string | boolean,
-  entities: EntitiesMap,
-  path: string[],
-  depth = 0
-): boolean {
-  if (typeof expected === 'object' && expected !== null) {
+): void {
+  if (typeof expected === 'object' && expected) {
     // Expected is an object
     // either its a special operator or just an object to check equality against
 
     if (isSpecialOperator(expected)) {
       // Special operation check is a base condition
       // specialCheck may recurse depending upon the check ($$unsetOrMatches)
-      return specialCheck(actual, expected, entities, path, depth);
+      specialCheck(actual, expected, entities, path, depth);
+      return;
     } else {
       // Just a plain object, however this object can contain special operations
       // So we need to recurse over each key,value
-      let ok = true;
       const expectedEntries = Object.entries(expected);
 
-      if (depth > 1 && Object.keys(actual).length !== Object.keys(expected).length) {
-        throw new Error(`[${Object.keys(actual)}] length !== [${Object.keys(expected)}]`);
+      if (depth > 1) {
+        expect(actual, `Expected actual to exist at ${path.join('')}`).to.exist;
+        expect(
+          Object.keys(actual),
+          `[${Object.keys(actual)}] length !== [${Object.keys(expected)}]`
+        ).to.have.lengthOf(Object.keys(expected).length);
       }
 
       for (const [key, value] of expectedEntries) {
         path.push(Array.isArray(expected) ? `[${key}]` : `.${key}`); // record what key we're at
         depth += 1;
-        ok &&= expectResultCheck(actual[key], value, entities, path, depth);
+        resultCheck(actual[key], value, entities, path, depth);
         depth -= 1;
         path.pop(); // if the recursion was successful we can drop the tested key
       }
-      return ok;
     }
   } else {
     // Here's our recursion base case
-    // expected is: number | string | boolean | null
-    return isDeepStrictEqual(actual, expected);
+    // expected is: number | Long | string | boolean | null
+    if (Long.isLong(actual) && typeof expected === 'number') {
+      // Long requires special equality check
+      expect(actual.equals(expected)).to.be.true;
+    } else if (Long.isLong(expected) && typeof actual === 'number') {
+      // Long requires special equality check
+      expect(expected.equals(actual)).to.be.true;
+    } else {
+      expect(actual).to.equal(expected);
+    }
   }
 }
 
@@ -172,45 +165,56 @@ export function specialCheck(
   path: string[] = [],
   depth = 0
 ): boolean {
-  let ok = false;
   if (isUnsetOrMatchesOperator(expected)) {
     // $$unsetOrMatches
-    ok = true; // start with true assumption
-    if (actual === null || actual === undefined) ok = true;
+    if (actual === null || actual === undefined) return;
     else {
       depth += 1;
-      ok &&= expectResultCheck(actual, expected.$$unsetOrMatches, entities, path, depth);
+      resultCheck(actual, expected.$$unsetOrMatches, entities, path, depth);
       depth -= 1;
     }
   } else if (isMatchesEntityOperator(expected)) {
     // $$matchesEntity
     const entity = entities.get(expected.$$matchesEntity);
-    if (!entity) ok = false;
-    else ok = isDeepStrictEqual(actual, entity);
+    if (
+      typeof actual === 'object' && // an object
+      actual && // that isn't null
+      'equals' in actual && // with an equals
+      typeof actual.equals === 'function' // method
+    ) {
+      expect(actual.equals(entity)).to.be.true;
+    } else {
+      expect(actual).to.equal(entity);
+    }
   } else if (isMatchesHexBytesOperator(expected)) {
     // $$matchesHexBytes
     const expectedBuffer = Buffer.from(expected.$$matchesHexBytes, 'hex');
-    ok = expectedBuffer.every((byte, index) => byte === actual[index]);
+    expect(expectedBuffer.every((byte, index) => byte === actual[index])).to.be.true;
   } else if (isSessionLsidOperator(expected)) {
     // $$sessionLsid
     const session = entities.getEntity('session', expected.$$sessionLsid, false);
-    if (!session) ok = false;
-    else ok = session.id.id.buffer.equals(actual.lsid.id.buffer);
+    expect(session, `Session ${expected.$$sessionLsid} does not exist in entities`).to.exist;
+    const entitySessionHex = session.id.id.buffer.toString('hex').toUpperCase();
+    const actualSessionHex = actual.id.buffer.toString('hex').toUpperCase();
+    expect(
+      entitySessionHex,
+      `Session entity ${expected.$$sessionLsid} does not match lsid`
+    ).to.equal(actualSessionHex);
   } else if (isTypeOperator(expected)) {
     // $$type
+    let ok: boolean;
     const types = Array.isArray(expected.$$type) ? expected.$$type : [expected.$$type];
     for (const type of types) {
       ok ||= TYPE_MAP.get(type)(actual);
     }
+    expect(ok, `Expected [${actual}] to be one of [${types}]`).to.be.true;
   } else if (isExistsOperator(expected)) {
-    // $$exists - unique, this op uses the path to check if the key is (not) in actual
+    // $$exists
     const actualExists = actual !== undefined && actual !== null;
-    ok = (expected.$$exists && actualExists) || (!expected.$$exists && !actualExists);
+    expect((expected.$$exists && actualExists) || (!expected.$$exists && !actualExists)).to.be.true;
   } else {
-    throw new Error(`Unknown special operator: ${JSON.stringify(expected)}`);
+    expect.fail(`Unknown special operator: ${JSON.stringify(expected)}`);
   }
-
-  return ok;
 }
 
 export function matchesEvents(
@@ -225,14 +229,14 @@ export function matchesEvents(
     const expectedEvent = expected[index];
 
     if (expectedEvent.commandStartedEvent && actualEvent instanceof CommandStartedEvent) {
-      expectResultCheck(actualEvent, expectedEvent.commandStartedEvent, entities, [
+      resultCheck(actualEvent, expectedEvent.commandStartedEvent, entities, [
         `events[${index}].commandStartedEvent`
       ]);
     } else if (
       expectedEvent.commandSucceededEvent &&
       actualEvent instanceof CommandSucceededEvent
     ) {
-      expectResultCheck(actualEvent, expectedEvent.commandSucceededEvent, entities, [
+      resultCheck(actualEvent, expectedEvent.commandSucceededEvent, entities, [
         `events[${index}].commandSucceededEvent`
       ]);
     } else if (expectedEvent.commandFailedEvent && actualEvent instanceof CommandFailedEvent) {
@@ -254,48 +258,42 @@ export function expectErrorCheck(
   }
 
   if (expected.errorContains) {
-    if (error.message.includes(expected.errorContains)) {
-      throw new Error(
-        `Error message was supposed to contain '${expected.errorContains}' but had '${error.message}'`
-      );
-    }
+    expect(error.message).to.include(expected.errorContains);
   }
 
   if (!(error instanceof MongoError)) {
-    throw new Error(`Assertions need ${error} to be a MongoError`);
+    // if statement asserts type for TS, expect will always fail
+    expect(error).to.be.instanceOf(MongoError);
+    return;
   }
 
   if (expected.errorCode) {
-    if (error.code !== expected.errorCode) {
-      throw new Error(`${error} was supposed to have code '${expected.errorCode}'`);
-    }
+    expect(error).to.have.property('code', expected.errorCode);
   }
 
   if (expected.errorCodeName) {
-    if (error.codeName !== expected.errorCodeName) {
-      throw new Error(`${error} was supposed to have '${expected.errorCodeName}' codeName`);
-    }
+    expect(error).to.have.property('codeName', expected.errorCodeName);
   }
 
   if (expected.errorLabelsContain) {
     for (const errorLabel of expected.errorLabelsContain) {
-      if (!error.hasErrorLabel(errorLabel)) {
-        throw new Error(`${error} was supposed to have '${errorLabel}'`);
-      }
+      expect(
+        error.hasErrorLabel(errorLabel),
+        `Error was supposed to have label ${errorLabel}, has [${error.errorLabels}]`
+      ).to.be.true;
     }
   }
 
   if (expected.errorLabelsOmit) {
     for (const errorLabel of expected.errorLabelsOmit) {
-      if (error.hasErrorLabel(errorLabel)) {
-        throw new Error(`${error} was not supposed to have '${errorLabel}'`);
-      }
+      expect(
+        error.hasErrorLabel(errorLabel),
+        `Error was supposed to have label ${errorLabel}, has [${error.errorLabels}]`
+      ).to.be.false;
     }
   }
 
   if (expected.expectResult) {
-    if (!expectResultCheck(error, expected.expectResult, entities)) {
-      throw new Error(`${error} supposed to match result ${JSON.stringify(expected.expectResult)}`);
-    }
+    resultCheck(error, expected.expectResult, entities);
   }
 }

--- a/test/functional/unified-spec-runner/runner.ts
+++ b/test/functional/unified-spec-runner/runner.ts
@@ -187,7 +187,7 @@ export async function runUnifiedTest(
   }
 }
 
-export async function runUnifiedSuite(specTests: uni.UnifiedSuite[]): Promise<void> {
+export function runUnifiedSuite(specTests: uni.UnifiedSuite[]): void {
   for (const unifiedSuite of specTests) {
     context(String(unifiedSuite.description), function () {
       for (const test of unifiedSuite.tests) {

--- a/test/functional/unified-spec-runner/unified-runner.test.ts
+++ b/test/functional/unified-spec-runner/unified-runner.test.ts
@@ -1,0 +1,17 @@
+import { loadSpecTests } from '../../spec/index';
+import { runUnifiedSuite } from './runner';
+
+describe('Unified test format runner', function unifiedTestRunner() {
+  // Valid tests that should pass
+  runUnifiedSuite(loadSpecTests('unified-test-format/valid-pass'));
+
+  // Valid tests that should fail
+  // for (const unifiedSuite of loadSpecTests('unified-test-format/valid-fail')) {
+  //   // TODO
+  // }
+
+  // Tests that are invalid, would be good to gracefully fail on
+  // for (const unifiedSuite of loadSpecTests('unified-test-format/invalid')) {
+  //   // TODO
+  // }
+});

--- a/test/functional/unified-spec-runner/unified-utils.ts
+++ b/test/functional/unified-spec-runner/unified-utils.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import type { CollectionOrDatabaseOptions, RunOnRequirement } from './schema';
 import type { TestConfiguration } from './unified.test';
 import { gte as semverGte, lte as semverLte } from 'semver';
-import { CollectionOptions, DbOptions } from '../../../src';
+import { CollectionOptions, DbOptions, MongoClient } from '../../../src';
 import { isDeepStrictEqual } from 'util';
 
 const ENABLE_UNIFIED_TEST_LOGGING = false;
@@ -10,7 +10,11 @@ export function log(message: unknown, ...optionalParameters: unknown[]): void {
   if (ENABLE_UNIFIED_TEST_LOGGING) console.warn(message, ...optionalParameters);
 }
 
-export function topologySatisfies(config: TestConfiguration, r: RunOnRequirement): boolean {
+export async function topologySatisfies(
+  config: TestConfiguration,
+  r: RunOnRequirement,
+  utilClient: MongoClient
+): Promise<boolean> {
   let ok = true;
   if (r.minServerVersion) {
     const minVersion = patchVersion(r.minServerVersion);
@@ -28,8 +32,14 @@ export function topologySatisfies(config: TestConfiguration, r: RunOnRequirement
       ReplicaSetWithPrimary: 'replicaset',
       Sharded: 'sharded'
     }[config.topologyType];
-    if (!topologyType) throw new Error(`Topology undiscovered: ${config.topologyType}`);
-    ok &&= r.topologies.includes(topologyType);
+
+    if (r.topologies.includes('sharded-replicaset')) {
+      const shards = await utilClient.db('config').collection('shards').find({}).toArray();
+      ok &&= shards.every(shard => shard.host.split(',').length > 1);
+    } else {
+      if (!topologyType) throw new Error(`Topology undiscovered: ${config.topologyType}`);
+      ok &&= r.topologies.includes(topologyType);
+    }
   }
 
   if (r.serverParameters) {

--- a/test/functional/unified-spec-runner/unified-utils.ts
+++ b/test/functional/unified-spec-runner/unified-utils.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import type { CollectionOrDatabaseOptions, RunOnRequirement } from './schema';
-import type { TestConfiguration } from './unified.test';
 import { gte as semverGte, lte as semverLte } from 'semver';
 import { CollectionOptions, DbOptions, MongoClient } from '../../../src';
 import { isDeepStrictEqual } from 'util';
+import { TestConfiguration } from './runner';
 
 const ENABLE_UNIFIED_TEST_LOGGING = false;
 export function log(message: unknown, ...optionalParameters: unknown[]): void {

--- a/test/functional/unified-spec-runner/unified.test.ts
+++ b/test/functional/unified-spec-runner/unified.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ReadPreference } from '../../../src/read_preference';
 import { loadSpecTests } from '../../spec/index';
 import * as uni from './schema';
-import { patchVersion, zip, log, topologySatisfies } from './unified-utils';
+import { patchVersion, zip, topologySatisfies } from './unified-utils';
 import { CommandEvent, EntitiesMap } from './entities';
 import { ns } from '../../../src/utils';
 import { executeOperationAndCheck } from './operations';
@@ -15,6 +15,26 @@ export type TestConfiguration = InstanceType<
 interface MongoDBMochaTestContext extends Mocha.Context {
   configuration: TestConfiguration;
 }
+
+const SKIPPED_TESTS = [
+  // These were already skipped in our existing spec tests
+  'unpin after transient error within a transaction and commit',
+  'Dirty explicit session is discarded',
+
+  // TODO Un-skip these to complete unified runner
+  'withTransaction inherits transaction options from client',
+  'withTransaction inherits transaction options from defaultTransactionOptions',
+  'remain pinned after non-transient Interrupted error on insertOne',
+  'unpin after transient error within a transaction',
+  'Client side error in command starting transaction',
+  'explicitly create collection using create command',
+  'create index on a non-existing collection',
+  'InsertMany succeeds after PrimarySteppedDown',
+  'withTransaction and no transaction options set',
+  'withTransaction explicit transaction options',
+  'InsertOne fails after connection failure when retryWrites option is false',
+  'InsertOne fails after multiple retryable writeConcernErrors'
+];
 
 async function runOne(
   ctx: MongoDBMochaTestContext,
@@ -34,108 +54,134 @@ async function runOne(
     ctx.skip();
   }
 
-  const UTIL_CLIENT = ctx.configuration.newClient();
-  await UTIL_CLIENT.connect();
-  ctx.defer(async () => await UTIL_CLIENT.close());
+  if (SKIPPED_TESTS.includes(test.description)) {
+    ctx.skip();
+  }
 
-  // Must fetch parameters before checking runOnRequirements
-  ctx.configuration.parameters = await UTIL_CLIENT.db().admin().command({ getParameter: '*' });
+  const utilClient = ctx.configuration.newClient();
 
-  // If test.runOnRequirements is specified, the test runner MUST skip the test unless one or more
-  // runOnRequirement objects are satisfied.
-  const allRequirements = [
-    ...(unifiedSuite.runOnRequirements ?? []),
-    ...(test.runOnRequirements ?? [])
-  ];
-  for (const requirement of allRequirements) {
-    if (!topologySatisfies(ctx.configuration, requirement)) {
+  let entities;
+  try {
+    await utilClient.connect();
+
+    // Must fetch parameters before checking runOnRequirements
+    ctx.configuration.parameters = await utilClient.db().admin().command({ getParameter: '*' });
+
+    // If test.runOnRequirements is specified, the test runner MUST skip the test unless one or more
+    // runOnRequirement objects are satisfied.
+    const allRequirements = [
+      ...(unifiedSuite.runOnRequirements ?? []),
+      ...(test.runOnRequirements ?? [])
+    ];
+
+    let doesNotMeetRunOnRequirement = allRequirements.length > 0;
+
+    for (const requirement of allRequirements) {
+      if (await topologySatisfies(ctx.configuration, requirement, utilClient)) {
+        doesNotMeetRunOnRequirement = false; // it does meet a run on requirement!
+        break;
+      }
+    }
+
+    if (doesNotMeetRunOnRequirement) {
       ctx.skip();
     }
-  }
 
-  // If initialData is specified, for each collectionData therein the test runner MUST drop the
-  // collection and insert the specified documents (if any) using a "majority" write concern. If no
-  // documents are specified, the test runner MUST create the collection with a "majority" write concern.
-  // The test runner MUST use the internal MongoClient for these operations.
-  if (unifiedSuite.initialData) {
-    for (const collData of unifiedSuite.initialData) {
-      const db = UTIL_CLIENT.db(collData.databaseName);
-      const collection = db.collection(collData.collectionName, {
-        writeConcern: { w: 'majority' }
-      });
-      const collectionList = await db.listCollections({ name: collData.collectionName }).toArray();
-      if (collectionList.length !== 0) {
-        expect(await collection.drop()).to.be.true;
-      }
-
-      if (collData.documents.length === 0) {
-        await db.createCollection(collData.collectionName, {
+    // If initialData is specified, for each collectionData therein the test runner MUST drop the
+    // collection and insert the specified documents (if any) using a "majority" write concern. If no
+    // documents are specified, the test runner MUST create the collection with a "majority" write concern.
+    // The test runner MUST use the internal MongoClient for these operations.
+    if (unifiedSuite.initialData) {
+      for (const collData of unifiedSuite.initialData) {
+        const db = utilClient.db(collData.databaseName);
+        const collection = db.collection(collData.collectionName, {
           writeConcern: { w: 'majority' }
         });
-        continue;
+        const collectionList = await db
+          .listCollections({ name: collData.collectionName })
+          .toArray();
+        if (collectionList.length !== 0) {
+          expect(await collection.drop()).to.be.true;
+        }
       }
 
-      await collection.insertMany(collData.documents);
-    }
-  }
+      for (const collData of unifiedSuite.initialData) {
+        const db = utilClient.db(collData.databaseName);
+        const collection = db.collection(collData.collectionName, {
+          writeConcern: { w: 'majority' }
+        });
 
-  const entities = await EntitiesMap.createEntities(ctx.configuration, unifiedSuite.createEntities);
-  ctx.defer(async () => await entities.cleanup());
+        if (!collData.documents?.length) {
+          await db.createCollection(collData.collectionName, {
+            writeConcern: { w: 'majority' }
+          });
+          continue;
+        }
 
-  // Workaround for SERVER-39704:
-  // test runners MUST execute a non-transactional distinct command on
-  // each mongos server before running any test that might execute distinct within a transaction.
-  // To ease the implementation, test runners MAY execute distinct before every test.
-  if (
-    ctx.topologyType === uni.TopologyType.sharded ||
-    ctx.topologyType === uni.TopologyType.shardedReplicaset
-  ) {
-    for (const [, collection] of entities.mapOf('collection')) {
-      await UTIL_CLIENT.db(ns(collection.namespace).db).command({
-        distinct: collection.collectionName,
-        key: '_id'
-      });
-    }
-  }
-
-  for (const operation of test.operations) {
-    await executeOperationAndCheck(operation, entities);
-  }
-
-  const clientEvents = new Map<string, CommandEvent[]>();
-  // If any event listeners were enabled on any client entities,
-  // the test runner MUST now disable those event listeners.
-  for (const [id, client] of entities.mapOf('client')) {
-    clientEvents.set(id, client.stopCapturingEvents());
-  }
-
-  if (test.expectEvents) {
-    for (const expectedEventList of test.expectEvents) {
-      const clientId = expectedEventList.client;
-      const actualEvents = clientEvents.get(clientId);
-
-      expect(actualEvents, `No client entity found with id ${clientId}`).to.exist;
-      matchesEvents(expectedEventList.events, actualEvents, entities);
-    }
-  }
-
-  if (test.outcome) {
-    for (const collectionData of test.outcome) {
-      const collection = UTIL_CLIENT.db(collectionData.databaseName).collection(
-        collectionData.collectionName
-      );
-      const findOpts = {
-        readConcern: 'local' as const,
-        readPreference: ReadPreference.primary,
-        sort: { _id: 'asc' as const }
-      };
-      const documents = await collection.find({}, findOpts).toArray();
-
-      expect(documents).to.have.lengthOf(collectionData.documents.length);
-      for (const [expected, actual] of zip(collectionData.documents, documents)) {
-        expect(actual).to.include(expected, 'Test outcome did not match expected');
+        await collection.insertMany(collData.documents);
       }
     }
+
+    entities = await EntitiesMap.createEntities(ctx.configuration, unifiedSuite.createEntities);
+
+    // Workaround for SERVER-39704:
+    // test runners MUST execute a non-transactional distinct command on
+    // each mongos server before running any test that might execute distinct within a transaction.
+    // To ease the implementation, test runners MAY execute distinct before every test.
+    if (
+      ctx.topologyType === uni.TopologyType.sharded ||
+      ctx.topologyType === uni.TopologyType.shardedReplicaset
+    ) {
+      for (const [, collection] of entities.mapOf('collection')) {
+        await utilClient.db(ns(collection.namespace).db).command({
+          distinct: collection.collectionName,
+          key: '_id'
+        });
+      }
+    }
+
+    for (const operation of test.operations) {
+      await executeOperationAndCheck(operation, entities, utilClient);
+    }
+
+    const clientEvents = new Map<string, CommandEvent[]>();
+    // If any event listeners were enabled on any client entities,
+    // the test runner MUST now disable those event listeners.
+    for (const [id, client] of entities.mapOf('client')) {
+      clientEvents.set(id, client.stopCapturingEvents());
+    }
+
+    if (test.expectEvents) {
+      for (const expectedEventList of test.expectEvents) {
+        const clientId = expectedEventList.client;
+        const actualEvents = clientEvents.get(clientId);
+
+        expect(actualEvents, `No client entity found with id ${clientId}`).to.exist;
+        matchesEvents(expectedEventList.events, actualEvents, entities);
+      }
+    }
+
+    if (test.outcome) {
+      for (const collectionData of test.outcome) {
+        const collection = utilClient
+          .db(collectionData.databaseName)
+          .collection(collectionData.collectionName);
+        const findOpts = {
+          readConcern: 'local' as const,
+          readPreference: ReadPreference.primary,
+          sort: { _id: 'asc' as const }
+        };
+        const documents = await collection.find({}, findOpts).toArray();
+
+        expect(documents).to.have.lengthOf(collectionData.documents.length);
+        for (const [expected, actual] of zip(collectionData.documents, documents)) {
+          expect(actual).to.include(expected, 'Test outcome did not match expected');
+        }
+      }
+    }
+  } finally {
+    await utilClient.close();
+    await entities?.cleanup();
   }
 }
 
@@ -146,17 +192,10 @@ describe('Unified test format', function unifiedTestRunner() {
     expect(semverSatisfies(schemaVersion, uni.SupportedVersion)).to.be.true;
     context(String(unifiedSuite.description), function runUnifiedTest() {
       for (const test of unifiedSuite.tests) {
-        it(String(test.description), async function runOneUnifiedTest() {
-          try {
+        it(String(test.description), {
+          metadata: { sessions: { skipLeakTests: true } },
+          test: async function runOneUnifiedTest() {
             await runOne(this as MongoDBMochaTestContext, unifiedSuite, test);
-          } catch (error) {
-            if (error.message.includes('not implemented.')) {
-              log(`${test.description}: was skipped due to missing functionality`);
-              log(error.stack);
-              this.skip();
-            } else {
-              throw error;
-            }
           }
         });
       }

--- a/test/tools/runner/config.js
+++ b/test/tools/runner/config.js
@@ -1,6 +1,7 @@
 'use strict';
 const url = require('url');
 const qs = require('querystring');
+const { expect } = require('chai');
 
 const { MongoClient } = require('../../../src/mongo_client');
 const { Topology } = require('../../../src/sdam/topology');
@@ -17,6 +18,7 @@ const { HostAddress } = require('../../../src/utils');
  * @property {string} [authMechanism] - Authmechanism name
  * @property {Record<string, any>} [authMechanismProperties] - additional options for auth mechanism
  * @property {string} [authSource] - authSource override in searchParams of URI
+ * @property {boolean} [useMultipleMongoses] - if set will use concatenate all known HostAddresses in URI
  */
 
 /**
@@ -217,7 +219,13 @@ class TestConfiguration {
       }
     }
 
-    const actualHostsString = this.options.hostAddresses.map(ha => ha.toString()).join(',');
+    let actualHostsString;
+    if (options.useMultipleMongoses) {
+      expect(this.options.hostAddresses).to.have.length.greaterThan(1);
+      actualHostsString = this.options.hostAddresses.map(ha => ha.toString()).join(',');
+    } else {
+      actualHostsString = this.options.hostAddresses[0].toString();
+    }
 
     const connectionString = url.toString().replace(FILLER_HOST, actualHostsString);
 

--- a/test/tools/runner/config.js
+++ b/test/tools/runner/config.js
@@ -1,13 +1,23 @@
 'use strict';
 const url = require('url');
 const qs = require('querystring');
-const util = require('util');
 
 const { MongoClient } = require('../../../src/mongo_client');
 const { Topology } = require('../../../src/sdam/topology');
 const { TopologyType } = require('../../../src/sdam/common');
 const { parseURI } = require('../../../src/connection_string');
 const { HostAddress } = require('../../../src/utils');
+
+/**
+ * @typedef {Object} UrlOptions
+ * @property {string} [db] - dbName to put in the path section override
+ * @property {string} [replicaSet] - replicaSet name override
+ * @property {string} [username] - Username for auth section
+ * @property {string} [password] - Password for auth section
+ * @property {string} [authMechanism] - Authmechanism name
+ * @property {Record<string, any>} [authMechanismProperties] - additional options for auth mechanism
+ * @property {string} [authSource] - authSource override in searchParams of URI
+ */
 
 /**
  * @param {Record<string, any>} obj
@@ -168,75 +178,50 @@ class TestConfiguration {
     return new Topology(hosts, options);
   }
 
-  url(username, password, options) {
-    options = options || {};
+  /**
+   * Construct a connection URL using nodejs's whatwg URL similar to how connection_string.ts
+   * works
+   *
+   * @param {UrlOptions} [options] - overrides and settings for URI generation
+   */
+  url(options) {
+    options = { db: this.options.db, replicaSet: this.options.replicaSet, ...options };
 
-    const query = {};
-    if (this.options.replicaSet) {
-      Object.assign(query, { replicaSet: this.options.replicaSet });
+    const FILLER_HOST = 'fillerHost';
+
+    const url = new URL(`mongodb://${FILLER_HOST}`);
+
+    if (options.replicaSet) {
+      url.searchParams.append('replicaSet', options.replicaSet);
     }
 
-    let multipleHosts;
-    if (this.options.hosts.length > 1) {
-      // NOTE: The only way to force a sharded topology with the driver is to duplicate
-      //       the host entry. This will eventually be solved by autodetection.
-      if (this.topologyType === TopologyType.Sharded) {
-        const firstHost = this.options.hostAddresses[0];
-        multipleHosts = `${firstHost.host}:${firstHost.port}`;
-      } else {
-        multipleHosts = this.options.hostAddresses
-          .reduce((built, host) => {
-            built.push(typeof host.port === 'number' ? `${host.host}:${host.port}` : host.host);
-            return built;
-          }, [])
-          .join(',');
-      }
-    }
+    url.pathname = `/${options.db}`;
 
-    /** @type {Record<string, any>} */
-    const urlObject = {
-      protocol: 'mongodb',
-      slashes: true,
-      pathname: `/${this.options.db}`,
-      query
-    };
+    if (options.username) url.username = options.username;
+    if (options.password) url.password = options.password;
 
-    if (multipleHosts) {
-      Object.assign(urlObject, { hostname: '%s' });
-    } else {
-      Object.assign(urlObject, {
-        hostname: this.options.host,
-        port: this.options.port
-      });
-    }
-
-    if (username || password) {
-      urlObject.auth = password == null ? username : `${username}:${password}`;
-
-      if (options.authMechanism || this.options.authMechanism) {
-        Object.assign(query, {
-          authMechanism: options.authMechanism || this.options.authMechanism
-        });
+    if (options.username || options.password) {
+      if (options.authMechanism) {
+        url.searchParams.append('authMechanism', options.authMechanism);
       }
 
-      if (options.authMechanismProperties || this.options.authMechanismProperties) {
-        Object.assign(query, {
-          authMechanismProperties: convertToConnStringMap(
-            options.authMechanismProperties || this.options.authMechanismProperties
-          )
-        });
+      if (options.authMechanismProperties) {
+        url.searchParams.append(
+          'authMechanismProperties',
+          convertToConnStringMap(options.authMechanismProperties)
+        );
       }
 
       if (options.authSource) {
-        query.authSource = options.authSource;
+        url.searchParams.append('authSource', options.authSource);
       }
     }
 
-    if (multipleHosts) {
-      return util.format(url.format(urlObject), multipleHosts);
-    }
+    const actualHostsString = this.options.hostAddresses.map(ha => ha.toString()).join(',');
 
-    return url.format(urlObject);
+    const connectionString = url.toString().replace(FILLER_HOST, actualHostsString);
+
+    return connectionString;
   }
 
   writeConcernMax() {


### PR DESCRIPTION
Adds a number of operations, makes use of chai expect instead of boolean
for assertions to track stack traces, adds session and bucket entity
types. Passes utilClient through to operation functions which are"
inlined into the operations map to get type checking to work.
Modifies url helper function to make multipleMongoses detection work.
