### PR TITLE
test(NODE-3070): Ensure that SDAM should ignore the writeErrors field

### DIFF
--- a/test/spec/server-discovery-and-monitoring/errors/write_errors_ignored.json
+++ b/test/spec/server-discovery-and-monitoring/errors/write_errors_ignored.json
@@ -1,0 +1,96 @@
+{
+  "description": "writeErrors field is ignored",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "description": "Primary A is discovered",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            },
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "description": "Ignore command error with writeErrors field",
+      "applicationErrors": [
+        {
+          "address": "a:27017",
+          "when": "afterHandshakeCompletes",
+          "maxWireVersion": 9,
+          "type": "command",
+          "response": {
+            "ok": 1,
+            "writeErrors": [
+              {
+                "errmsg": "NotMasterNoSlaveOk",
+                "code": 13435
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            },
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/errors/write_errors_ignored.yml
+++ b/test/spec/server-discovery-and-monitoring/errors/write_errors_ignored.yml
@@ -1,0 +1,41 @@
+description: writeErrors field is ignored
+uri: mongodb://a/?replicaSet=rs
+phases:
+- description: Primary A is discovered
+  responses:
+  - - a:27017
+    - ok: 1
+      ismaster: true
+      hosts:
+      - a:27017
+      setName: rs
+      minWireVersion: 0
+      maxWireVersion: 9
+      topologyVersion: &topologyVersion_1_1
+        processId:
+          "$oid": '000000000000000000000001'
+        counter:
+          "$numberLong": '1'
+  outcome: &outcome
+    servers:
+      a:27017:
+        type: RSPrimary
+        setName: rs
+        topologyVersion: *topologyVersion_1_1
+        pool:
+          generation: 0
+    topologyType: ReplicaSetWithPrimary
+    logicalSessionTimeoutMinutes: null
+    setName: rs
+
+- description: Ignore command error with writeErrors field
+  applicationErrors:
+  - address: a:27017
+    when: afterHandshakeCompletes
+    maxWireVersion: 9
+    type: command
+    response:
+      ok: 1
+      writeErrors:
+      - { errmsg: NotMasterNoSlaveOk, code: 13435 }
+  outcome: *outcome


### PR DESCRIPTION
Spec sync, 3.6 branch
