### PR TITLE
fix(sdam): topology no longer causes close event

### DIFF
--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -359,7 +359,6 @@ class Topology extends EventEmitter {
           this.emit('topologyClosed', new events.TopologyClosedEvent(this.s.id));
 
           stateTransition(this, STATE_CLOSED);
-          this.emit('close');
 
           if (typeof callback === 'function') {
             callback(err);

--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -3688,10 +3688,9 @@ describe('Operation Examples', function() {
         // REMOVE-LINE done();
         // REMOVE-LINE var db = client.db(configuration.db);
         // BEGIN
-        var db = client.db(configuration.db);
         test.equal(null, err);
 
-        db.on('close', function() {
+        client.on('close', function() {
           done();
         });
 


### PR DESCRIPTION
The topology was emitting both a "topologyClosed" and "close"
event which are bubbled up to the MongoClient. This was causing
two "close" events to be emitted from the MongoClient when the
client is closed.

NODE-3219

There was one test on this branch looking for that event that was
looking for that event and not "topologyClosed", so I'm wondering
if this should not be backported.
