### PR TITLE
fix(NODE-3206): Make distinct use any[] type instead of Document[]

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1013,25 +1013,20 @@ export class Collection {
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
-  distinct(key: string): Promise<Document[]>;
-  distinct(key: string, callback: Callback<Document[]>): void;
-  distinct(key: string, query: Document): Promise<Document[]>;
-  distinct(key: string, query: Document, callback: Callback<Document[]>): void;
-  distinct(key: string, query: Document, options: DistinctOptions): Promise<Document[]>;
+  distinct(key: string): Promise<any[]>;
+  distinct(key: string, callback: Callback<any[]>): void;
+  distinct(key: string, query: Document): Promise<any[]>;
+  distinct(key: string, query: Document, callback: Callback<any[]>): void;
+  distinct(key: string, query: Document, options: DistinctOptions): Promise<any[]>;
+  distinct(key: string, query: Document, options: DistinctOptions, callback: Callback<any[]>): void;
   distinct(
     key: string,
-    query: Document,
-    options: DistinctOptions,
-    callback: Callback<Document[]>
-  ): void;
-  distinct(
-    key: string,
-    query?: Document | DistinctOptions | Callback<Document[]>,
-    options?: DistinctOptions | Callback<Document[]>,
-    callback?: Callback<Document[]>
-  ): Promise<Document[]> | void {
+    query?: Document | DistinctOptions | Callback<any[]>,
+    options?: DistinctOptions | Callback<any[]>,
+    callback?: Callback<any[]>
+  ): Promise<any[]> | void {
     if (typeof query === 'function') {
-      (callback = query as Callback<Document[]>), (query = {}), (options = {});
+      (callback = query as Callback<any[]>), (query = {}), (options = {});
     } else {
       if (arguments.length === 3 && typeof options === 'function') {
         (callback = options), (options = {});

--- a/src/operations/distinct.ts
+++ b/src/operations/distinct.ts
@@ -14,7 +14,7 @@ export type DistinctOptions = CommandOperationOptions;
  * Return a list of distinct values for the given key across a collection.
  * @internal
  */
-export class DistinctOperation extends CommandOperation<Document[]> {
+export class DistinctOperation extends CommandOperation<any[]> {
   options: DistinctOptions;
   collection: Collection;
   /** Field of the document to find distinct values for. */
@@ -39,7 +39,7 @@ export class DistinctOperation extends CommandOperation<Document[]> {
     this.query = query;
   }
 
-  execute(server: Server, session: ClientSession, callback: Callback<Document[]>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<any[]>): void {
     const coll = this.collection;
     const key = this.key;
     const query = this.query;


### PR DESCRIPTION
## Description

Fixes distinct() being erroneously typed as Document[] instead of any[] (NODE-3206)