### PR TITLE
fix: unmerged writeConcern options

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -388,6 +388,7 @@ const collectionKeys = [
   'serializeFunctions',
   'strict',
   'readConcern',
+  'writeConcern',
   'ignoreUndefined',
   'promoteValues',
   'promoteBuffers',
@@ -434,7 +435,7 @@ Db.prototype.collection = function(name, options, callback) {
   }
 
   // Merge in all needed options and ensure correct writeConcern merging from db level
-  options = mergeOptionsAndWriteConcern(options, this.s.options, collectionKeys, true);
+  options = mergeOptionsAndWriteConcern(options, this.s.options, collectionKeys);
 
   // Execute
   if (options == null || !options.strict) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -290,16 +290,13 @@ var filterOptions = function(options, names) {
 var writeConcernKeys = ['w', 'j', 'wtimeout', 'fsync'];
 
 // Merge the write concern options
-var mergeOptionsAndWriteConcern = function(targetOptions, sourceOptions, keys, mergeWriteConcern) {
+var mergeOptionsAndWriteConcern = function(targetOptions, sourceOptions, keys) {
   // Mix in any allowed options
   for (var i = 0; i < keys.length; i++) {
     if (!targetOptions[keys[i]] && sourceOptions[keys[i]] !== undefined) {
       targetOptions[keys[i]] = sourceOptions[keys[i]];
     }
   }
-
-  // No merging of write concern
-  if (!mergeWriteConcern) return targetOptions;
 
   // Found no write Concern options
   var found = false;


### PR DESCRIPTION
## Description

In 3.6.4 was added a depreciation warning about how writeConcern options should be formatted

https://github.com/mongodb/node-mongodb-native/blob/d67ffa7a2e3f86734c7e9b6944aab1d765b9e75e/lib/write_concern.js#L78-L80

#2743 solves the problem of multiple emitions of depreciation warning, but digging into the code to find why this warning is triggered so many times, I found that `sourceOptions.writeConcern` is never merged into `targetOptions.writeConcern` in `utils.mergeOptionsAndWriteConcern`
https://github.com/mongodb/node-mongodb-native/blob/d67ffa7a2e3f86734c7e9b6944aab1d765b9e75e/lib/utils.js#L289-L322

To fix it, my proposal is to add `writeConcern` to the `collectionKeys` in db.js. Also, `utils.mergeOptionsAndWriteConcern` is not part of the public API and used only 1 time in db.js, so I propose to remove the trailing, always `true`, argument : `mergeWriteConcern`

The original bug was reported here: https://jira.mongodb.org/browse/NODE-3114