### PR TITLE
feat(NODE-3331): offer downleveled types for legacy typescript versions

### DIFF
--- a/.evergreen/run-checks.sh
+++ b/.evergreen/run-checks.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
-set -o errexit  # Exit the script with error if any of the commands fail
+set -o errexit # Exit the script with error if any of the commands fail
 
 export PROJECT_DIRECTORY="$(pwd)"
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
+set -o xtrace
+
 npm run check:lint
+
+echo "Typescript $(npx tsc -v)"
+# check resolution uses the default latest types
+echo "import * as mdb from '.'" > file.ts && npx tsc --noEmit --traceResolution file.ts | grep 'mongodb.d.ts' && rm file.ts
+
+npm i --no-save typescript@4.0.2 # there is no 4.0.0
+echo "Typescript $(npx tsc -v)"
+npx tsc --noEmit mongodb.ts34.d.ts
+# check that resolution uses the downleveled types
+echo "import * as mdb from '.'" > file.ts && npx tsc --noEmit --traceResolution file.ts | grep 'mongodb.ts34.d.ts' && rm file.ts

--- a/.evergreen/run-checks.sh
+++ b/.evergreen/run-checks.sh
@@ -6,8 +6,6 @@ NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
-set -o xtrace
-
 npm run check:lint
 
 echo "Typescript $(npx tsc -v)"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ For version compatibility matrices, please refer to the following links:
 - [MongoDB](https://docs.mongodb.com/drivers/node/compatibility#mongodb-compatibility)
 - [NodeJS](https://docs.mongodb.com/drivers/node/compatibility#language-compatibility)
 
+#### Typescript Version
+
+We recommend using the latest version of typescript, however we do provide a [downleveled](https://github.com/sandersn/downlevel-dts#readme) version of the type definitions that we test compiling against `typescript@4.0.2`.
+Since typescript [does not restrict breaking changes to major versions](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes) we consider this support best effort.
+If you run into any unexpected compiler failures please let us know and we will do our best to correct it.
+
 ## Installation
 
 The recommended way to get started using the Node.js 4.0 driver is by using the `npm` (Node Package Manager) to install the dependency in your project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.5.tgz",
-      "integrity": "sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+      "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
       "dev": true
     },
     "@babel/core": {
@@ -134,9 +134,9 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz",
-      "integrity": "sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+      "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
@@ -299,9 +299,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
-      "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+      "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
       "dev": true
     },
     "@babel/template": {
@@ -327,9 +327,9 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
-      "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+      "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
@@ -337,7 +337,7 @@
         "@babel/helper-function-name": "^7.14.5",
         "@babel/helper-hoist-variables": "^7.14.5",
         "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.5",
+        "@babel/parser": "^7.14.7",
         "@babel/types": "^7.14.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -746,9 +746,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
-      "integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==",
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -770,13 +770,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.0.tgz",
-      "integrity": "sha512-KcF6p3zWhf1f8xO84tuBailV5cN92vhS+VT7UJsPzGBm9VnQqfI9AsiMUFUCYHTYPg1uCCo+HyiDnpDuvkAMfQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.1.tgz",
+      "integrity": "sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.28.0",
-        "@typescript-eslint/scope-manager": "4.28.0",
+        "@typescript-eslint/experimental-utils": "4.28.1",
+        "@typescript-eslint/scope-manager": "4.28.1",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -796,55 +796,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.0.tgz",
-      "integrity": "sha512-9XD9s7mt3QWMk82GoyUpc/Ji03vz4T5AYlHF9DcoFNfJ/y3UAclRsfGiE2gLfXtyC+JRA3trR7cR296TEb1oiQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.1.tgz",
+      "integrity": "sha512-n8/ggadrZ+uyrfrSEchx3jgODdmcx7MzVM2sI3cTpI/YlfSm0+9HEUaWw3aQn2urL2KYlWYMDgn45iLfjDYB+Q==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.28.0",
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/typescript-estree": "4.28.0",
+        "@typescript-eslint/scope-manager": "4.28.1",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/typescript-estree": "4.28.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.0.tgz",
-      "integrity": "sha512-7x4D22oPY8fDaOCvkuXtYYTQ6mTMmkivwEzS+7iml9F9VkHGbbZ3x4fHRwxAb5KeuSkLqfnYjs46tGx2Nour4A==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.1.tgz",
+      "integrity": "sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.28.0",
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/typescript-estree": "4.28.0",
+        "@typescript-eslint/scope-manager": "4.28.1",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/typescript-estree": "4.28.1",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.0.tgz",
-      "integrity": "sha512-eCALCeScs5P/EYjwo6se9bdjtrh8ByWjtHzOkC4Tia6QQWtQr3PHovxh3TdYTuFcurkYI4rmFsRFpucADIkseg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz",
+      "integrity": "sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/visitor-keys": "4.28.0"
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/visitor-keys": "4.28.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.0.tgz",
-      "integrity": "sha512-p16xMNKKoiJCVZY5PW/AfILw2xe1LfruTcfAKBj3a+wgNYP5I9ZEKNDOItoRt53p4EiPV6iRSICy8EPanG9ZVA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.1.tgz",
+      "integrity": "sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.0.tgz",
-      "integrity": "sha512-m19UQTRtxMzKAm8QxfKpvh6OwQSXaW1CdZPoCaQuLwAq7VZMNuhJmZR4g5281s2ECt658sldnJfdpSZZaxUGMQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz",
+      "integrity": "sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/visitor-keys": "4.28.0",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/visitor-keys": "4.28.1",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -864,12 +864,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.0.tgz",
-      "integrity": "sha512-PjJyTWwrlrvM5jazxYF5ZPs/nl0kHDZMVbuIcbpawVXaDPelp3+S9zpOz5RmVUfS/fD5l5+ZXNKnWhNYjPzCvw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz",
+      "integrity": "sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.0",
+        "@typescript-eslint/types": "4.28.1",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -1317,9 +1317,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001239",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
-      "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==",
+      "version": "1.0.30001241",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
+      "integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==",
       "dev": true
     },
     "caseless": {
@@ -1834,9 +1834,9 @@
       "dev": true
     },
     "coveralls": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
+      "integrity": "sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==",
       "dev": true,
       "requires": {
         "js-yaml": "^3.13.1",
@@ -2222,6 +2222,28 @@
         "minimatch": "^3.0.4"
       }
     },
+    "downlevel-dts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.7.0.tgz",
+      "integrity": "sha512-tcjGqElN0/oad/LJBlaxmZ3zOYEQOBbGuirKzif8s1jeRiWBdNX9H6OBFlRjOQkosXgV+qSjs4osuGCivyZ4Jw==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.3.2",
+        "shelljs": "^0.8.3",
+        "typescript": "^4.1.0-dev.20201026"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -2233,9 +2255,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.752",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
-      "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==",
+      "version": "1.3.761",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.761.tgz",
+      "integrity": "sha512-7a/wV/plM/b95XjTdA2Q4zAxxExTDKkNQpTiaU/nVT8tGCQVtX9NsnTjhALBFICpOB58hU6xg5fFC3CT2Bybpg==",
       "dev": true
     },
     "emoji-regex": {
@@ -2575,9 +2597,9 @@
       }
     },
     "eslint-rule-docs": {
-      "version": "1.1.228",
-      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.228.tgz",
-      "integrity": "sha512-msP/OPR619Yft3HS4D9OkajQ6djnvWdq/rUgTLPndnmfCFsEtTLsPDSEsqQkpsTIp39mc3TUap3jUs/rsYd0Og==",
+      "version": "1.1.229",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.229.tgz",
+      "integrity": "sha512-blQpqOoFiGr9wcH+MEgfMHcxizaXUaXXEc07R0avaZeivVmoPhvepHsh1UfdbtvC/KNZPcLzdpPIEpZIdgUSdQ==",
       "dev": true
     },
     "eslint-scope": {
@@ -2707,17 +2729,16 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       }
     },
     "fast-json-stable-stringify": {
@@ -4360,9 +4381,9 @@
       "dev": true
     },
     "marked": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.1.tgz",
