### PR TITLE
fix(NODE-3511): deprecate fullResponse and remove associated buggy code paths

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -63,6 +63,8 @@ const kDescription = Symbol('description');
 const kIsMaster = Symbol('ismaster');
 /** @internal */
 const kAutoEncrypter = Symbol('autoEncrypter');
+/** @internal */
+const kFullResult = Symbol('fullResult');
 
 /** @internal */
 export interface QueryOptions extends BSONSerializeOptions {
@@ -89,7 +91,7 @@ export interface CommandOptions extends BSONSerializeOptions {
   readPreference?: ReadPreferenceLike;
   raw?: boolean;
   monitoring?: boolean;
-  fullResult?: boolean;
+  [kFullResult]?: boolean;
   socketTimeoutMS?: number;
   /** Session to use for the operation */
   session?: ClientSession;
@@ -492,7 +494,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     write(
       this,
       query,
-      { fullResult: true, ...pluckBSONSerializeOptions(options) },
+      { [kFullResult]: true, ...pluckBSONSerializeOptions(options) },
       (err, result) => {
         if (err || !result) return callback(err, result);
         if (isExplain && result.documents && result.documents[0]) {
@@ -511,7 +513,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     options: GetMoreOptions,
     callback: Callback<Document>
   ): void {
-    const fullResult = typeof options.fullResult === 'boolean' ? options.fullResult : false;
+    const fullResult = !!options[kFullResult];
     const wireVersion = maxWireVersion(this);
     if (!cursorId) {
       // TODO(NODE-3483): Replace this with a MongoCommandError
@@ -526,7 +528,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
         Object.assign(options, { ...pluckBSONSerializeOptions(options) })
       );
 
-      queryOptions.fullResult = true;
+      queryOptions[kFullResult] = true;
       queryOptions.command = true;
       write(this, getMoreOp, queryOptions, (err, response) => {
         if (fullResult) return callback(err, response);
@@ -591,7 +593,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     this.command(
       ns,
       { killCursors: ns.collection, cursors: cursorIds },
-      { fullResult: true, ...options },
+      { [kFullResult]: true, ...options },
       (err, response) => {
         if (err || !response) return callback(err);
         if (response.cursorNotFound) {
@@ -773,7 +775,7 @@ function write(
     requestId: command.requestId,
     cb: callback,
     session: options.session,
-    fullResult: typeof options.fullResult === 'boolean' ? options.fullResult : false,
+    fullResult: !!options[kFullResult],
     noResponse: typeof options.noResponse === 'boolean' ? options.noResponse : false,
     documentsReturnedIn: options.documentsReturnedIn,
     command: !!options.command,

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -81,7 +81,7 @@ export interface QueryOptions extends BSONSerializeOptions {
   oplogReplay?: boolean;
 }
 
-/** @public */
+/** @internal */
 export interface CommandOptions extends BSONSerializeOptions {
   command?: boolean;
   slaveOk?: boolean;

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -31,7 +31,7 @@ export interface CommandOperationOptions
   extends OperationOptions,
     WriteConcernOptions,
     ExplainOptions {
-  /** Return the full server response for the command */
+  /** @deprecated This option does nothing */
   fullResponse?: boolean;
   /** Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported) */
   readConcern?: ReadConcernLike;
@@ -66,7 +66,6 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
   explain?: Explain;
-  fullResponse?: boolean;
   logger?: Logger;
 
   constructor(parent?: OperationParent, options?: CommandOperationOptions) {
@@ -87,8 +86,6 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
 
     this.readConcern = ReadConcern.fromOptions(options);
     this.writeConcern = WriteConcern.fromOptions(options);
-    this.fullResponse =
-      options && typeof options.fullResponse === 'boolean' ? options.fullResponse : false;
 
     // TODO(NODE-2056): make logger another "inheritable" property
     if (parent && parent.logger) {
@@ -169,6 +166,6 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
       }
     }
 
-    server.command(this.ns, cmd, { fullResult: !!this.fullResponse, ...options }, callback);
+    server.command(this.ns, cmd, { ...options }, callback);
   }
 }

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -166,6 +166,6 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
       }
     }
 
-    server.command(this.ns, cmd, { ...options }, callback);
+    server.command(this.ns, cmd, options, callback);
   }
 }

--- a/src/operations/distinct.ts
+++ b/src/operations/distinct.ts
@@ -80,7 +80,7 @@ export class DistinctOperation extends CommandOperation<any[]> {
         return;
       }
 
-      callback(undefined, this.options.fullResponse || this.explain ? result : result.values);
+      callback(undefined, this.explain ? result : result.values);
     });
   }
 }

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -166,7 +166,6 @@ export class FindOperation extends CommandOperation<Document> {
       this.ns,
       findCommand,
       {
-        fullResult: !!this.fullResponse,
         ...this.options,
         ...this.bsonOptions,
         documentsReturnedIn: 'firstBatch',

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -48,7 +48,6 @@ export abstract class AbstractOperation<TResult = any> {
   cmd!: Document;
   readPreference: ReadPreference;
   server!: Server;
-  fullResponse?: boolean;
   bypassPinningCheck: boolean;
 
   // BSON serialization options


### PR DESCRIPTION
## Description
NODE-3511

**What changed?**
Removing the never properly implemented `fullResponse` option from the codebase, also marking `CommandOptions` internal, since they are, in fact, internal use only. Also, removing the ability to externally affect the `fullResult` option (TS compilation would break if `fullResult` is passed in as a command option, but nothing is stopping regular js users from setting it and overriding our internal settings - we should confirm with shell that they aren't using it for some niche functionality, but otherwise this should be safe to disable)