### PR TITLE
chore(NODE-2998): move connection-string parsing into separate package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4556,8 +4556,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -5241,6 +5240,14 @@
             "path-is-absolute": "^1.0.0"
           }
         }
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-1.0.0.tgz",
+      "integrity": "sha512-s2kSyqM/PgvLHKzc67eK/syC4n2eXu4Q2XWA4gJOgMvOk1/bsZ8jW04EBFabfNHgw66gYSovx9F623eKEkpfGA==",
+      "requires": {
+        "whatwg-url": "^8.4.0"
       }
     },
     "mongodb-mock-server": {
@@ -6179,8 +6186,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -7554,6 +7560,14 @@
         "punycode": "^2.1.1"
       }
     },
+    "tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
     "trim-newlines": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
@@ -8072,6 +8086,21 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+    },
+    "whatwg-url": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
+      "integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
+      "requires": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "bson": "^4.4.0",
-    "denque": "^1.5.0"
+    "denque": "^1.5.0",
+    "mongodb-connection-string-url": "^1.0.0"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/test/functional/mongo_client.test.js
+++ b/test/functional/mongo_client.test.js
@@ -66,7 +66,7 @@ describe('MongoClient', function () {
     },
     test() {
       expect(() => this.configuration.newClient('user:password@localhost:27017/test')).to.throw(
-        'Invalid connection string user:password@localhost:27017/test'
+        'Invalid connection string "user:password@localhost:27017/test"'
       );
     }
   });

--- a/test/tools/runner/config.js
+++ b/test/tools/runner/config.js
@@ -1,4 +1,5 @@
 'use strict';
+const ConnectionString = require('mongodb-connection-string-url').default;
 const url = require('url');
 const qs = require('querystring');
 const { expect } = require('chai');
@@ -6,7 +7,6 @@ const { expect } = require('chai');
 const { MongoClient } = require('../../../src/mongo_client');
 const { Topology } = require('../../../src/sdam/topology');
 const { TopologyType } = require('../../../src/sdam/common');
-const { parseURI } = require('../../../src/connection_string');
 const { HostAddress } = require('../../../src/utils');
 
 /**
@@ -35,7 +35,8 @@ function convertToConnStringMap(obj) {
 
 class TestConfiguration {
   constructor(uri, context) {
-    const { url, hosts } = parseURI(uri);
+    const url = new ConnectionString(uri);
+    const { hosts } = url;
     const hostAddresses = hosts.map(HostAddress.fromString);
     this.topologyType = context.topologyType;
     this.version = context.version;


### PR DESCRIPTION
## Description

**What changed?**

As discussed earlier this year, this moves the connection string
parsing into a separate package for mongodb-connection-string-specific
URL parsing. The code in that package is based very closely on the
original code in the driver here.

**Are there any files to ignore?**

No.