### PR TITLE
fix(NODE-3546): revert findOne not found result type to null

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -297,6 +297,7 @@ export abstract class AbstractCursor<
   /** Get the next available document from the cursor, returns null if no more documents are available. */
   next(): Promise<TSchema | null>;
   next(callback: Callback<TSchema | null>): void;
+  next(callback?: Callback<TSchema | null>): Promise<TSchema | null> | void;
   next(callback?: Callback<TSchema | null>): Promise<TSchema | null> | void {
     return maybePromise(callback, done => {
       if (this[kId] === Long.ZERO) {

--- a/test/functional/crud_api.test.js
+++ b/test/functional/crud_api.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const test = require('./shared').assert;
 const { expect } = require('chai');
-const { ReturnDocument } = require('../../src');
+const { ReturnDocument, ObjectId } = require('../../src');
 const setupDatabase = require('./shared').setupDatabase;
 
 // instanceof cannot be use reliably to detect the new models in js due to scoping and new
@@ -12,6 +12,27 @@ const setupDatabase = require('./shared').setupDatabase;
 describe('CRUD API', function () {
   before(function () {
     return setupDatabase(this.configuration);
+  });
+
+  it('should correctly execute findOne method using crud api', async function () {
+    const configuration = this.configuration;
+    const client = configuration.newClient();
+    await client.connect();
+    const db = client.db(configuration.db);
+    const collection = db.collection('t');
+
+    await collection.insertOne({ findOneTest: 1 });
+
+    const findOneResult = await collection.findOne({ findOneTest: 1 });
+
+    expect(findOneResult).to.have.property('findOneTest', 1);
+    expect(findOneResult).to.have.property('_id').that.is.instanceOf(ObjectId);
+
+    const findNoneResult = await collection.findOne({ findOneTest: 2 });
+    expect(findNoneResult).to.be.null;
+
+    await collection.drop();
+    await client.close();
   });
 
   it('should correctly execute find method using crud api', {

--- a/test/functional/sessions.test.js
+++ b/test/functional/sessions.test.js
@@ -301,8 +301,8 @@ describe('Sessions', function () {
         controlSession = client.startSession();
 
         // set up sessions with two sets of cluster times
-        expect(await collection.findOne({}, { session: controlSession })).to.be.undefined;
-        expect(await collection.findOne({}, { session: testSession })).to.be.undefined;
+        expect(await collection.findOne({}, { session: controlSession })).to.be.null;
+        expect(await collection.findOne({}, { session: testSession })).to.be.null;
         await collection.insertOne({ apple: 'green' });
         expect(await collection.findOne({}, { session: otherSession }))
           .property('apple')

--- a/test/types/community/collection/findX.test-d.ts
+++ b/test/types/community/collection/findX.test-d.ts
@@ -87,9 +87,7 @@ cursor.forEach(
   }
 );
 
-expectType<Bag | undefined>(
-  await collectionBag.findOne({ color: 'red' }, { projection: { cost: 1 } })
-);
+expectType<Bag | null>(await collectionBag.findOne({ color: 'red' }, { projection: { cost: 1 } }));
 
 const overrideFind = await collectionBag.findOne<{ cost: number }>(
   { color: 'white' },
@@ -98,7 +96,7 @@ const overrideFind = await collectionBag.findOne<{ cost: number }>(
 expectType<PropExists<typeof overrideFind, 'color'>>(false);
 
 // Overriding findOne, makes the return that exact type
-expectType<{ cost: number } | undefined>(
+expectType<{ cost: number } | null>(
   await collectionBag.findOne<{ cost: number }>({ color: 'red' }, { projection: { cost: 1 } })
 );
 
@@ -121,13 +119,13 @@ interface House {
 
 const car = db.collection<Car>('car');
 
-expectNotType<House | undefined>(await car.findOne({}));
+expectNotType<House | null>(await car.findOne({}));
 
 interface Car {
   make: string;
 }
 
-function printCar(car: Car | undefined) {
+function printCar(car: Car | null) {
   console.log(car ? `A car of ${car.make} make` : 'No car');
 }
 
@@ -232,12 +230,12 @@ interface TypedDb extends Db {
 const typedDb = client.db('test2') as TypedDb;
 
 const person = typedDb.collection('people').findOne({});
-expectType<Promise<Person | undefined>>(person);
+expectType<Promise<Person | null>>(person);
 
 typedDb.collection('people').findOne({}, function (_err, person) {
-  expectType<Person | undefined>(person);
+  expectType<Person | null | undefined>(person); // null is if nothing is found, undefined is when there is an error defined
 });
 
 typedDb.collection('things').findOne({}, function (_err, thing) {
-  expectType<Thing | undefined>(thing);
+  expectType<Thing | null | undefined>(thing);
 });

--- a/test/types/union_schema.test-d.ts
+++ b/test/types/union_schema.test-d.ts
@@ -31,9 +31,9 @@ expectAssignable<ShapeInsert>({ height: 4, width: 4 });
 expectAssignable<ShapeInsert>({ radius: 4 });
 
 const c: Collection<Shape> = null as never;
-expectType<Promise<Shape | undefined>>(c.findOne({ height: 4, width: 4 }));
+expectType<Promise<Shape | null>>(c.findOne({ height: 4, width: 4 }));
 // collection API can only respect TSchema given, cannot pick a type inside a union
-expectNotType<Promise<Rectangle | undefined>>(c.findOne({ height: 4, width: 4 }));
+expectNotType<Promise<Rectangle | null>>(c.findOne({ height: 4, width: 4 }));
 
 interface A {
   _id: number;


### PR DESCRIPTION
findOne will now return null
ModifyResult correctly types value to be null or TSchema