### PR TITLE
fix(NODE-3183,NODE-3249): bring versioned API impl up to date

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -86,7 +86,7 @@ function performInitialHandshake(
   }
 
   const authContext = new AuthContext(conn, credentials, options);
-  prepareHandshakeDocument(conn.serverApi, authContext, (err, handshakeDoc) => {
+  prepareHandshakeDocument(authContext, (err, handshakeDoc) => {
     if (err || !handshakeDoc) {
       return callback(err);
     }
@@ -158,13 +158,10 @@ export interface HandshakeDocument extends Document {
   saslSupportedMechs?: string;
 }
 
-function prepareHandshakeDocument(
-  serverApi: ServerApi | undefined,
-  authContext: AuthContext,
-  callback: Callback<HandshakeDocument>
-) {
+function prepareHandshakeDocument(authContext: AuthContext, callback: Callback<HandshakeDocument>) {
   const options = authContext.options;
   const compressors = options.compressors ? options.compressors : [];
+  const { serverApi } = authContext.connection;
 
   const handshakeDoc: HandshakeDocument = {
     [serverApi?.version ? 'hello' : 'ismaster']: true,

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -13,7 +13,6 @@ import {
 } from './wire_protocol/constants';
 import type { Document } from '../bson';
 
-import type { ServerApi } from '../mongo_client';
 import type { Socket, SocketConnectOpts } from 'net';
 import type { TLSSocket, ConnectionOptions as TLSConnectionOpts } from 'tls';
 import { Int32 } from '../bson';

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -340,7 +340,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     let finalCmd = Object.assign({}, cmd);
     const inTransaction = session && (session.inTransaction() || isTransactionCommand(finalCmd));
 
-    if (this.serverApi && supportsVersionedApi(cmd, session)) {
+    if (this.serverApi) {
       const { version, strict, deprecationErrors } = this.serverApi;
       finalCmd.apiVersion = version;
       if (strict != null) finalCmd.apiStrict = strict;
@@ -664,16 +664,6 @@ function supportsOpMsg(conn: Connection) {
   }
 
   return maxWireVersion(conn) >= 6 && !description.__nodejs_mock_server__;
-}
-
-function supportsVersionedApi(cmd: Document, session?: ClientSession) {
-  const inTransaction = session && (session.inTransaction() || isTransactionCommand(cmd));
-  // if an API version was declared, add the apiVersion option to every command, except:
-  // a. only in the initial command of a transaction
-  // b. only in a Cursor's initiating command, not subsequent getMore commands
-  return (
-    (!inTransaction || session?.transaction.isStarting) && !cmd.commitTransaction && !cmd.getMore
-  );
 }
 
 function messageHandler(conn: Connection) {

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -221,15 +221,18 @@ function checkServer(monitor: Monitor, callback: Callback<Document>) {
 
   const connection = monitor[kConnection];
   if (connection && !connection.closed) {
+    const { serverApi } = connection;
     const connectTimeoutMS = monitor.options.connectTimeoutMS;
     const maxAwaitTimeMS = monitor.options.heartbeatFrequencyMS;
     const topologyVersion = monitor[kServer].description.topologyVersion;
     const isAwaitable = topologyVersion != null;
 
-    const cmd =
-      isAwaitable && topologyVersion
-        ? { ismaster: true, maxAwaitTimeMS, topologyVersion: makeTopologyVersion(topologyVersion) }
-        : { ismaster: true };
+    const cmd = {
+      [serverApi?.version ? 'hello' : 'ismaster']: true,
+      ...(isAwaitable && topologyVersion
+        ? { maxAwaitTimeMS, topologyVersion: makeTopologyVersion(topologyVersion) }
+        : {})
+    };
 
     const options = isAwaitable
       ? {
@@ -252,6 +255,10 @@ function checkServer(monitor: Monitor, callback: Callback<Document>) {
       if (err) {
         failureHandler(err);
         return;
+      }
+      if ('isWritablePrimary' in isMaster) {
+        // Provide pre-hello-style response document.
+        isMaster.ismaster = isMaster.isWritablePrimary;
       }
 
       const rttPinger = monitor[kRTTPinger];

--- a/test/disabled/mongos/events.test.js
+++ b/test/disabled/mongos/events.test.js
@@ -20,7 +20,7 @@ describe('EventEmitters (Mongos)', function () {
     test: function (done) {
       test.server.setMessageHandler(req => {
         const doc = req.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           req.reply(Object.assign({}, test.defaultFields));
         }
       });

--- a/test/disabled/mongos/retryable_writes.test.js
+++ b/test/disabled/mongos/retryable_writes.test.js
@@ -36,7 +36,7 @@ describe('Retryable Writes (Mongos)', function () {
       const messageHandler = () => {
         return request => {
           const doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(test.defaultFields);
           } else if (doc.insert) {
             command = doc;
@@ -90,7 +90,7 @@ describe('Retryable Writes (Mongos)', function () {
       const messageHandler = () => {
         return request => {
           const doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(test.defaultFields);
           } else if (doc.insert) {
             insertCount++;
@@ -147,7 +147,7 @@ describe('Retryable Writes (Mongos)', function () {
       const messageHandler = () => {
         return request => {
           const doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(test.defaultFields);
           } else if (doc.insert) {
             insertCount++;

--- a/test/disabled/mongos/sessions.test.js
+++ b/test/disabled/mongos/sessions.test.js
@@ -92,7 +92,7 @@ describe('Sessions (Mongos)', function () {
 
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(
             Object.assign({}, mock.DEFAULT_ISMASTER, {
               msg: 'isdbgrid',
@@ -176,7 +176,7 @@ describe('Sessions (Mongos)', function () {
         const clusterTime = genClusterTime(Date.now());
         test.server.setMessageHandler(request => {
           const doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(
               Object.assign({}, mock.DEFAULT_ISMASTER_36, {
                 msg: 'isdbgrid',

--- a/test/disabled/mongos_mocks/mixed_seed_list.test.js
+++ b/test/disabled/mongos_mocks/mixed_seed_list.test.js
@@ -48,7 +48,7 @@ describe('Mongos Mixed Seed List (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -57,7 +57,7 @@ describe('Mongos Mixed Seed List (mocks)', function () {
 
         mongos2.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[1]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -124,7 +124,7 @@ describe('Mongos Mixed Seed List (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -133,7 +133,7 @@ describe('Mongos Mixed Seed List (mocks)', function () {
 
         mongos2.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[1]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });

--- a/test/disabled/mongos_mocks/multiple_proxies.test.js
+++ b/test/disabled/mongos_mocks/multiple_proxies.test.js
@@ -36,7 +36,7 @@ describe('Mongos Multiple Proxies (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -45,7 +45,7 @@ describe('Mongos Multiple Proxies (mocks)', function () {
 
         mongos2.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -121,7 +121,7 @@ describe('Mongos Multiple Proxies (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -131,7 +131,7 @@ describe('Mongos Multiple Proxies (mocks)', function () {
         mongos2.setMessageHandler(request => {
           setTimeout(() => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(serverIsMaster[0]);
             } else if (doc.insert) {
               request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });

--- a/test/disabled/mongos_mocks/proxy_failover.test.js
+++ b/test/disabled/mongos_mocks/proxy_failover.test.js
@@ -32,7 +32,7 @@ describe('Mongos Proxy Failover (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             mongos1.destroy();
@@ -42,7 +42,7 @@ describe('Mongos Proxy Failover (mocks)', function () {
 
         mongos2.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -106,7 +106,7 @@ describe('Mongos Proxy Failover (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert && currentStep === 0) {
             setTimeout(() => request.connection.destroy(), 1600);
@@ -117,7 +117,7 @@ describe('Mongos Proxy Failover (mocks)', function () {
 
         mongos2.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -201,7 +201,7 @@ describe('Mongos Proxy Failover (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert && currentStep === 0) {
             setTimeout(() => request.connection.destroy(), 1600);
@@ -212,7 +212,7 @@ describe('Mongos Proxy Failover (mocks)', function () {
 
         mongos2.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert && currentStep === 0) {
             setTimeout(() => request.connection.destroy(), 1600);

--- a/test/disabled/mongos_mocks/proxy_read_preference.test.js
+++ b/test/disabled/mongos_mocks/proxy_read_preference.test.js
@@ -36,7 +36,7 @@ describe('Mongos Proxy Read Preference (mocks)', function () {
         mongos1.setMessageHandler(request => {
           var doc = request.document;
 
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.$query && doc.$readPreference) {
             command = doc;
@@ -115,7 +115,7 @@ describe('Mongos Proxy Read Preference (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.$query && doc.$readPreference) {
             command = doc;
@@ -195,7 +195,7 @@ describe('Mongos Proxy Read Preference (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.$query && doc.$readPreference) {
             command = doc;

--- a/test/disabled/mongos_mocks/single_proxy_connection.test.js
+++ b/test/disabled/mongos_mocks/single_proxy_connection.test.js
@@ -41,7 +41,7 @@ describe('Mongos Single Proxy Connection (mocks)', function () {
         server.setMessageHandler(request => {
           var doc = request.document;
 
-          if (doc.ismaster && currentStep === 0) {
+          if ((doc.ismaster || doc.hello) && currentStep === 0) {
             request.reply(serverIsMaster[0]);
             currentStep += 1;
           } else if (doc.insert && currentStep === 1) {
@@ -51,7 +51,7 @@ describe('Mongos Single Proxy Connection (mocks)', function () {
               stopRespondingPrimary = false;
               setTimeout(() => request.connection.destroy(), 1500);
             }
-          } else if (doc.ismaster) {
+          } else if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert && currentStep === 2) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -120,7 +120,7 @@ describe('Mongos Single Proxy Connection (mocks)', function () {
         server.setMessageHandler(request => {
           var doc = request.document;
 
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.find) {
             setTimeout(() => {

--- a/test/disabled/pool.test.js
+++ b/test/disabled/pool.test.js
@@ -18,7 +18,7 @@ describe('Pool (unit)', function () {
   it('should throw a MongoWriteConcernError when a writeConcernError is present', function (done) {
     test.server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         return request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.insert) {
         return request.reply({
@@ -53,7 +53,7 @@ describe('Pool (unit)', function () {
   it('should not allow overriding `slaveOk` when connected to a mongos', function (done) {
     test.server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(Object.assign({ msg: 'isdbgrid' }, mock.DEFAULT_ISMASTER));
       } else if (doc.insert) {
         request.reply({ ok: 1 });

--- a/test/disabled/replset/auth.test.js
+++ b/test/disabled/replset/auth.test.js
@@ -36,7 +36,7 @@ describe('Auth (ReplSet)', function () {
 
     test.primaryServer.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         setTimeout(() => request.reply(test.primaryStates[0]));
       } else if (doc.saslStart) {
         finish();
@@ -45,7 +45,7 @@ describe('Auth (ReplSet)', function () {
 
     test.firstSecondaryServer.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         timeoutIds.push(setTimeout(() => request.reply(test.firstSecondaryStates[0]), 2000));
       } else if (doc.saslStart) {
         finish();

--- a/test/disabled/replset/compression.test.js
+++ b/test/disabled/replset/compression.test.js
@@ -15,7 +15,7 @@ describe('Compression (ReplSet)', function () {
     const compressionData = [];
     test.primaryServer.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         compressionData.push(doc.compression);
         request.reply(test.primaryStates[0]);
       }
@@ -23,7 +23,7 @@ describe('Compression (ReplSet)', function () {
 
     test.firstSecondaryServer.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         compressionData.push(doc.compression);
         request.reply(test.firstSecondaryStates[0]);
       }

--- a/test/disabled/replset/retryable_writes.test.js
+++ b/test/disabled/replset/retryable_writes.test.js
@@ -35,7 +35,7 @@ describe('Retryable Writes (ReplSet)', function () {
       let command = null;
       test.primaryServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(test.primaryStates[0]);
         } else if (doc.insert) {
           command = doc;
@@ -85,7 +85,7 @@ describe('Retryable Writes (ReplSet)', function () {
 
       test.primaryServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(test.primaryStates[0]);
         } else if (doc.insert) {
           insertCount++;
@@ -141,7 +141,7 @@ describe('Retryable Writes (ReplSet)', function () {
 
       test.primaryServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(test.primaryStates[0]);
         } else if (doc.insert) {
           insertCount++;

--- a/test/disabled/replset/sessions.test.js
+++ b/test/disabled/replset/sessions.test.js
@@ -143,7 +143,7 @@ describe('Sessions (ReplSet)', function () {
     test: function (done) {
       test.arbiterServer.setMessageHandler(req => {
         const doc = req.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           req.reply(Object.assign({}, test.arbiterStates[0], { logicalSessionTimeoutMinutes: 2 }));
         }
       });

--- a/test/disabled/replset/step_down.test.js
+++ b/test/disabled/replset/step_down.test.js
@@ -56,7 +56,7 @@ describe('Step Down (ReplSet)', function () {
       const makeMessageHandler = states => request => {
         const state = states[this.stateCounter % states.length];
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           return request.reply(state);
         }
 

--- a/test/disabled/replset/transactions_feature_decoration.test.js
+++ b/test/disabled/replset/transactions_feature_decoration.test.js
@@ -101,7 +101,7 @@ describe('Transaction Feature Decoration', function () {
             try {
               const doc = request.document;
 
-              if (doc.ismaster) {
+              if (doc.ismaster || doc.hello) {
                 return request.reply(test.primaryStates[0]);
               }
 

--- a/test/disabled/rs_mocks/add_remove.test.js
+++ b/test/disabled/rs_mocks/add_remove.test.js
@@ -124,28 +124,28 @@ describe('ReplSet Add Remove (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[currentIsMasterIndex]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[currentIsMasterIndex]);
           }
         });
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[0]);
           }
         });
 
         arbiterServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(arbiter[currentIsMasterIndex]);
           }
         });
@@ -300,28 +300,28 @@ describe('ReplSet Add Remove (mocks)', function () {
 
         primaryServer.setMessageHandler(function (request) {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[currentIsMasterIndex]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(function (request) {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[currentIsMasterIndex]);
           }
         });
 
         secondSecondaryServer.setMessageHandler(function (request) {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[currentIsMasterIndex]);
           }
         });
 
         arbiterServer.setMessageHandler(function (request) {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(arbiter[currentIsMasterIndex]);
           }
         });
@@ -520,28 +520,28 @@ describe('ReplSet Add Remove (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[currentIsMasterIndex]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[currentIsMasterIndex]);
           }
         });
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[currentIsMasterIndex]);
           }
         });
 
         arbiterServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(arbiter[currentIsMasterIndex]);
           }
         });
@@ -720,28 +720,28 @@ describe('ReplSet Add Remove (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[currentIsMasterIndex]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[currentIsMasterIndex]);
           }
         });
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[0]);
           }
         });
 
         arbiterServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(arbiter[currentIsMasterIndex]);
           }
         });

--- a/test/disabled/rs_mocks/all_servers_close.test.js
+++ b/test/disabled/rs_mocks/all_servers_close.test.js
@@ -89,7 +89,7 @@ describe('ReplSet All Servers Close (mocks)', function () {
             request.connection.destroy();
           } else {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[0]);
             } else if (doc.insert) {
               request.reply({ ok: 1, n: 1 });
@@ -103,7 +103,7 @@ describe('ReplSet All Servers Close (mocks)', function () {
           } else {
             var doc = request.document;
 
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[0]);
             }
           }
@@ -115,7 +115,7 @@ describe('ReplSet All Servers Close (mocks)', function () {
           } else {
             var doc = request.document;
 
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(arbiter[0]);
             }
           }
@@ -233,7 +233,7 @@ describe('ReplSet All Servers Close (mocks)', function () {
               request.connection.destroy();
             } else {
               var doc = request.document;
-              if (doc.ismaster) {
+              if (doc.ismaster || doc.hello) {
                 request.reply(primary[0]);
               }
             }
@@ -244,7 +244,7 @@ describe('ReplSet All Servers Close (mocks)', function () {
               request.connection.destroy();
             } else {
               var doc = request.document;
-              if (doc.ismaster) {
+              if (doc.ismaster || doc.hello) {
                 request.reply(firstSecondary[0]);
               }
             }
@@ -255,7 +255,7 @@ describe('ReplSet All Servers Close (mocks)', function () {
               request.connection.destroy();
             } else {
               var doc = request.document;
-              if (doc.ismaster) {
+              if (doc.ismaster || doc.hello) {
                 request.reply(arbiter[0]);
               }
             }

--- a/test/disabled/rs_mocks/connection.test.js
+++ b/test/disabled/rs_mocks/connection.test.js
@@ -84,21 +84,21 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           }
         });
 
         arbiterServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(arbiter[0]);
           }
         });
@@ -207,21 +207,21 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
           primaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[0]);
             }
           });
 
           firstSecondaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[0]);
             }
           });
 
           arbiterServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(arbiter[0]);
             }
           });
@@ -311,14 +311,14 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           }
         });
@@ -408,7 +408,7 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           }
         });
@@ -488,14 +488,14 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
           firstSecondaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[0]);
             }
           });
 
           arbiterServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(arbiter[0]);
             }
           });
@@ -602,21 +602,21 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
           primaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[0]);
             }
           });
 
           firstSecondaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[0]);
             }
           });
 
           arbiterServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(arbiter[0]);
             }
           });
@@ -725,21 +725,21 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           }
         });
 
         arbiterServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(arbiter[0]);
           }
         });
@@ -820,14 +820,14 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           }
         });
@@ -931,21 +931,21 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
           primaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[0]);
             }
           });
 
           firstSecondaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[0]);
             }
           });
 
           arbiterServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(arbiter[0]);
             }
           });
@@ -1038,14 +1038,14 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           }
         });
 
         arbiterServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(arbiter[0]);
           }
         });
@@ -1144,21 +1144,21 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
           primaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[0]);
             }
           });
 
           firstSecondaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[0]);
             }
           });
 
           arbiterServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(arbiter[0]);
             }
           });
