### PR TITLE
fix(operations): fix deprecation warning in Node.js 14

### DIFF
--- a/lib/operations/operation.js
+++ b/lib/operations/operation.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Explain = require('../explain').Explain;
-const MongoError = require('../core').MongoError;
+const MongoError = require('../core/error').MongoError;
 
 const Aspect = {
   READ_OPERATION: Symbol('READ_OPERATION'),


### PR DESCRIPTION
## Description

**What changed?**

#2626 introduced a deprecation warning in Node.js 14 due to a circular import, because `../core/index.js` eventually imports `operations/operation.js`. This works around the deprecation warning and makes sure `MongoError` is actually defined in this file.

**Are there any files to ignore?**

Nope