### PR TITLE
fix(sdam): topology no longer causes close event

### DIFF
--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -448,7 +448,6 @@ export class Topology extends EventEmitter {
           this.emit(Topology.TOPOLOGY_CLOSED, new TopologyClosedEvent(this.s.id));
 
           stateTransition(this, STATE_CLOSED);
-          this.emit('close');
 
           if (typeof callback === 'function') {
             callback(err);


### PR DESCRIPTION
The topology was emitting both a "topologyClosed" and "close"
event which are bubbled up to the MongoClient. This was causing
two "close" events to be emitted from the MongoClient when the
client is closed.

NODE-3219

Note that there were no tests explicitly looking for that event, but there
are tests looking for the `topologyClosed` event, so I assume this just
slipped through.