@@ -1243,14 +1243,14 @@ describe('ReplSet Connection Tests (mocks)', function () {
 
           firstSecondaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[0]);
             }
           });
 
           arbiterServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(arbiter[0]);
             }
           });

--- a/test/disabled/rs_mocks/failover.test.js
+++ b/test/disabled/rs_mocks/failover.test.js
@@ -135,7 +135,7 @@ describe('ReplSet Failover (mocks)', function () {
           if (die) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[currentIsMasterIndex]);
             }
           }
@@ -146,7 +146,7 @@ describe('ReplSet Failover (mocks)', function () {
           if (die) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[currentIsMasterIndex]);
             }
           }
@@ -157,7 +157,7 @@ describe('ReplSet Failover (mocks)', function () {
           if (die) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(secondSecondary[currentIsMasterIndex]);
             }
           }
@@ -342,7 +342,7 @@ describe('ReplSet Failover (mocks)', function () {
           if (die) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[currentIsMasterIndex]);
             }
           }
@@ -353,7 +353,7 @@ describe('ReplSet Failover (mocks)', function () {
           if (die) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[currentIsMasterIndex]);
             }
           }
@@ -364,7 +364,7 @@ describe('ReplSet Failover (mocks)', function () {
           if (die) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(secondSecondary[currentIsMasterIndex]);
             }
           }

