### PR TITLE
fix(NODE-3513): default command monitoring to off

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -724,7 +724,7 @@ export const OPTIONS = {
     type: 'uint'
   },
   monitorCommands: {
-    default: true,
+    default: false,
     type: 'boolean'
   },
   name: {

--- a/test/functional/causal_consistency.test.js
+++ b/test/functional/causal_consistency.test.js
@@ -11,7 +11,7 @@ describe('Causal Consistency', function () {
 
   beforeEach(function () {
     test.commands = { started: [], succeeded: [] };
-    test.client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 });
+    test.client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1, monitorCommands: true });
     test.client.on('commandStarted', event => {
       if (ignoredCommands.indexOf(event.commandName) === -1) test.commands.started.push(event);
     });

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3564,7 +3564,10 @@ describe('Cursor', function () {
     test: function (done) {
       var started = [];
       const configuration = this.configuration;
-      const client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
+      const client = configuration.newClient(configuration.writeConcernMax(), {
+        maxPoolSize: 1,
+        monitorCommands: true
+      });
       client.on('commandStarted', function (event) {
         if (event.commandName === 'count') started.push(event);
       });

--- a/test/functional/find_and_modify.test.js
+++ b/test/functional/find_and_modify.test.js
@@ -21,7 +21,11 @@ describe('Find and Modify', function () {
       var succeeded = [];
 
       var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        maxPoolSize: 1,
+        monitorCommands: true
+      });
+
       client.on('commandStarted', function (event) {
         if (event.commandName === 'findAndModify') started.push(event);
       });
@@ -85,7 +89,11 @@ describe('Find and Modify', function () {
       var succeeded = [];
 
       var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        maxPoolSize: 1,
+        monitorCommands: true
+      });
+
       client.on('commandStarted', function (event) {
         if (event.commandName === 'findAndModify') started.push(event);
       });
@@ -146,7 +154,8 @@ describe('Find and Modify', function () {
       url = url.indexOf('?') !== -1 ? f('%s&%s', url, 'fsync=true') : f('%s?%s', url, 'fsync=true');
 
       // Establish connection to db
-      const client = configuration.newClient(url, { sslValidate: false });
+      const client = configuration.newClient(url, { sslValidate: false, monitorCommands: true });
+
       client.on('commandStarted', function (event) {
         if (event.commandName === 'findAndModify') started.push(event);
       });

--- a/test/functional/index.test.js
+++ b/test/functional/index.test.js
@@ -947,7 +947,10 @@ describe('Indexes', function () {
       var configuration = this.configuration;
       var started = [];
       var succeeded = [];
-      var client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        maxPoolSize: 1,
+        monitorCommands: true
+      });
 
       client.on('commandStarted', function (event) {
         if (event.commandName === 'createIndexes') started.push(event);

--- a/test/functional/insert.test.js
+++ b/test/functional/insert.test.js
@@ -2377,7 +2377,10 @@ describe('Insert', function () {
       var succeeded = [];
 
       var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        maxPoolSize: 1,
+        monitorCommands: true
+      });
       client.on('commandStarted', function (event) {
         if (event.commandName === 'insert') started.push(event);
       });
@@ -2409,39 +2412,10 @@ describe('Insert', function () {
       var succeeded = [];
 
       var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
-      client.on('commandStarted', function (event) {
-        if (event.commandName === 'insert') started.push(event);
+      var client = configuration.newClient(configuration.writeConcernMax(), {
+        maxPoolSize: 1,
+        monitorCommands: true
       });
-
-      client.on('commandSucceeded', function (event) {
-        if (event.commandName === 'insert') succeeded.push(event);
-      });
-
-      client.connect(function (err, client) {
-        var db = client.db(configuration.db);
-        expect(err).to.not.exist;
-
-        db.collection('apm_test')
-          .insertMany([{ a: 1 }], { forceServerObjectId: true })
-          .then(function () {
-            expect(started[0].command.documents[0]._id).to.not.exist;
-
-            client.close(done);
-          });
-      });
-    }
-  });
-
-  it('Correctly allow forceServerObjectId for insertMany', {
-    metadata: { requires: { topology: ['single'] } },
-
-    test: function (done) {
-      var started = [];
-      var succeeded = [];
-
-      var configuration = this.configuration;
-      var client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
       client.on('commandStarted', function (event) {
         if (event.commandName === 'insert') started.push(event);
       });

--- a/test/unit/mongo_client_options.test.js
+++ b/test/unit/mongo_client_options.test.js
@@ -2,6 +2,7 @@
 const os = require('os');
 const fs = require('fs');
 const { expect } = require('chai');
+const { getSymbolFrom } = require('../tools/utils');
 const { parseOptions } = require('../../src/connection_string');
 const { ReadConcern } = require('../../src/read_concern');
 const { WriteConcern } = require('../../src/write_concern');
@@ -448,6 +449,71 @@ describe('MongoOptions', function () {
       expect(() => parseOptions('mongodb://localhost/?serverApi=1')).to.throw(
         'URI cannot contain `serverApi`, it can only be passed to the client'
       );
+    });
+  });
+
+  describe('default options', () => {
+    const doNotCheckEq = Symbol('do not check equality');
+    const KNOWN_DEFAULTS = [
+      ['connecttimeoutms', 30000],
+      ['directconnection', false],
+      ['forceserverobjectid', false],
+      ['heartbeatfrequencyms', 10000],
+      ['keepalive', true],
+      ['keepaliveinitialdelay', 120000],
+      ['localthresholdms', 15],
+      ['logger', doNotCheckEq],
+      ['maxidletimems', 0],
+      ['maxpoolsize', 100],
+      ['minpoolsize', 0],
+      ['minheartbeatfrequencyms', 500],
+      ['monitorcommands', false], // NODE-3513
+      ['nodelay', true],
+      ['raw', false],
+      ['retryreads', true],
+      ['retrywrites', true],
+      ['serverselectiontimeoutms', 30000],
+      ['sockettimeoutms', 0],
+      ['waitqueuetimeoutms', 0],
+      ['zlibcompressionlevel', 0],
+
+      // map to objects that are not worth checking deep equality
+      ['compressors', doNotCheckEq],
+      ['readpreference', doNotCheckEq],
+      ['pkfactory', doNotCheckEq]
+    ];
+
+    const findMatchingKey = (o, searchKey) => {
+      return Object.keys(o).filter(key => {
+        return key.toLowerCase() === searchKey;
+      })[0];
+    };
+
+    it(`should define known defaults in client.options`, () => {
+      const client = new MongoClient('mongodb://localhost');
+      const clientOptions = client.options;
+
+      for (const [optionName, value] of KNOWN_DEFAULTS) {
+        const camelCaseName = findMatchingKey(clientOptions, optionName);
+        expect(camelCaseName, `did not find a camelcase match for ${optionName}`).to.be.a('string');
+
+        expect(clientOptions).to.have.property(camelCaseName);
+
+        if (value !== doNotCheckEq) {
+          expect(clientOptions).to.have.property(camelCaseName).that.deep.equals(value);
+        }
+      }
+    });
+
+    it('set monitorCommands to false (NODE-3513)', function () {
+      const client = new MongoClient('mongodb://localhost');
+      const clientOptions = client.options;
+
+      expect(clientOptions).to.have.property('monitorCommands', false);
+      expect(client.s.options).to.have.property('monitorCommands', false);
+      expect(client).to.have.property('monitorCommands', false);
+      const optionsSym = getSymbolFrom(client, 'options');
+      expect(client[optionsSym]).to.have.property('monitorCommands', false);
     });
   });
 });

--- a/test/unit/mongo_client_options.test.js
+++ b/test/unit/mongo_client_options.test.js
@@ -515,5 +515,23 @@ describe('MongoOptions', function () {
       const optionsSym = getSymbolFrom(client, 'options');
       expect(client[optionsSym]).to.have.property('monitorCommands', false);
     });
+
+    it('respects monitorCommands option passed in', function () {
+      const clientViaOpt = new MongoClient('mongodb://localhost', { monitorCommands: true });
+      const clientViaUri = new MongoClient('mongodb://localhost?monitorCommands=true');
+
+      const testTable = [
+        [clientViaOpt, clientViaOpt.options],
+        [clientViaUri, clientViaUri.options]
+      ];
+
+      for (const [client, clientOptions] of testTable) {
+        expect(clientOptions).to.have.property('monitorCommands', true);
+        expect(client.s.options).to.have.property('monitorCommands', true);
+        expect(client).to.have.property('monitorCommands', true);
+        const optionsSym = getSymbolFrom(client, 'options');
+        expect(client[optionsSym]).to.have.property('monitorCommands', true);
+      }
+    });
   });
 });


### PR DESCRIPTION
Revert an accidental default enabling of command monitoring
