### PR TITLE
refactor(NODE-3157)!: update find and modify interfaces for 4.0

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -45,7 +45,9 @@ import {
   FindOneAndDeleteOperation,
   FindOneAndReplaceOperation,
   FindOneAndUpdateOperation,
-  FindAndModifyOptions
+  FindOneAndDeleteOptions,
+  FindOneAndReplaceOptions,
+  FindOneAndUpdateOptions
 } from './operations/find_and_modify';
 import {
   InsertOneOperation,
@@ -1098,15 +1100,15 @@ export class Collection {
    */
   findOneAndDelete(filter: Document): Promise<Document>;
   findOneAndDelete(filter: Document, callback: Callback<Document>): void;
-  findOneAndDelete(filter: Document, options: FindAndModifyOptions): Promise<Document>;
+  findOneAndDelete(filter: Document, options: FindOneAndDeleteOptions): Promise<Document>;
   findOneAndDelete(
     filter: Document,
-    options: FindAndModifyOptions,
+    options: FindOneAndDeleteOptions,
     callback: Callback<Document>
   ): void;
   findOneAndDelete(
     filter: Document,
-    options?: FindAndModifyOptions | Callback<Document>,
+    options?: FindOneAndDeleteOptions | Callback<Document>,
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
@@ -1131,18 +1133,18 @@ export class Collection {
   findOneAndReplace(
     filter: Document,
     replacement: Document,
-    options: FindAndModifyOptions
+    options: FindOneAndReplaceOptions
   ): Promise<Document>;
   findOneAndReplace(
     filter: Document,
     replacement: Document,
-    options: FindAndModifyOptions,
+    options: FindOneAndReplaceOptions,
     callback: Callback<Document>
   ): void;
   findOneAndReplace(
     filter: Document,
     replacement: Document,
-    options?: FindAndModifyOptions | Callback<Document>,
+    options?: FindOneAndReplaceOptions | Callback<Document>,
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
@@ -1167,18 +1169,18 @@ export class Collection {
   findOneAndUpdate(
     filter: Document,
     update: Document,
-    options: FindAndModifyOptions
+    options: FindOneAndUpdateOptions
   ): Promise<Document>;
   findOneAndUpdate(
     filter: Document,
     update: Document,
-    options: FindAndModifyOptions,
+    options: FindOneAndUpdateOptions,
     callback: Callback<Document>
   ): void;
   findOneAndUpdate(
     filter: Document,
     update: Document,
-    options?: FindAndModifyOptions | Callback<Document>,
+    options?: FindOneAndUpdateOptions | Callback<Document>,
     callback?: Callback<Document>
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,11 @@ export type { EstimatedDocumentCountOptions } from './operations/estimated_docum
 export type { EvalOptions } from './operations/eval';
 export type { FindOptions } from './operations/find';
 export type { Sort, SortDirection } from './sort';
-export type { FindAndModifyOptions } from './operations/find_and_modify';
+export type {
+  FindOneAndDeleteOptions,
+  FindOneAndReplaceOptions,
+  FindOneAndUpdateOptions
+} from './operations/find_and_modify';
 export type {
   IndexSpecification,
   CreateIndexesOptions,

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -23,8 +23,6 @@ export interface FindAndModifyOptions extends CommandOperationOptions {
   upsert?: boolean;
   /** Limits the fields to return for all matching documents. */
   projection?: Document;
-  /** @deprecated use `projection` instead */
-  fields?: Document;
   /** Determines which document the operation modifies if the query selects multiple documents. */
   sort?: Sort;
   /** Optional list of array filters referenced in filtered positional operators */
@@ -88,10 +86,8 @@ export class FindAndModifyOperation extends CommandOperation<Document> {
     cmd.remove = options.remove ? true : false;
     cmd.upsert = options.upsert ? true : false;
 
-    const projection = options.projection || options.fields;
-
-    if (projection) {
-      cmd.fields = projection;
+    if (options.projection) {
+      cmd.fields = options.projection;
     }
 
     if (options.arrayFilters) {
@@ -162,7 +158,6 @@ export class FindOneAndDeleteOperation extends FindAndModifyOperation {
   constructor(collection: Collection, filter: Document, options: FindAndModifyOptions) {
     // Final options
     const finalOptions = Object.assign({}, options);
-    finalOptions.fields = options.projection;
     finalOptions.remove = true;
 
     // Basic validation
@@ -184,7 +179,6 @@ export class FindOneAndReplaceOperation extends FindAndModifyOperation {
   ) {
     // Final options
     const finalOptions = Object.assign({}, options);
-    finalOptions.fields = options.projection;
     finalOptions.update = true;
     finalOptions.new = options.returnOriginal !== void 0 ? !options.returnOriginal : false;
     finalOptions.upsert = options.upsert !== void 0 ? !!options.upsert : false;
@@ -215,7 +209,6 @@ export class FindOneAndUpdateOperation extends FindAndModifyOperation {
   ) {
     // Final options
     const finalOptions = Object.assign({}, options);
-    finalOptions.fields = options.projection;
     finalOptions.update = true;
     finalOptions.new =
       typeof options.returnOriginal === 'boolean' ? !options.returnOriginal : false;

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -74,7 +74,6 @@ interface FindAndModifyOptions extends CommandOperationOptions {
 
   // NOTE: These types are a misuse of options, can we think of a way to remove them?
   remove?: boolean;
-  new?: boolean;
 }
 
 /** @internal */
@@ -121,9 +120,15 @@ export class FindAndModifyOperation extends CommandOperation<Document> {
       cmd.sort = sort;
     }
 
-    cmd.new = options.new ? true : false;
+    if (!options.remove) {
+      cmd.new = typeof options.returnOriginal === 'boolean' ? !options.returnOriginal : false;
+      cmd.upsert = typeof options.upsert === 'boolean' ? options.upsert : false;
+      if (doc) {
+        cmd.update = doc;
+      }
+    }
+
     cmd.remove = options.remove ? true : false;
-    cmd.upsert = options.upsert ? true : false;
 
     if (options.projection) {
       cmd.fields = options.projection;
@@ -131,10 +136,6 @@ export class FindAndModifyOperation extends CommandOperation<Document> {
 
     if (options.arrayFilters) {
       cmd.arrayFilters = options.arrayFilters;
-    }
-
-    if (doc && !options.remove) {
-      cmd.update = doc;
     }
 
     if (options.maxTimeMS) {
@@ -212,8 +213,6 @@ export class FindOneAndReplaceOperation extends FindAndModifyOperation {
   ) {
     // Final options
     const finalOptions = Object.assign({}, options);
-    finalOptions.new = options.returnOriginal !== void 0 ? !options.returnOriginal : false;
-    finalOptions.upsert = options.upsert !== void 0 ? !!options.upsert : false;
 
     if (filter == null || typeof filter !== 'object') {
       throw new TypeError('Filter parameter must be an object');
@@ -241,9 +240,6 @@ export class FindOneAndUpdateOperation extends FindAndModifyOperation {
   ) {
     // Final options
     const finalOptions = Object.assign({}, options);
-    finalOptions.new =
-      typeof options.returnOriginal === 'boolean' ? !options.returnOriginal : false;
-    finalOptions.upsert = typeof options.upsert === 'boolean' ? options.upsert : false;
 
     if (filter == null || typeof filter !== 'object') {
       throw new TypeError('Filter parameter must be an object');

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -16,7 +16,53 @@ import { Sort, formatSort } from '../sort';
 import type { ClientSession } from '../sessions';
 
 /** @public */
-export interface FindAndModifyOptions extends CommandOperationOptions {
+export interface FindOneAndDeleteOptions extends CommandOperationOptions {
+  /** An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.*/
+  hint?: Document;
+  /** Limits the fields to return for all matching documents. */
+  projection?: Document;
+  /** Determines which document the operation modifies if the query selects multiple documents. */
+  sort?: Sort;
+}
+
+/** @public */
+export interface FindOneAndReplaceOptions extends CommandOperationOptions {
+  /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
+  bypassDocumentValidation?: boolean;
+  /** An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.*/
+  hint?: Document;
+  /** Limits the fields to return for all matching documents. */
+  projection?: Document;
+  /** When false, returns the updated document rather than the original. The default is true. */
+  returnOriginal?: boolean;
+  /** Determines which document the operation modifies if the query selects multiple documents. */
+  sort?: Sort;
+  /** Upsert the document if it does not exist. */
+  upsert?: boolean;
+}
+
+/** @public */
+export interface FindOneAndUpdateOptions extends CommandOperationOptions {
+  /** Optional list of array filters referenced in filtered positional operators */
+  arrayFilters?: Document[];
+  /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
+  bypassDocumentValidation?: boolean;
+  /** An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.*/
+  hint?: Document;
+  /** Limits the fields to return for all matching documents. */
+  projection?: Document;
+  /** When false, returns the updated document rather than the original. The default is true. */
+  returnOriginal?: boolean;
+  /** Determines which document the operation modifies if the query selects multiple documents. */
+  sort?: Sort;
+  /** Upsert the document if it does not exist. */
+  upsert?: boolean;
+}
+
+// TODO: NODE-1812 to deprecate returnOriginal for returnDocument
+
+/** @internal */
+interface FindAndModifyOptions extends CommandOperationOptions {
   /** When false, returns the updated document rather than the original. The default is true. */
   returnOriginal?: boolean;
   /** Upsert the document if it does not exist. */

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -1,11 +1,5 @@
 import { ReadPreference } from '../read_preference';
-import {
-  maxWireVersion,
-  applyRetryableWrites,
-  decorateWithCollation,
-  hasAtomicOperators,
-  Callback
-} from '../utils';
+import { maxWireVersion, decorateWithCollation, hasAtomicOperators, Callback } from '../utils';
 import { MongoError } from '../error';
 import { CommandOperation, CommandOperationOptions } from './command';
 import { defineAspects, Aspect } from './operation';
@@ -79,7 +73,6 @@ interface FindAndModifyOptions extends CommandOperationOptions {
   hint?: Document;
 
   // NOTE: These types are a misuse of options, can we think of a way to remove them?
-  update?: boolean;
   remove?: boolean;
   new?: boolean;
 }
@@ -116,7 +109,7 @@ export class FindAndModifyOperation extends CommandOperation<Document> {
     const query = this.query;
     const sort = formatSort(this.sort);
     const doc = this.doc;
-    let options = { ...this.options, ...this.bsonOptions };
+    const options = { ...this.options, ...this.bsonOptions };
 
     // Create findAndModify command object
     const cmd: Document = {
@@ -147,12 +140,6 @@ export class FindAndModifyOperation extends CommandOperation<Document> {
     if (options.maxTimeMS) {
       cmd.maxTimeMS = options.maxTimeMS;
     }
-
-    // No check on the documents
-    options.checkKeys = false;
-
-    // Final options for retryable writes
-    options = applyRetryableWrites(options, coll.s.db);
 
     // Decorate the findAndModify command with the write Concern
     if (options.writeConcern) {
@@ -225,7 +212,6 @@ export class FindOneAndReplaceOperation extends FindAndModifyOperation {
   ) {
     // Final options
     const finalOptions = Object.assign({}, options);
-    finalOptions.update = true;
     finalOptions.new = options.returnOriginal !== void 0 ? !options.returnOriginal : false;
     finalOptions.upsert = options.upsert !== void 0 ? !!options.upsert : false;
 
@@ -255,7 +241,6 @@ export class FindOneAndUpdateOperation extends FindAndModifyOperation {
   ) {
     // Final options
     const finalOptions = Object.assign({}, options);
-    finalOptions.update = true;
     finalOptions.new =
       typeof options.returnOriginal === 'boolean' ? !options.returnOriginal : false;
     finalOptions.upsert = typeof options.upsert === 'boolean' ? options.upsert : false;

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -84,7 +84,7 @@ const OperationTypes = Object.freeze({
 type OperationType = typeof OperationTypes[keyof typeof OperationTypes];
 
 /** @internal */
-export class FindAndModifyOperation extends CommandOperation<Document> {
+class FindAndModifyOperation extends CommandOperation<Document> {
   options: FindAndModifyOptions;
   collection: Collection;
   query: Document;
@@ -95,9 +95,8 @@ export class FindAndModifyOperation extends CommandOperation<Document> {
   constructor(
     collection: Collection,
     query: Document,
-    sort: Sort | undefined,
     doc: Document | undefined,
-    options?: FindAndModifyOptions
+    options: FindAndModifyOptions
   ) {
     super(collection, options);
     this.options = options ?? {};
@@ -107,7 +106,7 @@ export class FindAndModifyOperation extends CommandOperation<Document> {
 
     this.collection = collection;
     this.query = query;
-    this.sort = sort;
+    this.sort = options.sort;
     this.doc = doc;
   }
 
@@ -202,13 +201,13 @@ export class FindAndModifyOperation extends CommandOperation<Document> {
 
 /** @internal */
 export class FindOneAndDeleteOperation extends FindAndModifyOperation {
-  constructor(collection: Collection, filter: Document, options: FindAndModifyOptions) {
+  constructor(collection: Collection, filter: Document, options: FindOneAndDeleteOptions) {
     // Basic validation
     if (filter == null || typeof filter !== 'object') {
       throw new TypeError('Filter parameter must be an object');
     }
 
-    super(collection, filter, options.sort, undefined, options);
+    super(collection, filter, undefined, options);
     this.operationType = OperationTypes.deleteOne;
   }
 }
@@ -219,7 +218,7 @@ export class FindOneAndReplaceOperation extends FindAndModifyOperation {
     collection: Collection,
     filter: Document,
     replacement: Document,
-    options: FindAndModifyOptions
+    options: FindOneAndReplaceOptions
   ) {
     if (filter == null || typeof filter !== 'object') {
       throw new TypeError('Filter parameter must be an object');
@@ -233,7 +232,7 @@ export class FindOneAndReplaceOperation extends FindAndModifyOperation {
       throw new TypeError('Replacement document must not contain atomic operators');
     }
 
-    super(collection, filter, options.sort, replacement, options);
+    super(collection, filter, replacement, options);
     this.operationType = OperationTypes.replaceOne;
   }
 }
@@ -244,7 +243,7 @@ export class FindOneAndUpdateOperation extends FindAndModifyOperation {
     collection: Collection,
     filter: Document,
     update: Document,
-    options: FindAndModifyOptions
+    options: FindOneAndUpdateOptions
   ) {
     if (filter == null || typeof filter !== 'object') {
       throw new TypeError('Filter parameter must be an object');
@@ -258,7 +257,7 @@ export class FindOneAndUpdateOperation extends FindAndModifyOperation {
       throw new TypeError('Update document requires atomic operators');
     }
 
-    super(collection, filter, options.sort, update, options);
+    super(collection, filter, update, options);
     this.operationType = OperationTypes.updateOne;
   }
 }


### PR DESCRIPTION
## Description

**What changed?**
NODE-3157 Updated public facing option interfaces for find and modify operations: `findOneAndDelete()`, `findOneAndReplace()`, `findOneAndUpdate()`.

BREAKING: Legacy `fields` option no longer supported, use `projection` instead.