### PR TITLE
NODE-3152: ensure AWS environment variables are applied properly

### DIFF
--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -61,16 +61,19 @@ export class MongoCredentials {
     this.mechanismProperties = options.mechanismProperties || {};
 
     if (this.mechanism.match(/MONGODB-AWS/i)) {
-      if (this.username == null && process.env.AWS_ACCESS_KEY_ID) {
+      if (!this.username && process.env.AWS_ACCESS_KEY_ID) {
         this.username = process.env.AWS_ACCESS_KEY_ID;
       }
 
-      if (this.password == null && process.env.AWS_SECRET_ACCESS_KEY) {
+      if (!this.password && process.env.AWS_SECRET_ACCESS_KEY) {
         this.password = process.env.AWS_SECRET_ACCESS_KEY;
       }
 
-      if (this.mechanismProperties.AWS_SESSION_TOKEN == null && process.env.AWS_SESSION_TOKEN) {
-        this.mechanismProperties.AWS_SESSION_TOKEN = process.env.AWS_SESSION_TOKEN;
+      if (!this.mechanismProperties.AWS_SESSION_TOKEN && process.env.AWS_SESSION_TOKEN) {
+        this.mechanismProperties = {
+          ...this.mechanismProperties,
+          AWS_SESSION_TOKEN: process.env.AWS_SESSION_TOKEN
+        };
       }
     }
 


### PR DESCRIPTION
## Description
The AWS environment variables were not detected properly.

The checks for `username == null` and `password == null` would always return false as the static `merge(...)` method that is used to create an instance of `MongoCredentials` defaulted to an empty string as value for both.

Furthermore, the `AWS_SESSION_TOKEN` _must be applied_ if it is present in the environment variables and takes precedence over any other value. See https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#environment-variables:
> However, if AWS_SESSION_TOKEN is set Drivers MUST use its value as the session token.

The direct assignment of `AWS_SESSION_TOKEN` would also potentially fail as it happened that `this.mechanismProperties` was initialized with an already freezed object throwing an error. That's why I changed that to a destructured assignment.

With those changes I am able to run all my E2E tests in mongosh for AWS authentication successfully.

Please note that I did not know where to add test cases for the driver and would ask you to either give me a hint so I can add them or add them on your own :)