### PR TITLE
fix(NODE-2944): Reintroduce bson-ext support

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -516,6 +516,16 @@ functions:
           rm -f ./prepare_client_encryption.sh
 
           MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
+  run bson-ext test:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        timeout_secs: 60
+        script: |
+          ${PREPARE_SHELL}
+
+          MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-bson-ext-test.sh
   upload test results:
     - command: attach.xunit_results
       params:
@@ -1353,6 +1363,18 @@ tasks:
           VERSION: '4.4'
           TOPOLOGY: server
       - func: run custom csfle tests
+  - name: run-bson-ext-test
+    tags:
+      - run-bson-ext-test
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_NAME: erbium
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          TOPOLOGY: server
+      - func: run bson-ext test
 buildvariants:
   - name: macos-1014-dubnium
     display_name: macOS 10.14 Node Dubnium
@@ -1685,6 +1707,11 @@ buildvariants:
     run_on: ubuntu1804-test
     tasks:
       - run-custom-csfle-tests
+  - name: rhel70-bson-ext-test
+    display_name: BSON Ext Test
+    run_on: rhel70
+    tasks:
+      - run-bson-ext-test
   - name: mongosh_integration_tests
     display_name: mongosh integration tests
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -561,6 +561,17 @@ functions:
 
           MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
 
+  "run bson-ext test":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        timeout_secs: 60
+        script: |
+          ${PREPARE_SHELL}
+
+          MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-bson-ext-test.sh
+
   "upload test results":
     # Upload the xunit-format test results.
     - command: attach.xunit_results

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -533,6 +533,11 @@ BUILD_VARIANTS.push({
   display_name: 'Custom FLE Version Test',
   run_on: 'ubuntu1804-test',
   tasks: ['run-custom-csfle-tests']
+}, {
+  name: 'rhel70-bson-ext-test',
+  display_name: 'BSON Ext Test',
+  run_on: 'rhel70',
+  tasks: ['run-bson-ext-test']
 });
 
 // singleton build variant for mongosh integration tests
@@ -588,6 +593,28 @@ SINGLETON_TASKS.push({
       }
     },
     { func: 'run custom csfle tests' }
+  ]
+});
+
+// special case for custom CSFLE test
+SINGLETON_TASKS.push({
+  name: 'run-bson-ext-test',
+  tags: ['run-bson-ext-test'],
+  commands: [
+    {
+      func: 'install dependencies',
+      vars: {
+        NODE_LTS_NAME: 'erbium',
+      },
+    },
+    {
+      func: 'bootstrap mongo-orchestration',
+      vars: {
+        VERSION: '4.4',
+        TOPOLOGY: 'server'
+      }
+    },
+    { func: 'run bson-ext test' }
   ]
 });
 

--- a/.evergreen/run-bson-ext-test.sh
+++ b/.evergreen/run-bson-ext-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+[ -s "$PROJECT_DIRECTORY/node-artifacts/nvm/nvm.sh" ] && source "$PROJECT_DIRECTORY"/node-artifacts/nvm/nvm.sh
+
+npm install bson-ext
+
+export MONGODB_URI=${MONGODB_URI}
+
+npm run check:test

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "kerberos": "^1.1.0",
     "mongodb-client-encryption": "^1.0.0",
     "snappy": "^6.1.1",
