### PR TITLE
fix(NODE-3358): Command monitoring objects hold internal state references

### DIFF
--- a/lib/command_utils.js
+++ b/lib/command_utils.js
@@ -2,6 +2,7 @@
 const Msg = require('./core/connection/msg').Msg;
 const KillCursor = require('./core/connection/commands').KillCursor;
 const GetMore = require('./core/connection/commands').GetMore;
+const deepCopy = require('./utils').deepCopy;
 
 /** Commands that we want to redact because of the sensitive nature of their contents */
 const SENSITIVE_COMMANDS = new Set([
@@ -63,17 +64,17 @@ const extractCommand = command => {
   let extractedCommand;
   if (command instanceof GetMore) {
     extractedCommand = {
-      getMore: command.cursorId,
+      getMore: deepCopy(command.cursorId),
       collection: collectionName(command),
       batchSize: command.numberToReturn
     };
   } else if (command instanceof KillCursor) {
     extractedCommand = {
       killCursors: collectionName(command),
-      cursors: command.cursorIds
+      cursors: deepCopy(command.cursorIds)
     };
   } else if (command instanceof Msg) {
-    extractedCommand = command.command;
+    extractedCommand = deepCopy(command.command);
   } else if (command.query && command.query.$query) {
     let result;
     if (command.ns === 'admin.$cmd') {
@@ -84,12 +85,13 @@ const extractCommand = command => {
       result = { find: collectionName(command) };
       Object.keys(LEGACY_FIND_QUERY_MAP).forEach(key => {
         if (typeof command.query[key] !== 'undefined')
-          result[LEGACY_FIND_QUERY_MAP[key]] = command.query[key];
+          result[LEGACY_FIND_QUERY_MAP[key]] = deepCopy(command.query[key]);
       });
     }
 
     Object.keys(LEGACY_FIND_OPTIONS_MAP).forEach(key => {
-      if (typeof command[key] !== 'undefined') result[LEGACY_FIND_OPTIONS_MAP[key]] = command[key];
+      if (typeof command[key] !== 'undefined')
+        result[LEGACY_FIND_OPTIONS_MAP[key]] = deepCopy(command[key]);
     });
 
     OP_QUERY_KEYS.forEach(key => {
@@ -106,7 +108,7 @@ const extractCommand = command => {
       extractedCommand = result;
     }
   } else {
-    extractedCommand = command.query || command;
+    extractedCommand = command.query ? deepCopy(command.query) : deepCopy(command);
   }
 
   const commandName = Object.keys(extractedCommand)[0];

--- a/lib/command_utils.js
+++ b/lib/command_utils.js
@@ -108,7 +108,7 @@ const extractCommand = command => {
       extractedCommand = result;
     }
   } else {
-    extractedCommand = command.query ? deepCopy(command.query) : deepCopy(command);
+    extractedCommand = deepCopy(command.query || command);
   }
 
   const commandName = Object.keys(extractedCommand)[0];

--- a/lib/command_utils.js
+++ b/lib/command_utils.js
@@ -1,0 +1,122 @@
+'use strict';
+const Msg = require('./core/connection/msg').Msg;
+const KillCursor = require('./core/connection/commands').KillCursor;
+const GetMore = require('./core/connection/commands').GetMore;
+
+/** Commands that we want to redact because of the sensitive nature of their contents */
+const SENSITIVE_COMMANDS = new Set([
+  'authenticate',
+  'saslStart',
+  'saslContinue',
+  'getnonce',
+  'createUser',
+  'updateUser',
+  'copydbgetnonce',
+  'copydbsaslstart',
+  'copydb'
+]);
+
+const HELLO_COMMANDS = new Set(['hello', 'ismaster', 'isMaster']);
+
+const LEGACY_FIND_QUERY_MAP = {
+  $query: 'filter',
+  $orderby: 'sort',
+  $hint: 'hint',
+  $comment: 'comment',
+  $maxScan: 'maxScan',
+  $max: 'max',
+  $min: 'min',
+  $returnKey: 'returnKey',
+  $showDiskLoc: 'showRecordId',
+  $maxTimeMS: 'maxTimeMS',
+  $snapshot: 'snapshot'
+};
+
+const LEGACY_FIND_OPTIONS_MAP = {
+  numberToSkip: 'skip',
+  numberToReturn: 'batchSize',
+  returnFieldsSelector: 'projection'
+};
+
+const OP_QUERY_KEYS = [
+  'tailable',
+  'oplogReplay',
+  'noCursorTimeout',
+  'awaitData',
+  'partial',
+  'exhaust'
+];
+
+const collectionName = command => command.ns.split('.')[1];
+
+const shouldRedactCommand = (commandName, cmd) =>
+  SENSITIVE_COMMANDS.has(commandName) ||
+  (HELLO_COMMANDS.has(commandName) && !!cmd.speculativeAuthenticate);
+
+/**
+ * Extract the actual command from the query, possibly upconverting if it's a legacy
+ * format
+ *
+ * @param {Object} command the command
+ */
+const extractCommand = command => {
+  let extractedCommand;
+  if (command instanceof GetMore) {
+    extractedCommand = {
+      getMore: command.cursorId,
+      collection: collectionName(command),
+      batchSize: command.numberToReturn
+    };
+  } else if (command instanceof KillCursor) {
+    extractedCommand = {
+      killCursors: collectionName(command),
+      cursors: command.cursorIds
+    };
+  } else if (command instanceof Msg) {
+    extractedCommand = command.command;
+  } else if (command.query && command.query.$query) {
+    let result;
+    if (command.ns === 'admin.$cmd') {
+      // upconvert legacy command
+      result = Object.assign({}, command.query.$query);
+    } else {
+      // upconvert legacy find command
+      result = { find: collectionName(command) };
+      Object.keys(LEGACY_FIND_QUERY_MAP).forEach(key => {
+        if (typeof command.query[key] !== 'undefined')
+          result[LEGACY_FIND_QUERY_MAP[key]] = command.query[key];
+      });
+    }
+
+    Object.keys(LEGACY_FIND_OPTIONS_MAP).forEach(key => {
+      if (typeof command[key] !== 'undefined') result[LEGACY_FIND_OPTIONS_MAP[key]] = command[key];
+    });
+
+    OP_QUERY_KEYS.forEach(key => {
+      if (command[key]) result[key] = command[key];
+    });
+
+    if (typeof command.pre32Limit !== 'undefined') {
+      result.limit = command.pre32Limit;
+    }
+
+    if (command.query.$explain) {
+      extractedCommand = { explain: result };
+    } else {
+      extractedCommand = result;
+    }
+  } else {
+    extractedCommand = command.query || command;
+  }
+
+  const commandName = Object.keys(extractedCommand)[0];
+  return {
+    cmd: extractedCommand,
+    name: commandName,
+    shouldRedact: shouldRedactCommand(commandName, extractedCommand)
+  };
+};
+
+module.exports = {
+  extractCommand
+};

--- a/lib/core/connection/apm.js
+++ b/lib/core/connection/apm.js
@@ -1,128 +1,15 @@
 'use strict';
-const Msg = require('../connection/msg').Msg;
 const KillCursor = require('../connection/commands').KillCursor;
 const GetMore = require('../connection/commands').GetMore;
 const calculateDurationInMs = require('../../utils').calculateDurationInMs;
-
-/** Commands that we want to redact because of the sensitive nature of their contents */
-const SENSITIVE_COMMANDS = new Set([
-  'authenticate',
-  'saslStart',
-  'saslContinue',
-  'getnonce',
-  'createUser',
-  'updateUser',
-  'copydbgetnonce',
-  'copydbsaslstart',
-  'copydb'
-]);
-
-const HELLO_COMMANDS = new Set(['hello', 'ismaster', 'isMaster']);
+const extractCommand = require('../../command_utils').extractCommand;
 
 // helper methods
-const extractCommandName = commandDoc => Object.keys(commandDoc)[0];
 const namespace = command => command.ns;
 const databaseName = command => command.ns.split('.')[0];
-const collectionName = command => command.ns.split('.')[1];
 const generateConnectionId = pool =>
   pool.options ? `${pool.options.host}:${pool.options.port}` : pool.address;
-const maybeRedact = (commandName, cmd, result) =>
-  SENSITIVE_COMMANDS.has(commandName) ||
-  (HELLO_COMMANDS.has(commandName) && cmd.speculativeAuthenticate)
-    ? {}
-    : result;
 const isLegacyPool = pool => pool.s && pool.queue;
-
-const LEGACY_FIND_QUERY_MAP = {
-  $query: 'filter',
-  $orderby: 'sort',
-  $hint: 'hint',
-  $comment: 'comment',
-  $maxScan: 'maxScan',
-  $max: 'max',
-  $min: 'min',
-  $returnKey: 'returnKey',
-  $showDiskLoc: 'showRecordId',
-  $maxTimeMS: 'maxTimeMS',
-  $snapshot: 'snapshot'
-};
-
-const LEGACY_FIND_OPTIONS_MAP = {
-  numberToSkip: 'skip',
-  numberToReturn: 'batchSize',
-  returnFieldsSelector: 'projection'
-};
-
-const OP_QUERY_KEYS = [
-  'tailable',
-  'oplogReplay',
-  'noCursorTimeout',
-  'awaitData',
-  'partial',
-  'exhaust'
-];
-
-/**
- * Extract the actual command from the query, possibly upconverting if it's a legacy
- * format
- *
- * @param {Object} command the command
- */
-const extractCommand = command => {
-  if (command instanceof GetMore) {
-    return {
-      getMore: command.cursorId,
-      collection: collectionName(command),
-      batchSize: command.numberToReturn
-    };
-  }
-
-  if (command instanceof KillCursor) {
-    return {
-      killCursors: collectionName(command),
-      cursors: command.cursorIds
-    };
-  }
-
-  if (command instanceof Msg) {
-    return command.command;
-  }
-
-  if (command.query && command.query.$query) {
-    let result;
-    if (command.ns === 'admin.$cmd') {
-      // upconvert legacy command
-      result = Object.assign({}, command.query.$query);
-    } else {
-      // upconvert legacy find command
-      result = { find: collectionName(command) };
-      Object.keys(LEGACY_FIND_QUERY_MAP).forEach(key => {
-        if (typeof command.query[key] !== 'undefined')
-          result[LEGACY_FIND_QUERY_MAP[key]] = command.query[key];
-      });
-    }
-
-    Object.keys(LEGACY_FIND_OPTIONS_MAP).forEach(key => {
-      if (typeof command[key] !== 'undefined') result[LEGACY_FIND_OPTIONS_MAP[key]] = command[key];
-    });
-
-    OP_QUERY_KEYS.forEach(key => {
-      if (command[key]) result[key] = command[key];
-    });
-
-    if (typeof command.pre32Limit !== 'undefined') {
-      result.limit = command.pre32Limit;
-    }
-
-    if (command.query.$explain) {
-      return { explain: result };
-    }
-
-    return result;
-  }
-
-  return command.query ? command.query : command;
-};
 
 const extractReply = (command, reply) => {
   if (command instanceof GetMore) {
@@ -183,15 +70,15 @@ class CommandStartedEvent {
    * @param {Object} command the command
    */
   constructor(pool, command) {
-    const cmd = extractCommand(command);
-    const commandName = extractCommandName(cmd);
+    const extractedCommand = extractCommand(command);
+    const commandName = extractedCommand.name;
     const connectionDetails = extractConnectionDetails(pool);
 
     Object.assign(this, connectionDetails, {
       requestId: command.requestId,
       databaseName: databaseName(command),
       commandName,
-      command: maybeRedact(commandName, cmd, cmd)
+      command: extractedCommand.shouldRedact ? {} : extractedCommand.cmd
     });
   }
 }
@@ -207,15 +94,15 @@ class CommandSucceededEvent {
    * @param {Array} started a high resolution tuple timestamp of when the command was first sent, to calculate duration
    */
   constructor(pool, command, reply, started) {
-    const cmd = extractCommand(command);
-    const commandName = extractCommandName(cmd);
+    const extractedCommand = extractCommand(command);
+    const commandName = extractedCommand.name;
     const connectionDetails = extractConnectionDetails(pool);
 
     Object.assign(this, connectionDetails, {
       requestId: command.requestId,
       commandName,
       duration: calculateDurationInMs(started),
-      reply: maybeRedact(commandName, cmd, extractReply(command, reply))
+      reply: extractedCommand.shouldRedact ? {} : extractReply(command, reply)
     });
   }
 }
@@ -231,15 +118,15 @@ class CommandFailedEvent {
    * @param {Array} started a high resolution tuple timestamp of when the command was first sent, to calculate duration
    */
   constructor(pool, command, error, started) {
-    const cmd = extractCommand(command);
-    const commandName = extractCommandName(cmd);
+    const extractedCommand = extractCommand(command);
+    const commandName = extractedCommand.name;
     const connectionDetails = extractConnectionDetails(pool);
 
     Object.assign(this, connectionDetails, {
       requestId: command.requestId,
       commandName,
       duration: calculateDurationInMs(started),
-      failure: maybeRedact(commandName, cmd, error)
+      failure: extractedCommand.shouldRedact ? {} : error
     });
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -871,7 +871,6 @@ function emitWarningOnce(message) {
   }
 }
 
-// Copied from https://github.com/mongodb/node-mongodb-native/blob/70cace8343bead2f3c1a6d0cf07e20a8c4a9f45f/src/utils.ts
 function isSuperset(set, subset) {
   set = Array.isArray(set) ? new Set(set) : set;
   subset = Array.isArray(subset) ? new Set(subset) : subset;
@@ -883,7 +882,6 @@ function isSuperset(set, subset) {
   return true;
 }
 
-// Copied from https://github.com/mongodb/node-mongodb-native/blob/70cace8343bead2f3c1a6d0cf07e20a8c4a9f45f/src/utils.ts
 function isRecord(value, requiredKeys) {
   const toString = Object.prototype.toString;
   const hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -918,7 +916,6 @@ function isRecord(value, requiredKeys) {
  * NOTE: This is not meant to be the perfect implementation of a deep copy,
  * but instead something that is good enough for the purposes of
  * command monitoring.
- * Copied from https://github.com/mongodb/node-mongodb-native/blob/70cace8343bead2f3c1a6d0cf07e20a8c4a9f45f/src/utils.ts
  */
 function deepCopy(value) {
   if (value == null) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -871,6 +871,85 @@ function emitWarningOnce(message) {
   }
 }
 
+// Copied from https://github.com/mongodb/node-mongodb-native/blob/70cace8343bead2f3c1a6d0cf07e20a8c4a9f45f/src/utils.ts
+function isSuperset(set, subset) {
+  set = Array.isArray(set) ? new Set(set) : set;
+  subset = Array.isArray(subset) ? new Set(subset) : subset;
+  for (const elem of subset) {
+    if (!set.has(elem)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Copied from https://github.com/mongodb/node-mongodb-native/blob/70cace8343bead2f3c1a6d0cf07e20a8c4a9f45f/src/utils.ts
+function isRecord(value, requiredKeys) {
+  const toString = Object.prototype.toString;
+  const hasOwnProperty = Object.prototype.hasOwnProperty;
+  const isObject = v => toString.call(v) === '[object Object]';
+  if (!isObject(value)) {
+    return false;
+  }
+
+  const ctor = value.constructor;
+  if (ctor && ctor.prototype) {
+    if (!isObject(ctor.prototype)) {
+      return false;
+    }
+
+    // Check to see if some method exists from the Object exists
+    if (!hasOwnProperty.call(ctor.prototype, 'isPrototypeOf')) {
+      return false;
+    }
+  }
+
+  if (requiredKeys) {
+    const keys = Object.keys(value);
+    return isSuperset(keys, requiredKeys);
+  }
+
+  return true;
+}
+
+/**
+ * Make a deep copy of an object
+ *
+ * NOTE: This is not meant to be the perfect implementation of a deep copy,
+ * but instead something that is good enough for the purposes of
+ * command monitoring.
+ * Copied from https://github.com/mongodb/node-mongodb-native/blob/70cace8343bead2f3c1a6d0cf07e20a8c4a9f45f/src/utils.ts
+ */
+function deepCopy(value) {
+  if (value == null) {
+    return value;
+  } else if (Array.isArray(value)) {
+    return value.map(item => deepCopy(item));
+  } else if (isRecord(value)) {
+    const res = {};
+    for (const key in value) {
+      res[key] = deepCopy(value[key]);
+    }
+    return res;
+  }
+
+  const ctor = value.constructor;
+  if (ctor) {
+    switch (ctor.name.toLowerCase()) {
+      case 'date':
+        return new ctor(Number(value));
+      case 'map':
+        return new Map(value);
+      case 'set':
+        return new Set(value);
+      case 'buffer':
+        return Buffer.from(value);
+    }
+  }
+
+  return value;
+}
+
 module.exports = {
   filterOptions,
   mergeOptions,
@@ -907,5 +986,6 @@ module.exports = {
   hasAtomicOperators,
   MONGODB_WARNING_CODE,
   emitWarning,
-  emitWarningOnce
+  emitWarningOnce,
+  deepCopy
 };

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -705,16 +705,15 @@ describe('APM', function() {
   describe('Internal state references', function() {
     let client;
 
-    beforeEach(function(done) {
+    beforeEach(function() {
       client = this.configuration.newClient(
         { writeConcern: { w: 1 } },
         { maxPoolSize: 1, monitorCommands: true }
       );
-      done();
     });
 
     afterEach(function(done) {
-      client.close(() => done());
+      client.close(done);
     });
 
     it('should not allow mutation of internal state from commands returned by event monitoring', function() {

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -702,42 +702,53 @@ describe('APM', function() {
   });
 
   // NODE-3358
-  it('should not allow mutation of internal state from commands returned by event monitoring', function() {
-    const started = [];
-    const succeeded = [];
-    const client = this.configuration.newClient(
-      { writeConcern: { w: 1 } },
-      { maxPoolSize: 1, monitorCommands: true }
-    );
-    client.on('commandStarted', filterForCommands('insert', started));
-    client.on('commandSucceeded', filterForCommands('insert', succeeded));
-    let documentToInsert = { a: { b: 1 } };
-    return client
-      .connect()
-      .then(client => {
-        const db = client.db(this.configuration.db);
-        return db.collection('apm_test').insertOne(documentToInsert);
-      })
-      .then(r => {
-        expect(r)
-          .to.have.property('insertedId')
-          .that.is.an('object');
-        expect(started).to.have.lengthOf(1);
-        // Check if contents of returned document are equal to document inserted (by value)
-        expect(documentToInsert).to.deep.equal(started[0].command.documents[0]);
-        // Check if the returned document is a clone of the original. This confirms that the
-        // reference is not the same.
-        expect(documentToInsert !== started[0].command.documents[0]).to.equal(true);
-        expect(documentToInsert.a !== started[0].command.documents[0].a).to.equal(true);
+  describe('Internal state references', function() {
+    let client;
 
-        started[0].command.documents[0].a.b = 2;
-        expect(documentToInsert.a.b).to.equal(1);
+    beforeEach(function(done) {
+      client = this.configuration.newClient(
+        { writeConcern: { w: 1 } },
+        { maxPoolSize: 1, monitorCommands: true }
+      );
+      done();
+    });
 
-        expect(started[0].commandName).to.equal('insert');
-        expect(started[0].command.insert).to.equal('apm_test');
-        expect(succeeded).to.have.lengthOf(1);
-        return client.close();
-      });
+    afterEach(function(done) {
+      client.close(() => done());
+    });
+
+    it('should not allow mutation of internal state from commands returned by event monitoring', function() {
+      const started = [];
+      const succeeded = [];
+      const documentToInsert = { a: { b: 1 } };
+      client.on('commandStarted', filterForCommands('insert', started));
+      client.on('commandSucceeded', filterForCommands('insert', succeeded));
+      return client
+        .connect()
+        .then(client => {
+          const db = client.db(this.configuration.db);
+          return db.collection('apm_test').insertOne(documentToInsert);
+        })
+        .then(r => {
+          expect(r)
+            .to.have.property('insertedId')
+            .that.is.an('object');
+          expect(started).to.have.lengthOf(1);
+          // Check if contents of returned document are equal to document inserted (by value)
+          expect(documentToInsert).to.deep.equal(started[0].command.documents[0]);
+          // Check if the returned document is a clone of the original. This confirms that the
+          // reference is not the same.
+          expect(documentToInsert !== started[0].command.documents[0]).to.equal(true);
+          expect(documentToInsert.a !== started[0].command.documents[0].a).to.equal(true);
+
+          started[0].command.documents[0].a.b = 2;
+          expect(documentToInsert.a.b).to.equal(1);
+
+          expect(started[0].commandName).to.equal('insert');
+          expect(started[0].command.insert).to.equal('apm_test');
+          expect(succeeded).to.have.lengthOf(1);
+        });
+    });
   });
 
   it('should correctly receive the APM events for deleteOne', {

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -701,6 +701,45 @@ describe('APM', function() {
     }
   });
 
+  // NODE-3358
+  it('should not allow mutation of internal state from commands returned by event monitoring', function() {
+    const started = [];
+    const succeeded = [];
+    const client = this.configuration.newClient(
+      { writeConcern: { w: 1 } },
+      { maxPoolSize: 1, monitorCommands: true }
+    );
+    client.on('commandStarted', filterForCommands('insert', started));
+    client.on('commandSucceeded', filterForCommands('insert', succeeded));
+    let documentToInsert = { a: { b: 1 } };
+    return client
+      .connect()
+      .then(client => {
+        const db = client.db(this.configuration.db);
+        return db.collection('apm_test').insertOne(documentToInsert);
+      })
+      .then(r => {
+        expect(r)
+          .to.have.property('insertedId')
+          .that.is.an('object');
+        expect(started).to.have.lengthOf(1);
+        // Check if contents of returned document are equal to document inserted (by value)
+        expect(documentToInsert).to.deep.equal(started[0].command.documents[0]);
+        // Check if the returned document is a clone of the original. This confirms that the
+        // reference is not the same.
+        expect(documentToInsert !== started[0].command.documents[0]).to.equal(true);
+        expect(documentToInsert.a !== started[0].command.documents[0].a).to.equal(true);
+
+        started[0].command.documents[0].a.b = 2;
+        expect(documentToInsert.a.b).to.equal(1);
+
+        expect(started[0].commandName).to.equal('insert');
+        expect(started[0].command.insert).to.equal('apm_test');
+        expect(succeeded).to.have.lengthOf(1);
+        return client.close();
+      });
+  });
+
   it('should correctly receive the APM events for deleteOne', {
     metadata: { requires: { topology: ['single', 'replicaset'] } },
 

--- a/test/unit/cmap/apm_events.test.js
+++ b/test/unit/cmap/apm_events.test.js
@@ -23,7 +23,7 @@ describe('Command Monitoring Events - unit/cmap', function() {
   ];
 
   for (const command of commands) {
-    it(`should make a deep copy of object of type: ${command.constructor.name}`, () => {
+    it(`CommandStartedEvent should make a deep copy of object of type: ${command.constructor.name}`, () => {
       const ev = new CommandStartedEvent({ id: 'someId', address: 'someHost' }, command);
       if (command instanceof Query) {
         if (command.ns === 'admin.$cmd') {

--- a/test/unit/cmap/apm_events.test.js
+++ b/test/unit/cmap/apm_events.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const Msg = require('../../../lib/core/connection/msg').Msg;
+const GetMore = require('../../../lib/core/connection/commands').GetMore;
+const Query = require('../../../lib/core/connection/commands').Query;
+const KillCursor = require('../../../lib/core/connection/commands').KillCursor;
+const CommandStartedEvent = require('../../../lib/core/connection/apm').CommandStartedEvent;
+const expect = require('chai').expect;
+const Long = require('bson').Long;
+
+describe('Command Monitoring Events - unit/cmap', function() {
+  const commands = [
+    new Query({}, 'admin.$cmd', { a: { b: 10 }, $query: { b: 10 } }, {}),
+    new Query({}, 'hello', { a: { b: 10 }, $query: { b: 10 } }, {}),
+    new Msg({}, 'admin.$cmd', { b: { c: 20 } }, {}),
+    new Msg({}, 'hello', { b: { c: 20 } }, {}),
+    new GetMore({}, 'admin.$cmd', Long.fromNumber(10)),
+    new GetMore({}, 'hello', Long.fromNumber(10)),
+    new KillCursor({}, 'admin.$cmd', [Long.fromNumber(100), Long.fromNumber(200)]),
+    new KillCursor({}, 'hello', [Long.fromNumber(100), Long.fromNumber(200)]),
+    { ns: 'admin.$cmd', query: { $query: { a: 16 } } },
+    { ns: 'hello there', f1: { h: { a: 52, b: { c: 10, d: [1, 2, 3, 5] } } } }
+  ];
+
+  for (const command of commands) {
+    it(`should make a deep copy of object of type: ${command.constructor.name}`, () => {
+      const ev = new CommandStartedEvent({ id: 'someId', address: 'someHost' }, command);
+      if (command instanceof Query) {
+        if (command.ns === 'admin.$cmd') {
+          expect(ev.command !== command.query.$query).to.equal(true);
+          for (const k in command.query.$query) {
+            expect(ev.command[k]).to.deep.equal(command.query.$query[k]);
+          }
+        } else {
+          expect(ev.command.filter !== command.query.$query).to.equal(true);
+          for (const k in command.query.$query) {
+            expect(ev.command.filter[k]).to.deep.equal(command.query.$query[k]);
+          }
+        }
+      } else if (command instanceof Msg) {
+        expect(ev.command !== command.command).to.equal(true);
+        expect(ev.command).to.deep.equal(command.command);
+      } else if (command instanceof GetMore) {
+        // NOTE: BSON Longs pass strict equality when their internal values are equal
+        // i.e.
+        // let l1 = Long(10);
+        // let l2 = Long(10);
+        // l1 === l2 // returns true
+        // expect(ev.command.getMore !== command.cursorId).to.equal(true);
+        expect(ev.command.getMore).to.deep.equal(command.cursorId);
+
+        ev.command.getMore = Long.fromNumber(50128);
+        expect(command.cursorId).to.not.deep.equal(ev.command.getMore);
+      } else if (command instanceof KillCursor) {
+        expect(ev.command.cursors !== command.cursorIds).to.equal(true);
+        expect(ev.command.cursors).to.deep.equal(command.cursorIds);
+      } else if (typeof command === 'object') {
+        if (command.ns === 'admin.$cmd') {
+          expect(ev.command !== command.query.$query).to.equal(true);
+          for (const k in command.query.$query) {
+            expect(ev.command[k]).to.deep.equal(command.query.$query[k]);
+          }
+        }
+      }
+    });
+  }
+});


### PR DESCRIPTION
Modify extractCommand function used in apm event constructors to make deep copies of the command passed in

**What changed?**
- lib/command_utils.js (cherry-picked from https://github.com/mongodb/node-mongodb-native/commit/299b9699c78a69d1b1219ef40604990ab36ef0ee)
- lib/core/connection/apm.js
- lib/utils.js
- test/functional/apm.test.js
- test/unit/cmap/apm_events.test.js

