### PR TITLE
refactor(NODE-3402): Implement MongoAPIError and its children

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -754,7 +754,7 @@ export class FindOperators {
   /** Add a single update operation to the bulk operation */
   updateOne(updateDocument: Document): BulkOperationBase {
     if (!hasAtomicOperators(updateDocument)) {
-      throw new MongoDriverError('Update document requires atomic operators');
+      throw new MongoInvalidArgumentError('Update document requires atomic operators');
     }
 
     const currentOp = buildCurrentOp(this.bulkOperation);
@@ -767,7 +767,7 @@ export class FindOperators {
   /** Add a replace one operation to the bulk operation */
   replaceOne(replacement: Document): BulkOperationBase {
     if (hasAtomicOperators(replacement)) {
-      throw new MongoDriverError('Replacement document must not use atomic operators');
+      throw new MongoInvalidArgumentError('Replacement document must not use atomic operators');
     }
 
     const currentOp = buildCurrentOp(this.bulkOperation);
@@ -1084,7 +1084,7 @@ export abstract class BulkOperationBase {
     if ('replaceOne' in op || 'updateOne' in op || 'updateMany' in op) {
       if ('replaceOne' in op) {
         if ('q' in op.replaceOne) {
-          throw new MongoDriverError('Raw operations are not allowed');
+          throw new MongoInvalidArgumentError('Raw operations are not allowed');
         }
         const updateStatement = makeUpdateStatement(
           op.replaceOne.filter,
@@ -1099,7 +1099,7 @@ export abstract class BulkOperationBase {
 
       if ('updateOne' in op) {
         if ('q' in op.updateOne) {
-          throw new MongoDriverError('Raw operations are not allowed');
+          throw new MongoInvalidArgumentError('Raw operations are not allowed');
         }
         const updateStatement = makeUpdateStatement(op.updateOne.filter, op.updateOne.update, {
           ...op.updateOne,
@@ -1113,7 +1113,7 @@ export abstract class BulkOperationBase {
 
       if ('updateMany' in op) {
         if ('q' in op.updateMany) {
-          throw new MongoDriverError('Raw operations are not allowed');
+          throw new MongoInvalidArgumentError('Raw operations are not allowed');
         }
         const updateStatement = makeUpdateStatement(op.updateMany.filter, op.updateMany.update, {
           ...op.updateMany,
@@ -1128,7 +1128,7 @@ export abstract class BulkOperationBase {
 
     if ('deleteOne' in op) {
       if ('q' in op.deleteOne) {
-        throw new MongoDriverError('Raw operations are not allowed');
+        throw new MongoInvalidArgumentError('Raw operations are not allowed');
       }
       return this.addToOperationsList(
         BatchType.DELETE,
@@ -1138,7 +1138,7 @@ export abstract class BulkOperationBase {
 
     if ('deleteMany' in op) {
       if ('q' in op.deleteMany) {
-        throw new MongoDriverError('Raw operations are not allowed');
+        throw new MongoInvalidArgumentError('Raw operations are not allowed');
       }
       return this.addToOperationsList(
         BatchType.DELETE,

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -5,7 +5,8 @@ import {
   AnyError,
   MONGODB_ERROR_CODES,
   MongoServerError,
-  MongoDriverError
+  MongoDriverError,
+  MongoInvalidArgumentError
 } from '../error';
 import {
   applyRetryableWrites,
@@ -1049,7 +1050,7 @@ export abstract class BulkOperationBase {
    */
   find(selector: Document): FindOperators {
     if (!selector) {
-      throw new MongoDriverError('Bulk find operation must specify a selector');
+      throw new MongoInvalidArgumentError('Bulk find operation must specify a selector');
     }
 
     // Save a current selector
@@ -1091,7 +1092,7 @@ export abstract class BulkOperationBase {
           { ...op.replaceOne, multi: false }
         );
         if (hasAtomicOperators(updateStatement.u)) {
-          throw new MongoDriverError('Replacement document must not use atomic operators');
+          throw new MongoInvalidArgumentError('Replacement document must not use atomic operators');
         }
         return this.addToOperationsList(BatchType.UPDATE, updateStatement);
       }
@@ -1105,7 +1106,7 @@ export abstract class BulkOperationBase {
           multi: false
         });
         if (!hasAtomicOperators(updateStatement.u)) {
-          throw new MongoDriverError('Update document requires atomic operators');
+          throw new MongoInvalidArgumentError('Update document requires atomic operators');
         }
         return this.addToOperationsList(BatchType.UPDATE, updateStatement);
       }
@@ -1119,7 +1120,7 @@ export abstract class BulkOperationBase {
           multi: true
         });
         if (!hasAtomicOperators(updateStatement.u)) {
-          throw new MongoDriverError('Update document requires atomic operators');
+          throw new MongoInvalidArgumentError('Update document requires atomic operators');
         }
         return this.addToOperationsList(BatchType.UPDATE, updateStatement);
       }

--- a/src/bulk/ordered.ts
+++ b/src/bulk/ordered.ts
@@ -4,7 +4,7 @@ import type { Document } from '../bson';
 import type { Collection } from '../collection';
 import type { UpdateStatement } from '../operations/update';
 import type { DeleteStatement } from '../operations/delete';
-import { MongoDriverError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError } from '../error';
 
 /** @public */
 export class OrderedBulkOperation extends BulkOperationBase {
@@ -68,7 +68,7 @@ export class OrderedBulkOperation extends BulkOperationBase {
 
     // We have an array of documents
     if (Array.isArray(document)) {
-      throw new MongoDriverError('Operation passed in cannot be an Array');
+      throw new MongoInvalidArgumentError('Operation passed in cannot be an Array');
     }
 
     this.s.currentBatch.originalIndexes.push(this.s.currentIndex);

--- a/src/bulk/ordered.ts
+++ b/src/bulk/ordered.ts
@@ -4,7 +4,7 @@ import type { Document } from '../bson';
 import type { Collection } from '../collection';
 import type { UpdateStatement } from '../operations/update';
 import type { DeleteStatement } from '../operations/delete';
-import { MongoDriverError, MongoInvalidArgumentError } from '../error';
+import { MongoInvalidArgumentError } from '../error';
 
 /** @public */
 export class OrderedBulkOperation extends BulkOperationBase {
@@ -26,7 +26,7 @@ export class OrderedBulkOperation extends BulkOperationBase {
 
     // Throw error if the doc is bigger than the max BSON size
     if (bsonSize >= this.s.maxBsonObjectSize)
-      throw new MongoDriverError(
+      throw new MongoInvalidArgumentError(
         `Document is larger than the maximum size ${this.s.maxBsonObjectSize}`
       );
 

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -1,5 +1,11 @@
 import Denque = require('denque');
-import { MongoError, AnyError, isResumableError, MongoDriverError } from './error';
+import {
+  MongoError,
+  AnyError,
+  isResumableError,
+  MongoDriverError,
+  MongoInvalidArgumentError
+} from './error';
 import { AggregateOperation, AggregateOptions } from './operations/aggregate';
 import {
   maxWireVersion,
@@ -255,7 +261,7 @@ export class ChangeStream<TSchema extends Document = Document> extends TypedEven
     } else if (parent instanceof MongoClient) {
       this.type = CHANGE_DOMAIN_TYPES.CLUSTER;
     } else {
-      throw new MongoDriverError(
+      throw new MongoInvalidArgumentError(
         'parent provided to ChangeStream constructor is not an instance of Collection, Db, or MongoClient'
       );
     }
@@ -357,7 +363,7 @@ export class ChangeStream<TSchema extends Document = Document> extends TypedEven
    */
   stream(options?: CursorStreamOptions): Readable {
     this.streamOptions = options;
-    if (!this.cursor) throw new MongoDriverError(NO_CURSOR_ERROR);
+    if (!this.cursor) throw new MongoInvalidArgumentError(NO_CURSOR_ERROR);
     return this.cursor.stream(options);
   }
 

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -21,7 +21,9 @@ export class GSSAPI extends AuthProvider {
   auth(authContext: AuthContext, callback: Callback): void {
     const { connection, credentials } = authContext;
     if (credentials == null)
-      return callback(new MongoMissingCredentialsError('credentials required'));
+      return callback(
+        new MongoMissingCredentialsError('credentials required for gssapi authentication')
+      );
     const { username } = credentials;
     function externalCommand(
       command: Document,

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -1,5 +1,10 @@
 import { AuthProvider, AuthContext } from './auth_provider';
-import { MongoDriverError, MongoError } from '../../error';
+import {
+  MongoDriverError,
+  MongoMissingCredentialsError,
+  MongoError,
+  MongoMissingDependencyError
+} from '../../error';
 import { Kerberos, KerberosClient } from '../../deps';
 import { Callback, ns } from '../../utils';
 import type { Document } from '../../bson';
@@ -15,7 +20,8 @@ import * as dns from 'dns';
 export class GSSAPI extends AuthProvider {
   auth(authContext: AuthContext, callback: Callback): void {
     const { connection, credentials } = authContext;
-    if (credentials == null) return callback(new MongoDriverError('credentials required'));
+    if (credentials == null)
+      return callback(new MongoMissingCredentialsError('credentials required'));
     const { username } = credentials;
     function externalCommand(
       command: Document,
@@ -25,7 +31,7 @@ export class GSSAPI extends AuthProvider {
     }
     makeKerberosClient(authContext, (err, client) => {
       if (err) return callback(err);
-      if (client == null) return callback(new MongoDriverError('gssapi client missing'));
+      if (client == null) return callback(new MongoMissingDependencyError('gssapi client missing'));
       client.step('', (err, payload) => {
         if (err) return callback(err);
 

--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -1,7 +1,7 @@
 // Resolves the default auth mechanism according to
 
 import type { Document } from '../../bson';
-import { MongoDriverError } from '../../error';
+import { MongoDriverError, MongoMissingCredentialsError } from '../../error';
 import { AuthMechanism } from './defaultAuthProviders';
 
 // https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst
@@ -122,7 +122,7 @@ export class MongoCredentials {
         this.mechanism === AuthMechanism.MONGODB_SCRAM_SHA256) &&
       !this.username
     ) {
-      throw new MongoDriverError(`Username required for mechanism '${this.mechanism}'`);
+      throw new MongoMissingCredentialsError(`Username required for mechanism '${this.mechanism}'`);
     }
 
     if (

--- a/src/cmap/auth/mongocr.ts
+++ b/src/cmap/auth/mongocr.ts
@@ -1,13 +1,13 @@
 import * as crypto from 'crypto';
 import { AuthProvider, AuthContext } from './auth_provider';
 import { Callback, ns } from '../../utils';
-import { MongoDriverError } from '../../error';
+import { MongoMissingCredentialsError } from '../../error';
 
 export class MongoCR extends AuthProvider {
   auth(authContext: AuthContext, callback: Callback): void {
     const { connection, credentials } = authContext;
     if (!credentials) {
-      return callback(new MongoDriverError('AuthContext must provide credentials.'));
+      return callback(new MongoMissingCredentialsError('AuthContext must provide credentials.'));
     }
     const username = credentials.username;
     const password = credentials.password;

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -4,7 +4,7 @@ import * as url from 'url';
 import * as BSON from '../../bson';
 import { AuthProvider, AuthContext } from './auth_provider';
 import { MongoCredentials } from './mongo_credentials';
-import { MongoDriverError } from '../../error';
+import { MongoDriverError, MongoCompatibilityError } from '../../error';
 import { maxWireVersion, Callback, ns } from '../../utils';
 import type { BSONSerializeOptions } from '../../bson';
 
@@ -42,7 +42,9 @@ export class MongoDBAWS extends AuthProvider {
 
     if (maxWireVersion(connection) < 9) {
       callback(
-        new MongoDriverError('MONGODB-AWS authentication requires MongoDB version 4.4 or later')
+        new MongoCompatibilityError(
+          'MONGODB-AWS authentication requires MongoDB version 4.4 or later'
+        )
       );
       return;
     }

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -4,7 +4,11 @@ import * as url from 'url';
 import * as BSON from '../../bson';
 import { AuthProvider, AuthContext } from './auth_provider';
 import { MongoCredentials } from './mongo_credentials';
-import { MongoDriverError, MongoCompatibilityError } from '../../error';
+import {
+  MongoDriverError,
+  MongoMissingCredentialsError,
+  MongoCompatibilityError
+} from '../../error';
 import { maxWireVersion, Callback, ns } from '../../utils';
 import type { BSONSerializeOptions } from '../../bson';
 
@@ -32,7 +36,7 @@ export class MongoDBAWS extends AuthProvider {
   auth(authContext: AuthContext, callback: Callback): void {
     const { connection, credentials } = authContext;
     if (!credentials) {
-      return callback(new MongoDriverError('AuthContext must provide credentials.'));
+      return callback(new MongoMissingCredentialsError('AuthContext must provide credentials.'));
     }
 
     if ('kModuleError' in aws4) {
@@ -151,7 +155,9 @@ interface AWSCredentials {
 function makeTempCredentials(credentials: MongoCredentials, callback: Callback<MongoCredentials>) {
   function done(creds: AWSCredentials) {
     if (!creds.AccessKeyId || !creds.SecretAccessKey || !creds.Token) {
-      callback(new MongoDriverError('Could not obtain temporary MONGODB-AWS credentials'));
+      callback(
+        new MongoMissingCredentialsError('Could not obtain temporary MONGODB-AWS credentials')
+      );
       return;
     }
 

--- a/src/cmap/auth/plain.ts
+++ b/src/cmap/auth/plain.ts
@@ -1,13 +1,13 @@
 import { Binary } from '../../bson';
 import { AuthProvider, AuthContext } from './auth_provider';
-import { MongoDriverError } from '../../error';
+import { MongoMissingCredentialsError } from '../../error';
 import { Callback, ns } from '../../utils';
 
 export class Plain extends AuthProvider {
   auth(authContext: AuthContext, callback: Callback): void {
     const { connection, credentials } = authContext;
     if (!credentials) {
-      return callback(new MongoDriverError('AuthContext must provide credentials.'));
+      return callback(new MongoMissingCredentialsError('AuthContext must provide credentials.'));
     }
     const username = credentials.username;
     const password = credentials.password;

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -1,6 +1,12 @@
 import * as crypto from 'crypto';
 import { Binary, Document } from '../../bson';
-import { AnyError, MongoServerError, MongoInvalidArgumentError } from '../../error';
+import {
+  AnyError,
+  MongoDriverError,
+  MongoServerError,
+  MongoInvalidArgumentError,
+  MongoMissingCredentialsError
+} from '../../error';
 import { AuthProvider, AuthContext } from './auth_provider';
 import { Callback, ns, emitWarning } from '../../utils';
 import type { MongoCredentials } from './mongo_credentials';
@@ -103,10 +109,12 @@ function makeFirstMessage(
 function executeScram(cryptoMethod: CryptoMethod, authContext: AuthContext, callback: Callback) {
   const { connection, credentials } = authContext;
   if (!credentials) {
-    return callback(new MongoDriverError('AuthContext must provide credentials.'));
+    return callback(new MongoMissingCredentialsError('AuthContext must provide credentials.'));
   }
   if (!authContext.nonce) {
-    return callback(new MongoDriverError('AuthContext must contain a valid nonce property'));
+    return callback(
+      new MongoInvalidArgumentError('AuthContext must contain a valid nonce property')
+    );
   }
   const nonce = authContext.nonce;
   const db = credentials.source;
@@ -131,10 +139,10 @@ function continueScramConversation(
   const connection = authContext.connection;
   const credentials = authContext.credentials;
   if (!credentials) {
-    return callback(new MongoDriverError('AuthContext must provide credentials.'));
+    return callback(new MongoMissingCredentialsError('AuthContext must provide credentials.'));
   }
   if (!authContext.nonce) {
-    return callback(new MongoDriverError('Unable to continue SCRAM without valid nonce'));
+    return callback(new MongoInvalidArgumentError('Unable to continue SCRAM without valid nonce'));
   }
   const nonce = authContext.nonce;
 

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto';
 import { Binary, Document } from '../../bson';
-import { AnyError, MongoDriverError, MongoServerError } from '../../error';
+import { AnyError, MongoServerError, MongoInvalidArgumentError } from '../../error';
 import { AuthProvider, AuthContext } from './auth_provider';
 import { Callback, ns, emitWarning } from '../../utils';
 import type { MongoCredentials } from './mongo_credentials';
@@ -240,15 +240,15 @@ function parsePayload(payload: string) {
 
 function passwordDigest(username: string, password: string) {
   if (typeof username !== 'string') {
-    throw new MongoDriverError('username must be a string');
+    throw new MongoInvalidArgumentError('username must be a string');
   }
 
   if (typeof password !== 'string') {
-    throw new MongoDriverError('password must be a string');
+    throw new MongoInvalidArgumentError('password must be a string');
   }
 
   if (password.length === 0) {
-    throw new MongoDriverError('password cannot be empty');
+    throw new MongoInvalidArgumentError('password cannot be empty');
   }
 
   const md5 = crypto.createHash('md5');

--- a/src/cmap/auth/x509.ts
+++ b/src/cmap/auth/x509.ts
@@ -1,5 +1,5 @@
 import { AuthProvider, AuthContext } from './auth_provider';
-import { MongoDriverError } from '../../error';
+import { MongoMissingCredentialsError } from '../../error';
 import type { Document } from '../../bson';
 import { Callback, ns } from '../../utils';
 import type { MongoCredentials } from './mongo_credentials';
@@ -9,7 +9,7 @@ export class X509 extends AuthProvider {
   prepare(handshakeDoc: HandshakeDocument, authContext: AuthContext, callback: Callback): void {
     const { credentials } = authContext;
     if (!credentials) {
-      return callback(new MongoDriverError('AuthContext must provide credentials.'));
+      return callback(new MongoMissingCredentialsError('AuthContext must provide credentials.'));
     }
     Object.assign(handshakeDoc, {
       speculativeAuthenticate: x509AuthenticateCommand(credentials)
@@ -22,7 +22,7 @@ export class X509 extends AuthProvider {
     const connection = authContext.connection;
     const credentials = authContext.credentials;
     if (!credentials) {
-      return callback(new MongoDriverError('AuthContext must provide credentials.'));
+      return callback(new MongoMissingCredentialsError('AuthContext must provide credentials.'));
     }
     const response = authContext.response;
 

--- a/src/cmap/commands.ts
+++ b/src/cmap/commands.ts
@@ -5,7 +5,7 @@ import { OP_QUERY, OP_GETMORE, OP_KILL_CURSORS, OP_MSG } from './wire_protocol/c
 import type { Long, Document, BSONSerializeOptions } from '../bson';
 import type { ClientSession } from '../sessions';
 import type { CommandOptions } from './connection';
-import { MongoDriverError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError } from '../error';
 
 // Incrementing request id
 let _requestId = 0;
@@ -77,12 +77,12 @@ export class Query {
 
   constructor(ns: string, query: Document, options: OpQueryOptions) {
     // Basic options needed to be passed in
-    if (ns == null) throw new MongoDriverError('ns must be specified for query');
-    if (query == null) throw new MongoDriverError('query must be specified for query');
+    if (ns == null) throw new MongoInvalidArgumentError('ns must be specified for query');
+    if (query == null) throw new MongoInvalidArgumentError('query must be specified for query');
 
     // Validate that we are not passing 0x00 in the collection name
     if (ns.indexOf('\x00') !== -1) {
-      throw new MongoDriverError('namespace cannot contain a null character');
+      throw new MongoInvalidArgumentError('namespace cannot contain a null character');
     }
 
     // Basic options

--- a/src/cmap/commands.ts
+++ b/src/cmap/commands.ts
@@ -852,7 +852,7 @@ export class BinMsg {
         this.index += bsonSize;
       } else if (payloadType === 1) {
         // It was decided that no driver makes use of payload type 1
-        throw new MongoDriverError('OP_MSG Payload Type 1 detected unsupported protocol');
+        throw new MongoInvalidArgumentError('OP_MSG Payload Type 1 detected unsupported protocol');
       }
     }
 

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -6,7 +6,8 @@ import {
   MongoNetworkTimeoutError,
   AnyError,
   MongoDriverError,
-  MongoServerError
+  MongoServerError,
+  MongoInvalidArgumentError
 } from '../error';
 import { AUTH_PROVIDERS, AuthMechanism } from './auth/defaultAuthProviders';
 import { AuthContext } from './auth/auth_provider';
@@ -230,7 +231,7 @@ export const LEGAL_TCP_SOCKET_OPTIONS = [
 
 function parseConnectOptions(options: ConnectionOptions): SocketConnectOpts {
   const hostAddress = options.hostAddress;
-  if (!hostAddress) throw new MongoDriverError('HostAddress required');
+  if (!hostAddress) throw new MongoInvalidArgumentError('HostAddress required');
 
   const result: Partial<net.TcpNetConnectOpts & net.IpcNetConnectOpts> = {};
   for (const name of LEGAL_TCP_SOCKET_OPTIONS) {

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -6,6 +6,7 @@ import {
   MongoNetworkTimeoutError,
   AnyError,
   MongoDriverError,
+  MongoCompatibilityError,
   MongoServerError,
   MongoInvalidArgumentError
 } from '../error';
@@ -59,13 +60,13 @@ function checkSupportedServer(ismaster: Document, options: ConnectionOptions) {
     const message = `Server at ${options.hostAddress} reports minimum wire version ${JSON.stringify(
       ismaster.minWireVersion
     )}, but this version of the Node.js Driver requires at most ${MAX_SUPPORTED_WIRE_VERSION} (MongoDB ${MAX_SUPPORTED_SERVER_VERSION})`;
-    return new MongoDriverError(message);
+    return new MongoCompatibilityError(message);
   }
 
   const message = `Server at ${options.hostAddress} reports maximum wire version ${
     JSON.stringify(ismaster.maxWireVersion) ?? 0
   }, but this version of the Node.js Driver requires at least ${MIN_SUPPORTED_WIRE_VERSION} (MongoDB ${MIN_SUPPORTED_SERVER_VERSION})`;
-  return new MongoDriverError(message);
+  return new MongoCompatibilityError(message);
 }
 
 function performInitialHandshake(

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -87,7 +87,9 @@ function performInitialHandshake(
       !(credentials.mechanism === AuthMechanism.MONGODB_DEFAULT) &&
       !AUTH_PROVIDERS.get(credentials.mechanism)
     ) {
-      callback(new MongoDriverError(`authMechanism '${credentials.mechanism}' not supported`));
+      callback(
+        new MongoCompatibilityError(`authMechanism '${credentials.mechanism}' not supported`)
+      );
       return;
     }
   }

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -3,7 +3,7 @@ import { Logger } from '../logger';
 import { APM_EVENTS, Connection, ConnectionEvents, ConnectionOptions } from './connection';
 import { connect } from './connect';
 import { eachAsync, makeCounter, Callback } from '../utils';
-import { MongoDriverError, MongoError } from '../error';
+import { MongoDriverError, MongoError, MongoInvalidArgumentError } from '../error';
 import { PoolClosedError, WaitQueueTimeoutError } from './errors';
 import {
   ConnectionPoolCreatedEvent,
@@ -174,7 +174,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     });
 
     if (this.options.minPoolSize > this.options.maxPoolSize) {
-      throw new MongoDriverError(
+      throw new MongoInvalidArgumentError(
         'Connection pool minimum size must not be greater than maximum pool size'
       );
     }

--- a/src/cmap/wire_protocol/shared.ts
+++ b/src/cmap/wire_protocol/shared.ts
@@ -1,6 +1,6 @@
 import { ServerType } from '../../sdam/common';
 import { TopologyDescription } from '../../sdam/topology_description';
-import { MongoDriverError } from '../../error';
+import { MongoInvalidArgumentError } from '../../error';
 import { ReadPreference } from '../../read_preference';
 import type { Document } from '../../bson';
 import type { OpQueryOptions } from '../commands';
@@ -28,7 +28,7 @@ export function getReadPreference(cmd: Document, options?: ReadPreferenceOption)
   }
 
   if (!(readPreference instanceof ReadPreference)) {
-    throw new MongoDriverError('read preference must be a ReadPreference instance');
+    throw new MongoInvalidArgumentError('read preference must be a ReadPreference instance');
   }
 
   return readPreference;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -8,7 +8,7 @@ import {
   getTopology
 } from './utils';
 import { Document, BSONSerializeOptions, resolveBSONOptions } from './bson';
-import { MongoDriverError } from './error';
+import { MongoInvalidArgumentError } from './error';
 import { UnorderedBulkOperation } from './bulk/unordered';
 import { OrderedBulkOperation } from './bulk/ordered';
 import { ChangeStream, ChangeStreamOptions } from './change_stream';
@@ -390,7 +390,7 @@ export class Collection<TSchema extends Document = Document> {
     options = options || { ordered: true };
 
     if (!Array.isArray(operations)) {
-      throw new MongoDriverError('operations must be an array of documents');
+      throw new MongoInvalidArgumentError('operations must be an array of documents');
     }
 
     return executeOperation(
@@ -700,7 +700,9 @@ export class Collection<TSchema extends Document = Document> {
     callback?: Callback<TSchema>
   ): Promise<TSchema | undefined> | void {
     if (callback !== undefined && typeof callback !== 'function') {
-      throw new MongoDriverError('Third parameter to `findOne()` must be a callback or undefined');
+      throw new MongoInvalidArgumentError(
+        'Third parameter to `findOne()` must be a callback or undefined'
+      );
     }
 
     if (typeof filter === 'function')
@@ -730,10 +732,12 @@ export class Collection<TSchema extends Document = Document> {
   find<T = TSchema>(filter: Filter<T>, options?: FindOptions<T>): FindCursor<T>;
   find(filter?: Filter<TSchema>, options?: FindOptions<TSchema>): FindCursor<TSchema> {
     if (arguments.length > 2) {
-      throw new MongoDriverError('Third parameter to `collection.find()` must be undefined');
+      throw new MongoInvalidArgumentError(
+        'Third parameter to `collection.find()` must be undefined'
+      );
     }
     if (typeof options === 'function') {
-      throw new MongoDriverError('`options` parameter must not be function');
+      throw new MongoInvalidArgumentError('`options` parameter must not be function');
     }
 
     return new FindCursor<TSchema>(
@@ -1369,13 +1373,17 @@ export class Collection<TSchema extends Document = Document> {
     options?: AggregateOptions
   ): AggregationCursor<T> {
     if (arguments.length > 2) {
-      throw new MongoDriverError('Third parameter to `collection.aggregate()` must be undefined');
+      throw new MongoInvalidArgumentError(
+        'Third parameter to `collection.aggregate()` must be undefined'
+      );
     }
     if (!Array.isArray(pipeline)) {
-      throw new MongoDriverError('`pipeline` parameter must be an array of aggregation stages');
+      throw new MongoInvalidArgumentError(
+        '`pipeline` parameter must be an array of aggregation stages'
+      );
     }
     if (typeof options === 'function') {
-      throw new MongoDriverError('`options` parameter must not be function');
+      throw new MongoInvalidArgumentError('`options` parameter must not be function');
     }
 
     return new AggregationCursor(
@@ -1448,7 +1456,7 @@ export class Collection<TSchema extends Document = Document> {
     // Out must always be defined (make sure we don't break weirdly on pre 1.8+ servers)
     // TODO NODE-3339: Figure out if this is still necessary given we no longer officially support pre-1.8
     if (options?.out == null) {
-      throw new MongoDriverError(
+      throw new MongoInvalidArgumentError(
         'the out option parameter must be defined, see mongodb docs for possible values'
       );
     }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -546,7 +546,7 @@ export abstract class AbstractCursor<
   maxTimeMS(value: number): this {
     assertUninitialized(this);
     if (typeof value !== 'number') {
-      throw new MongoDriverError('maxTimeMS must be a number');
+      throw new MongoInvalidArgumentError('maxTimeMS must be a number');
     }
 
     this[kOptions].maxTimeMS = value;
@@ -565,7 +565,7 @@ export abstract class AbstractCursor<
     }
 
     if (typeof value !== 'number') {
-      throw new MongoDriverError('batchSize requires an integer');
+      throw new MongoInvalidArgumentError('batchSize requires an integer');
     }
 
     this[kOptions].batchSize = value;

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -1,7 +1,7 @@
 import { Callback, maybePromise, MongoDBNamespace, ns } from '../utils';
 import { Long, Document, BSONSerializeOptions, pluckBSONSerializeOptions } from '../bson';
 import { ClientSession } from '../sessions';
-import { MongoDriverError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError } from '../error';
 import { ReadPreference, ReadPreferenceLike } from '../read_preference';
 import type { Server } from '../sdam/server';
 import type { Topology } from '../sdam/topology';
@@ -319,7 +319,7 @@ export abstract class AbstractCursor<
     callback?: Callback<void>
   ): Promise<void> | void {
     if (typeof iterator !== 'function') {
-      throw new MongoDriverError('Missing required parameter `iterator`');
+      throw new MongoInvalidArgumentError('Missing required parameter `iterator`');
     }
     return maybePromise(callback, done => {
       const transform = this[kTransform];
@@ -462,11 +462,11 @@ export abstract class AbstractCursor<
   addCursorFlag(flag: CursorFlag, value: boolean): this {
     assertUninitialized(this);
     if (!CURSOR_FLAGS.includes(flag)) {
-      throw new MongoDriverError(`flag ${flag} is not one of ${CURSOR_FLAGS}`);
+      throw new MongoInvalidArgumentError(`flag ${flag} is not one of ${CURSOR_FLAGS}`);
     }
 
     if (typeof value !== 'boolean') {
-      throw new MongoDriverError(`flag ${flag} must be a boolean value`);
+      throw new MongoInvalidArgumentError(`flag ${flag} must be a boolean value`);
     }
 
     this[kOptions][flag] = value;
@@ -517,7 +517,7 @@ export abstract class AbstractCursor<
     } else if (typeof readPreference === 'string') {
       this[kOptions].readPreference = ReadPreference.fromString(readPreference);
     } else {
-      throw new MongoDriverError('Invalid read preference: ' + readPreference);
+      throw new MongoInvalidArgumentError('Invalid read preference: ' + readPreference);
     }
 
     return this;

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -1,5 +1,5 @@
 import type { Document } from '../bson';
-import { MongoDriverError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError } from '../error';
 import type { ExplainVerbosityLike } from '../explain';
 import { CountOperation, CountOptions } from '../operations/count';
 import { executeOperation, ExecutionResult } from '../operations/execute_operation';
@@ -129,7 +129,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
     callback?: Callback<number>
   ): Promise<number> | void {
     if (typeof options === 'boolean') {
-      throw new MongoDriverError('Invalid first parameter to count');
+      throw new MongoInvalidArgumentError('Invalid first parameter to count');
     }
 
     if (typeof options === 'function') (callback = options), (options = {});
@@ -241,7 +241,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
   addQueryModifier(name: string, value: string | boolean | number | Document): this {
     assertUninitialized(this);
     if (name[0] !== '$') {
-      throw new MongoDriverError(`${name} is not a valid query modifier`);
+      throw new MongoInvalidArgumentError(`${name} is not a valid query modifier`);
     }
 
     // Strip of the $
@@ -290,7 +290,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
         break;
 
       default:
-        throw new MongoDriverError(`invalid query modifier: ${name}`);
+        throw new MongoInvalidArgumentError(`invalid query modifier: ${name}`);
     }
 
     return this;
@@ -315,7 +315,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
   maxAwaitTimeMS(value: number): this {
     assertUninitialized(this);
     if (typeof value !== 'number') {
-      throw new MongoDriverError('maxAwaitTimeMS must be a number');
+      throw new MongoInvalidArgumentError('maxAwaitTimeMS must be a number');
     }
 
     this[kBuiltOptions].maxAwaitTimeMS = value;
@@ -330,7 +330,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
   maxTimeMS(value: number): this {
     assertUninitialized(this);
     if (typeof value !== 'number') {
-      throw new MongoDriverError('maxTimeMS must be a number');
+      throw new MongoInvalidArgumentError('maxTimeMS must be a number');
     }
 
     this[kBuiltOptions].maxTimeMS = value;
@@ -387,7 +387,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
   allowDiskUse(): this {
     assertUninitialized(this);
     if (!this[kBuiltOptions].sort) {
-      throw new MongoDriverError('allowDiskUse requires a sort specification');
+      throw new MongoInvalidArgumentError('allowDiskUse requires a sort specification');
     }
     this[kBuiltOptions].allowDiskUse = true;
     return this;
@@ -416,7 +416,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
     }
 
     if (typeof value !== 'number') {
-      throw new MongoDriverError('limit requires an integer');
+      throw new MongoInvalidArgumentError('limit requires an integer');
     }
 
     this[kBuiltOptions].limit = value;
@@ -435,7 +435,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
     }
 
     if (typeof value !== 'number') {
-      throw new MongoDriverError('skip requires an integer');
+      throw new MongoInvalidArgumentError('skip requires an integer');
     }
 
     this[kBuiltOptions].skip = value;

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,4 @@
-import { MongoDriverError } from './error';
+import { MongoMissingDependencyError } from './error';
 import type { MongoClient } from './mongo_client';
 import type { deserialize, Document, serialize } from './bson';
 import type { Callback } from './utils';
@@ -20,8 +20,8 @@ function makeErrorModule(error: any) {
 
 export let Kerberos:
   | typeof import('kerberos')
-  | { kModuleError: MongoDriverError } = makeErrorModule(
-  new MongoDriverError(
+  | { kModuleError: MongoMissingDependencyError } = makeErrorModule(
+  new MongoMissingDependencyError(
     'Optional module `kerberos` not found. Please install it to enable kerberos authentication'
   )
 );
@@ -40,8 +40,10 @@ export interface KerberosClient {
   unwrap: (challenge: string, callback?: Callback<string>) => Promise<string> | void;
 }
 
-export let Snappy: typeof import('snappy') | { kModuleError: MongoDriverError } = makeErrorModule(
-  new MongoDriverError(
+export let Snappy:
+  | typeof import('snappy')
+  | { kModuleError: MongoMissingDependencyError } = makeErrorModule(
+  new MongoMissingDependencyError(
     'Optional module `snappy` not found. Please install it to enable snappy compression'
   )
 );
@@ -52,8 +54,8 @@ try {
 
 export let saslprep:
   | typeof import('saslprep')
-  | { kModuleError: MongoDriverError } = makeErrorModule(
-  new MongoDriverError(
+  | { kModuleError: MongoMissingDependencyError } = makeErrorModule(
+  new MongoMissingDependencyError(
     'Optional module `saslprep` not found.' +
       ' Please install it to enable Stringprep Profile for User Names and Passwords'
   )
@@ -63,8 +65,10 @@ try {
   saslprep = require('saslprep');
 } catch {} // eslint-disable-line
 
-export let aws4: typeof import('aws4') | { kModuleError: MongoDriverError } = makeErrorModule(
-  new MongoDriverError(
+export let aws4:
+  | typeof import('aws4')
+  | { kModuleError: MongoMissingDependencyError } = makeErrorModule(
+  new MongoMissingDependencyError(
     'Optional module `aws4` not found. Please install it to enable AWS authentication'
   )
 );

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { MongoClient, MongoClientOptions } from './mongo_client';
 import type { AutoEncrypter, AutoEncryptionOptions } from './deps';
-import { MongoDriverError } from './error';
+import { MongoDriverError, MongoMissingDependencyError } from './error';
 import { deserialize, serialize } from './bson';
 import type { Callback } from './utils';
 import { MONGO_CLIENT_EVENTS } from './operations/connect';
@@ -106,7 +106,7 @@ export class Encrypter {
     try {
       require.resolve('mongodb-client-encryption');
     } catch (err) {
-      throw new MongoDriverError(
+      throw new MongoMissingDependencyError(
         'Auto-encryption requested, but the module is not installed. ' +
           'Please add `mongodb-client-encryption` as a dependency of your project'
       );
@@ -114,7 +114,7 @@ export class Encrypter {
 
     const mongodbClientEncryption = require('mongodb-client-encryption');
     if (typeof mongodbClientEncryption.extension !== 'function') {
-      throw new MongoDriverError(
+      throw new MongoMissingDependencyError(
         'loaded version of `mongodb-client-encryption` does not have property `extension`. ' +
           'Please make sure you are loading the correct version of `mongodb-client-encryption`'
       );

--- a/src/error.ts
+++ b/src/error.ts
@@ -245,6 +245,44 @@ export class MongoParseError extends MongoDriverError {
   }
 }
 
+export class MongoAPIError extends MongoDriverError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MongoAPIError';
+  }
+}
+
+export class MongoInvalidArgumentError extends MongoAPIError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MongoInvalidArgumentError';
+  }
+}
+
+export class MongoCompatibilityError extends MongoAPIError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MongoCompatibilityError';
+  }
+}
+export class MongoClientInstantiationError extends MongoAPIError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MongoClientInstantiationError';
+  }
+}
+export class MongoMissingCredentialsError extends MongoAPIError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MongoMissingCredentialsError';
+  }
+}
+export class MongoMissingDependencyError extends MongoAPIError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MongoMissingDependencyError';
+  }
+}
 /**
  * An error signifying a general system issue
  * @public

--- a/src/error.ts
+++ b/src/error.ts
@@ -245,42 +245,93 @@ export class MongoParseError extends MongoDriverError {
   }
 }
 
+/**
+ * An error generated when the user misuses the driver API
+ *
+ * @privateRemarks
+ * Should **never** be directly instantiated
+ *
+ * @public
+ * @category Error
+ */
+
 export class MongoAPIError extends MongoDriverError {
-  constructor(message: string) {
+  protected constructor(message: string) {
     super(message);
-    this.name = 'MongoAPIError';
+  }
+
+  get name(): string {
+    return 'MongoAPIError';
   }
 }
 
+/**
+ * An error generated when the user supplies malformed or unexpected arguments
+ * or when a required argument or field is not provided.
+ *
+ *
+ * @public
+ * @category Error
+ */
 export class MongoInvalidArgumentError extends MongoAPIError {
   constructor(message: string) {
     super(message);
-    this.name = 'MongoInvalidArgumentError';
+  }
+
+  get name(): string {
+    return 'MongoInvalidArgumentError';
   }
 }
 
+/**
+ * An error generated when a feature that is not enabled or allowed for the current server
+ * configuration is used
+ *
+ *
+ * @public
+ * @category Error
+ */
 export class MongoCompatibilityError extends MongoAPIError {
   constructor(message: string) {
     super(message);
-    this.name = 'MongoCompatibilityError';
+  }
+
+  get name(): string {
+    return 'MongoCompatibilityError';
   }
 }
-export class MongoClientInstantiationError extends MongoAPIError {
-  constructor(message: string) {
-    super(message);
-    this.name = 'MongoClientInstantiationError';
-  }
-}
+
+/**
+ * An error generated when the user fails to provide authentication credentials before attempting
+ * to connect to a mongo server instance.
+ *
+ *
+ * @public
+ * @category Error
+ */
 export class MongoMissingCredentialsError extends MongoAPIError {
   constructor(message: string) {
     super(message);
-    this.name = 'MongoMissingCredentialsError';
+  }
+
+  get name(): string {
+    return 'MongoMissingCredentialsError';
   }
 }
+
+/**
+ * An error generated when a required module or dependency is not present in the local environment
+ *
+ * @public
+ * @category Error
+ */
 export class MongoMissingDependencyError extends MongoAPIError {
   constructor(message: string) {
     super(message);
-    this.name = 'MongoMissingDependencyError';
+  }
+
+  get name(): string {
+    return 'MongoMissingDependencyError';
   }
 }
 /**

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import { format } from 'util';
-import { MongoDriverError, MongoInvalidArgumentError } from './error';
+import { MongoInvalidArgumentError } from './error';
 
 // Filters for classes
 const classFilters: any = {};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import { format } from 'util';
-import { MongoDriverError } from './error';
+import { MongoDriverError, MongoInvalidArgumentError } from './error';
 
 // Filters for classes
 const classFilters: any = {};
@@ -222,7 +222,7 @@ export class Logger {
    */
   static setCurrentLogger(logger: LoggerFunction): void {
     if (typeof logger !== 'function') {
-      throw new MongoDriverError('current logger must be a function');
+      throw new MongoInvalidArgumentError('current logger must be a function');
     }
 
     currentLogger = logger;
@@ -253,7 +253,7 @@ export class Logger {
       newLevel !== LoggerLevel.DEBUG &&
       newLevel !== LoggerLevel.WARN
     ) {
-      throw new MongoDriverError(`${newLevel} is an illegal logging level`);
+      throw new MongoInvalidArgumentError(`${newLevel} is an illegal logging level`);
     }
 
     level = newLevel;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -556,7 +556,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     }
 
     if (callback == null) {
-      throw new MongoDriverError('Missing required callback parameter');
+      throw new MongoInvalidArgumentError('Missing required callback parameter');
     }
 
     const session = this.startSession(options);

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -1,7 +1,7 @@
 import { Db, DbOptions } from './db';
 import { ChangeStream, ChangeStreamOptions } from './change_stream';
 import type { ReadPreference, ReadPreferenceMode } from './read_preference';
-import { AnyError, MongoDriverError } from './error';
+import { AnyError, MongoDriverError, MongoInvalidArgumentError } from './error';
 import type { W, WriteConcern } from './write_concern';
 import {
   maybePromise,
@@ -403,7 +403,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
   connect(callback: Callback<MongoClient>): void;
   connect(callback?: Callback<MongoClient>): Promise<MongoClient> | void {
     if (callback && typeof callback !== 'function') {
-      throw new MongoDriverError('`connect` only accepts a callback');
+      throw new MongoInvalidArgumentError('`connect` only accepts a callback');
     }
 
     return maybePromise(callback, cb => {

--- a/src/operations/add_user.ts
+++ b/src/operations/add_user.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'crypto';
 import { Aspect, defineAspects } from './operation';
 import { CommandOperation, CommandOperationOptions } from './command';
-import { MongoDriverError } from '../error';
+import { MongoInvalidArgumentError } from '../error';
 import { Callback, emitWarningOnce, getTopology } from '../utils';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
@@ -54,7 +54,7 @@ export class AddUserOperation extends CommandOperation<Document> {
     // Error out if digestPassword set
     if (options.digestPassword != null) {
       return callback(
-        new MongoDriverError(
+        new MongoInvalidArgumentError(
           'The digestPassword option is not supported via add_user. ' +
             "Please use db.command('createUser', ...) instead for this option."
         )

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -5,7 +5,7 @@ import {
   CollationOptions
 } from './command';
 import { ReadPreference } from '../read_preference';
-import { MongoDriverError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError } from '../error';
 import { maxWireVersion } from '../utils';
 import { Aspect, defineAspects, Hint } from './operation';
 import type { Callback } from '../utils';
@@ -75,11 +75,13 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
     }
 
     if (this.explain && this.writeConcern) {
-      throw new MongoDriverError('"explain" cannot be used on an aggregate call with writeConcern');
+      throw new MongoInvalidArgumentError(
+        '"explain" cannot be used on an aggregate call with writeConcern'
+      );
     }
 
     if (options?.cursor != null && typeof options.cursor !== 'object') {
-      throw new MongoDriverError('cursor options must be an object');
+      throw new MongoInvalidArgumentError('cursor options must be an object');
     }
   }
 

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -5,7 +5,7 @@ import {
   CollationOptions
 } from './command';
 import { ReadPreference } from '../read_preference';
-import { MongoDriverError, MongoInvalidArgumentError } from '../error';
+import { MongoInvalidArgumentError } from '../error';
 import { maxWireVersion } from '../utils';
 import { Aspect, defineAspects, Hint } from './operation';
 import type { Callback } from '../utils';

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -4,7 +4,7 @@ import { WriteConcern, WriteConcernOptions } from '../write_concern';
 import { maxWireVersion, MongoDBNamespace, Callback, decorateWithExplain } from '../utils';
 import type { ReadPreference } from '../read_preference';
 import { ClientSession, commandSupportsReadConcern } from '../sessions';
-import { MongoDriverError } from '../error';
+import { MongoInvalidArgumentError, MongoCompatibilityError } from '../error';
 import type { Logger } from '../logger';
 import type { Server } from '../sdam/server';
 import type { BSONSerializeOptions, Document } from '../bson';
@@ -98,7 +98,7 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
     if (this.hasAspect(Aspect.EXPLAINABLE)) {
       this.explain = Explain.fromOptions(options);
     } else if (options?.explain !== undefined) {
-      throw new MongoDriverError(`explain is not supported on this command`);
+      throw new MongoInvalidArgumentError(`explain is not supported on this command`);
     }
   }
 
@@ -131,7 +131,7 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
 
     if (options.collation && serverWireVersion < SUPPORTS_WRITE_CONCERN_AND_COLLATION) {
       callback(
-        new MongoDriverError(
+        new MongoCompatibilityError(
           `Server ${server.name}, which reports wire version ${serverWireVersion}, does not support collation`
         )
       );

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -1,4 +1,4 @@
-import { MongoDriverError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError } from '../error';
 import { Topology, TOPOLOGY_EVENTS } from '../sdam/topology';
 import { resolveSRVRecord } from '../connection_string';
 import type { Callback } from '../utils';
@@ -21,7 +21,7 @@ export function connect(
   callback: Callback<MongoClient>
 ): void {
   if (!callback) {
-    throw new MongoDriverError('no callback function provided');
+    throw new MongoInvalidArgumentError('no callback function provided');
   }
 
   // If a connection already been established, we can terminate early

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -5,7 +5,7 @@ import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
 import type { ClientSession } from '../sessions';
-import { MongoDriverError, MongoServerError } from '../error';
+import { MongoServerError, MongoCompatibilityError } from '../error';
 import type { WriteConcernOptions } from '../write_concern';
 
 /** @public */
@@ -82,21 +82,23 @@ export class DeleteOperation extends CommandOperation<Document> {
 
     if (options.explain !== undefined && maxWireVersion(server) < 3) {
       return callback
-        ? callback(new MongoDriverError(`server ${server.name} does not support explain on delete`))
+        ? callback(
+            new MongoCompatibilityError(`server ${server.name} does not support explain on delete`)
+          )
         : undefined;
     }
 
     const unacknowledgedWrite = this.writeConcern && this.writeConcern.w === 0;
     if (unacknowledgedWrite || maxWireVersion(server) < 5) {
       if (this.statements.find((o: Document) => o.hint)) {
-        callback(new MongoDriverError(`servers < 3.4 do not support hint on delete`));
+        callback(new MongoCompatibilityError(`servers < 3.4 do not support hint on delete`));
         return;
       }
     }
 
     const statementWithCollation = this.statements.find(statement => !!statement.collation);
     if (statementWithCollation && collationNotSupported(server, statementWithCollation)) {
-      callback(new MongoDriverError(`server ${server.name} does not support collation`));
+      callback(new MongoCompatibilityError(`server ${server.name} does not support collation`));
       return;
     }
 

--- a/src/operations/distinct.ts
+++ b/src/operations/distinct.ts
@@ -4,7 +4,7 @@ import { decorateWithCollation, decorateWithReadConcern, Callback, maxWireVersio
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
-import { MongoDriverError } from '../error';
+import { MongoCompatibilityError } from '../error';
 import type { ClientSession } from '../sessions';
 
 /** @public */
@@ -68,7 +68,9 @@ export class DistinctOperation extends CommandOperation<any[]> {
     }
 
     if (this.explain && maxWireVersion(server) < 4) {
-      callback(new MongoDriverError(`server ${server.name} does not support explain on distinct`));
+      callback(
+        new MongoCompatibilityError(`server ${server.name} does not support explain on distinct`)
+      );
       return;
     }
 

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -4,6 +4,7 @@ import {
   isRetryableError,
   MONGODB_ERROR_CODES,
   MongoDriverError,
+  MongoCompatibilityError,
   MongoServerError
 } from '../error';
 import { Aspect, AbstractOperation } from './operation';
@@ -90,7 +91,7 @@ export function executeOperation<
     } else if (session) {
       // If the user passed an explicit session and we are still, after server selection,
       // trying to run against a topology that doesn't support sessions we error out.
-      return cb(new MongoDriverError('Current topology does not support sessions'));
+      return cb(new MongoCompatibilityError('Current topology does not support sessions'));
     }
 
     try {

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -86,6 +86,7 @@ export function executeOperation<
         owner = Symbol();
         session = topology.startSession({ owner, explicit: false });
       } else if (session.hasEnded) {
+        // TODO: Change this out for MongoExpiredSessionError
         return cb(new MongoDriverError('Use of expired sessions is not permitted'));
       }
     } else if (session) {
@@ -127,6 +128,7 @@ function executeWithServerSelection(
 
   if (inTransaction && !readPreference.equals(ReadPreference.primary)) {
     callback(
+      // TODO: Change this out for MongoTransactionError
       new MongoDriverError(
         `Read preference in a transaction must be primary, not: ${readPreference.mode}`
       )
@@ -188,6 +190,7 @@ function executeWithServerSelection(
     session.inTransaction()
   ) {
     callback(
+      // TODO: Change this out for MongoTransactionError
       new MongoDriverError(
         `Read preference in a transaction must be primary, not: ${readPreference.mode}`
       )

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -6,7 +6,7 @@ import {
   normalizeHintField,
   decorateWithExplain
 } from '../utils';
-import { MongoDriverError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError } from '../error';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
@@ -84,14 +84,14 @@ export class FindOperation extends CommandOperation<Document> {
     this.ns = ns;
 
     if (typeof filter !== 'object' || Array.isArray(filter)) {
-      throw new MongoDriverError('Query filter must be a plain object or ObjectId');
+      throw new MongoInvalidArgumentError('Query filter must be a plain object or ObjectId');
     }
 
     // If the filter is a buffer, validate that is a valid BSON document
     if (Buffer.isBuffer(filter)) {
       const objectSize = filter[0] | (filter[1] << 8) | (filter[2] << 16) | (filter[3] << 24);
       if (objectSize !== filter.length) {
-        throw new MongoDriverError(
+        throw new MongoInvalidArgumentError(
           `query filter raw message size does not match message header size [${filter.length}] != [${objectSize}]`
         );
       }

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -6,7 +6,7 @@ import {
   normalizeHintField,
   decorateWithExplain
 } from '../utils';
-import { MongoDriverError, MongoInvalidArgumentError } from '../error';
+import { MongoInvalidArgumentError, MongoCompatibilityError } from '../error';
 import type { Document } from '../bson';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
@@ -107,13 +107,15 @@ export class FindOperation extends CommandOperation<Document> {
     const serverWireVersion = maxWireVersion(server);
     const options = this.options;
     if (typeof options.allowDiskUse !== 'undefined' && serverWireVersion < 4) {
-      callback(new MongoDriverError('The `allowDiskUse` option is not supported on MongoDB < 3.2'));
+      callback(
+        new MongoCompatibilityError('The `allowDiskUse` option is not supported on MongoDB < 3.2')
+      );
       return;
     }
 
     if (options.collation && serverWireVersion < SUPPORTS_WRITE_CONCERN_AND_COLLATION) {
       callback(
-        new MongoDriverError(
+        new MongoCompatibilityError(
           `Server ${server.name}, which reports wire version ${serverWireVersion}, does not support collation`
         )
       );
@@ -124,7 +126,7 @@ export class FindOperation extends CommandOperation<Document> {
     if (serverWireVersion < 4) {
       if (this.readConcern && this.readConcern.level !== 'local') {
         callback(
-          new MongoDriverError(
+          new MongoCompatibilityError(
             `server find command does not support a readConcern level of ${this.readConcern.level}`
           )
         );

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -1,6 +1,6 @@
 import { ReadPreference } from '../read_preference';
 import { maxWireVersion, decorateWithCollation, hasAtomicOperators, Callback } from '../utils';
-import { MongoDriverError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError } from '../error';
 import { CommandOperation, CommandOperationOptions } from './command';
 import { defineAspects, Aspect } from './operation';
 import type { Document } from '../bson';
@@ -203,7 +203,7 @@ export class FindOneAndDeleteOperation extends FindAndModifyOperation {
   constructor(collection: Collection, filter: Document, options: FindOneAndDeleteOptions) {
     // Basic validation
     if (filter == null || typeof filter !== 'object') {
-      throw new MongoDriverError('Filter parameter must be an object');
+      throw new MongoInvalidArgumentError('Filter parameter must be an object');
     }
 
     super(collection, filter, options);
@@ -220,15 +220,15 @@ export class FindOneAndReplaceOperation extends FindAndModifyOperation {
     options: FindOneAndReplaceOptions
   ) {
     if (filter == null || typeof filter !== 'object') {
-      throw new MongoDriverError('Filter parameter must be an object');
+      throw new MongoInvalidArgumentError('Filter parameter must be an object');
     }
 
     if (replacement == null || typeof replacement !== 'object') {
-      throw new MongoDriverError('Replacement parameter must be an object');
+      throw new MongoInvalidArgumentError('Replacement parameter must be an object');
     }
 
     if (hasAtomicOperators(replacement)) {
-      throw new MongoDriverError('Replacement document must not contain atomic operators');
+      throw new MongoInvalidArgumentError('Replacement document must not contain atomic operators');
     }
 
     super(collection, filter, options);
@@ -246,15 +246,15 @@ export class FindOneAndUpdateOperation extends FindAndModifyOperation {
     options: FindOneAndUpdateOptions
   ) {
     if (filter == null || typeof filter !== 'object') {
-      throw new MongoDriverError('Filter parameter must be an object');
+      throw new MongoInvalidArgumentError('Filter parameter must be an object');
     }
 
     if (update == null || typeof update !== 'object') {
-      throw new MongoDriverError('Update parameter must be an object');
+      throw new MongoInvalidArgumentError('Update parameter must be an object');
     }
 
     if (!hasAtomicOperators(update)) {
-      throw new MongoDriverError('Update document requires atomic operators');
+      throw new MongoInvalidArgumentError('Update document requires atomic operators');
     }
 
     super(collection, filter, options);

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -1,6 +1,6 @@
 import { ReadPreference } from '../read_preference';
 import { maxWireVersion, decorateWithCollation, hasAtomicOperators, Callback } from '../utils';
-import { MongoDriverError, MongoInvalidArgumentError } from '../error';
+import { MongoInvalidArgumentError, MongoCompatibilityError } from '../error';
 import { CommandOperation, CommandOperationOptions } from './command';
 import { defineAspects, Aspect } from './operation';
 import type { Document } from '../bson';
@@ -172,7 +172,7 @@ class FindAndModifyOperation extends CommandOperation<Document> {
       const unacknowledgedWrite = this.writeConcern?.w === 0;
       if (unacknowledgedWrite || maxWireVersion(server) < 8) {
         callback(
-          new MongoDriverError(
+          new MongoCompatibilityError(
             'The current topology does not support a hint on findAndModify commands'
           )
         );
@@ -185,7 +185,9 @@ class FindAndModifyOperation extends CommandOperation<Document> {
 
     if (this.explain && maxWireVersion(server) < 4) {
       callback(
-        new MongoDriverError(`server ${server.name} does not support explain on findAndModify`)
+        new MongoCompatibilityError(
+          `server ${server.name} does not support explain on findAndModify`
+        )
       );
       return;
     }

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -1,6 +1,6 @@
 import { indexInformation, IndexInformationOptions } from './common_functions';
 import { AbstractOperation, Aspect, defineAspects } from './operation';
-import { MONGODB_ERROR_CODES, MongoDriverError, MongoServerError } from '../error';
+import { MONGODB_ERROR_CODES, MongoServerError, MongoCompatibilityError } from '../error';
 import {
   maxWireVersion,
   parseIndexOptions,
@@ -188,7 +188,7 @@ export class CreateIndexesOperation<
       // Did the user pass in a collation, check if our write server supports it
       if (indexes[i].collation && serverWireVersion < 5) {
         callback(
-          new MongoDriverError(
+          new MongoCompatibilityError(
             `Server ${server.name}, which reports wire version ${serverWireVersion}, ` +
               'does not support collation'
           )
@@ -213,7 +213,7 @@ export class CreateIndexesOperation<
     if (options.commitQuorum != null) {
       if (serverWireVersion < 9) {
         callback(
-          new MongoDriverError(
+          new MongoCompatibilityError(
             '`commitQuorum` option for `createIndexes` not supported on servers < 4.4'
           )
         );

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -1,4 +1,4 @@
-import { MongoDriverError, MongoServerError } from '../error';
+import { MongoServerError, MongoInvalidArgumentError } from '../error';
 import { defineAspects, Aspect, AbstractOperation } from './operation';
 import { CommandOperation, CommandOperationOptions } from './command';
 import { prepareDocs } from './common_functions';
@@ -100,7 +100,7 @@ export class InsertManyOperation extends AbstractOperation<InsertManyResult> {
     super(options);
 
     if (!Array.isArray(docs)) {
-      throw new MongoDriverError('docs parameter must be an array of documents');
+      throw new MongoInvalidArgumentError('docs parameter must be an array of documents');
     }
 
     this.options = options;

--- a/src/operations/map_reduce.ts
+++ b/src/operations/map_reduce.ts
@@ -12,7 +12,7 @@ import { CommandOperation, CommandOperationOptions } from './command';
 import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
 import type { Sort } from '../sort';
-import { MongoDriverError, MongoServerError } from '../error';
+import { MongoServerError, MongoCompatibilityError } from '../error';
 import type { ObjectId } from '../bson';
 import { Aspect, defineAspects } from './operation';
 import type { ClientSession } from '../sessions';
@@ -165,7 +165,9 @@ export class MapReduceOperation extends CommandOperation<Document | Document[]> 
     }
 
     if (this.explain && maxWireVersion(server) < 9) {
-      callback(new MongoDriverError(`server ${server.name} does not support explain on mapReduce`));
+      callback(
+        new MongoCompatibilityError(`server ${server.name} does not support explain on mapReduce`)
+      );
       return;
     }
 

--- a/src/operations/set_profiling_level.ts
+++ b/src/operations/set_profiling_level.ts
@@ -50,9 +50,7 @@ export class SetProfilingLevelOperation extends CommandOperation<ProfilingLevel>
     const level = this.level;
 
     if (!levelValues.has(level)) {
-      return callback(
-        new MongoInvalidArgumentError('Error: illegal profiling level value ' + level)
-      );
+      return callback(new MongoInvalidArgumentError('Illegal profiling level value ' + level));
     }
 
     super.executeCommand(server, session, { profile: this.profile }, (err, doc) => {

--- a/src/operations/set_profiling_level.ts
+++ b/src/operations/set_profiling_level.ts
@@ -3,7 +3,7 @@ import type { Callback } from '../utils';
 import type { Server } from '../sdam/server';
 import type { Db } from '../db';
 import type { ClientSession } from '../sessions';
-import { MongoDriverError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError } from '../error';
 const levelValues = new Set(['off', 'slow_only', 'all']);
 
 /** @public */
@@ -50,7 +50,9 @@ export class SetProfilingLevelOperation extends CommandOperation<ProfilingLevel>
     const level = this.level;
 
     if (!levelValues.has(level)) {
-      return callback(new MongoDriverError('Error: illegal profiling level value ' + level));
+      return callback(
+        new MongoInvalidArgumentError('Error: illegal profiling level value ' + level)
+      );
     }
 
     super.executeCommand(server, session, { profile: this.profile }, (err, doc) => {

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -11,7 +11,7 @@ import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
 import type { ObjectId, Document } from '../bson';
 import type { ClientSession } from '../sessions';
-import { MongoDriverError, MongoServerError } from '../error';
+import { MongoDriverError, MongoServerError, MongoInvalidArgumentError } from '../error';
 
 /** @public */
 export interface UpdateOptions extends CommandOperationOptions {
@@ -144,7 +144,7 @@ export class UpdateOneOperation extends UpdateOperation {
     );
 
     if (!hasAtomicOperators(update)) {
-      throw new MongoDriverError('Update document requires atomic operators');
+      throw new MongoInvalidArgumentError('Update document requires atomic operators');
     }
   }
 
@@ -181,7 +181,7 @@ export class UpdateManyOperation extends UpdateOperation {
     );
 
     if (!hasAtomicOperators(update)) {
-      throw new MongoDriverError('Update document requires atomic operators');
+      throw new MongoInvalidArgumentError('Update document requires atomic operators');
     }
   }
 
@@ -235,7 +235,7 @@ export class ReplaceOneOperation extends UpdateOperation {
     );
 
     if (hasAtomicOperators(replacement)) {
-      throw new MongoDriverError('Replacement document must not contain atomic operators');
+      throw new MongoInvalidArgumentError('Replacement document must not contain atomic operators');
     }
   }
 

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -11,12 +11,7 @@ import type { Server } from '../sdam/server';
 import type { Collection } from '../collection';
 import type { ObjectId, Document } from '../bson';
 import type { ClientSession } from '../sessions';
-import {
-  MongoDriverError,
-  MongoServerError,
-  MongoInvalidArgumentError,
-  MongoCompatibilityError
-} from '../error';
+import { MongoServerError, MongoInvalidArgumentError, MongoCompatibilityError } from '../error';
 
 /** @public */
 export interface UpdateOptions extends CommandOperationOptions {
@@ -275,11 +270,11 @@ export function makeUpdateStatement(
   options: UpdateOptions & { multi?: boolean }
 ): UpdateStatement {
   if (filter == null || typeof filter !== 'object') {
-    throw new MongoDriverError('selector must be a valid JavaScript object');
+    throw new MongoInvalidArgumentError('selector must be a valid JavaScript object');
   }
 
   if (update == null || typeof update !== 'object') {
-    throw new MongoDriverError('document must be a valid JavaScript object');
+    throw new MongoInvalidArgumentError('document must be a valid JavaScript object');
   }
 
   const op: UpdateStatement = { q: filter, u: update };

--- a/src/promise_provider.ts
+++ b/src/promise_provider.ts
@@ -1,4 +1,4 @@
-import { MongoDriverError } from './error';
+import { MongoInvalidArgumentError } from './error';
 
 /** @internal */
 const kPromise = Symbol('promise');
@@ -19,7 +19,7 @@ export class PromiseProvider {
   /** Validates the passed in promise library */
   static validate(lib: unknown): lib is PromiseConstructor {
     if (typeof lib !== 'function')
-      throw new MongoDriverError(`Promise must be a function, got ${lib}`);
+      throw new MongoInvalidArgumentError(`Promise must be a function, got ${lib}`);
     return !!lib;
   }
 

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -1,7 +1,7 @@
 import type { TagSet } from './sdam/server_description';
 import type { Document } from './bson';
 import type { ClientSession } from './sessions';
-import { MongoDriverError } from './error';
+import { MongoInvalidArgumentError } from './error';
 
 /** @public */
 export type ReadPreferenceLike = ReadPreference | ReadPreferenceMode;
@@ -84,13 +84,13 @@ export class ReadPreference {
    */
   constructor(mode: ReadPreferenceMode, tags?: TagSet[], options?: ReadPreferenceOptions) {
     if (!ReadPreference.isValid(mode)) {
-      throw new MongoDriverError(`Invalid read preference mode ${JSON.stringify(mode)}`);
+      throw new MongoInvalidArgumentError(`Invalid read preference mode ${JSON.stringify(mode)}`);
     }
     if (options === undefined && typeof tags === 'object' && !Array.isArray(tags)) {
       options = tags;
       tags = undefined;
     } else if (tags && !Array.isArray(tags)) {
-      throw new MongoDriverError('ReadPreference tags must be an array');
+      throw new MongoInvalidArgumentError('ReadPreference tags must be an array');
     }
 
     this.mode = mode;
@@ -102,7 +102,7 @@ export class ReadPreference {
     options = options ?? {};
     if (options.maxStalenessSeconds != null) {
       if (options.maxStalenessSeconds <= 0) {
-        throw new MongoDriverError('maxStalenessSeconds must be a positive integer');
+        throw new MongoInvalidArgumentError('maxStalenessSeconds must be a positive integer');
       }
 
       this.maxStalenessSeconds = options.maxStalenessSeconds;
@@ -114,17 +114,19 @@ export class ReadPreference {
 
     if (this.mode === ReadPreference.PRIMARY) {
       if (this.tags && Array.isArray(this.tags) && this.tags.length > 0) {
-        throw new MongoDriverError('Primary read preference cannot be combined with tags');
+        throw new MongoInvalidArgumentError('Primary read preference cannot be combined with tags');
       }
 
       if (this.maxStalenessSeconds) {
-        throw new MongoDriverError(
+        throw new MongoInvalidArgumentError(
           'Primary read preference cannot be combined with maxStalenessSeconds'
         );
       }
 
       if (this.hedge) {
-        throw new MongoDriverError('Primary read preference cannot be combined with hedge');
+        throw new MongoInvalidArgumentError(
+          'Primary read preference cannot be combined with hedge'
+        );
       }
     }
   }
@@ -193,7 +195,7 @@ export class ReadPreference {
         });
       }
     } else if (!(r instanceof ReadPreference)) {
-      throw new MongoDriverError('Invalid read preference: ' + r);
+      throw new MongoInvalidArgumentError('Invalid read preference: ' + r);
     }
 
     return options;

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -34,6 +34,7 @@ import {
   isNodeShuttingDownError,
   isNetworkErrorBeforeHandshake,
   MongoDriverError,
+  MongoCompatibilityError,
   MongoInvalidArgumentError
 } from '../error';
 import {
@@ -278,7 +279,7 @@ export class Server extends TypedEventEmitter<ServerEvents> {
 
     // error if collation not supported
     if (collationNotSupported(this, cmd)) {
-      callback(new MongoDriverError(`server ${this.name} does not support collation`));
+      callback(new MongoCompatibilityError(`server ${this.name} does not support collation`));
       return;
     }
 

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -33,7 +33,8 @@ import {
   isRetryableWriteError,
   isNodeShuttingDownError,
   isNetworkErrorBeforeHandshake,
-  MongoDriverError
+  MongoDriverError,
+  MongoInvalidArgumentError
 } from '../error';
 import {
   Connection,
@@ -260,15 +261,15 @@ export class Server extends TypedEventEmitter<ServerEvents> {
     }
 
     if (callback == null) {
-      throw new MongoDriverError('callback must be provided');
+      throw new MongoInvalidArgumentError('callback must be provided');
     }
 
     if (ns.db == null || typeof ns === 'string') {
-      throw new MongoDriverError('ns must not be a string');
+      throw new MongoInvalidArgumentError('ns must not be a string');
     }
 
     if (this.s.state === STATE_CLOSING || this.s.state === STATE_CLOSED) {
-      callback(new MongoDriverError('server is closed'));
+      callback(new MongoInvalidArgumentError('server is closed'));
       return;
     }
 

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -1,6 +1,6 @@
 import { ServerType, TopologyType } from './common';
 import { ReadPreference } from '../read_preference';
-import { MongoDriverError, MongoInvalidArgumentError } from '../error';
+import { MongoCompatibilityError, MongoInvalidArgumentError } from '../error';
 import type { TopologyDescription } from './topology_description';
 import type { ServerDescription, TagSet } from './server_description';
 
@@ -227,7 +227,7 @@ export function readPreferenceServerSelector(readPreference: ReadPreference): Se
       readPreference.minWireVersion &&
       readPreference.minWireVersion > commonWireVersion
     ) {
-      throw new MongoDriverError(
+      throw new MongoCompatibilityError(
         `Minimum wire version '${readPreference.minWireVersion}' required, but found '${commonWireVersion}'`
       );
     }

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -1,6 +1,6 @@
 import { ServerType, TopologyType } from './common';
 import { ReadPreference } from '../read_preference';
-import { MongoDriverError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError } from '../error';
 import type { TopologyDescription } from './topology_description';
 import type { ServerDescription, TagSet } from './server_description';
 
@@ -50,13 +50,13 @@ function maxStalenessReducer(
   const maxStalenessVariance =
     (topologyDescription.heartbeatFrequencyMS + IDLE_WRITE_PERIOD) / 1000;
   if (maxStaleness < maxStalenessVariance) {
-    throw new MongoDriverError(
+    throw new MongoInvalidArgumentError(
       `maxStalenessSeconds must be at least ${maxStalenessVariance} seconds`
     );
   }
 
   if (maxStaleness < SMALLEST_MAX_STALENESS_SECONDS) {
-    throw new MongoDriverError(
+    throw new MongoInvalidArgumentError(
       `maxStalenessSeconds must be at least ${SMALLEST_MAX_STALENESS_SECONDS} seconds`
     );
   }
@@ -214,7 +214,7 @@ function knownFilter(server: ServerDescription): boolean {
  */
 export function readPreferenceServerSelector(readPreference: ReadPreference): ServerSelector {
   if (!readPreference.isValid()) {
-    throw new MongoDriverError('Invalid read preference specified');
+    throw new MongoInvalidArgumentError('Invalid read preference specified');
   }
 
   return (

--- a/src/sdam/srv_polling.ts
+++ b/src/sdam/srv_polling.ts
@@ -2,7 +2,7 @@ import * as dns from 'dns';
 import { Logger, LoggerOptions } from '../logger';
 import { HostAddress } from '../utils';
 import { TypedEventEmitter } from '../mongo_types';
-import { MongoDriverError } from '../error';
+import { MongoInvalidArgumentError } from '../error';
 
 /**
  * Determines whether a provided address matches the provided parent domain in order
@@ -67,7 +67,7 @@ export class SrvPoller extends TypedEventEmitter<SrvPollerEvents> {
     super();
 
     if (!options || !options.srvHost) {
-      throw new MongoDriverError('options for SrvPoller must exist and include srvHost');
+      throw new MongoInvalidArgumentError('options for SrvPoller must exist and include srvHost');
     }
 
     this.srvHost = options.srvHost;

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -11,7 +11,7 @@ import {
 } from '../sessions';
 import { SrvPoller, SrvPollingEvent } from './srv_polling';
 import { CMAP_EVENTS, ConnectionPoolEvents } from '../cmap/connection_pool';
-import { MongoServerSelectionError, MongoDriverError } from '../error';
+import { MongoServerSelectionError, MongoCompatibilityError, MongoDriverError } from '../error';
 import { readPreferenceServerSelector, ServerSelector } from './server_selection';
 import {
   makeStateMachine,
@@ -694,7 +694,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
     // first update the TopologyDescription
     this.s.description = this.s.description.update(serverDescription);
     if (this.s.description.compatibilityError) {
-      this.emit(Topology.ERROR, new MongoDriverError(this.s.description.compatibilityError));
+      this.emit(Topology.ERROR, new MongoCompatibilityError(this.s.description.compatibilityError));
       return;
     }
 

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -274,6 +274,8 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       } else if (seed instanceof HostAddress) {
         seedlist.push(seed);
       } else {
+        // NODE-3402
+        // FIXME: May need to me a MongoParseError
         throw new MongoDriverError(`Topology cannot be constructed from ${JSON.stringify(seed)}`);
       }
     }

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -3,7 +3,7 @@ import * as WIRE_CONSTANTS from '../cmap/wire_protocol/constants';
 import { TopologyType, ServerType } from './common';
 import type { ObjectId, Document } from '../bson';
 import type { SrvPollingEvent } from './srv_polling';
-import { MongoDriverError, MongoError } from '../error';
+import { MongoDriverError, MongoError, MongoInvalidArgumentError } from '../error';
 
 // constants related to compatibility checks
 const MIN_SUPPORTED_SERVER_VERSION = WIRE_CONSTANTS.MIN_SUPPORTED_SERVER_VERSION;
@@ -431,7 +431,7 @@ function updateRsWithPrimaryFromMember(
   setName?: string
 ): TopologyType {
   if (setName == null) {
-    throw new MongoDriverError('setName is required');
+    throw new MongoInvalidArgumentError('setName is required');
   }
 
   if (

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -3,7 +3,7 @@ import * as WIRE_CONSTANTS from '../cmap/wire_protocol/constants';
 import { TopologyType, ServerType } from './common';
 import type { ObjectId, Document } from '../bson';
 import type { SrvPollingEvent } from './srv_polling';
-import { MongoDriverError, MongoError, MongoInvalidArgumentError } from '../error';
+import { MongoError, MongoInvalidArgumentError } from '../error';
 
 // constants related to compatibility checks
 const MIN_SUPPORTED_SERVER_VERSION = WIRE_CONSTANTS.MIN_SUPPORTED_SERVER_VERSION;

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -269,7 +269,7 @@ class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
       topologyMaxWireVersion != null &&
       topologyMaxWireVersion < minWireVersionForShardedTransactions
     ) {
-      throw new MongoDriverError(
+      throw new MongoCompatibilityError(
         'Transactions are not supported on sharded clusters in MongoDB < 4.2.'
       );
     }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -6,6 +6,7 @@ import { resolveClusterTime, ClusterTime } from './sdam/common';
 import { isSharded } from './cmap/wire_protocol/shared';
 import {
   MongoError,
+  MongoInvalidArgumentError,
   isRetryableError,
   MongoNetworkError,
   MongoWriteConcernError,
@@ -433,7 +434,9 @@ function attemptTransaction<TSchema>(
 
   if (!isPromiseLike(promise)) {
     session.abortTransaction();
-    throw new MongoDriverError('Function provided to `withTransaction` must return a Promise');
+    throw new MongoInvalidArgumentError(
+      'Function provided to `withTransaction` must return a Promise'
+    );
   }
 
   return promise.then(

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,4 +1,4 @@
-import { MongoDriverError } from './error';
+import { MongoInvalidArgumentError } from './error';
 
 /** @public */
 export type SortDirection =
@@ -45,7 +45,7 @@ function prepareDirection(direction: any = 1): SortDirectionForCmd {
     case '-1':
       return -1;
     default:
-      throw new MongoDriverError(`Invalid sort direction: ${JSON.stringify(direction)}`);
+      throw new MongoInvalidArgumentError(`Invalid sort direction: ${JSON.stringify(direction)}`);
   }
 }
 
@@ -118,7 +118,7 @@ export function formatSort(
   if (sort == null) return undefined;
   if (typeof sort === 'string') return new Map([[sort, prepareDirection(direction)]]);
   if (typeof sort !== 'object') {
-    throw new MongoDriverError(`Invalid sort format: ${JSON.stringify(sort)}`);
+    throw new MongoInvalidArgumentError(`Invalid sort format: ${JSON.stringify(sort)}`);
   }
   if (!Array.isArray(sort)) {
     return isMap(sort) ? mapToMap(sort) : Object.keys(sort).length ? objectToMap(sort) : undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import * as os from 'os';
 import * as crypto from 'crypto';
 import { PromiseProvider } from './promise_provider';
-import { AnyError, MongoParseError, MongoDriverError, MongoInvalidArgumentError } from './error';
+import { AnyError, MongoParseError, MongoDriverError, MongoCompatibilityError, MongoInvalidArgumentError } from './error';
 import { WriteConcern, WriteConcernOptions, W } from './write_concern';
 import type { Server } from './sdam/server';
 import type { Topology } from './sdam/topology';
@@ -399,7 +399,7 @@ export function decorateWithCollation(
     if (capabilities && capabilities.commandsTakeCollation) {
       command.collation = options.collation;
     } else {
-      throw new MongoDriverError(`Current topology does not support collation`);
+      throw new MongoCompatibilityError(`Current topology does not support collation`);
     }
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,13 @@
 import * as os from 'os';
 import * as crypto from 'crypto';
 import { PromiseProvider } from './promise_provider';
-import { AnyError, MongoParseError, MongoDriverError, MongoCompatibilityError, MongoInvalidArgumentError } from './error';
+import {
+  AnyError,
+  MongoParseError,
+  MongoDriverError,
+  MongoCompatibilityError,
+  MongoInvalidArgumentError
+} from './error';
 import { WriteConcern, WriteConcernOptions, W } from './write_concern';
 import type { Server } from './sdam/server';
 import type { Topology } from './sdam/topology';
@@ -289,7 +295,9 @@ export function executeLegacyOperation(
 
   // Return a Promise
   if (args[args.length - 1] != null) {
-    throw new MongoInvalidArgumentError('final argument to `executeLegacyOperation` must be a callback');
+    throw new MongoInvalidArgumentError(
+      'final argument to `executeLegacyOperation` must be a callback'
+    );
   }
 
   return new Promise<any>((resolve, reject) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import * as os from 'os';
 import * as crypto from 'crypto';
 import { PromiseProvider } from './promise_provider';
-import { AnyError, MongoParseError, MongoDriverError } from './error';
+import { AnyError, MongoParseError, MongoDriverError, MongoInvalidArgumentError } from './error';
 import { WriteConcern, WriteConcernOptions, W } from './write_concern';
 import type { Server } from './sdam/server';
 import type { Topology } from './sdam/topology';
@@ -54,27 +54,27 @@ export function getSingleProperty(
  */
 export function checkCollectionName(collectionName: string): void {
   if ('string' !== typeof collectionName) {
-    throw new MongoDriverError('collection name must be a String');
+    throw new MongoInvalidArgumentError('collection name must be a String');
   }
 
   if (!collectionName || collectionName.indexOf('..') !== -1) {
-    throw new MongoDriverError('collection names cannot be empty');
+    throw new MongoInvalidArgumentError('collection names cannot be empty');
   }
 
   if (
     collectionName.indexOf('$') !== -1 &&
     collectionName.match(/((^\$cmd)|(oplog\.\$main))/) == null
   ) {
-    throw new MongoDriverError("collection names must not contain '$'");
+    throw new MongoInvalidArgumentError("collection names must not contain '$'");
   }
 
   if (collectionName.match(/^\.|\.$/) != null) {
-    throw new MongoDriverError("collection names must not start or end with '.'");
+    throw new MongoInvalidArgumentError("collection names must not start or end with '.'");
   }
 
   // Validate that we are not passing 0x00 in the collection name
   if (collectionName.indexOf('\x00') !== -1) {
-    throw new MongoDriverError('collection names cannot contain a null character');
+    throw new MongoInvalidArgumentError('collection names cannot contain a null character');
   }
 }
 
@@ -228,7 +228,7 @@ export function executeLegacyOperation(
   const Promise = PromiseProvider.get();
 
   if (!Array.isArray(args)) {
-    throw new MongoDriverError('This method requires an array of arguments to apply');
+    throw new MongoInvalidArgumentError('This method requires an array of arguments to apply');
   }
 
   options = options ?? {};
@@ -248,7 +248,7 @@ export function executeLegacyOperation(
       const optionsIndex = args.length - 2;
       args[optionsIndex] = Object.assign({}, args[optionsIndex], { session: session });
     } else if (opOptions.session && opOptions.session.hasEnded) {
-      throw new MongoDriverError('Use of expired sessions is not permitted');
+      throw new MongoInvalidArgumentError('Use of expired sessions is not permitted');
     }
   }
 
@@ -289,7 +289,7 @@ export function executeLegacyOperation(
 
   // Return a Promise
   if (args[args.length - 1] != null) {
-    throw new MongoDriverError('final argument to `executeLegacyOperation` must be a callback');
+    throw new MongoInvalidArgumentError('final argument to `executeLegacyOperation` must be a callback');
   }
 
   return new Promise<any>((resolve, reject) => {
@@ -921,7 +921,7 @@ export function now(): number {
 /** @internal */
 export function calculateDurationInMs(started: number): number {
   if (typeof started !== 'number') {
-    throw new MongoDriverError('numeric value required to calculate duration');
+    throw new MongoInvalidArgumentError('numeric value required to calculate duration');
   }
 
   const elapsed = now() - started;
@@ -1222,7 +1222,7 @@ export class BufferPool {
   /** Reads the requested number of bytes, optionally consuming them */
   read(size: number, consume = true): Buffer {
     if (typeof size !== 'number' || size < 0) {
-      throw new MongoDriverError('Parameter size must be a non-negative number');
+      throw new MongoInvalidArgumentError('Parameter size must be a non-negative number');
     }
 
     if (size > this[kLength]) {
@@ -1324,7 +1324,7 @@ export class HostAddress {
         throw new MongoParseError('Invalid port (zero) with hostname');
       }
     } else {
-      throw new MongoDriverError('Either socketPath or host must be defined.');
+      throw new MongoInvalidArgumentError('Either socketPath or host must be defined.');
     }
     Object.freeze(this);
   }


### PR DESCRIPTION
## Description

Implement the errors detailed in docs/errors.md from NODE-3363 that fall under MongoAPIError

**What changed?**
Replaced some MongoDriverError instances with the following errors where appropriate

- MongoInvalidArgumentError
- MongoMissingDependencyError
- MongoMissingCredentialsError
- MongoCompatibilityError

