### PR TITLE
fix(NODE-3510): omit incorrect `| void` in declaration of Promise overload of `rename()`

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -621,7 +621,7 @@ export class Collection<TSchema extends Document = Document> {
    */
   rename(newName: string): Promise<Collection>;
   rename(newName: string, callback: Callback<Collection>): void;
-  rename(newName: string, options: RenameOptions): Promise<Collection> | void;
+  rename(newName: string, options: RenameOptions): Promise<Collection>;
   rename(newName: string, options: RenameOptions, callback: Callback<Collection>): void;
   rename(
     newName: string,


### PR DESCRIPTION
## Description

One of the TS overloaded declarations for `rename()` had a `| void` which AFAIK is incorrect. If a method returns a `Promise`, it should never be typed `| void`.  The problem doesn't show up in any other overload declarations, so I assume this was just a bug, not a statement about weird behavior of this method.

**What changed?**

I removed the `| void` for this overload's declaration. 

**Are there any files to ignore?**

No.