--- a/test/disabled/rs_mocks/maintanance_mode.test.js
+++ b/test/disabled/rs_mocks/maintanance_mode.test.js
@@ -123,28 +123,28 @@ describe('ReplSet Maintenance Mode (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[currentIsMasterIndex]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[currentIsMasterIndex]);
           }
         });
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[currentIsMasterIndex]);
           }
         });
 
         arbiterServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(arbiter[currentIsMasterIndex]);
           }
         });

--- a/test/disabled/rs_mocks/monitoring.test.js
+++ b/test/disabled/rs_mocks/monitoring.test.js
@@ -119,7 +119,7 @@ describe('ReplSet Monitoring (mocks)', function () {
             }
 
             function handleMessage(doc) {
-              if (doc.ismaster && currentIsMasterState === 0) {
+              if ((doc.ismaster || doc.hello) && currentIsMasterState === 0) {
                 request.reply(primary[currentIsMasterState]);
               } else if (doc.insert && currentIsMasterState === 0) {
                 request.reply({
@@ -136,7 +136,7 @@ describe('ReplSet Monitoring (mocks)', function () {
 
           firstSecondaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[currentIsMasterState]);
             } else if (doc.insert && currentIsMasterState === 1) {
               request.reply({
@@ -152,7 +152,7 @@ describe('ReplSet Monitoring (mocks)', function () {
 
           secondSecondaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(secondSecondary[currentIsMasterState]);
             } else if (doc.insert && currentIsMasterState === 0) {
               request.reply({ note: 'from execCommand', ok: 0, errmsg: 'not master' });
@@ -303,21 +303,21 @@ describe('ReplSet Monitoring (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster && currentIsMasterState === 0) {
+          if ((doc.ismaster || doc.hello) && currentIsMasterState === 0) {
             request.reply(primary[currentIsMasterState]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[currentIsMasterState]);
           }
         });
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[currentIsMasterState]);
           }
         });

--- a/test/disabled/rs_mocks/no_primary_found.test.js
+++ b/test/disabled/rs_mocks/no_primary_found.test.js
@@ -89,7 +89,7 @@ describe('ReplSet No Primary Found (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           }
         });
@@ -97,7 +97,7 @@ describe('ReplSet No Primary Found (mocks)', function () {
         firstSecondaryServer.setMessageHandler(request => {
           setTimeout(() => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[0]);
             }
           }, 9000000); // never respond?
@@ -105,7 +105,7 @@ describe('ReplSet No Primary Found (mocks)', function () {
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[0]);
           }
         });
@@ -113,7 +113,7 @@ describe('ReplSet No Primary Found (mocks)', function () {
         arbiterServer.setMessageHandler(request => {
           setTimeout(() => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(arbiter[0]);
             }
           }, 9000000); // never respond?

--- a/test/disabled/rs_mocks/operation.test.js
+++ b/test/disabled/rs_mocks/operation.test.js
@@ -57,7 +57,7 @@ describe('ReplSet Operations (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[currentIsMasterIndex]);
           } else if (doc.count) {
             request.reply({ ok: 1, n: 1 });
@@ -125,7 +125,7 @@ describe('ReplSet Operations (mocks)', function () {
 
           primaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[currentIsMasterIndex]);
             } else if (doc.count) {
               request.reply({ ok: 1, n: 1 });

--- a/test/disabled/rs_mocks/primary_loses_network.test.js
+++ b/test/disabled/rs_mocks/primary_loses_network.test.js
@@ -105,21 +105,21 @@ describe('ReplSet Primary Loses Network (mocks)', function () {
           // Fail primary
           if (step >= 1) return;
 
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[currentIsMasterIndex]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[currentIsMasterIndex]);
           }
         });
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[currentIsMasterIndex]);
           }
         });

--- a/test/disabled/rs_mocks/read_preferences.test.js
+++ b/test/disabled/rs_mocks/read_preferences.test.js
@@ -85,7 +85,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
         primaryServer.setMessageHandler(request => {
           // Get the document
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -94,7 +94,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -103,7 +103,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -219,7 +219,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -228,7 +228,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -237,7 +237,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -353,7 +353,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -362,7 +362,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -371,7 +371,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -507,7 +507,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -516,7 +516,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -673,7 +673,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           } else if (doc.count) {
             request.connection.destroy();
@@ -682,7 +682,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -691,7 +691,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -843,7 +843,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -852,7 +852,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -861,7 +861,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.fromNumber(3), n: 1, ok: 1 });
@@ -983,7 +983,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -992,7 +992,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -1001,7 +1001,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -1102,7 +1102,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
           primaryServer.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[0]);
             } else if (doc.count) {
               request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -1212,7 +1212,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -1221,7 +1221,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });
@@ -1230,7 +1230,7 @@ describe('ReplSet Read Preferences (mocks)', function () {
 
         secondSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(secondSecondary[0]);
           } else if (doc.count) {
             request.reply({ waitedMS: Long.ZERO, n: 1, ok: 1 });

--- a/test/disabled/rs_mocks/step_down.test.js
+++ b/test/disabled/rs_mocks/step_down.test.js
@@ -85,7 +85,7 @@
 //           var request = yield primaryServer.receive();
 //           var doc = request.document;
 
-//           if(doc.ismaster) {
+//           if (doc.ismaster || doc.hello) {
 //             request.reply(primary[currentState]);
 //           } else if(doc.find) {
 //             request.reply({
@@ -126,7 +126,7 @@
 //           var request = yield firstSecondaryServer.receive();
 //           var doc = request.document;
 
-//           if(doc.ismaster) {
+//           if (doc.ismaster || doc.hello) {
 //             request.reply(firstSecondary[currentState]);
 //           } else if(doc.find) {
 //             request.reply({
@@ -167,7 +167,7 @@
 //           var request = yield arbiterServer.receive();
 //           var doc = request.document;
 
-//           if(doc.ismaster) {
+//           if (doc.ismaster || doc.hello) {
 //             request.reply(arbiter[0]);
 //           }
 //         }

--- a/test/disabled/sdam_monitoring_mocks/mongos_topology.test.js
+++ b/test/disabled/sdam_monitoring_mocks/mongos_topology.test.js
@@ -36,7 +36,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert && currentStep === 1) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -45,7 +45,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function () {
 
         mongos2.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -235,7 +235,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             mongos1.destroy();
@@ -246,7 +246,7 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function () {
 
         mongos2.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           } else if (doc.insert) {
             request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -425,16 +425,16 @@ describe.skip('Mongos SDAM Monitoring (mocks)', function () {
 
         mongos1.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster && currentStep === 0) {
+          if ((doc.ismaster || doc.hello) && currentStep === 0) {
             request.reply(serverIsMaster[0]);
-          } else if (doc.ismaster && currentStep === 1) {
+          } else if ((doc.ismaster || doc.hello) && currentStep === 1) {
             setTimeout(() => request.connection.destroy(), 1600);
           }
         });
 
         mongos2.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           }
         });

