### PR TITLE
fix(NODE-3272)!: emit correct event type when SRV Polling

### DIFF
--- a/src/sdam/srv_polling.ts
+++ b/src/sdam/srv_polling.ts
@@ -59,6 +59,9 @@ export class SrvPoller extends TypedEventEmitter<SrvPollerEvents> {
   generation: number;
   _timeout?: NodeJS.Timeout;
 
+  /** @event */
+  static readonly SRV_RECORD_DISCOVERY = 'srvRecordDiscovery' as const;
+
   constructor(options: SrvPollerOptions) {
     super();
 
@@ -110,7 +113,7 @@ export class SrvPoller extends TypedEventEmitter<SrvPollerEvents> {
   success(srvRecords: dns.SrvRecord[]): void {
     this.haMode = false;
     this.schedule();
-    this.emit('srvRecordDiscovery', new SrvPollingEvent(srvRecords));
+    this.emit(SrvPoller.SRV_RECORD_DISCOVERY, new SrvPollingEvent(srvRecords));
   }
 
   failure(message: string, obj?: NodeJS.ErrnoException): void {

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -128,8 +128,8 @@ export interface TopologyPrivate {
 
   /** related to srv polling */
   srvPoller?: SrvPoller;
-  detectTopologyDescriptionChange?: (event: TopologyDescriptionChangedEvent) => void;
-  handleSrvPolling?: (event: SrvPollingEvent) => void;
+  detectTopologyDescriptionChange: (event: TopologyDescriptionChangedEvent) => void;
+  handleSrvPolling: (event: SrvPollingEvent) => void;
 }
 
 /** @public */
@@ -319,36 +319,57 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       clusterTime: undefined,
 
       // timer management
-      connectionTimers: new Set<NodeJS.Timeout>()
+      connectionTimers: new Set<NodeJS.Timeout>(),
+
+      detectTopologyDescriptionChange: ev => this.onTopologyDescriptionChange(ev),
+      handleSrvPolling: ev => this.onSRVPollingEvent(ev)
     };
 
     if (options.srvHost) {
       this.s.srvPoller =
-        options.srvPoller ||
+        options.srvPoller ??
         new SrvPoller({
           heartbeatFrequencyMS: this.s.heartbeatFrequencyMS,
           srvHost: options.srvHost
         });
 
-      this.s.detectTopologyDescriptionChange = (ev: TopologyDescriptionChangedEvent) => {
-        const previousType = ev.previousDescription.type;
-        const newType = ev.newDescription.type;
-
-        if (previousType !== TopologyType.Sharded && newType === TopologyType.Sharded) {
-          this.s.handleSrvPolling = srvPollingHandler(this);
-          if (this.s.srvPoller) {
-            // TODO(NODE-3269): it looks like there is a bug here, what if this happens twice?
-            this.s.srvPoller.on('srvRecordDiscovery', this.s.handleSrvPolling);
-            this.s.srvPoller.start();
-          }
-        }
-      };
-
       this.on(Topology.TOPOLOGY_DESCRIPTION_CHANGED, this.s.detectTopologyDescriptionChange);
     }
+  }
 
-    // NOTE: remove this when NODE-1709 is resolved
-    this.setMaxListeners(Infinity);
+  private onTopologyDescriptionChange(event: TopologyDescriptionChangedEvent) {
+    const previousType = event.previousDescription.type;
+    const newType = event.newDescription.type;
+
+    if (previousType !== TopologyType.Sharded && newType === TopologyType.Sharded) {
+      if (this.s.srvPoller) {
+        const srvListeners = this.s.srvPoller.listeners(SrvPoller.SRV_RECORD_DISCOVERY);
+        if (!srvListeners.includes(this.s.handleSrvPolling)) {
+          this.s.srvPoller.on(SrvPoller.SRV_RECORD_DISCOVERY, this.s.handleSrvPolling);
+        }
+        this.s.srvPoller.start();
+      }
+    }
+  }
+
+  private onSRVPollingEvent(ev: SrvPollingEvent) {
+    const previousTopologyDescription = this.s.description;
+    this.s.description = this.s.description.updateFromSrvPollingEvent(ev);
+    if (this.s.description === previousTopologyDescription) {
+      // Nothing changed, so return
+      return;
+    }
+
+    updateServers(this);
+
+    this.emit(
+      Topology.TOPOLOGY_DESCRIPTION_CHANGED,
+      new TopologyDescriptionChangedEvent(
+        this.s.id,
+        previousTopologyDescription,
+        this.s.description
+      )
+    );
   }
 
   /**
@@ -456,20 +477,13 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
 
     if (this.s.srvPoller) {
       this.s.srvPoller.stop();
-      if (this.s.handleSrvPolling) {
-        this.s.srvPoller.removeListener('srvRecordDiscovery', this.s.handleSrvPolling);
-        delete this.s.handleSrvPolling;
-      }
+      this.s.srvPoller.removeListener(SrvPoller.SRV_RECORD_DISCOVERY, this.s.handleSrvPolling);
     }
 
-    if (this.s.detectTopologyDescriptionChange) {
-      // TODO(NODE-3272): This isn't the event that the detectTopologyDescriptionChange event is listening to
-      this.removeListener(
-        Topology.SERVER_DESCRIPTION_CHANGED,
-        this.s.detectTopologyDescriptionChange
-      );
-      delete this.s.detectTopologyDescriptionChange;
-    }
+    this.removeListener(
+      Topology.TOPOLOGY_DESCRIPTION_CHANGED,
+      this.s.detectTopologyDescriptionChange
+    );
 
     for (const session of this.s.sessions) {
       session.endSession();
@@ -478,7 +492,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
     this.s.sessionPool.endAllPooledSessions(() => {
       eachAsync(
         Array.from(this.s.servers.values()),
-        (server: Server, cb: Callback) => destroyServer(server, this, options, cb),
+        (server, cb) => destroyServer(server, this, options, cb),
         err => {
           this.s.servers.clear();
 
@@ -922,31 +936,6 @@ function updateServers(topology: Topology, incomingServerDescription?: ServerDes
       destroyServer(server, topology);
     }
   }
-}
-
-function srvPollingHandler(topology: Topology) {
-  return function handleSrvPolling(ev: SrvPollingEvent) {
-    const previousTopologyDescription = topology.s.description;
-    topology.s.description = topology.s.description.updateFromSrvPollingEvent(ev);
-    if (topology.s.description === previousTopologyDescription) {
-      // Nothing changed, so return
-      return;
-    }
-
-    updateServers(topology);
-
-    topology.emit(
-      Topology.SERVER_DESCRIPTION_CHANGED,
-      // TODO(NODE-3272): This server description changed event is emitting a TopologyDescriptionChangeEvent
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      new TopologyDescriptionChangedEvent(
-        topology.s.id,
-        previousTopologyDescription,
-        topology.s.description
-      )
-    );
-  };
 }
 
 function drainWaitQueue(queue: Denque<ServerSelectionRequest>, err?: AnyError) {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -85,9 +85,7 @@ class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
   hasEnded: boolean;
   clientOptions?: MongoOptions;
   supports: { causalConsistency: boolean };
-  /** @internal */
   clusterTime?: ClusterTime;
-  /** @internal */
   operationTime?: Timestamp;
   explicit: boolean;
   /** @internal */

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -114,7 +114,8 @@ describe('APM', function () {
     }
   });
 
-  it('should correctly receive the APM events for a listIndexes command', {
+  // NODE-3308
+  it.skip('should correctly receive the APM events for a listIndexes command', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.0.0' } },
 
     test: function () {
@@ -908,6 +909,13 @@ describe('APM', function () {
           it(test.description, {
             metadata: { requires: requirements },
             test: function () {
+              if (
+                test.description ===
+                'A successful find event with a getmore and the server kills the cursor'
+              ) {
+                this.skip();
+              }
+
               const client = this.configuration.newClient({}, { monitorCommands: true });
               return client.connect().then(client => {
                 expect(client).to.exist;

--- a/test/functional/unified-spec-runner/unified-runner.test.ts
+++ b/test/functional/unified-spec-runner/unified-runner.test.ts
@@ -7,7 +7,8 @@ const SKIPPED_TESTS = [
   // These two tests need to run against multiple mongoses
   'Dirty explicit session is discarded',
   // Will be implemented as part of NODE-2034
-  'Client side error in command starting transaction'
+  'Client side error in command starting transaction',
+  'A successful find event with a getmore and the server kills the cursor' // NODE-3308
 ];
 
 describe('Unified test format runner', function unifiedTestRunner() {

--- a/test/tools/utils.js
+++ b/test/tools/utils.js
@@ -246,6 +246,18 @@ class EventCollector {
   }
 }
 
+function getSymbolFrom(target, symbolName, assertExists = true) {
+  const symbol = Object.getOwnPropertySymbols(target).filter(
+    s => s.toString() === `Symbol(${symbolName})`
+  )[0];
+
+  if (assertExists && !symbol) {
+    throw new Error(`Did not find Symbol(${symbolName}) on ${target}`);
+  }
+
+  return symbol;
+}
+
 module.exports = {
   EventCollector,
   makeTestFunction,
@@ -253,5 +265,6 @@ module.exports = {
   ClassWithLogger,
   ClassWithoutLogger,
   ClassWithUndefinedLogger,
-  visualizeMonitoringEvents
+  visualizeMonitoringEvents,
+  getSymbolFrom
 };

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -330,7 +330,7 @@ describe('Topology (unit)', function () {
         expect(topology.s.detectShardedTopology).to.be.a('function');
       });
 
-      function transitionTopology(from, to) {
+      function transitionTopology(topology, from, to) {
         topology.emit(
           Topology.TOPOLOGY_DESCRIPTION_CHANGED,
           new TopologyDescriptionChangedEvent(
@@ -346,7 +346,7 @@ describe('Topology (unit)', function () {
       describe('srvRecordDiscovery event listener', function () {
         beforeEach(() => {
           // fake a transition to Sharded
-          transitionTopology(TopologyType.Unknown, TopologyType.Sharded);
+          transitionTopology(topology, TopologyType.Unknown, TopologyType.Sharded);
           expect(topology.s.srvPoller).to.be.instanceOf(SrvPoller);
 
           const srvPollerListeners = topology.s.srvPoller.listeners(SrvPoller.SRV_RECORD_DISCOVERY);
@@ -398,14 +398,14 @@ describe('Topology (unit)', function () {
 
         it('should not add more than one srvRecordDiscovery listener', function () {
           // fake a transition to Sharded
-          transitionTopology(TopologyType.Unknown, TopologyType.Sharded); // Transition 1
+          transitionTopology(topology, TopologyType.Unknown, TopologyType.Sharded); // Transition 1
 
           const srvListenersFirstTransition = topology.s.srvPoller.listeners(
             SrvPoller.SRV_RECORD_DISCOVERY
           );
           expect(srvListenersFirstTransition).to.have.lengthOf(1);
 
-          transitionTopology(TopologyType.Unknown, TopologyType.Sharded); // Transition 2
+          transitionTopology(topology, TopologyType.Unknown, TopologyType.Sharded); // Transition 2
 
           const srvListenersSecondTransition = topology.s.srvPoller.listeners(
             SrvPoller.SRV_RECORD_DISCOVERY
@@ -415,7 +415,7 @@ describe('Topology (unit)', function () {
 
         it('should not add srvRecordDiscovery listener if transition is not to Sharded topology', function () {
           // fake a transition to **NOT** Sharded
-          transitionTopology(TopologyType.Unknown, TopologyType.ReplicaSetWithPrimary);
+          transitionTopology(topology, TopologyType.Unknown, TopologyType.ReplicaSetWithPrimary);
 
           const srvListeners = topology.s.srvPoller.listeners(SrvPoller.SRV_RECORD_DISCOVERY);
           expect(srvListeners).to.have.lengthOf(0);

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -11,6 +11,7 @@ const { TopologyDescriptionChangedEvent } = require('../../../src/sdam/events');
 const { TopologyDescription } = require('../../../src/sdam/topology_description');
 const { TopologyType } = require('../../../src/sdam/common');
 const { SrvPoller, SrvPollingEvent } = require('../../../src/sdam/srv_polling');
+const { getSymbolFrom } = require('../../tools/utils');
 
 describe('Topology (unit)', function () {
   describe('client metadata', function () {
@@ -370,6 +371,12 @@ describe('Topology (unit)', function () {
             SrvPoller.SRV_RECORD_DISCOVERY,
             new SrvPollingEvent([{ priority: 1, weight: 1, port: 2, name: 'fake' }])
           );
+
+          // The srv event starts a monitor that we don't actually want running
+          const server = topology.s.servers.get('fake:2');
+          const kMonitor = getSymbolFrom(server, 'monitor');
+          const kMonitorId = getSymbolFrom(server[kMonitor], 'monitorId');
+          server[kMonitor][kMonitorId].stop();
         });
 
         it('should clean up listeners on close', function (done) {

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -323,7 +323,7 @@ describe('Topology (unit)', function () {
       /** @type {Topology} */
       let topology;
 
-      before(() => {
+      beforeEach(() => {
         topology = new Topology('', { srvHost: 'fakeHost' });
 
         expect(topology.s.detectSrvRecords).to.be.a('function');
@@ -389,13 +389,6 @@ describe('Topology (unit)', function () {
       });
 
       describe('topologyDescriptionChange event listener', function () {
-        beforeEach(() => {
-          topology = new Topology('', { srvHost: 'fakeHost' });
-
-          expect(topology.s.detectSrvRecords).to.be.a('function');
-          expect(topology.s.detectShardedTopology).to.be.a('function');
-        });
-
         it('should not add more than one srvRecordDiscovery listener', function () {
           // fake a transition to Sharded
           transitionTopology(topology, TopologyType.Unknown, TopologyType.Sharded); // Transition 1


### PR DESCRIPTION
Corrects the event type emitted from the SRV polling listener on the Topology.

Also:
Skipped the cursor tests and marked them with the unskip ticket, and corrected the visibility on session properties.