### PR TITLE
docs(NODE-3492): Deprecate CloseCursorOptions

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -51,7 +51,8 @@ export const CURSOR_FLAGS = [
   'partial'
 ] as const;
 
-/** @public */
+/** @public
+ * @deprecated This interface is deprecated */
 export interface CursorCloseOptions {
   /** Bypass calling killCursors when closing the cursor. */
   /** @deprecated  the skipKillCursors option is deprecated*/

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -51,9 +51,7 @@ export const CURSOR_FLAGS = [
   'partial'
 ] as const;
 
-/** @public
- *  @deprecated Not used
- * */
+/** @public */
 export interface CursorCloseOptions {
   /** Bypass calling killCursors when closing the cursor. */
   skipKillCursors?: boolean;
@@ -374,13 +372,15 @@ export abstract class AbstractCursor<
     });
   }
 
-  /**
-   * @remarks
-   * The `options` argument is deprecated
-   */
   close(): void;
   close(callback: Callback): void;
+  /**
+   * @deprecated options argument is deprecated
+   */
   close(options: CursorCloseOptions): Promise<void>;
+  /**
+   * @deprecated options argument is deprecated
+   */
   close(options: CursorCloseOptions, callback: Callback): void;
   close(options?: CursorCloseOptions | Callback, callback?: Callback): Promise<void> | void {
     if (typeof options === 'function') (callback = options), (options = {});

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -51,8 +51,9 @@ export const CURSOR_FLAGS = [
   'partial'
 ] as const;
 
-/** @public */
-// TODO: Remove this as the option is never used. (NODE-3489)
+/** @public
+ *  @deprecated Not used
+ * */
 export interface CursorCloseOptions {
   /** Bypass calling killCursors when closing the cursor. */
   skipKillCursors?: boolean;
@@ -373,7 +374,11 @@ export abstract class AbstractCursor<
     });
   }
 
-  close(): Promise<void>;
+  /**
+   * @remarks
+   * The `options` argument is deprecated
+   */
+  close(): void;
   close(callback: Callback): void;
   close(options: CursorCloseOptions): Promise<void>;
   close(options: CursorCloseOptions, callback: Callback): void;

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -54,6 +54,7 @@ export const CURSOR_FLAGS = [
 /** @public */
 export interface CursorCloseOptions {
   /** Bypass calling killCursors when closing the cursor. */
+  /** @deprecated  the skipKillCursors option is deprecated*/
   skipKillCursors?: boolean;
 }
 

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -55,7 +55,7 @@ export const CURSOR_FLAGS = [
  * @deprecated This interface is deprecated */
 export interface CursorCloseOptions {
   /** Bypass calling killCursors when closing the cursor. */
-  /** @deprecated  the skipKillCursors option is deprecated*/
+  /** @deprecated  the skipKillCursors option is deprecated */
   skipKillCursors?: boolean;
 }
 


### PR DESCRIPTION
## Description
Deprecate CloseCursorOptions

**What changed?**

- src/cursor/abstract_cursor.ts

