### PR TITLE
fix(NODE-3417): allow calling `db()` before MongoClient is connected

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -473,13 +473,6 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     // Copy the options and add out internal override of the not shared flag
     const finalOptions = Object.assign({}, this[kOptions], options);
 
-    // If no topology throw an error message
-    if (!this.topology) {
-      throw new MongoDriverError(
-        'MongoClient must be connected before calling MongoClient.prototype.db'
-      );
-    }
-
     // Return the db object
     const db = new Db(this, dbName, finalOptions);
 


### PR DESCRIPTION
## Description

Removed an error case that will make Automattic/mongoose#8702 much easier.

**What changed?**

Removed a check that looks unnecessary because the `Db()` constructor no longer takes a `topology` param.

**Are there any files to ignore?**
