### PR TITLE
fix(NODE-2944): Reintroduce bson-ext support

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -516,6 +516,16 @@ functions:
           rm -f ./prepare_client_encryption.sh
 
           MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
+  run bson-ext test:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        timeout_secs: 60
+        script: |
+          ${PREPARE_SHELL}
+
+          MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-bson-ext-test.sh
   upload test results:
     - command: attach.xunit_results
       params:
@@ -1353,6 +1363,18 @@ tasks:
           VERSION: '4.4'
           TOPOLOGY: server
       - func: run custom csfle tests
+  - name: run-bson-ext-test
+    tags:
+      - run-bson-ext-test
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_NAME: erbium
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          TOPOLOGY: server
+      - func: run bson-ext test
 buildvariants:
   - name: macos-1014-dubnium
     display_name: macOS 10.14 Node Dubnium

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1707,6 +1707,11 @@ buildvariants:
     run_on: ubuntu1804-test
     tasks:
       - run-custom-csfle-tests
+  - name: ubuntu1804-run-bson-ext-test
+    display_name: BSON EXT Test
+    run_on: ubuntu1804-test
+    tasks:
+      - run-bson-ext-test
   - name: mongosh_integration_tests
     display_name: mongosh integration tests
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1369,12 +1369,14 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
           TOPOLOGY: server
       - func: run bson-ext test
+        vars:
+          NODE_LTS_NAME: fermium
 buildvariants:
   - name: macos-1014-dubnium
     display_name: macOS 10.14 Node Dubnium

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -561,6 +561,17 @@ functions:
 
           MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
 
+  "run bson-ext test":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        timeout_secs: 60
+        script: |
+          ${PREPARE_SHELL}
+
+          MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-bson-ext-test.sh
+
   "upload test results":
     # Upload the xunit-format test results.
     - command: attach.xunit_results

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -533,6 +533,11 @@ BUILD_VARIANTS.push({
   display_name: 'Custom FLE Version Test',
   run_on: 'ubuntu1804-test',
   tasks: ['run-custom-csfle-tests']
+},{
+  name: 'ubuntu1804-run-bson-ext-test',
+  display_name: 'BSON EXT Test',
+  run_on: 'ubuntu1804-test',
+  tasks: ['run-bson-ext-test']
 });
 
 // singleton build variant for mongosh integration tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -604,7 +604,7 @@ SINGLETON_TASKS.push({
     {
       func: 'install dependencies',
       vars: {
-        NODE_LTS_NAME: 'erbium',
+        NODE_LTS_NAME: 'fermium',
       },
     },
     {
@@ -614,7 +614,11 @@ SINGLETON_TASKS.push({
         TOPOLOGY: 'server'
       }
     },
-    { func: 'run bson-ext test' }
+    { func: 'run bson-ext test',
+      vars: {
+        NODE_LTS_NAME: 'fermium',
+      }
+    }
   ]
 });
 

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -591,6 +591,28 @@ SINGLETON_TASKS.push({
   ]
 });
 
+// special case for custom BSON-ext test
+SINGLETON_TASKS.push({
+  name: 'run-bson-ext-test',
+  tags: ['run-bson-ext-test'],
+  commands: [
+    {
+      func: 'install dependencies',
+      vars: {
+        NODE_LTS_NAME: 'erbium',
+      },
+    },
+    {
+      func: 'bootstrap mongo-orchestration',
+      vars: {
+        VERSION: '4.4',
+        TOPOLOGY: 'server'
+      }
+    },
+    { func: 'run bson-ext test' }
+  ]
+});
+
 const fileData = yaml.safeLoad(fs.readFileSync(`${__dirname}/config.yml.in`, 'utf8'));
 fileData.tasks = (fileData.tasks || []).concat(BASE_TASKS).concat(TASKS).concat(SINGLETON_TASKS);
 fileData.buildvariants = (fileData.buildvariants || []).concat(BUILD_VARIANTS);

