### PR TITLE
refactor(NODE-3324): bump max wire version to 13

### DIFF
--- a/src/cmap/wire_protocol/constants.ts
+++ b/src/cmap/wire_protocol/constants.ts
@@ -1,7 +1,7 @@
 export const MIN_SUPPORTED_SERVER_VERSION = '2.6';
-export const MAX_SUPPORTED_SERVER_VERSION = '4.4';
+export const MAX_SUPPORTED_SERVER_VERSION = '5.0';
 export const MIN_SUPPORTED_WIRE_VERSION = 2;
-export const MAX_SUPPORTED_WIRE_VERSION = 9;
+export const MAX_SUPPORTED_WIRE_VERSION = 13;
 export const OP_REPLY = 1;
 export const OP_UPDATE = 2001;
 export const OP_INSERT = 2002;

--- a/test/unit/wire_version.test.js
+++ b/test/unit/wire_version.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const mock = require('../tools/mock');
+const { expect } = require('chai');
+const { MongoServerSelectionError } = require('../../src/error');
+
+const minCompatErrMsg = `minimum wire version ${
+  Number.MAX_SAFE_INTEGER - 1
+}, but this version of the Node.js Driver requires at most 13`;
+const maxCompatErrMsg = `reports maximum wire version 1, but this version of the Node.js Driver requires at least 2`;
+
+describe('Wire Protocol Version', () => {
+  /** @type {mock.MockServer} */
+  let server;
+
+  function setWireProtocolMessageHandler(min, max) {
+    server.setMessageHandler(req => {
+      const doc = req.document;
+      if (doc.ismaster || doc.hello) {
+        const hello = {
+          ...mock.DEFAULT_ISMASTER_36,
+          minWireVersion: min,
+          maxWireVersion: max
+        };
+        return req.reply(hello);
+      }
+    });
+  }
+
+  beforeEach(async () => {
+    server = await mock.createServer();
+  });
+  afterEach(async () => {
+    await mock.cleanup();
+  });
+
+  describe('minimum is greater than 13', () => {
+    it('should raise a compatibility error', async function () {
+      setWireProtocolMessageHandler(Number.MAX_SAFE_INTEGER - 1, Number.MAX_SAFE_INTEGER);
+
+      /** @type {import('../../src/mongo_client').MongoClient} */
+      const client = this.configuration.newClient(
+        `mongodb://${server.uri()}/wireVersionTest?serverSelectionTimeoutMS=200`
+      );
+      try {
+        await client.connect();
+        expect.fail('should fail to select server!');
+      } catch (error) {
+        expect(error).to.be.instanceOf(MongoServerSelectionError);
+        expect(error).to.have.property('message').that.includes(minCompatErrMsg);
+      }
+      await client.close();
+    });
+  });
+
+  describe('maximum is less than 2', () => {
+    it('should raise a compatibility error', async function () {
+      setWireProtocolMessageHandler(1, 1);
+
+      /** @type {import('../../src/mongo_client').MongoClient} */
+      const client = this.configuration.newClient(
+        `mongodb://${server.uri()}/wireVersionTest?serverSelectionTimeoutMS=200`
+      );
+      try {
+        await client.connect();
+        expect.fail('should fail to select server!');
+      } catch (error) {
+        expect(error).to.be.instanceOf(MongoServerSelectionError);
+        expect(error).to.have.property('message').that.includes(maxCompatErrMsg);
+      }
+      await client.close();
+    });
+  });
+});


### PR DESCRIPTION
Bumps the version and adds a test to capture the errors caused by out of range versions.