### PR TITLE
test: complete unified test runner

### DIFF
--- a/src/apm.ts
+++ b/src/apm.ts
@@ -30,7 +30,7 @@ export class Instrumentation extends EventEmitter {
     const instrumentation = this;
     mongoClientClass.prototype.connect = function (this: MongoClient, callback: Callback) {
       // override monitorCommands to be switched on
-      this.s.options = { ...(this.s.options ?? {}), monitorCommands: true };
+      this.monitorCommands = true;
 
       this.on(Connection.COMMAND_STARTED, event =>
         instrumentation.emit(Instrumentation.STARTED, event)

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -230,14 +230,14 @@ export type WithSessionCallback = (session: ClientSession) => Promise<any> | voi
 /** @internal */
 export interface MongoClientPrivate {
   url: string;
-  options?: MongoClientOptions;
   sessions: Set<ClientSession>;
-  readConcern?: ReadConcern;
-  writeConcern?: WriteConcern;
-  readPreference: ReadPreference;
   bsonOptions: BSONSerializeOptions;
   namespace: MongoDBNamespace;
-  logger: Logger;
+  readonly options?: MongoOptions;
+  readonly readConcern?: ReadConcern;
+  readonly writeConcern?: WriteConcern;
+  readonly readPreference: ReadPreference;
+  readonly logger: Logger;
 }
 
 const kOptions = Symbol('options');
@@ -293,29 +293,36 @@ export class MongoClient extends EventEmitter {
    */
   [kOptions]: MongoOptions;
 
-  // debugging
-  originalUri;
-  originalOptions;
-
   constructor(url: string, options?: MongoClientOptions) {
     super();
 
-    this.originalUri = url;
-    this.originalOptions = options;
-
     this[kOptions] = parseOptions(url, this, options);
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const client = this;
 
     // The internal state
     this.s = {
       url,
-      options: this[kOptions],
       sessions: new Set(),
-      readConcern: this[kOptions].readConcern,
-      writeConcern: this[kOptions].writeConcern,
-      readPreference: this[kOptions].readPreference,
       bsonOptions: resolveBSONOptions(this[kOptions]),
       namespace: ns('admin'),
-      logger: this[kOptions].logger
+
+      get options() {
+        return client[kOptions];
+      },
+      get readConcern() {
+        return client[kOptions].readConcern;
+      },
+      get writeConcern() {
+        return client[kOptions].writeConcern;
+      },
+      get readPreference() {
+        return client[kOptions].readPreference;
+      },
+      get logger() {
+        return client[kOptions].logger;
+      }
     };
   }
 
@@ -325,6 +332,16 @@ export class MongoClient extends EventEmitter {
 
   get serverApi(): Readonly<ServerApi | undefined> {
     return this[kOptions].serverApi && Object.freeze({ ...this[kOptions].serverApi });
+  }
+  /**
+   * Intended for APM use only
+   * @internal
+   */
+  get monitorCommands(): boolean {
+    return this[kOptions].monitorCommands;
+  }
+  set monitorCommands(value: boolean) {
+    this[kOptions].monitorCommands = value;
   }
 
   get autoEncrypter(): AutoEncrypter | undefined {

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -50,7 +50,7 @@ import type { MongoCredentials } from '../cmap/auth/mongo_credentials';
 import type { Transaction } from '../transactions';
 import type { CloseOptions } from '../cmap/connection_pool';
 import { DestroyOptions, Connection } from '../cmap/connection';
-import type { MongoClientOptions, ServerApi } from '../mongo_client';
+import type { MongoOptions, ServerApi } from '../mongo_client';
 import { DEFAULT_OPTIONS } from '../connection_string';
 import { serialize, deserialize } from '../bson';
 
@@ -566,7 +566,7 @@ export class Topology extends EventEmitter {
   }
 
   /** Start a logical session */
-  startSession(options: ClientSessionOptions, clientOptions?: MongoClientOptions): ClientSession {
+  startSession(options: ClientSessionOptions, clientOptions?: MongoOptions): ClientSession {
     const session = new ClientSession(this, this.s.sessionPool, options, clientOptions);
     session.once('ended', () => {
       this.s.sessions.delete(session);

--- a/test/functional/unified-spec-runner/entities.ts
+++ b/test/functional/unified-spec-runner/entities.ts
@@ -178,7 +178,9 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
     const map = new EntitiesMap();
     for (const entity of entities ?? []) {
       if ('client' in entity) {
-        const uri = config.url({ useMultipleMongoses: entity.client.useMultipleMongoses });
+        const useMultipleMongoses =
+          config.topologyType === 'Sharded' && entity.client.useMultipleMongoses;
+        const uri = config.url({ useMultipleMongoses });
         const client = new UnifiedMongoClient(uri, entity.client);
         await client.connect();
         map.set(entity.client.id, client);

--- a/test/functional/unified-spec-runner/entities.ts
+++ b/test/functional/unified-spec-runner/entities.ts
@@ -1,4 +1,11 @@
-import { MongoClient, Db, Collection, GridFSBucket, Document } from '../../../src/index';
+import {
+  MongoClient,
+  Db,
+  Collection,
+  GridFSBucket,
+  Document,
+  HostAddress
+} from '../../../src/index';
 import { ReadConcern } from '../../../src/read_concern';
 import { WriteConcern } from '../../../src/write_concern';
 import { ReadPreference } from '../../../src/read_preference';
@@ -16,10 +23,6 @@ import { TestConfiguration } from './runner';
 
 interface UnifiedChangeStream extends ChangeStream {
   eventCollector: InstanceType<typeof import('../../tools/utils')['EventCollector']>;
-}
-
-interface UnifiedClientSession extends ClientSession {
-  client: UnifiedMongoClient;
 }
 
 export type CommandEvent = CommandStartedEvent | CommandSucceededEvent | CommandFailedEvent;
@@ -75,23 +78,49 @@ export class UnifiedMongoClient extends MongoClient {
     }
     return this.events;
   }
+}
 
-  async enableFailPoint(failPoint: Document): Promise<Document> {
-    const admin = this.db().admin();
+export class FailPointMap extends Map<string, Document> {
+  async enableFailPoint(
+    addressOrClient: HostAddress | UnifiedMongoClient,
+    failPoint: Document
+  ): Promise<Document> {
+    let client: MongoClient;
+    let address: string;
+    if (addressOrClient instanceof MongoClient) {
+      client = addressOrClient;
+      address = client.topology.s.seedlist.join(',');
+    } else {
+      // create a new client
+      address = addressOrClient.toString();
+      client = new MongoClient(`mongodb://${address}`);
+      await client.connect();
+    }
+
+    const admin = client.db('admin');
     const result = await admin.command(failPoint);
+
+    if (!(addressOrClient instanceof MongoClient)) {
+      // we created this client
+      await client.close();
+    }
+
     expect(result).to.have.property('ok', 1);
-    this.failPoints.push(failPoint.configureFailPoint);
+    this.set(address, failPoint.configureFailPoint);
     return result;
   }
 
-  async disableFailPoints(): Promise<Document[]> {
-    return Promise.all(
-      this.failPoints.map(configureFailPoint =>
-        this.db().admin().command({
-          configureFailPoint,
-          mode: 'off'
-        })
-      )
+  async disableFailPoints(): Promise<void> {
+    const entries = Array.from(this.entries());
+    await Promise.all(
+      entries.map(async ([hostAddress, configureFailPoint]) => {
+        const client = new MongoClient(`mongodb://${hostAddress}`);
+        await client.connect();
+        const admin = client.db('admin');
+        const result = await admin.command({ configureFailPoint, mode: 'off' });
+        expect(result).to.have.property('ok', 1);
+        await client.close();
+      })
     );
   }
 }
@@ -100,7 +129,7 @@ export type Entity =
   | UnifiedMongoClient
   | Db
   | Collection
-  | UnifiedClientSession
+  | ClientSession
   | UnifiedChangeStream
   | GridFSBucket
   | Document; // Results from operations
@@ -124,10 +153,17 @@ ENTITY_CTORS.set('bucket', GridFSBucket);
 ENTITY_CTORS.set('stream', ChangeStream);
 
 export class EntitiesMap<E = Entity> extends Map<string, E> {
+  failPoints: FailPointMap;
+
+  constructor(entries?: readonly (readonly [string, E])[] | null) {
+    super(entries);
+    this.failPoints = new FailPointMap();
+  }
+
   mapOf(type: 'client'): EntitiesMap<UnifiedMongoClient>;
   mapOf(type: 'db'): EntitiesMap<Db>;
   mapOf(type: 'collection'): EntitiesMap<Collection>;
-  mapOf(type: 'session'): EntitiesMap<UnifiedClientSession>;
+  mapOf(type: 'session'): EntitiesMap<ClientSession>;
   mapOf(type: 'bucket'): EntitiesMap<GridFSBucket>;
   mapOf(type: 'stream'): EntitiesMap<UnifiedChangeStream>;
   mapOf(type: EntityTypeId): EntitiesMap<Entity> {
@@ -141,7 +177,7 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
   getEntity(type: 'client', key: string, assertExists?: boolean): UnifiedMongoClient;
   getEntity(type: 'db', key: string, assertExists?: boolean): Db;
   getEntity(type: 'collection', key: string, assertExists?: boolean): Collection;
-  getEntity(type: 'session', key: string, assertExists?: boolean): UnifiedClientSession;
+  getEntity(type: 'session', key: string, assertExists?: boolean): ClientSession;
   getEntity(type: 'bucket', key: string, assertExists?: boolean): GridFSBucket;
   getEntity(type: 'stream', key: string, assertExists?: boolean): UnifiedChangeStream;
   getEntity(type: EntityTypeId, key: string, assertExists = true): Entity {
@@ -161,8 +197,8 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
   }
 
   async cleanup(): Promise<void> {
+    await this.failPoints.disableFailPoints();
     for (const [, client] of this.mapOf('client')) {
-      await client.disableFailPoints();
       await client.close();
     }
     for (const [, session] of this.mapOf('session')) {
@@ -230,10 +266,7 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
           }
         }
 
-        const session = client.startSession(options) as UnifiedClientSession;
-        // targetedFailPoint operations need to access the client the session came from
-        session.client = client;
-
+        const session = client.startSession(options);
         map.set(entity.session.id, session);
       } else if ('bucket' in entity) {
         const db = map.getEntity('db', entity.bucket.database);

--- a/test/functional/unified-spec-runner/operations.ts
+++ b/test/functional/unified-spec-runner/operations.ts
@@ -249,7 +249,7 @@ operations.set('findOneAndUpdate', async ({ entities, operation }) => {
 
 operations.set('failPoint', async ({ entities, operation }) => {
   const client = entities.getEntity('client', operation.arguments.client);
-  return client.enableFailPoint(operation.arguments.failPoint);
+  return entities.failPoints.enableFailPoint(client, operation.arguments.failPoint);
 });
 
 operations.set('insertOne', async ({ entities, operation }) => {
@@ -309,8 +309,10 @@ operations.set('startTransaction', async ({ entities, operation }) => {
 operations.set('targetedFailPoint', async ({ entities, operation }) => {
   const session = entities.getEntity('session', operation.arguments.session);
   expect(session.transaction.isPinned, 'Session must be pinned for a targetedFailPoint').to.be.true;
-  const client = session.client;
-  return client.enableFailPoint(operation.arguments.failPoint);
+  await entities.failPoints.enableFailPoint(
+    session.transaction._pinnedServer.s.description.hostAddress,
+    operation.arguments.failPoint
+  );
 });
 
 operations.set('delete', async ({ entities, operation }) => {

--- a/test/functional/unified-spec-runner/operations.ts
+++ b/test/functional/unified-spec-runner/operations.ts
@@ -136,7 +136,7 @@ operations.set('assertSessionNotDirty', async ({ entities, operation }) => {
 
 operations.set('assertSessionPinned', async ({ entities, operation }) => {
   const session = entities.getEntity('session', operation.arguments.session);
-  expect(session.transaction.isPinned).to.be.false;
+  expect(session.transaction.isPinned).to.be.true;
 });
 
 operations.set('assertSessionUnpinned', async ({ entities, operation }) => {
@@ -310,7 +310,7 @@ operations.set('targetedFailPoint', async ({ entities, operation }) => {
   const session = entities.getEntity('session', operation.arguments.session);
   expect(session.transaction.isPinned, 'Session must be pinned for a targetedFailPoint').to.be.true;
   const client = session.client;
-  client.enableFailPoint(operation.arguments.failPoint);
+  return client.enableFailPoint(operation.arguments.failPoint);
 });
 
 operations.set('delete', async ({ entities, operation }) => {

--- a/test/functional/unified-spec-runner/runner.ts
+++ b/test/functional/unified-spec-runner/runner.ts
@@ -15,30 +15,11 @@ interface MongoDBMochaTestContext extends Mocha.Context {
   configuration: TestConfiguration;
 }
 
-const SKIPPED_TESTS = [
-  // These were already skipped in our existing spec tests
-  'unpin after transient error within a transaction and commit',
-  'Dirty explicit session is discarded',
-
-  // TODO Un-skip these to complete unified runner
-  'withTransaction inherits transaction options from client',
-  'withTransaction inherits transaction options from defaultTransactionOptions',
-  'remain pinned after non-transient Interrupted error on insertOne',
-  'unpin after transient error within a transaction',
-  'Client side error in command starting transaction',
-  'explicitly create collection using create command',
-  'create index on a non-existing collection',
-  'InsertMany succeeds after PrimarySteppedDown',
-  'withTransaction and no transaction options set',
-  'withTransaction explicit transaction options',
-  'InsertOne fails after connection failure when retryWrites option is false',
-  'InsertOne fails after multiple retryable writeConcernErrors'
-];
-
 export async function runUnifiedTest(
   ctx: MongoDBMochaTestContext,
   unifiedSuite: uni.UnifiedSuite,
-  test: uni.Test
+  test: uni.Test,
+  testsToSkip?: string[]
 ): Promise<void> {
   // Some basic expectations we can catch early
   expect(test).to.exist;
@@ -56,7 +37,7 @@ export async function runUnifiedTest(
     ctx.skip();
   }
 
-  if (SKIPPED_TESTS.includes(test.description)) {
+  if (testsToSkip?.includes(test.description)) {
     ctx.skip();
   }
 
@@ -76,18 +57,11 @@ export async function runUnifiedTest(
       ...(test.runOnRequirements ?? [])
     ];
 
-    let doesNotMeetRunOnRequirement = false;
-
     for (const requirement of allRequirements) {
       const met = await topologySatisfies(ctx.configuration, requirement, utilClient);
       if (!met) {
-        doesNotMeetRunOnRequirement = true; // it doesn't meet a run on requirement
-        break;
+        return ctx.skip();
       }
-    }
-
-    if (doesNotMeetRunOnRequirement) {
-      ctx.skip();
     }
 
     // If initialData is specified, for each collectionData therein the test runner MUST drop the
@@ -188,14 +162,14 @@ export async function runUnifiedTest(
   }
 }
 
-export function runUnifiedSuite(specTests: uni.UnifiedSuite[]): void {
+export function runUnifiedSuite(specTests: uni.UnifiedSuite[], testsToSkip?: string[]): void {
   for (const unifiedSuite of specTests) {
     context(String(unifiedSuite.description), function () {
       for (const test of unifiedSuite.tests) {
         it(String(test.description), {
           metadata: { sessions: { skipLeakTests: true } },
           test: async function () {
-            await runUnifiedTest(this, unifiedSuite, test);
+            await runUnifiedTest(this, unifiedSuite, test, testsToSkip);
           }
         });
       }

--- a/test/functional/unified-spec-runner/unified-runner.test.ts
+++ b/test/functional/unified-spec-runner/unified-runner.test.ts
@@ -1,17 +1,16 @@
 import { loadSpecTests } from '../../spec/index';
 import { runUnifiedSuite } from './runner';
 
+const SKIPPED_TESTS = [
+  // commitTransaction retry seems to be swallowed by mongos in this case
+  'unpin after transient error within a transaction and commit',
+  // These two tests need to run against multiple mongoses
+  'Dirty explicit session is discarded',
+  // Will be implemented as part of NODE-2034
+  'Client side error in command starting transaction'
+];
+
 describe('Unified test format runner', function unifiedTestRunner() {
   // Valid tests that should pass
-  runUnifiedSuite(loadSpecTests('unified-test-format/valid-pass'));
-
-  // Valid tests that should fail
-  // for (const unifiedSuite of loadSpecTests('unified-test-format/valid-fail')) {
-  //   // TODO
-  // }
-
-  // Tests that are invalid, would be good to gracefully fail on
-  // for (const unifiedSuite of loadSpecTests('unified-test-format/invalid')) {
-  //   // TODO
-  // }
+  runUnifiedSuite(loadSpecTests('unified-test-format/valid-pass'), SKIPPED_TESTS);
 });


### PR DESCRIPTION
Completes the unified runner by passing all the poc spec tests.

NODE-2287

## Notes
There's some additional work in here that I'm happy to break out into its own ticket, but it came up in debugging:
- Sessions claimed to accept MongoClientOptions when they were instead receiving MongoOptions, guaranteed to have the well typed WC,RP,RC etc. 
- The issue blocking transactions from working was that my test provided an options object that had `{ writeConcern: undefined }` and that would overwrite the client options that were supposed to be inherited. I can go back and fix the test to not defined a key if the value is undefined but maybe this is unexpected enough to fix in driver, so here I used `??` and explicit fetching of the options to resolve the correct value
- APM overwrites the `client.s.options` which put `client[kOptions]` and `client.options` out of sync. There is also an opportunity for the `client.s.WC/RP/RC` values to be out of sync with `client[kOptions]`. Changing these to getters gives us one source of truth for client options.
