### PR TITLE
NODE-3008: Remove existing session from cloned cursors.

### DIFF
--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -54,6 +54,7 @@ export class AggregationCursor extends AbstractCursor {
 
   clone(): AggregationCursor {
     const clonedOptions = mergeOptions({}, this[kOptions]);
+    delete clonedOptions.session;
     return new AggregationCursor(this[kParent], this.topology, this.namespace, this[kPipeline], {
       ...clonedOptions
     });

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -54,6 +54,7 @@ export class FindCursor extends AbstractCursor {
 
   clone(): FindCursor {
     const clonedOptions = mergeOptions({}, this[kBuiltOptions]);
+    delete clonedOptions.session;
     return new FindCursor(this.topology, this.namespace, this[kFilter], {
       ...clonedOptions
     });

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -1693,6 +1693,74 @@ describe('Cursor', function () {
     }
   });
 
+  it('removes session wheen cloning a find cursor', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    test: function (done) {
+      const configuration = this.configuration;
+      const client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+
+        const db = client.db(configuration.db);
+        db.createCollection('clone_find_cursor_session', (err, collection) => {
+          expect(err).to.not.exist;
+
+          collection.insertOne({ a: 1 }, configuration.writeConcernMax(), err => {
+            expect(err).to.not.exist;
+
+            const cursor = collection.find();
+            const clonedCursor = cursor.clone();
+            cursor.toArray(err => {
+              expect(err).to.not.exist;
+              clonedCursor.toArray(err => {
+                expect(err).to.not.exist;
+                client.close();
+                done();
+              });
+            });
+          });
+        });
+      });
+    }
+  });
+
+  it('removes session wheen cloning an aggregation cursor', {
+    metadata: {
+      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
+    },
+
+    test: function (done) {
+      const configuration = this.configuration;
+      const client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+
+        const db = client.db(configuration.db);
+        db.createCollection('clone_aggregation_cursor_session', (err, collection) => {
+          expect(err).to.not.exist;
+
+          collection.insertOne({ a: 1 }, configuration.writeConcernMax(), err => {
+            expect(err).to.not.exist;
+
+            const cursor = collection.aggregate([{ $match: { a: 1 } }]);
+            const clonedCursor = cursor.clone();
+            cursor.toArray(err => {
+              expect(err).to.not.exist;
+              clonedCursor.toArray(err => {
+                expect(err).to.not.exist;
+                client.close();
+                done();
+              });
+            });
+          });
+        });
+      });
+    }
+  });
+
   it('destroying a stream stops it', {
     // Add a tag that our runner can trigger on
     // in this case we are setting that node needs to be higher than 0.10.X to run


### PR DESCRIPTION
Port up to the 4.0 branch with added tests.