### PR TITLE
NODE-2951: Don't auto destroy read stream on Node 14+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ logs
 pids
 *.pid
 *.seed
+*.swp
 *.tmp
 *.dat
 *.png

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -730,6 +730,7 @@ export function assertUninitialized(cursor: AbstractCursor): void {
 function makeCursorStream(cursor: AbstractCursor) {
   const readable = new Readable({
     objectMode: true,
+    autoDestroy: false,
     highWaterMark: 1
   });
 

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -1550,6 +1550,50 @@ describe('Cursor', function () {
     }
   });
 
+  it('does not auto destroy streams', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    test: function (done) {
+      const docs = [];
+
+      for (var i = 0; i < 10; i++) {
+        docs.push({ a: i + 1 });
+      }
+
+      const configuration = this.configuration;
+      const client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+        //this.defer(() => client.close());
+
+        const db = client.db(configuration.db);
+        db.createCollection('does_not_autodestroy_streams', (err, collection) => {
+          expect(err).to.not.exist;
+
+          collection.insertMany(docs, configuration.writeConcernMax(), err => {
+            expect(err).to.not.exist;
+
+            const cursor = collection.find();
+            const stream = cursor.stream();
+            stream.on('close', () => {
+              expect.fail('extra close event must not be called');
+            });
+            stream.on('end', () => {
+              client.close();
+              done();
+            });
+            stream.on('data', doc => {
+              expect(doc).to.exist;
+            });
+            stream.resume();
+          });
+        });
+      });
+    }
+  });
+
   it('should be able to stream documents', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run


### PR DESCRIPTION
The new autoDestroy option for streams in Node 14+ would emit an extra close event when the stream has ended.