### PR TITLE
fix(NODE-3192): check clusterTime is defined before access

### DIFF
--- a/lib/core/wireprotocol/command.js
+++ b/lib/core/wireprotocol/command.js
@@ -45,14 +45,20 @@ function _command(server, ns, cmd, options, callback) {
   const shouldUseOpMsg = supportsOpMsg(server);
   const session = options.session;
 
-  let clusterTime = server.clusterTime;
+  const serverClusterTime = server.clusterTime;
+  let clusterTime = serverClusterTime;
   let finalCmd = Object.assign({}, cmd);
   if (hasSessionSupport(server) && session) {
+    const sessionClusterTime = session.clusterTime;
     if (
-      session.clusterTime &&
-      session.clusterTime.clusterTime.greaterThan(clusterTime.clusterTime)
+      serverClusterTime &&
+      serverClusterTime.clusterTime &&
+      sessionClusterTime &&
+      sessionClusterTime.clusterTime
     ) {
-      clusterTime = session.clusterTime;
+      if (sessionClusterTime.clusterTime.greaterThan(serverClusterTime.clusterTime)) {
+        clusterTime = sessionClusterTime;
+      }
     }
 
     const err = applySession(session, finalCmd, options);
@@ -61,8 +67,8 @@ function _command(server, ns, cmd, options, callback) {
     }
   }
 
-  // if we have a known cluster time, gossip it
   if (clusterTime) {
+    // if we have a known cluster time, gossip it
     finalCmd.$clusterTime = clusterTime;
   }
 

--- a/lib/core/wireprotocol/command.js
+++ b/lib/core/wireprotocol/command.js
@@ -54,11 +54,10 @@ function _command(server, ns, cmd, options, callback) {
       serverClusterTime &&
       serverClusterTime.clusterTime &&
       sessionClusterTime &&
-      sessionClusterTime.clusterTime
+      sessionClusterTime.clusterTime &&
+      sessionClusterTime.clusterTime.greaterThan(serverClusterTime.clusterTime)
     ) {
-      if (sessionClusterTime.clusterTime.greaterThan(serverClusterTime.clusterTime)) {
-        clusterTime = sessionClusterTime;
-      }
+      clusterTime = sessionClusterTime;
     }
 
     const err = applySession(session, finalCmd, options);


### PR DESCRIPTION
The fix is really just making the if statement on line 53 check the correct properties before accessing them, but I also created some variables to help track which cluster time is being used where.
