### PR TITLE
fix: update read_preference_tags and maxStalenessSeconds

### DIFF
--- a/lib/url_parser.js
+++ b/lib/url_parser.js
@@ -615,6 +615,8 @@ function parseConnectionString(url, options) {
   // If no read preference set it to primary
   if (!dbOptions.readPreference) {
     dbOptions.readPreference = 'primary';
+    dbOptions.read_preference_tags = null;
+    dbOptions.maxStalenessSeconds = null;
   }
 
   // make sure that user-provided options are applied with priority


### PR DESCRIPTION
If the client is falling back to `primary` read preference, it should also ignore the `read_preference_tags` and `maxStalenessSeconds` both of which are incompatible with `primary` read preference.

## Description
- If a URL contains `read_preference_tags` but does not contain `readPreference`, the code flows till the creation of `ReadPreference.primary` at which point it errors out with the message that `Primary read preference cannot be combined with tags`.
- A Mongo URL like this surfaced this problem. `readPreferences` was being ignored as the correct parameter is `readPreference`. The client was falling back to `primary` read preference but was also accepting the `readPreferenceTags` and sending them forward for creation of `ReadPreference` object.

```
mongodb://localhost:27017/data?replicaSet=replicaSetDummy&retryWrites=true&w=majority&readPreferences=secondary&readPreferenceTags=usage:services,purpose:read
```

**What changed?**
- If the client is falling back to `primary` read preference, the change ignores the `read_preference_tags` and `maxStalenessSeconds` both of which are incompatible with `primary` read preference.

**Are there any files to ignore?**
NA