### PR TITLE
fix(NODE-3109): prevent servername from being IP

### DIFF
--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -243,7 +243,7 @@ function parseSslOptions(family, options) {
   }
 
   // Set default sni servername to be the same as host
-  if (result.servername == null) {
+  if (result.servername == null && !net.isIP(result.host)) {
     result.servername = result.host;
   }
 


### PR DESCRIPTION
servername should only ever be a hostname. Add a condition
to check if the host is an IP and skip auto setting the servername.

