### PR TITLE
test(NODE-2856): Check that defaultTransactionOptions get used from session

### DIFF
--- a/lib/core/topologies/read_preference.js
+++ b/lib/core/topologies/read_preference.js
@@ -102,6 +102,7 @@ const VALID_MODES = [
  * @return {ReadPreference}
  */
 ReadPreference.fromOptions = function(options) {
+  debugger;
   if (!options) return null;
   const readPreference = options.readPreference;
   if (!readPreference) return null;
@@ -133,6 +134,7 @@ ReadPreference.fromOptions = function(options) {
  * @returns {(ReadPreference|null)} The resolved read preference
  */
 ReadPreference.resolve = function(parent, options) {
+  debugger;
   options = options || {};
   const session = options.session;
 

--- a/lib/core/topologies/read_preference.js
+++ b/lib/core/topologies/read_preference.js
@@ -102,7 +102,6 @@ const VALID_MODES = [
  * @return {ReadPreference}
  */
 ReadPreference.fromOptions = function(options) {
-  debugger;
   if (!options) return null;
   const readPreference = options.readPreference;
   if (!readPreference) return null;
@@ -134,7 +133,6 @@ ReadPreference.fromOptions = function(options) {
  * @returns {(ReadPreference|null)} The resolved read preference
  */
 ReadPreference.resolve = function(parent, options) {
-  debugger;
   options = options || {};
   const session = options.session;
 

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -761,11 +761,10 @@ describe('ReadPreference', function() {
   });
 
   it('should use session readPreference instead of client readPreference', {
-    metadata: { requires: { topology: ['single', 'replicaset'] } },
+    metadata: { requires: { unifiedTopology: true, topology: ['single', 'replicaset'] } },
     test: function(done) {
       const configuration = this.configuration;
       const client = this.configuration.newClient(configuration.writeConcernMax(), {
-        useUnifiedTopology: true,
         readPreference: 'primaryPreferred'
       });
 
@@ -773,8 +772,8 @@ describe('ReadPreference', function() {
         this.defer(() => {
           client.close();
         });
-        expect(err).to.be.null;
-        expect(client).to.not.be.null;
+        expect(err).to.not.exist;
+        expect(client).to.exist;
         const session = client.startSession({
           defaultTransactionOptions: { readPreference: 'secondary' },
           causalConsistency: true
@@ -782,7 +781,7 @@ describe('ReadPreference', function() {
 
         session.startTransaction();
         const result = ReadPreference.resolve(client, { session: session });
-        expect(result).to.not.be.undefined;
+        expect(result).to.exist;
         expect(result.mode).to.deep.equal('secondary');
         session.abortTransaction();
 

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -795,8 +795,7 @@ describe('ReadPreference', function() {
         });
         session.startTransaction();
         const result = ReadPreference.resolve(client, { session: session });
-        expect(result).to.exist;
-        expect(result.mode).to.deep.equal('secondary');
+        expect(result).to.have.property('mode', 'secondary');
       }
     });
   });

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -759,4 +759,25 @@ describe('ReadPreference', function() {
         });
     })
   });
+
+  it('should use session readPreference', function(done) {
+    const configuration = this.configuration;
+    const client = this.configuration.newClient(configuration.writeConcernMax(), {
+      useUnifiedTopology: true,
+      readPreference: 'primaryPreferred'
+    });
+
+    client.connect((err, client) => {
+      expect(err).to.not.exist;
+      this.defer(() => client.close());
+      const session = client.startSession({
+        readPreference: 'secondary',
+        causalConsistency: true
+      });
+
+      const result = ReadPreference.resolve(client, { session: session });
+      expect(result.mode).to.equal('secondary');
+      done();
+    });
+  });
 });

--- a/test/functional/readpreference.test.js
+++ b/test/functional/readpreference.test.js
@@ -773,10 +773,6 @@ describe('ReadPreference', function() {
       });
       expect(err).to.be.null;
       expect(client).to.not.be.null;
-      const db = client.db(configuration.db);
-      const collection = db.collection('read_pref_1', {
-        readPreference: ReadPreference.SECONDARY_PREFERRED
-      });
       const session = client.startSession({
         defaultTransactionOptions: { readPreference: 'secondary' },
         causalConsistency: true


### PR DESCRIPTION
## Description
Test verifying that transactions get their `readPreference` from `SessionOptions` passed at session instantiation

**What changed?**
- lib/core/topologies/read_preference.js
- test/functional/readpreference.test.js