### PR TITLE
docs(NODE-3481): deprecate unref in 4.1

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -701,7 +701,10 @@ export class Db {
     );
   }
 
-  /** Unref all sockets */
+  /**
+   * Unref all sockets
+   * @deprecated This function is deprecated and will be removed in the 5.0 driver.
+   */
   unref(): void {
     getTopology(this).unref();
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -703,7 +703,7 @@ export class Db {
 
   /**
    * Unref all sockets
-   * @deprecated This function is deprecated and will be removed in the 5.0 driver.
+   * @deprecated This function is deprecated and will be removed in the next major version.
    */
   unref(): void {
     getTopology(this).unref();

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -771,7 +771,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
   }
 
   /**
-   * @deprecated This function is deprecated and will be removed in the 5.0 driver.
+   * @deprecated This function is deprecated and will be removed in the next major version.
    */
   unref(): void {
     emitWarning('`unref` is a noop and will be removed in the next major version');

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -770,6 +770,9 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
     return this.s.state === STATE_CLOSED;
   }
 
+  /**
+   * @deprecated This function is deprecated and will be removed in the 5.0 driver.
+   */
   unref(): void {
     emitWarning('not implemented: `unref`');
   }

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -774,7 +774,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
    * @deprecated This function is deprecated and will be removed in the 5.0 driver.
    */
   unref(): void {
-    emitWarning('not implemented: `unref`');
+    emitWarning('`unref` is a noop and will be removed in the next major version');
   }
 
   // NOTE: There are many places in code where we explicitly check the last isMaster

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -4,6 +4,8 @@ import { Collection } from '../../src/collection';
 import { AggregationCursor } from '../../src/cursor/aggregation_cursor';
 import type { FindCursor } from '../../src/cursor/find_cursor';
 import type { Document } from 'bson';
+import { Db } from '../../src';
+import { Topology } from '../../src/sdam/topology';
 
 // We wish to keep these APIs but continue to ensure they are marked as deprecated.
 expectDeprecated(Collection.prototype.insert);
@@ -11,6 +13,8 @@ expectDeprecated(Collection.prototype.update);
 expectDeprecated(Collection.prototype.remove);
 expectDeprecated(Collection.prototype.count);
 expectDeprecated(AggregationCursor.prototype.geoNear);
+expectDeprecated(Topology.prototype.unref);
+expectDeprecated(Db.prototype.unref);
 
 // test mapped cursor types
 const client = new MongoClient('');


### PR DESCRIPTION
## Description

Unref is now deprecated and marked to be removed in the next major version.