### PR TITLE
fix(NODE-3197): revert setImmediate in waitQueue

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -231,7 +231,7 @@ export class ConnectionPool extends EventEmitter {
     }
 
     this[kWaitQueue].push(waitQueueMember);
-    setImmediate(() => processWaitQueue(this));
+    process.nextTick(() => processWaitQueue(this));
   }
 
   /**
@@ -256,7 +256,7 @@ export class ConnectionPool extends EventEmitter {
       destroyConnection(this, connection, reason);
     }
 
-    setImmediate(() => processWaitQueue(this));
+    process.nextTick(() => processWaitQueue(this));
   }
 
   /**
@@ -429,7 +429,7 @@ function createConnection(pool: ConnectionPool, callback?: Callback<Connection>)
 
     // otherwise add it to the pool for later acquisition, and try to process the wait queue
     pool[kConnections].push(connection);
-    setImmediate(() => processWaitQueue(pool));
+    process.nextTick(() => processWaitQueue(pool));
   });
 }
 

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -231,7 +231,7 @@ export class ConnectionPool extends EventEmitter {
     }
 
     this[kWaitQueue].push(waitQueueMember);
-    process.nextTick(() => processWaitQueue(this));
+    process.nextTick(processWaitQueue, this);
   }
 
   /**
@@ -256,7 +256,7 @@ export class ConnectionPool extends EventEmitter {
       destroyConnection(this, connection, reason);
     }
 
-    process.nextTick(() => processWaitQueue(this));
+    process.nextTick(processWaitQueue, this);
   }
 
   /**
@@ -429,7 +429,7 @@ function createConnection(pool: ConnectionPool, callback?: Callback<Connection>)
 
     // otherwise add it to the pool for later acquisition, and try to process the wait queue
     pool[kConnections].push(connection);
-    process.nextTick(() => processWaitQueue(pool));
+    process.nextTick(processWaitQueue, pool);
   });
 }
 


### PR DESCRIPTION
A performance regression was identified in switching the connection pool to using setImmediate instead of process.nextTick for wait queue processing. This patch reverts that change.

NODE-3197