### PR TITLE
fix(cmap): undo flipping of `beforeHandshake` flag for timeout errors

### DIFF
--- a/lib/cmap/connection.js
+++ b/lib/cmap/connection.js
@@ -122,7 +122,7 @@ class Connection extends EventEmitter {
       if (issue.isTimeout) {
         op.cb(
           new MongoNetworkTimeoutError(`connection ${this.id} to ${this.address} timed out`, {
-            beforeHandshake: !!this[kIsMaster]
+            beforeHandshake: this[kIsMaster] == null
           })
         );
       } else if (issue.isClose) {

--- a/lib/cmap/connection.js
+++ b/lib/cmap/connection.js
@@ -122,7 +122,7 @@ class Connection extends EventEmitter {
       if (issue.isTimeout) {
         op.cb(
           new MongoNetworkTimeoutError(`connection ${this.id} to ${this.address} timed out`, {
-            beforeHandshake: this[kIsMaster] == null
+            beforeHandshake: this.ismaster == null
           })
         );
       } else if (issue.isClose) {

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -102,9 +102,7 @@ class MongoNetworkError extends MongoError {
     super(message);
     this.name = 'MongoNetworkError';
 
-    if (options && options.beforeHandshake === true) {
-      this[kBeforeHandshake] = true;
-    }
+    this[kBeforeHandshake] = !!(options && options.beforeHandshake === true);
   }
 }
 

--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -102,7 +102,9 @@ class MongoNetworkError extends MongoError {
     super(message);
     this.name = 'MongoNetworkError';
 
-    this[kBeforeHandshake] = !!(options && options.beforeHandshake === true);
+    if (options && typeof options.beforeHandshake === 'boolean') {
+      this[kBeforeHandshake] = options.beforeHandshake;
+    }
   }
 }
 

--- a/test/unit/cmap/connection.test.js
+++ b/test/unit/cmap/connection.test.js
@@ -66,4 +66,63 @@ describe('Connection', function() {
       }
     );
   });
+
+  it('streams that timeout after handshake should have error[kBeforeHandshake] be false', function(done) {
+    server.setMessageHandler(request => {
+      const doc = request.document;
+      if (doc.ismaster) {
+        request.reply(mock.DEFAULT_ISMASTER_36);
+      }
+      // respond to no other requests to trigger timeout event
+    });
+
+    const address = server.address();
+    const options = {
+      bson: new BSON(),
+      connectionType: Connection,
+      host: address.host,
+      port: address.port
+    };
+
+    connect(options, (err, conn) => {
+      expect(err).to.be.a('undefined');
+      expect(conn).to.be.instanceOf(Connection);
+
+      conn.command('$admin.cmd', { ping: 1 }, { socketTimeout: 50 }, err => {
+        const beforeHandshakeSymbol = Object.getOwnPropertySymbols(err)[0];
+        expect(beforeHandshakeSymbol).to.be.a('symbol');
+        expect(err)
+          .to.have.property(beforeHandshakeSymbol)
+          .equals(false);
+
+        done();
+      });
+    });
+  });
+
+  it('streams that timeout before handshake should have error[kBeforeHandshake] be true', function(done) {
+    // respond to no requests to trigger timeout event
+    server.setMessageHandler(() => {});
+
+    const address = server.address();
+    const options = {
+      bson: new BSON(),
+      connectionType: Connection,
+      host: address.host,
+      port: address.port,
+      socketTimeout: 50
+    };
+
+    connect(options, (err, conn) => {
+      expect(conn).to.be.a('undefined');
+
+      const beforeHandshakeSymbol = Object.getOwnPropertySymbols(err)[0];
+      expect(beforeHandshakeSymbol).to.be.a('symbol');
+      expect(err)
+        .to.have.property(beforeHandshakeSymbol)
+        .equals(true);
+
+      done();
+    });
+  });
 });

--- a/test/unit/cmap/connection.test.js
+++ b/test/unit/cmap/connection.test.js
@@ -67,7 +67,7 @@ describe('Connection', function() {
     );
   });
 
-  it('streams that timeout after handshake should have error[kBeforeHandshake] be false', function(done) {
+  it('should throw a network error with kBeforeHandshake set to false on timeout after hand shake', function(done) {
     server.setMessageHandler(request => {
       const doc = request.document;
       if (doc.ismaster) {
@@ -87,20 +87,21 @@ describe('Connection', function() {
     connect(options, (err, conn) => {
       expect(err).to.be.a('undefined');
       expect(conn).to.be.instanceOf(Connection);
+      expect(conn)
+        .to.have.property('ismaster')
+        .that.is.a('object');
 
       conn.command('$admin.cmd', { ping: 1 }, { socketTimeout: 50 }, err => {
         const beforeHandshakeSymbol = Object.getOwnPropertySymbols(err)[0];
         expect(beforeHandshakeSymbol).to.be.a('symbol');
-        expect(err)
-          .to.have.property(beforeHandshakeSymbol)
-          .equals(false);
+        expect(err).to.have.property(beforeHandshakeSymbol, false);
 
         done();
       });
     });
   });
 
-  it('streams that timeout before handshake should have error[kBeforeHandshake] be true', function(done) {
+  it('should throw a network error with kBeforeHandshake set to true on timeout before hand shake', function(done) {
     // respond to no requests to trigger timeout event
     server.setMessageHandler(() => {});
 
@@ -118,9 +119,7 @@ describe('Connection', function() {
 
       const beforeHandshakeSymbol = Object.getOwnPropertySymbols(err)[0];
       expect(beforeHandshakeSymbol).to.be.a('symbol');
-      expect(err)
-        .to.have.property(beforeHandshakeSymbol)
-        .equals(true);
+      expect(err).to.have.property(beforeHandshakeSymbol, true);
 
       done();
     });

--- a/test/unit/error.test.js
+++ b/test/unit/error.test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const expect = require('chai').expect;
+const MongoNetworkError = require('../../lib/core/error').MongoNetworkError;
+
+describe('MongoErrors', function() {
+  describe('MongoNetworkError', function() {
+    it('should only define beforeHandshake symbol if boolean option passed in', function() {
+      const errorWithOptionTrue = new MongoNetworkError('', { beforeHandshake: true });
+      expect(Object.getOwnPropertySymbols(errorWithOptionTrue).length).to.equal(1);
+
+      const errorWithOptionFalse = new MongoNetworkError('', { beforeHandshake: false });
+      expect(Object.getOwnPropertySymbols(errorWithOptionFalse).length).to.equal(1);
+
+      const errorWithBadOption = new MongoNetworkError('', { beforeHandshake: 'not boolean' });
+      expect(Object.getOwnPropertySymbols(errorWithBadOption).length).to.equal(0);
+
+      const errorWithoutOption = new MongoNetworkError('');
+      expect(Object.getOwnPropertySymbols(errorWithoutOption).length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
## Description

I ran into this issue when upgrading Mongoose to 3.6.7 (https://github.com/Automattic/mongoose/pull/10265). 3.6.7 did some refactoring with https://github.com/mongodb/node-mongodb-native/commit/f1afcc4efbc41ce436812a6bfa22843e939ab5cf that seems to have unintentionally flipped the `beforeHandshake` flag on timeout errors. This causes the topology to _always_ switch to 'Unknown' state when there's an operation timeout.

**What changed?**

Undoing a change that I think may have been accidental.

**Are there any files to ignore?**
