### PR TITLE
fix(NODE-3150): allow retrieving PCRE-style RegExp

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -48,7 +48,6 @@ export interface BSONSerializeOptions
       | 'evalFunctions'
       | 'cacheFunctions'
       | 'cacheFunctionsCrc32'
-      | 'bsonRegExp'
       | 'allowObjectSmallerThanBufferSize'
       | 'index'
     > {
@@ -64,6 +63,7 @@ export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSe
     promoteLongs,
     serializeFunctions,
     ignoreUndefined,
+    bsonRegExp,
     raw
   } = options;
   return {
@@ -73,6 +73,7 @@ export function pluckBSONSerializeOptions(options: BSONSerializeOptions): BSONSe
     promoteLongs,
     serializeFunctions,
     ignoreUndefined,
+    bsonRegExp,
     raw
   };
 }
@@ -94,6 +95,7 @@ export function resolveBSONOptions(
     promoteValues: options?.promoteValues ?? parentOptions?.promoteValues ?? true,
     promoteBuffers: options?.promoteBuffers ?? parentOptions?.promoteBuffers ?? false,
     ignoreUndefined: options?.ignoreUndefined ?? parentOptions?.ignoreUndefined ?? false,
+    bsonRegExp: options?.bsonRegExp ?? parentOptions?.bsonRegExp ?? false,
     serializeFunctions: options?.serializeFunctions ?? parentOptions?.serializeFunctions ?? false,
     fieldsAsRaw: options?.fieldsAsRaw ?? parentOptions?.fieldsAsRaw ?? {}
   };

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -18,7 +18,8 @@ const AWS_EC2_PATH = '/latest/meta-data/iam/security-credentials';
 const bsonOptions: BSONSerializeOptions = {
   promoteLongs: true,
   promoteValues: true,
-  promoteBuffers: false
+  promoteBuffers: false,
+  bsonRegExp: false
 };
 
 interface AWSSaslContinuePayload {

--- a/src/cmap/commands.ts
+++ b/src/cmap/commands.ts
@@ -491,6 +491,7 @@ export class Response {
   promoteLongs: boolean;
   promoteValues: boolean;
   promoteBuffers: boolean;
+  bsonRegExp?: boolean;
   index?: number;
 
   constructor(
@@ -502,7 +503,12 @@ export class Response {
     this.parsed = false;
     this.raw = message;
     this.data = msgBody;
-    this.opts = opts ?? { promoteLongs: true, promoteValues: true, promoteBuffers: false };
+    this.opts = opts ?? {
+      promoteLongs: true,
+      promoteValues: true,
+      promoteBuffers: false,
+      bsonRegExp: false
+    };
 
     // Read the message header
     this.length = msgHeader.length;
@@ -530,6 +536,7 @@ export class Response {
       typeof this.opts.promoteValues === 'boolean' ? this.opts.promoteValues : true;
     this.promoteBuffers =
       typeof this.opts.promoteBuffers === 'boolean' ? this.opts.promoteBuffers : false;
+    this.bsonRegExp = typeof this.opts.bsonRegExp === 'boolean' ? this.opts.bsonRegExp : false;
   }
 
   isParsed(): boolean {
@@ -547,13 +554,15 @@ export class Response {
     const promoteLongs = options.promoteLongs ?? this.opts.promoteLongs;
     const promoteValues = options.promoteValues ?? this.opts.promoteValues;
     const promoteBuffers = options.promoteBuffers ?? this.opts.promoteBuffers;
+    const bsonRegExp = options.bsonRegExp ?? this.opts.bsonRegExp;
     let bsonSize;
 
     // Set up the options
     const _options: BSONSerializeOptions = {
-      promoteLongs: promoteLongs,
-      promoteValues: promoteValues,
-      promoteBuffers: promoteBuffers
+      promoteLongs,
+      promoteValues,
+      promoteBuffers,
+      bsonRegExp
     };
 
     // Position within OP_REPLY at which documents start
@@ -765,6 +774,7 @@ export class BinMsg {
   promoteLongs: boolean;
   promoteValues: boolean;
   promoteBuffers: boolean;
+  bsonRegExp: boolean;
   documents: (Document | Buffer)[];
   index?: number;
 
@@ -777,7 +787,12 @@ export class BinMsg {
     this.parsed = false;
     this.raw = message;
     this.data = msgBody;
-    this.opts = opts ?? { promoteLongs: true, promoteValues: true, promoteBuffers: false };
+    this.opts = opts ?? {
+      promoteLongs: true,
+      promoteValues: true,
+      promoteBuffers: false,
+      bsonRegExp: false
+    };
 
     // Read the message header
     this.length = msgHeader.length;
@@ -796,6 +811,7 @@ export class BinMsg {
       typeof this.opts.promoteValues === 'boolean' ? this.opts.promoteValues : true;
     this.promoteBuffers =
       typeof this.opts.promoteBuffers === 'boolean' ? this.opts.promoteBuffers : false;
+    this.bsonRegExp = typeof this.opts.bsonRegExp === 'boolean' ? this.opts.bsonRegExp : false;
 
     this.documents = [];
   }
@@ -816,12 +832,14 @@ export class BinMsg {
     const promoteLongs = options.promoteLongs ?? this.opts.promoteLongs;
     const promoteValues = options.promoteValues ?? this.opts.promoteValues;
     const promoteBuffers = options.promoteBuffers ?? this.opts.promoteBuffers;
+    const bsonRegExp = options.bsonRegExp ?? this.opts.bsonRegExp;
 
     // Set up the options
     const _options: BSONSerializeOptions = {
-      promoteLongs: promoteLongs,
-      promoteValues: promoteValues,
-      promoteBuffers: promoteBuffers
+      promoteLongs,
+      promoteValues,
+      promoteBuffers,
+      bsonRegExp
     };
 
     while (this.index < this.data.length) {

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -792,6 +792,7 @@ function write(
     promoteLongs: typeof options.promoteLongs === 'boolean' ? options.promoteLongs : true,
     promoteValues: typeof options.promoteValues === 'boolean' ? options.promoteValues : true,
     promoteBuffers: typeof options.promoteBuffers === 'boolean' ? options.promoteBuffers : false,
+    bsonRegExp: typeof options.bsonRegExp === 'boolean' ? options.bsonRegExp : false,
     raw: typeof options.raw === 'boolean' ? options.raw : false,
     started: 0
   };

--- a/src/cmap/wire_protocol/shared.ts
+++ b/src/cmap/wire_protocol/shared.ts
@@ -42,7 +42,8 @@ export function applyCommonQueryOptions(
     raw: typeof options.raw === 'boolean' ? options.raw : false,
     promoteLongs: typeof options.promoteLongs === 'boolean' ? options.promoteLongs : true,
     promoteValues: typeof options.promoteValues === 'boolean' ? options.promoteValues : true,
-    promoteBuffers: typeof options.promoteBuffers === 'boolean' ? options.promoteBuffers : false
+    promoteBuffers: typeof options.promoteBuffers === 'boolean' ? options.promoteBuffers : false,
+    bsonRegExp: typeof options.bsonRegExp === 'boolean' ? options.bsonRegExp : false
   });
 
   if (options.session) {

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -588,6 +588,9 @@ export const OPTIONS = {
   autoEncryption: {
     type: 'record'
   },
+  bsonRegExp: {
+    type: 'boolean'
+  },
   serverApi: {
     target: 'serverApi',
     transform({ values: [version] }): ServerApi {

--- a/src/db.ts
+++ b/src/db.ts
@@ -61,7 +61,6 @@ const DB_OPTIONS_ALLOW_LIST = [
   'raw',
   'authSource',
   'ignoreUndefined',
-  'promoteLongs',
   'readConcern',
   'retryMiliSeconds',
   'numberOfRetries',
@@ -69,6 +68,7 @@ const DB_OPTIONS_ALLOW_LIST = [
   'logger',
   'promoteBuffers',
   'promoteLongs',
+  'bsonRegExp',
   'promoteValues',
   'compression',
   'retryWrites'

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -25,6 +25,7 @@ const ILLEGAL_COMMAND_FIELDS = new Set([
   'promoteLongs',
   'promoteValues',
   'promoteBuffers',
+  'bsonRegExp',
   'serializeFunctions',
   'ignoreUndefined'
 ]);

--- a/src/operations/map_reduce.ts
+++ b/src/operations/map_reduce.ts
@@ -30,6 +30,7 @@ const exclusionList = [
   'promoteLongs',
   'promoteValues',
   'promoteBuffers',
+  'bsonRegExp',
   'serializeFunctions',
   'ignoreUndefined',
   'scope' // this option is reformatted thus exclude the original

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -55,35 +55,6 @@ import type { AutoEncrypter } from '../deps';
 import type { ServerApi } from '../mongo_client';
 import { TypedEventEmitter } from '../mongo_types';
 
-// Used for filtering out fields for logging
-const DEBUG_FIELDS = [
-  'reconnect',
-  'reconnectTries',
-  'reconnectInterval',
-  'emitError',
-  'cursorFactory',
-  'host',
-  'port',
-  'size',
-  'keepAlive',
-  'keepAliveInitialDelay',
-  'noDelay',
-  'connectionTimeout',
-  'checkServerIdentity',
-  'socketTimeoutMS',
-  'ssl',
-  'ca',
-  'crl',
-  'cert',
-  'key',
-  'rejectUnauthorized',
-  'promoteLongs',
-  'promoteValues',
-  'promoteBuffers',
-  'bsonRegExp',
-  'servername'
-];
-
 const stateTransition = makeStateMachine({
   [STATE_CLOSED]: [STATE_CLOSED, STATE_CONNECTING],
   [STATE_CONNECTING]: [STATE_CONNECTING, STATE_CLOSING, STATE_CONNECTED, STATE_CLOSED],

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -55,6 +55,35 @@ import type { AutoEncrypter } from '../deps';
 import type { ServerApi } from '../mongo_client';
 import { TypedEventEmitter } from '../mongo_types';
 
+// Used for filtering out fields for logging
+const DEBUG_FIELDS = [
+  'reconnect',
+  'reconnectTries',
+  'reconnectInterval',
+  'emitError',
+  'cursorFactory',
+  'host',
+  'port',
+  'size',
+  'keepAlive',
+  'keepAliveInitialDelay',
+  'noDelay',
+  'connectionTimeout',
+  'checkServerIdentity',
+  'socketTimeoutMS',
+  'ssl',
+  'ca',
+  'crl',
+  'cert',
+  'key',
+  'rejectUnauthorized',
+  'promoteLongs',
+  'promoteValues',
+  'promoteBuffers',
+  'bsonRegExp',
+  'servername'
+];
+
 const stateTransition = makeStateMachine({
   [STATE_CLOSED]: [STATE_CLOSED, STATE_CONNECTING],
   [STATE_CONNECTING]: [STATE_CONNECTING, STATE_CLOSING, STATE_CONNECTED, STATE_CLOSED],

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -9,6 +9,7 @@ expectType<boolean | undefined>(options.ignoreUndefined);
 expectType<boolean | undefined>(options.promoteLongs);
 expectType<boolean | undefined>(options.promoteBuffers);
 expectType<boolean | undefined>(options.promoteValues);
+expectType<boolean | undefined>(options.bsonRegExp);
 expectType<Document | undefined>(options.fieldsAsRaw);
 
 type PermittedBSONOptionKeys =
@@ -18,6 +19,7 @@ type PermittedBSONOptionKeys =
   | 'promoteLongs'
   | 'promoteBuffers'
   | 'promoteValues'
+  | 'bsonRegExp'
   | 'fieldsAsRaw'
   | 'raw';
 

--- a/test/unit/bson_regex.test.js
+++ b/test/unit/bson_regex.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const { expect } = require('chai');
+const { BSONRegExp } = require('../../src/index');
+const mock = require('../tools/mock');
+
+describe('BSONRegExp', () => {
+  let server;
+  afterEach(() => mock.cleanup());
+  beforeEach(async () => {
+    server = await mock.createServer();
+    server.setMessageHandler(request => {
+      const doc = request.document;
+      if (doc.ismaster || doc.hello) {
+        request.reply({ ...mock.DEFAULT_ISMASTER });
+      } else if (doc.insert) {
+        // insertOne handle
+        request.reply({ ok: 1 });
+      } else if (doc.find) {
+        // findOne handle
+        request.reply({
+          ok: 1,
+          cursor: { id: 1, firstBatch: [{ regex: new BSONRegExp('abc', 'imx') }] }
+        });
+      } else if (doc.endSessions) {
+        request.reply({ ok: 1 });
+      }
+    });
+  });
+
+  describe('option passed to client', () => {});
+  describe('option passed to db', () => {});
+  describe('option passed to collection', () => {});
+
+  // Start here
+  describe('bsonRegex option passed to operation', () => {
+    // it('should respond with BSONRexExp class', async function () {
+    //   // create and connect to client
+    //   const client = this.configuration.newClient(`mongodb://${server.uri()}/`); // bsonRegex
+    //   await client.connect();
+
+    //   const db = client.db('a');
+    //   const collection = db.collection('b');
+
+    //   await collection.insertOne({ regex: new BSONRegExp('abc', 'imx') });
+    //   const res = await collection.findOne(
+    //     { regex: new BSONRegExp('abc', 'imx') },
+    //     { bsonRegExp: true }
+    //   );
+
+    //   expect(res).has.property('regex').that.is.instanceOf(BSONRegExp);
+    // });
+
+    it('should respond with BSONRexExp class REAL MONGO', async function () {
+      // create and connect to client
+      const client = this.configuration.newClient(); // bsonRegex
+      await client.connect();
+
+      const db = client.db('a');
+      const collection = db.collection('b');
+
+      await collection.insertOne({ regex: new BSONRegExp('abc', 'imx') });
+      const res = await collection.findOne(
+        { regex: new BSONRegExp('abc', 'imx') },
+        { bsonRegExp: false }
+      );
+
+      expect(res).has.property('regex').that.is.instanceOf(BSONRegExp);
+
+      await client.close();
+    });
+  });
+});

--- a/test/unit/bson_regex.test.js
+++ b/test/unit/bson_regex.test.js
@@ -5,7 +5,7 @@ const { BSONRegExp } = require('../../src/index');
 
 describe('BSONRegExp', () => {
   describe('bsonRegExp option', () => {
-    it('should respond with BSONRegExp class with flag passed to db', async function () {
+    it('should respond with BSONRegExp class with option passed to db', async function () {
       let client;
       try {
         // create and connect to client
@@ -24,7 +24,7 @@ describe('BSONRegExp', () => {
       }
     });
 
-    it('should respond with BSONRegExp class with flag passed to collection', async function () {
+    it('should respond with BSONRegExp class with option passed to collection', async function () {
       let client;
       try {
         // create and connect to client
@@ -43,7 +43,7 @@ describe('BSONRegExp', () => {
       }
     });
 
-    it('should respond with BSONRegExp class with flag passed to operation', async function () {
+    it('should respond with BSONRegExp class with option passed to operation', async function () {
       let client;
       try {
         // create and connect to client

--- a/test/unit/bson_regex.test.js
+++ b/test/unit/bson_regex.test.js
@@ -5,64 +5,32 @@ const { BSONRegExp } = require('../../src/index');
 
 describe('BSONRegExp', () => {
   describe('bsonRegExp option', () => {
-    it('should respond with BSONRegExp class with option passed to db', async function () {
-      let client;
-      try {
-        // create and connect to client
-        client = this.configuration.newClient();
-        await client.connect();
+    // define client and option for tests to use
+    let client;
+    const option = { bsonRegExp: true };
+    for (const passOptionTo of ['client', 'db', 'collection', 'operation']) {
+      it(`should respond with BSONRegExp class with option passed to ${passOptionTo}`, async function () {
+        try {
+          client = this.configuration.newClient(passOptionTo === 'client' ? option : undefined);
+          await client.connect();
 
-        const db = client.db('a', { bsonRegExp: true });
-        const collection = db.collection('b');
+          const db = client.db('bson_regex_db', passOptionTo === 'db' ? option : undefined);
+          const collection = db.collection(
+            'bson_regex_coll',
+            passOptionTo === 'collection' ? option : undefined
+          );
 
-        await collection.insertOne({ regex: new BSONRegExp('abc', 'imx') });
-        const res = await collection.findOne({ regex: new BSONRegExp('abc', 'imx') });
+          await collection.insertOne({ regex: new BSONRegExp('abc', 'imx') });
+          const res = await collection.findOne(
+            { regex: new BSONRegExp('abc', 'imx') },
+            passOptionTo === 'operation' ? option : undefined
+          );
 
-        expect(res).has.property('regex').that.is.instanceOf(BSONRegExp);
-      } finally {
-        await client.close();
-      }
-    });
-
-    it('should respond with BSONRegExp class with option passed to collection', async function () {
-      let client;
-      try {
-        // create and connect to client
-        client = this.configuration.newClient(); // bsonRegex
-        await client.connect();
-
-        const db = client.db('a');
-        const collection = db.collection('b', { bsonRegExp: true });
-
-        await collection.insertOne({ regex: new BSONRegExp('abc', 'imx') });
-        const res = await collection.findOne({ regex: new BSONRegExp('abc', 'imx') });
-
-        expect(res).has.property('regex').that.is.instanceOf(BSONRegExp);
-      } finally {
-        await client.close();
-      }
-    });
-
-    it('should respond with BSONRegExp class with option passed to operation', async function () {
-      let client;
-      try {
-        // create and connect to client
-        client = this.configuration.newClient(); // bsonRegex
-        await client.connect();
-
-        const db = client.db('a');
-        const collection = db.collection('b');
-
-        await collection.insertOne({ regex: new BSONRegExp('abc', 'imx') });
-        const res = await collection.findOne(
-          { regex: new BSONRegExp('abc', 'imx') },
-          { bsonRegExp: true }
-        );
-
-        expect(res).has.property('regex').that.is.instanceOf(BSONRegExp);
-      } finally {
-        await client.close();
-      }
-    });
+          expect(res).has.property('regex').that.is.instanceOf(BSONRegExp);
+        } finally {
+          await client.close();
+        }
+      });
+    }
   });
 });


### PR DESCRIPTION
## Description
- Allowed retrieving PCRE-style RegExp by adding `bsonRegExp` option to commands, collections, and dbs
- Added unit tests for the `bsonRegExp` option
