### PR TITLE
chore(NODE-3198): bump optional-require for yarn v2 pnp support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3590,9 +3590,9 @@
       }
     },
     "optional-require": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.2.tgz",
-      "integrity": "sha512-HZubVd6IfHsbnpdNF/ICaSAzBUEW1TievpkjY3tB4Jnk8L7+pJ3conPzUt3Mn/6OZx9uzTDOHYPGA8/AxYHBOg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
+      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
     },
     "optionator": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bl": "^2.2.1",
     "bson": "^1.1.4",
     "denque": "^1.4.1",
-    "optional-require": "^1.0.2",
+    "optional-require": "^1.0.3",
     "safe-buffer": "^5.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

This PR upgrades `optional-require` to `1.0.3` for Yarn v2 PnP support. See https://jira.mongodb.org/browse/NODE-3198 for justification.