-      "integrity": "sha512-5XFS69o9CzDpQDSpUYC+AN2xvq8yl1EGa5SG/GI1hP78/uTeo3PDfiDNmsUyiahpyhToDDJhQk7fNtJsga+KVw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
       "dev": true
     },
     "mdurl": {
@@ -6157,13 +6178,14 @@
       }
     },
     "shiki": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.3.tgz",
-      "integrity": "sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.5.tgz",
+      "integrity": "sha512-XFn+rl3wIowDjzdr5DlHoHgQphXefgUTs2bNp/bZu4WF9gTrTLnKwio3f28VjiFG6Jpip7yQn/p4mMj6OrjrtQ==",
       "dev": true,
       "requires": {
+        "json5": "^2.2.0",
         "onigasm": "^2.2.5",
-        "vscode-textmate": "^5.2.0"
+        "vscode-textmate": "5.2.0"
       }
     },
     "signal-exit": {
@@ -7189,9 +7211,9 @@
       }
     },
     "typedoc": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.0.tgz",
-      "integrity": "sha512-InmPBVlpOXptIkg/WnsQhbGYhv9cuDh/cRACUSautQ0QwcJPLAK2kHcfP0Pld6z/NiDvHc159fMq2qS+b/ALUw==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.2.tgz",
+      "integrity": "sha512-SR1ByJB3USg+jxoxwzMRP07g/0f/cQUE5t7gOh1iTUyjTPyJohu9YSKRlK+MSXXqlhIq+m0jkEHEG5HoY7/Adg==",
       "dev": true,
       "requires": {
         "glob": "^7.1.7",
@@ -7254,9 +7276,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
-      "integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
       "dev": true,
       "optional": true
     },