--- a/.evergreen/run-bson-ext-test.sh
+++ b/.evergreen/run-bson-ext-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Supported/used environment variables:
+#       SSL                     Set to enable SSL. Defaults to "nossl"
+#       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
+#       TEST_NPM_SCRIPT         Script to npm run. Defaults to "check:test"
+#       SKIP_DEPS               Skip installing dependencies
+#       NO_EXIT                 Don't exit early from tests that leak resources
+
+MONGODB_URI=${MONGODB_URI:-}
+TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-check:test}
+if [[ -z "${NO_EXIT}" ]]; then
+  TEST_NPM_SCRIPT="$TEST_NPM_SCRIPT -- --exit"
+fi
+
+# ssl setup
+SSL=${SSL:-nossl}
+if [ "$SSL" != "nossl" ]; then
+   export SSL_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
+   export SSL_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
+fi
+
+# run tests
+echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"
+
+if [[ -z "${SKIP_DEPS}" ]]; then
+  source "${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
+else
+  export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
+  NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
+  export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+  if [[ "$OS" == "Windows_NT" ]]; then
+    NVM_HOME=$(cygpath -m -a "$NVM_DIR")
+    export NVM_HOME
+    NVM_SYMLINK=$(cygpath -m -a "$NODE_ARTIFACTS_PATH/bin")
+    export NVM_SYMLINK
+    NVM_ARTIFACTS_PATH=$(cygpath -m -a "$NODE_ARTIFACTS_PATH/bin")
+    export NVM_ARTIFACTS_PATH
+    PATH=$(cygpath $NVM_SYMLINK):$(cygpath $NVM_HOME):$PATH
+    export PATH
+    echo "updated path on windows PATH=$PATH"
+  else
+    [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+  fi
+  echo "initializing NVM, NVM_DIR=$NVM_DIR"
+fi
+
+npm install bson-ext
+
+export MONGODB_API_VERSION=${MONGODB_API_VERSION}
+export MONGODB_URI=${MONGODB_URI}
+
+npm run "${TEST_NPM_SCRIPT}"

--- a/.evergreen/run-bson-ext-test.sh
+++ b/.evergreen/run-bson-ext-test.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+[ -s "$PROJECT_DIRECTORY/node-artifacts/nvm/nvm.sh" ] && source "$PROJECT_DIRECTORY"/node-artifacts/nvm/nvm.sh
+
 set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
@@ -6,7 +9,6 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       SSL                     Set to enable SSL. Defaults to "nossl"
 #       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
 #       TEST_NPM_SCRIPT         Script to npm run. Defaults to "check:test"
-#       SKIP_DEPS               Skip installing dependencies
 
 MONGODB_URI=${MONGODB_URI:-}
 TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-check:test}
@@ -20,28 +22,6 @@ fi
 
 # run tests
 echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"
-
-if [[ -z "${SKIP_DEPS}" ]]; then
-  source "${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
-else
-  export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
-  NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
-  export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
-  if [[ "$OS" == "Windows_NT" ]]; then
-    NVM_HOME=$(cygpath -m -a "$NVM_DIR")
-    export NVM_HOME
-    NVM_SYMLINK=$(cygpath -m -a "$NODE_ARTIFACTS_PATH/bin")
-    export NVM_SYMLINK
-    NVM_ARTIFACTS_PATH=$(cygpath -m -a "$NODE_ARTIFACTS_PATH/bin")
-    export NVM_ARTIFACTS_PATH
-    PATH=$(cygpath $NVM_SYMLINK):$(cygpath $NVM_HOME):$PATH
-    export PATH
-    echo "updated path on windows PATH=$PATH"
-  else
-    [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
-  fi
-  echo "initializing NVM, NVM_DIR=$NVM_DIR"
-fi
 
 npm install bson-ext
 

--- a/.evergreen/run-bson-ext-test.sh
+++ b/.evergreen/run-bson-ext-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -o xtrace   # Write all commands first to stderr
+set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported/used environment variables:
@@ -7,13 +7,9 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
 #       TEST_NPM_SCRIPT         Script to npm run. Defaults to "check:test"
 #       SKIP_DEPS               Skip installing dependencies
-#       NO_EXIT                 Don't exit early from tests that leak resources
 
 MONGODB_URI=${MONGODB_URI:-}
 TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-check:test}
