### PR TITLE
fix(NODE-1843): bulk operations ignoring provided sessions

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1200,7 +1200,8 @@ export abstract class BulkOperationBase {
     }
 
     this.s.executed = true;
-    return executeLegacyOperation(this.s.topology, executeCommands, [this, options, callback]);
+    const finalOptions = { ...this.s.options, ...options };
+    return executeLegacyOperation(this.s.topology, executeCommands, [this, finalOptions, callback]);
   }
 
   /**

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -2015,9 +2015,18 @@ describe('Bulk', function () {
       client = config.newClient();
       await client.connect();
 
-      collection = client
+      try {
+        await client
+          .db('bulk_operation_writes_test')
+          .collection('bulk_write_transaction_test')
+          .drop();
+      } catch (_) {
+        // do not care
+      }
+
+      collection = await client
         .db('bulk_operation_writes_test')
-        .collection('bulk_write_transaction_test');
+        .createCollection('bulk_write_transaction_test');
 
       await collection.deleteMany({});
     });
@@ -2027,7 +2036,7 @@ describe('Bulk', function () {
       async test() {
         const session = client.startSession();
         session.startTransaction({
-          readConcern: { level: 'snapshot' },
+          readConcern: { level: 'majority' },
           writeConcern: { w: 'majority' }
         });
 
@@ -2077,7 +2086,7 @@ describe('Bulk', function () {
 
             await session.abortTransaction();
           },
-          { readConcern: { level: 'snapshot' }, writeConcern: { w: 'majority' } }
+          { readConcern: { level: 'majority' }, writeConcern: { w: 'majority' } }
         );
 
         await session.endSession();

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -2032,7 +2032,7 @@ describe('Bulk', function () {
     });
 
     it('should abort ordered/unordered bulk operation writes', {
-      metadata: { requires: { mongodb: '>= 3.6', topology: ['replicaset'] } },
+      metadata: { requires: { mongodb: '>= 4.2', topology: ['replicaset'] } },
       async test() {
         const session = client.startSession();
         session.startTransaction({
@@ -2067,7 +2067,7 @@ describe('Bulk', function () {
     });
 
     it('should abort ordered/unordered bulk operation writes using withTransaction', {
-      metadata: { requires: { mongodb: '>= 3.6', topology: ['replicaset'] } },
+      metadata: { requires: { mongodb: '>= 4.2', topology: ['replicaset'] } },
       async test() {
         const session = client.startSession();
 

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -2032,11 +2032,11 @@ describe('Bulk', function () {
     });
 
     it('should abort ordered/unordered bulk operation writes', {
-      metadata: { requires: { mongodb: '>= 3.6', topology: ['replicaset', 'sharded'] } },
+      metadata: { requires: { mongodb: '>= 3.6', topology: ['replicaset'] } },
       async test() {
         const session = client.startSession();
         session.startTransaction({
-          readConcern: { level: 'majority' },
+          readConcern: { level: 'local' },
           writeConcern: { w: 'majority' }
         });
 
@@ -2067,7 +2067,7 @@ describe('Bulk', function () {
     });
 
     it('should abort ordered/unordered bulk operation writes using withTransaction', {
-      metadata: { requires: { mongodb: '>= 3.6', topology: ['replicaset', 'sharded'] } },
+      metadata: { requires: { mongodb: '>= 3.6', topology: ['replicaset'] } },
       async test() {
         const session = client.startSession();
 
@@ -2086,7 +2086,7 @@ describe('Bulk', function () {
 
             await session.abortTransaction();
           },
-          { readConcern: { level: 'majority' }, writeConcern: { w: 'majority' } }
+          { readConcern: { level: 'local' }, writeConcern: { w: 'majority' } }
         );
 
         await session.endSession();


### PR DESCRIPTION
The BulkOperationBase class wasn't making use of the options provided at construction time during execution time.

NODE-1843