### PR TITLE
fix(NODE-2883): Aggregate Operation should not require parent parameter

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -489,7 +489,7 @@ export class ChangeStreamCursor<TSchema extends Document = Document> extends Abs
   }
 
   _initialize(session: ClientSession, callback: Callback<ExecutionResult>): void {
-    const aggregateOperation = new AggregateOperation(this.pipeline, this.namespace, {
+    const aggregateOperation = new AggregateOperation(this.namespace, this.pipeline, {
       ...this.cursorOptions,
       ...this.options,
       session

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -489,15 +489,11 @@ export class ChangeStreamCursor<TSchema extends Document = Document> extends Abs
   }
 
   _initialize(session: ClientSession, callback: Callback<ExecutionResult>): void {
-    const aggregateOperation = new AggregateOperation(
-      { s: { namespace: this.namespace } },
-      this.pipeline,
-      {
-        ...this.cursorOptions,
-        ...this.options,
-        session
-      }
-    );
+    const aggregateOperation = new AggregateOperation(this.pipeline, this.namespace, {
+      ...this.cursorOptions,
+      ...this.options,
+      session
+    });
 
     executeOperation(this.topology, aggregateOperation, (err, response) => {
       if (err || response == null) {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1387,7 +1387,6 @@ export class Collection<TSchema extends Document = Document> {
     }
 
     return new AggregationCursor(
-      this as TODO_NODE_3286,
       getTopology(this),
       this.s.namespace,
       pipeline,

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -7,7 +7,6 @@ import type { Sort } from '../sort';
 import type { Topology } from '../sdam/topology';
 import type { Callback, MongoDBNamespace } from '../utils';
 import type { ClientSession } from '../sessions';
-import type { OperationParent } from '../operations/command';
 import type { AbstractCursorOptions } from './abstract_cursor';
 import type { ExplainVerbosityLike } from '../explain';
 import type { Projection } from '../mongo_types';
@@ -15,8 +14,6 @@ import type { Projection } from '../mongo_types';
 /** @public */
 export interface AggregationCursorOptions extends AbstractCursorOptions, AggregateOptions {}
 
-/** @internal */
-const kParent = Symbol('parent');
 /** @internal */
 const kPipeline = Symbol('pipeline');
 /** @internal */
@@ -31,15 +28,13 @@ const kOptions = Symbol('options');
  */
 export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchema> {
   /** @internal */
-  [kParent]: OperationParent; // TODO: NODE-2883
-  /** @internal */
   [kPipeline]: Document[];
   /** @internal */
   [kOptions]: AggregateOptions;
 
   /** @internal */
   constructor(
-    parent: OperationParent,
+    //parent: OperationParent,
     topology: Topology,
     namespace: MongoDBNamespace,
     pipeline: Document[] = [],
@@ -47,7 +42,7 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
   ) {
     super(topology, namespace, options);
 
-    this[kParent] = parent;
+    //this[kParent] = parent;
     this[kPipeline] = pipeline;
     this[kOptions] = options;
   }
@@ -59,7 +54,7 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
   clone(): AggregationCursor<TSchema> {
     const clonedOptions = mergeOptions({}, this[kOptions]);
     delete clonedOptions.session;
-    return new AggregationCursor(this[kParent], this.topology, this.namespace, this[kPipeline], {
+    return new AggregationCursor(this.topology, this.namespace, this[kPipeline], {
       ...clonedOptions
     });
   }
@@ -70,7 +65,7 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
 
   /** @internal */
   _initialize(session: ClientSession | undefined, callback: Callback<ExecutionResult>): void {
-    const aggregateOperation = new AggregateOperation(this[kParent], this[kPipeline], {
+    const aggregateOperation = new AggregateOperation(this[kPipeline], this.namespace, {
       ...this[kOptions],
       ...this.cursorOptions,
       session
@@ -97,7 +92,7 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
 
     return executeOperation(
       this.topology,
-      new AggregateOperation(this[kParent], this[kPipeline], {
+      new AggregateOperation(this[kPipeline], this.namespace, {
         ...this[kOptions], // NOTE: order matters here, we may need to refine this
         ...this.cursorOptions,
         explain: verbosity

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -41,7 +41,6 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
   ) {
     super(topology, namespace, options);
 
-    //this[kParent] = parent;
     this[kPipeline] = pipeline;
     this[kOptions] = options;
   }

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -34,7 +34,6 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
 
   /** @internal */
   constructor(
-    //parent: OperationParent,
     topology: Topology,
     namespace: MongoDBNamespace,
     pipeline: Document[] = [],
@@ -65,7 +64,7 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
 
   /** @internal */
   _initialize(session: ClientSession | undefined, callback: Callback<ExecutionResult>): void {
-    const aggregateOperation = new AggregateOperation(this[kPipeline], this.namespace, {
+    const aggregateOperation = new AggregateOperation(this.namespace, this[kPipeline], {
       ...this[kOptions],
       ...this.cursorOptions,
       session
@@ -92,7 +91,7 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
 
     return executeOperation(
       this.topology,
-      new AggregateOperation(this[kPipeline], this.namespace, {
+      new AggregateOperation(this.namespace, this[kPipeline], {
         ...this[kOptions], // NOTE: order matters here, we may need to refine this
         ...this.cursorOptions,
         explain: verbosity

--- a/src/db.ts
+++ b/src/db.ts
@@ -301,7 +301,6 @@ export class Db {
     }
 
     return new AggregationCursor(
-      this,
       getTopology(this),
       this.s.namespace,
       pipeline,

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -47,11 +47,8 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
 
     this.options = options ?? {};
 
-    if (ns.collection === undefined || ns.collection === '') {
-      this.target = DB_AGGREGATE_COLLECTION;
-    } else {
-      this.target = ns.collection;
-    }
+    // Covers when ns.collection is null, undefined or the empty string, use DB_AGGREGATE_COLLECTION
+    this.target = ns.collection || DB_AGGREGATE_COLLECTION;
 
     this.pipeline = pipeline;
 

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -42,11 +42,11 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
   pipeline: Document[];
   hasWriteStage: boolean;
 
-  constructor(pipeline: Document[], ns?: MongoDBNamespace, options?: AggregateOptions) {
-    super(undefined, Object.assign({ dbName: ns?.db }, options));
+  constructor(ns: MongoDBNamespace, pipeline: Document[], options?: AggregateOptions) {
+    super(undefined, { dbName: ns?.db, ...options });
 
     this.options = options ?? {};
-    this.target = ns && ns.collection ? ns.collection : DB_AGGREGATE_COLLECTION;
+    this.target = ns?.collection ?? DB_AGGREGATE_COLLECTION;
 
     this.pipeline = pipeline;
 

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -43,10 +43,10 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
   hasWriteStage: boolean;
 
   constructor(ns: MongoDBNamespace, pipeline: Document[], options?: AggregateOptions) {
-    super(undefined, { dbName: ns?.db, ...options });
+    super(undefined, { ...options, dbName: ns.db });
 
     this.options = options ?? {};
-    this.target = ns?.collection ?? DB_AGGREGATE_COLLECTION;
+    this.target = ns.collection || DB_AGGREGATE_COLLECTION;
 
     this.pipeline = pipeline;
 

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -1,12 +1,7 @@
-import {
-  CommandOperation,
-  CommandOperationOptions,
-  OperationParent,
-  CollationOptions
-} from './command';
+import { CommandOperation, CommandOperationOptions, CollationOptions } from './command';
 import { ReadPreference } from '../read_preference';
 import { MongoInvalidArgumentError } from '../error';
-import { maxWireVersion } from '../utils';
+import { maxWireVersion, MongoDBNamespace } from '../utils';
 import { Aspect, defineAspects, Hint } from './operation';
 import type { Callback } from '../utils';
 import type { Document } from '../bson';
@@ -47,14 +42,11 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
   pipeline: Document[];
   hasWriteStage: boolean;
 
-  constructor(parent: OperationParent, pipeline: Document[], options?: AggregateOptions) {
-    super(parent, options);
+  constructor(pipeline: Document[], ns?: MongoDBNamespace, options?: AggregateOptions) {
+    super(undefined, Object.assign({ dbName: ns?.db }, options));
 
     this.options = options ?? {};
-    this.target =
-      parent.s.namespace && parent.s.namespace.collection
-        ? parent.s.namespace.collection
-        : DB_AGGREGATE_COLLECTION;
+    this.target = ns && ns.collection ? ns.collection : DB_AGGREGATE_COLLECTION;
 
     this.pipeline = pipeline;
 

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -46,7 +46,12 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
     super(undefined, { ...options, dbName: ns.db });
 
     this.options = options ?? {};
-    this.target = ns.collection || DB_AGGREGATE_COLLECTION;
+
+    if (ns.collection === undefined || ns.collection === '') {
+      this.target = DB_AGGREGATE_COLLECTION;
+    } else {
+      this.target = ns.collection;
+    }
 
     this.pipeline = pipeline;
 

--- a/src/operations/count_documents.ts
+++ b/src/operations/count_documents.ts
@@ -29,7 +29,7 @@ export class CountDocumentsOperation extends AggregateOperation<number> {
 
     pipeline.push({ $group: { _id: 1, n: { $sum: 1 } } });
 
-    super(pipeline, collection.s.namespace, options);
+    super(collection.s.namespace, pipeline, options);
   }
 
   execute(server: Server, session: ClientSession, callback: Callback<number>): void {

--- a/src/operations/count_documents.ts
+++ b/src/operations/count_documents.ts
@@ -29,7 +29,7 @@ export class CountDocumentsOperation extends AggregateOperation<number> {
 
     pipeline.push({ $group: { _id: 1, n: { $sum: 1 } } });
 
-    super(collection, pipeline, options);
+    super(pipeline, collection.s.namespace, options);
   }
 
   execute(server: Server, session: ClientSession, callback: Callback<number>): void {


### PR DESCRIPTION
## Description

Remove parent parameter from AggregateOperation and parent reference from AggregationCursor and change any instantiation of these internal classes to match their new signature

**What changed?**

* src/change_stream.ts
* src/collection.ts
* src/cursor/aggregation_cursor.ts
* src/db.ts
* src/operations/aggregate.ts
* src/operations/count_documents.ts