### PR TITLE
fix(NODE-3109): prevent servername from being IP [PORT 4.0]

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -248,7 +248,7 @@ function parseSslOptions(options: ConnectionOptions): TLSConnectionOpts {
   }
 
   // Set default sni servername to be the same as host
-  if (result.servername == null) {
+  if (result.servername == null && result.host && !net.isIP(result.host)) {
     result.servername = result.host;
   }
 


### PR DESCRIPTION
PORT to 4.0

servername should only ever be a hostname. Add a condition
to check if the host is an IP and skip auto setting the servername.