### PR TITLE
fix: remove catch for synchronous socket errors and remove validation on nodejs option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -623,9 +623,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
-      "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==",
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/chai-subset": "^1.3.3",
     "@types/kerberos": "^1.1.0",
     "@types/mocha": "^8.2.0",
-    "@types/node": "^14.6.4",
+    "@types/node": "^14.14.31",
     "@types/saslprep": "^1.0.0",
     "@types/semver": "^7.3.4",
     "@typescript-eslint/eslint-plugin": "^4.15.1",

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -247,15 +247,6 @@ function parseSslOptions(options: ConnectionOptions): TLSConnectionOpts {
     }
   }
 
-  // Override checkServerIdentity behavior
-  if (!options.checkServerIdentity) {
-    // Skip the identity check by retuning undefined as per node documents
-    // https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
-    result.checkServerIdentity = () => undefined;
-  } else if (typeof options.checkServerIdentity === 'function') {
-    result.checkServerIdentity = options.checkServerIdentity;
-  }
-
   // Set default sni servername to be the same as host
   if (result.servername == null) {
     result.servername = result.host;

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -289,18 +289,14 @@ function makeConnection(options: ConnectionOptions, _callback: CallbackWithType<
     _callback(err, ret);
   };
 
-  try {
-    if (useTLS) {
-      const tlsSocket = tls.connect(parseSslOptions(options));
-      if (typeof tlsSocket.disableRenegotiation === 'function') {
-        tlsSocket.disableRenegotiation();
-      }
-      socket = tlsSocket;
-    } else {
-      socket = net.createConnection(parseConnectOptions(options));
+  if (useTLS) {
+    const tlsSocket = tls.connect(parseSslOptions(options));
+    if (typeof tlsSocket.disableRenegotiation === 'function') {
+      tlsSocket.disableRenegotiation();
     }
-  } catch (err) {
-    return callback(err);
+    socket = tlsSocket;
+  } else {
+    socket = net.createConnection(parseConnectOptions(options));
   }
 
   socket.setKeepAlive(keepAlive, keepAliveInitialDelay);

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -575,16 +575,6 @@ export const OPTIONS = {
   checkKeys: {
     type: 'boolean'
   },
-  checkServerIdentity: {
-    target: 'checkServerIdentity',
-    transform({
-      values: [value]
-    }): boolean | ((hostname: string, cert: Document) => Error | undefined) {
-      if (typeof value !== 'boolean' && typeof value !== 'function')
-        throw new MongoParseError('check server identity must be a boolean or custom function');
-      return value as boolean | ((hostname: string, cert: Document) => Error | undefined);
-    }
-  },
   compressors: {
     default: 'none',
     target: 'compressors',
@@ -1041,6 +1031,7 @@ export const OPTIONS = {
   enableTrace: { type: 'any' },
   requestCert: { type: 'any' },
   rejectUnauthorized: { type: 'any' },
+  checkServerIdentity: { type: 'any' },
   ALPNProtocols: { type: 'any' },
   SNICallback: { type: 'any' },
   session: { type: 'any' },

--- a/test/functional/index.test.js
+++ b/test/functional/index.test.js
@@ -1174,7 +1174,7 @@ describe('Indexes', function () {
     metadata: {
       requires: {
         topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'],
-        mongodb: '>=3.0.0'
+        mongodb: '>=3.0.0 <=4.8.0'
       }
     },
 


### PR DESCRIPTION
Our validation for a nodejs option suggested that an option could be a boolean when it can actually only be false or a function. In addition this removes the catching of synchronous errors thrown from socket creation. 

NODE-3061