### PR TITLE
fix(NODE-3441): fix typings for createIndexes

### DIFF
--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -70,7 +70,7 @@ export type IndexSpecification = OneOrMore<
 >;
 
 /** @public */
-export interface IndexDescription {
+export interface IndexDescription extends CreateIndexesOptions {
   collation?: CollationOptions;
   name?: string;
   key: Document;

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -35,6 +35,7 @@ const VALID_INDEX_OPTIONS = new Set([
   'expireAfterSeconds',
   'storageEngine',
   'collation',
+  'version',
 
   // text indexes
   'weights',
@@ -70,7 +71,28 @@ export type IndexSpecification = OneOrMore<
 >;
 
 /** @public */
-export interface IndexDescription extends CreateIndexesOptions {
+export interface IndexDescription
+  extends Pick<
+    CreateIndexesOptions,
+    | 'background'
+    | 'unique'
+    | 'partialFilterExpression'
+    | 'sparse'
+    | 'hidden'
+    | 'expireAfterSeconds'
+    | 'storageEngine'
+    | 'version'
+    | 'weights'
+    | 'default_language'
+    | 'language_override'
+    | 'textIndexVersion'
+    | '2dsphereIndexVersion'
+    | 'bits'
+    | 'min'
+    | 'max'
+    | 'bucketSize'
+    | 'wildcardProjection'
+  > {
   collation?: CollationOptions;
   name?: string;
   key: Document;
@@ -90,9 +112,12 @@ export interface CreateIndexesOptions extends CommandOperationOptions {
   sparse?: boolean;
   /** Allows you to expire data on indexes applied to a data (MongoDB 2.2 or higher) */
   expireAfterSeconds?: number;
+  /** Allows users to configure the storage engine on a per-index basis when creating an index. (MongoDB 3.0 or higher) */
   storageEngine?: Document;
   /** (MongoDB 4.4. or higher) Specifies how many data-bearing members of a replica set, including the primary, must complete the index builds successfully before the primary marks the indexes as ready. This option accepts the same values for the "w" field in a write concern plus "votingMembers", which indicates all voting data-bearing nodes. */
   commitQuorum?: number | string;
+  /** Specifies the index version number, either 0 or 1. */
+  version?: number;
   // text indexes
   weights?: Document;
   default_language?: string;
@@ -110,6 +135,8 @@ export interface CreateIndexesOptions extends CommandOperationOptions {
   bucketSize?: number;
   // wildcard indexes
   wildcardProjection?: Document;
+  /** Specifies that the index should exist on the target collection but should not be used by the query planner when executing operations. (MongoDB 4.4 or higher) */
+  hidden?: boolean;
 }
 
 function makeIndexSpec(indexSpec: IndexSpecification, options: any): IndexDescription {

--- a/test/types/index_options.test-d.ts
+++ b/test/types/index_options.test-d.ts
@@ -1,0 +1,25 @@
+import { expectAssignable, expectNotAssignable } from 'tsd';
+import type { IndexDescription } from '../../src';
+
+// test that all valid index options are allowed in IndexDescription
+expectAssignable<IndexDescription>({ key: {}, background: true });
+expectAssignable<IndexDescription>({ key: {}, expireAfterSeconds: 2400 });
+expectAssignable<IndexDescription>({ key: {}, name: 'index_1' });
+expectAssignable<IndexDescription>({ key: {}, sparse: true });
+expectAssignable<IndexDescription>({ key: {}, storageEngine: {} });
+expectAssignable<IndexDescription>({ key: {}, unique: true });
+expectAssignable<IndexDescription>({ key: {}, version: 1 });
+expectAssignable<IndexDescription>({ key: {}, default_language: 'english' });
+expectAssignable<IndexDescription>({ key: {}, language_override: 'english' });
+expectAssignable<IndexDescription>({ key: {}, textIndexVersion: 2 });
+expectAssignable<IndexDescription>({ key: {}, weights: {} });
+expectAssignable<IndexDescription>({ key: {}, '2dsphereIndexVersion': 2 });
+expectAssignable<IndexDescription>({ key: {}, bits: 1 });
+expectAssignable<IndexDescription>({ key: {}, max: 1.1 });
+expectAssignable<IndexDescription>({ key: {}, min: 9.9 });
+expectAssignable<IndexDescription>({ key: {}, bucketSize: 100 });
+expectAssignable<IndexDescription>({ key: {}, partialFilterExpression: {} });
+expectAssignable<IndexDescription>({ key: {}, collation: { locale: 'en' } });
+expectAssignable<IndexDescription>({ key: {}, wildcardProjection: {} });
+expectAssignable<IndexDescription>({ key: {}, hidden: true });
+expectNotAssignable<IndexDescription>({ key: {}, invalidOption: 2400 });

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -1,5 +1,4 @@
-import { expectType, expectDeprecated, expectError } from 'tsd';
-
+import { expectType, expectDeprecated } from 'tsd';
 import { MongoClient } from '../../src/mongo_client';
 import { Collection } from '../../src/collection';
 import { AggregationCursor } from '../../src/cursor/aggregation_cursor';
@@ -32,8 +31,3 @@ const composedMap = mappedAgg.map<string>(x => x.toString());
 expectType<AggregationCursor<string>>(composedMap);
 expectType<string | null>(await composedMap.next());
 expectType<string[]>(await composedMap.toArray());
-
-// test that VALID_INDEX_OPTIONS like expireAfterSeconds are allowed in IndexDefinitions
-coll.createIndexes([{ key: { event: 1 }, name: 'event', expireAfterSeconds: 2400 }]);
-// test that invalid options are not allowed
-expectError(coll.createIndexes([{ key: { event: 1 }, name: 'event', invalidOption: 2400 }]));

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType, expectDeprecated } from 'tsd';
+import { expectType, expectDeprecated, expectError } from 'tsd';
 
 import { MongoClient } from '../../src/mongo_client';
 import { Collection } from '../../src/collection';
@@ -32,3 +32,8 @@ const composedMap = mappedAgg.map<string>(x => x.toString());
 expectType<AggregationCursor<string>>(composedMap);
 expectType<string | null>(await composedMap.next());
 expectType<string[]>(await composedMap.toArray());
+
+// test that VALID_INDEX_OPTIONS like expireAfterSeconds are allowed in IndexDefinitions
+coll.createIndexes([{ key: { event: 1 }, name: 'event', expireAfterSeconds: 2400 }]);
+// test that invalid options are not allowed
+expectError(coll.createIndexes([{ key: { event: 1 }, name: 'event', invalidOption: 2400 }]));


### PR DESCRIPTION
This isn't super clear from the index management specification, but it seems like `IndexDescription` needs to extend `CreateIndexesOptions`, since each index description may also contain options.