### PR TITLE
test: legacy spec runner improvements

### DIFF
--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -135,29 +135,8 @@ function generateTopologyTests(testSuites, testContext, filter) {
           beforeEach(() => prepareDatabaseForSuite(testSuite, testContext));
           afterEach(() => testContext.cleanupAfterSuite());
           testSuite.tests.forEach(spec => {
-            it(spec.description, function () {
-              if (requires.authEnabled && process.env.AUTH !== 'auth') {
-                // TODO: We do not have a way to determine if auth is enabled in our mocha metadata
-                // We need to do a admin.command({getCmdLineOpts: 1}) if it errors (code=13) auth is on
-                this.skip();
-              }
-
-              if (
-                spec.operations.some(
-                  op => op.name === 'waitForEvent' && op.arguments.event === 'PoolReadyEvent'
-                )
-              ) {
-                // TODO(NODE-2994): Connection storms work will add new events to connection pool
-                this.skip();
-              }
-
-              if (
-                spec.skipReason ||
-                (filter && typeof filter === 'function' && !filter(spec, this.configuration))
-              ) {
-                return this.skip();
-              }
-
+            const maybeIt = shouldRunSpecTest.call(this, requires, spec, filter) ? it : it.skip;
+            maybeIt(spec.description, function () {
               let testPromise = Promise.resolve();
               if (spec.failPoint) {
                 testPromise = testPromise.then(() => testContext.enableFailPoint(spec.failPoint));
@@ -178,6 +157,31 @@ function generateTopologyTests(testSuites, testContext, filter) {
       });
     });
   });
+}
+
+function shouldRunSpecTest(requires, spec, filter) {
+  if (requires.authEnabled && process.env.AUTH !== 'auth') {
+    // TODO: We do not have a way to determine if auth is enabled in our mocha metadata
+    // We need to do a admin.command({getCmdLineOpts: 1}) if it errors (code=13) auth is on
+    return false;
+  }
+
+  if (
+    spec.operations.some(
+      op => op.name === 'waitForEvent' && op.arguments.event === 'PoolReadyEvent'
+    )
+  ) {
+    // TODO(NODE-2994): Connection storms work will add new events to connection pool
+    return false;
+  }
+
+  if (
+    spec.skipReason ||
+    (filter && typeof filter === 'function' && !filter(spec, this.configuration))
+  ) {
+    return false;
+  }
+  return true;
 }
 
 // Test runner helpers

--- a/test/functional/spec-runner/index.js
+++ b/test/functional/spec-runner/index.js
@@ -129,13 +129,14 @@ function generateTopologyTests(testSuites, testContext, filter) {
     environmentRequirementList.forEach(requires => {
       const suiteName = `${testSuite.name} - ${requires.topology.join()}`;
       describe(suiteName, {
-        // FIXME: calling this.skip() inside tests triggers the leak checker, disable until fixed
-        metadata: { requires, sessions: { skipLeakTests: true } },
+        metadata: { requires },
         test: function () {
           beforeEach(() => prepareDatabaseForSuite(testSuite, testContext));
           afterEach(() => testContext.cleanupAfterSuite());
           testSuite.tests.forEach(spec => {
-            const maybeIt = shouldRunSpecTest.call(this, requires, spec, filter) ? it : it.skip;
+            const maybeIt = shouldRunSpecTest(this.configuration, requires, spec, filter)
+              ? it
+              : it.skip;
             maybeIt(spec.description, function () {
               let testPromise = Promise.resolve();
               if (spec.failPoint) {
@@ -159,9 +160,9 @@ function generateTopologyTests(testSuites, testContext, filter) {
   });
 }
 
-function shouldRunSpecTest(requires, spec, filter) {
+function shouldRunSpecTest(configuration, requires, spec, filter) {
   if (requires.authEnabled && process.env.AUTH !== 'auth') {
-    // TODO: We do not have a way to determine if auth is enabled in our mocha metadata
+    // TODO(NODE-3488): We do not have a way to determine if auth is enabled in our mocha metadata
     // We need to do a admin.command({getCmdLineOpts: 1}) if it errors (code=13) auth is on
     return false;
   }
@@ -175,10 +176,7 @@ function shouldRunSpecTest(requires, spec, filter) {
     return false;
   }
 
-  if (
-    spec.skipReason ||
-    (filter && typeof filter === 'function' && !filter(spec, this.configuration))
-  ) {
+  if (spec.skipReason || (filter && typeof filter === 'function' && !filter(spec, configuration))) {
     return false;
   }
   return true;

--- a/test/functional/spec-runner/utils.js
+++ b/test/functional/spec-runner/utils.js
@@ -10,7 +10,7 @@ function resolveConnectionString(configuration, spec, context) {
     isShardedEnvironment && !useMultipleMongoses
       ? `mongodb://${configuration.host}:${configuration.port}/${
           configuration.db
-        }?directConnection=false${authSource ? '&authSource=${authSource}' : ''}`
+        }?directConnection=false${authSource ? `&authSource=${authSource}` : ''}`
       : configuration.url({ username, password, authSource });
   return connectionString;
 }


### PR DESCRIPTION
- Allow skipped tests to skip `beforeEach/afterEach` hooks, significantly speeding up test runs particularly against remote servers with higher latency.
- Fixes a bug in the URL returned by the legacy test runner when `isShardedEnvironment && !useMultipleMongoses`