### PR TITLE
fix(NODE-1502): Command monitoring commands should be copies

### DIFF
--- a/src/cmap/command_monitoring_events.ts
+++ b/src/cmap/command_monitoring_events.ts
@@ -1,4 +1,4 @@
-import { GetMore, KillCursor, Msg, Query, WriteProtocolMessageType } from './commands';
+import { GetMore, KillCursor, Msg, WriteProtocolMessageType } from './commands';
 import { calculateDurationInMs, deepCopy } from '../utils';
 import type { ConnectionPool } from './connection_pool';
 import type { Connection } from './connection';

--- a/src/cmap/command_monitoring_events.ts
+++ b/src/cmap/command_monitoring_events.ts
@@ -181,7 +181,7 @@ const OP_QUERY_KEYS = [
 function extractCommand(command: WriteProtocolMessageType): Document {
   if (command instanceof GetMore) {
     return {
-      getMore: command.cursorId,
+      getMore: deepCopy(command.cursorId),
       collection: collectionName(command),
       batchSize: command.numberToReturn
     };
@@ -190,15 +190,15 @@ function extractCommand(command: WriteProtocolMessageType): Document {
   if (command instanceof KillCursor) {
     return {
       killCursors: collectionName(command),
-      cursors: command.cursorIds
+      cursors: deepCopy(command.cursorIds)
     };
   }
 
   if (command instanceof Msg) {
-    return command.command;
+    return deepCopy(command.command);
   }
 
-  if (command.query && command.query.$query) {
+  if (command.query?.$query) {
     let result: Document;
     if (command.ns === 'admin.$cmd') {
       // up-convert legacy command
@@ -208,7 +208,7 @@ function extractCommand(command: WriteProtocolMessageType): Document {
       result = { find: collectionName(command) };
       Object.keys(LEGACY_FIND_QUERY_MAP).forEach(key => {
         if (typeof command.query[key] !== 'undefined') {
-          result[LEGACY_FIND_QUERY_MAP[key]] = command.query[key];
+          result[LEGACY_FIND_QUERY_MAP[key]] = deepCopy(command.query[key]);
         }
       });
     }
@@ -216,7 +216,7 @@ function extractCommand(command: WriteProtocolMessageType): Document {
     Object.keys(LEGACY_FIND_OPTIONS_MAP).forEach(key => {
       const legacyKey = key as keyof typeof LEGACY_FIND_OPTIONS_MAP;
       if (typeof command[legacyKey] !== 'undefined') {
-        result[LEGACY_FIND_OPTIONS_MAP[legacyKey]] = command[legacyKey];
+        result[LEGACY_FIND_OPTIONS_MAP[legacyKey]] = deepCopy(command[legacyKey]);
       }
     });
 

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -14,8 +14,7 @@ import {
   Callback,
   MongoDBNamespace,
   maxWireVersion,
-  HostAddress,
-  deepCopy
+  HostAddress
 } from '../utils';
 import {
   AnyError,
@@ -800,26 +799,25 @@ function write(
 
   // if command monitoring is enabled we need to modify the callback here
   if (conn.monitorCommands) {
-    const clonedCommand: WriteProtocolMessageType = deepCopy(command);
-    conn.emit(Connection.COMMAND_STARTED, new CommandStartedEvent(conn, clonedCommand));
+    conn.emit(Connection.COMMAND_STARTED, new CommandStartedEvent(conn, command));
 
     operationDescription.started = now();
     operationDescription.cb = (err, reply) => {
       if (err) {
         conn.emit(
           Connection.COMMAND_FAILED,
-          new CommandFailedEvent(conn, clonedCommand, err, operationDescription.started)
+          new CommandFailedEvent(conn, command, err, operationDescription.started)
         );
       } else {
         if (reply && (reply.ok === 0 || reply.$err)) {
           conn.emit(
             Connection.COMMAND_FAILED,
-            new CommandFailedEvent(conn, clonedCommand, reply, operationDescription.started)
+            new CommandFailedEvent(conn, command, reply, operationDescription.started)
           );
         } else {
           conn.emit(
             Connection.COMMAND_SUCCEEDED,
-            new CommandSucceededEvent(conn, clonedCommand, reply, operationDescription.started)
+            new CommandSucceededEvent(conn, command, reply, operationDescription.started)
           );
         }
       }

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -757,39 +757,6 @@ function streamIdentifier(stream: Stream) {
   return uuidV4().toString('hex');
 }
 
-// FIXME: ensure this does a deep copy
-function cloneCommand(command: WriteProtocolMessageType): WriteProtocolMessageType {
-  let clonedCommand: WriteProtocolMessageType;
-  if (command === null || command === undefined) {
-    clonedCommand = command;
-  } else if (command instanceof Query) {
-    clonedCommand = <Query>{ ...command };
-    clonedCommand.query = { ...command.query };
-    clonedCommand.returnFieldSelector = { ...command.returnFieldSelector };
-  } else if (command instanceof Msg) {
-    clonedCommand = <Msg>{ ...command };
-    clonedCommand.command = { ...command.command };
-    clonedCommand.options = { ...command.options };
-  } else if (command instanceof GetMore) {
-    clonedCommand = <GetMore>{ ...command };
-    // FIXME: get this deep copy to work
-    clonedCommand.cursorId = Long.fromNumber(command.cursorId.toNumber());
-  } else if (command instanceof KillCursor) {
-    //clonedCommand = _clone(command);
-    clonedCommand = <KillCursor>{ ...command };
-    // FIXME: get this deep copy to work
-    const cursorIds: Long[] = [];
-    command.cursorIds.forEach(id => {
-      cursorIds.push(id);
-    });
-    clonedCommand.cursorIds = cursorIds;
-  } else {
-    throw new Error(`Unrecognized command: ${command}`);
-  }
-
-  return clonedCommand as WriteProtocolMessageType;
-}
-
 function write(
   conn: Connection,
   command: WriteProtocolMessageType,

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -766,7 +766,6 @@ function write(
   if (typeof options === 'function') {
     callback = options;
   }
-  const clonedCommand = deepCopy(command);
 
   options = options ?? {};
   const operationDescription: OperationDescription = {
@@ -801,6 +800,7 @@ function write(
 
   // if command monitoring is enabled we need to modify the callback here
   if (conn.monitorCommands) {
+    const clonedCommand: WriteProtocolMessageType = deepCopy(command);
     conn.emit(Connection.COMMAND_STARTED, new CommandStartedEvent(conn, clonedCommand));
 
     operationDescription.started = now();

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -659,38 +659,37 @@ describe('APM', function () {
   });
 
   // NODE-1502
-  it('should not allow mutation of internal state from commands returned by event monitoring', {
-    metadata: { requires: { topology: ['single', 'replicaset'], mongodb: '>=3.0.0' } },
-    test: function () {
-      const self = this;
-      const started = [];
-      const succeeded = [];
-      const client = self.configuration.newClient(
-        { writeConcern: { w: 1 } },
-        { maxPoolSize: 1, monitorCommands: true }
-      );
-      client.on('commandStarted', filterForCommands('insert', started));
-      client.on('commandSucceeded', filterForCommands('insert', succeeded));
+  it('should not allow mutation of internal state from commands returned by event monitoring', function () {
+    const self = this;
+    const started = [];
+    const succeeded = [];
+    const client = self.configuration.newClient(
+      { writeConcern: { w: 1 } },
+      { maxPoolSize: 1, monitorCommands: true }
+    );
+    client.on('commandStarted', filterForCommands('insert', started));
+    client.on('commandSucceeded', filterForCommands('insert', succeeded));
 
-      return client.connect().then(client => {
-        const db = client.db(self.configuration.db);
-        let documentToInsert = { a: 1 };
-        return db
-          .collection('apm_test')
-          .insertOne(documentToInsert, { forceServerObjectId: true })
-          .then(r => {
-            // Check if the returned document is a clone of the original
-            expect(documentToInsert).to.not.equal(started[0].command.documents[0]);
+    return client.connect().then(client => {
+      const db = client.db(self.configuration.db);
+      let documentToInsert = { a: { b: 1 } };
+      return db
+        .collection('apm_test')
+        .insertOne(documentToInsert)
+        .then(r => {
+          expect(r).property('insertedId').to.exist;
+          expect(started.length).to.equal(1);
+          expect(documentToInsert).to.eql(started[0].command.documents[0]);
+          // Check if the returned document is a clone of the original
+          expect(documentToInsert).to.not.equal(started[0].command.documents[0]);
+          expect(documentToInsert.a).to.not.equal(started[0].command.documents[0].a);
 
-            expect(r).property('insertedId').to.exist;
-            expect(started.length).to.equal(1);
-            expect(started[0].commandName).to.equal('insert');
-            expect(started[0].command.insert).to.equal('apm_test');
-            expect(succeeded.length).to.equal(1);
-            return client.close();
-          });
-      });
-    }
+          expect(started[0].commandName).to.equal('insert');
+          expect(started[0].command.insert).to.equal('apm_test');
+          expect(succeeded.length).to.equal(1);
+          return client.close();
+        });
+    });
   });
 
   describe('spec tests', function () {

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -659,43 +659,40 @@ describe('APM', function () {
   });
 
   // NODE-1502
-  it('should not allow mutation of internal state from commands returned by event monitoring', {
-    metadata: {
-      /*requires: { mongodb: '>= 3.6.0' } */
-    },
-    test: function () {
-      const self = this;
-      const started = [];
-      const succeeded = [];
-      const client = self.configuration.newClient(
-        { writeConcern: { w: 1 } },
-        { maxPoolSize: 1, monitorCommands: true }
-      );
-      client.on('commandStarted', filterForCommands('insert', started));
-      client.on('commandSucceeded', filterForCommands('insert', succeeded));
-      let documentToInsert = { a: { b: 1 } };
-      return client
-        .connect()
-        .then(client => {
-          const db = client.db(self.configuration.db);
-          return db.collection('apm_test').insertOne(documentToInsert);
-        })
-        .then(r => {
-          expect(r).to.have.property('insertedId').that.is.an('object');
-          expect(started.length).to.equal(1);
-          // Check if contents of returned document are equal to document inserted (by value)
-          expect(documentToInsert).to.deep.equal(started[0].command.documents[0]);
-          // Check if the returned document is a clone of the original. This confirms that the
-          // reference is not the same.
-          expect(documentToInsert !== started[0].command.documents[0]).to.equal(true);
-          expect(documentToInsert.a !== started[0].command.documents[0].a).to.equal(true);
+  it('should not allow mutation of internal state from commands returned by event monitoring', function () {
+    const started = [];
+    const succeeded = [];
+    const client = this.configuration.newClient(
+      { writeConcern: { w: 1 } },
+      { maxPoolSize: 1, monitorCommands: true }
+    );
+    client.on('commandStarted', filterForCommands('insert', started));
+    client.on('commandSucceeded', filterForCommands('insert', succeeded));
+    let documentToInsert = { a: { b: 1 } };
+    return client
+      .connect()
+      .then(client => {
+        const db = client.db(this.configuration.db);
+        return db.collection('apm_test').insertOne(documentToInsert);
+      })
+      .then(r => {
+        expect(r).to.have.property('insertedId').that.is.an('object');
+        expect(started).to.have.lengthOf(1);
+        // Check if contents of returned document are equal to document inserted (by value)
+        expect(documentToInsert).to.deep.equal(started[0].command.documents[0]);
+        // Check if the returned document is a clone of the original. This confirms that the
+        // reference is not the same.
+        expect(documentToInsert !== started[0].command.documents[0]).to.equal(true);
+        expect(documentToInsert.a !== started[0].command.documents[0].a).to.equal(true);
 
-          expect(started[0].commandName).to.equal('insert');
-          expect(started[0].command.insert).to.equal('apm_test');
-          expect(succeeded.length).to.equal(1);
-          return client.close();
-        });
-    }
+        started[0].command.documents[0].a.b = 2;
+        expect(documentToInsert.a.b).to.equal(1);
+
+        expect(started[0].commandName).to.equal('insert');
+        expect(started[0].command.insert).to.equal('apm_test');
+        expect(succeeded).to.have.lengthOf(1);
+        return client.close();
+      });
   });
 
   describe('spec tests', function () {

--- a/test/functional/multiple_db.test.js
+++ b/test/functional/multiple_db.test.js
@@ -85,7 +85,9 @@ describe('Multiple Databases', function () {
             { returnDocument: ReturnDocument.AFTER },
             function (err) {
               expect(err).to.not.exist;
-              client.close(done);
+              collection.drop(() => {
+                client.close(done);
+              });
             }
           );
         });

--- a/test/unit/cmap/command_monitoring_events.test.js
+++ b/test/unit/cmap/command_monitoring_events.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const mock = require('../../tools/mock');
+const { connect } = require('../../../src/cmap/connect');
+const { Connection } = require('../../../src/cmap/connection');
+const { Msg, Query, GetMore, KillCursor } = require('../../../src/cmap/commands');
+const { CommandStartedEvent } = require('../../../src/cmap/command_monitoring_events');
+const { expect } = require('chai');
+const { Long } = require('bson');
+
+describe('Command Monitoring Events - unit/cmap', function () {
+  let server;
+  after(() => mock.cleanup());
+  before(() => mock.createServer().then(s => (server = s)));
+
+  it('should never hold references to commands passed into CommandStartedEvent objects', function (done) {
+    const commands = [
+      new Query('admin.$cmd', { a: { b: 10 }, $query: { b: 10 } }, {}),
+      new Query('hello', { a: { b: 10 }, $query: { b: 10 } }, {}),
+      new Msg('admin.$cmd', { b: { c: 20 } }, {}),
+      new Msg('hello', { b: { c: 20 } }, {}),
+      new GetMore('admin.$cmd', Long.fromNumber(10)),
+      new GetMore('hello', Long.fromNumber(10)),
+      new KillCursor('admin.$cmd', [Long.fromNumber(100), Long.fromNumber(200)]),
+      new KillCursor('hello', [Long.fromNumber(100), Long.fromNumber(200)])
+    ];
+
+    server.setMessageHandler(request => {
+      const doc = request.document;
+      if (doc.ismaster || doc.hello) {
+        request.reply(mock.DEFAULT_ISMASTER_36);
+      }
+
+      // blackhole all other requests
+    });
+
+    connect({ connectionType: Connection, hostAddress: server.hostAddress() }, (err, conn) => {
+      expect(err).to.be.undefined;
+      expect(conn).to.not.be.undefined;
+
+      commands.forEach(c => {
+        const ev = new CommandStartedEvent(conn, c);
+        if (c instanceof Query) {
+          if (c.ns === 'admin.$cmd') {
+            expect(ev.command !== c.query.$query).to.equal(true);
+            for (const k in c.query.$query) {
+              expect(ev.command[k]).to.deep.equal(c.query.$query[k]);
+            }
+          } else {
+            expect(ev.command.filter !== c.query.$query).to.equal(true);
+            for (const k in c.query.$query) {
+              expect(ev.command.filter[k]).to.deep.equal(c.query.$query[k]);
+            }
+          }
+        } else if (c instanceof Msg) {
+          expect(ev.command !== c.command).to.equal(true);
+          expect(ev.command).to.deep.equal(c.command);
+        } else if (c instanceof GetMore) {
+          // NOTE: BSON Longs pass strict equality when their internal values are equal
+          // i.e.
+          // let l1 = Long(10);
+          // let l2 = Long(10);
+          // l1 === l2 // returns true
+          // expect(ev.command.getMore !== c.cursorId).to.equal(true);
+          expect(ev.command.getMore).to.deep.equal(c.cursorId);
+
+          ev.command.getMore = Long.fromNumber(50128);
+          expect(c.cursorId).to.not.deep.equal(ev.command.getMore);
+        } else if (c instanceof KillCursor) {
+          expect(ev.command.cursors !== c.cursorIds).to.equal(true);
+          expect(ev.command.cursors).to.deep.equal(c.cursorIds);
+        }
+      });
+
+      done();
+    });
+  });
+});

--- a/test/unit/cmap/command_monitoring_events.test.js
+++ b/test/unit/cmap/command_monitoring_events.test.js
@@ -19,47 +19,46 @@ describe('Command Monitoring Events - unit/cmap', function () {
     { ns: 'hello there', f1: { h: { a: 52, b: { c: 10, d: [1, 2, 3, 5] } } } }
   ];
 
-  commands.forEach(c => {
-    it(`should make a deep copy of object of type: ${c.constructor.name}`, done => {
-      const ev = new CommandStartedEvent({ id: 'someId', address: 'someHost' }, c);
-      if (c instanceof Query) {
-        if (c.ns === 'admin.$cmd') {
-          expect(ev.command !== c.query.$query).to.equal(true);
-          for (const k in c.query.$query) {
-            expect(ev.command[k]).to.deep.equal(c.query.$query[k]);
+  for (const command of commands) {
+    it(`should make a deep copy of object of type: ${command.constructor.name}`, () => {
+      const ev = new CommandStartedEvent({ id: 'someId', address: 'someHost' }, command);
+      if (command instanceof Query) {
+        if (command.ns === 'admin.$cmd') {
+          expect(ev.command !== command.query.$query).to.equal(true);
+          for (const k in command.query.$query) {
+            expect(ev.command[k]).to.deep.equal(command.query.$query[k]);
           }
         } else {
-          expect(ev.command.filter !== c.query.$query).to.equal(true);
-          for (const k in c.query.$query) {
-            expect(ev.command.filter[k]).to.deep.equal(c.query.$query[k]);
+          expect(ev.command.filter !== command.query.$query).to.equal(true);
+          for (const k in command.query.$query) {
+            expect(ev.command.filter[k]).to.deep.equal(command.query.$query[k]);
           }
         }
-      } else if (c instanceof Msg) {
-        expect(ev.command !== c.command).to.equal(true);
-        expect(ev.command).to.deep.equal(c.command);
-      } else if (c instanceof GetMore) {
+      } else if (command instanceof Msg) {
+        expect(ev.command !== command.command).to.equal(true);
+        expect(ev.command).to.deep.equal(command.command);
+      } else if (command instanceof GetMore) {
         // NOTE: BSON Longs pass strict equality when their internal values are equal
         // i.e.
         // let l1 = Long(10);
         // let l2 = Long(10);
         // l1 === l2 // returns true
-        // expect(ev.command.getMore !== c.cursorId).to.equal(true);
-        expect(ev.command.getMore).to.deep.equal(c.cursorId);
+        // expect(ev.command.getMore !== command.cursorId).to.equal(true);
+        expect(ev.command.getMore).to.deep.equal(command.cursorId);
 
         ev.command.getMore = Long.fromNumber(50128);
-        expect(c.cursorId).to.not.deep.equal(ev.command.getMore);
-      } else if (c instanceof KillCursor) {
-        expect(ev.command.cursors !== c.cursorIds).to.equal(true);
-        expect(ev.command.cursors).to.deep.equal(c.cursorIds);
-      } else if (typeof c === 'object') {
-        if (c.ns === 'admin.$cmd') {
-          expect(ev.command !== c.query.$query).to.equal(true);
-          for (const k in c.query.$query) {
-            expect(ev.command[k]).to.deep.equal(c.query.$query[k]);
+        expect(command.cursorId).to.not.deep.equal(ev.command.getMore);
+      } else if (command instanceof KillCursor) {
+        expect(ev.command.cursors !== command.cursorIds).to.equal(true);
+        expect(ev.command.cursors).to.deep.equal(command.cursorIds);
+      } else if (typeof command === 'object') {
+        if (command.ns === 'admin.$cmd') {
+          expect(ev.command !== command.query.$query).to.equal(true);
+          for (const k in command.query.$query) {
+            expect(ev.command[k]).to.deep.equal(command.query.$query[k]);
           }
         }
       }
-      done();
     });
-  });
+  }
 });

--- a/test/unit/cmap/command_monitoring_events.test.js
+++ b/test/unit/cmap/command_monitoring_events.test.js
@@ -1,77 +1,64 @@
 'use strict';
 
-const mock = require('../../tools/mock');
-const { connect } = require('../../../src/cmap/connect');
-const { Connection } = require('../../../src/cmap/connection');
 const { Msg, Query, GetMore, KillCursor } = require('../../../src/cmap/commands');
 const { CommandStartedEvent } = require('../../../src/cmap/command_monitoring_events');
 const { expect } = require('chai');
 const { Long } = require('bson');
 
 describe('Command Monitoring Events - unit/cmap', function () {
-  let server;
-  after(() => mock.cleanup());
-  before(() => mock.createServer().then(s => (server = s)));
+  const commands = [
+    new Query('admin.$cmd', { a: { b: 10 }, $query: { b: 10 } }, {}),
+    new Query('hello', { a: { b: 10 }, $query: { b: 10 } }, {}),
+    new Msg('admin.$cmd', { b: { c: 20 } }, {}),
+    new Msg('hello', { b: { c: 20 } }, {}),
+    new GetMore('admin.$cmd', Long.fromNumber(10)),
+    new GetMore('hello', Long.fromNumber(10)),
+    new KillCursor('admin.$cmd', [Long.fromNumber(100), Long.fromNumber(200)]),
+    new KillCursor('hello', [Long.fromNumber(100), Long.fromNumber(200)]),
+    { ns: 'admin.$cmd', query: { $query: { a: 16 } } },
+    { ns: 'hello there', f1: { h: { a: 52, b: { c: 10, d: [1, 2, 3, 5] } } } }
+  ];
 
-  it('should never hold references to commands passed into CommandStartedEvent objects', function (done) {
-    const commands = [
-      new Query('admin.$cmd', { a: { b: 10 }, $query: { b: 10 } }, {}),
-      new Query('hello', { a: { b: 10 }, $query: { b: 10 } }, {}),
-      new Msg('admin.$cmd', { b: { c: 20 } }, {}),
-      new Msg('hello', { b: { c: 20 } }, {}),
-      new GetMore('admin.$cmd', Long.fromNumber(10)),
-      new GetMore('hello', Long.fromNumber(10)),
-      new KillCursor('admin.$cmd', [Long.fromNumber(100), Long.fromNumber(200)]),
-      new KillCursor('hello', [Long.fromNumber(100), Long.fromNumber(200)])
-    ];
-
-    server.setMessageHandler(request => {
-      const doc = request.document;
-      if (doc.ismaster || doc.hello) {
-        request.reply(mock.DEFAULT_ISMASTER_36);
-      }
-
-      // blackhole all other requests
-    });
-
-    connect({ connectionType: Connection, hostAddress: server.hostAddress() }, (err, conn) => {
-      expect(err).to.be.undefined;
-      expect(conn).to.not.be.undefined;
-
-      commands.forEach(c => {
-        const ev = new CommandStartedEvent(conn, c);
-        if (c instanceof Query) {
-          if (c.ns === 'admin.$cmd') {
-            expect(ev.command !== c.query.$query).to.equal(true);
-            for (const k in c.query.$query) {
-              expect(ev.command[k]).to.deep.equal(c.query.$query[k]);
-            }
-          } else {
-            expect(ev.command.filter !== c.query.$query).to.equal(true);
-            for (const k in c.query.$query) {
-              expect(ev.command.filter[k]).to.deep.equal(c.query.$query[k]);
-            }
+  commands.forEach(c => {
+    it(`should make a deep copy of object of type: ${c.constructor.name}`, done => {
+      const ev = new CommandStartedEvent({ id: 'someId', address: 'someHost' }, c);
+      if (c instanceof Query) {
+        if (c.ns === 'admin.$cmd') {
+          expect(ev.command !== c.query.$query).to.equal(true);
+          for (const k in c.query.$query) {
+            expect(ev.command[k]).to.deep.equal(c.query.$query[k]);
           }
-        } else if (c instanceof Msg) {
-          expect(ev.command !== c.command).to.equal(true);
-          expect(ev.command).to.deep.equal(c.command);
-        } else if (c instanceof GetMore) {
-          // NOTE: BSON Longs pass strict equality when their internal values are equal
-          // i.e.
-          // let l1 = Long(10);
-          // let l2 = Long(10);
-          // l1 === l2 // returns true
-          // expect(ev.command.getMore !== c.cursorId).to.equal(true);
-          expect(ev.command.getMore).to.deep.equal(c.cursorId);
-
-          ev.command.getMore = Long.fromNumber(50128);
-          expect(c.cursorId).to.not.deep.equal(ev.command.getMore);
-        } else if (c instanceof KillCursor) {
-          expect(ev.command.cursors !== c.cursorIds).to.equal(true);
-          expect(ev.command.cursors).to.deep.equal(c.cursorIds);
+        } else {
+          expect(ev.command.filter !== c.query.$query).to.equal(true);
+          for (const k in c.query.$query) {
+            expect(ev.command.filter[k]).to.deep.equal(c.query.$query[k]);
+          }
         }
-      });
+      } else if (c instanceof Msg) {
+        expect(ev.command !== c.command).to.equal(true);
+        expect(ev.command).to.deep.equal(c.command);
+      } else if (c instanceof GetMore) {
+        // NOTE: BSON Longs pass strict equality when their internal values are equal
+        // i.e.
+        // let l1 = Long(10);
+        // let l2 = Long(10);
+        // l1 === l2 // returns true
+        // expect(ev.command.getMore !== c.cursorId).to.equal(true);
+        expect(ev.command.getMore).to.deep.equal(c.cursorId);
 
+        ev.command.getMore = Long.fromNumber(50128);
+        expect(c.cursorId).to.not.deep.equal(ev.command.getMore);
+      } else if (c instanceof KillCursor) {
+        expect(ev.command.cursors !== c.cursorIds).to.equal(true);
+        expect(ev.command.cursors).to.deep.equal(c.cursorIds);
+      } else if (typeof c === 'object') {
+        if (c.ns === 'admin.$cmd') {
+          expect(ev.command !== c.query.$query).to.equal(true);
+          for (const k in c.query.$query) {
+            expect(ev.command[k]).to.deep.equal(c.query.$query[k]);
+          }
+        }
+      }
       done();
     });
   });


### PR DESCRIPTION
## Description
Changed events for Command monitoring to hold copies of the commands instead of the commands themselves to prevent changing state in event monitoring by modifying `extractCommand` function in src/cmap/command_monitoring_events.ts

**What changed?**
- src/cmap/command_monitoring_events.ts
- test/functional/apm.test.js
- test/functional/multiple_db.test.js
- test/unit/cmap/command_monitoring_events.test.js