### PR TITLE
chore(NODE-3303): deprecate md5 hash and isConnected

### DIFF
--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -7,6 +7,7 @@ var shallowClone = require('../utils').shallowClone;
 var toError = require('../utils').toError;
 var util = require('util');
 var executeLegacyOperation = require('../utils').executeLegacyOperation;
+const deprecateOptions = require('../utils').deprecateOptions;
 
 var DEFAULT_GRIDFS_BUCKET_OPTIONS = {
   bucketName: 'fs',
@@ -79,21 +80,28 @@ util.inherits(GridFSBucket, Emitter);
  * @param {object} [options.metadata] Optional object to store in the file document's `metadata` field
  * @param {string} [options.contentType] Optional string to store in the file document's `contentType` field
  * @param {array} [options.aliases] Optional array of strings to store in the file document's `aliases` field
- * @param {boolean} [options.disableMD5=false] If true, disables adding an md5 field to file data
+ * @param {boolean} [options.disableMD5=false] (DEPRECATED) If true, disables adding an md5 field to file data
  * @return {GridFSBucketWriteStream}
  */
 
-GridFSBucket.prototype.openUploadStream = function(filename, options) {
-  if (options) {
-    options = shallowClone(options);
-  } else {
-    options = {};
+GridFSBucket.prototype.openUploadStream = deprecateOptions(
+  {
+    name: 'GridFSBucket.openUploadStream',
+    deprecatedOptions: ['disableMD5'],
+    optionsIndex: 1
+  },
+  function(filename, options) {
+    if (options) {
+      options = shallowClone(options);
+    } else {
+      options = {};
+    }
+    if (!options.chunkSizeBytes) {
+      options.chunkSizeBytes = this.s.options.chunkSizeBytes;
+    }
+    return new GridFSBucketWriteStream(this, filename, options);
   }
-  if (!options.chunkSizeBytes) {
-    options.chunkSizeBytes = this.s.options.chunkSizeBytes;
-  }
-  return new GridFSBucketWriteStream(this, filename, options);
-};
+);
 
 /**
  * Returns a writable stream (GridFSBucketWriteStream) for writing
@@ -107,25 +115,32 @@ GridFSBucket.prototype.openUploadStream = function(filename, options) {
  * @param {object} [options.metadata] Optional object to store in the file document's `metadata` field
  * @param {string} [options.contentType] Optional string to store in the file document's `contentType` field
  * @param {array} [options.aliases] Optional array of strings to store in the file document's `aliases` field
- * @param {boolean} [options.disableMD5=false] If true, disables adding an md5 field to file data
+ * @param {boolean} [options.disableMD5=false] (DEPRECATED) If true, disables adding an md5 field to file data
  * @return {GridFSBucketWriteStream}
  */
 
-GridFSBucket.prototype.openUploadStreamWithId = function(id, filename, options) {
-  if (options) {
-    options = shallowClone(options);
-  } else {
-    options = {};
+GridFSBucket.prototype.openUploadStreamWithId = deprecateOptions(
+  {
+    name: 'GridFSBucket.openUploadStreamWithId',
+    deprecatedOptions: ['disableMD5'],
+    optionsIndex: 2
+  },
+  function(id, filename, options) {
+    if (options) {
+      options = shallowClone(options);
+    } else {
+      options = {};
+    }
+
+    if (!options.chunkSizeBytes) {
+      options.chunkSizeBytes = this.s.options.chunkSizeBytes;
+    }
+
+    options.id = id;
+
+    return new GridFSBucketWriteStream(this, filename, options);
   }
-
-  if (!options.chunkSizeBytes) {
-    options.chunkSizeBytes = this.s.options.chunkSizeBytes;
-  }
-
-  options.id = id;
-
-  return new GridFSBucketWriteStream(this, filename, options);
-};
+);
 
 /**
  * Returns a readable stream (GridFSBucketReadStream) for streaming file

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -5,10 +5,9 @@ var crypto = require('crypto');
 var stream = require('stream');
 var util = require('util');
 var Buffer = require('safe-buffer').Buffer;
+const deprecateOptions = require('../utils').deprecateOptions;
 
-var ERROR_NAMESPACE_NOT_FOUND = 26;
-
-module.exports = GridFSBucketWriteStream;
+const ERROR_NAMESPACE_NOT_FOUND = 26;
 
 /**
  * A writable stream that enables you to write buffers to GridFS.
@@ -31,42 +30,49 @@ module.exports = GridFSBucketWriteStream;
  * @fires GridFSBucketWriteStream#finish
  */
 
-function GridFSBucketWriteStream(bucket, filename, options) {
-  options = options || {};
-  stream.Writable.call(this, options);
-  this.bucket = bucket;
-  this.chunks = bucket.s._chunksCollection;
-  this.filename = filename;
-  this.files = bucket.s._filesCollection;
-  this.options = options;
-  // Signals the write is all done
-  this.done = false;
+const GridFSBucketWriteStream = deprecateOptions(
+  {
+    name: 'GridFSBucketWriteStream',
+    deprecatedOptions: ['disableMD5'],
+    optionsIndex: 2
+  },
+  function(bucket, filename, options) {
+    options = options || {};
+    stream.Writable.call(this, options);
+    this.bucket = bucket;
+    this.chunks = bucket.s._chunksCollection;
+    this.filename = filename;
+    this.files = bucket.s._filesCollection;
+    this.options = options;
+    // Signals the write is all done
+    this.done = false;
 
-  this.id = options.id ? options.id : core.BSON.ObjectId();
-  this.chunkSizeBytes = this.options.chunkSizeBytes;
-  this.bufToStore = Buffer.alloc(this.chunkSizeBytes);
-  this.length = 0;
-  this.md5 = !options.disableMD5 && crypto.createHash('md5');
-  this.n = 0;
-  this.pos = 0;
-  this.state = {
-    streamEnd: false,
-    outstandingRequests: 0,
-    errored: false,
-    aborted: false,
-    promiseLibrary: this.bucket.s.promiseLibrary
-  };
+    this.id = options.id ? options.id : core.BSON.ObjectId();
+    this.chunkSizeBytes = this.options.chunkSizeBytes;
+    this.bufToStore = Buffer.alloc(this.chunkSizeBytes);
+    this.length = 0;
+    this.md5 = !options.disableMD5 && crypto.createHash('md5');
+    this.n = 0;
+    this.pos = 0;
+    this.state = {
+      streamEnd: false,
+      outstandingRequests: 0,
+      errored: false,
+      aborted: false,
+      promiseLibrary: this.bucket.s.promiseLibrary
+    };
 
-  if (!this.bucket.s.calledOpenUploadStream) {
-    this.bucket.s.calledOpenUploadStream = true;
+    if (!this.bucket.s.calledOpenUploadStream) {
+      this.bucket.s.calledOpenUploadStream = true;
 
-    var _this = this;
-    checkIndexes(this, function() {
-      _this.bucket.s.checkedIndexes = true;
-      _this.bucket.emit('index');
-    });
+      var _this = this;
+      checkIndexes(this, function() {
+        _this.bucket.s.checkedIndexes = true;
+        _this.bucket.emit('index');
+      });
+    }
   }
-}
+);
 
 util.inherits(GridFSBucketWriteStream, stream.Writable);
 
@@ -539,3 +545,5 @@ function checkAborted(_this, callback) {
   }
   return false;
 }
+
+module.exports = GridFSBucketWriteStream;

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -364,17 +364,18 @@ MongoClient.prototype.db = function(dbName, options) {
  * Check if MongoClient is connected
  *
  * @method
+ * @deprecated
  * @param {object} [options] Optional settings.
  * @param {boolean} [options.noListener=false] Do not make the db an event listener to the original connection.
  * @param {boolean} [options.returnNonCachedInstance=false] Control if you want to return a cached instance or have a new one created
  * @return {boolean}
  */
-MongoClient.prototype.isConnected = function(options) {
+MongoClient.prototype.isConnected = deprecate(function(options) {
   options = options || {};
 
   if (!this.topology) return false;
   return this.topology.isConnected(options);
-};
+}, 'isConnected is deprecated and will be removed in the next major version');
 
 /**
  * Connect to MongoDB using a url as documented at


### PR DESCRIPTION
There was surprisingly little that hasn't already been correctly marked.