-    "bson-ext": "^2.0.0"
+    "bson-ext": "^4.0.0"
   },
   "dependencies": {
     "bson": "^4.2.2",

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -1,11 +1,14 @@
 import type { OperationParent } from './operations/command';
-// import type * as _BSON from 'bson';
-// let BSON: typeof _BSON = require('bson');
-// try {
-//   BSON = require('bson-ext');
-// } catch {} // eslint-disable-line
 
-// export = BSON;
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+let BSON = require('bson');
+try {
+  BSON = require('bson-ext');
+} catch {} // eslint-disable-line
+
+export const deserialize = BSON.deserialize as typeof import('bson').deserialize;
+export const serialize = BSON.serialize as typeof import('bson').serialize;
+export const calculateObjectSize = BSON.calculateObjectSize as typeof import('bson').calculateObjectSize;
 
 export {
   Long,
@@ -22,42 +25,21 @@ export {
   BSONRegExp,
   BSONSymbol,
   Map,
-  deserialize,
-  serialize,
-  calculateObjectSize
+  Document
 } from 'bson';
 
-/** @public */
-export interface Document {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-}
+import type { DeserializeOptions, SerializeOptions } from 'bson';
 
-import type { SerializeOptions } from 'bson';
-
-// TODO: Remove me when types from BSON are updated
 /**
  * BSON Serialization options.
  * @public
  */
-export interface BSONSerializeOptions extends Omit<SerializeOptions, 'index'> {
-  /** Return document results as raw BSON buffers */
-  fieldsAsRaw?: { [key: string]: boolean };
-  /** Promotes BSON values to native types where possible, set to false to only receive wrapper types */
-  promoteValues?: boolean;
-  /** Promotes Binary BSON values to native Node Buffers */
-  promoteBuffers?: boolean;
-  /** Promotes long values to number if they fit inside the 53 bits resolution */
-  promoteLongs?: boolean;
-  /** Serialize functions on any object */
-  serializeFunctions?: boolean;
-  /** Specify if the BSON serializer should ignore undefined fields */
-  ignoreUndefined?: boolean;
-
+export interface BSONOptions extends Omit<SerializeOptions, 'index'>, DeserializeOptions {
+  /** Return BSON filled buffers from operations */
   raw?: boolean;
 }
 
-export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSerializeOptions {
+export function pluckBSONSerializeOptions(options: BSONOptions): BSONOptions {
   const {
     fieldsAsRaw,
     promoteValues,
@@ -84,10 +66,7 @@ export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSe
  *
  * @internal
  */
-export function resolveBSONOptions(
-  options?: BSONSerializeOptions,
-  parent?: OperationParent
-): BSONSerializeOptions {
+export function resolveBSONOptions(options?: BSONOptions, parent?: OperationParent): BSONOptions {
   const parentOptions = parent?.bsonOptions;
   return {
     raw: options?.raw ?? parentOptions?.raw ?? false,

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1,5 +1,5 @@
 import { PromiseProvider } from '../promise_provider';
-import { Long, ObjectId, Document, BSONSerializeOptions, resolveBSONOptions } from '../bson';
+import { Long, ObjectId, Document, BSONOptions, resolveBSONOptions } from '../bson';
 import { MongoError, MongoWriteConcernError, AnyError, MONGODB_ERROR_CODES } from '../error';
 import {
   applyRetryableWrites,
@@ -831,7 +831,7 @@ export interface BulkOperationPrivate {
   // Options
   options: BulkWriteOptions;
   // BSON options
-  bsonOptions: BSONSerializeOptions;
+  bsonOptions: BSONOptions;
   // Document used to build a bulk operation
   currentOp?: Document;
   // Executed
@@ -1130,7 +1130,7 @@ export abstract class BulkOperationBase {
     );
   }
 
-  get bsonOptions(): BSONSerializeOptions {
+  get bsonOptions(): BSONOptions {
     return this.s.bsonOptions;
   }
 

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -6,7 +6,7 @@ import { AuthProvider, AuthContext } from './auth_provider';
 import { MongoCredentials } from './mongo_credentials';
 import { MongoError } from '../../error';
 import { maxWireVersion, Callback, ns } from '../../utils';
-import type { BSONSerializeOptions } from '../../bson';
+import type { BSONOptions } from '../../bson';
 
 import { aws4 } from '../../deps';
 import { AuthMechanism } from './defaultAuthProviders';
@@ -15,7 +15,7 @@ const ASCII_N = 110;
 const AWS_RELATIVE_URI = 'http://169.254.170.2';
 const AWS_EC2_URI = 'http://169.254.169.254';
 const AWS_EC2_PATH = '/latest/meta-data/iam/security-credentials';
-const bsonOptions: BSONSerializeOptions = {
+const bsonOptions: BSONOptions = {
   promoteLongs: true,
   promoteValues: true,
   promoteBuffers: false

--- a/src/cmap/commands.ts
+++ b/src/cmap/commands.ts
@@ -2,7 +2,7 @@ import { ReadPreference } from '../read_preference';
 import * as BSON from '../bson';
 import { databaseNamespace } from '../utils';
 import { OP_QUERY, OP_GETMORE, OP_KILL_CURSORS, OP_MSG } from './wire_protocol/constants';
-import type { Long, Document, BSONSerializeOptions } from '../bson';
+import type { Long, Document, BSONOptions } from '../bson';
 import type { ClientSession } from '../sessions';
 import type { CommandOptions } from './connection';
 import { MongoError } from '../error';
@@ -463,7 +463,7 @@ export interface MessageHeader {
   fromCompressed?: boolean;
 }
 
-export interface OpResponseOptions extends BSONSerializeOptions {
+export interface OpResponseOptions extends BSONOptions {
   raw?: boolean;
   documentsReturnedIn?: string | null;
 }
@@ -550,7 +550,7 @@ export class Response {
     let bsonSize;
 
     // Set up the options
-    const _options: BSONSerializeOptions = {
+    const _options: BSONOptions = {
       promoteLongs: promoteLongs,
       promoteValues: promoteValues,
       promoteBuffers: promoteBuffers
@@ -818,7 +818,7 @@ export class BinMsg {
     const promoteBuffers = options.promoteBuffers ?? this.opts.promoteBuffers;
 
     // Set up the options
-    const _options: BSONSerializeOptions = {
+    const _options: BSONOptions = {
       promoteLongs: promoteLongs,
       promoteValues: promoteValues,
       promoteBuffers: promoteBuffers

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -33,7 +33,7 @@ import {
   OpQueryOptions,
   Msg
 } from './commands';
-import { BSONSerializeOptions, Document, Long, pluckBSONSerializeOptions } from '../bson';
+import { BSONOptions, Document, Long, pluckBSONSerializeOptions } from '../bson';
 import type { AutoEncrypter } from '../deps';
 import type { MongoCredentials } from './auth/mongo_credentials';
 import type { Stream } from './connect';
@@ -55,7 +55,7 @@ const kIsMaster = Symbol('ismaster');
 const kAutoEncrypter = Symbol('autoEncrypter');
 
 /** @internal */
-export interface QueryOptions extends BSONSerializeOptions {
+export interface QueryOptions extends BSONOptions {
   readPreference: ReadPreference;
   documentsReturnedIn?: string;
   batchSize?: number;
@@ -72,7 +72,7 @@ export interface QueryOptions extends BSONSerializeOptions {
 }
 
 /** @public */
-export interface CommandOptions extends BSONSerializeOptions {
+export interface CommandOptions extends BSONOptions {
   command?: boolean;
   slaveOk?: boolean;
   /** Specify read preference if command supports it */

--- a/src/cmap/message_stream.ts
+++ b/src/cmap/message_stream.ts
@@ -10,7 +10,7 @@ import {
   CompressorName,
   CompressorId
 } from './wire_protocol/compression';
-import type { Document, BSONSerializeOptions } from '../bson';
+import type { Document, BSONOptions } from '../bson';
 import { BufferPool, Callback } from '../utils';
 import type { ClientSession } from '../sessions';
 
@@ -26,7 +26,7 @@ export interface MessageStreamOptions extends DuplexOptions {
 }
 
 /** @internal */
-export interface OperationDescription extends BSONSerializeOptions {
+export interface OperationDescription extends BSONOptions {
   started: number;
   cb: Callback<Document>;
   command: boolean;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -7,7 +7,7 @@ import {
   Callback,
   getTopology
 } from './utils';
-import { Document, BSONSerializeOptions, resolveBSONOptions } from './bson';
+import { Document, BSONOptions, resolveBSONOptions } from './bson';
 import { MongoError } from './error';
 import { UnorderedBulkOperation } from './bulk/unordered';
 import { OrderedBulkOperation } from './bulk/ordered';
@@ -91,10 +91,7 @@ import { FindCursor } from './cursor/find_cursor';
 import type { CountOptions } from './operations/count';
 
 /** @public */
-export interface CollectionOptions
-  extends BSONSerializeOptions,
-    WriteConcernOptions,
-    LoggerOptions {
+export interface CollectionOptions extends BSONOptions, WriteConcernOptions, LoggerOptions {
   slaveOk?: boolean;
   /** Returns an error if the collection does not exist */
   strict?: boolean;
@@ -111,7 +108,7 @@ export interface CollectionPrivate {
   options: any;
   namespace: MongoDBNamespace;
   readPreference?: ReadPreference;
-  bsonOptions: BSONSerializeOptions;
+  bsonOptions: BSONOptions;
   slaveOk?: boolean;
   collectionHint?: Hint;
   readConcern?: ReadConcern;
@@ -216,7 +213,7 @@ export class Collection {
     return this.s.readPreference;
   }
 
-  get bsonOptions(): BSONSerializeOptions {
+  get bsonOptions(): BSONOptions {
     return this.s.bsonOptions;
   }
 

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -1,5 +1,5 @@
 import { Callback, maybePromise, MongoDBNamespace, ns } from '../utils';
-import { Long, Document, BSONSerializeOptions, pluckBSONSerializeOptions } from '../bson';
+import { Long, Document, BSONOptions, pluckBSONSerializeOptions } from '../bson';
 import { ClientSession } from '../sessions';
 import { MongoError } from '../error';
 import { ReadPreference, ReadPreferenceLike } from '../read_preference';
@@ -48,7 +48,7 @@ export interface CursorStreamOptions {
 export type CursorFlag = typeof CURSOR_FLAGS[number];
 
 /** @public */
-export interface AbstractCursorOptions extends BSONSerializeOptions {
+export interface AbstractCursorOptions extends BSONOptions {
   session?: ClientSession;
   readPreference?: ReadPreferenceLike;
   readConcern?: ReadConcernLike;

--- a/src/db.ts
+++ b/src/db.ts
@@ -8,7 +8,7 @@ import {
 } from './utils';
 import { loadAdmin } from './dynamic_loaders';
 import { AggregationCursor } from './cursor/aggregation_cursor';
-import { Document, BSONSerializeOptions, resolveBSONOptions } from './bson';
+import { Document, BSONOptions, resolveBSONOptions } from './bson';
 import { ReadPreference, ReadPreferenceLike } from './read_preference';
 import { MongoError } from './error';
 import { Collection, CollectionOptions } from './collection';
@@ -82,13 +82,13 @@ export interface DbPrivate {
   readPreference?: ReadPreference;
   pkFactory: PkFactory;
   readConcern?: ReadConcern;
-  bsonOptions: BSONSerializeOptions;
+  bsonOptions: BSONOptions;
   writeConcern?: WriteConcern;
   namespace: MongoDBNamespace;
 }
 
 /** @public */
-export interface DbOptions extends BSONSerializeOptions, WriteConcernOptions, LoggerOptions {
+export interface DbOptions extends BSONOptions, WriteConcernOptions, LoggerOptions {
   /** If the database authentication is dependent on another databaseName. */
   authSource?: string;
   /** Force server to assign _id values instead of driver. */
@@ -201,7 +201,7 @@ export class Db {
     return this.s.readPreference;
   }
 
-  get bsonOptions(): BSONSerializeOptions {
+  get bsonOptions(): BSONOptions {
     return this.s.bsonOptions;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ export { SrvPollingEvent } from './sdam/srv_polling';
 
 // type only exports below, these are removed from emitted JS
 export type { AdminPrivate } from './admin';
-export type { Document, BSONSerializeOptions } from './bson';
+export type { Document, BSONOptions as BSONSerializeOptions } from './bson';
 export type {
   InsertOneModel,
   ReplaceOneModel,

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -16,7 +16,7 @@ import { connect, MONGO_CLIENT_EVENTS } from './operations/connect';
 import { PromiseProvider } from './promise_provider';
 import type { Logger, LoggerLevelId } from './logger';
 import type { ReadConcern, ReadConcernLevelId, ReadConcernLike } from './read_concern';
-import { BSONSerializeOptions, Document, resolveBSONOptions } from './bson';
+import { BSONOptions, Document, resolveBSONOptions } from './bson';
 import type { AutoEncrypter, AutoEncryptionOptions } from './deps';
 import type { AuthMechanismId } from './cmap/auth/defaultAuthProviders';
 import type { Topology, TopologyEvents } from './sdam/topology';
@@ -98,7 +98,7 @@ export type SupportedNodeConnectionOptions = SupportedTLSConnectionOptions &
  * @public
  * @see https://docs.mongodb.com/manual/reference/connection-string
  */
-export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeConnectionOptions {
+export interface MongoClientOptions extends BSONOptions, SupportedNodeConnectionOptions {
   /** Specifies the name of the replica set, if the mongod is a member of a replica set. */
   replicaSet?: string;
   /** Enables or disables TLS/SSL for the connection. */
@@ -246,7 +246,7 @@ export type WithSessionCallback = (session: ClientSession) => Promise<any> | voi
 export interface MongoClientPrivate {
   url: string;
   sessions: Set<ClientSession>;
-  bsonOptions: BSONSerializeOptions;
+  bsonOptions: BSONOptions;
   namespace: MongoDBNamespace;
   readonly options?: MongoOptions;
   readonly readConcern?: ReadConcern;
@@ -378,7 +378,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     return this.s.readPreference;
   }
 
-  get bsonOptions(): BSONSerializeOptions {
+  get bsonOptions(): BSONOptions {
     return this.s.bsonOptions;
   }
 

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -7,7 +7,7 @@ import { ClientSession, commandSupportsReadConcern } from '../sessions';
 import { MongoError } from '../error';
 import type { Logger } from '../logger';
 import type { Server } from '../sdam/server';
-import type { BSONSerializeOptions, Document } from '../bson';
+import type { BSONOptions, Document } from '../bson';
 import type { ReadConcernLike } from './../read_concern';
 import { Explain, ExplainOptions } from '../explain';
 
@@ -56,7 +56,7 @@ export interface OperationParent {
   writeConcern?: WriteConcern;
   readPreference?: ReadPreference;
   logger?: Logger;
-  bsonOptions?: BSONSerializeOptions;
+  bsonOptions?: BSONOptions;
 }
 
 /** @internal */

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -5,7 +5,7 @@ import { prepareDocs } from './common_functions';
 import type { Callback, MongoDBNamespace } from '../utils';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
-import type { ObjectId, Document, BSONSerializeOptions } from '../bson';
+import type { ObjectId, Document, BSONOptions } from '../bson';
 import type { BulkWriteOptions } from '../bulk/common';
 import { WriteConcern, WriteConcernOptions } from '../write_concern';
 import type { ClientSession } from '../sessions';
@@ -45,7 +45,7 @@ export class InsertOperation extends CommandOperation<Document> {
 }
 
 /** @public */
-export interface InsertOneOptions extends BSONSerializeOptions, WriteConcernOptions {
+export interface InsertOneOptions extends BSONOptions, WriteConcernOptions {
   /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
   bypassDocumentValidation?: boolean;
   /** Force server to assign _id values instead of driver. */

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -1,6 +1,6 @@
 import { ReadPreference, ReadPreferenceLike } from '../read_preference';
 import type { ClientSession } from '../sessions';
-import { Document, BSONSerializeOptions, resolveBSONOptions } from '../bson';
+import { Document, BSONOptions, resolveBSONOptions } from '../bson';
 import type { MongoDBNamespace, Callback } from '../utils';
 import type { Server } from '../sdam/server';
 
@@ -20,7 +20,7 @@ export interface OperationConstructor extends Function {
 }
 
 /** @public */
-export interface OperationOptions extends BSONSerializeOptions {
+export interface OperationOptions extends BSONOptions {
   /** Specify ClientSession for this command */
   session?: ClientSession;
   willRetryWrites?: boolean;
@@ -46,7 +46,7 @@ export abstract class AbstractOperation<TResult = any> {
   fullResponse?: boolean;
 
   // BSON serialization options
-  bsonOptions?: BSONSerializeOptions;
+  bsonOptions?: BSONOptions;
 
   // TODO: Each operation defines its own options, there should be better typing here
   options: Document;

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -44,7 +44,7 @@ import {
   TopologyClosedEvent,
   TopologyDescriptionChangedEvent
 } from './events';
-import type { Document, BSONSerializeOptions } from '../bson';
+import type { Document, BSONOptions } from '../bson';
 import type { MongoCredentials } from '../cmap/auth/mongo_credentials';
 import type { Transaction } from '../transactions';
 import type { CloseOptions } from '../cmap/connection_pool';
@@ -131,7 +131,7 @@ export interface TopologyPrivate {
 }
 
 /** @public */
-export interface TopologyOptions extends BSONSerializeOptions, ServerOptions {
+export interface TopologyOptions extends BSONOptions, ServerOptions {
   hosts: HostAddress[];
   retryWrites: boolean;
   retryReads: boolean;

--- a/test/unit/bson_import.test.js
+++ b/test/unit/bson_import.test.js
@@ -1,0 +1,48 @@
+'use strict';
+const { expect } = require('chai');
+const BSON = require('../../src/bson');
+
+describe('BSON Library Import', function () {
+  it('should import bson-ext if it exists', function () {
+    try {
+      require('bson-ext');
+    } catch (_) {
+      this.skip();
+    }
+    expect(BSON.deserialize).to.be.a('function');
+    expect(BSON.serialize).to.be.a('function');
+    expect(BSON.calculateObjectSize).to.be.a('function');
+    // Confirms we are using the bson-ext library
+    expect(BSON.deserialize.toString()).to.include('[native code]');
+    expect(BSON.serialize.toString()).to.include('[native code]');
+    expect(BSON.calculateObjectSize.toString()).to.include('[native code]');
+  });
+
+  it('bson-ext should correctly round trip a Long', function () {
+    try {
+      require('bson-ext');
+    } catch (_) {
+      this.skip();
+    }
+
+    const longValue = BSON.Long.fromNumber(2);
+
+    const roundTrip = BSON.deserialize(BSON.serialize({ longValue }));
+
+    expect(roundTrip).has.property('longValue');
+  });
+  it('should import js-bson if bson-ext does not exist', function () {
+    try {
+      require('bson-ext');
+      this.skip();
+      // eslint-disable-next-line no-empty
+    } catch (_) {}
+    expect(BSON.deserialize).to.be.a('function');
+    expect(BSON.serialize).to.be.a('function');
+    expect(BSON.calculateObjectSize).to.be.a('function');
+
+    expect(BSON.deserialize.toString()).to.not.include('[native code]');
+    expect(BSON.serialize.toString()).to.not.include('[native code]');
+    expect(BSON.calculateObjectSize.toString()).to.not.include('[native code]');
+  });
+});


### PR DESCRIPTION
bson-ext now gets imported automatically if it is installed.
Additionally:
I renamed the BSONSerializeOptions to BSONOptions since it is both the serialize and deserialize options. And I now have us rely on importing the types from the BSON library which brings through the documentation. 