### PR TITLE
fix(NODE-3393): snapshot time not applied if distinct executed first

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -891,11 +891,12 @@ export function updateSessionFromResponse(session: ClientSession, document: Docu
     session.transaction._recoveryToken = document.recoveryToken;
   }
 
-  if (
-    document.cursor?.atClusterTime &&
-    session?.[kSnapshotEnabled] &&
-    session[kSnapshotTime] === undefined
-  ) {
-    session[kSnapshotTime] = document.cursor.atClusterTime;
+  if (session?.[kSnapshotEnabled] && session[kSnapshotTime] === undefined) {
+    // find and aggregate commands return atClusterTime on the cursor
+    // distinct includes it in the response body
+    const atClusterTime = document.cursor?.atClusterTime || document.atClusterTime;
+    if (atClusterTime) {
+      session[kSnapshotTime] = atClusterTime;
+    }
   }
 }

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -201,34 +201,20 @@ describe('Sessions - functional', function () {
       expect(sessionTests).to.be.an('object');
       context(String(sessionTests.description), function () {
         // TODO: NODE-3393 fix test runner to apply session to all operations
-        const skipTestMap = {
-          'snapshot-sessions': [
-            'countDocuments operation with snapshot',
-            'Distinct operation with snapshot',
-            'Mixed operation with snapshot'
-          ],
-          'snapshot-sessions-not-supported-client-error': [
-            'Client error on distinct with snapshot'
-          ],
-          'snapshot-sessions-not-supported-server-error': [
-            'Server returns an error on distinct with snapshot'
-          ],
-          'snapshot-sessions-unsupported-ops': [
-            'Server returns an error on listCollections with snapshot',
-            'Server returns an error on listDatabases with snapshot',
-            'Server returns an error on listIndexes with snapshot',
-            'Server returns an error on runCommand with snapshot',
-            'Server returns an error on findOneAndUpdate with snapshot',
-            'Server returns an error on deleteOne with snapshot',
-            'Server returns an error on updateOne with snapshot'
-          ]
-        };
-        const testsToSkip = skipTestMap[sessionTests.description] || [];
+        // const skipTestMap = {
+        //   'snapshot-sessions': [
+        //     'countDocuments operation with snapshot',
+        //     'Distinct operation with snapshot',
+        //     'Mixed operation with snapshot'
+        //   ],
+        //   'snapshot-sessions-not-supported-client-error': ['Client error on distinct with snapshot']
+        // };
+        // const testsToSkip = skipTestMap[sessionTests.description] || [];
         for (const test of sessionTests.tests) {
           it(String(test.description), {
             metadata: { sessions: { skipLeakTests: true } },
             test: async function () {
-              await runUnifiedTest(this, sessionTests, test, testsToSkip);
+              await runUnifiedTest(this, sessionTests, test, []);
             }
           });
         }

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -200,16 +200,11 @@ describe('Sessions - functional', function () {
     for (const sessionTests of loadSpecTests(path.join('sessions', 'unified'))) {
       expect(sessionTests).to.be.an('object');
       context(String(sessionTests.description), function () {
-        // TODO: NODE-3393 fix test runner to apply session to all operations
-        const skipTestMap = {
-          'snapshot-sessions': ['Distinct operation with snapshot']
-        };
-        const testsToSkip = skipTestMap[sessionTests.description] || [];
         for (const test of sessionTests.tests) {
           it(String(test.description), {
             metadata: { sessions: { skipLeakTests: true } },
             test: async function () {
-              await runUnifiedTest(this, sessionTests, test, testsToSkip);
+              await runUnifiedTest(this, sessionTests, test);
             }
           });
         }

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -201,20 +201,15 @@ describe('Sessions - functional', function () {
       expect(sessionTests).to.be.an('object');
       context(String(sessionTests.description), function () {
         // TODO: NODE-3393 fix test runner to apply session to all operations
-        // const skipTestMap = {
-        //   'snapshot-sessions': [
-        //     'countDocuments operation with snapshot',
-        //     'Distinct operation with snapshot',
-        //     'Mixed operation with snapshot'
-        //   ],
-        //   'snapshot-sessions-not-supported-client-error': ['Client error on distinct with snapshot']
-        // };
-        // const testsToSkip = skipTestMap[sessionTests.description] || [];
+        const skipTestMap = {
+          'snapshot-sessions': ['Distinct operation with snapshot']
+        };
+        const testsToSkip = skipTestMap[sessionTests.description] || [];
         for (const test of sessionTests.tests) {
           it(String(test.description), {
             metadata: { sessions: { skipLeakTests: true } },
             test: async function () {
-              await runUnifiedTest(this, sessionTests, test, []);
+              await runUnifiedTest(this, sessionTests, test, testsToSkip);
             }
           });
         }

--- a/test/functional/unified-spec-runner/operations.ts
+++ b/test/functional/unified-spec-runner/operations.ts
@@ -281,8 +281,6 @@ operations.set('insertOne', async ({ entities, operation }) => {
 
 operations.set('insertMany', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
-  // TODO: remove comment if all tests pass
-  // PREVIOUSLY:  ordered: operation.arguments.ordered ?? true
   const { documents, ...opts } = operation.arguments;
   return collection.insertMany(documents, opts);
 });

--- a/test/functional/unified-spec-runner/operations.ts
+++ b/test/functional/unified-spec-runner/operations.ts
@@ -219,8 +219,8 @@ operations.set('createCollection', async ({ entities, operation }) => {
 
 operations.set('createFindCursor', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
-  const { filter, sort, batchSize, limit, let: vars } = operation.arguments;
-  const cursor = collection.find(filter, { sort, batchSize, limit, let: vars });
+  const { filter, ...opts } = operation.arguments;
+  const cursor = collection.find(filter, opts);
   // The spec dictates that we create the cursor and force the find command
   // to execute, but don't move the cursor forward. hasNext() accomplishes
   // this.
@@ -242,7 +242,8 @@ operations.set('deleteOne', async ({ entities, operation }) => {
 
 operations.set('dropCollection', async ({ entities, operation }) => {
   const db = entities.getEntity('db', operation.object);
-  return await db.dropCollection(operation.arguments.collection);
+  const { collection, ...opts } = operation.arguments;
+  return await db.dropCollection(collection, opts);
 });
 
 operations.set('endSession', async ({ entities, operation }) => {
@@ -317,12 +318,8 @@ operations.set('listIndexes', async ({ entities, operation }) => {
 
 operations.set('replaceOne', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
-  return collection.replaceOne(operation.arguments.filter, operation.arguments.replacement, {
-    bypassDocumentValidation: operation.arguments.bypassDocumentValidation,
-    collation: operation.arguments.collation,
-    hint: operation.arguments.hint,
-    upsert: operation.arguments.upsert
-  });
+  const { filter, replacement, ...opts } = operation.arguments;
+  return collection.replaceOne(filter, replacement, opts);
 });
 
 operations.set('startTransaction', async ({ entities, operation }) => {
@@ -396,7 +393,8 @@ operations.set('countDocuments', async ({ entities, operation }) => {
 
 operations.set('deleteMany', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
-  return collection.deleteMany(operation.arguments.filter);
+  const { filter, ...opts } = operation.arguments;
+  return collection.deleteMany(filter, opts);
 });
 
 operations.set('distinct', async ({ entities, operation }) => {
@@ -412,7 +410,8 @@ operations.set('estimatedDocumentCount', async ({ entities, operation }) => {
 
 operations.set('findOneAndDelete', async ({ entities, operation }) => {
   const collection = entities.getEntity('collection', operation.object);
-  return collection.findOneAndDelete(operation.arguments.filter);
+  const { filter, ...opts } = operation.arguments;
+  return collection.findOneAndDelete(filter, opts);
 });
 
 operations.set('runCommand', async ({ entities, operation }: OperationFunctionParams) => {


### PR DESCRIPTION
## Description

NODE-3393, NODE-3394

This PR started out as a fix to our spec runner which was selectively passing in sessions instead of applying them to all operations. Fixing the last test revealed a bug in the original snapshot session reads implementation: the `atClusterTime` from the server response was not applied to the session if the first operation executed against it was `distinct`. This PR includes the fix for that issue.
