### PR TITLE
fix(NODE-3397): report more helpful error with unsupported authMechanism in initial handshake

### DIFF
--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -180,7 +180,7 @@ function prepareHandshakeDocument(authContext, callback) {
 
     const authProvider = AUTH_PROVIDERS[credentials.mechanism];
     if (authProvider == null) {
-      return callback(new MongoError(`authMechanism '${credentials.mechanism}' not supported`)); 
+      return callback(new MongoError(`No AuthProvider for ${credentials.mechanism} defined.`));
     }
     authProvider.prepare(handshakeDoc, authContext, callback);
     return;

--- a/lib/core/connection/connect.js
+++ b/lib/core/connection/connect.js
@@ -179,6 +179,9 @@ function prepareHandshakeDocument(authContext, callback) {
     }
 
     const authProvider = AUTH_PROVIDERS[credentials.mechanism];
+    if (authProvider == null) {
+      return callback(new MongoError(`authMechanism '${credentials.mechanism}' not supported`)); 
+    }
     authProvider.prepare(handshakeDoc, authContext, callback);
     return;
   }


### PR DESCRIPTION
## Description

I haven't been able to repro this locally, but there's a user that ran into this case at Automattic/mongoose#10377. Figured this change is sufficiently straightforward that it's worthwhile to patch without digging into it much further.

**What changed?**

Added a quick check for `null` or `undefined` before calling a method on an object

**Are there any files to ignore?**
