### PR TITLE
fix(NODE-3174): Preserve sort key order for numeric string keys

### DIFF
--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -673,6 +673,20 @@ describe('APM', function () {
       Object.keys(expected).forEach(key => {
         expect(actual).to.include.key(key);
 
+        // TODO: This is a workaround that works because all sorts in the specs
+        // are objects with one key; ideally we'd want to adjust the spec definitions
+        // to indicate whether order matters for any given key and set general
+        // expectations accordingly
+        if (key === 'sort') {
+          expect(actual[key]).to.be.instanceOf(Map);
+          expect(Object.keys(expected[key])).to.have.lengthOf(1);
+          expect(actual[key].size).to.equal(1);
+          expect(actual[key].get(Object.keys(expected[key])[0])).to.equal(
+            Object.values(expected[key])[0]
+          );
+          return;
+        }
+
         if (Array.isArray(expected[key])) {
           expect(actual[key]).to.be.instanceOf(Array);
           expect(actual[key]).to.have.lengthOf(expected[key].length);

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -676,7 +676,7 @@ describe('APM', function () {
         // TODO: This is a workaround that works because all sorts in the specs
         // are objects with one key; ideally we'd want to adjust the spec definitions
         // to indicate whether order matters for any given key and set general
-        // expectations accordingly
+        // expectations accordingly (see NODE-3235)
         if (key === 'sort') {
           expect(actual[key]).to.be.instanceOf(Map);
           expect(Object.keys(expected[key])).to.have.lengthOf(1);

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -4175,7 +4175,8 @@ describe('Cursor', function () {
           const cursor = collection.find({}, { sort: input });
           cursor.next(err => {
             expect(err).to.not.exist;
-            expect(events[0].command.sort).to.deep.equal(output);
+            expect(events[0].command.sort).to.be.instanceOf(Map);
+            expect(Array.from(events[0].command.sort)).to.deep.equal(Array.from(output));
             cursor.close(done);
           });
         });
@@ -4189,54 +4190,97 @@ describe('Cursor', function () {
           const cursor = collection.find({}).sort(input);
           cursor.next(err => {
             expect(err).to.not.exist;
-            expect(events[0].command.sort).to.deep.equal(output);
+            expect(events[0].command.sort).to.be.instanceOf(Map);
+            expect(Array.from(events[0].command.sort)).to.deep.equal(Array.from(output));
             cursor.close(done);
           });
         });
       });
 
-    it('should use find options object', findSort({ alpha: 1 }, { alpha: 1 }));
-    it('should use find options string', findSort('alpha', { alpha: 1 }));
-    it('should use find options shallow array', findSort(['alpha', 1], { alpha: 1 }));
-    it('should use find options deep array', findSort([['alpha', 1]], { alpha: 1 }));
+    it('should use find options object', findSort({ alpha: 1 }, new Map([['alpha', 1]])));
+    it('should use find options string', findSort('alpha', new Map([['alpha', 1]])));
+    it('should use find options shallow array', findSort(['alpha', 1], new Map([['alpha', 1]])));
+    it('should use find options deep array', findSort([['alpha', 1]], new Map([['alpha', 1]])));
 
-    it('should use cursor.sort object', cursorSort({ alpha: 1 }, { alpha: 1 }));
-    it('should use cursor.sort string', cursorSort('alpha', { alpha: 1 }));
-    it('should use cursor.sort shallow array', cursorSort(['alpha', 1], { alpha: 1 }));
-    it('should use cursor.sort deep array', cursorSort([['alpha', 1]], { alpha: 1 }));
+    it('should use cursor.sort object', cursorSort({ alpha: 1 }, new Map([['alpha', 1]])));
+    it('should use cursor.sort string', cursorSort('alpha', new Map([['alpha', 1]])));
+    it('should use cursor.sort shallow array', cursorSort(['alpha', 1], new Map([['alpha', 1]])));
+    it('should use cursor.sort deep array', cursorSort([['alpha', 1]], new Map([['alpha', 1]])));
 
     it('formatSort - one key', () => {
-      expect(formatSort('alpha')).to.deep.equal({ alpha: 1 });
-      expect(formatSort(['alpha'])).to.deep.equal({ alpha: 1 });
-      expect(formatSort('alpha', 1)).to.deep.equal({ alpha: 1 });
-      expect(formatSort('alpha', 'asc')).to.deep.equal({ alpha: 1 });
-      expect(formatSort([['alpha', 'asc']])).to.deep.equal({ alpha: 1 });
-      expect(formatSort('alpha', 'ascending')).to.deep.equal({ alpha: 1 });
-      expect(formatSort({ alpha: 1 })).to.deep.equal({ alpha: 1 });
-      expect(formatSort('beta')).to.deep.equal({ beta: 1 });
-      expect(formatSort(['beta'])).to.deep.equal({ beta: 1 });
-      expect(formatSort('beta', -1)).to.deep.equal({ beta: -1 });
-      expect(formatSort('beta', 'desc')).to.deep.equal({ beta: -1 });
-      expect(formatSort('beta', 'descending')).to.deep.equal({ beta: -1 });
-      expect(formatSort({ beta: -1 })).to.deep.equal({ beta: -1 });
-      expect(formatSort({ alpha: { $meta: 'hi' } })).to.deep.equal({
-        alpha: { $meta: 'hi' }
-      });
+      // TODO: rewrite these tests
+      expect(formatSort('alpha')).to.deep.equal(new Map([['alpha', 1]]));
+      expect(formatSort(['alpha'])).to.deep.equal(new Map([['alpha', 1]]));
+      expect(formatSort('alpha', 1)).to.deep.equal(new Map([['alpha', 1]]));
+      expect(formatSort('alpha', 'asc')).to.deep.equal(new Map([['alpha', 1]]));
+      expect(formatSort([['alpha', 'asc']])).to.deep.equal(new Map([['alpha', 1]]));
+      expect(formatSort('alpha', 'ascending')).to.deep.equal(new Map([['alpha', 1]]));
+      expect(formatSort({ alpha: 1 })).to.deep.equal(new Map([['alpha', 1]]));
+      expect(formatSort('beta')).to.deep.equal(new Map([['beta', 1]]));
+      expect(formatSort(['beta'])).to.deep.equal(new Map([['beta', 1]]));
+      expect(formatSort('beta', -1)).to.deep.equal(new Map([['beta', -1]]));
+      expect(formatSort('beta', 'desc')).to.deep.equal(new Map([['beta', -1]]));
+      expect(formatSort('beta', 'descending')).to.deep.equal(new Map([['beta', -1]]));
+      expect(formatSort({ beta: -1 })).to.deep.equal(new Map([['beta', -1]]));
+      expect(formatSort({ alpha: { $meta: 'hi' } })).to.deep.equal(
+        new Map([['alpha', { $meta: 'hi' }]])
+      );
     });
 
     it('formatSort - multi key', () => {
-      expect(formatSort(['alpha', 'beta'])).to.deep.equal({ alpha: 1, beta: 1 });
-      expect(formatSort({ alpha: 1, beta: 1 })).to.deep.equal({ alpha: 1, beta: 1 });
+      expect(formatSort(['alpha', 'beta'])).to.deep.equal(
+        new Map([
+          ['alpha', 1],
+          ['beta', 1]
+        ])
+      );
+      expect(formatSort({ alpha: 1, beta: 1 })).to.deep.equal(
+        new Map([
+          ['alpha', 1],
+          ['beta', 1]
+        ])
+      );
       expect(
         formatSort([
           ['alpha', 'asc'],
           ['beta', 'ascending']
         ])
-      ).to.deep.equal({ alpha: 1, beta: 1 });
-      expect(formatSort({ alpha: { $meta: 'hi' }, beta: 'ascending' })).to.deep.equal({
-        alpha: { $meta: 'hi' },
-        beta: 1
-      });
+      ).to.deep.equal(
+        new Map([
+          ['alpha', 1],
+          ['beta', 1]
+        ])
+      );
+      expect(
+        formatSort(
+          new Map([
+            ['alpha', 'asc'],
+            ['beta', 'ascending']
+          ])
+        )
+      ).to.deep.equal(
+        new Map([
+          ['alpha', 1],
+          ['beta', 1]
+        ])
+      );
+      expect(
+        formatSort([
+          ['3', 'asc'],
+          ['1', 'ascending']
+        ])
+      ).to.deep.equal(
+        new Map([
+          ['3', 1],
+          ['1', 1]
+        ])
+      );
+      expect(formatSort({ alpha: { $meta: 'hi' }, beta: 'ascending' })).to.deep.equal(
+        new Map([
+          ['alpha', { $meta: 'hi' }],
+          ['beta', 1]
+        ])
+      );
     });
 
     it('should use allowDiskUse option on sort', {
@@ -4249,7 +4293,7 @@ describe('Cursor', function () {
           cursor.next(err => {
             expect(err).to.not.exist;
             const { command } = events.shift();
-            expect(command.sort).to.deep.equal({ alpha: 1 });
+            expect(command.sort).to.deep.equal(new Map([['alpha', 1]]));
             expect(command.allowDiskUse).to.be.true;
             cursor.close(done);
           });

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -4208,7 +4208,7 @@ describe('Cursor', function () {
     it('should use cursor.sort deep array', cursorSort([['alpha', 1]], new Map([['alpha', 1]])));
 
     it('formatSort - one key', () => {
-      // TODO: rewrite these tests
+      // TODO (NODE-3236): These are unit tests for a standalone function and should be moved out of the cursor context file
       expect(formatSort('alpha')).to.deep.equal(new Map([['alpha', 1]]));
       expect(formatSort(['alpha'])).to.deep.equal(new Map([['alpha', 1]]));
       expect(formatSort('alpha', 1)).to.deep.equal(new Map([['alpha', 1]]));

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -414,14 +414,26 @@ function validateExpectations(commandEvents, spec, savedSessionData) {
 
     const actualCommand = actual.command;
     const expectedCommand = expected.command;
+    if (expectedCommand.sort) {
+      // TODO: This is a workaround that works because all sorts in the specs
+      // are objects with one key; ideally we'd want to adjust the spec definitions
+      // to indicate whether order matters for any given key and set general
+      // expectations accordingly
+      expect(Object.keys(expectedCommand.sort)).to.have.lengthOf(1);
+      expect(actualCommand.sort).to.be.instanceOf(Map);
+      expect(actualCommand.sort.size).to.equal(1);
+      const expectedKey = Object.keys(expectedCommand.sort)[0];
+      expect(actualCommand.sort).to.have.all.keys(expectedKey);
+      actualCommand.sort = { [expectedKey]: actualCommand.sort.get(expectedKey) };
+    }
 
     expect(actualCommand).withSessionData(savedSessionData).to.matchMongoSpec(expectedCommand);
   });
 }
 
 function normalizeCommandShapes(commands) {
-  return commands.map(def =>
-    JSON.parse(
+  return commands.map(def => {
+    const output = JSON.parse(
       EJSON.stringify(
         {
           command: def.command,
@@ -430,8 +442,13 @@ function normalizeCommandShapes(commands) {
         },
         { relaxed: true }
       )
-    )
-  );
+    );
+    // TODO: this is a workaround to preserve sort Map type
+    if (def.command.sort) {
+      output.command.sort = def.command.sort;
+    }
+    return output;
+  });
 }
 
 function extractCrudResult(result, operation) {

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -418,7 +418,7 @@ function validateExpectations(commandEvents, spec, savedSessionData) {
       // TODO: This is a workaround that works because all sorts in the specs
       // are objects with one key; ideally we'd want to adjust the spec definitions
       // to indicate whether order matters for any given key and set general
-      // expectations accordingly
+      // expectations accordingly (see NODE-3235)
       expect(Object.keys(expectedCommand.sort)).to.have.lengthOf(1);
       expect(actualCommand.sort).to.be.instanceOf(Map);
       expect(actualCommand.sort.size).to.equal(1);
@@ -443,7 +443,7 @@ function normalizeCommandShapes(commands) {
         { relaxed: true }
       )
     );
-    // TODO: this is a workaround to preserve sort Map type
+    // TODO: this is a workaround to preserve sort Map type until NODE-3235 is completed
     if (def.command.sort) {
       output.command.sort = def.command.sort;
     }

--- a/test/functional/unified-spec-runner/match.ts
+++ b/test/functional/unified-spec-runner/match.ts
@@ -142,7 +142,7 @@ export function resultCheck(
           // TODO: This is a workaround that works because all sorts in the specs
           // are objects with one key; ideally we'd want to adjust the spec definitions
           // to indicate whether order matters for any given key and set general
-          // expectations accordingly
+          // expectations accordingly (see NODE-3235)
           expect(Object.keys(value)).to.have.lengthOf(1);
           expect(actual[key]).to.be.instanceOf(Map);
           expect(actual[key].size).to.equal(1);

--- a/test/functional/unified-spec-runner/match.ts
+++ b/test/functional/unified-spec-runner/match.ts
@@ -138,7 +138,21 @@ export function resultCheck(
       for (const [key, value] of expectedEntries) {
         path.push(Array.isArray(expected) ? `[${key}]` : `.${key}`); // record what key we're at
         depth += 1;
-        resultCheck(actual[key], value, entities, path, depth);
+        if (key === 'sort') {
+          // TODO: This is a workaround that works because all sorts in the specs
+          // are objects with one key; ideally we'd want to adjust the spec definitions
+          // to indicate whether order matters for any given key and set general
+          // expectations accordingly
+          expect(Object.keys(value)).to.have.lengthOf(1);
+          expect(actual[key]).to.be.instanceOf(Map);
+          expect(actual[key].size).to.equal(1);
+          const expectedSortKey = Object.keys(value)[0];
+          expect(actual[key]).to.have.all.keys(expectedSortKey);
+          const objFromActual = { [expectedSortKey]: actual[key].get(expectedSortKey) };
+          resultCheck(objFromActual, value, entities, path, depth);
+        } else {
+          resultCheck(actual[key], value, entities, path, depth);
+        }
         depth -= 1;
         path.pop(); // if the recursion was successful we can drop the tested key
       }


### PR DESCRIPTION
## Description

Updated internal representation of sort to use a map instead of a plain object in order to preserve correct ordering for multi-key sort queries; also enabled the use of a map type to specify input sort options
