### PR TITLE
test: add db name with commas escaped test

### DIFF
--- a/test/spec/initial-dns-seedlist-discovery/dbname-with-commas-escaped.json
+++ b/test/spec/initial-dns-seedlist-discovery/dbname-with-commas-escaped.json
@@ -1,0 +1,19 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/some%2Cdb?replicaSet=repl0",
+  "seeds": [
+    "test1.test.build.10gen.cc:27017",
+    "test1.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "defaultDatabase": "some,db"
+  }
+}

--- a/test/spec/initial-dns-seedlist-discovery/dbname-with-commas-escaped.yml
+++ b/test/spec/initial-dns-seedlist-discovery/dbname-with-commas-escaped.yml
@@ -1,0 +1,13 @@
+uri: "mongodb+srv://test1.test.build.10gen.cc/some%2Cdb?replicaSet=repl0"
+seeds:
+  - test1.test.build.10gen.cc:27017
+  - test1.test.build.10gen.cc:27018
+hosts:
+  - localhost:27017
+  - localhost:27018
+  - localhost:27019
+options:
+  replicaSet: repl0
+  ssl: true
+parsed_options:
+  defaultDatabase: some,db


### PR DESCRIPTION
This is the reference implementation for the additional request for testing db names with commas where the string is escaped. https://github.com/mongodb/specifications/pull/1001