### PR TITLE
fix(NODE-3116): Move negative time check up in async interval

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1010,6 +1010,7 @@ export function makeInterruptibleAsyncInterval(
     // to reschedule.
     if (timeUntilNextCall < 0) {
       executeAndReschedule();
+      return;
     }
 
     // debounce multiple calls to wake within the `minInterval`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1004,6 +1004,14 @@ export function makeInterruptibleAsyncInterval(
     // never completes, the `timeUntilNextCall` will continue to grow
     // negatively unbounded, so it will never trigger a reschedule here.
 
+    // This is possible in virtualized environments like AWS Lambda where our
+    // clock is unreliable. In these cases the timer is "running" but never
+    // actually completes, so we want to execute immediately and then attempt
+    // to reschedule.
+    if (timeUntilNextCall < 0) {
+      executeAndReschedule();
+    }
+
     // debounce multiple calls to wake within the `minInterval`
     if (timeSinceLastWake < minInterval) {
       return;
@@ -1013,14 +1021,6 @@ export function makeInterruptibleAsyncInterval(
     // faster than the `minInterval`
     if (timeUntilNextCall > minInterval) {
       reschedule(minInterval);
-    }
-
-    // This is possible in virtualized environments like AWS Lambda where our
-    // clock is unreliable. In these cases the timer is "running" but never
-    // actually completes, so we want to execute immediately and then attempt
-    // to reschedule.
-    if (timeUntilNextCall < 0) {
-      executeAndReschedule();
     }
   }
 


### PR DESCRIPTION
NODE-3116

@mbroadst Do you see any negative implications in moving this check up to the first one?