### PR TITLE
test(NODE-3461): refactor lb manual to full test run

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -169,7 +169,6 @@ functions:
           TOPOLOGY="${TOPOLOGY}" \
           SKIP_DEPS=${SKIP_DEPS|1} \
           NO_EXIT=${NO_EXIT|1} \
-          TEST_NPM_SCRIPT="check:load-balancer" \
           FAKE_MONGODB_SERVICE_ID="true" \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
   run checks:

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -192,7 +192,6 @@ functions:
           TOPOLOGY="${TOPOLOGY}" \
           SKIP_DEPS=${SKIP_DEPS|1} \
           NO_EXIT=${NO_EXIT|1} \
-          TEST_NPM_SCRIPT="check:load-balancer" \
           FAKE_MONGODB_SERVICE_ID="true" \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "check:ts": "tsc -v && tsc --noEmit",
     "check:atlas": "mocha --config \"test/manual/mocharc.json\" test/manual/atlas_connectivity.test.js",
     "check:adl": "mocha test/manual/data_lake.test.js",
-    "check:load-balancer": "mocha test/manual/load-balancer.test.js",
     "check:ocsp": "mocha --config \"test/manual/mocharc.json\" test/manual/ocsp_support.test.js",
     "check:kerberos": "mocha --config \"test/manual/mocharc.json\" test/manual/kerberos.test.js",
     "check:tls": "mocha --config \"test/manual/mocharc.json\" test/manual/tls_support.test.js",

