### PR TITLE
Remove callback from Collection.initializeOrderedBulkOp()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2199,7 +2199,6 @@ Collection.prototype.initializeUnorderedBulkOp = function(options) {
  * @param {object|WriteConcern} [options.writeConcern] Specify write concern settings.
  * @param {ClientSession} [options.session] optional session to use for this operation
  * @param {boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
- * @param {OrderedBulkOperation} callback The command result callback
  * @return {null}
  */
 Collection.prototype.initializeOrderedBulkOp = function(options) {


### PR DESCRIPTION
## Description
This makes the docs match the behavior of the function since this does not accept a callback. 

**What changed?**
There are no code changes, only deleted a line in the JSDoc comment referring to the callback parameter which does not exist

**Are there any files to ignore?**
No
