### PR TITLE
fix(NODE-3442): AsyncIterator has incorrect return type

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/whatwg-url": "^8.2.1",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
+    "bluebird": "^3.7.2",
     "chai": "^4.2.0",
     "chai-subset": "^1.6.0",
     "chalk": "^4.1.0",

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -224,10 +224,11 @@ export abstract class AbstractCursor<
   [Symbol.asyncIterator](): AsyncIterator<TSchema, void> {
     return {
       next: () =>
-        this.next().then(value => {
-          if (value !== null && value !== undefined) return { value, done: false };
-          return { value: undefined, done: true };
-        })
+        this.next().then(value =>
+          value !== null && value !== undefined
+            ? { value, done: false }
+            : { value: undefined, done: true }
+        )
     };
   }
 

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -221,9 +221,13 @@ export abstract class AbstractCursor<
     return this[kDocuments].splice(0, number ?? this[kDocuments].length);
   }
 
-  [Symbol.asyncIterator](): AsyncIterator<TSchema | null> {
+  [Symbol.asyncIterator](): AsyncIterator<TSchema, void> {
     return {
-      next: () => this.next<TSchema>().then(value => ({ value, done: value === null }))
+      next: () =>
+        this.next().then(value => {
+          if (value !== null && value !== undefined) return { value, done: false };
+          return { value: undefined, done: true };
+        })
     };
   }
 

--- a/test/types/community/cursor.test-d.ts
+++ b/test/types/community/cursor.test-d.ts
@@ -94,7 +94,7 @@ expectType<{ name: string }[]>(
 
 void async function () {
   for await (const item of cursor) {
-    if (!item) break;
+    expectNotType<{ foo: number } | null>(item);
     expectType<number>(item.foo);
   }
 };

--- a/test/unit/execute_legacy_operation.test.js
+++ b/test/unit/execute_legacy_operation.test.js
@@ -28,9 +28,8 @@ describe('executeLegacyOperation', function () {
     expect(caughtError).to.equal(expectedError);
   });
 
-  it('should reject promise with errors on throw errors, and rethrow error', function (done) {
+  it('should reject promise with errors on throw errors, and rethrow error', function () {
     const expectedError = new Error('THIS IS AN ERROR');
-    let callbackError;
 
     const topology = {
       logicalSessionTimeoutMinutes: null
@@ -39,18 +38,10 @@ describe('executeLegacyOperation', function () {
       throw expectedError;
     };
 
-    const callback = err => (callbackError = err);
     const options = { skipSessions: true };
 
-    executeLegacyOperation(topology, operation, [{}, null], options).then(null, callback);
-
-    setTimeout(() => {
-      try {
-        expect(callbackError).to.equal(expectedError);
-        done();
-      } catch (e) {
-        done(e);
-      }
+    return executeLegacyOperation(topology, operation, [{}, null], options).then(null, err => {
+      expect(err).to.equal(expectedError);
     });
   });
 });


### PR DESCRIPTION
The AsyncIterator had TSchema or null as its return type the truth is that the for await loop ends when the next function returns null so you never get null in your loop. 