--- a/src/db.ts
+++ b/src/db.ts
@@ -319,18 +319,11 @@ export class Db {
    * @param name - the collection name we wish to access.
    * @returns return the new Collection instance
    */
-  collection<TSchema extends Document = Document>(name: string): Collection<TSchema>;
   collection<TSchema extends Document = Document>(
     name: string,
-    options: CollectionOptions
-  ): Collection<TSchema>;
-  collection<TSchema extends Document = Document>(
-    name: string,
-    options?: CollectionOptions
+    options: CollectionOptions = {}
   ): Collection<TSchema> {
-    if (!options) {
-      options = {};
-    } else if (typeof options === 'function') {
+    if (typeof options === 'function') {
       // TODO(NODE-3485): Replace this with MongoDeprecationError
       throw new MongoDriverError('The callback form of this helper has been removed.');
     }

--- a/src/db.ts
+++ b/src/db.ts
@@ -322,6 +322,10 @@ export class Db {
   collection<TSchema extends Document = Document>(name: string): Collection<TSchema>;
   collection<TSchema extends Document = Document>(
     name: string,
+    options: CollectionOptions
+  ): Collection<TSchema>;
+  collection<TSchema extends Document = Document>(
+    name: string,
     options?: CollectionOptions
   ): Collection<TSchema> {
     if (!options) {

--- a/test/functional/load-balancer-spec.test.js
+++ b/test/functional/load-balancer-spec.test.js
@@ -15,15 +15,7 @@ const SKIP = [
   //       in sub-optimal pinning.
   'pinned connections are not returned after an network error during getMore',
   'pinned connections are not returned to the pool after a non-network error on getMore',
-  'stale errors are ignored',
-
-  // NOTE: The driver correctly fails these 2 tests in non LB mode due to validation that
-  // loadBalanced=true is only valid as a URI option and not a regular driver option according
-  // to the spec. However the unified test runner implementation incorrectly passes URI options
-  // as regular driver options to the MongoClient. There are additional unit tests to cover
-  // these cases that demostrate this works as intended.
-  'operations against non-load balanced clusters fail if URI contains loadBalanced=true',
-  'operations against non-load balanced clusters succeed if URI contains loadBalanced=false'
+  'stale errors are ignored'
 ];
 
 describe('Load Balancer Unified Tests', function () {

--- a/test/functional/load-balancer-spec.test.js
+++ b/test/functional/load-balancer-spec.test.js
@@ -15,16 +15,16 @@ const SKIP = [
   //       in sub-optimal pinning.
   'pinned connections are not returned after an network error during getMore',
   'pinned connections are not returned to the pool after a non-network error on getMore',
-  'stale errors are ignored'
-];
+  'stale errors are ignored',
 
-require('../functional/retryable_reads.test');
-require('../functional/retryable_writes.test');
-require('../functional/uri_options_spec.test');
-require('../functional/change_stream_spec.test');
-require('../functional/versioned-api.test');
-require('../unit/core/mongodb_srv.test');
-require('../unit/sdam/server_selection/spec.test');
+  // NOTE: The driver correctly fails these 2 tests in non LB mode due to validation that
+  // loadBalanced=true is only valid as a URI option and not a regular driver option according
+  // to the spec. However the unified test runner implementation incorrectly passes URI options
+  // as regular driver options to the MongoClient. There are additional unit tests to cover
+  // these cases that demostrate this works as intended.
+  'operations against non-load balanced clusters fail if URI contains loadBalanced=true',
+  'operations against non-load balanced clusters succeed if URI contains loadBalanced=false'
+];
 
 describe('Load Balancer Unified Tests', function () {
   this.timeout(10000);

--- a/test/functional/load-balancer-spec.test.js
+++ b/test/functional/load-balancer-spec.test.js
@@ -16,9 +16,8 @@ const SKIP = [
   'pinned connections are not returned after an network error during getMore',
   'pinned connections are not returned to the pool after a non-network error on getMore',
   'stale errors are ignored',
-  // NOTE: The driver correctly fails these 2 tests in non LB mode due to validation that
-  // loadBalanced=true is only valid as a URI option and not a regular driver option according
-  // to the spec. In versions that are 3.4 or less an error still occurs but a different one (connection closes).
+  // NOTE: The driver correctly fails these 2 tests in non LB mode for server versions greater than 3.4.
+  // In versions that are 3.4 or less an error still occurs but a different one (connection closes).
   // TODO(NODE-3543): fix the path-ing that will produce errors for older servers
   'operations against non-load balanced clusters fail if URI contains loadBalanced=true',
   'operations against non-load balanced clusters succeed if URI contains loadBalanced=false'

--- a/test/functional/load-balancer-spec.test.js
+++ b/test/functional/load-balancer-spec.test.js
@@ -15,7 +15,13 @@ const SKIP = [
   //       in sub-optimal pinning.
   'pinned connections are not returned after an network error during getMore',
   'pinned connections are not returned to the pool after a non-network error on getMore',
-  'stale errors are ignored'
+  'stale errors are ignored',
+  // NOTE: The driver correctly fails these 2 tests in non LB mode due to validation that
+  // loadBalanced=true is only valid as a URI option and not a regular driver option according
+  // to the spec. In versions that are 3.4 or less an error still occurs but a different one (connection closes).
+  // TODO(NODE-3543): fix the path-ing that will produce errors for older servers
+  'operations against non-load balanced clusters fail if URI contains loadBalanced=true',
+  'operations against non-load balanced clusters succeed if URI contains loadBalanced=false'
 ];
 
 describe('Load Balancer Unified Tests', function () {

--- a/test/functional/unified-spec-runner/entities.ts
+++ b/test/functional/unified-spec-runner/entities.ts
@@ -112,10 +112,9 @@ export class UnifiedMongoClient extends MongoClient {
     return connectionString.toString();
   }
 
-  constructor(url: string, description: ClientEntity) {
-    super(UnifiedMongoClient.connectionString(url, description.uriOptions), {
+  constructor(uri: string, description: ClientEntity) {
+    super(UnifiedMongoClient.connectionString(uri, description.uriOptions), {
       monitorCommands: true,
-      ...description.uriOptions,
       serverApi: description.serverApi ? description.serverApi : serverApiConfig()
     });
 

--- a/test/functional/unified-spec-runner/match.ts
+++ b/test/functional/unified-spec-runner/match.ts
@@ -326,29 +326,31 @@ export function expectErrorCheck(
     return;
   }
 
+  const expectMessage = `\n\nOriginal Error Stack:\n${error.stack}\n\n`;
+
   if (expected.errorContains != null) {
-    expect(error.message).to.include(expected.errorContains);
+    expect(error.message, expectMessage).to.include(expected.errorContains);
   }
 
   if (!(error instanceof MongoError)) {
     // if statement asserts type for TS, expect will always fail
-    expect(error).to.be.instanceOf(MongoError);
+    expect(error, expectMessage).to.be.instanceOf(MongoError);
     return;
   }
 
   if (expected.errorCode != null) {
-    expect(error).to.have.property('code', expected.errorCode);
+    expect(error, expectMessage).to.have.property('code', expected.errorCode);
   }
 
   if (expected.errorCodeName != null) {
-    expect(error).to.have.property('codeName', expected.errorCodeName);
+    expect(error, expectMessage).to.have.property('codeName', expected.errorCodeName);
   }
 
   if (expected.errorLabelsContain != null) {
     for (const errorLabel of expected.errorLabelsContain) {
       expect(
         error.hasErrorLabel(errorLabel),
-        `Error was supposed to have label ${errorLabel}, has [${error.errorLabels}]`
+        `Error was supposed to have label ${errorLabel}, has [${error.errorLabels}] -- ${expectMessage}`
       ).to.be.true;
     }
   }
@@ -357,7 +359,7 @@ export function expectErrorCheck(
     for (const errorLabel of expected.errorLabelsOmit) {
       expect(
         error.hasErrorLabel(errorLabel),
-        `Error was supposed to have label ${errorLabel}, has [${error.errorLabels}]`
+        `Error was supposed to have label ${errorLabel}, has [${error.errorLabels}] -- ${expectMessage}`
       ).to.be.false;
     }
   }

--- a/test/functional/unified-spec-runner/schema.ts
+++ b/test/functional/unified-spec-runner/schema.ts
@@ -1,3 +1,4 @@
+import { ServerApiVersion } from '../../../src';
 import type { Document, ObjectId } from '../../../src/bson';
 import type { ReadConcernLevel } from '../../../src/read_concern';
 import type { ReadPreferenceMode } from '../../../src/read_preference';
@@ -96,7 +97,7 @@ export type EntityDescription =
   | { stream: StreamEntity }
   | { session: SessionEntity };
 export interface ServerApi {
-  version: string;
+  version: ServerApiVersion;
   strict?: boolean;
   deprecationErrors?: boolean;
 }

--- a/test/functional/unified-spec-runner/unified-utils.ts
+++ b/test/functional/unified-spec-runner/unified-utils.ts
@@ -5,6 +5,7 @@ import { gte as semverGte, lte as semverLte } from 'semver';
 import { CollectionOptions, DbOptions, MongoClient } from '../../../src';
 import { isDeepStrictEqual } from 'util';
 import { TestConfiguration } from './runner';
+import ConnectionString from 'mongodb-connection-string-url';
 
 const ENABLE_UNIFIED_TEST_LOGGING = false;
 export function log(message: unknown, ...optionalParameters: unknown[]): void {
@@ -97,4 +98,15 @@ export function translateOptions(options: Document): Document {
     translatedOptions.returnDocument = options.returnDocument.toLowerCase();
   }
   return translatedOptions as Document;
+}
+
+export function makeConnectionString(
+  uri: string,
+  uriOptions: Record<string, unknown> = {}
+): string {
+  const connectionString = new ConnectionString(uri);
+  for (const [name, value] of Object.entries(uriOptions ?? {})) {
+    connectionString.searchParams.set(name, String(value));
+  }
+  return connectionString.toString();
 }

--- a/test/tools/runner/index.js
+++ b/test/tools/runner/index.js
@@ -1,5 +1,9 @@
 'use strict';
 
+require('source-map-support').install({
+  hookRequire: true
+});
+
 const path = require('path');
 const fs = require('fs');
 const { MongoClient } = require('../../../src');

--- a/test/tools/runner/index.js
+++ b/test/tools/runner/index.js
@@ -66,7 +66,8 @@ before(function (_done) {
   // );
 
   const options = MONGODB_API_VERSION ? { serverApi: MONGODB_API_VERSION } : {};
-  const client = new MongoClient(MONGODB_URI, options);
+  const loadBalanced = SINGLE_MONGOS_LB_URI && MULTI_MONGOS_LB_URI;
+  const client = new MongoClient(loadBalanced ? SINGLE_MONGOS_LB_URI : MONGODB_URI, options);
   const done = err => client.close(err2 => _done(err || err2));
 
   client.connect(err => {


### PR DESCRIPTION
Removes the manual test and runs the entire test suite. The load balancer unified tests are moved into the `test/functional` directory and the test runner setup is changed to put the topology in the correct load balancer mode.