### PR TITLE
fix(NODE-3377): driver should allow arbitrary explain levels

### DIFF
--- a/lib/explain.js
+++ b/lib/explain.js
@@ -2,16 +2,9 @@
 
 const MongoError = require('./core/error').MongoError;
 
-const ExplainVerbosity = {
-  queryPlanner: 'queryPlanner',
-  queryPlannerExtended: 'queryPlannerExtended',
-  executionStats: 'executionStats',
-  allPlansExecution: 'allPlansExecution'
-};
-
 /**
  * @class
- * @property {'queryPlanner'|'queryPlannerExtended'|'executionStats'|'allPlansExecution'} verbosity The verbosity mode for the explain output.
+ * @property {string} verbosity The verbosity mode for the explain output, e.g.: 'queryPlanner', 'queryPlannerExtended', 'executionStats', 'allPlansExecution'.
  */
 class Explain {
   /**
@@ -21,7 +14,7 @@ class Explain {
    * and false as "queryPlanner". Prior to server version 3.6, aggregate()
    * ignores the verbosity parameter and executes in "queryPlanner".
    *
-   * @param {'queryPlanner'|'queryPlannerExtended'|'executionStats'|'allPlansExecution'|boolean} [verbosity] The verbosity mode for the explain output.
+   * @param {string|boolean} [verbosity] The verbosity mode for the explain output.
    */
   constructor(verbosity) {
     if (typeof verbosity === 'boolean') {
@@ -35,7 +28,7 @@ class Explain {
    * Construct an Explain given an options object.
    *
    * @param {object} [options] The options object from which to extract the explain.
-   * @param {'queryPlanner'|'queryPlannerExtended'|'executionStats'|'allPlansExecution'|boolean} [options.explain] The verbosity mode for the explain output
+   * @param {string|boolean} [options.explain] The verbosity mode for the explain output.
    * @return {Explain}
    */
   static fromOptions(options) {
@@ -44,11 +37,11 @@ class Explain {
     }
 
     const explain = options.explain;
-    if (typeof explain === 'boolean' || explain in ExplainVerbosity) {
+    if (typeof explain === 'boolean' || typeof explain === 'string') {
       return new Explain(options.explain);
     }
 
-    throw new MongoError(`explain must be one of ${Object.keys(ExplainVerbosity)} or a boolean`);
+    throw new MongoError(`explain must be a string or a boolean`);
   }
 }
 


### PR DESCRIPTION
## Description

NODE-3377, backport arbitrary explain level fix from 4.0 (#2834)
