### PR TITLE
fix: Invalid case on writeconcern makes skip check fail

### DIFF
--- a/lib/operations/connect.js
+++ b/lib/operations/connect.js
@@ -569,7 +569,7 @@ function createUnifiedOptions(finalOptions, options) {
     'mongos_options'
   ];
   const noMerge = ['readconcern', 'compression', 'autoencryption'];
-  const skip = ['w', 'wtimeout', 'j', 'journal', 'fsync', 'writeConcern'];
+  const skip = ['w', 'wtimeout', 'j', 'journal', 'fsync', 'writeconcern'];
 
   for (const name in options) {
     if (skip.indexOf(name.toLowerCase()) !== -1) {


### PR DESCRIPTION
## Description

When deprecating top-level writeConcern keys, some code was added to specifically skip them in `createUnifiedOptions`. You can see the change [here](https://github.com/mongodb/node-mongodb-native/pull/2624/files#diff-499ac669b51189e3130d91b7bf24cc7ca905950d199baea11c763981b231ff25R615)

This was ok for all keys except writeConcern, as the key being checked is cast to lowercase, but the original value is not. If given an input key of `writeConcern` it is converted to `writeconcern` and then always compared against `writeConcern` causing the check to always be false. This means that if you have connection options of:

```
writeConcern: {
  w: 1
}
```

the createUnifiedOptions function will ultimately add w:1 to the final options object and result in deprecation errors being thrown, despite a valid config.

It seems the values in `skip` are not used anywhere else, so the simplest solution was to change the case of the value in the `skip` array.