-if [[ -z "${NO_EXIT}" ]]; then
-  TEST_NPM_SCRIPT="$TEST_NPM_SCRIPT -- --exit"
-fi
 
 # ssl setup
 SSL=${SSL:-nossl}

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -48,7 +48,9 @@ export interface BSONSerializeOptions
       | 'evalFunctions'
       | 'cacheFunctions'
       | 'cacheFunctionsCrc32'
+      | 'bsonRegExp'
       | 'allowObjectSmallerThanBufferSize'
+      | 'index'
     > {
   /** Return BSON filled buffers from operations */
   raw?: boolean;

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -1,10 +1,21 @@
-// import type * as _BSON from 'bson';
-// let BSON: typeof _BSON = require('bson');
-// try {
-//   BSON = require('bson-ext');
-// } catch {} // eslint-disable-line
+import type {
+  serialize as serializeFn,
+  deserialize as deserializeFn,
+  calculateObjectSize as calculateObjectSizeFn
+} from 'bson';
 
-// export = BSON;
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+let BSON = require('bson');
+try {
+  BSON = require('bson-ext');
+} catch {} // eslint-disable-line
+
+/** @internal */
+export const deserialize = BSON.deserialize as typeof deserializeFn;
+/** @internal */
+export const serialize = BSON.serialize as typeof serializeFn;
+/** @internal */
+export const calculateObjectSize = BSON.calculateObjectSize as typeof calculateObjectSizeFn;
 
 export {
   Long,
@@ -21,38 +32,26 @@ export {
   BSONRegExp,
   BSONSymbol,
   Map,
-  deserialize,
-  serialize,
-  calculateObjectSize
+  Document
 } from 'bson';
 
-/** @public */
-export interface Document {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-}
+import type { DeserializeOptions, SerializeOptions } from 'bson';
 
-import type { SerializeOptions } from 'bson';
-
-// TODO: Remove me when types from BSON are updated
 /**
  * BSON Serialization options.
  * @public
  */
-export interface BSONSerializeOptions extends Omit<SerializeOptions, 'index'> {
-  /** Return document results as raw BSON buffers */
-  fieldsAsRaw?: { [key: string]: boolean };
-  /** Promotes BSON values to native types where possible, set to false to only receive wrapper types */
-  promoteValues?: boolean;
-  /** Promotes Binary BSON values to native Node Buffers */
-  promoteBuffers?: boolean;
-  /** Promotes long values to number if they fit inside the 53 bits resolution */
-  promoteLongs?: boolean;
-  /** Serialize functions on any object */
-  serializeFunctions?: boolean;
-  /** Specify if the BSON serializer should ignore undefined fields */
-  ignoreUndefined?: boolean;
-
+export interface BSONSerializeOptions
+  extends Omit<SerializeOptions, 'index'>,
+    Omit<
+      DeserializeOptions,
+      | 'evalFunctions'
+      | 'cacheFunctions'
+      | 'cacheFunctionsCrc32'
+      | 'bsonRegExp'
+      | 'allowObjectSmallerThanBufferSize'
+    > {
+  /** Return BSON filled buffers from operations */
   raw?: boolean;
 }
 

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -48,7 +48,6 @@ export interface BSONSerializeOptions
       | 'evalFunctions'
       | 'cacheFunctions'
       | 'cacheFunctionsCrc32'
-      | 'bsonRegExp'
       | 'allowObjectSmallerThanBufferSize'
     > {
   /** Return BSON filled buffers from operations */

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,3 +358,4 @@ export type {
   MetaProjectionOperators,
   MetaSortOperators
 } from './mongo_types';
+export type { serialize, deserialize } from './bson';

--- a/test/benchmarks/driverBench/common.js
+++ b/test/benchmarks/driverBench/common.js
@@ -1,9 +1,10 @@
+/* eslint-disable no-restricted-modules */
 'use strict';
 
 const fs = require('fs');
 const path = require('path');
-const { MongoClient } = require('../../../src/mongo_client');
-const { GridFsBucket } = require('../../../src/gridfs-stream');
+const { MongoClient } = require('../../..');
+const { GridFSBucket } = require('../../..');
 
 const DB_NAME = 'perftest';
 const COLLECTION_NAME = 'corpus';
@@ -54,7 +55,7 @@ function dropCollection() {
 }
 
 function initBucket() {
-  this.bucket = new GridFsBucket(this.db);
+  this.bucket = new GridFSBucket(this.db);
 }
 
 function dropBucket() {

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -5,7 +5,13 @@ const MongoBench = require('../mongoBench');
 const Runner = MongoBench.Runner;
 const commonHelpers = require('./common');
 
-const BSON = require('bson');
+let BSON = require('bson');
+try {
+  BSON = require('bson-ext');
+} catch (_) {
+  // do not care
+}
+
 const { EJSON } = require('bson');
 
 const makeClient = commonHelpers.makeClient;
@@ -359,5 +365,8 @@ benchmarkRunner
       driverBench
     };
   })
-  .then(data => console.log(data))
+  .then(data => {
+    data.bsonType = BSON.serialize.toString().includes('native code') ? 'bson-ext' : 'js-bson';
+    console.log(data);
+  })
   .catch(err => console.error(err));

--- a/test/functional/insert.test.js
+++ b/test/functional/insert.test.js
@@ -1577,7 +1577,7 @@ describe('Insert', function () {
         var collection = db.collection('bson_types_insert_1');
 
         var document = {
-          symbol: new BSONSymbol('abcdefghijkl'),
+          string: 'abcdefghijkl',
           objid: new ObjectId('abcdefghijkl'),
           double: new Double(1),
           binary: new Binary(Buffer.from('hello world')),
@@ -1590,9 +1590,9 @@ describe('Insert', function () {
           expect(err).to.not.exist;
           test.ok(result);
 
-          collection.findOne({ symbol: new BSONSymbol('abcdefghijkl') }, function (err, doc) {
+          collection.findOne({ string: 'abcdefghijkl' }, function (err, doc) {
             expect(err).to.not.exist;
-            test.equal('abcdefghijkl', doc.symbol.toString());
+            test.equal('abcdefghijkl', doc.string.toString());
 
             collection.findOne({ objid: new ObjectId('abcdefghijkl') }, function (err, doc) {
               expect(err).to.not.exist;

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType } from 'tsd';
-import { BSONSerializeOptions, Document } from '../../src/bson';
+import type { BSONSerializeOptions, Document } from '../../src/bson';
 
 const options: BSONSerializeOptions = {};
 
@@ -10,7 +10,6 @@ expectType<boolean | undefined>(options.promoteLongs);
 expectType<boolean | undefined>(options.promoteBuffers);
 expectType<boolean | undefined>(options.promoteValues);
 expectType<Document | undefined>(options.fieldsAsRaw);
-expectType<boolean | undefined>(options.bsonRegExp);
 
 type PermittedBSONOptionKeys =
   | 'checkKeys'
@@ -19,7 +18,8 @@ type PermittedBSONOptionKeys =
   | 'promoteLongs'
   | 'promoteBuffers'
   | 'promoteValues'
-  | 'bsonRegExp';
+  | 'fieldsAsRaw'
+  | 'raw';
 
 const keys = (null as unknown) as PermittedBSONOptionKeys;
 // creates an explicit allow list assertion

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -1,0 +1,26 @@
+import { expectType } from 'tsd';
+import { BSONSerializeOptions, Document } from '../../src/bson';
+
+const options: BSONSerializeOptions = {};
+
+expectType<boolean | undefined>(options.checkKeys);
+expectType<boolean | undefined>(options.serializeFunctions);
+expectType<boolean | undefined>(options.ignoreUndefined);
+expectType<boolean | undefined>(options.promoteLongs);
+expectType<boolean | undefined>(options.promoteBuffers);
+expectType<boolean | undefined>(options.promoteValues);
+expectType<Document | undefined>(options.fieldsAsRaw);
+expectType<boolean | undefined>(options.bsonRegExp);
+
+type PermittedBSONOptionKeys =
+  | 'checkKeys'
+  | 'serializeFunctions'
+  | 'ignoreUndefined'
+  | 'promoteLongs'
+  | 'promoteBuffers'
+  | 'promoteValues'
+  | 'bsonRegExp';
+
+const keys = (null as unknown) as PermittedBSONOptionKeys;
+// creates an explicit allow list assertion
+expectType<keyof BSONSerializeOptions>(keys);

--- a/test/unit/bson_import.test.js
+++ b/test/unit/bson_import.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { expect } = require('chai');
+const BSON = require('../../src/bson');
+
+describe('BSON Library Import', function () {
+  it('should import bson-ext if it exists', function () {
+    try {
+      require('bson-ext');
+    } catch (_) {
+      this.skip();
+    }
+    expect(BSON.deserialize).to.be.a('function');
+    expect(BSON.serialize).to.be.a('function');
+    expect(BSON.calculateObjectSize).to.be.a('function');
+    // Confirms we are using the bson-ext library
+    expect(BSON.deserialize.toString()).to.include('[native code]');
+    expect(BSON.serialize.toString()).to.include('[native code]');
+    expect(BSON.calculateObjectSize.toString()).to.include('[native code]');
+  });
+
+  it('bson-ext should correctly round trip a Long', function () {
+    try {
+      require('bson-ext');
+    } catch (_) {
+      this.skip();
+    }
+
+    const longValue = BSON.Long.fromNumber(2);
+
+    const roundTrip = BSON.deserialize(BSON.serialize({ longValue }));
+
+    expect(roundTrip).has.property('longValue');
+  });
+  it('should import js-bson if bson-ext does not exist', function () {
+    try {
+      require('bson-ext');
+      this.skip();
+      // eslint-disable-next-line no-empty
+    } catch (_) {}
+    expect(BSON.deserialize).to.be.a('function');
+    expect(BSON.serialize).to.be.a('function');
+    expect(BSON.calculateObjectSize).to.be.a('function');
+
+    expect(BSON.deserialize.toString()).to.not.include('[native code]');
+    expect(BSON.serialize.toString()).to.not.include('[native code]');
+    expect(BSON.calculateObjectSize.toString()).to.not.include('[native code]');
+  });
+});

--- a/test/unit/bson_import.test.js
+++ b/test/unit/bson_import.test.js
@@ -3,47 +3,83 @@
 const { expect } = require('chai');
 const BSON = require('../../src/bson');
 
-describe('BSON Library Import', function () {
-  it('should import bson-ext if it exists', function () {
-    try {
-      require('bson-ext');
-    } catch (_) {
-      this.skip();
+function isBSONExtInstalled() {
+  try {
+    require.resolve('bson-ext');
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+describe('When importing BSON', function () {
+  const types = [
+    ['Long', 23],
+    ['ObjectId', '123456789123456789123456'],
+    ['Binary', Buffer.from('abc', 'ascii')],
+    ['Timestamp', 23],
+    ['Code', 'function(){}'],
+    ['MinKey', undefined],
+    ['MaxKey', undefined],
+    ['Decimal128', '2.34'],
+    ['Int32', 23],
+    ['Double', 2.3],
+    ['BSONRegExp', 'abc']
+  ];
+  // Omitted types since they're deprecated:
+  // BSONSymbol
+  // DBRef
+
+  const options = {
+    promoteValues: false,
+    bsonRegExp: true
+  };
+
+  function testTypes() {
+    for (const [type, ctorArg] of types) {
+      it(`should correctly round trip ${type}`, function () {
+        const typeCtor = BSON[type];
+        expect(typeCtor).to.be.a('function');
+        const doc = { key: new typeCtor(ctorArg) };
+        const outputDoc = BSON.deserialize(BSON.serialize(doc), options);
+        expect(outputDoc).to.have.property('key').that.is.instanceOf(typeCtor);
+        expect(outputDoc).to.deep.equal(doc);
+      });
     }
-    expect(BSON.deserialize).to.be.a('function');
-    expect(BSON.serialize).to.be.a('function');
-    expect(BSON.calculateObjectSize).to.be.a('function');
-    // Confirms we are using the bson-ext library
-    expect(BSON.deserialize.toString()).to.include('[native code]');
-    expect(BSON.serialize.toString()).to.include('[native code]');
-    expect(BSON.calculateObjectSize.toString()).to.include('[native code]');
+
+    it('should correctly round trip Map', function () {
+      expect(BSON.Map).to.be.a('function');
+      const doc = { key: new BSON.Map([['2', 2]]) };
+      const outputDoc = BSON.deserialize(BSON.serialize(doc));
+      expect(outputDoc).to.have.nested.property('key.2', 2);
+    });
+  }
+
+  describe('bson-ext should be imported if it exists', function () {
+    before(function () {
+      if (!isBSONExtInstalled()) {
+        this.skip();
+      }
+
+      expect(BSON.deserialize.toString()).to.include('[native code]');
+      expect(BSON.serialize.toString()).to.include('[native code]');
+      expect(BSON.calculateObjectSize.toString()).to.include('[native code]');
+    });
+
+    testTypes();
   });
 
-  it('bson-ext should correctly round trip a Long', function () {
-    try {
-      require('bson-ext');
-    } catch (_) {
-      this.skip();
-    }
+  describe('js-bson should be imported by default', function () {
+    before(function () {
+      if (isBSONExtInstalled()) {
+        this.skip();
+      }
 
-    const longValue = BSON.Long.fromNumber(2);
+      expect(BSON.deserialize.toString()).to.not.include('[native code]');
+      expect(BSON.serialize.toString()).to.not.include('[native code]');
+      expect(BSON.calculateObjectSize.toString()).to.not.include('[native code]');
+    });
 
-    const roundTrip = BSON.deserialize(BSON.serialize({ longValue }));
-
-    expect(roundTrip).has.property('longValue');
-  });
-  it('should import js-bson if bson-ext does not exist', function () {
-    try {
-      require('bson-ext');
-      this.skip();
-      // eslint-disable-next-line no-empty
-    } catch (_) {}
-    expect(BSON.deserialize).to.be.a('function');
-    expect(BSON.serialize).to.be.a('function');
-    expect(BSON.calculateObjectSize).to.be.a('function');
-
-    expect(BSON.deserialize.toString()).to.not.include('[native code]');
-    expect(BSON.serialize.toString()).to.not.include('[native code]');
-    expect(BSON.calculateObjectSize.toString()).to.not.include('[native code]');
+    testTypes();
   });
 });

--- a/test/unit/bson_import.test.js
+++ b/test/unit/bson_import.test.js
@@ -55,12 +55,14 @@ describe('When importing BSON', function () {
     });
   }
 
-  describe('bson-ext should be imported if it exists', function () {
+  describe('bson-ext', function () {
     before(function () {
       if (!isBSONExtInstalled()) {
         this.skip();
       }
+    });
 
+    it('should be imported if it exists', function () {
       expect(BSON.deserialize.toString()).to.include('[native code]');
       expect(BSON.serialize.toString()).to.include('[native code]');
       expect(BSON.calculateObjectSize.toString()).to.include('[native code]');
@@ -69,12 +71,14 @@ describe('When importing BSON', function () {
     testTypes();
   });
 
-  describe('js-bson should be imported by default', function () {
+  describe('js-bson', function () {
     before(function () {
       if (isBSONExtInstalled()) {
         this.skip();
       }
+    });
 
+    it('should be imported by default', function () {
       expect(BSON.deserialize.toString()).to.not.include('[native code]');
       expect(BSON.serialize.toString()).to.not.include('[native code]');
       expect(BSON.calculateObjectSize.toString()).to.not.include('[native code]');


### PR DESCRIPTION
- Update benchmark imports
- Add bson-ext test to CI

I've also updated the BSONSerializeOptions to use the options exported from our BSON library now, this pipes through the documentation from there so we don't have duplication. 

While I'm here, (and before the major release) how do we feel about renaming `BSONSerializeOptions` -> `BSONOptions`?
The truth is it is for both serialize and deserialize.