### PR TITLE
fix(NODE-3411): remove explicit fallback batch size for getMore calls

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -512,7 +512,7 @@ export class ChangeStreamCursor<TSchema extends Document = Document> extends Abs
     });
   }
 
-  _getMore(batchSize: number, callback: Callback): void {
+  _getMore(batchSize: number | undefined, callback: Callback): void {
     super._getMore(batchSize, (err, response) => {
       if (err) {
         return callback(err);

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -94,15 +94,17 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
   }
 
   /** @internal */
-  _getMore(batchSize: number, callback: Callback<Document>): void {
+  _getMore(batchSize: number | undefined, callback: Callback<Document>): void {
     // NOTE: this is to support client provided limits in pre-command servers
     const numReturned = this[kNumReturned];
     if (numReturned) {
       const limit = this[kBuiltOptions].limit;
       batchSize =
-        limit && limit > 0 && numReturned + batchSize > limit ? limit - numReturned : batchSize;
+        limit && limit > 0 && (batchSize === undefined || numReturned + batchSize > limit)
+          ? limit - numReturned
+          : batchSize;
 
-      if (batchSize <= 0) {
+      if (batchSize !== undefined && batchSize <= 0) {
         return this.close(callback);
       }
     }

--- a/test/functional/apm.test.js
+++ b/test/functional/apm.test.js
@@ -597,18 +597,19 @@ describe('APM', function () {
             return db
               .collection('apm_test_u_4')
               .aggregate([{ $match: {} }])
+              .batchSize(1000)
               .toArray();
           })
           .then(r => {
             expect(r).to.exist;
-            expect(started).to.have.length(4);
-            expect(succeeded).to.have.length(4);
+            expect(started).to.have.length(3);
+            expect(succeeded).to.have.length(3);
             const cursors = succeeded.map(x => x.reply.cursor);
 
             // Check we have a cursor
             expect(cursors[0].id).to.exist;
             expect(cursors[0].id.toString()).to.equal(cursors[1].id.toString());
-            expect(cursors[3].id.toString()).to.equal('0');
+            expect(cursors[2].id.toString()).to.equal('0');
 
             return client.close();
           });


### PR DESCRIPTION
Removes the explicit fallback batch size of `1000` for `getMore` calls of cursors. This will cause the driver to use the default behavior of the server which is to return up to 16MB of data in the `getMore` call.

Note that the _initial_ `find` operation for example will continue to use the server's default 101 results if the user does not immediately specify a `batchSize`.
