### PR TITLE
fix(NODE-3416): make change stream generic default to Document

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -189,7 +189,7 @@ export type ChangeStreamEvents = {
  * Creates a new Change Stream instance. Normally created using {@link Collection#watch|Collection.watch()}.
  * @public
  */
-export class ChangeStream<TSchema extends Document> extends TypedEventEmitter<ChangeStreamEvents> {
+export class ChangeStream<TSchema extends Document = Document> extends TypedEventEmitter<ChangeStreamEvents> {
   pipeline: Document[];
   options: ChangeStreamOptions;
   parent: MongoClient | Db | Collection;

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -189,7 +189,9 @@ export type ChangeStreamEvents = {
  * Creates a new Change Stream instance. Normally created using {@link Collection#watch|Collection.watch()}.
  * @public
  */
-export class ChangeStream<TSchema extends Document = Document> extends TypedEventEmitter<ChangeStreamEvents> {
+export class ChangeStream<TSchema extends Document = Document> extends TypedEventEmitter<
+  ChangeStreamEvents
+> {
   pipeline: Document[];
   options: ChangeStreamOptions;
   parent: MongoClient | Db | Collection;


### PR DESCRIPTION
## Description

In most places, the node driver defaults to using `Document` if no generic param is provided. `ChangeStream` looks to be an exception.

**What changed?**

Added a default generic param to ChangeStream

**Are there any files to ignore?**

Nope
