### PR TITLE
fix(NODE-3275): Fix enum type export naming and serverApi validation

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -21,11 +21,11 @@ import type { CommandOperationOptions, CollationOptions } from '../operations/co
 import type { Hint } from '../operations/operation';
 
 /** @public */
-export const BatchType = {
+export const BatchType = Object.freeze({
   INSERT: 1,
   UPDATE: 2,
   DELETE: 3
-} as const;
+} as const);
 
 /** @public */
 export type BatchType = typeof BatchType[keyof typeof BatchType];

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -28,7 +28,7 @@ export const BatchType = {
 } as const;
 
 /** @public */
-export type BatchTypeId = typeof BatchType[keyof typeof BatchType];
+export type BatchType = typeof BatchType[keyof typeof BatchType];
 
 /** @public */
 export interface InsertOneModel {
@@ -136,12 +136,12 @@ export class Batch<T = Document> {
   originalZeroIndex: number;
   currentIndex: number;
   originalIndexes: number[];
-  batchType: BatchTypeId;
+  batchType: BatchType;
   operations: T[];
   size: number;
   sizeBytes: number;
 
-  constructor(batchType: BatchTypeId, originalZeroIndex: number) {
+  constructor(batchType: BatchType, originalZeroIndex: number) {
     this.originalZeroIndex = originalZeroIndex;
     this.currentIndex = 0;
     this.originalIndexes = [];
@@ -1220,7 +1220,7 @@ export abstract class BulkOperationBase {
   }
 
   abstract addToOperationsList(
-    batchType: BatchTypeId,
+    batchType: BatchType,
     document: Document | UpdateStatement | DeleteStatement
   ): this;
 }

--- a/src/bulk/ordered.ts
+++ b/src/bulk/ordered.ts
@@ -1,5 +1,5 @@
 import * as BSON from '../bson';
-import { BulkOperationBase, Batch, BatchType, BulkWriteOptions, BatchTypeId } from './common';
+import { BulkOperationBase, Batch, BatchType, BulkWriteOptions } from './common';
 import type { Document } from '../bson';
 import type { Collection } from '../collection';
 import type { UpdateStatement } from '../operations/update';
@@ -12,7 +12,7 @@ export class OrderedBulkOperation extends BulkOperationBase {
   }
 
   addToOperationsList(
-    batchType: BatchTypeId,
+    batchType: BatchType,
     document: Document | UpdateStatement | DeleteStatement
   ): this {
     // Get the bsonSize

--- a/src/bulk/unordered.ts
+++ b/src/bulk/unordered.ts
@@ -1,12 +1,5 @@
 import * as BSON from '../bson';
-import {
-  BulkOperationBase,
-  Batch,
-  BatchType,
-  BulkWriteOptions,
-  BulkWriteResult,
-  BatchTypeId
-} from './common';
+import { BulkOperationBase, Batch, BatchType, BulkWriteOptions, BulkWriteResult } from './common';
 import type { Callback } from '../utils';
 import type { Document } from '../bson';
 import type { Collection } from '../collection';
@@ -28,7 +21,7 @@ export class UnorderedBulkOperation extends BulkOperationBase {
   }
 
   addToOperationsList(
-    batchType: BatchTypeId,
+    batchType: BatchType,
     document: Document | UpdateStatement | DeleteStatement
   ): this {
     // Get the bsonSize

--- a/src/cmap/auth/defaultAuthProviders.ts
+++ b/src/cmap/auth/defaultAuthProviders.ts
@@ -7,7 +7,7 @@ import { MongoDBAWS } from './mongodb_aws';
 import type { AuthProvider } from './auth_provider';
 
 /** @public */
-export const AuthMechanism = {
+export const AuthMechanism = Object.freeze({
   MONGODB_AWS: 'MONGODB-AWS',
   MONGODB_CR: 'MONGODB-CR',
   MONGODB_DEFAULT: 'DEFAULT',
@@ -16,7 +16,7 @@ export const AuthMechanism = {
   MONGODB_SCRAM_SHA1: 'SCRAM-SHA-1',
   MONGODB_SCRAM_SHA256: 'SCRAM-SHA-256',
   MONGODB_X509: 'MONGODB-X509'
-} as const;
+} as const);
 
 /** @public */
 export type AuthMechanism = typeof AuthMechanism[keyof typeof AuthMechanism];

--- a/src/cmap/auth/defaultAuthProviders.ts
+++ b/src/cmap/auth/defaultAuthProviders.ts
@@ -19,9 +19,9 @@ export const AuthMechanism = {
 } as const;
 
 /** @public */
-export type AuthMechanismId = typeof AuthMechanism[keyof typeof AuthMechanism];
+export type AuthMechanism = typeof AuthMechanism[keyof typeof AuthMechanism];
 
-export const AUTH_PROVIDERS = new Map<AuthMechanismId | string, AuthProvider>([
+export const AUTH_PROVIDERS = new Map<AuthMechanism | string, AuthProvider>([
   [AuthMechanism.MONGODB_AWS, new MongoDBAWS()],
   [AuthMechanism.MONGODB_CR, new MongoCR()],
   [AuthMechanism.MONGODB_GSSAPI, new GSSAPI()],

--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -1,10 +1,10 @@
 // Resolves the default auth mechanism according to
 
 import type { Document } from '../../bson';
-import { AuthMechanismId, AuthMechanism } from './defaultAuthProviders';
+import { AuthMechanism } from './defaultAuthProviders';
 
 // https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst
-function getDefaultAuthMechanism(ismaster?: Document): AuthMechanismId {
+function getDefaultAuthMechanism(ismaster?: Document): AuthMechanism {
   if (ismaster) {
     // If ismaster contains saslSupportedMechs, use scram-sha-256
     // if it is available, else scram-sha-1
@@ -30,7 +30,7 @@ export interface MongoCredentialsOptions {
   password: string;
   source: string;
   db?: string;
-  mechanism?: AuthMechanismId;
+  mechanism?: AuthMechanism;
   mechanismProperties: Document;
 }
 
@@ -46,7 +46,7 @@ export class MongoCredentials {
   /** The database that the user should authenticate against */
   readonly source: string;
   /** The method used to authenticate */
-  readonly mechanism: AuthMechanismId;
+  readonly mechanism: AuthMechanism;
   /** Special properties used by some types of auth mechanisms */
   readonly mechanismProperties: Document;
 

--- a/src/cmap/message_stream.ts
+++ b/src/cmap/message_stream.ts
@@ -7,8 +7,7 @@ import {
   decompress,
   uncompressibleCommands,
   Compressor,
-  CompressorName,
-  CompressorId
+  CompressorName
 } from './wire_protocol/compression';
 import type { Document, BSONSerializeOptions } from '../bson';
 import { BufferPool, Callback } from '../utils';
@@ -178,7 +177,7 @@ function processIncomingData(stream: MessageStream, callback: Callback<Buffer>) 
   messageHeader.fromCompressed = true;
   messageHeader.opCode = message.readInt32LE(MESSAGE_HEADER_SIZE);
   messageHeader.length = message.readInt32LE(MESSAGE_HEADER_SIZE + 4);
-  const compressorID: CompressorId = message[MESSAGE_HEADER_SIZE + 8] as CompressorId;
+  const compressorID: Compressor = message[MESSAGE_HEADER_SIZE + 8] as Compressor;
   const compressedBuffer = message.slice(MESSAGE_HEADER_SIZE + 9);
 
   // recalculate based on wrapped opcode

--- a/src/cmap/wire_protocol/compression.ts
+++ b/src/cmap/wire_protocol/compression.ts
@@ -11,7 +11,8 @@ export const Compressor = Object.freeze({
   zlib: 2
 } as const);
 
-export type Compressor = typeof Compressor[keyof typeof Compressor];
+/** @public */
+export type Compressor = typeof Compressor[CompressorName];
 
 /** @public */
 export type CompressorName = keyof typeof Compressor;

--- a/src/cmap/wire_protocol/compression.ts
+++ b/src/cmap/wire_protocol/compression.ts
@@ -11,7 +11,7 @@ export const Compressor = Object.freeze({
   zlib: 2
 } as const);
 
-export type CompressorId = typeof Compressor[keyof typeof Compressor];
+export type Compressor = typeof Compressor[keyof typeof Compressor];
 
 /** @public */
 export type CompressorName = keyof typeof Compressor;
@@ -61,7 +61,7 @@ export function compress(
 
 // Decompress a message using the given compressor
 export function decompress(
-  compressorID: CompressorId,
+  compressorID: Compressor,
   compressedData: Buffer,
   callback: Callback<Buffer>
 ): void {

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -2,8 +2,8 @@ import * as dns from 'dns';
 import * as fs from 'fs';
 import { URL, URLSearchParams } from 'url';
 import { AuthMechanism } from './cmap/auth/defaultAuthProviders';
-import { ReadPreference, ReadPreferenceModeId } from './read_preference';
-import { ReadConcern, ReadConcernLevelId } from './read_concern';
+import { ReadPreference, ReadPreferenceMode } from './read_preference';
+import { ReadConcern, ReadConcernLevel } from './read_concern';
 import { W, WriteConcern } from './write_concern';
 import { MongoParseError } from './error';
 import {
@@ -818,7 +818,7 @@ export const OPTIONS = {
     transform({ values: [level], options }) {
       return ReadConcern.fromOptions({
         ...options.readConcern,
-        level: level as ReadConcernLevelId
+        level: level as ReadConcernLevel
       });
     }
   },
@@ -845,7 +845,7 @@ export const OPTIONS = {
           maxStalenessSeconds: options.readPreference?.maxStalenessSeconds
         };
         return new ReadPreference(
-          value as ReadPreferenceModeId,
+          value as ReadPreferenceMode,
           options.readPreference?.tags,
           rpOpts
         );

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -23,7 +23,8 @@ import {
   MongoClientOptions,
   MongoOptions,
   PkFactory,
-  ServerApi
+  ServerApi,
+  ServerApiVersion
 } from './mongo_client';
 import { MongoCredentials } from './cmap/auth/mongo_credentials';
 import type { TagSet } from './sdam/server_description';
@@ -590,10 +591,24 @@ export const OPTIONS = {
   serverApi: {
     target: 'serverApi',
     transform({ values: [version] }): ServerApi {
-      if (typeof version === 'string') {
-        return { version };
+      const serverApiToValidate =
+        typeof version === 'string' ? ({ version } as ServerApi) : (version as ServerApi);
+      const versionToValidate = serverApiToValidate && serverApiToValidate.version;
+      if (!versionToValidate) {
+        throw new MongoParseError(
+          `Invalid \`serverApi\` property; must specify a version as one of the following strings: "${Object.values(
+            ServerApiVersion
+          ).join('", "')}"`
+        );
       }
-      return version as ServerApi;
+      if (!Object.values(ServerApiVersion).some(v => v === versionToValidate)) {
+        throw new MongoParseError(
+          `Invalid server API version=${versionToValidate}; must be one of the following strings: "${Object.values(
+            ServerApiVersion
+          ).join('", "')}"`
+        );
+      }
+      return serverApiToValidate;
     }
   },
   checkKeys: {

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -596,16 +596,16 @@ export const OPTIONS = {
       const versionToValidate = serverApiToValidate && serverApiToValidate.version;
       if (!versionToValidate) {
         throw new MongoParseError(
-          `Invalid \`serverApi\` property; must specify a version as one of the following strings: "${Object.values(
+          `Invalid \`serverApi\` property; must specify a version from the following enum: ["${Object.values(
             ServerApiVersion
-          ).join('", "')}"`
+          ).join('", "')}"]`
         );
       }
       if (!Object.values(ServerApiVersion).some(v => v === versionToValidate)) {
         throw new MongoParseError(
-          `Invalid server API version=${versionToValidate}; must be one of the following strings: "${Object.values(
+          `Invalid server API version=${versionToValidate}; must be in the following enum: ["${Object.values(
             ServerApiVersion
-          ).join('", "')}"`
+          ).join('", "')}"]`
         );
       }
       return serverApiToValidate;

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -27,7 +27,7 @@ import {
 } from './mongo_client';
 import { MongoCredentials } from './cmap/auth/mongo_credentials';
 import type { TagSet } from './sdam/server_description';
-import { Logger, LoggerLevelId } from './logger';
+import { Logger, LoggerLevel } from './logger';
 import { PromiseProvider } from './promise_provider';
 import { Encrypter } from './encrypter';
 
@@ -728,7 +728,7 @@ export const OPTIONS = {
   loggerLevel: {
     target: 'logger',
     transform({ values: [value] }) {
-      return new Logger('MongoClient', { loggerLevel: value as LoggerLevelId });
+      return new Logger('MongoClient', { loggerLevel: value as LoggerLevel });
     }
   },
   maxIdleTimeMS: {

--- a/src/db.ts
+++ b/src/db.ts
@@ -42,7 +42,7 @@ import { RenameOperation, RenameOptions } from './operations/rename';
 import {
   SetProfilingLevelOperation,
   SetProfilingLevelOptions,
-  ProfilingLevelId
+  ProfilingLevel
 } from './operations/set_profiling_level';
 import { executeOperation } from './operations/execute_operation';
 import type { IndexInformationOptions } from './operations/common_functions';
@@ -635,22 +635,22 @@ export class Db {
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
-  setProfilingLevel(level: ProfilingLevelId): Promise<ProfilingLevelId>;
-  setProfilingLevel(level: ProfilingLevelId, callback: Callback<ProfilingLevelId>): void;
+  setProfilingLevel(level: ProfilingLevel): Promise<ProfilingLevel>;
+  setProfilingLevel(level: ProfilingLevel, callback: Callback<ProfilingLevel>): void;
   setProfilingLevel(
-    level: ProfilingLevelId,
+    level: ProfilingLevel,
     options: SetProfilingLevelOptions
-  ): Promise<ProfilingLevelId>;
+  ): Promise<ProfilingLevel>;
   setProfilingLevel(
-    level: ProfilingLevelId,
+    level: ProfilingLevel,
     options: SetProfilingLevelOptions,
-    callback: Callback<ProfilingLevelId>
+    callback: Callback<ProfilingLevel>
   ): void;
   setProfilingLevel(
-    level: ProfilingLevelId,
-    options?: SetProfilingLevelOptions | Callback<ProfilingLevelId>,
-    callback?: Callback<ProfilingLevelId>
-  ): Promise<ProfilingLevelId> | void {
+    level: ProfilingLevel,
+    options?: SetProfilingLevelOptions | Callback<ProfilingLevel>,
+    callback?: Callback<ProfilingLevel>
+  ): Promise<ProfilingLevel> | void {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -77,7 +77,7 @@ export const AutoEncryptionLoggerLevel = Object.freeze({
 } as const);
 
 /** @public */
-export type AutoEncryptionLoggerLevelId = typeof AutoEncryptionLoggerLevel[keyof typeof AutoEncryptionLoggerLevel];
+export type AutoEncryptionLoggerLevel = typeof AutoEncryptionLoggerLevel[keyof typeof AutoEncryptionLoggerLevel];
 
 /** @public */
 export interface AutoEncryptionOptions {
@@ -153,7 +153,7 @@ export interface AutoEncryptionOptions {
   bypassAutoEncryption?: boolean;
   options?: {
     /** An optional hook to catch logging messages from the underlying encryption engine */
-    logger?: (level: AutoEncryptionLoggerLevelId, message: string) => void;
+    logger?: (level: AutoEncryptionLoggerLevel, message: string) => void;
   };
   extraOptions?: {
     /**

--- a/src/explain.ts
+++ b/src/explain.ts
@@ -1,12 +1,15 @@
 import { MongoError } from './error';
 
 /** @public */
-export const ExplainVerbosity = {
+export const ExplainVerbosity = Object.freeze({
   queryPlanner: 'queryPlanner',
   queryPlannerExtended: 'queryPlannerExtended',
   executionStats: 'executionStats',
   allPlansExecution: 'allPlansExecution'
-} as const;
+} as const);
+
+/** @public */
+export type ExplainVerbosity = typeof ExplainVerbosity[keyof typeof ExplainVerbosity];
 
 /**
  * For backwards compatibility, true is interpreted as "allPlansExecution"
@@ -14,7 +17,7 @@ export const ExplainVerbosity = {
  * ignores the verbosity parameter and executes in "queryPlanner".
  * @public
  */
-export type ExplainVerbosityLike = keyof typeof ExplainVerbosity | boolean;
+export type ExplainVerbosityLike = ExplainVerbosity | boolean;
 
 /** @public */
 export interface ExplainOptions {
@@ -24,7 +27,7 @@ export interface ExplainOptions {
 
 /** @internal */
 export class Explain {
-  verbosity: keyof typeof ExplainVerbosity;
+  verbosity: ExplainVerbosity;
 
   constructor(verbosity: ExplainVerbosityLike) {
     if (typeof verbosity === 'boolean') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,6 @@ export type {
   DriverInfo,
   MongoOptions,
   ServerApi,
-  ServerApiVersionId,
   SupportedNodeConnectionOptions,
   SupportedTLSConnectionOptions,
   SupportedTLSSocketOptions,
@@ -281,10 +280,9 @@ export type {
   UpdateStatement
 } from './operations/update';
 export type { ValidateCollectionOptions } from './operations/validate_collection';
-export type { ReadConcern, ReadConcernLike, ReadConcernLevelId } from './read_concern';
+export type { ReadConcern, ReadConcernLike } from './read_concern';
 export type {
   ReadPreferenceLike,
-  ReadPreferenceModeId,
   ReadPreferenceOptions,
   ReadPreferenceLikeOptions,
   ReadPreferenceFromOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,6 @@ export type {
   OperationTime,
   ResumeOptions
 } from './change_stream';
-export type { AuthMechanismId } from './cmap/auth/defaultAuthProviders';
 export type { MongoCredentials, MongoCredentialsOptions } from './cmap/auth/mongo_credentials';
 export type {
   WriteProtocolMessageType,
@@ -179,7 +178,7 @@ export type {
   CursorFlag
 } from './cursor/abstract_cursor';
 export type { DbPrivate, DbOptions } from './db';
-export type { AutoEncryptionOptions, AutoEncryptionLoggerLevelId, AutoEncrypter } from './deps';
+export type { AutoEncryptionOptions, AutoEncrypter } from './deps';
 export type { AnyError, ErrorDescription } from './error';
 export type { Explain, ExplainOptions, ExplainVerbosityLike } from './explain';
 export type {
@@ -199,7 +198,7 @@ export type {
   TFileId,
   GridFSBucketWriteStream
 } from './gridfs-stream/upload';
-export type { LoggerOptions, LoggerFunction, LoggerLevelId } from './logger';
+export type { LoggerOptions, LoggerFunction } from './logger';
 export type {
   MongoClientEvents,
   MongoClientPrivate,
@@ -273,7 +272,7 @@ export type { ProfilingLevelOptions } from './operations/profiling_level';
 export type { RemoveUserOptions } from './operations/remove_user';
 export type { RenameOptions } from './operations/rename';
 export type { RunCommandOptions } from './operations/run_command';
-export type { ProfilingLevelId, SetProfilingLevelOptions } from './operations/set_profiling_level';
+export type { SetProfilingLevelOptions } from './operations/set_profiling_level';
 export type { CollStatsOptions, DbStatsOptions } from './operations/stats';
 export type {
   UpdateResult,
@@ -291,7 +290,7 @@ export type {
   ReadPreferenceFromOptions,
   HedgeOptions
 } from './read_preference';
-export type { ClusterTime, ServerTypeId, TimerQueue, TopologyTypeId } from './sdam/common';
+export type { ClusterTime, TimerQueue } from './sdam/common';
 export type {
   Monitor,
   MonitorEvents,
@@ -330,7 +329,7 @@ export type {
   ServerSessionId,
   WithTransactionCallback
 } from './sessions';
-export type { TransactionOptions, Transaction, TxnState, TxnStateId } from './transactions';
+export type { TransactionOptions, Transaction, TxnState } from './transactions';
 export type {
   Callback,
   ClientMetadata,
@@ -344,13 +343,7 @@ export type {
 export type { WriteConcern, W, WriteConcernOptions, WriteConcernSettings } from './write_concern';
 export type { ExecutionResult } from './operations/execute_operation';
 export type { InternalAbstractCursorOptions } from './cursor/abstract_cursor';
-export type {
-  BulkOperationBase,
-  BulkOperationPrivate,
-  BatchTypeId,
-  FindOperators,
-  Batch
-} from './bulk/common';
+export type { BulkOperationBase, BulkOperationPrivate, FindOperators, Batch } from './bulk/common';
 export type { OrderedBulkOperation } from './bulk/ordered';
 export type { UnorderedBulkOperation } from './bulk/unordered';
 export type { Encrypter, EncrypterOptions } from './encrypter';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,7 +4,7 @@ import { MongoError } from './error';
 // Filters for classes
 const classFilters: any = {};
 let filteredClasses: any = {};
-let level: LoggerLevelId;
+let level: LoggerLevel;
 
 // Save the process id
 const pid = process.pid;
@@ -26,7 +26,7 @@ export const LoggerLevel = Object.freeze({
 } as const);
 
 /** @public */
-export type LoggerLevelId = typeof LoggerLevel[keyof typeof LoggerLevel];
+export type LoggerLevel = typeof LoggerLevel[keyof typeof LoggerLevel];
 
 /** @public */
 export type LoggerFunction = (message?: any, ...optionalParams: any[]) => void;
@@ -34,7 +34,7 @@ export type LoggerFunction = (message?: any, ...optionalParams: any[]) => void;
 /** @public */
 export interface LoggerOptions {
   logger?: LoggerFunction;
-  loggerLevel?: LoggerLevelId;
+  loggerLevel?: LoggerLevel;
 }
 
 /**
@@ -246,7 +246,7 @@ export class Logger {
    *
    * @param newLevel - Set current log level (debug, warn, info, error)
    */
-  static setLevel(newLevel: LoggerLevelId): void {
+  static setLevel(newLevel: LoggerLevel): void {
     if (
       newLevel !== LoggerLevel.INFO &&
       newLevel !== LoggerLevel.ERROR &&

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -1,6 +1,6 @@
 import { Db, DbOptions } from './db';
 import { ChangeStream, ChangeStreamOptions } from './change_stream';
-import type { ReadPreference, ReadPreferenceModeId } from './read_preference';
+import type { ReadPreference, ReadPreferenceMode } from './read_preference';
 import { MongoError, AnyError } from './error';
 import type { W, WriteConcern } from './write_concern';
 import {
@@ -15,7 +15,7 @@ import {
 import { connect, MONGO_CLIENT_EVENTS } from './operations/connect';
 import { PromiseProvider } from './promise_provider';
 import type { Logger, LoggerLevel } from './logger';
-import type { ReadConcern, ReadConcernLevelId, ReadConcernLike } from './read_concern';
+import type { ReadConcern, ReadConcernLevel, ReadConcernLike } from './read_concern';
 import { BSONSerializeOptions, Document, resolveBSONOptions } from './bson';
 import type { AutoEncrypter, AutoEncryptionOptions } from './deps';
 import type { AuthMechanism } from './cmap/auth/defaultAuthProviders';
@@ -34,16 +34,16 @@ import type { Encrypter } from './encrypter';
 import { TypedEventEmitter } from './mongo_types';
 
 /** @public */
-export const ServerApiVersion = {
+export const ServerApiVersion = Object.freeze({
   v1: '1'
-};
+} as const);
 
 /** @public */
-export type ServerApiVersionId = typeof ServerApiVersion[keyof typeof ServerApiVersion];
+export type ServerApiVersion = typeof ServerApiVersion[keyof typeof ServerApiVersion];
 
 /** @public */
 export interface ServerApi {
-  version: string | ServerApiVersionId;
+  version: string | ServerApiVersion;
   strict?: boolean;
   deprecationErrors?: boolean;
 }
@@ -138,9 +138,9 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   /** Specify a read concern for the collection (only MongoDB 3.2 or higher supported) */
   readConcern?: ReadConcernLike;
   /** The level of isolation */
-  readConcernLevel?: ReadConcernLevelId;
+  readConcernLevel?: ReadConcernLevel;
   /** Specifies the read preferences for this connection */
-  readPreference?: ReadPreferenceModeId | ReadPreference;
+  readPreference?: ReadPreferenceMode | ReadPreference;
   /** Specifies, in seconds, how stale a secondary can be before the client stops using it for read operations. */
   maxStalenessSeconds?: number;
   /** Specifies the tags document as a comma-separated list of colon-separated key-value pairs.  */
@@ -215,7 +215,7 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   /** Enable command monitoring for this client */
   monitorCommands?: boolean;
   /** Server API version */
-  serverApi?: ServerApi | ServerApiVersionId;
+  serverApi?: ServerApi | ServerApiVersion;
   /**
    * Optionally enable client side auto encryption
    *

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -43,7 +43,7 @@ export type ServerApiVersion = typeof ServerApiVersion[keyof typeof ServerApiVer
 
 /** @public */
 export interface ServerApi {
-  version: string | ServerApiVersion;
+  version: ServerApiVersion;
   strict?: boolean;
   deprecationErrors?: boolean;
 }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -14,11 +14,11 @@ import {
 } from './utils';
 import { connect, MONGO_CLIENT_EVENTS } from './operations/connect';
 import { PromiseProvider } from './promise_provider';
-import type { Logger, LoggerLevelId } from './logger';
+import type { Logger, LoggerLevel } from './logger';
 import type { ReadConcern, ReadConcernLevelId, ReadConcernLike } from './read_concern';
 import { BSONSerializeOptions, Document, resolveBSONOptions } from './bson';
 import type { AutoEncrypter, AutoEncryptionOptions } from './deps';
-import type { AuthMechanismId } from './cmap/auth/defaultAuthProviders';
+import type { AuthMechanism } from './cmap/auth/defaultAuthProviders';
 import type { Topology, TopologyEvents } from './sdam/topology';
 import type { ClientSession, ClientSessionOptions } from './sessions';
 import type { TagSet } from './sdam/server_description';
@@ -150,7 +150,7 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   /** Specify the database name associated with the user’s credentials. */
   authSource?: string;
   /** Specify the authentication mechanism that MongoDB will use to authenticate the connection. */
-  authMechanism?: AuthMechanismId;
+  authMechanism?: AuthMechanism;
   /** Specify properties for the specified authMechanism as a comma-separated list of colon-separated key-value pairs. */
   authMechanismProperties?: {
     SERVICE_NAME?: string;
@@ -209,7 +209,7 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   /** A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible */
   promiseLibrary?: any;
   /** The logging level */
-  loggerLevel?: LoggerLevelId;
+  loggerLevel?: LoggerLevel;
   /** Custom logger object */
   logger?: Logger;
   /** Enable command monitoring for this client */

--- a/src/operations/set_profiling_level.ts
+++ b/src/operations/set_profiling_level.ts
@@ -13,18 +13,18 @@ export const ProfilingLevel = Object.freeze({
 } as const);
 
 /** @public */
-export type ProfilingLevelId = typeof ProfilingLevel[keyof typeof ProfilingLevel];
+export type ProfilingLevel = typeof ProfilingLevel[keyof typeof ProfilingLevel];
 
 /** @public */
 export type SetProfilingLevelOptions = CommandOperationOptions;
 
 /** @internal */
-export class SetProfilingLevelOperation extends CommandOperation<ProfilingLevelId> {
+export class SetProfilingLevelOperation extends CommandOperation<ProfilingLevel> {
   options: SetProfilingLevelOptions;
-  level: ProfilingLevelId;
+  level: ProfilingLevel;
   profile: 0 | 1 | 2;
 
-  constructor(db: Db, level: ProfilingLevelId, options: SetProfilingLevelOptions) {
+  constructor(db: Db, level: ProfilingLevel, options: SetProfilingLevelOptions) {
     super(db, options);
     this.options = options;
     switch (level) {
@@ -45,7 +45,7 @@ export class SetProfilingLevelOperation extends CommandOperation<ProfilingLevelI
     this.level = level;
   }
 
-  execute(server: Server, session: ClientSession, callback: Callback<ProfilingLevelId>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<ProfilingLevel>): void {
     const level = this.level;
 
     if (!levelValues.has(level)) {

--- a/src/read_concern.ts
+++ b/src/read_concern.ts
@@ -1,19 +1,19 @@
 import type { Document } from './bson';
 
 /** @public */
-export const ReadConcernLevel = {
+export const ReadConcernLevel = Object.freeze({
   local: 'local',
   majority: 'majority',
   linearizable: 'linearizable',
   available: 'available',
   snapshot: 'snapshot'
-} as const;
+} as const);
 
 /** @public */
-export type ReadConcernLevelId = keyof typeof ReadConcernLevel;
+export type ReadConcernLevel = typeof ReadConcernLevel[keyof typeof ReadConcernLevel];
 
 /** @public */
-export type ReadConcernLike = ReadConcern | { level: ReadConcernLevelId } | ReadConcernLevelId;
+export type ReadConcernLike = ReadConcern | { level: ReadConcernLevel } | ReadConcernLevel;
 
 /**
  * The MongoDB ReadConcern, which allows for control of the consistency and isolation properties
@@ -23,10 +23,10 @@ export type ReadConcernLike = ReadConcern | { level: ReadConcernLevelId } | Read
  * @see https://docs.mongodb.com/manual/reference/read-concern/index.html
  */
 export class ReadConcern {
-  level: ReadConcernLevelId | string;
+  level: ReadConcernLevel | string;
 
   /** Constructs a ReadConcern from the read concern level.*/
-  constructor(level: ReadConcernLevelId) {
+  constructor(level: ReadConcernLevel) {
     /**
      * A spec test exists that allows level to be any string.
      * "invalid readConcern with out stage"
@@ -43,7 +43,7 @@ export class ReadConcern {
    */
   static fromOptions(options?: {
     readConcern?: ReadConcernLike;
-    level?: ReadConcernLevelId;
+    level?: ReadConcernLevel;
   }): ReadConcern | undefined {
     if (options == null) {
       return;

--- a/src/sdam/common.ts
+++ b/src/sdam/common.ts
@@ -21,7 +21,7 @@ export const TopologyType = Object.freeze({
 } as const);
 
 /** @public */
-export type TopologyTypeId = typeof TopologyType[keyof typeof TopologyType];
+export type TopologyType = typeof TopologyType[keyof typeof TopologyType];
 
 /**
  * An enumeration of server types we know about
@@ -40,7 +40,7 @@ export const ServerType = Object.freeze({
 } as const);
 
 /** @public */
-export type ServerTypeId = typeof ServerType[keyof typeof ServerType];
+export type ServerType = typeof ServerType[keyof typeof ServerType];
 
 /** @internal */
 export type TimerQueue = Set<NodeJS.Timeout>;

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -1,15 +1,15 @@
 import { arrayStrictEqual, errorStrictEqual, now, HostAddress } from '../utils';
-import { ServerType, ServerTypeId } from './common';
+import { ServerType } from './common';
 import { ObjectId, Long, Document } from '../bson';
 import type { ClusterTime } from './common';
 
-const WRITABLE_SERVER_TYPES = new Set<ServerTypeId>([
+const WRITABLE_SERVER_TYPES = new Set<ServerType>([
   ServerType.RSPrimary,
   ServerType.Standalone,
   ServerType.Mongos
 ]);
 
-const DATA_BEARING_SERVER_TYPES = new Set<ServerTypeId>([
+const DATA_BEARING_SERVER_TYPES = new Set<ServerType>([
   ServerType.RSPrimary,
   ServerType.RSSecondary,
   ServerType.Mongos,
@@ -46,7 +46,7 @@ export interface ServerDescriptionOptions {
 export class ServerDescription {
   private _hostAddress: HostAddress;
   address: string;
-  type: ServerTypeId;
+  type: ServerType;
   hosts: string[];
   passives: string[];
   arbiters: string[];
@@ -205,7 +205,7 @@ export class ServerDescription {
 }
 
 // Parses an `ismaster` message and determines the server type
-export function parseServerType(ismaster?: Document): ServerTypeId {
+export function parseServerType(ismaster?: Document): ServerType {
   if (!ismaster || !ismaster.ok) {
     return ServerType.Unknown;
   }

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -1,6 +1,6 @@
 import { ServerDescription } from './server_description';
 import * as WIRE_CONSTANTS from '../cmap/wire_protocol/constants';
-import { TopologyType, ServerType, TopologyTypeId, ServerTypeId } from './common';
+import { TopologyType, ServerType } from './common';
 import type { ObjectId, Document } from '../bson';
 import type { SrvPollingEvent } from './srv_polling';
 
@@ -10,9 +10,9 @@ const MAX_SUPPORTED_SERVER_VERSION = WIRE_CONSTANTS.MAX_SUPPORTED_SERVER_VERSION
 const MIN_SUPPORTED_WIRE_VERSION = WIRE_CONSTANTS.MIN_SUPPORTED_WIRE_VERSION;
 const MAX_SUPPORTED_WIRE_VERSION = WIRE_CONSTANTS.MAX_SUPPORTED_WIRE_VERSION;
 
-const MONGOS_OR_UNKNOWN = new Set<ServerTypeId>([ServerType.Mongos, ServerType.Unknown]);
-const MONGOS_OR_STANDALONE = new Set<ServerTypeId>([ServerType.Mongos, ServerType.Standalone]);
-const NON_PRIMARY_RS_MEMBERS = new Set<ServerTypeId>([
+const MONGOS_OR_UNKNOWN = new Set<ServerType>([ServerType.Mongos, ServerType.Unknown]);
+const MONGOS_OR_STANDALONE = new Set<ServerType>([ServerType.Mongos, ServerType.Standalone]);
+const NON_PRIMARY_RS_MEMBERS = new Set<ServerType>([
   ServerType.RSSecondary,
   ServerType.RSArbiter,
   ServerType.RSOther
@@ -29,7 +29,7 @@ export interface TopologyDescriptionOptions {
  * @public
  */
 export class TopologyDescription {
-  type: TopologyTypeId;
+  type: TopologyType;
   setName?: string;
   maxSetVersion?: number;
   maxElectionId?: ObjectId;
@@ -46,7 +46,7 @@ export class TopologyDescription {
    * Create a TopologyDescription
    */
   constructor(
-    topologyType: TopologyTypeId,
+    topologyType: TopologyType,
     serverDescriptions?: Map<string, ServerDescription>,
     setName?: string,
     maxSetVersion?: number,
@@ -314,7 +314,7 @@ export class TopologyDescription {
   }
 }
 
-function topologyTypeForServerType(serverType: ServerTypeId): TopologyTypeId {
+function topologyTypeForServerType(serverType: ServerType): TopologyType {
   switch (serverType) {
     case ServerType.Standalone:
       return TopologyType.Single;
@@ -357,7 +357,7 @@ function updateRsFromPrimary(
   setName?: string,
   maxSetVersion?: number,
   maxElectionId?: ObjectId
-): [TopologyTypeId, string?, number?, ObjectId?] {
+): [TopologyType, string?, number?, ObjectId?] {
   setName = setName || serverDescription.setName;
   if (setName !== serverDescription.setName) {
     serverDescriptions.delete(serverDescription.address);
@@ -425,7 +425,7 @@ function updateRsWithPrimaryFromMember(
   serverDescriptions: Map<string, ServerDescription>,
   serverDescription: ServerDescription,
   setName?: string
-): TopologyTypeId {
+): TopologyType {
   if (setName == null) {
     throw new TypeError('setName is required');
   }
@@ -444,7 +444,7 @@ function updateRsNoPrimaryFromMember(
   serverDescriptions: Map<string, ServerDescription>,
   serverDescription: ServerDescription,
   setName?: string
-): [TopologyTypeId, string?] {
+): [TopologyType, string?] {
   const topologyType = TopologyType.ReplicaSetNoPrimary;
   setName = setName || serverDescription.setName;
   if (setName !== serverDescription.setName) {
@@ -465,7 +465,7 @@ function updateRsNoPrimaryFromMember(
   return [topologyType, setName];
 }
 
-function checkHasPrimary(serverDescriptions: Map<string, ServerDescription>): TopologyTypeId {
+function checkHasPrimary(serverDescriptions: Map<string, ServerDescription>): TopologyType {
   for (const serverDescription of serverDescriptions.values()) {
     if (serverDescription.type === ServerType.RSPrimary) {
       return TopologyType.ReplicaSetWithPrimary;

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,13 +1,7 @@
 import { PromiseProvider } from './promise_provider';
 import { Binary, Long, Timestamp, Document } from './bson';
 import { ReadPreference } from './read_preference';
-import {
-  isTransactionCommand,
-  TxnState,
-  Transaction,
-  TransactionOptions,
-  TxnStateId
-} from './transactions';
+import { isTransactionCommand, TxnState, Transaction, TransactionOptions } from './transactions';
 import { resolveClusterTime, ClusterTime } from './sdam/common';
 import { isSharded } from './cmap/wire_protocol/shared';
 import {
@@ -398,7 +392,7 @@ function attemptTransactionCommit(
   });
 }
 
-const USER_EXPLICIT_TXN_END_STATES = new Set<TxnStateId>([
+const USER_EXPLICIT_TXN_END_STATES = new Set<TxnState>([
   TxnState.NO_TRANSACTION,
   TxnState.TRANSACTION_COMMITTED,
   TxnState.TRANSACTION_ABORTED

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -17,9 +17,9 @@ export const TxnState = Object.freeze({
 } as const);
 
 /** @internal */
-export type TxnStateId = typeof TxnState[keyof typeof TxnState];
+export type TxnState = typeof TxnState[keyof typeof TxnState];
 
-const stateMachine: { [state in TxnStateId]: TxnStateId[] } = {
+const stateMachine: { [state in TxnState]: TxnState[] } = {
   [TxnState.NO_TRANSACTION]: [TxnState.NO_TRANSACTION, TxnState.STARTING_TRANSACTION],
   [TxnState.STARTING_TRANSACTION]: [
     TxnState.TRANSACTION_IN_PROGRESS,
@@ -66,7 +66,7 @@ export interface TransactionOptions extends CommandOperationOptions {
  */
 export class Transaction {
   /** @internal */
-  state: TxnStateId;
+  state: TxnState;
   options: TransactionOptions;
   _pinnedServer?: Server;
   _recoveryToken?: Document;
@@ -125,7 +125,7 @@ export class Transaction {
    * @returns Whether this session is presently in a transaction
    */
   get isActive(): boolean {
-    const activeStates: TxnStateId[] = [
+    const activeStates: TxnState[] = [
       TxnState.STARTING_TRANSACTION,
       TxnState.TRANSACTION_IN_PROGRESS
     ];
@@ -137,7 +137,7 @@ export class Transaction {
    * @internal
    * @param nextState - The new state to transition to
    */
-  transition(nextState: TxnStateId): void {
+  transition(nextState: TxnState): void {
     const nextStates = stateMachine[this.state];
     if (nextStates && nextStates.includes(nextState)) {
       this.state = nextState;

--- a/test/functional/unified-spec-runner/schema.ts
+++ b/test/functional/unified-spec-runner/schema.ts
@@ -1,6 +1,6 @@
 import type { Document } from '../../../src/bson';
-import type { ReadConcernLevelId } from '../../../src/read_concern';
-import type { ReadPreferenceModeId } from '../../../src/read_preference';
+import type { ReadConcernLevel } from '../../../src/read_concern';
+import type { ReadPreferenceMode } from '../../../src/read_preference';
 import type { TagSet } from '../../../src/sdam/server_description';
 import type { W } from '../../../src/write_concern';
 
@@ -23,12 +23,12 @@ export interface UnifiedSuite {
   tests: [Test, ...Test[]];
   _yamlAnchors?: Document;
 }
-export const TopologyType = {
+export const TopologyType = Object.freeze({
   single: 'single',
   replicaset: 'replicaset',
   sharded: 'sharded',
   shardedReplicaset: 'sharded-replicaset'
-} as const;
+} as const);
 export type TopologyId = typeof TopologyType[keyof typeof TopologyType];
 export interface RunOnRequirement {
   maxServerVersion?: string;
@@ -89,10 +89,10 @@ export interface ServerApi {
 }
 export interface CollectionOrDatabaseOptions {
   readConcern?: {
-    level: ReadConcernLevelId;
+    level: ReadConcernLevel;
   };
   readPreference?: {
-    mode: ReadPreferenceModeId;
+    mode: ReadPreferenceMode;
     maxStalenessSeconds: number;
     tags: TagSet[];
     hedge: { enabled: boolean };


### PR DESCRIPTION
## Description
NODE-3275

Make type exports for enums use the same name as the enums themselves
