### PR TITLE
fix(NODE-2026): support SERVICE_REALM authentication mechanism property

### DIFF
--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -50,8 +50,8 @@ describe('Kerberos', function () {
     });
   });
 
-  // TODO: this test only tests that these properties do not crash anything - but not that they actually have an effect
-  it('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
+  // Unskip this test when a proper setup is available - see NODE-3060
+  it.skip('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
     const client = new MongoClient(
       `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false,SERVICE_REALM:windows&maxPoolSize=1`
     );


### PR DESCRIPTION
Introduces support for the `SERVICE_REALM` authentication mechanism property. It will be work as expected in Windows environments due to the underlying nature of the GSSAPI implementation on *nix.

The logic to compute the Service Principal Name (SPN) is as follows:
1. Combine service name and hostname (with a `/` in between for Windows and an `@` otherwise)
2. If present, attach the `SERVICE_REALM` with an `@` to the result of step 1.

The logic is taken from the C driver where you can find the steps mangled as follows:
1. "Join" the array of `[serviceName, hostName, serviceRealm]` with `@` (see https://github.com/mongodb/mongo-c-driver/blob/f1093ba1686b8bf876eed67e0c7f59918649ef15/src/libmongoc/src/mongoc/mongoc-cluster-sspi.c#L61-L71)
2. If there is no `/` in the SPN (which is not the case after step 1), replace the first `@` with a `/` (see https://github.com/mongodb/mongo-c-driver/blob/5b91fb983fc5badf38e2debeb4ce6c231b73605b/src/libmongoc/src/mongoc/mongoc-sspi.c#L176-L182)

I was able to successfully test this behavior in a Windows environment with Kerberos enabled.