### PR TITLE
fix(NODE-2035): exceptions thrown from awaited cursor forEach do not propagate

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -324,12 +324,12 @@ export abstract class AbstractCursor<
           if (doc == null) return done();
           let result;
           // NOTE: no need to transform because `next` will do this automatically
-          //try {
-          result = iterator(doc); // TODO(NODE-3283): Improve transform typing
-          /*} catch (e) {
+          try {
+            result = iterator(doc); // TODO(NODE-3283): Improve transform typing
+          } catch (e) {
             return done(e);
           }
-          */
+
           if (result === false) return done();
 
           // these do need to be transformed since they are copying the rest of the batch

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -324,20 +324,25 @@ export abstract class AbstractCursor<
           if (doc == null) return done();
           let result;
           // NOTE: no need to transform because `next` will do this automatically
-          try {
-            result = iterator(doc); // TODO(NODE-3283): Improve transform typing
-          } catch (e) {
+          //try {
+          result = iterator(doc); // TODO(NODE-3283): Improve transform typing
+          /*} catch (e) {
             return done(e);
           }
+          */
           if (result === false) return done();
 
           // these do need to be transformed since they are copying the rest of the batch
           const internalDocs = this[kDocuments].splice(0, this[kDocuments].length);
           if (internalDocs) {
             for (let i = 0; i < internalDocs.length; ++i) {
-              result = iterator(
-                (transform ? transform(internalDocs[i]) : internalDocs[i]) as T // TODO(NODE-3283): Improve transform typing
-              );
+              try {
+                result = iterator(
+                  (transform ? transform(internalDocs[i]) : internalDocs[i]) as T // TODO(NODE-3283): Improve transform typing
+                );
+              } catch (e) {
+                return done(e);
+              }
               if (result === false) return done();
             }
           }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -321,7 +321,6 @@ export abstract class AbstractCursor<
       const fetchDocs = () => {
         next<T>(this, true, (err, doc) => {
           if (err || doc == null) return done(err);
-          if (doc == null) return done();
           let result;
           // NOTE: no need to transform because `next` will do this automatically
           try {
@@ -334,17 +333,15 @@ export abstract class AbstractCursor<
 
           // these do need to be transformed since they are copying the rest of the batch
           const internalDocs = this[kDocuments].splice(0, this[kDocuments].length);
-          if (internalDocs) {
-            for (let i = 0; i < internalDocs.length; ++i) {
-              try {
-                result = iterator(
-                  (transform ? transform(internalDocs[i]) : internalDocs[i]) as T // TODO(NODE-3283): Improve transform typing
-                );
-              } catch (error) {
-                return done(error);
-              }
-              if (result === false) return done();
+          for (let i = 0; i < internalDocs.length; ++i) {
+            try {
+              result = iterator(
+                (transform ? transform(internalDocs[i]) : internalDocs[i]) as T // TODO(NODE-3283): Improve transform typing
+              );
+            } catch (error) {
+              return done(error);
             }
+            if (result === false) return done();
           }
 
           fetchDocs();

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -322,9 +322,13 @@ export abstract class AbstractCursor<
         next<T>(this, true, (err, doc) => {
           if (err || doc == null) return done(err);
           if (doc == null) return done();
-
+          let result;
           // NOTE: no need to transform because `next` will do this automatically
-          let result = iterator(doc); // TODO(NODE-3283): Improve transform typing
+          try {
+            result = iterator(doc); // TODO(NODE-3283): Improve transform typing
+          } catch (e) {
+            return done(e);
+          }
           if (result === false) return done();
 
           // these do need to be transformed since they are copying the rest of the batch

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -326,8 +326,8 @@ export abstract class AbstractCursor<
           // NOTE: no need to transform because `next` will do this automatically
           try {
             result = iterator(doc); // TODO(NODE-3283): Improve transform typing
-          } catch (e) {
-            return done(e);
+          } catch (error) {
+            return done(error);
           }
 
           if (result === false) return done();
@@ -340,8 +340,8 @@ export abstract class AbstractCursor<
                 result = iterator(
                   (transform ? transform(internalDocs[i]) : internalDocs[i]) as T // TODO(NODE-3283): Improve transform typing
                 );
-              } catch (e) {
-                return done(e);
+              } catch (error) {
+                return done(error);
               }
               if (result === false) return done();
             }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -625,7 +625,7 @@ export function maybePromise<T>(
       };
     });
   }
-
+  // FIXME: NODE-2035: when not provided with a callback, we return a promise with an unhandled erjection
   wrapper((err, res) => {
     if (err != null) {
       try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -625,7 +625,7 @@ export function maybePromise<T>(
       };
     });
   }
-  // FIXME: NODE-2035: when not provided with a callback, we return a promise with an unhandled erjection
+
   wrapper((err, res) => {
     if (err != null) {
       try {

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3924,9 +3924,14 @@ describe('Cursor', function () {
             .forEach(() => {
               throw new Error('FAILURE IN FOREACH CALL');
             })
-            .catch(err => {
-              expect(err.message).to.deep.equal('FAILURE IN FOREACH CALL');
-            });
+            .then(
+              () => {
+                expect(false).to.equal(true, 'Failed to catch error thrown in awaited forEach');
+              },
+              err => {
+                expect(err.message).to.deep.equal('FAILURE IN FOREACH CALL');
+              }
+            );
         }).to.not.throw();
       })
       .catch(console.error);

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3911,9 +3911,9 @@ describe('Cursor', function () {
       client = configuration.newClient({ w: 1 }, { maxPoolSize: 1 });
     });
 
-    afterEach(function () {
-      cursor.close();
-      client.close();
+    afterEach(async function () {
+      await cursor.close();
+      await client.close();
     });
 
     // NODE-2035

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3940,7 +3940,6 @@ describe('Cursor', function () {
           expect.fail('Error in forEach call not caught');
         })
         .catch(err => {
-          console.log(err.message);
           expect(err.message).to.deep.equal('FAILURE IN FOREACH CALL');
         });
     });

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3910,12 +3910,17 @@ describe('Cursor', function () {
     let db;
     return client
       .connect()
-      .then(() => {
-        this.defer(() => client.close());
-        db = client.db(configuration.db);
-        collection = db.collection('cursor_session_tests2');
-        return collection.insertMany(docs);
-      }, console.error)
+      .then(
+        () => {
+          this.defer(() => client.close());
+          db = client.db(configuration.db);
+          collection = db.collection('cursor_session_tests2');
+          return collection.insertMany(docs);
+        },
+        () => {
+          expect.fail('Failed to connect to client');
+        }
+      )
       .then(() => {
         const cursor = collection.find({});
         this.defer(() => cursor.close());
@@ -3935,7 +3940,7 @@ describe('Cursor', function () {
         }).to.not.throw();
       })
       .catch(() => {
-        expect.fail('Failed to make connection');
+        expect.fail('Failed to insert documents');
       });
   });
 

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3932,20 +3932,17 @@ describe('Cursor', function () {
           $exists: true
         }
       });
-      async function checkForEach() {
-        await cursor
-          .forEach(() => {
-            throw new Error('FAILURE IN FOREACH CALL');
-          })
-          .then(() => {
-            expect.fail('Error in forEach call not caught');
-          })
-          .catch(err => {
-            console.log(err.message);
-            expect(err.message).to.deep.equal('FAILURE IN FOREACH CALL');
-          });
-      }
-      await checkForEach();
+      await cursor
+        .forEach(() => {
+          throw new Error('FAILURE IN FOREACH CALL');
+        })
+        .then(() => {
+          expect.fail('Error in forEach call not caught');
+        })
+        .catch(err => {
+          console.log(err.message);
+          expect(err.message).to.deep.equal('FAILURE IN FOREACH CALL');
+        });
     });
   });
 

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3919,6 +3919,25 @@ describe('Cursor', function () {
     });
   });
 
