### PR TITLE
test(NODE-3118): run CSFLE integration tests from libmongocrypt repo

### DIFF
--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -58,6 +58,9 @@ npm install
 
 npm link mongodb-client-encryption
 
+# make a global link of mongodb
+npm link
+
 export MONGODB_URI=${MONGODB_URI}
 set +o errexit # We want to run both test suites even if the first fails
 npx mocha test/functional/client_side_encryption
@@ -72,7 +75,14 @@ pushd csfle-deps-tmp/libmongocrypt/bindings/node
 # these tests will start their own
 killall mongocryptd
 
-npm install
+npm install --ignore-scripts
+rm -rf build prebuilds
+npx node-gyp configure
+npx node-gyp build
+
+rm -rf node_modules/mongodb
+npm link mongodb
+
 # needs to be empty
 export MONGODB_NODE_SKIP_LIVE_TESTS=""
 # all of the below must be defined (as well as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)

--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -5,6 +5,10 @@ if [ -z ${AWS_ACCESS_KEY_ID+omitted} ]; then echo "AWS_ACCESS_KEY_ID is unset" &
 if [ -z ${AWS_SECRET_ACCESS_KEY+omitted} ]; then echo "AWS_SECRET_ACCESS_KEY is unset" && exit 1; fi
 if [ -z ${CSFLE_KMS_PROVIDERS+omitted} ]; then echo "CSFLE_KMS_PROVIDERS is unset" && exit 1; fi
 
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+export CSFLE_KMS_PROVIDERS=${CSFLE_KMS_PROVIDERS}
+
 [ -s "$PROJECT_DIRECTORY/node-artifacts/nvm/nvm.sh" ] && source "$PROJECT_DIRECTORY"/node-artifacts/nvm/nvm.sh
 
 set -o xtrace   # Write all commands first to stderr
@@ -40,12 +44,46 @@ pushd libmongocrypt/bindings/node
 source ./.evergreen/find_cmake.sh
 bash ./etc/build-static.sh
 
+npm install --ignore-scripts
+rm -rf build prebuilds
+npx node-gyp configure
+npx node-gyp build
+# make a global mongodb-client-encryption link
+npm link
+
 popd # libmongocrypt/bindings/node
 popd # csfle-deps-tmp
 
 npm install
 
-cp -r csfle-deps-tmp/libmongocrypt/bindings/node node_modules/mongodb-client-encryption
+npm link mongodb-client-encryption
 
 export MONGODB_URI=${MONGODB_URI}
+set +o errexit # We want to run both test suites even if the first fails
 npx mocha test/functional/client_side_encryption
+DRIVER_CSFLE_TEST_RESULT=$?
+set -o errexit
+
+# Great! our drivers tests pass but
+# there are tests inside the bindings repo that we also want to check
+
+pushd csfle-deps-tmp/libmongocrypt/bindings/node
+
+# these tests will start their own
+killall mongocryptd
+
+npm install
+# needs to be empty
+export MONGODB_NODE_SKIP_LIVE_TESTS=""
+# all of the below must be defined (as well as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)
+export AWS_REGION="us-east-1"
+export AWS_CMK_ID="arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+npm test
+
+popd # libmongocrypt/bindings/node
+
+# Exit the script in a way that will show evergreen a pass or fail
+if [ $DRIVER_CSFLE_TEST_RESULT -ne 0 ]; then
+  echo "Driver tests failed, look above for results"
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "check:kerberos": "mocha --config \"test/manual/mocharc.json\" test/manual/kerberos.test.js",
     "check:tls": "mocha --config \"test/manual/mocharc.json\" test/manual/tls_support.test.js",
     "check:ldap": "mocha --config \"test/manual/mocharc.json\" test/manual/ldap.test.js",
+    "check:csfle": "mocha test/functional/client_side_encryption",
     "prepare": "node etc/prepare.js",
     "release": "standard-version -i HISTORY.md",
     "test": "npm run check:lint && npm run check:test"

