### PR TITLE
[PORT] fix: move session support check to operation layer

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -464,10 +464,6 @@ export class MongoClient extends EventEmitter {
       throw new MongoError('Must connect to a server before calling this method');
     }
 
-    if (!this.topology.hasSessionSupport()) {
-      throw new MongoError('Current topology does not support sessions');
-    }
-
     return this.topology.startSession(options, this.s.options);
   }
 

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -38,7 +38,7 @@ const kSession = Symbol('session');
  * a specific aspect.
  * @internal
  */
-export abstract class AbstractOperation<T> {
+export abstract class AbstractOperation<TResult = any> {
   ns!: MongoDBNamespace;
   cmd!: Document;
   readPreference: ReadPreference;
@@ -47,6 +47,9 @@ export abstract class AbstractOperation<T> {
 
   // BSON serialization options
   bsonOptions?: BSONSerializeOptions;
+
+  // TODO: Each operation defines its own options, there should be better typing here
+  options: Document;
 
   [kSession]: ClientSession;
 
@@ -61,9 +64,11 @@ export abstract class AbstractOperation<T> {
     if (options.session) {
       this[kSession] = options.session;
     }
+
+    this.options = options;
   }
 
-  abstract execute(server: Server, session: ClientSession, callback: Callback<T>): void;
+  abstract execute(server: Server, session: ClientSession, callback: Callback<TResult>): void;
 
   hasAspect(aspect: symbol): boolean {
     const ctor = this.constructor as OperationConstructor;

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -571,7 +571,7 @@ function endTransaction(session: ClientSession, commandName: string, callback: C
           });
         }
 
-        executeOperation(
+        return executeOperation(
           session.topology,
           new RunAdminCommandOperation(undefined, command, {
             session,
@@ -579,8 +579,6 @@ function endTransaction(session: ClientSession, commandName: string, callback: C
           }),
           (_err, _reply) => commandHandler(_err as MongoError, _reply)
         );
-
-        return;
       }
 
       commandHandler(err as MongoError, reply);

--- a/test/functional/index.test.js
+++ b/test/functional/index.test.js
@@ -1174,7 +1174,7 @@ describe('Indexes', function () {
     metadata: {
       requires: {
         topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'],
-        mongodb: '>=3.0.0'
+        mongodb: '>=3.0.0 <=4.8.0'
       }
     },
 


### PR DESCRIPTION
Session support check is now performed after server selection
this ensures the monitor was able to update the topology description

NODE-3100