+  it('should propagate error when exceptions are thrown from an awaited forEach call', function () {
+    const configuration = this.configuration;
+    const client = configuration.newClient({ w: 1 }, { maxPoolSize: 1 });
+    return client.connect().then(() => {
+      const db = client.db(configuration.db);
+      const collection = db.collection('cursor_session_tests2');
+      const cursor = collection.find();
+      //this.defer(() => );
+      async function testAsync() {
+        let val = await cursor.forEach(d => {
+          console.log('hello, this is a message');
+          throw new Error('FAILURE');
+        });
+        //console.log(val);
+      }
+      return testAsync().then(cursor.close);
+    });
+  });
+
   it('should return false when exhausted and hasNext called more than once', function (done) {
     const configuration = this.configuration;
     const client = configuration.newClient({ w: 1 }, { maxPoolSize: 1 });

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3918,19 +3918,19 @@ describe('Cursor', function () {
       .then(() => {
         const cursor = collection.find({});
         async function testAsync() {
-          let val;
+          let promiseResult;
           try {
-            val = await cursor
+            promiseResult = await cursor
               .forEach(() => {
                 throw new Error('FAILURE IN FOREACH CALL');
               })
               .catch(err => {
-                expect(err.message).to.eql('FAILURE IN FOREACH CALL');
+                expect(err.message).to.deep.equal('FAILURE IN FOREACH CALL');
               });
           } catch (err) {
-            expect(err).to.equal(undefined);
+            expect(err).to.be.undefined;
           }
-          expect(val).to.be.undefined;
+          expect(promiseResult).to.be.undefined;
           cursor.close();
           client.close();
         }

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3926,7 +3926,7 @@ describe('Cursor', function () {
             })
             .then(
               () => {
-                expect(false).to.equal(true, 'Failed to catch error thrown in awaited forEach');
+                expect.fail('Failed to catch error thrown in awaited forEach');
               },
               err => {
                 expect(err.message).to.deep.equal('FAILURE IN FOREACH CALL');
@@ -3934,7 +3934,9 @@ describe('Cursor', function () {
             );
         }).to.not.throw();
       })
-      .catch(console.error);
+      .catch(() => {
+        expect.fail('Failed to make connection');
+      });
   });
 
   it('should return a promise when no callback supplied to forEach method', function () {

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3932,16 +3932,20 @@ describe('Cursor', function () {
           $exists: true
         }
       });
-      expect(async function () {
+      async function checkForEach() {
         await cursor
           .forEach(() => {
             throw new Error('FAILURE IN FOREACH CALL');
+          })
+          .then(() => {
+            expect.fail('Error in forEach call not caught');
           })
           .catch(err => {
             console.log(err.message);
             expect(err.message).to.deep.equal('FAILURE IN FOREACH CALL');
           });
-      }).to.not.throw();
+      }
+      await checkForEach();
     });
   });
 


### PR DESCRIPTION
## Description
Catch and propagate exceptions in awaited cursor.forEach

**What changed?**
- src/cursor/abstract\_cursor.ts
- test/functional/cursor.js