### PR TITLE
fix: session support detection spec compliance

### DIFF
--- a/lib/core/sdam/topology_description.js
+++ b/lib/core/sdam/topology_description.js
@@ -72,17 +72,17 @@ class TopologyDescription {
     // value among ServerDescriptions of all data-bearing server types. If any have a null
     // logicalSessionTimeoutMinutes, then TopologyDescription.logicalSessionTimeoutMinutes MUST be
     // set to null.
-    this.logicalSessionTimeoutMinutes = undefined;
+    this.logicalSessionTimeoutMinutes = null;
     for (const addressServerTuple of this.servers) {
       const server = addressServerTuple[1];
       if (server.isReadable) {
         if (server.logicalSessionTimeoutMinutes == null) {
           // If any of the servers have a null logicalSessionsTimeout, then the whole topology does
-          this.logicalSessionTimeoutMinutes = undefined;
+          this.logicalSessionTimeoutMinutes = null;
           break;
         }
 
-        if (this.logicalSessionTimeoutMinutes === undefined) {
+        if (this.logicalSessionTimeoutMinutes == null) {
           // First server with a non null logicalSessionsTimeout
           this.logicalSessionTimeoutMinutes = server.logicalSessionTimeoutMinutes;
           continue;

--- a/lib/core/sdam/topology_description.js
+++ b/lib/core/sdam/topology_description.js
@@ -72,12 +72,30 @@ class TopologyDescription {
     // value among ServerDescriptions of all data-bearing server types. If any have a null
     // logicalSessionTimeoutMinutes, then TopologyDescription.logicalSessionTimeoutMinutes MUST be
     // set to null.
-    const readableServers = Array.from(this.servers.values()).filter(s => s.isReadable);
-    this.logicalSessionTimeoutMinutes = readableServers.reduce((result, server) => {
-      if (server.logicalSessionTimeoutMinutes == null) return null;
-      if (result == null) return server.logicalSessionTimeoutMinutes;
-      return Math.min(result, server.logicalSessionTimeoutMinutes);
-    }, null);
+    this.logicalSessionTimeoutMinutes = undefined;
+    for (const addressServerTuple of this.servers) {
+      const server = addressServerTuple[1];
+      if (server.isReadable) {
+        if (server.logicalSessionTimeoutMinutes == null) {
+          // If any of the servers have a null logicalSessionsTimeout, then the whole topology does
+          this.logicalSessionTimeoutMinutes = undefined;
+          break;
+        }
+
+        if (this.logicalSessionTimeoutMinutes === undefined) {
+          // First server with a non null logicalSessionsTimeout
+          this.logicalSessionTimeoutMinutes = server.logicalSessionTimeoutMinutes;
+          continue;
+        }
+
+        // Always select the smaller of the:
+        // current server logicalSessionsTimeout and the topologies logicalSessionsTimeout
+        this.logicalSessionTimeoutMinutes = Math.min(
+          this.logicalSessionTimeoutMinutes,
+          server.logicalSessionTimeoutMinutes
+        );
+      }
+    }
   }
 
   /**

--- a/test/unit/core/common.js
+++ b/test/unit/core/common.js
@@ -41,8 +41,8 @@ class ReplSetFixture {
         arbiters: [this.arbiterServer.uri()]
       });
 
-      this.defineReplSetStates();
-      // this.configureMessageHandlers();
+      if (!options.doNotInitStates) this.defineReplSetStates();
+      if (!options.doNotInitHandlers) this.configureMessageHandlers();
     });
   }
 

--- a/test/unit/core/common.js
+++ b/test/unit/core/common.js
@@ -11,30 +11,39 @@ class ReplSetFixture {
     this.electionIds = [new ObjectId(), new ObjectId()];
   }
 
+  uri(dbName) {
+    return `mongodb://${this.primaryServer.uri()},${this.firstSecondaryServer.uri()},${this.secondSecondaryServer.uri()}/${dbName ||
+      'test'}?replicaSet=rs`;
+  }
+
   setup(options) {
     options = options || {};
     const ismaster = options.ismaster ? options.ismaster : mock.DEFAULT_ISMASTER_36;
 
-    return Promise.all([mock.createServer(), mock.createServer(), mock.createServer()]).then(
-      servers => {
-        this.servers = servers;
-        this.primaryServer = servers[0];
-        this.firstSecondaryServer = servers[1];
-        this.arbiterServer = servers[2];
+    return Promise.all([
+      mock.createServer(),
+      mock.createServer(),
+      mock.createServer(),
+      mock.createServer()
+    ]).then(servers => {
+      this.servers = servers;
+      this.primaryServer = servers[0];
+      this.firstSecondaryServer = servers[1];
+      this.secondSecondaryServer = servers[2];
+      this.arbiterServer = servers[3];
 
-        this.defaultFields = Object.assign({}, ismaster, {
-          __nodejs_mock_server__: true,
-          setName: 'rs',
-          setVersion: 1,
-          electionId: this.electionIds[0],
-          hosts: this.servers.map(server => server.uri()),
-          arbiters: [this.arbiterServer.uri()]
-        });
+      this.defaultFields = Object.assign({}, ismaster, {
+        __nodejs_mock_server__: true,
+        setName: 'rs',
+        setVersion: 1,
+        electionId: this.electionIds[0],
+        hosts: this.servers.map(server => server.uri()),
+        arbiters: [this.arbiterServer.uri()]
+      });
 
-        this.defineReplSetStates();
-        this.configureMessageHandlers();
-      }
-    );
+      this.defineReplSetStates();
+      // this.configureMessageHandlers();
+    });
   }
 
   defineReplSetStates() {
@@ -55,6 +64,16 @@ class ReplSetFixture {
         me: this.firstSecondaryServer.uri(),
         primary: this.primaryServer.uri(),
         tags: { loc: 'sf' }
+      })
+    ];
+
+    this.secondSecondaryStates = [
+      Object.assign({}, this.defaultFields, {
+        ismaster: false,
+        secondary: true,
+        me: this.secondSecondaryServer.uri(),
+        primary: this.primaryServer.uri(),
+        tags: { loc: 'la' }
       })
     ];
 


### PR DESCRIPTION
Discovered while working on a help ticket the reduce callback in the topology description
doesn't correctly return null if it's in the middle of the list of servers.