### PR TITLE
fix(NODE-3166): allowInvalidHostnames and allowInvalidCertificates flags are ignored

### DIFF
--- a/test/unit/mongo_client_options.test.js
+++ b/test/unit/mongo_client_options.test.js
@@ -298,21 +298,42 @@ describe('MongoOptions', function () {
   });
 
   it('transforms tlsAllowInvalidCertificates and tlsAllowInvalidHostnames correctly', function () {
-    const options = parseOptions('mongodb://localhost/', {
+    const optionsTrue = parseOptions('mongodb://localhost/', {
       tlsAllowInvalidCertificates: true,
       tlsAllowInvalidHostnames: true
     });
-    expect(options.rejectUnauthorized).to.equal(false);
-    expect(options.checkServerIdentity).to.be.a('function');
-    expect(options.checkServerIdentity()).to.equal(undefined);
+    expect(optionsTrue.rejectUnauthorized).to.equal(false);
+    expect(optionsTrue.checkServerIdentity).to.be.a('function');
+    expect(optionsTrue.checkServerIdentity()).to.equal(undefined);
+
+    const optionsFalse = parseOptions('mongodb://localhost/', {
+      tlsAllowInvalidCertificates: false,
+      tlsAllowInvalidHostnames: false
+    });
+    expect(optionsFalse.rejectUnauthorized).to.equal(true);
+    expect(optionsFalse.checkServerIdentity).not.exist;
+
+    const optionsUndefined = parseOptions('mongodb://localhost/');
+    expect(optionsUndefined.rejectUnauthorized).not.exist;
+    expect(optionsUndefined.checkServerIdentity).not.exist;
   });
 
   it('transforms tlsInsecure correctly', function () {
-    const options = parseOptions('mongodb://localhost/', {
+    const optionsTrue = parseOptions('mongodb://localhost/', {
       tlsInsecure: true
     });
-    expect(options.rejectUnauthorized).to.equal(false);
-    expect(options.checkServerIdentity).to.be.a('function');
-    expect(options.checkServerIdentity()).to.equal(undefined);
+    expect(optionsTrue.rejectUnauthorized).to.equal(false);
+    expect(optionsTrue.checkServerIdentity).to.be.a('function');
+    expect(optionsTrue.checkServerIdentity()).to.equal(undefined);
+
+    const optionsFalse = parseOptions('mongodb://localhost/', {
+      tlsInsecure: false
+    });
+    expect(optionsFalse.rejectUnauthorized).to.equal(true);
+    expect(optionsFalse.checkServerIdentity).to.not.exist;
+
+    const optionsUndefined = parseOptions('mongodb://localhost/');
+    expect(optionsUndefined.rejectUnauthorized).to.not.exist;
+    expect(optionsUndefined.checkServerIdentity).to.not.exist;
   });
 });

--- a/test/unit/mongo_client_options.test.js
+++ b/test/unit/mongo_client_options.test.js
@@ -296,4 +296,23 @@ describe('MongoOptions', function () {
     expect(options.credentials.username).to.equal('USERNAME');
     expect(options.credentials.password).to.equal('PASSWORD');
   });
+
+  it('transforms tlsAllowInvalidCertificates and tlsAllowInvalidHostnames correctly', function () {
+    const options = parseOptions('mongodb://localhost/', {
+      tlsAllowInvalidCertificates: true,
+      tlsAllowInvalidHostnames: true
+    });
+    expect(options.rejectUnauthorized).to.equal(false);
+    expect(options.checkServerIdentity).to.be.a('function');
+    expect(options.checkServerIdentity()).to.equal(undefined);
+  });
+
+  it('transforms tlsInsecure correctly', function () {
+    const options = parseOptions('mongodb://localhost/', {
+      tlsInsecure: true
+    });
+    expect(options.rejectUnauthorized).to.equal(false);
+    expect(options.checkServerIdentity).to.be.a('function');
+    expect(options.checkServerIdentity()).to.equal(undefined);
+  });
 });

--- a/test/unit/mongo_client_options.test.js
+++ b/test/unit/mongo_client_options.test.js
@@ -311,11 +311,11 @@ describe('MongoOptions', function () {
       tlsAllowInvalidHostnames: false
     });
     expect(optionsFalse.rejectUnauthorized).to.equal(true);
-    expect(optionsFalse.checkServerIdentity).not.exist;
+    expect(optionsFalse.checkServerIdentity).to.equal(undefined);
 
     const optionsUndefined = parseOptions('mongodb://localhost/');
-    expect(optionsUndefined.rejectUnauthorized).not.exist;
-    expect(optionsUndefined.checkServerIdentity).not.exist;
+    expect(optionsUndefined.rejectUnauthorized).to.equal(undefined);
+    expect(optionsUndefined.checkServerIdentity).to.equal(undefined);
   });
 
   it('transforms tlsInsecure correctly', function () {
@@ -330,10 +330,10 @@ describe('MongoOptions', function () {
       tlsInsecure: false
     });
     expect(optionsFalse.rejectUnauthorized).to.equal(true);
-    expect(optionsFalse.checkServerIdentity).to.not.exist;
+    expect(optionsFalse.checkServerIdentity).to.equal(undefined);
 
     const optionsUndefined = parseOptions('mongodb://localhost/');
-    expect(optionsUndefined.rejectUnauthorized).to.not.exist;
-    expect(optionsUndefined.checkServerIdentity).to.not.exist;
+    expect(optionsUndefined.rejectUnauthorized).to.equal(undefined);
+    expect(optionsUndefined.checkServerIdentity).to.equal(undefined);
   });
 });


### PR DESCRIPTION
The insecure TLS flags were not being correctly translated to the equivalent nodejs options.