### PR TITLE
fix: MongoError circular dependency

### DIFF
--- a/lib/operations/operation.js
+++ b/lib/operations/operation.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Explain = require('../explain').Explain;
-const MongoError = require('../core').MongoError;
+const MongoError = require('../core/error').MongoError;
 
 const Aspect = {
   READ_OPERATION: Symbol('READ_OPERATION'),

--- a/lib/operations/options_operation.js
+++ b/lib/operations/options_operation.js
@@ -2,7 +2,7 @@
 
 const OperationBase = require('./operation').OperationBase;
 const handleCallback = require('../utils').handleCallback;
-const MongoError = require('../core').MongoError;
+const MongoError = require('../core/error').MongoError;
 
 class OptionsOperation extends OperationBase {
   constructor(collection, options) {

--- a/lib/operations/options_operation.js
+++ b/lib/operations/options_operation.js
@@ -2,7 +2,7 @@
 
 const OperationBase = require('./operation').OperationBase;
 const handleCallback = require('../utils').handleCallback;
-const MongoError = require('../core/error').MongoError;
+const MongoError = require('../core').MongoError;
 
 class OptionsOperation extends OperationBase {
   constructor(collection, options) {


### PR DESCRIPTION
Bugfix for: "Accessing non-existent property 'MongoError' of module exports inside circular dependency"

Related to https://developer.mongodb.com/community/forums/t/warning-accessing-non-existent-property-mongoerror-of-module-exports-inside-circular-dependency/15411

## Description

**What changed?**

**Are there any files to ignore?**
