### PR TITLE
fix: peg optional-require version to >= 1.0.3, < 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bl": "^2.2.1",
     "bson": "^1.1.4",
     "denque": "^1.4.1",
-    "optional-require": "^1.0.3",
+    "optional-require": "~1.0.3",
     "safe-buffer": "^5.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

See https://github.com/jchip/optional-require/pull/6 . optional-require v1.1.0 uses spread operators, so Node v4 tests fail with:

```
module.exports = (...args) => lib.makeOptionalRequire(...args);
                  ^^^

SyntaxError: Unexpected token ...
```

**What changed?**

Changed range to use `~`, which specifically excludes 1.1.0 and 1.0.2.

```
> semver.satisfies('1.1.0', '~1.0.3')
false
> semver.satisfies('1.0.2', '~1.0.3')
false
> semver.satisfies('1.0.4', '~1.0.3')
true
> 
```

Personally, I'd strongly prefer if the driver used exact versions in `package.json`, or at least `~`. `^` is very risky in my experience.

**Are there any files to ignore?**
