### PR TITLE
refactor(NODE-1812)!: replace returnOriginal with returnDocument option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ export { BatchType } from './bulk/common';
 export { AuthMechanism } from './cmap/auth/defaultAuthProviders';
 export { CURSOR_FLAGS } from './cursor/abstract_cursor';
 export { Compressor } from './cmap/wire_protocol/compression';
+export { ReturnDocument } from './operations/find_and_modify';
 export { ExplainVerbosity } from './explain';
 export { ReadConcernLevel } from './read_concern';
 export { ReadPreferenceMode } from './read_preference';

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -12,8 +12,8 @@ import type { WriteConcern, WriteConcernSettings } from '../write_concern';
 
 /** @public */
 export const ReturnDocument = Object.freeze({
-  BEFORE: 'Before',
-  AFTER: 'After'
+  BEFORE: 'before',
+  AFTER: 'after'
 } as const);
 
 /** @public */
@@ -37,7 +37,7 @@ export interface FindOneAndReplaceOptions extends CommandOperationOptions {
   hint?: Document;
   /** Limits the fields to return for all matching documents. */
   projection?: Document;
-  /** When set to 'After', returns the updated document rather than the original. The default is 'Before'.  */
+  /** When set to 'after', returns the updated document rather than the original. The default is 'before'.  */
   returnDocument?: ReturnDocument;
   /** Determines which document the operation modifies if the query selects multiple documents. */
   sort?: Sort;
@@ -55,7 +55,7 @@ export interface FindOneAndUpdateOptions extends CommandOperationOptions {
   hint?: Document;
   /** Limits the fields to return for all matching documents. */
   projection?: Document;
-  /** When set to 'After', returns the updated document rather than the original. The default is 'Before'.  */
+  /** When set to 'after', returns the updated document rather than the original. The default is 'before'.  */
   returnDocument?: ReturnDocument;
   /** Determines which document the operation modifies if the query selects multiple documents. */
   sort?: Sort;

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -11,6 +11,15 @@ import type { ClientSession } from '../sessions';
 import type { WriteConcern, WriteConcernSettings } from '../write_concern';
 
 /** @public */
+export const ReturnDocument = Object.freeze({
+  BEFORE: 'Before',
+  AFTER: 'After'
+} as const);
+
+/** @public */
+export type ReturnDocument = typeof ReturnDocument[keyof typeof ReturnDocument];
+
+/** @public */
 export interface FindOneAndDeleteOptions extends CommandOperationOptions {
   /** An optional hint for query optimization. See the {@link https://docs.mongodb.com/manual/reference/command/update/#update-command-hint|update command} reference for more information.*/
   hint?: Document;
@@ -28,8 +37,8 @@ export interface FindOneAndReplaceOptions extends CommandOperationOptions {
   hint?: Document;
   /** Limits the fields to return for all matching documents. */
   projection?: Document;
-  /** When false, returns the updated document rather than the original. The default is true. */
-  returnOriginal?: boolean;
+  /** When set to 'After', returns the updated document rather than the original. The default is 'Before'.  */
+  returnDocument?: ReturnDocument;
   /** Determines which document the operation modifies if the query selects multiple documents. */
   sort?: Sort;
   /** Upsert the document if it does not exist. */
@@ -46,15 +55,13 @@ export interface FindOneAndUpdateOptions extends CommandOperationOptions {
   hint?: Document;
   /** Limits the fields to return for all matching documents. */
   projection?: Document;
-  /** When false, returns the updated document rather than the original. The default is true. */
-  returnOriginal?: boolean;
+  /** When set to 'After', returns the updated document rather than the original. The default is 'Before'.  */
+  returnDocument?: ReturnDocument;
   /** Determines which document the operation modifies if the query selects multiple documents. */
   sort?: Sort;
   /** Upsert the document if it does not exist. */
   upsert?: boolean;
 }
-
-// TODO: NODE-1812 to deprecate returnOriginal for returnDocument
 
 /** @internal */
 interface FindAndModifyCmdBase {
@@ -74,7 +81,7 @@ function configureFindAndModifyCmdBaseUpdateOpts(
   cmdBase: FindAndModifyCmdBase,
   options: FindOneAndReplaceOptions | FindOneAndUpdateOptions
 ): FindAndModifyCmdBase {
-  cmdBase.new = options.returnOriginal === false;
+  cmdBase.new = options.returnDocument === ReturnDocument.AFTER;
   cmdBase.upsert = options.upsert === true;
 
   if (options.bypassDocumentValidation === true) {

--- a/test/functional/crud_api.test.js
+++ b/test/functional/crud_api.test.js
@@ -1,6 +1,7 @@
 'use strict';
 const test = require('./shared').assert;
 const { expect } = require('chai');
+const { ReturnDocument } = require('../../src');
 const setupDatabase = require('./shared').setupDatabase;
 
 // instanceof cannot be use reliably to detect the new models in js due to scoping and new
@@ -784,7 +785,7 @@ describe('CRUD API', function () {
               {
                 projection: { b: 1, c: 1 },
                 sort: { a: 1 },
-                returnOriginal: false,
+                returnDocument: ReturnDocument.AFTER,
                 upsert: true
               },
               function (err, r) {
@@ -816,7 +817,7 @@ describe('CRUD API', function () {
               {
                 projection: { b: 1, d: 1 },
                 sort: { a: 1 },
-                returnOriginal: false,
+                returnDocument: ReturnDocument.AFTER,
                 upsert: true
               },
               function (err, r) {

--- a/test/functional/crud_spec.test.js
+++ b/test/functional/crud_spec.test.js
@@ -320,14 +320,10 @@ describe('CRUD spec', function () {
     const filter = args.filter;
     const second = args.update || args.replacement;
     const options = Object.assign({}, args);
-    if (options.returnDocument) {
-      options.returnOriginal = options.returnDocument === 'After' ? false : true;
-    }
 
     delete options.filter;
     delete options.update;
     delete options.replacement;
-    delete options.returnDocument;
 
     const opName = scenarioTest.operation.name;
     const findPromise =

--- a/test/functional/crud_spec.test.js
+++ b/test/functional/crud_spec.test.js
@@ -320,6 +320,9 @@ describe('CRUD spec', function () {
     const filter = args.filter;
     const second = args.update || args.replacement;
     const options = Object.assign({}, args);
+    if (options.returnDocument) {
+      options.returnDocument = options.returnDocument.toLowerCase();
+    }
 
     delete options.filter;
     delete options.update;

--- a/test/functional/find.test.js
+++ b/test/functional/find.test.js
@@ -3,7 +3,7 @@ const test = require('./shared').assert;
 const { setupDatabase, withMonitoredClient } = require('./shared');
 const { expect } = require('chai');
 const sinon = require('sinon');
-const { Code, ObjectId, Long, Binary } = require('../../src');
+const { Code, ObjectId, Long, Binary, ReturnDocument } = require('../../src');
 
 describe('Find', function () {
   before(function () {
@@ -810,7 +810,7 @@ describe('Find', function () {
             collection.findOneAndUpdate(
               { a: 1 },
               { $set: { b: 3 } },
-              { returnOriginal: false },
+              { returnDocument: ReturnDocument.AFTER },
               function (err, updated_doc) {
                 test.equal(1, updated_doc.value.a);
                 test.equal(3, updated_doc.value.b);
@@ -846,7 +846,7 @@ describe('Find', function () {
                             collection.findOneAndUpdate(
                               { a: 4 },
                               { $set: { b: 3 } },
-                              { returnOriginal: false, upsert: true },
+                              { returnDocument: ReturnDocument.AFTER, upsert: true },
                               function (err, updated_doc) {
                                 test.equal(4, updated_doc.value.a);
                                 test.equal(3, updated_doc.value.b);
@@ -861,7 +861,10 @@ describe('Find', function () {
                                     collection.findOneAndUpdate(
                                       { a: 100 },
                                       { $set: { b: 5 } },
-                                      { returnOriginal: false, projection: { b: 1 } },
+                                      {
+                                        returnDocument: ReturnDocument.AFTER,
+                                        projection: { b: 1 }
+                                      },
                                       function (err, updated_doc) {
                                         test.equal(2, Object.keys(updated_doc.value).length);
                                         test.equal(
@@ -913,7 +916,7 @@ describe('Find', function () {
             collection.findOneAndUpdate(
               { a: 1 },
               { $set: { b: 3 } },
-              { returnOriginal: false, projection: { a: 1 } },
+              { returnDocument: ReturnDocument.AFTER, projection: { a: 1 } },
               function (err, updated_doc) {
                 test.equal(2, Object.keys(updated_doc.value).length);
                 test.equal(1, updated_doc.value.a);
@@ -1160,7 +1163,7 @@ describe('Find', function () {
             collection.findOneAndUpdate(
               { a: 2 },
               { $set: { b: 3 } },
-              { returnOriginal: false },
+              { returnDocument: ReturnDocument.AFTER },
               function (err, result) {
                 test.equal(2, result.value.a);
                 test.equal(3, result.value.b);
@@ -1252,7 +1255,7 @@ describe('Find', function () {
             collection.findOneAndUpdate(
               { _id: id },
               { $set: { 'c.c': 100 } },
-              { returnOriginal: false },
+              { returnDocument: ReturnDocument.AFTER },
               function (err, item) {
                 test.equal(doc._id.toString(), item.value._id.toString());
                 test.equal(doc.a, item.value.a);
@@ -1289,7 +1292,11 @@ describe('Find', function () {
           collection.findOneAndUpdate(
             { _id: self._id, 'plays.uuid': _uuid },
             { $set: { 'plays.$.active': true } },
-            { returnOriginal: false, projection: { plays: 0, results: 0 }, safe: true },
+            {
+              returnDocument: ReturnDocument.AFTER,
+              projection: { plays: 0, results: 0 },
+              safe: true
+            },
             function (err) {
               expect(err).to.not.exist;
               client.close(done);
@@ -1437,7 +1444,7 @@ describe('Find', function () {
             collection.findOneAndUpdate(
               { a: 1 },
               { $set: { b: 3 } },
-              { returnOriginal: false },
+              { returnDocument: ReturnDocument.AFTER },
               function (err, updated_doc) {
                 expect(err).to.not.exist;
                 expect(updated_doc.value).to.not.exist;
@@ -1500,7 +1507,7 @@ describe('Find', function () {
                     'transactions.id': { $ne: transaction.transactionId }
                   },
                   { $push: { transactions: transaction } },
-                  { returnOriginal: false, safe: true },
+                  { returnDocument: ReturnDocument.AFTER, safe: true },
                   function (err) {
                     expect(err).to.not.exist;
                     client.close(done);
@@ -1587,7 +1594,7 @@ describe('Find', function () {
           function (err, collection) {
             var q = { x: 1 };
             var set = { y: 2, _id: new ObjectId() };
-            var opts = { returnOriginal: false, upsert: true };
+            var opts = { returnDocument: ReturnDocument.AFTER, upsert: true };
             // Original doc
             var doc = { _id: new ObjectId(), x: 1 };
 
@@ -2316,7 +2323,7 @@ describe('Find', function () {
             collection.findOneAndUpdate(
               { a: 1 },
               { $set: { b: 3 } },
-              { returnOriginal: false },
+              { returnDocument: ReturnDocument.AFTER },
               function (err, updated_doc) {
                 test.equal(1, updated_doc.value.a);
                 test.equal(3, updated_doc.value.b);

--- a/test/functional/insert.test.js
+++ b/test/functional/insert.test.js
@@ -16,7 +16,8 @@ const {
   MinKey,
   MaxKey,
   Code,
-  MongoBulkWriteError
+  MongoBulkWriteError,
+  ReturnDocument
 } = require('../../src');
 
 /**
@@ -967,7 +968,11 @@ describe('Insert', function () {
                 collection.findOneAndUpdate(
                   { str: 'String' },
                   { $set: { f: function () {} } },
-                  { returnOriginal: false, safe: true, serializeFunctions: true },
+                  {
+                    returnDocument: ReturnDocument.AFTER,
+                    safe: true,
+                    serializeFunctions: true
+                  },
                   function (err, result) {
                     test.ok(result.value.f._bsontype === 'Code');
                     client.close(done);

--- a/test/functional/multiple_db.test.js
+++ b/test/functional/multiple_db.test.js
@@ -1,6 +1,7 @@
 'use strict';
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
+const { ReturnDocument } = require('../../src');
 const { expect } = require('chai');
 
 describe('Multiple Databases', function () {
@@ -78,12 +79,15 @@ describe('Multiple Databases', function () {
 
         db_instance.collection('counters', function (err, collection) {
           expect(err).to.not.exist;
-          collection.findOneAndUpdate({}, { $inc: { db: 1 } }, { returnOriginal: false }, function (
-            err
-          ) {
-            expect(err).to.not.exist;
-            client.close(done);
-          });
+          collection.findOneAndUpdate(
+            {},
+            { $inc: { db: 1 } },
+            { returnDocument: ReturnDocument.AFTER },
+            function (err) {
+              expect(err).to.not.exist;
+              client.close(done);
+            }
+          );
         });
       });
     }

--- a/test/functional/operation_example.test.js
+++ b/test/functional/operation_example.test.js
@@ -3,7 +3,7 @@ const { assert: test } = require('./shared');
 const { setupDatabase } = require('./shared');
 const { format: f } = require('util');
 const { Topology } = require('../../src/sdam/topology');
-const { Code, ObjectId } = require('../../src');
+const { Code, ObjectId, ReturnDocument } = require('../../src');
 
 const chai = require('chai');
 const expect = chai.expect;
@@ -1532,7 +1532,7 @@ describe('Operation Examples', function () {
             collection.findOneAndUpdate(
               { a: 1 },
               { $set: { b1: 1 } },
-              { returnOriginal: false },
+              { returnDocument: ReturnDocument.AFTER },
               function (err, doc) {
                 expect(err).to.not.exist;
                 test.equal(1, doc.value.a);
@@ -1558,7 +1558,11 @@ describe('Operation Examples', function () {
                       collection.findOneAndUpdate(
                         { d: 1 },
                         { $set: { d: 1, f: 1 } },
-                        { returnOriginal: false, upsert: true, writeConcern: { w: 1 } },
+                        {
+                          returnDocument: ReturnDocument.AFTER,
+                          upsert: true,
+                          writeConcern: { w: 1 }
+                        },
                         function (err, doc) {
                           expect(err).to.not.exist;
                           test.equal(1, doc.value.d);
@@ -6406,7 +6410,7 @@ describe('Operation Examples', function () {
             {
               projection: { b: 1, c: 1 },
               sort: { a: 1 },
-              returnOriginal: false,
+              returnDocument: ReturnDocument.AFTER,
               upsert: true
             },
             function (err, r) {
@@ -6462,7 +6466,7 @@ describe('Operation Examples', function () {
             {
               projection: { b: 1, d: 1 },
               sort: { a: 1 },
-              returnOriginal: false,
+              returnDocument: ReturnDocument.AFTER,
               upsert: true
             },
             function (err, r) {

--- a/test/functional/operation_generators_example.test.js
+++ b/test/functional/operation_generators_example.test.js
@@ -1,7 +1,7 @@
 'use strict';
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
-const { Code } = require('../../src');
+const { Code, ReturnDocument } = require('../../src');
 const { expect } = require('chai');
 
 /**************************************************************************
@@ -906,7 +906,7 @@ describe('Operation (Generators)', function () {
         var doc = yield collection.findOneAndUpdate(
           { a: 1 },
           { $set: { b1: 1 } },
-          { returnOriginal: false }
+          { returnDocument: ReturnDocument.AFTER }
         );
         test.equal(1, doc.value.a);
         test.equal(1, doc.value.b1);
@@ -924,7 +924,7 @@ describe('Operation (Generators)', function () {
         doc = yield collection.findOneAndUpdate(
           { d: 1 },
           { $set: { d: 1, f: 1 } },
-          { returnOriginal: false, upsert: true, writeConcern: { w: 1 } }
+          { returnDocument: ReturnDocument.AFTER, upsert: true, writeConcern: { w: 1 } }
         );
         test.equal(1, doc.value.d);
         test.equal(1, doc.value.f);
@@ -4375,7 +4375,7 @@ describe('Operation (Generators)', function () {
           {
             projection: { b: 1, c: 1 },
             sort: { a: 1 },
-            returnOriginal: false,
+            returnDocument: ReturnDocument.AFTER,
             upsert: true
           }
         );
@@ -4430,7 +4430,7 @@ describe('Operation (Generators)', function () {
           {
             projection: { b: 1, d: 1 },
             sort: { a: 1 },
-            returnOriginal: false,
+            returnDocument: ReturnDocument.AFTER,
             upsert: true
           }
         );

--- a/test/functional/operation_promises_example.test.js
+++ b/test/functional/operation_promises_example.test.js
@@ -2,7 +2,7 @@
 var f = require('util').format;
 var test = require('./shared').assert;
 var setupDatabase = require('./shared').setupDatabase;
-const { Code } = require('../../src');
+const { Code, ReturnDocument } = require('../../src');
 const { expect } = require('chai');
 
 var delay = function (ms) {
@@ -918,7 +918,7 @@ describe('Operation (Promises)', function () {
             return collection.findOneAndUpdate(
               { a: 1 },
               { $set: { b1: 1 } },
-              { returnOriginal: false }
+              { returnDocument: ReturnDocument.AFTER }
             );
           })
           .then(function (doc) {
@@ -943,7 +943,7 @@ describe('Operation (Promises)', function () {
             return collection.findOneAndUpdate(
               { d: 1 },
               { $set: { d: 1, f: 1 } },
-              { returnOriginal: false, upsert: true, writeConcern: { w: 1 } }
+              { returnDocument: ReturnDocument.AFTER, upsert: true, writeConcern: { w: 1 } }
             );
           })
           .then(function (doc) {
@@ -4766,7 +4766,7 @@ describe('Operation (Promises)', function () {
               {
                 projection: { b: 1, c: 1 },
                 sort: { a: 1 },
-                returnOriginal: false,
+                returnDocument: ReturnDocument.AFTER,
                 upsert: true
               }
             )
@@ -4821,7 +4821,7 @@ describe('Operation (Promises)', function () {
               {
                 projection: { b: 1, d: 1 },
                 sort: { a: 1 },
-                returnOriginal: false,
+                returnDocument: ReturnDocument.AFTER,
                 upsert: true
               }
             );

--- a/test/functional/retryable_writes.test.js
+++ b/test/functional/retryable_writes.test.js
@@ -136,8 +136,10 @@ function generateArguments(test) {
     Object.keys(test.operation.arguments).forEach(arg => {
       if (arg === 'requests') {
         args.push(test.operation.arguments[arg].map(convertBulkWriteOperation));
-      } else if (arg === 'upsert' || arg === 'returnDocument') {
-        options[arg] = test.operation.arguments[arg];
+      } else if (arg === 'upsert') {
+        options.upsert = test.operation.arguments[arg];
+      } else if (arg === 'returnDocument') {
+        options.returnDocument = test.operation.arguments[arg].toLowerCase();
       } else {
         args.push(test.operation.arguments[arg]);
       }

--- a/test/functional/retryable_writes.test.js
+++ b/test/functional/retryable_writes.test.js
@@ -136,11 +136,8 @@ function generateArguments(test) {
     Object.keys(test.operation.arguments).forEach(arg => {
       if (arg === 'requests') {
         args.push(test.operation.arguments[arg].map(convertBulkWriteOperation));
-      } else if (arg === 'upsert') {
-        options.upsert = test.operation.arguments[arg];
-      } else if (arg === 'returnDocument') {
-        const returnDocument = test.operation.arguments[arg];
-        options.returnOriginal = returnDocument === 'Before';
+      } else if (arg === 'upsert' || arg === 'returnDocument') {
+        options[arg] = test.operation.arguments[arg];
       } else {
         args.push(test.operation.arguments[arg]);
       }

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -680,11 +680,6 @@ function testOperation(operation, obj, context, options) {
             return;
           }
 
-          if (key === 'returnDocument') {
-            opOptions.returnOriginal = operation.arguments[key] === 'Before' ? true : false;
-            return;
-          }
-
           if (key === 'options') {
             Object.assign(opOptions, operation.arguments[key]);
             if (opOptions.readPreference) {

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -680,6 +680,11 @@ function testOperation(operation, obj, context, options) {
             return;
           }
 
+          if (key === 'returnDocument') {
+            opOptions.returnDocument = operation.arguments[key].toLowerCase();
+            return;
+          }
+
           if (key === 'options') {
             Object.assign(opOptions, operation.arguments[key]);
             if (opOptions.readPreference) {

--- a/test/functional/unified-spec-runner/operations.ts
+++ b/test/functional/unified-spec-runner/operations.ts
@@ -234,17 +234,14 @@ operations.set('find', async ({ entities, operation }) => {
 
 operations.set('findOneAndReplace', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
-  return collection.findOneAndReplace(operation.arguments.filter, operation.arguments.replacement);
+  const { filter, replacement, ...opts } = operation.arguments;
+  return collection.findOneAndReplace(filter, replacement, { ...opts });
 });
 
 operations.set('findOneAndUpdate', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
-  const returnOriginal = operation.arguments.returnDocument === 'Before';
-  return (
-    await collection.findOneAndUpdate(operation.arguments.filter, operation.arguments.update, {
-      returnOriginal
-    })
-  ).value;
+  const { filter, update, ...opts } = operation.arguments;
+  return (await collection.findOneAndUpdate(update, { ...opts })).value;
 });
 
 operations.set('failPoint', async ({ entities, operation }) => {

--- a/test/functional/unified-spec-runner/operations.ts
+++ b/test/functional/unified-spec-runner/operations.ts
@@ -10,6 +10,7 @@ import { EntitiesMap } from './entities';
 import { expectErrorCheck, resultCheck } from './match';
 import type { OperationDescription } from './schema';
 import { CommandStartedEvent } from '../../../src/cmap/command_monitoring_events';
+import { translateOptions } from './unified-utils';
 
 interface OperationFunctionParams {
   client: MongoClient;
@@ -235,19 +236,13 @@ operations.set('find', async ({ entities, operation }) => {
 operations.set('findOneAndReplace', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
   const { filter, replacement, ...opts } = operation.arguments;
-  if (opts.returnDocument) {
-    opts.returnDocument = opts.returnDocument.toLowerCase();
-  }
-  return collection.findOneAndReplace(filter, replacement, { ...opts });
+  return collection.findOneAndReplace(filter, replacement, translateOptions(opts));
 });
 
 operations.set('findOneAndUpdate', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
   const { filter, update, ...opts } = operation.arguments;
-  if (opts.returnDocument) {
-    opts.returnDocument = opts.returnDocument.toLowerCase();
-  }
-  return (await collection.findOneAndUpdate(filter, update, { ...opts })).value;
+  return (await collection.findOneAndUpdate(filter, update, translateOptions(opts))).value;
 });
 
 operations.set('failPoint', async ({ entities, operation }) => {

--- a/test/functional/unified-spec-runner/operations.ts
+++ b/test/functional/unified-spec-runner/operations.ts
@@ -235,13 +235,19 @@ operations.set('find', async ({ entities, operation }) => {
 operations.set('findOneAndReplace', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
   const { filter, replacement, ...opts } = operation.arguments;
+  if (opts.returnDocument) {
+    opts.returnDocument = opts.returnDocument.toLowerCase();
+  }
   return collection.findOneAndReplace(filter, replacement, { ...opts });
 });
 
 operations.set('findOneAndUpdate', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
   const { filter, update, ...opts } = operation.arguments;
-  return (await collection.findOneAndUpdate(update, { ...opts })).value;
+  if (opts.returnDocument) {
+    opts.returnDocument = opts.returnDocument.toLowerCase();
+  }
+  return (await collection.findOneAndUpdate(filter, update, { ...opts })).value;
 });
 
 operations.set('failPoint', async ({ entities, operation }) => {

--- a/test/functional/unified-spec-runner/unified-utils.ts
+++ b/test/functional/unified-spec-runner/unified-utils.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import type { Document } from '../../../src';
 import type { CollectionOrDatabaseOptions, RunOnRequirement } from './schema';
 import { gte as semverGte, lte as semverLte } from 'semver';
 import { CollectionOptions, DbOptions, MongoClient } from '../../../src';
@@ -81,4 +82,12 @@ export function patchDbOptions(options: CollectionOrDatabaseOptions): DbOptions 
 export function patchCollectionOptions(options: CollectionOrDatabaseOptions): CollectionOptions {
   // TODO
   return { ...options } as CollectionOptions;
+}
+
+export function translateOptions(options: Document): Document {
+  const translatedOptions = { ...options };
+  if (options.returnDocument) {
+    translatedOptions.returnDocument = options.returnDocument.toLowerCase();
+  }
+  return translatedOptions as Document;
 }


### PR DESCRIPTION
## Description

NODE-1812

BREAKING: `returnOriginal` option no longer supported for `findOneAndReplace()` and `findOneAndUpdate()` collection methods, use the new `returnDocument` enum instead.

Replaced `returnOriginal` with `returnDocument` option in order to conform with shared drivers spec.
