### PR TITLE
fix(NODE-1797): Error when ChangeStream used as iterator and emitter concurrently

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -274,6 +274,7 @@ export class ChangeStream<TSchema extends Document> extends TypedEventEmitter<Ch
     this.cursor = createChangeStreamCursor(this, options);
 
     this[kClosed] = false;
+    this[kMode] = false;
 
     // Listen for any `change` listeners being added to ChangeStream
     this.on('newListener', eventName => {

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -1814,13 +1814,12 @@ describe('Change Streams', function () {
       if (repeatInsert) {
         clearInterval(repeatInsert);
       }
-
       if (changeStream && !changeStream.closed) {
-        await changeStream.close().catch(changeStream.close);
+        await changeStream.close();
       }
 
       if (client) {
-        await client.close().catch(client.close);
+        await client.close();
       }
 
       await mock.cleanup();
@@ -1832,7 +1831,7 @@ describe('Change Streams', function () {
       {
         metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
         test: async function () {
-          changeStream.on('change', () => {});
+          await new Promise(resolve => changeStream.on('change', resolve));
           try {
             await changeStream.hasNext().catch(err => {
               expect.fail(err.message);
@@ -1850,10 +1849,10 @@ describe('Change Streams', function () {
       {
         metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
         test: async function () {
-          changeStream.on('change', () => {});
+          await new Promise(resolve => changeStream.on('change', resolve));
 
           try {
-            changeStream.hasNext(() => {});
+            await new Promise(resolve => changeStream.hasNext(resolve));
           } catch (error) {
             return expect(error).to.be.instanceof(MongoDriverError);
           }
@@ -1870,7 +1869,7 @@ describe('Change Streams', function () {
             .hasNext()
             .catch(() => expect.fail('Failed to set changeStream to iterator'));
           try {
-            changeStream.on('change', () => {});
+            await new Promise(resolve => changeStream.on('change', resolve));
           } catch (error) {
             return expect(error).to.be.instanceof(MongoDriverError);
           }
@@ -1884,9 +1883,9 @@ describe('Change Streams', function () {
       {
         metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
         test: async function () {
-          changeStream.hasNext(() => {});
+          await new Promise(resolve => changeStream.hasNext(resolve));
           try {
-            changeStream.on('change', () => {});
+            await new Promise(resolve => changeStream.on('change', resolve));
           } catch (error) {
             return expect(error).to.be.instanceof(MongoDriverError);
           }
@@ -1899,7 +1898,7 @@ describe('Change Streams', function () {
       {
         metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
         test: async function () {
-          changeStream.once('change', () => {});
+          await new Promise(resolve => changeStream.once('change', resolve));
           try {
             await changeStream.next().catch(err => {
               expect.fail(err.message);
@@ -1917,10 +1916,10 @@ describe('Change Streams', function () {
       {
         metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
         test: async function () {
-          changeStream.once('change', () => {});
+          await new Promise(resolve => changeStream.once('change', resolve));
 
           try {
-            changeStream.next(() => {});
+            await new Promise(resolve => changeStream.next(resolve));
           } catch (error) {
             return expect(error).to.be.instanceof(MongoDriverError);
           }
@@ -1937,7 +1936,7 @@ describe('Change Streams', function () {
             .tryNext()
             .catch(() => expect.fail('Failed to set changeStream to iterator'));
           try {
-            changeStream.on('change', () => {});
+            await new Promise(resolve => changeStream.on('change', resolve));
           } catch (error) {
             return expect(error).to.be.instanceof(MongoDriverError);
           }
@@ -1951,9 +1950,9 @@ describe('Change Streams', function () {
       {
         metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
         test: async function () {
-          changeStream.tryNext(() => {});
+          await new Promise(resolve => changeStream.tryNext(resolve));
           try {
-            changeStream.on('change', () => {});
+            await new Promise(resolve => changeStream.on('change', resolve));
           } catch (error) {
             return expect(error).to.be.instanceof(MongoDriverError);
           }

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -1825,7 +1825,7 @@ describe('Change Streams', function () {
     });
 
     it(
-      'should throw MongoDriverError when set as an emitter with "on" and used as an iterator with "hasNext" using promises',
+      'should throw MongoDriverError when set as an emitter with "on" and used as an iterator with "hasNext"',
       {
         metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
         test: async function () {
@@ -1843,23 +1843,7 @@ describe('Change Streams', function () {
     );
 
     it(
-      'should throw MongoDriverError when set as an emitter with "on" and used as an iterator with "hasNext" using callbacks',
-      {
-        metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-        test: async function () {
-          await new Promise(resolve => changeStream.on('change', resolve));
-
-          try {
-            await new Promise(resolve => changeStream.hasNext(resolve));
-          } catch (error) {
-            return expect(error).to.be.instanceof(MongoDriverError);
-          }
-          return expect.fail('Should not reach here');
-        }
-      }
-    );
-    it(
-      'should throw MongoDriverError when set as an iterator with "hasNext" and used as an emitter with "on" using promises',
+      'should throw MongoDriverError when set as an iterator with "hasNext" and used as an emitter with "on"',
       {
         metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
         test: async function () {
@@ -1877,22 +1861,7 @@ describe('Change Streams', function () {
     );
 
     it(
-      'should throw MongoDriverError when set as an iterator with "hasNext" and used as an emitter with "on" using callbacks',
-      {
-        metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-        test: async function () {
-          await new Promise(resolve => changeStream.hasNext(resolve));
-          try {
-            await new Promise(resolve => changeStream.on('change', resolve));
-          } catch (error) {
-            return expect(error).to.be.instanceof(MongoDriverError);
-          }
-          return expect.fail('Should not reach here');
-        }
-      }
-    );
-    it(
-      'should throw MongoDriverError when set as an emitter with "once" and used as an iterator with "next" using promises',
+      'should throw MongoDriverError when set as an emitter with "once" and used as an iterator with "next"',
       {
         metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
         test: async function () {
@@ -1910,45 +1879,13 @@ describe('Change Streams', function () {
     );
 
     it(
-      'should throw MongoDriverError when set as an emitter with "once" and used as an iterator with "next" using callbacks',
-      {
-        metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-        test: async function () {
-          await new Promise(resolve => changeStream.once('change', resolve));
-
-          try {
-            await new Promise(resolve => changeStream.next(resolve));
-          } catch (error) {
-            return expect(error).to.be.instanceof(MongoDriverError);
-          }
-          return expect.fail('Should not reach here');
-        }
-      }
-    );
-    it(
-      'should throw MongoDriverError when set as an iterator with "tryNext" and used as an emitter with "on" using promises',
+      'should throw MongoDriverError when set as an iterator with "tryNext" and used as an emitter with "on"',
       {
         metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
         test: async function () {
           await changeStream
             .tryNext()
             .catch(() => expect.fail('Failed to set changeStream to iterator'));
-          try {
-            await new Promise(resolve => changeStream.on('change', resolve));
-          } catch (error) {
-            return expect(error).to.be.instanceof(MongoDriverError);
-          }
-          return expect.fail('Should not reach here');
-        }
-      }
-    );
-
-    it(
-      'should throw MongoDriverError when set as an iterator with "tryNext" and used as an emitter with "on" using callbacks',
-      {
-        metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-        test: async function () {
-          await new Promise(resolve => changeStream.tryNext(resolve));
           try {
             await new Promise(resolve => changeStream.on('change', resolve));
           } catch (error) {

--- a/test/functional/change_stream.test.js
+++ b/test/functional/change_stream.test.js
@@ -1814,18 +1814,16 @@ describe('Change Streams', function () {
       if (repeatInsert) {
         clearInterval(repeatInsert);
       }
-      if (changeStream && !changeStream.closed) {
+      if (changeStream) {
         await changeStream.close();
       }
 
+      await mock.cleanup();
       if (client) {
         await client.close();
       }
-
-      await mock.cleanup();
     });
 
-    // TODO: Better Errors
     it(
       'should throw MongoDriverError when set as an emitter with "on" and used as an iterator with "hasNext" using promises',
       {
@@ -2145,7 +2143,6 @@ describe('Change Streams', function () {
         this.changeStream.on('resumeTokenChanged', resumeToken => {
           this.resumeTokenChangedEvents.push({ resumeToken });
         });
-        this.changeStream.isEmitter = false;
 
         return this.changeStream;
       }


### PR DESCRIPTION
## Description

Throw appropriate error when a ChangeStream object is used as both an iterator and an emitter

**What changed?**

* src/change_stream.ts
* test/functional/change_stream.test.js