--- a/test/disabled/sdam_monitoring_mocks/replset_topology.test.js
+++ b/test/disabled/sdam_monitoring_mocks/replset_topology.test.js
@@ -117,21 +117,21 @@ describe.skip('ReplSet SDAM Monitoring (mocks)', function () {
 
         primaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[step]);
           }
         });
 
         firstSecondaryServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(firstSecondary[step]);
           }
         });
 
         arbiterServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(arbiter[step]);
           }
         });

--- a/test/disabled/sdam_monitoring_mocks/single_topology.test.js
+++ b/test/disabled/sdam_monitoring_mocks/single_topology.test.js
@@ -33,7 +33,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function () {
 
         mockServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           }
         });
@@ -170,7 +170,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function () {
 
         mockServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(serverIsMaster[0]);
           }
         });

--- a/test/disabled/single/sessions.test.js
+++ b/test/disabled/single/sessions.test.js
@@ -53,7 +53,7 @@ describe('Sessions (Single)', function () {
 
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(
             Object.assign({}, mock.DEFAULT_ISMASTER, {
               $clusterTime: clusterTime
@@ -98,7 +98,7 @@ describe('Sessions (Single)', function () {
 
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(
             Object.assign({}, mock.DEFAULT_ISMASTER, {
               $clusterTime: clusterTime
@@ -362,7 +362,7 @@ describe('Sessions (Single)', function () {
       let commands = [];
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(
             Object.assign({}, mock.DEFAULT_ISMASTER, {
               maxWireVersion: 6
@@ -435,7 +435,7 @@ describe('Sessions (Single)', function () {
       let commands = [];
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(
             Object.assign({}, mock.DEFAULT_ISMASTER, {
               maxWireVersion: 6
@@ -509,7 +509,7 @@ describe('Sessions (Single)', function () {
 
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(
             Object.assign({}, mock.DEFAULT_ISMASTER, {
               maxWireVersion: 6
@@ -538,7 +538,7 @@ describe('Sessions (Single)', function () {
 
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(
             Object.assign({}, mock.DEFAULT_ISMASTER, {
               maxWireVersion: 6
@@ -576,7 +576,7 @@ describe('Sessions (Single)', function () {
 
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(
             Object.assign({}, mock.DEFAULT_ISMASTER, {
               maxWireVersion: 6
@@ -614,7 +614,7 @@ describe('Sessions (Single)', function () {
       let insertCount = 0;
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(mock.DEFAULT_ISMASTER_36);
         } else if (doc.insert) {
           request.reply({
@@ -658,7 +658,7 @@ describe('Sessions (Single)', function () {
 
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(
             Object.assign({}, mock.DEFAULT_ISMASTER, {
               maxWireVersion: 6

--- a/test/disabled/single_mocks/compression.test.js
+++ b/test/disabled/single_mocks/compression.test.js
@@ -62,7 +62,7 @@ describe('Single Compression (mocks)', function () {
         server.setMessageHandler(request => {
           var doc = request.document;
 
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             if (!firstIsMasterSeen) {
               expect(request.response.documents[0].compression).to.have.members(['snappy', 'zlib']);
 
@@ -163,7 +163,7 @@ describe('Single Compression (mocks)', function () {
         let firstIsMasterSeen = false;
         server.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             if (!firstIsMasterSeen) {
               expect(request.response.documents[0].compression).to.have.members(['snappy', 'zlib']);
               expect(server.isCompressed).to.be.false;
@@ -260,7 +260,7 @@ describe('Single Compression (mocks)', function () {
         let firstIsMasterSeen = false;
         server.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             if (!firstIsMasterSeen) {
               expect(request.response.documents[0].compression).to.have.members(['snappy', 'zlib']);
               expect(server.isCompressed).to.be.false;
@@ -357,7 +357,7 @@ describe('Single Compression (mocks)', function () {
       let firstIsMasterSeen = false;
       server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           if (!firstIsMasterSeen) {
             if (doc.compression == null) {
               expect(server.isCompressed).to.be.false;

--- a/test/functional/buffering_proxy.test.js
+++ b/test/functional/buffering_proxy.test.js
@@ -137,7 +137,7 @@ describe.skip('Buffering Proxy', function () {
           if (die) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[currentIsMasterIndex]);
             } else if (doc.insert) {
               request.reply({ ok: 1, n: 1 });
@@ -155,7 +155,7 @@ describe.skip('Buffering Proxy', function () {
           if (die || dieSecondary) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[currentIsMasterIndex]);
             } else if (doc.endSessions) {
               request.reply({ ok: 1 });
@@ -169,7 +169,7 @@ describe.skip('Buffering Proxy', function () {
           if (die || dieSecondary) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(secondSecondary[currentIsMasterIndex]);
             } else if (doc.endSessions) {
               request.reply({ ok: 1 });
@@ -354,7 +354,7 @@ describe.skip('Buffering Proxy', function () {
           if (die || diePrimary) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(primary[currentIsMasterIndex]);
             } else if (doc.endSessions) {
               request.reply({ ok: 1 });
@@ -368,7 +368,7 @@ describe.skip('Buffering Proxy', function () {
           if (die) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(firstSecondary[currentIsMasterIndex]);
             } else if (doc.count) {
               request.reply({ ok: 1, n: 10 });
@@ -386,7 +386,7 @@ describe.skip('Buffering Proxy', function () {
           if (die) {
             request.connection.destroy();
           } else {
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(secondSecondary[currentIsMasterIndex]);
             } else if (doc.count) {
               request.reply({ ok: 1, n: 10 });

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -840,7 +840,7 @@ describe('Change Streams', function () {
         primaryServer.setMessageHandler(request => {
           const doc = request.document;
 
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(
               Object.assign(
                 {
@@ -941,7 +941,7 @@ describe('Change Streams', function () {
 
           if (die) {
             request.connection.destroy();
-          } else if (doc.ismaster) {
+          } else if (doc.ismaster || doc.hello) {
             request.reply(
               Object.assign(
                 {
@@ -1035,7 +1035,7 @@ describe('Change Streams', function () {
           const doc = request.document;
 
           // Create a server that responds to the initial aggregation to connect to the server, but not to subsequent getMore requests
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(
               Object.assign(
                 {
@@ -1446,7 +1446,7 @@ describe('Change Streams', function () {
           const doc = request.document;
 
           // Create a server that responds to the initial aggregation to connect to the server, but not to subsequent getMore requests
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(
               Object.assign(
                 {
@@ -1730,7 +1730,7 @@ describe('Change Streams', function () {
       function primaryServerHandler(request) {
         try {
           const doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             return request.reply(makeIsMaster(server));
           } else if (doc.aggregate) {
             return request.reply(AGGREGATE_RESPONSE);
@@ -1920,7 +1920,7 @@ describe('Change Streams', function () {
     class MockServerManager {
       constructor(config, commandIterators) {
         this.config = config;
-        this.cmdList = new Set(['ismaster', 'endSessions', 'aggregate', 'getMore']);
+        this.cmdList = new Set(['ismaster', 'hello', 'endSessions', 'aggregate', 'getMore']);
         this.database = 'test_db';
         this.collection = 'test_coll';
         this.ns = `${this.database}.${this.collection}`;
@@ -2016,6 +2016,10 @@ describe('Change Streams', function () {
           ok: 1,
           hosts: [uri]
         });
+      }
+
+      hello() {
+        return this.ismaster();
       }
 
       endSessions() {
@@ -2747,7 +2751,7 @@ context('NODE-2626 - handle null changes without error', function () {
   it('changeStream should close if cursor id for initial aggregate is Long.ZERO', function (done) {
     mockServer.setMessageHandler(req => {
       const doc = req.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         return req.reply(mock.DEFAULT_ISMASTER_36);
       }
       if (doc.aggregate) {

--- a/test/functional/collations.test.js
+++ b/test/functional/collations.test.js
@@ -26,7 +26,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.count) {
           commandResult = doc;
@@ -62,7 +62,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.aggregate) {
           commandResult = doc;
@@ -100,7 +100,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         var doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.distinct) {
           commandResult = doc;
@@ -136,7 +136,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         var doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.mapReduce) {
           commandResult = doc;
@@ -177,7 +177,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         var doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.delete) {
           commandResult = doc;
@@ -213,7 +213,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.update) {
           commandResult = doc;
@@ -251,7 +251,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.find) {
           commandResult = doc;
@@ -287,7 +287,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.find) {
           commandResult = doc;
@@ -325,7 +325,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.find) {
           commandResult = doc;
@@ -361,7 +361,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.listCollections) {
           request.reply({
@@ -403,7 +403,7 @@ describe('Collation', function () {
 
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.find) {
           request.reply({ ok: 1 });
@@ -437,7 +437,7 @@ describe('Collation', function () {
 
       testContext.server.setMessageHandler(request => {
         var doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.find) {
           request.reply({ ok: 1 });
@@ -474,7 +474,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.update) {
           commandResult = doc;
@@ -527,7 +527,7 @@ describe('Collation', function () {
 
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.update) {
           request.reply({ ok: 1 });
@@ -578,7 +578,7 @@ describe('Collation', function () {
 
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.update) {
           request.reply({ ok: 1 });
@@ -629,7 +629,7 @@ describe('Collation', function () {
       let commandResult;
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.createIndexes) {
           commandResult = doc;
@@ -667,7 +667,7 @@ describe('Collation', function () {
 
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.createIndexes) {
           request.reply({ ok: 1 });
@@ -702,7 +702,7 @@ describe('Collation', function () {
 
       testContext.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(primary[0]);
         } else if (doc.createIndexes) {
           request.reply({ ok: 1 });

--- a/test/functional/collection.test.js
+++ b/test/functional/collection.test.js
@@ -758,7 +758,7 @@ describe('Collection', function () {
           }
         }
 
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
         } else if (doc.endSessions) {
           request.reply({ ok: 1 });

--- a/test/functional/command_write_concern.test.js
+++ b/test/functional/command_write_concern.test.js
@@ -56,7 +56,7 @@ class WriteConcernTest {
 
       primaryServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(self.serverStates.primary[0]);
         } else if (doc[resultKey]) {
           self.commandResult = doc;
@@ -68,7 +68,7 @@ class WriteConcernTest {
 
       firstSecondaryServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(self.serverStates.firstSecondary[0]);
         } else if (doc.endSessions) {
           request.reply({ ok: 1 });
@@ -77,7 +77,7 @@ class WriteConcernTest {
 
       arbiterServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(self.serverStates.arbiter[0]);
         } else if (doc.endSessions) {
           request.reply({ ok: 1 });

--- a/test/functional/max_staleness.test.js
+++ b/test/functional/max_staleness.test.js
@@ -17,7 +17,7 @@ describe('Max Staleness', function () {
       const serverIsMaster = [Object.assign({}, defaultFields)];
       server.setMessageHandler(request => {
         var doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(serverIsMaster[0]);
           return;
         }

--- a/test/functional/replicaset_mock.test.js
+++ b/test/functional/replicaset_mock.test.js
@@ -31,7 +31,7 @@ describe('ReplSet (mocks)', function () {
 
       test.mongos1.setMessageHandler(request => {
         var doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(serverIsMaster[0]);
         } else if (doc.insert) {
           request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });
@@ -42,7 +42,7 @@ describe('ReplSet (mocks)', function () {
 
       test.mongos2.setMessageHandler(request => {
         var doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(serverIsMaster[1]);
         } else if (doc.insert) {
           request.reply({ ok: 1, n: doc.documents, lastOp: new Date() });

--- a/test/functional/unified-spec-runner/match.ts
+++ b/test/functional/unified-spec-runner/match.ts
@@ -129,10 +129,14 @@ export function resultCheck(
 
       if (depth > 1) {
         expect(actual, `Expected actual to exist at ${path.join('')}`).to.exist;
+        const actualKeys = Object.keys(actual);
+        const expectedKeys = Object.keys(expected);
+        // Don't check for full key set equality because some of the actual keys
+        // might be e.g. $$unsetOrMatches, which can be omitted.
         expect(
-          Object.keys(actual),
-          `[${Object.keys(actual)}] length !== [${Object.keys(expected)}]`
-        ).to.have.lengthOf(Object.keys(expected).length);
+          actualKeys.filter(key => !expectedKeys.includes(key)),
+          `[${Object.keys(actual)}] has more than the expected keys: [${Object.keys(expected)}]`
+        ).to.have.lengthOf(0);
       }
 
       for (const [key, value] of expectedEntries) {

--- a/test/functional/view.test.js
+++ b/test/functional/view.test.js
@@ -24,7 +24,7 @@ describe('Views', function () {
 
         singleServer.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(primary[0]);
           } else if (doc.listCollections) {
             request.reply({

--- a/test/spec/server-discovery-and-monitoring/integration/connectTimeoutMS.json
+++ b/test/spec/server-discovery-and-monitoring/integration/connectTimeoutMS.json
@@ -42,7 +42,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "connectTimeoutMS=0",
                 "blockConnection": true,

--- a/test/spec/server-discovery-and-monitoring/integration/connectTimeoutMS.yml
+++ b/test/spec/server-discovery-and-monitoring/integration/connectTimeoutMS.yml
@@ -33,7 +33,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: connectTimeoutMS=0
                 blockConnection: true
                 blockTimeMS: 550

--- a/test/spec/server-discovery-and-monitoring/integration/isMaster-command-error.json
+++ b/test/spec/server-discovery-and-monitoring/integration/isMaster-command-error.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "commandErrorHandshakeTest",
           "closeConnection": false,
@@ -120,7 +121,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "commandErrorCheckTest",
                 "closeConnection": false,

--- a/test/spec/server-discovery-and-monitoring/integration/isMaster-command-error.yml
+++ b/test/spec/server-discovery-and-monitoring/integration/isMaster-command-error.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
-          failCommands: ["isMaster"]
+          failCommands: ["isMaster", "hello"]
           appName: commandErrorHandshakeTest
           closeConnection: false
           errorCode: 91 # ShutdownInProgress
@@ -94,7 +94,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: commandErrorCheckTest
                 closeConnection: false
                 blockConnection: true

--- a/test/spec/server-discovery-and-monitoring/integration/isMaster-network-error.json
+++ b/test/spec/server-discovery-and-monitoring/integration/isMaster-network-error.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "networkErrorHandshakeTest",
           "closeConnection": true
@@ -119,7 +120,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "networkErrorCheckTest",
                 "closeConnection": true

--- a/test/spec/server-discovery-and-monitoring/integration/isMaster-network-error.yml
+++ b/test/spec/server-discovery-and-monitoring/integration/isMaster-network-error.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
-          failCommands: ["isMaster"]
+          failCommands: ["isMaster", "hello"]
           appName: networkErrorHandshakeTest
           closeConnection: true
     clientOptions:
@@ -93,7 +93,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: networkErrorCheckTest
                 closeConnection: true
       # The network error on the next check should mark the server Unknown and

--- a/test/spec/server-discovery-and-monitoring/integration/isMaster-timeout.json
+++ b/test/spec/server-discovery-and-monitoring/integration/isMaster-timeout.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "timeoutMonitorHandshakeTest",
           "blockConnection": true,
@@ -120,7 +121,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "timeoutMonitorCheckTest",
                 "blockConnection": true,

--- a/test/spec/server-discovery-and-monitoring/integration/isMaster-timeout.yml
+++ b/test/spec/server-discovery-and-monitoring/integration/isMaster-timeout.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
-          failCommands: ["isMaster"]
+          failCommands: ["isMaster", "hello"]
           appName: timeoutMonitorHandshakeTest
           blockConnection: true
           blockTimeMS: 1000
@@ -93,7 +93,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: timeoutMonitorCheckTest
                 blockConnection: true
                 # blockTimeMS is evaluated after the waiting for heartbeatFrequencyMS server-side, so this value only

--- a/test/spec/server-discovery-and-monitoring/integration/minPoolSize-error.json
+++ b/test/spec/server-discovery-and-monitoring/integration/minPoolSize-error.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "SDAMminPoolSizeError",
           "closeConnection": true

--- a/test/spec/server-discovery-and-monitoring/integration/minPoolSize-error.yml
+++ b/test/spec/server-discovery-and-monitoring/integration/minPoolSize-error.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { skip: 3 }
       data:
-        failCommands: ["isMaster"]
+        failCommands: ["isMaster", "hello"]
         appName: SDAMminPoolSizeError
         closeConnection: true
     clientOptions:

--- a/test/spec/versioned-api/crud-api-version-1-strict.json
+++ b/test/spec/versioned-api/crud-api-version-1-strict.json
@@ -1,6 +1,6 @@
 {
   "description": "CRUD Api Version 1 (strict)",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.9"
@@ -141,6 +141,11 @@
     },
     {
       "description": "aggregate on database appends declared API version",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "aggregate",
@@ -301,6 +306,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -353,7 +364,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -396,6 +410,9 @@
                       "u": {
                         "_id": 4,
                         "x": 44
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
                       },
                       "upsert": true
                     }
@@ -639,7 +656,7 @@
       ]
     },
     {
-      "description": "find command with declared API version appends to the command, but getMore does not",
+      "description": "find and getMore append API version",
       "operations": [
         {
           "name": "find",
@@ -700,14 +717,10 @@
                       "long"
                     ]
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
+                  "apiStrict": true,
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -966,6 +979,9 @@
                         "_id": 4,
                         "x": 44
                       },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
                       "upsert": true
                     }
                   ],
@@ -1021,7 +1037,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -1071,6 +1090,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/test/spec/versioned-api/crud-api-version-1-strict.yml
+++ b/test/spec/versioned-api/crud-api-version-1-strict.yml
@@ -1,6 +1,6 @@
 description: "CRUD Api Version 1 (strict)"
 
-schemaVersion: "1.1"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "4.9"
@@ -62,6 +62,10 @@ tests:
                 <<: *expectedApiVersion
 
   - description: "aggregate on database appends declared API version"
+    runOnRequirements:
+        # serverless does not support either of the current database-level aggregation stages ($listLocalSessions and
+        # $currentOp)
+      - serverless: "forbid"
     operations:
       - name: aggregate
         object: *adminDatabase
@@ -116,7 +120,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -128,7 +135,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -140,7 +150,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "countDocuments appends declared API version"
@@ -231,7 +244,7 @@ tests:
                   - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
-  - description: "find command with declared API version appends to the command, but getMore does not"
+  - description: "find and getMore append API version"
     operations:
       - name: find
         object: *collection
@@ -255,9 +268,7 @@ tests:
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
-                apiVersion: { $$exists: false }
-                apiStrict: { $$exists: false }
-                apiDeprecationErrors: { $$exists: false }
+                <<: *expectedApiVersion
 
   - description: "findOneAndDelete appends declared API version"
     operations:
@@ -359,7 +370,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "updateMany appends declared API version"
@@ -376,7 +390,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
 
   - description: "updateOne appends declared API version"
@@ -393,5 +410,8 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion

--- a/test/spec/versioned-api/crud-api-version-1.json
+++ b/test/spec/versioned-api/crud-api-version-1.json
@@ -1,6 +1,6 @@
 {
   "description": "CRUD Api Version 1",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.9"
@@ -141,6 +141,11 @@
     },
     {
       "description": "aggregate on database appends declared API version",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "aggregate",
@@ -298,6 +303,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -350,7 +361,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -393,6 +407,9 @@
                       "u": {
                         "_id": 4,
                         "x": 44
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
                       },
                       "upsert": true
                     }
@@ -631,7 +648,7 @@
       ]
     },
     {
-      "description": "find command with declared API version appends to the command, but getMore does not",
+      "description": "find and getMore append API version",
       "operations": [
         {
           "name": "find",
@@ -692,15 +709,11 @@
                       "long"
                     ]
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
+                  "apiDeprecationErrors": true
                 }
               }
             }
@@ -958,6 +971,9 @@
                         "_id": 4,
                         "x": 44
                       },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
                       "upsert": true
                     }
                   ],
@@ -1013,7 +1029,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -1063,6 +1082,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/test/spec/versioned-api/crud-api-version-1.yml
+++ b/test/spec/versioned-api/crud-api-version-1.yml
@@ -1,6 +1,6 @@
 description: "CRUD Api Version 1"
 
-schemaVersion: "1.1"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "4.9"
@@ -64,6 +64,10 @@ tests:
                 <<: *expectedApiVersion
 
   - description: "aggregate on database appends declared API version"
+    runOnRequirements:
+        # serverless does not support either of the current database-level aggregation stages ($listLocalSessions and
+        # $currentOp)
+      - serverless: forbid
     operations:
       - name: aggregate
         object: *adminDatabase
@@ -116,7 +120,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -128,7 +135,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -140,7 +150,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "countDocuments appends declared API version"
@@ -225,7 +238,7 @@ tests:
                   - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
-  - description: "find command with declared API version appends to the command, but getMore does not"
+  - description: "find and getMore append API version"
     operations:
       - name: find
         object: *collection
@@ -249,9 +262,7 @@ tests:
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
-                apiVersion: { $$exists: false }
-                apiStrict: { $$exists: false }
-                apiDeprecationErrors: { $$exists: false }
+                <<: *expectedApiVersion
 
   - description: "findOneAndDelete appends declared API version"
     operations:
@@ -353,7 +364,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "updateMany appends declared API version"
@@ -370,7 +384,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
 
   - description: "updateOne appends declared API version"
@@ -387,5 +404,8 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion

--- a/test/spec/versioned-api/runcommand-helper-no-api-version-declared.json
+++ b/test/spec/versioned-api/runcommand-helper-no-api-version-declared.json
@@ -1,6 +1,6 @@
 {
   "description": "RunCommand helper: No API version declared",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.9",
@@ -29,6 +29,11 @@
   "tests": [
     {
       "description": "runCommand does not inspect or change the command document",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -72,6 +77,11 @@
     },
     {
       "description": "runCommand does not prevent sending invalid API version declarations",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/test/spec/versioned-api/runcommand-helper-no-api-version-declared.yml
+++ b/test/spec/versioned-api/runcommand-helper-no-api-version-declared.yml
@@ -1,6 +1,6 @@
 description: "RunCommand helper: No API version declared"
 
-schemaVersion: "1.1"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "4.9"
@@ -19,6 +19,10 @@ createEntities:
 
 tests:
   - description: "runCommand does not inspect or change the command document"
+    runOnRequirements:
+      # serverless does not currently reject invalid API versions on
+      # certain commands (CLOUDP-87926)
+      - serverless: "forbid"
     operations:
       - name: runCommand
         object: *database
@@ -43,6 +47,10 @@ tests:
               databaseName: *databaseName
 
   - description: "runCommand does not prevent sending invalid API version declarations"
+    runOnRequirements:
+      # serverless does not currently reject invalid API versions on
+      # certain commands (CLOUDP-87926)
+      - serverless: "forbid"
     operations:
       - name: runCommand
         object: *database

--- a/test/spec/versioned-api/transaction-handling.json
+++ b/test/spec/versioned-api/transaction-handling.json
@@ -6,7 +6,8 @@
       "minServerVersion": "4.9",
       "topologies": [
         "replicaset",
-        "sharded-replicaset"
+        "sharded-replicaset",
+        "load-balanced"
       ]
     }
   ],
@@ -53,17 +54,6 @@
         "apiDeprecationErrors": {
           "$$unsetOrMatches": false
         }
-      },
-      {
-        "apiVersion": {
-          "$$exists": false
-        },
-        "apiStrict": {
-          "$$exists": false
-        },
-        "apiDeprecationErrors": {
-          "$$exists": false
-        }
       }
     ]
   },
@@ -97,12 +87,13 @@
   ],
   "tests": [
     {
-      "description": "Only the first command in a transaction declares an API version",
+      "description": "All commands in a transaction declare an API version",
       "runOnRequirements": [
         {
           "topologies": [
             "replicaset",
-            "sharded-replicaset"
+            "sharded-replicaset",
+            "load-balanced"
           ]
         }
       ],
@@ -193,119 +184,6 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "commitTransaction": 1,
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "Committing a transaction twice does not append server API options",
-      "runOnRequirements": [
-        {
-          "topologies": [
-            "replicaset",
-            "sharded-replicaset"
-          ]
-        }
-      ],
-      "operations": [
-        {
-          "name": "startTransaction",
-          "object": "session"
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session",
-            "document": {
-              "_id": 6,
-              "x": 66
-            }
-          },
-          "expectResult": {
-            "$$unsetOrMatches": {
-              "insertedId": {
-                "$$unsetOrMatches": 6
-              }
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session",
-            "document": {
-              "_id": 7,
-              "x": 77
-            }
-          },
-          "expectResult": {
-            "$$unsetOrMatches": {
-              "insertedId": {
-                "$$unsetOrMatches": 7
-              }
-            }
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session"
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session"
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "insert": "test",
-                  "documents": [
-                    {
-                      "_id": 6,
-                      "x": 66
-                    }
-                  ],
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "startTransaction": true,
                   "apiVersion": "1",
                   "apiStrict": {
                     "$$unsetOrMatches": false
@@ -319,62 +197,16 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "insert": "test",
-                  "documents": [
-                    {
-                      "_id": 7,
-                      "x": 77
-                    }
-                  ],
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
                   "commitTransaction": 1,
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "commitTransaction": 1,
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -384,12 +216,13 @@
       ]
     },
     {
-      "description": "abortTransaction does not include an API version",
+      "description": "abortTransaction includes an API version",
       "runOnRequirements": [
         {
           "topologies": [
             "replicaset",
-            "sharded-replicaset"
+            "sharded-replicaset",
+            "load-balanced"
           ]
         }
       ],
@@ -480,14 +313,12 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -499,14 +330,12 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }

--- a/test/spec/versioned-api/transaction-handling.yml
+++ b/test/spec/versioned-api/transaction-handling.yml
@@ -4,7 +4,7 @@ schemaVersion: "1.1"
 
 runOnRequirements:
   - minServerVersion: "4.9"
-    topologies: [ replicaset, sharded-replicaset ]
+    topologies: [ replicaset, sharded-replicaset, load-balanced ]
 
 createEntities:
   - client:
@@ -31,10 +31,6 @@ _yamlAnchors:
       apiVersion: "1"
       apiStrict: { $$unsetOrMatches: false }
       apiDeprecationErrors: { $$unsetOrMatches: false }
-    - &noApiVersion
-      apiVersion: { $$exists: false }
-      apiStrict: { $$exists: false }
-      apiDeprecationErrors: { $$exists: false }
 
 
 initialData:
@@ -48,9 +44,9 @@ initialData:
       - { _id: 5, x: 55 }
 
 tests:
-  - description: "Only the first command in a transaction declares an API version"
+  - description: "All commands in a transaction declare an API version"
     runOnRequirements:
-      - topologies: [ replicaset, sharded-replicaset ]
+      - topologies: [ replicaset, sharded-replicaset, load-balanced ]
     operations:
       - name: startTransaction
         object: *session
@@ -83,63 +79,15 @@ tests:
                 insert: *collectionName
                 documents: [ { _id: 7, x: 77 } ]
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
-                commitTransaction: 1
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-  - description: "Committing a transaction twice does not append server API options"
-    runOnRequirements:
-      - topologies: [ replicaset, sharded-replicaset ]
-    operations:
-      - name: startTransaction
-        object: *session
-      - name: insertOne
-        object: *collection
-        arguments:
-          session: *session
-          document: { _id: 6, x: 66 }
-        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 6 } } }
-      - name: insertOne
-        object: *collection
-        arguments:
-          session: *session
-          document: { _id: 7, x: 77 }
-        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 7 } } }
-      - name: commitTransaction
-        object: *session
-      - name: commitTransaction
-        object: *session
-    expectEvents:
-      - client: *client
-        events:
-          - commandStartedEvent:
-              command:
-                insert: *collectionName
-                documents: [ { _id: 6, x: 66 } ]
-                lsid: { $$sessionLsid: *session }
-                startTransaction: true
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
-                insert: *collectionName
-                documents: [ { _id: 7, x: 77 } ]
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
                 commitTransaction: 1
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
-                commitTransaction: 1
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-  - description: "abortTransaction does not include an API version"
+                <<: *expectedApiVersion
+  - description: "abortTransaction includes an API version"
     runOnRequirements:
-      - topologies: [ replicaset, sharded-replicaset ]
+      - topologies: [ replicaset, sharded-replicaset, load-balanced ]
     operations:
       - name: startTransaction
         object: *session
@@ -172,9 +120,9 @@ tests:
                 insert: *collectionName
                 documents: [ { _id: 7, x: 77 } ]
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
+                <<: *expectedApiVersion
           - commandStartedEvent:
               command:
                 abortTransaction: 1
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
+                <<: *expectedApiVersion

--- a/test/unit/bulk_write.test.js
+++ b/test/unit/bulk_write.test.js
@@ -32,7 +32,7 @@ describe('Bulk Writes', function () {
 
     test.server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });

--- a/test/unit/bypass_validation.test.js
+++ b/test/unit/bypass_validation.test.js
@@ -38,7 +38,7 @@ describe('bypass document validation', function () {
         }
       }
 
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });
@@ -91,7 +91,7 @@ describe('bypass document validation', function () {
         }
       }
 
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });
@@ -148,7 +148,7 @@ describe('bypass document validation', function () {
         }
       }
 
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });
@@ -197,7 +197,7 @@ describe('bypass document validation', function () {
         }
       }
 
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -15,7 +15,7 @@ describe('Client (unit)', function () {
     let handshake;
     server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         handshake = doc;
         request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.endSessions) {

--- a/test/unit/cmap/connection.test.js
+++ b/test/unit/cmap/connection.test.js
@@ -14,7 +14,7 @@ describe('Connection - unit/cmap', function () {
   it('should support fire-and-forget messages', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(mock.DEFAULT_ISMASTER_36);
       }
 
@@ -37,7 +37,7 @@ describe('Connection - unit/cmap', function () {
   it('should destroy streams which time out', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(mock.DEFAULT_ISMASTER_36);
       }
 

--- a/test/unit/cmap/connection_pool.test.js
+++ b/test/unit/cmap/connection_pool.test.js
@@ -44,7 +44,7 @@ describe('Connection Pool', function () {
   it('should destroy connections which have been closed', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(mock.DEFAULT_ISMASTER_36);
       } else {
         // destroy on any other command
@@ -86,7 +86,7 @@ describe('Connection Pool', function () {
   it('should propagate socket timeouts to connections', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(mock.DEFAULT_ISMASTER_36);
       } else {
         // blackhole other requests
@@ -116,7 +116,7 @@ describe('Connection Pool', function () {
   it('should clear timed out wait queue members if no connections are available', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(mock.DEFAULT_ISMASTER_36);
       }
     });
@@ -152,7 +152,7 @@ describe('Connection Pool', function () {
     it('should manage a connection for a successful operation', function (done) {
       server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(mock.DEFAULT_ISMASTER_36);
         }
       });
@@ -177,7 +177,7 @@ describe('Connection Pool', function () {
     it('should allow user interaction with an error', function (done) {
       server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.connection.destroy();
         }
       });
@@ -203,7 +203,7 @@ describe('Connection Pool', function () {
     it('should return an error to the original callback', function (done) {
       server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(mock.DEFAULT_ISMASTER_36);
         }
       });
@@ -225,7 +225,7 @@ describe('Connection Pool', function () {
     it('should still manage a connection if no callback is provided', function (done) {
       server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(mock.DEFAULT_ISMASTER_36);
         }
       });
@@ -397,7 +397,7 @@ describe('Connection Pool', function () {
       // and establish valid connections
       server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(mock.DEFAULT_ISMASTER_36);
         }
       });

--- a/test/unit/core/common.js
+++ b/test/unit/core/common.js
@@ -89,21 +89,21 @@ class ReplSetFixture {
   configureMessageHandlers() {
     this.primaryServer.setMessageHandler(request => {
       var doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(this.primaryStates[0]);
       }
     });
 
     this.firstSecondaryServer.setMessageHandler(request => {
       var doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(this.firstSecondaryStates[0]);
       }
     });
 
     this.arbiterServer.setMessageHandler(request => {
       var doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(this.arbiterStates[0]);
       }
     });

--- a/test/unit/core/connect.test.js
+++ b/test/unit/core/connect.test.js
@@ -35,7 +35,7 @@ describe('Connect Tests', function () {
       const doc = request.document;
       const $clusterTime = genClusterTime(Date.now());
 
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         whatHappened.ismaster = true;
         request.reply(
           Object.assign({}, mock.DEFAULT_ISMASTER, {
@@ -65,7 +65,7 @@ describe('Connect Tests', function () {
     test.server.setMessageHandler(request => {
       const doc = request.document;
       const $clusterTime = genClusterTime(Date.now());
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         whatHappened.ismaster = true;
         request.reply(
           Object.assign({}, mock.DEFAULT_ISMASTER, {

--- a/test/unit/core/response_test.js.test.js
+++ b/test/unit/core/response_test.js.test.js
@@ -28,7 +28,7 @@ describe('Response', function () {
 
       test.server.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(
             Object.assign({}, mock.DEFAULT_ISMASTER, {
               maxWireVersion: 6

--- a/test/unit/core/scram_iterations.test.js
+++ b/test/unit/core/scram_iterations.test.js
@@ -34,7 +34,7 @@ describe('SCRAM Iterations Tests', function () {
 
     server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         return request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.saslStart) {
         return request.reply({
@@ -80,7 +80,7 @@ describe('SCRAM Iterations Tests', function () {
 
     server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         return request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.saslStart) {
         return request.reply({
@@ -127,7 +127,7 @@ describe('SCRAM Iterations Tests', function () {
 
     server.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         return request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.saslStart) {
         return request.reply({

--- a/test/unit/core/sessions.test.js
+++ b/test/unit/core/sessions.test.js
@@ -68,7 +68,7 @@ describe('Sessions - unit/core', function () {
           test.server = server;
           test.server.setMessageHandler(request => {
             var doc = request.document;
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(
                 Object.assign({}, mock.DEFAULT_ISMASTER, { logicalSessionTimeoutMinutes: 10 })
               );

--- a/test/unit/core/write_concern_error.test.js
+++ b/test/unit/core/write_concern_error.test.js
@@ -83,7 +83,7 @@ describe('WriteConcernError', function () {
   it('should expose a user command writeConcern error like a normal WriteConcernError', function (done) {
     test.primaryServer.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         setTimeout(() => request.reply(test.primaryStates[0]));
       } else if (doc.createUser) {
         setTimeout(() => request.reply(RAW_USER_WRITE_CONCERN_ERROR));
@@ -124,7 +124,7 @@ describe('WriteConcernError', function () {
   it('should propagate writeConcernError.errInfo ', function (done) {
     test.primaryServer.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         setTimeout(() => request.reply(test.primaryStates[0]));
       } else if (doc.createUser) {
         setTimeout(() => request.reply(RAW_USER_WRITE_CONCERN_ERROR_INFO));

--- a/test/unit/create_index_error.test.js
+++ b/test/unit/create_index_error.test.js
@@ -19,7 +19,7 @@ describe('CreateIndexError', function () {
     test.server.setMessageHandler(request => {
       const doc = request.document;
 
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         return request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       }
 

--- a/test/unit/db_list_collections.test.js
+++ b/test/unit/db_list_collections.test.js
@@ -11,7 +11,7 @@ describe('db.listCollections', function () {
       server.setMessageHandler(request => {
         const doc = request.document;
 
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           return request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
         }
 

--- a/test/unit/sdam/monitoring.test.js
+++ b/test/unit/sdam/monitoring.test.js
@@ -25,7 +25,7 @@ describe('monitoring', function () {
   it('should record roundTripTime', function (done) {
     mockServer.setMessageHandler(request => {
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });
@@ -63,7 +63,7 @@ describe('monitoring', function () {
       }
 
       const doc = request.document;
-      if (doc.ismaster) {
+      if (doc.ismaster || doc.hello) {
         request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });
@@ -90,7 +90,7 @@ describe('monitoring', function () {
     it('should connect and issue an initial server check', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
         }
       });
@@ -107,7 +107,7 @@ describe('monitoring', function () {
     it('should ignore attempts to connect when not already closed', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
         }
       });
@@ -125,7 +125,7 @@ describe('monitoring', function () {
     it('should not initiate another check if one is in progress', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           setTimeout(() => request.reply(Object.assign({}, mock.DEFAULT_ISMASTER)), 250);
         }
       });
@@ -164,7 +164,7 @@ describe('monitoring', function () {
       let isMasterCount = 0;
       mockServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           isMasterCount++;
           if (isMasterCount === 2) {
             request.reply({ ok: 0, errmsg: 'forced from mock server' });

--- a/test/unit/sdam/srv_polling.test.js
+++ b/test/unit/sdam/srv_polling.test.js
@@ -327,7 +327,7 @@ describe('Mongos SRV Polling', function () {
           server.setMessageHandler(request => {
             const doc = request.document;
 
-            if (doc.ismaster) {
+            if (doc.ismaster || doc.hello) {
               request.reply(Object.assign({}, MONGOS_DEFAULT_ISMASTER));
             }
           });

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -34,7 +34,7 @@ describe('Topology (unit)', function () {
       const ismasters = [];
       mockServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           ismasters.push(doc);
           request.reply(mock.DEFAULT_ISMASTER);
         } else {
@@ -147,7 +147,7 @@ describe('Topology (unit)', function () {
         const doc = request.document;
 
         let initialIsMasterSent = false;
-        if (doc.ismaster && !initialIsMasterSent) {
+        if ((doc.ismaster || doc.hello) && !initialIsMasterSent) {
           request.reply(mock.DEFAULT_ISMASTER_36);
           initialIsMasterSent = true;
         } else {
@@ -182,7 +182,7 @@ describe('Topology (unit)', function () {
     it('should set server to unknown and reset pool on `node is recovering` error', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 9 }));
         } else if (doc.insert) {
           request.reply({ ok: 0, message: 'node is recovering', code: 11600 });
@@ -219,7 +219,7 @@ describe('Topology (unit)', function () {
     it('should set server to unknown and NOT reset pool on stepdown errors', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 9 }));
         } else if (doc.insert) {
           request.reply({ ok: 0, message: 'not master' });
@@ -256,7 +256,7 @@ describe('Topology (unit)', function () {
     it('should set server to unknown on non-timeout network error', function (done) {
       mockServer.setMessageHandler(request => {
         const doc = request.document;
-        if (doc.ismaster) {
+        if (doc.ismaster || doc.hello) {
           request.reply(Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 9 }));
         } else if (doc.insert) {
           request.connection.destroy();

--- a/test/unit/sessions/client.test.js
+++ b/test/unit/sessions/client.test.js
@@ -19,7 +19,7 @@ describe('Sessions - client/unit', function () {
       test() {
         test.server.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(Object.assign({}, mock.DEFAULT_ISMASTER));
           } else if (doc.endSessions) {
             request.reply({ ok: 1 });
@@ -46,7 +46,7 @@ describe('Sessions - client/unit', function () {
           .then(() => {
             replicaSetMock.firstSecondaryServer.setMessageHandler(request => {
               var doc = request.document;
-              if (doc.ismaster) {
+              if (doc.ismaster || doc.hello) {
                 const ismaster = replicaSetMock.firstSecondaryStates[0];
                 ismaster.logicalSessionTimeoutMinutes = 20;
                 request.reply(ismaster);
@@ -57,7 +57,7 @@ describe('Sessions - client/unit', function () {
 
             replicaSetMock.secondSecondaryServer.setMessageHandler(request => {
               var doc = request.document;
-              if (doc.ismaster) {
+              if (doc.ismaster || doc.hello) {
                 const ismaster = replicaSetMock.secondSecondaryStates[0];
                 ismaster.logicalSessionTimeoutMinutes = 10;
                 request.reply(ismaster);
@@ -68,7 +68,7 @@ describe('Sessions - client/unit', function () {
 
             replicaSetMock.arbiterServer.setMessageHandler(request => {
               var doc = request.document;
-              if (doc.ismaster) {
+              if (doc.ismaster || doc.hello) {
                 const ismaster = replicaSetMock.arbiterStates[0];
                 ismaster.logicalSessionTimeoutMinutes = 30;
                 request.reply(ismaster);
@@ -79,7 +79,7 @@ describe('Sessions - client/unit', function () {
 
             replicaSetMock.primaryServer.setMessageHandler(request => {
               var doc = request.document;
-              if (doc.ismaster) {
+              if (doc.ismaster || doc.hello) {
                 const ismaster = replicaSetMock.primaryStates[0];
                 ismaster.logicalSessionTimeoutMinutes = null;
                 request.reply(ismaster);
@@ -114,7 +114,7 @@ describe('Sessions - client/unit', function () {
       test: function (done) {
         test.server.setMessageHandler(request => {
           var doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(
               Object.assign({}, mock.DEFAULT_ISMASTER, {
                 logicalSessionTimeoutMinutes: 10

--- a/test/unit/sessions/collection.test.js
+++ b/test/unit/sessions/collection.test.js
@@ -21,7 +21,7 @@ describe('Sessions - unit/sessions', function () {
         let insertOperationTime = Timestamp.fromNumber(Date.now());
         test.server.setMessageHandler(request => {
           const doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(
               Object.assign({ logicalSessionTimeoutMinutes: 15 }, mock.DEFAULT_ISMASTER_36)
             );
@@ -61,7 +61,7 @@ describe('Sessions - unit/sessions', function () {
         const options = Object.freeze({});
         test.server.setMessageHandler(request => {
           const doc = request.document;
-          if (doc.ismaster) {
+          if (doc.ismaster || doc.hello) {
             request.reply(mock.DEFAULT_ISMASTER_36);
           } else if (doc.count || doc.aggregate || doc.endSessions) {
             request.reply({ ok: 1 });


### PR DESCRIPTION
## Description

**What changed?**

Bring the versioned API code up to date by addressing NODE-3183 and
NODE-3249.

Specifically:
- Bump the versioned API tests to the latest version using
  `./etc/update-spec-tests.sh versioned-api`.
- Manually apply the SDAM updates from
  https://github.com/mongodb/specifications/commit/9946950d65a6f79fdb3746bde2701d3632f9b399
  (because a full update would have also come with load balancer
  changes that do not pass yet).
- Update the test runner slightly to account for the fact that some
  fields may have only a `$$unsetOrMatches` operator as its contents
  and thus the set of expected keys in an “expected” object is
  not a fixed-size set. (This was necessary in order for the updated
  versioned-api tests to pass)
- Remove the special check for getMore and transaction commands, and
  now pass the apiVersion for them as well when it is specified.
- Use the `hello` command instead of `isMaster` when an API version is
  specified; make sure that the slightly different response format
  does not break anything by setting the `ismaster` property manually
  in that case.
- Updating the mock server message handlers to account for both types
  of handshakes, everywhere.

**Are there any files to ignore?**

I mean, the spec tests were really just updated automatically. The mock tests updates were performed semi-automatically, i.e. I did an automatic replacement and then went through all update sites + all message handlers manually to verify that they were not invalid changes. (Some of the tests are using replies like `mock.DEFAULT_ISMASTER_36`. I’m not sure if it makes sense to actually update those, considering that the name implies a MongoDB 3.6 response. I don’t think it hurts, though.)