--- a/src/error.ts
+++ b/src/error.ts
@@ -71,6 +71,9 @@ export interface ErrorDescription {
 /**
  * @public
  * @category Error
+ *
+ * @privateRemarks
+ * CSFLE has a dependency on this error, it uses the constructor with a string argument
  */
 export class MongoError extends Error {
   /** @internal */
@@ -192,7 +195,8 @@ export class MongoNetworkError extends MongoError {
   }
 }
 
-interface MongoNetworkTimeoutErrorOptions {
+/** @public */
+export interface MongoNetworkTimeoutErrorOptions {
   /** Indicates the timeout happened before a connection handshake completed */
   beforeHandshake: boolean;
 }
@@ -201,6 +205,9 @@ interface MongoNetworkTimeoutErrorOptions {
  * An error indicating a network timeout occurred
  * @public
  * @category Error
+ *
+ * @privateRemarks
+ * CSFLE has a dependency on this error with an instanceof check
  */
 export class MongoNetworkTimeoutError extends MongoNetworkError {
   constructor(message: string, options?: MongoNetworkTimeoutErrorOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export {
   MongoServerError,
   MongoDriverError,
   MongoNetworkError,
+  MongoNetworkTimeoutError,
   MongoSystemError,
   MongoServerSelectionError,
   MongoParseError,
@@ -186,7 +187,7 @@ export type {
 } from './cursor/abstract_cursor';
 export type { DbPrivate, DbOptions } from './db';
 export type { AutoEncryptionOptions, AutoEncrypter } from './deps';
-export type { AnyError, ErrorDescription } from './error';
+export type { AnyError, ErrorDescription, MongoNetworkTimeoutErrorOptions } from './error';
 export type { Explain, ExplainOptions, ExplainVerbosityLike } from './explain';
 export type {
   GridFSBucketReadStream,

--- a/test/functional/client_side_encryption/driver.test.js
+++ b/test/functional/client_side_encryption/driver.test.js
@@ -22,6 +22,30 @@ describe('Client Side Encryption Functional', function () {
 
   it('CSFLE_KMS_PROVIDERS should be valid EJSON', function () {
     if (process.env.CSFLE_KMS_PROVIDERS) {
+      /**
+       * The shape of CSFLE_KMS_PROVIDERS is as follows:
+       *
+       * interface CSFLE_kms_providers {
+       *    aws: {
+       *      accessKeyId: string;
+       *      secretAccessKey: string;
+       *   };
+       *   azure: {
+       *     tenantId: string;
+       *     clientId: string;
+       *     clientSecret: string;
+       *   };
+       *   gcp: {
+       *     email: string;
+       *     privateKey: string;
+       *   };
+       *   local: {
+       *     // EJSON handle converting this, its actually the canonical -> { $binary: { base64: string; subType: string } }
+       *     // **NOTE**: The dollar sign has to be escaped when using this as an ENV variable
+       *     key: Binary;
+       *   }
+       * }
+       */
       expect(() => BSON.EJSON.parse(process.env.CSFLE_KMS_PROVIDERS)).to.not.throw(SyntaxError);
     } else {
       this.skip();

--- a/test/functional/client_side_encryption/driver.test.js
+++ b/test/functional/client_side_encryption/driver.test.js
@@ -20,6 +20,14 @@ describe('Client Side Encryption Functional', function () {
     }
   };
 
+  it('CSFLE_KMS_PROVIDERS should be valid EJSON', function () {
+    if (process.env.CSFLE_KMS_PROVIDERS) {
+      expect(() => BSON.EJSON.parse(process.env.CSFLE_KMS_PROVIDERS)).to.not.throw(SyntaxError);
+    } else {
+      this.skip();
+    }
+  });
+
   describe('BSON Options', function () {
     beforeEach(function () {
       this.client = this.configuration.newClient();

--- a/test/functional/client_side_encryption/spec.test.js
+++ b/test/functional/client_side_encryption/spec.test.js
@@ -39,7 +39,7 @@ describe('Client Side Encryption', function () {
       !spec.description.match(/type=regex/) &&
       !spec.description.match(/type=symbol/) &&
       !spec.description.match(/maxWireVersion < 8/) &&
-      !spec.description.match(/Count with deterministic encryption/) // NODE-TODO
+      !spec.description.match(/Count with deterministic encryption/) // TODO(NODE-3369): Unskip
     );
   });
 });

--- a/test/functional/client_side_encryption/spec.test.js
+++ b/test/functional/client_side_encryption/spec.test.js
@@ -38,7 +38,8 @@ describe('Client Side Encryption', function () {
     return (
       !spec.description.match(/type=regex/) &&
       !spec.description.match(/type=symbol/) &&
-      !spec.description.match(/maxWireVersion < 8/)
+      !spec.description.match(/maxWireVersion < 8/) &&
+      !spec.description.match(/Count with deterministic encryption/) // NODE-TODO
     );
   });
 });


### PR DESCRIPTION
The custom CSFLE test variant will now run the mocha tests defined in the libmongocrypt/bindings/node directory.

I also skipped the count documents test because the command monitoring exposed the fact that count is run with an aggregate and not a count operation. 
