### PR TITLE
docs(NODE-3314): Changed '.equal()' to '.strictEqual()' in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ const dbName = 'myproject';
 const client = new MongoClient(url);
 // Use connect method to connect to the server
 client.connect(function(err) {
-  assert.equal(null, err);
+  assert.strictEqual(null, err);
   console.log('Connected successfully to server');
 
   const db = client.db(dbName);
@@ -226,9 +226,9 @@ const insertDocuments = function(db, callback) {
   const collection = db.collection('documents');
   // Insert some documents
   collection.insertMany([{ a: 1 }, { a: 2 }, { a: 3 }], function(err, result) {
-    assert.equal(err, null);
-    assert.equal(3, result.result.n);
-    assert.equal(3, result.ops.length);
+    assert.strictEqual(err, null);
+    assert.strictEqual(3, result.result.n);
+    assert.strictEqual(3, result.ops.length);
     console.log('Inserted 3 documents into the collection');
     callback(result);
   });
@@ -255,7 +255,7 @@ const dbName = 'myproject';
 
 // Use connect method to connect to the server
 MongoClient.connect(url, function(err, client) {
-  assert.equal(null, err);
+  assert.strictEqual(null, err);
   console.log('Connected successfully to server');
 
   const db = client.db(dbName);
@@ -289,7 +289,7 @@ const findDocuments = function(db, callback) {
   const collection = db.collection('documents');
   // Find some documents
   collection.find({}).toArray(function(err, docs) {
-    assert.equal(err, null);
+    assert.strictEqual(err, null);
     console.log('Found the following records');
     console.log(docs);
     callback(docs);
@@ -311,7 +311,7 @@ const dbName = 'myproject';
 
 // Use connect method to connect to the server
 MongoClient.connect(url, function(err, client) {
-  assert.equal(null, err);
+  assert.strictEqual(null, err);
   console.log('Connected correctly to server');
 
   const db = client.db(dbName);
@@ -334,7 +334,7 @@ const findDocuments = function(db, callback) {
   const collection = db.collection('documents');
   // Find some documents
   collection.find({ a: 3 }).toArray(function(err, docs) {
-    assert.equal(err, null);
+    assert.strictEqual(err, null);
     console.log('Found the following records');
     console.log(docs);
     callback(docs);
@@ -354,8 +354,8 @@ const updateDocument = function(db, callback) {
   const collection = db.collection('documents');
   // Update document where a is 2, set b equal to 1
   collection.updateOne({ a: 2 }, { $set: { b: 1 } }, function(err, result) {
-    assert.equal(err, null);
-    assert.equal(1, result.result.n);
+    assert.strictEqual(err, null);
+    assert.strictEqual(1, result.result.n);
     console.log('Updated the document with the field a equal to 2');
     callback(result);
   });
@@ -376,7 +376,7 @@ const dbName = 'myproject';
 
 // Use connect method to connect to the server
 MongoClient.connect(url, function(err, client) {
-  assert.equal(null, err);
+  assert.strictEqual(null, err);
   console.log('Connected successfully to server');
 
   const db = client.db(dbName);
@@ -399,8 +399,8 @@ const removeDocument = function(db, callback) {
   const collection = db.collection('documents');
   // Delete document where a is 3
   collection.deleteOne({ a: 3 }, function(err, result) {
-    assert.equal(err, null);
-    assert.equal(1, result.result.n);
+    assert.strictEqual(err, null);
+    assert.strictEqual(1, result.result.n);
     console.log('Removed the document with the field a equal to 3');
     callback(result);
   });
@@ -421,7 +421,7 @@ const dbName = 'myproject';
 
 // Use connect method to connect to the server
 MongoClient.connect(url, function(err, client) {
-  assert.equal(null, err);
+  assert.strictEqual(null, err);
   console.log('Connected successfully to server');
 
   const db = client.db(dbName);
@@ -464,7 +464,7 @@ const dbName = 'myproject';
 
 // Use connect method to connect to the server
 MongoClient.connect(url, function(err, client) {
-  assert.equal(null, err);
+  assert.strictEqual(null, err);
   console.log('Connected successfully to server');
 
   const db = client.db(dbName);


### PR DESCRIPTION
asserts.equal() is deprecated, changed it to assert.strictEqual().

## Description

**What changed?**
README.md - Changed the examples so they used asserts.strictEqual() instead of asserts.equal() (which is deprecated).

**Are there any files to ignore?**
No