### PR TITLE
refactor(NODE-3421): Replace MongoDriverError instances with MongoRuntimeError children

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1181,12 +1181,7 @@ export abstract class BulkOperationBase {
     options = options ?? {};
 
     if (this.s.executed) {
-      return handleEarlyError(
-        new MongoBatchReExecutionError(
-          'This batch has already been executed: Must create a new batch to execute'
-        ),
-        callback
-      );
+      return handleEarlyError(new MongoBatchReExecutionError(), callback);
     }
 
     const writeConcern = WriteConcern.fromOptions(options);

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -5,8 +5,8 @@ import {
   AnyError,
   MONGODB_ERROR_CODES,
   MongoServerError,
-  MongoDriverError,
-  MongoInvalidArgumentError
+  MongoInvalidArgumentError,
+  MongoBatchReExecutionError
 } from '../error';
 import {
   applyRetryableWrites,
@@ -1181,7 +1181,10 @@ export abstract class BulkOperationBase {
     options = options ?? {};
 
     if (this.s.executed) {
-      return handleEarlyError(new MongoDriverError('Batch cannot be re-executed'), callback);
+      return handleEarlyError(
+        new MongoBatchReExecutionError('Batch cannot be re-executed'),
+        callback
+      );
     }
 
     const writeConcern = WriteConcern.fromOptions(options);

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1182,7 +1182,9 @@ export abstract class BulkOperationBase {
 
     if (this.s.executed) {
       return handleEarlyError(
-        new MongoBatchReExecutionError('Batch cannot be re-executed'),
+        new MongoBatchReExecutionError(
+          'This batch has already been executed: Must create a new batch to execute'
+        ),
         callback
       );
     }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -295,7 +295,7 @@ export abstract class AbstractCursor<
   next<T = TSchema>(callback?: Callback<T | null>): Promise<T | null> | void {
     return maybePromise(callback, done => {
       if (this[kId] === Long.ZERO) {
-        return done(new MongoCursorExhaustedError('Cursor is exhausted'));
+        return done(new MongoCursorExhaustedError());
       }
 
       next(this, true, done);
@@ -310,7 +310,7 @@ export abstract class AbstractCursor<
   tryNext<T = TSchema>(callback?: Callback<T | null>): Promise<T | null> | void {
     return maybePromise(callback, done => {
       if (this[kId] === Long.ZERO) {
-        return done(new MongoCursorExhaustedError('Cursor is exhausted'));
+        return done(new MongoCursorExhaustedError());
       }
 
       next(this, false, done);
@@ -572,7 +572,7 @@ export abstract class AbstractCursor<
   batchSize(value: number): this {
     assertUninitialized(this);
     if (this[kOptions].tailable) {
-      throw new MongoTailableCursorError('Tailable cursors do not support batchSize');
+      throw new MongoTailableCursorError('Tailable cursor does not support batchSize');
     }
 
     if (typeof value !== 'number') {
@@ -785,7 +785,7 @@ function cleanupCursor(cursor: AbstractCursor, callback: Callback): void {
 /** @internal */
 export function assertUninitialized(cursor: AbstractCursor): void {
   if (cursor[kInitialized]) {
-    throw new MongoCursorInUseError('Cursor is already initialized');
+    throw new MongoCursorInUseError();
   }
 }
 

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -5,7 +5,8 @@ import {
   MongoDriverError,
   MongoInvalidArgumentError,
   MongoCursorExhaustedError,
-  MongoTailableCursorError
+  MongoTailableCursorError,
+  MongoCursorInUseError
 } from '../error';
 import { ReadPreference, ReadPreferenceLike } from '../read_preference';
 import type { Server } from '../sdam/server';
@@ -784,7 +785,7 @@ function cleanupCursor(cursor: AbstractCursor, callback: Callback): void {
 /** @internal */
 export function assertUninitialized(cursor: AbstractCursor): void {
   if (cursor[kInitialized]) {
-    throw new MongoDriverError('Cursor is already initialized');
+    throw new MongoCursorInUseError('Cursor is already initialized');
   }
 }
 

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -1,5 +1,5 @@
 import type { Document } from '../bson';
-import { MongoDriverError, MongoInvalidArgumentError } from '../error';
+import { MongoDriverError, MongoInvalidArgumentError, MongoTailableCursorError } from '../error';
 import type { ExplainVerbosityLike } from '../explain';
 import { CountOperation, CountOptions } from '../operations/count';
 import { executeOperation, ExecutionResult } from '../operations/execute_operation';
@@ -371,7 +371,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
   sort(sort: Sort | string, direction?: SortDirection): this {
     assertUninitialized(this);
     if (this[kBuiltOptions].tailable) {
-      throw new MongoDriverError('Tailable cursor does not support sorting');
+      throw new MongoTailableCursorError('Tailable cursor does not support sorting');
     }
 
     this[kBuiltOptions].sort = formatSort(sort, direction);
@@ -412,7 +412,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
   limit(value: number): this {
     assertUninitialized(this);
     if (this[kBuiltOptions].tailable) {
-      throw new MongoDriverError('Tailable cursor does not support limit');
+      throw new MongoTailableCursorError('Tailable cursor does not support limit');
     }
 
     if (typeof value !== 'number') {
@@ -431,7 +431,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
   skip(value: number): this {
     assertUninitialized(this);
     if (this[kBuiltOptions].tailable) {
-      throw new MongoDriverError('Tailable cursor does not support skip');
+      throw new MongoTailableCursorError('Tailable cursor does not support skip');
     }
 
     if (typeof value !== 'number') {

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -1,5 +1,5 @@
 import type { Document } from '../bson';
-import { MongoDriverError, MongoInvalidArgumentError, MongoTailableCursorError } from '../error';
+import { MongoInvalidArgumentError, MongoTailableCursorError } from '../error';
 import type { ExplainVerbosityLike } from '../explain';
 import { CountOperation, CountOptions } from '../operations/count';
 import { executeOperation, ExecutionResult } from '../operations/execute_operation';

--- a/src/error.ts
+++ b/src/error.ts
@@ -206,8 +206,12 @@ export class MongoRuntimeError extends MongoDriverError {
  * @category Error
  */
 export class MongoBatchReExecutionError extends MongoRuntimeError {
-  constructor(message: string) {
-    super(message);
+  constructor(message?: string) {
+    if (message !== undefined) {
+      super(message);
+    } else {
+      super('This batch has already been executed, create new batch to execute');
+    }
   }
 
   get name(): string {
@@ -389,8 +393,12 @@ export class MongoChangeStreamError extends MongoStreamError {
  * @category Error
  */
 export class MongoTailableCursorError extends MongoCursorError {
-  constructor(message: string) {
-    super(message);
+  constructor(message?: string) {
+    if (message !== undefined) {
+      super(message);
+    } else {
+      super('Tailable cursor does not support this operation');
+    }
   }
 
   get name(): string {
@@ -438,8 +446,12 @@ export class MongoGridFSChunkError extends MongoStreamError {
  * @category Error
  */
 export class MongoCursorInUseError extends MongoCursorError {
-  constructor(message: string) {
-    super(message);
+  constructor(message?: string) {
+    if (message !== undefined) {
+      super(message);
+    } else {
+      super('Cursor is already initialized');
+    }
   }
 
   get name(): string {
@@ -488,8 +500,12 @@ export class MongoServerClosedError extends MongoResourceClosedError {
  * @category Error
  */
 export class MongoCursorExhaustedError extends MongoCursorError {
-  constructor(message: string) {
-    super(message);
+  constructor(message?: string) {
+    if (message !== undefined) {
+      super(message);
+    } else {
+      super('Cursor is exhausted');
+    }
   }
 
   get name(): string {

--- a/src/error.ts
+++ b/src/error.ts
@@ -207,11 +207,7 @@ export class MongoRuntimeError extends MongoDriverError {
  */
 export class MongoBatchReExecutionError extends MongoRuntimeError {
   constructor(message?: string) {
-    if (message !== undefined) {
-      super(message);
-    } else {
-      super('This batch has already been executed, create new batch to execute');
-    }
+    super(message || 'This batch has already been executed, create new batch to execute');
   }
 
   get name(): string {
@@ -394,11 +390,7 @@ export class MongoChangeStreamError extends MongoStreamError {
  */
 export class MongoTailableCursorError extends MongoCursorError {
   constructor(message?: string) {
-    if (message !== undefined) {
-      super(message);
-    } else {
-      super('Tailable cursor does not support this operation');
-    }
+    super(message || 'Tailable cursor does not support this operation');
   }
 
   get name(): string {
@@ -447,11 +439,7 @@ export class MongoGridFSChunkError extends MongoStreamError {
  */
 export class MongoCursorInUseError extends MongoCursorError {
   constructor(message?: string) {
-    if (message !== undefined) {
-      super(message);
-    } else {
-      super('Cursor is already initialized');
-    }
+    super(message || 'Cursor is already initialized');
   }
 
   get name(): string {
@@ -501,11 +489,7 @@ export class MongoServerClosedError extends MongoResourceClosedError {
  */
 export class MongoCursorExhaustedError extends MongoCursorError {
   constructor(message?: string) {
-    if (message !== undefined) {
-      super(message);
-    } else {
-      super('Cursor is exhausted');
-    }
+    super(message || 'Cursor is exhausted');
   }
 
   get name(): string {

--- a/src/error.ts
+++ b/src/error.ts
@@ -435,23 +435,6 @@ export class MongoCursorInUseError extends MongoAPIError {
 }
 
 /**
- * An error generated when an attempt is made to access a resource
- * which has already been or will be closed/destroyed.
- *
- * @public
- * @category Error
- */
-export class MongoResourceClosedError extends MongoRuntimeError {
-  constructor(message: string) {
-    super(message);
-  }
-
-  get name(): string {
-    return 'MongoResourceClosedError';
-  }
-}
-
-/**
  * An error generated when an attempt is made to operate
  * on a closed/closing server.
  *

--- a/src/error.ts
+++ b/src/error.ts
@@ -179,6 +179,26 @@ export class MongoDriverError extends MongoError {
 }
 
 /**
+ * An error generated when the driver API is used incorrectly
+ *
+ * @privateRemarks
+ * Should **never** be directly instantiated
+ *
+ * @public
+ * @category Error
+ */
+
+export class MongoAPIError extends MongoDriverError {
+  protected constructor(message: string) {
+    super(message);
+  }
+
+  get name(): string {
+    return 'MongoAPIError';
+  }
+}
+
+/**
  * An error generated when the driver encounters unexpected input
  * or reaches an unexpected/invalid internal state
  *
@@ -205,7 +225,7 @@ export class MongoRuntimeError extends MongoDriverError {
  * @public
  * @category Error
  */
-export class MongoBatchReExecutionError extends MongoRuntimeError {
+export class MongoBatchReExecutionError extends MongoAPIError {
   constructor(message?: string) {
     super(message || 'This batch has already been executed, create new batch to execute');
   }
@@ -272,7 +292,7 @@ export class MongoDecompressionError extends MongoRuntimeError {
  * @public
  * @category Error
  */
-export class MongoNotConnectedError extends MongoRuntimeError {
+export class MongoNotConnectedError extends MongoAPIError {
   constructor(message: string) {
     super(message);
   }
@@ -289,7 +309,7 @@ export class MongoNotConnectedError extends MongoRuntimeError {
  * @public
  * @category Error
  */
-export class MongoTransactionError extends MongoRuntimeError {
+export class MongoTransactionError extends MongoAPIError {
   constructor(message: string) {
     super(message);
   }
@@ -306,7 +326,7 @@ export class MongoTransactionError extends MongoRuntimeError {
  * @public
  * @category Error
  */
-export class MongoExpiredSessionError extends MongoRuntimeError {
+export class MongoExpiredSessionError extends MongoAPIError {
   constructor(message: string) {
     super(message);
   }
@@ -334,45 +354,12 @@ export class MongoKerberosError extends MongoRuntimeError {
 }
 
 /**
- * An error thrown when the user attempts to operate on a cursor that is in a state which does not
- * support the attempted operation.
- *
- * @public
- * @category Error
- */
-export class MongoCursorError extends MongoRuntimeError {
-  constructor(message: string) {
-    super(message);
-  }
-
-  get name(): string {
-    return 'MongoCursorError';
-  }
-}
-
-/**
- * An error generated when a stream operation fails to execute.
- *
- * @public
- * @category Error
- */
-export class MongoStreamError extends MongoRuntimeError {
-  constructor(message: string) {
-    super(message);
-  }
-
-  get name(): string {
-    return 'MongoStreamError';
-  }
-}
-
-/**
  * An error generated when a ChangeStream operation fails to execute.
  *
  * @public
  * @category Error
  */
-export class MongoChangeStreamError extends MongoStreamError {
+export class MongoChangeStreamError extends MongoRuntimeError {
   constructor(message: string) {
     super(message);
   }
@@ -388,7 +375,7 @@ export class MongoChangeStreamError extends MongoStreamError {
  * @public
  * @category Error
  */
-export class MongoTailableCursorError extends MongoCursorError {
+export class MongoTailableCursorError extends MongoAPIError {
   constructor(message?: string) {
     super(message || 'Tailable cursor does not support this operation');
   }
@@ -403,7 +390,7 @@ export class MongoTailableCursorError extends MongoCursorError {
  * @public
  * @category Error
  */
-export class MongoGridFSStreamError extends MongoStreamError {
+export class MongoGridFSStreamError extends MongoRuntimeError {
   constructor(message: string) {
     super(message);
   }
@@ -420,7 +407,7 @@ export class MongoGridFSStreamError extends MongoStreamError {
  * @public
  * @category Error
  */
-export class MongoGridFSChunkError extends MongoStreamError {
+export class MongoGridFSChunkError extends MongoRuntimeError {
   constructor(message: string) {
     super(message);
   }
@@ -437,7 +424,7 @@ export class MongoGridFSChunkError extends MongoStreamError {
  * @public
  * @category Error
  */
-export class MongoCursorInUseError extends MongoCursorError {
+export class MongoCursorInUseError extends MongoAPIError {
   constructor(message?: string) {
     super(message || 'Cursor is already initialized');
   }
@@ -471,7 +458,7 @@ export class MongoResourceClosedError extends MongoRuntimeError {
  * @public
  * @category Error
  */
-export class MongoServerClosedError extends MongoResourceClosedError {
+export class MongoServerClosedError extends MongoAPIError {
   constructor(message: string) {
     super(message);
   }
@@ -487,7 +474,7 @@ export class MongoServerClosedError extends MongoResourceClosedError {
  * @public
  * @category Error
  */
-export class MongoCursorExhaustedError extends MongoCursorError {
+export class MongoCursorExhaustedError extends MongoAPIError {
   constructor(message?: string) {
     super(message || 'Cursor is exhausted');
   }
@@ -498,30 +485,13 @@ export class MongoCursorExhaustedError extends MongoCursorError {
 }
 
 /**
- * An error generated when an attempt is made to operate
- * on a closed/closing stream.
- *
- * @public
- * @category Error
- */
-export class MongoStreamClosedError extends MongoResourceClosedError {
-  constructor(message: string) {
-    super(message);
-  }
-
-  get name(): string {
-    return 'MongoStreamClosedError';
-  }
-}
-
-/**
  * An error generated when an attempt is made to operate on a
  * dropped, or otherwise unavailable, database.
  *
  * @public
  * @category Error
  */
-export class MongoTopologyClosedError extends MongoResourceClosedError {
+export class MongoTopologyClosedError extends MongoAPIError {
   constructor(message: string) {
     super(message);
   }
@@ -595,26 +565,6 @@ export class MongoParseError extends MongoDriverError {
 
   get name(): string {
     return 'MongoParseError';
-  }
-}
-
-/**
- * An error generated when the driver API is used incorrectly
- *
- * @privateRemarks
- * Should **never** be directly instantiated
- *
- * @public
- * @category Error
- */
-
-export class MongoAPIError extends MongoDriverError {
-  protected constructor(message: string) {
-    super(message);
-  }
-
-  get name(): string {
-    return 'MongoAPIError';
   }
 }
 

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -1,7 +1,12 @@
 import { Db, DbOptions } from './db';
 import { ChangeStream, ChangeStreamOptions } from './change_stream';
 import type { ReadPreference, ReadPreferenceMode } from './read_preference';
-import { AnyError, MongoDriverError, MongoInvalidArgumentError } from './error';
+import {
+  AnyError,
+  MongoDriverError,
+  MongoInvalidArgumentError,
+  MongoNotConnectedError
+} from './error';
 import type { W, WriteConcern } from './write_concern';
 import {
   maybePromise,
@@ -521,7 +526,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
   startSession(options?: ClientSessionOptions): ClientSession {
     options = Object.assign({ explicit: true }, options);
     if (!this.topology) {
-      throw new MongoDriverError('Must connect to a server before calling this method');
+      throw new MongoNotConnectedError('Must connect to a server before calling this method');
     }
 
     return this.topology.startSession(options, this.s.options);

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -526,7 +526,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
   startSession(options?: ClientSessionOptions): ClientSession {
     options = Object.assign({ explicit: true }, options);
     if (!this.topology) {
-      throw new MongoNotConnectedError('Must connect to a server before calling this method');
+      throw new MongoNotConnectedError('MongoClient must be connected to start a session');
     }
 
     return this.topology.startSession(options, this.s.options);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import {
   MongoParseError,
   MongoDriverError,
   MongoCompatibilityError,
+  MongoNotConnectedError,
   MongoInvalidArgumentError
 } from './error';
 import { WriteConcern, WriteConcernOptions, W } from './write_concern';
@@ -467,7 +468,7 @@ export function getTopology<T>(provider: MongoClient | Db | Collection<T>): Topo
     return provider.s.db.s.client.topology;
   }
 
-  throw new MongoDriverError('MongoClient must be connected to perform this operation');
+  throw new MongoNotConnectedError('MongoClient must be connected to perform this operation');
 }
 
 /**

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -7,7 +7,7 @@ const {
   ignoreNsNotFound
 } = require('./shared');
 const test = require('./shared').assert;
-const { MongoDriverError } = require('../../src/error');
+const { MongoDriverError, MongoBatchReExecutionError } = require('../../src/error');
 const { Long } = require('../../src');
 const crypto = require('crypto');
 const chai = require('chai');
@@ -1892,7 +1892,7 @@ describe('Bulk', function () {
         expect(result).to.exist;
 
         bulk.execute(err => {
-          expect(err).to.match(/This batch has already been executed, create new batch to execute/);
+          expect(err).to.be.instanceof(MongoBatchReExecutionError);
           done();
         });
       });

--- a/test/functional/bulk.test.js
+++ b/test/functional/bulk.test.js
@@ -1892,7 +1892,7 @@ describe('Bulk', function () {
         expect(result).to.exist;
 
         bulk.execute(err => {
-          expect(err).to.match(/Batch cannot be re-executed/);
+          expect(err).to.match(/This batch has already been executed, create new batch to execute/);
           done();
         });
       });


### PR DESCRIPTION
## Description

Replace appropriate MongoDriverError instances with instances of the following classes

* MongoBatchReExecutionError
* MongoCursorError
	* MongoCursorExhaustedError
	* MongoTailableCursorError
	* MongoCursorInUseError
* MongoNotConnectedError
