### PR TITLE
NODE-3120: Ensure monitor has rtt pinger in when calculating rtt

### DIFF
--- a/lib/core/sdam/monitor.js
+++ b/lib/core/sdam/monitor.js
@@ -222,9 +222,10 @@ function checkServer(monitor, callback) {
       }
 
       const isMaster = result.result;
-      const duration = isAwaitable
-        ? monitor[kRTTPinger].roundTripTime
-        : calculateDurationInMs(start);
+      const rttPinger = monitor[kRTTPinger];
+
+      const duration =
+        isAwaitable && rttPinger ? rttPinger.roundTripTime : calculateDurationInMs(start);
 
       monitor.emit(
         'serverHeartbeatSucceeded',


### PR DESCRIPTION
I couldn't get the driver into a state where this would occur, which is why there's no unit test here. But the 1 line of code change is the same as in the 4.0 branch and wouldn't have any potential negative impact.