### PR TITLE
fix(NODE-2905): support SERVICE_NAME authentication mechanism property

### DIFF
--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -6,6 +6,7 @@ import type { Document } from '../../bson';
 
 type MechanismProperties = {
   gssapiCanonicalizeHostName?: boolean;
+  SERVICE_NAME?: string;
 };
 
 import * as dns from 'dns';
@@ -72,15 +73,14 @@ function makeKerberosClient(authContext: AuthContext, callback: Callback<Kerbero
     return callback(Kerberos['kModuleError']);
   }
 
-  const { username, password, mechanismProperties } = credentials;
-  const serviceName =
-    mechanismProperties['gssapiservicename'] ||
-    mechanismProperties['gssapiServiceName'] ||
-    'mongodb';
+  const { username, password } = credentials;
+  const mechanismProperties = credentials.mechanismProperties as MechanismProperties;
+
+  const serviceName = mechanismProperties.SERVICE_NAME ?? 'mongodb';
 
   performGssapiCanonicalizeHostName(
     hostAddress.host,
-    mechanismProperties as MechanismProperties,
+    mechanismProperties,
     (err?: Error | MongoError, host?: string) => {
       if (err) return callback(err);
 

--- a/test/manual/README.md
+++ b/test/manual/README.md
@@ -1,0 +1,19 @@
+# Manual Tests
+
+This directory contains a set of manual tests that require setup of additional systems and thus cannot _just_ be run as part of the other unit tests.
+
+See the individual test files for details - only some will be described in this document.
+
+## Kerberos Tests
+The Kerberos tests are defined in [`kerberos.test.js](./kerberos.test.js). The following environment variables must be set up for the test to work properly:
+
+* `MONGODB_URI`: The full connection string including a valid User Principal Name to connect to a Kerberos-enabled MongoDB server (must include `authMechanism=GSSAPI`)
+* `KRB5_PRINCIPAL`: The User Principal Name specified in the connection string (i.e. `MONGODB_URI`)
+
+> Note: You have to initialize Kerberos locally before running the tests, e.g. by running `kinit` in order to acquire a valid TGT from the KDC.
+
+The test also requires a database `kerberos` to be present with a single document in the `test` collection having a `kerberos` property of boolean value `true`, e.g.:
+
+```
+use kerberos; db.test.insertOne({ kerberos: true })
+```

--- a/test/unit/core/connection_string.test.js
+++ b/test/unit/core/connection_string.test.js
@@ -8,7 +8,7 @@ const { AuthMechanism } = require('../../../src/cmap/auth/defaultAuthProviders')
 const expect = chai.expect;
 chai.use(require('chai-subset'));
 
-// NOTE: These are cases we could never check for unless we write out own
+// NOTE: These are cases we could never check for unless we write our own
 //       url parser. The node parser simply won't let these through, so we
 //       are safe skipping them.
 const skipTests = [
@@ -22,10 +22,7 @@ const skipTests = [
   'Unsupported option values are ignored',
 
   // We don't actually support `wtimeoutMS` which this test depends upon
-  'Deprecated (or unknown) options are ignored if replacement exists',
-
-  // We already handle this case in different ways
-  'may support deprecated gssapiServiceName option (GSSAPI)'
+  'Deprecated (or unknown) options are ignored if replacement exists'
 ];
 
 describe('Connection String', function () {


### PR DESCRIPTION
This PR adds support for the `SERVICE_NAME` authentication mechanism property that replaces the old `gssapiServiceName` query string parameter.

It also includes a test case that would set the `SERVICE_NAME` to an invalid value and verifies the connection consequently fails.

_NOTE:_ I've also started a small README file for the manual tests as I was initially unsure on how to run them locally.

Let me know if there's anything I need to adapt 😊 