### PR TITLE
fix(NODE-3380): perform retryable write checks against server

### DIFF
--- a/lib/core/sdam/server.js
+++ b/lib/core/sdam/server.js
@@ -167,6 +167,10 @@ class Server extends EventEmitter {
     return this.s.description;
   }
 
+  get supportsRetryableWrites() {
+    return supportsRetryableWrites(this);
+  }
+
   get name() {
     return this.s.description.address;
   }

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -668,12 +668,17 @@ class Topology extends EventEmitter {
         return;
       }
 
+      const notAlreadyRetrying = !options.retrying;
+      const retryWrites = !!options.retryWrites;
+      const hasSession = !!options.session;
+      const supportsRetryableWrites = server.supportsRetryableWrites;
+      const notInTransaction = !options.session.inTransaction();
       const willRetryWrite =
-        !options.retrying &&
-        !!options.retryWrites &&
-        options.session &&
-        server.supportsRetryableWrites &&
-        !options.session.inTransaction() &&
+        notAlreadyRetrying &&
+        retryWrites &&
+        hasSession &&
+        supportsRetryableWrites &&
+        notInTransaction &&
         isWriteCommand(cmd);
 
       const cb = (err, result) => {
@@ -930,13 +935,19 @@ function executeWriteOperation(args, options, callback) {
       return;
     }
 
+    const notAlreadyRetrying = !args.retrying;
+    const retryWrites = !!options.retryWrites;
+    const hasSession = !!options.session;
+    const supportsRetryableWrites = server.supportsRetryableWrites;
+    const notInTransaction = !options.session.inTransaction();
+    const notExplaining = options.explain === undefined;
     const willRetryWrite =
-      !args.retrying &&
-      !!options.retryWrites &&
-      options.session &&
-      server.supportsRetryableWrites &&
-      !options.session.inTransaction() &&
-      options.explain === undefined;
+      notAlreadyRetrying &&
+      retryWrites &&
+      hasSession &&
+      supportsRetryableWrites &&
+      notInTransaction &&
+      notExplaining;
 
     const handler = (err, result) => {
       if (!err) return callback(null, result);

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -672,7 +672,7 @@ class Topology extends EventEmitter {
       const retryWrites = !!options.retryWrites;
       const hasSession = !!options.session;
       const supportsRetryableWrites = server.supportsRetryableWrites;
-      const notInTransaction = !options.session.inTransaction();
+      const notInTransaction = !hasSession || !options.session.inTransaction();
       const willRetryWrite =
         notAlreadyRetrying &&
         retryWrites &&
@@ -939,7 +939,7 @@ function executeWriteOperation(args, options, callback) {
     const retryWrites = !!options.retryWrites;
     const hasSession = !!options.session;
     const supportsRetryableWrites = server.supportsRetryableWrites;
-    const notInTransaction = !options.session.inTransaction();
+    const notInTransaction = !hasSession || !options.session.inTransaction();
     const notExplaining = options.explain === undefined;
     const willRetryWrite =
       notAlreadyRetrying &&

--- a/lib/core/sdam/topology.js
+++ b/lib/core/sdam/topology.js
@@ -9,7 +9,6 @@ const events = require('./events');
 const Server = require('./server').Server;
 const relayEvents = require('../utils').relayEvents;
 const ReadPreference = require('../topologies/read_preference');
-const isRetryableWritesSupported = require('../topologies/shared').isRetryableWritesSupported;
 const CoreCursor = require('../cursor').CoreCursor;
 const deprecate = require('util').deprecate;
 const BSON = require('../connection/utils').retrieveBSON();
@@ -673,7 +672,7 @@ class Topology extends EventEmitter {
         !options.retrying &&
         !!options.retryWrites &&
         options.session &&
-        isRetryableWritesSupported(this) &&
+        server.supportsRetryableWrites &&
         !options.session.inTransaction() &&
         isWriteCommand(cmd);
 
@@ -925,19 +924,19 @@ function executeWriteOperation(args, options, callback) {
   const ns = args.ns;
   const ops = args.ops;
 
-  const willRetryWrite =
-    !args.retrying &&
-    !!options.retryWrites &&
-    options.session &&
-    isRetryableWritesSupported(topology) &&
-    !options.session.inTransaction() &&
-    options.explain === undefined;
-
   topology.selectServer(writableServerSelector(), options, (err, server) => {
     if (err) {
       callback(err, null);
       return;
     }
+
+    const willRetryWrite =
+      !args.retrying &&
+      !!options.retryWrites &&
+      options.session &&
+      server.supportsRetryableWrites &&
+      !options.session.inTransaction() &&
+      options.explain === undefined;
 
     const handler = (err, result) => {
       if (!err) return callback(null, result);


### PR DESCRIPTION
The driver was incorrectly checking for a `Single` topology instead of
a `Standalone` server when determining the retryability of write
operations.

NODE-3380
