### PR TITLE
chore: improve docker_cluster script

### DIFF
--- a/test/tools/docker-mongodb/Dockerfile
+++ b/test/tools/docker-mongodb/Dockerfile
@@ -24,6 +24,8 @@ ARG HOSTNAME
 
 RUN npm install -g m
 
+VOLUME ["/usr/local/m"]
+
 RUN mkdir /data
 
 # preload mongo binaries
@@ -47,7 +49,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 # 1. Build the docker image and tag it as e.g. `docker-mongodb`
 #    Then in the same folder as this Dockerfile, run
 #
-# > docker build -t [--no-cache] docker-mongodb .
+# > docker build [--no-cache] -t docker-mongodb .
 # Note: passing --no-cache will force a full rebuild i.e. if a new version of the server is released; otherwise it should be omitted to reduce build time
 
 # 2. Run the appropriate topology

--- a/test/tools/docker_cluster.sh
+++ b/test/tools/docker_cluster.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-DOCKER_IMAGE=node-mongodb-native/docker-mongodb
+DOCKER_IMAGE="node-mongodb-native/docker-mongodb"
+SHARED_VOLUME="type=volume,source=mongodb_binaries,target=/usr/local/m"
 
 function die_with_usage {
     printf "usage:\tdocker_cluster <server|replica_set|sharded_cluster|all> <mongo version>\n\tdocker_cluster killall\n"
@@ -10,13 +11,13 @@ function die_with_usage {
 
 function docker_mongodb {
     if [[ $1 == "replica_set" ]]; then
-        docker run --name "mongo_${1}_${2}" --rm -d -p 31000-31003:31000-31003 -e MONGO_VERSION=$2 ${DOCKER_IMAGE} replica
+        docker run --name "mongo_${1}_${2}" --rm --mount $SHARED_VOLUME -d -p 31000-31003:31000-31003 -e MONGO_VERSION=$2 ${DOCKER_IMAGE} replica
         echo "mongodb://localhost:31000/?replicaSet=rs"
     elif [[ $1 == "sharded_cluster" ]]; then
-        docker run --name "mongo_${1}_${2}" --rm -d -p 51000-51006:51000-51006 -e MONGO_VERSION=$2 ${DOCKER_IMAGE} sharded
+        docker run --name "mongo_${1}_${2}" --rm --mount $SHARED_VOLUME -d -p 51000-51006:51000-51006 -e MONGO_VERSION=$2 ${DOCKER_IMAGE} sharded
         echo "mongodb://localhost:51000,localhost:51001/"
     elif [[ $1 == "server" ]]; then
-        docker run --name "mongo_${1}_${2}" --rm -d -p 27017:27017 -e MONGO_VERSION=$2 -e HOSTNAME=$(hostname) ${DOCKER_IMAGE} single
+        docker run --name "mongo_${1}_${2}" --rm --mount $SHARED_VOLUME -d -p 27017:27017 -e MONGO_VERSION=$2 -e HOSTNAME=$(hostname) ${DOCKER_IMAGE} single
         echo "mongodb://localhost:27017"
     elif [[ $1 == "all" ]]; then
         docker_mongodb server $2 &


### PR DESCRIPTION
This PR improves the `test/tools/docker_cluster.sh` script added in #2597.

Downloaded mongoDB binaries are now stored in a persistent shared volume,
so they don't need to be re-downloaded each time a container is launched.