### PR TITLE
fix(NODE-3452): readonly filters not permitted by typings

### DIFF
--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -95,11 +95,11 @@ export interface FilterOperators<TValue> extends Document {
   $eq?: TValue;
   $gt?: TValue;
   $gte?: TValue;
-  $in?: TValue[];
+  $in?: ReadonlyArray<TValue>;
   $lt?: TValue;
   $lte?: TValue;
   $ne?: TValue;
-  $nin?: TValue[];
+  $nin?: ReadonlyArray<TValue>;
   // Logical
   $not?: TValue extends string ? FilterOperators<TValue> | RegExp : FilterOperators<TValue>;
   // Element
@@ -122,8 +122,8 @@ export interface FilterOperators<TValue> extends Document {
   $nearSphere?: Document;
   $maxDistance?: number;
   // Array
-  $all?: TValue extends ReadonlyArray<any> ? any[] : never;
-  $elemMatch?: TValue extends ReadonlyArray<any> ? Document : never;
+  $all?: ReadonlyArray<any>;
+  $elemMatch?: Document;
   $size?: TValue extends ReadonlyArray<any> ? number : never;
   // Bitwise
   $bitsAllClear?: BitwiseFilter;
@@ -137,7 +137,7 @@ export interface FilterOperators<TValue> extends Document {
 export type BitwiseFilter =
   | number /** numeric bit mask */
   | Binary /** BinData bit mask */
-  | number[]; /** `[ <position1>, <position2>, ... ]` */
+  | ReadonlyArray<number>; /** `[ <position1>, <position2>, ... ]` */
 
 /** @public */
 export const BSONType = Object.freeze({
@@ -286,7 +286,7 @@ export type PullAllOperator<TSchema> = ({
   readonly [key in KeysOfAType<TSchema, ReadonlyArray<any>>]?: TSchema[key];
 } &
   NotAcceptedFields<TSchema, ReadonlyArray<any>>) & {
-  readonly [key: string]: any[];
+  readonly [key: string]: ReadonlyArray<any>;
 };
 
 /** @public */
@@ -320,7 +320,7 @@ export type UpdateFilter<TSchema> = {
 export type Nullable<AnyType> = AnyType | null | undefined;
 
 /** @public */
-export type OneOrMore<T> = T | T[];
+export type OneOrMore<T> = T | ReadonlyArray<T>;
 
 /** @public */
 export type GenericListener = (...args: any[]) => void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -157,8 +157,8 @@ export function parseIndexOptions(indexSpec: IndexSpecification): IndexOptions {
     // {location:'2d', type:1}
     keys = Object.keys(indexSpec);
     keys.forEach(key => {
-      indexes.push(key + '_' + indexSpec[key]);
-      fieldHash[key] = indexSpec[key];
+      indexes.push(key + '_' + (indexSpec as any)[key]);
+      fieldHash[key] = (indexSpec as any)[key];
     });
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,9 +156,9 @@ export function parseIndexOptions(indexSpec: IndexSpecification): IndexOptions {
   } else if (isObject(indexSpec)) {
     // {location:'2d', type:1}
     keys = Object.keys(indexSpec);
-    keys.forEach(key => {
-      indexes.push(key + '_' + (indexSpec as any)[key]);
-      fieldHash[key] = (indexSpec as any)[key];
+    Object.entries(indexSpec).forEach(([key, value]) => {
+      indexes.push(key + '_' + value);
+      fieldHash[key] = value;
     });
   }
 

--- a/test/types/community/collection/findX.test-d.ts
+++ b/test/types/community/collection/findX.test-d.ts
@@ -135,3 +135,41 @@ expectNotType<FindOptions<Car>>({
 
 printCar(await car.findOne({}, options));
 printCar(await car.findOne({}, optionsWithProjection));
+
+// Readonly tests -- NODE-3452
+const colorCollection = client.db('test_db').collection<{ color: string }>('test_collection');
+const colorsFreeze: ReadonlyArray<string> = Object.freeze(['blue', 'red']);
+
+// Permitted Readonly fields
+expectType<FindCursor<{ color: string }>>(colorCollection.find({ color: { $in: colorsFreeze } }));
+expectType<FindCursor<{ color: string }>>(colorCollection.find({ color: { $nin: colorsFreeze } }));
+// $all and $elemMatch works against single fields (its just redundant)
+expectType<FindCursor<{ color: string }>>(colorCollection.find({ color: { $all: colorsFreeze } }));
+expectType<FindCursor<{ color: string }>>(
+  colorCollection.find({ color: { $elemMatch: colorsFreeze } })
+);
+
+const countCollection = client.db('test_db').collection<{ count: number }>('test_collection');
+expectType<FindCursor<{ count: number }>>(
+  countCollection.find({ count: { $bitsAnySet: Object.freeze([1, 0, 1]) } })
+);
+
+const listsCollection = client.db('test_db').collection<{ lists: string[] }>('test_collection');
+await listsCollection.updateOne({}, { list: { $pullAll: Object.freeze(['one', 'two']) } });
+expectType<FindCursor<{ lists: string[] }>>(listsCollection.find({ lists: { $size: 1 } }));
+
+const rdOnlyListsCollection = client
+  .db('test_db')
+  .collection<{ lists: ReadonlyArray<string> }>('test_collection');
+expectType<FindCursor<{ lists: ReadonlyArray<string> }>>(
+  rdOnlyListsCollection.find({ lists: { $size: 1 } })
+);
+
+// Before NODE-3452's fix we would get this strange result that included the filter shape joined with the actual schema
+expectNotType<FindCursor<{ color: string | { $in: ReadonlyArray<string> } }>>(
+  colorCollection.find({ color: { $in: colorsFreeze } })
+);
+
+// When you use the override, $in doesn't permit readonly
+colorCollection.find<{ color: string }>({ color: { $in: colorsFreeze } });
+colorCollection.find<{ color: string }>({ color: { $in: ['regularArray'] } });

--- a/test/types/community/collection/findX.test-d.ts
+++ b/test/types/community/collection/findX.test-d.ts
@@ -143,7 +143,7 @@ const colorsFreeze: ReadonlyArray<string> = Object.freeze(['blue', 'red']);
 // Permitted Readonly fields
 expectType<FindCursor<{ color: string }>>(colorCollection.find({ color: { $in: colorsFreeze } }));
 expectType<FindCursor<{ color: string }>>(colorCollection.find({ color: { $nin: colorsFreeze } }));
-// $all and $elemMatch works against single fields (its just redundant)
+// $all and $elemMatch works against single fields (it's just redundant)
 expectType<FindCursor<{ color: string }>>(colorCollection.find({ color: { $all: colorsFreeze } }));
 expectType<FindCursor<{ color: string }>>(
   colorCollection.find({ color: { $elemMatch: colorsFreeze } })

--- a/test/types/community/collection/findX.test-d.ts
+++ b/test/types/community/collection/findX.test-d.ts
@@ -139,19 +139,33 @@ printCar(await car.findOne({}, optionsWithProjection));
 // Readonly tests -- NODE-3452
 const colorCollection = client.db('test_db').collection<{ color: string }>('test_collection');
 const colorsFreeze: ReadonlyArray<string> = Object.freeze(['blue', 'red']);
+const colorsWritable: Array<string> = ['blue', 'red'];
 
 // Permitted Readonly fields
 expectType<FindCursor<{ color: string }>>(colorCollection.find({ color: { $in: colorsFreeze } }));
+expectType<FindCursor<{ color: string }>>(colorCollection.find({ color: { $in: colorsWritable } }));
 expectType<FindCursor<{ color: string }>>(colorCollection.find({ color: { $nin: colorsFreeze } }));
+expectType<FindCursor<{ color: string }>>(
+  colorCollection.find({ color: { $nin: colorsWritable } })
+);
 // $all and $elemMatch works against single fields (it's just redundant)
 expectType<FindCursor<{ color: string }>>(colorCollection.find({ color: { $all: colorsFreeze } }));
 expectType<FindCursor<{ color: string }>>(
+  colorCollection.find({ color: { $all: colorsWritable } })
+);
+expectType<FindCursor<{ color: string }>>(
   colorCollection.find({ color: { $elemMatch: colorsFreeze } })
+);
+expectType<FindCursor<{ color: string }>>(
+  colorCollection.find({ color: { $elemMatch: colorsWritable } })
 );
 
 const countCollection = client.db('test_db').collection<{ count: number }>('test_collection');
 expectType<FindCursor<{ count: number }>>(
   countCollection.find({ count: { $bitsAnySet: Object.freeze([1, 0, 1]) } })
+);
+expectType<FindCursor<{ count: number }>>(
+  countCollection.find({ count: { $bitsAnySet: [1, 0, 1] as number[] } })
 );
 
 const listsCollection = client.db('test_db').collection<{ lists: string[] }>('test_collection');
@@ -169,6 +183,9 @@ expectType<FindCursor<{ lists: ReadonlyArray<string> }>>(
 expectNotType<FindCursor<{ color: string | { $in: ReadonlyArray<string> } }>>(
   colorCollection.find({ color: { $in: colorsFreeze } })
 );
+
+// This is related to another bug that will be fixed in NODE-3454
+expectType<FindCursor<{ color: { $in: number } }>>(colorCollection.find({ color: { $in: 3 } }));
 
 // When you use the override, $in doesn't permit readonly
 colorCollection.find<{ color: string }>({ color: { $in: colorsFreeze } });

--- a/test/types/community/collection/insertX.test-d.ts
+++ b/test/types/community/collection/insertX.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError, expectNotAssignable, expectNotType, expectType } from 'tsd';
+import { expectAssignable, expectError, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import { MongoClient, ObjectId, OptionalId } from '../../../../src';
 import type { PropExists } from '../../utility_types';
 
@@ -225,7 +225,7 @@ expectType<number>(indexTypeResult2.insertedId);
 expectType<{ [key: number]: number }>(indexTypeResultMany2.insertedIds);
 
 // Readonly Tests -- NODE-3452
-const colorsColl = client.db('test').collection<{ colors: string[] }>('readonlyColors');
+const colorsColl = client.db('test').collection<{ colors: string[] }>('writableColors');
 const colorsFreeze: ReadonlyArray<string> = Object.freeze(['blue', 'red']);
 // Users must define their properties as readonly if they want to be able to insert readonly
 type InsertOneParam = Parameters<typeof colorsColl.insertOne>[0];
@@ -234,4 +234,6 @@ expectNotAssignable<InsertOneParam>({ colors: colorsFreeze });
 const rdOnlyColl = client
   .db('test')
   .collection<{ colors: ReadonlyArray<string> }>('readonlyColors');
-rdOnlyColl.insertOne({ colors: colorsFreeze }); // Just showing no error here
+rdOnlyColl.insertOne({ colors: colorsFreeze });
+const colorsWritable = ['a', 'b'];
+rdOnlyColl.insertOne({ colors: colorsWritable });

--- a/test/types/community/collection/insertX.test-d.ts
+++ b/test/types/community/collection/insertX.test-d.ts
@@ -225,13 +225,13 @@ expectType<number>(indexTypeResult2.insertedId);
 expectType<{ [key: number]: number }>(indexTypeResultMany2.insertedIds);
 
 // Readonly Tests -- NODE-3452
-const rdOnlyColl = client.db('test').collection<{ colors: string[] }>('readonlyColors');
+const colorsColl = client.db('test').collection<{ colors: string[] }>('readonlyColors');
 const colorsFreeze: ReadonlyArray<string> = Object.freeze(['blue', 'red']);
 // Users must define their properties as readonly if they want to be able to insert readonly
-type InsertOneParam = Parameters<typeof rdOnlyColl.insertOne>[0];
+type InsertOneParam = Parameters<typeof colorsColl.insertOne>[0];
 expectNotAssignable<InsertOneParam>({ colors: colorsFreeze });
 // Correct usage:
-const colorsColl = client
+const rdOnlyColl = client
   .db('test')
   .collection<{ colors: ReadonlyArray<string> }>('readonlyColors');
-colorsColl.insertOne({ colors: colorsFreeze }); // Just showing no error here
+rdOnlyColl.insertOne({ colors: colorsFreeze }); // Just showing no error here

--- a/test/types/community/collection/insertX.test-d.ts
+++ b/test/types/community/collection/insertX.test-d.ts
@@ -227,7 +227,7 @@ expectType<{ [key: number]: number }>(indexTypeResultMany2.insertedIds);
 // Readonly Tests -- NODE-3452
 const rdOnlyColl = client.db('test').collection<{ colors: string[] }>('readonlyColors');
 const colorsFreeze: ReadonlyArray<string> = Object.freeze(['blue', 'red']);
-// Users must defined their properties as readonly if they want to be able to insert readonly
+// Users must define their properties as readonly if they want to be able to insert readonly
 type InsertOneParam = Parameters<typeof rdOnlyColl.insertOne>[0];
 expectNotAssignable<InsertOneParam>({ colors: colorsFreeze });
 // Correct usage:

--- a/test/types/community/collection/insertX.test-d.ts
+++ b/test/types/community/collection/insertX.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError, expectNotType, expectType } from 'tsd';
+import { expectError, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import { MongoClient, ObjectId, OptionalId } from '../../../../src';
 import type { PropExists } from '../../utility_types';
 
@@ -223,3 +223,15 @@ expectType<PropExists<typeof indexTypeResultMany2, 'ops'>>(false);
 
 expectType<number>(indexTypeResult2.insertedId);
 expectType<{ [key: number]: number }>(indexTypeResultMany2.insertedIds);
+
+// Readonly Tests -- NODE-3452
+const rdOnlyColl = client.db('test').collection<{ colors: string[] }>('readonlyColors');
+const colorsFreeze: ReadonlyArray<string> = Object.freeze(['blue', 'red']);
+// Users must defined their properties as readonly if they want to be able to insert readonly
+type InsertOneParam = Parameters<typeof rdOnlyColl.insertOne>[0];
+expectNotAssignable<InsertOneParam>({ colors: colorsFreeze });
+// Correct usage:
+const colorsColl = client
+  .db('test')
+  .collection<{ colors: ReadonlyArray<string> }>('readonlyColors');
+colorsColl.insertOne({ colors: colorsFreeze }); // Just showing no error here

--- a/test/types/community/collection/insertX.test-d.ts
+++ b/test/types/community/collection/insertX.test-d.ts
@@ -1,4 +1,4 @@
-import { expectAssignable, expectError, expectNotAssignable, expectNotType, expectType } from 'tsd';
+import { expectError, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import { MongoClient, ObjectId, OptionalId } from '../../../../src';
 import type { PropExists } from '../../utility_types';
 

--- a/test/types/helper_types.test-d.ts
+++ b/test/types/helper_types.test-d.ts
@@ -8,7 +8,8 @@ import type {
   FilterOperations,
   OnlyFieldsOfType,
   IntegerType,
-  IsAny
+  IsAny,
+  OneOrMore
 } from '../../src/mongo_types';
 import { Decimal128, Double, Int32, Long, Document } from '../../src/index';
 
@@ -97,3 +98,8 @@ interface IndexedSchema {
 // This means we can't properly enforce the subtype and there doesn't seem to be a way to detect it
 // and reduce strictness like we can with any, users with indexed schemas will have to use `as any`
 expectNotAssignable<OnlyFieldsOfType<IndexedSchema, NumericType>>({ a: 2 });
+
+// OneOrMore should accept readonly arrays
+expectAssignable<OneOrMore<number>>(1);
+expectAssignable<OneOrMore<number>>([1, 2]);
+expectAssignable<OneOrMore<number>>(Object.freeze([1, 2]));


### PR DESCRIPTION
Under certain usages typescript will disallow readonly arrays, when overriding the results of a find is a notable usage, look to the tests for a more complete list. Additionally the result of find was resulting the in the schema unioned with filter operators, there's a test to confirm that no longer occurs.
