### PR TITLE
test(NODE-3234): sync initial dns seedlist tests

### DIFF
--- a/test/spec/initial-dns-seedlist-discovery/dbname-with-commas.json
+++ b/test/spec/initial-dns-seedlist-discovery/dbname-with-commas.json
@@ -1,0 +1,19 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/some,db?replicaSet=repl0",
+  "seeds": [
+    "test1.test.build.10gen.cc:27017",
+    "test1.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "defaultDatabase": "some,db"
+  }
+}

--- a/test/spec/initial-dns-seedlist-discovery/dbname-with-commas.yml
+++ b/test/spec/initial-dns-seedlist-discovery/dbname-with-commas.yml
@@ -1,0 +1,13 @@
+uri: "mongodb+srv://test1.test.build.10gen.cc/some,db?replicaSet=repl0"
+seeds:
+  - test1.test.build.10gen.cc:27017
+  - test1.test.build.10gen.cc:27018
+hosts:
+  - localhost:27017
+  - localhost:27018
+  - localhost:27019
+options:
+  replicaSet: repl0
+  ssl: true
+parsed_options:
+  defaultDatabase: some,db


### PR DESCRIPTION
Syncs the new tests to the 4.0 branch. No code changes required - they pass here.