@@ -7345,9 +7367,9 @@
       }
     },
     "vscode-textmate": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.4.0.tgz",
-      "integrity": "sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "walkdir": {
@@ -7371,9 +7393,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "whatwg-url": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.6.0.tgz",
-      "integrity": "sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
       "requires": {
         "lodash": "^4.7.0",
         "tr46": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,17 @@
     "lib",
     "src",
     "etc/prepare.js",
-    "mongodb.d.ts"
+    "mongodb.d.ts",
+    "mongodb.ts34.d.ts"
   ],
   "types": "mongodb.d.ts",
+  "typesVersions": {
+    "<=4.0.2": {
+      "mongodb.d.ts": [
+        "mongodb.ts34.d.ts"
+      ]
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:mongodb/node-mongodb-native.git"
@@ -49,6 +57,7 @@
     "chalk": "^4.1.0",
     "co": "4.6.0",
     "coveralls": "^3.0.11",
+    "downlevel-dts": "^0.7.0",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-jsdoc": "^30.7.8",
@@ -95,7 +104,7 @@
   "scripts": {
     "build:evergreen": "node .evergreen/generate_evergreen_tasks.js",
     "build:ts": "rimraf lib && tsc",
-    "build:dts": "npm run build:ts && api-extractor run && rimraf 'lib/**/*.d.ts*'",
+    "build:dts": "npm run build:ts && api-extractor run && rimraf 'lib/**/*.d.ts*' && downlevel-dts mongodb.d.ts mongodb.ts34.d.ts",
     "build:docs": "typedoc",
     "check:bench": "node test/benchmarks/driverBench",
     "check:coverage": "nyc npm run check:test",

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,6 +392,7 @@ export type {
   FilterOperations,
   KeysOfAType,
   KeysOfOtherType,
-  IsAny
+  IsAny,
+  OneOrMore
 } from './mongo_types';
 export type { serialize, deserialize } from './bson';

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -320,6 +320,9 @@ export type UpdateFilter<TSchema> = {
 export type Nullable<AnyType> = AnyType | null | undefined;
 
 /** @public */
+export type OneOrMore<T> = T | T[];
+
+/** @public */
 export type GenericListener = (...args: any[]) => void;
 
 /**

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -22,6 +22,7 @@ import type { Db } from '../db';
 import { AbstractCursor } from '../cursor/abstract_cursor';
 import type { ClientSession } from '../sessions';
 import { executeOperation, ExecutionResult } from './execute_operation';
+import type { OneOrMore } from '../mongo_types';
 
 const LIST_INDEXES_WIRE_VERSION = 3;
 const VALID_INDEX_OPTIONS = new Set([
@@ -58,14 +59,15 @@ const VALID_INDEX_OPTIONS = new Set([
 
 /** @public */
 export type IndexDirection = -1 | 1 | '2d' | '2dsphere' | 'text' | 'geoHaystack' | number;
+
 /** @public */
-export type IndexSpecification =
+export type IndexSpecification = OneOrMore<
   | string
   | [string, IndexDirection]
   | { [key: string]: IndexDirection }
   | [string, IndexDirection][]
   | { [key: string]: IndexDirection }[]
-  | IndexSpecification[];
+>;
 
 /** @public */
 export interface IndexDescription {


### PR DESCRIPTION
Downlevel-dts is now run when ever defintions are generated and our package points typescript versions equal to 4.0.2 and older to these defintions. They target the lowest version downlevel-dts supports which is 3.4. I added a check to our CI to make sure that 4.0.2 will use and remain compatible with these types.
