### PR TITLE
NODE-3122: Always close gridfs upload stream on finish

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1468,6 +1468,12 @@ buildvariants:
       - test-4.4-ocsp-soft-fail
       - test-4.4-ocsp-malicious-invalid-cert-mustStaple-server-does-not-staple
       - test-4.4-ocsp-malicious-no-responder-mustStaple-server-does-not-staple
+  - name: macos-1014-fermium
+    display_name: macOS 10.14 Node Fermium
+    run_on: macos-1014
+    expansions:
+      NODE_LTS_NAME: fermium
+    tasks: *ref_0
   - name: macos-1014-dubnium
     display_name: macOS 10.14 Node Dubnium
     run_on: macos-1014
@@ -1572,6 +1578,12 @@ buildvariants:
       - test-4.4-ocsp-soft-fail
       - test-4.4-ocsp-malicious-invalid-cert-mustStaple-server-does-not-staple
       - test-4.4-ocsp-malicious-no-responder-mustStaple-server-does-not-staple
+  - name: rhel70-fermium
+    display_name: RHEL 7.0 Node Fermium
+    run_on: rhel70-small
+    expansions:
+      NODE_LTS_NAME: fermium
+    tasks: *ref_1
   - name: rhel70-dubnium
     display_name: RHEL 7.0 Node Dubnium
     run_on: rhel70-small
@@ -1642,6 +1654,12 @@ buildvariants:
       - test-auth-kerberos-legacy
       - test-auth-kerberos-unified
       - test-auth-ldap
+  - name: ubuntu-14.04-fermium
+    display_name: Ubuntu 14.04 Node Fermium
+    run_on: ubuntu1404-test
+    expansions:
+      NODE_LTS_NAME: fermium
+    tasks: *ref_2
   - name: ubuntu-14.04-dubnium
     display_name: Ubuntu 14.04 Node Dubnium
     run_on: ubuntu1404-test
@@ -1735,6 +1753,13 @@ buildvariants:
       - test-4.4-ocsp-soft-fail
       - test-4.4-ocsp-malicious-invalid-cert-mustStaple-server-does-not-staple
       - test-4.4-ocsp-malicious-no-responder-mustStaple-server-does-not-staple
+  - name: ubuntu-18.04-fermium
+    display_name: Ubuntu 18.04 Node Fermium
+    run_on: ubuntu1804-test
+    expansions:
+      NODE_LTS_NAME: fermium
+      CLIENT_ENCRYPTION: true
+    tasks: *ref_3
   - name: ubuntu-18.04-dubnium
     display_name: Ubuntu 18.04 Node Dubnium
     run_on: ubuntu1804-test
@@ -1827,6 +1852,13 @@ buildvariants:
       NODE_LTS_NAME: argon
       MSVS_VERSION: 2013
     tasks: *ref_4
+  - name: windows-64-vs2015-fermium
+    display_name: Windows (VS2015) Node Fermium
+    run_on: windows-64-vs2015-large
+    expansions:
+      NODE_LTS_NAME: fermium
+      MSVS_VERSION: 2015
+    tasks: *ref_4
   - name: windows-64-vs2015-erbium
     display_name: Windows (VS2015) Node Erbium
     run_on: windows-64-vs2015-large
@@ -1861,6 +1893,13 @@ buildvariants:
     expansions:
       NODE_LTS_NAME: argon
       MSVS_VERSION: 2015
+    tasks: *ref_4
+  - name: windows-64-vs2017-fermium
+    display_name: Windows (VS2017) Node Fermium
+    run_on: windows-64-vs2017-large
+    expansions:
+      NODE_LTS_NAME: fermium
+      MSVS_VERSION: 2017
     tasks: *ref_4
   - name: windows-64-vs2017-erbium
     display_name: Windows (VS2017) Node Erbium

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -284,6 +284,7 @@ function checkDone(_this, callback) {
         return __handleError(_this, error, callback);
       }
       _this.emit('finish', filesDoc);
+      _this.emit('close');
     });
 
     return true;


### PR DESCRIPTION
Tests will hang on Node 14 so just updated Evergreen config with the fix.
