### PR TITLE
fix(NODE-2035): Exceptions thrown from awaited cursor forEach do not propagate

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -742,7 +742,12 @@ class Cursor extends CoreCursor {
           return false;
         }
         if (doc != null) {
-          iterator(doc);
+          try {
+            iterator(doc);
+          } catch (error) {
+            callback(error);
+            return false;
+          }
           return true;
         }
         if (doc == null && callback) {
@@ -762,7 +767,12 @@ class Cursor extends CoreCursor {
             fulfill(null);
             return false;
           } else {
-            iterator(doc);
+            try {
+              iterator(doc);
+            } catch (error) {
+              reject(error);
+              return false;
+            }
             return true;
           }
         });

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -4394,9 +4394,10 @@ describe('Cursor', function() {
 
     afterEach(function(done) {
       if (cursor) {
-        cursor.close().then(() => {
-          client.close().then(() => done());
-        });
+        cursor
+          .close()
+          .then(() => client.close())
+          .then(() => done());
       } else {
         client.close().then(() => done());
       }

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -4406,8 +4406,9 @@ describe('Cursor', function() {
     // NODE-2035
     it('should propagate error when exceptions are thrown from an awaited forEach call', function(done) {
       const docs = [{ unique_key_2035: 1 }, { unique_key_2035: 2 }, { unique_key_2035: 3 }];
-      collection.insertMany(docs).then(
-        () => {
+      collection
+        .insertMany(docs)
+        .then(() => {
           cursor = collection.find({
             unique_key_2035: {
               $exists: true
@@ -4430,11 +4431,8 @@ describe('Cursor', function() {
                 }
               }
             );
-        },
-        error => {
-          done(error);
-        }
-      );
+        })
+        .catch(error => done(error));
     });
   });
 


### PR DESCRIPTION
## Description
Catch and propagate exceptions in awaited cursor.forEach
**What changed?**
- lib/cursor.js
- test/functional/cursor.test.js
