### PR TITLE
fix(NODE-3574): reintroduce ObjectID export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9719,6 +9719,16 @@
         "semver": "^7.3.2",
         "shelljs": "^0.8.3",
         "typescript": "^4.1.0-dev.20201026"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "electron-to-chromium": {
@@ -10427,12 +10437,6 @@
         "safe-buffer": {
           "version": "5.1.2",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "string_decoder": {
@@ -11812,6 +11816,14 @@
             "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
           }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -12361,12 +12373,6 @@
           "version": "3.0.0",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
         }
       }
     },
@@ -12555,13 +12561,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "5.7.1",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -12875,6 +12877,14 @@
           "version": "4.0.0",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "supports-color": {
           "version": "5.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9719,16 +9719,6 @@
         "semver": "^7.3.2",
         "shelljs": "^0.8.3",
         "typescript": "^4.1.0-dev.20201026"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "electron-to-chromium": {
@@ -10437,6 +10427,12 @@
         "safe-buffer": {
           "version": "5.1.2",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "string_decoder": {
@@ -11816,14 +11812,6 @@
             "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
           }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -12373,6 +12361,12 @@
           "version": "3.0.0",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -12561,9 +12555,13 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.1",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -12877,14 +12875,6 @@
           "version": "4.0.0",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         },
         "supports-color": {
           "version": "5.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,13 @@ export {
   Map
 } from './bson';
 
+import { ObjectId } from 'bson';
+/**
+ * @public
+ * @deprecated Please use `ObjectId`
+ */
+export const ObjectID = ObjectId;
+
 export {
   MongoError,
   MongoServerError,

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -6,7 +6,7 @@ import type { FindCursor } from '../../src/cursor/find_cursor';
 import type { Document } from 'bson';
 import { Db } from '../../src';
 import { Topology } from '../../src/sdam/topology';
-import { ObjectId, ObjectID } from '../../src';
+import { ObjectId } from '../../src';
 
 // We wish to keep these APIs but continue to ensure they are marked as deprecated.
 expectDeprecated(Collection.prototype.insert);
@@ -16,7 +16,7 @@ expectDeprecated(Collection.prototype.count);
 expectDeprecated(AggregationCursor.prototype.geoNear);
 expectDeprecated(Topology.prototype.unref);
 expectDeprecated(Db.prototype.unref);
-expectDeprecated(ObjectID);
+// expectDeprecated(ObjectID); // not sure why tsd can't assert the deprecation
 expectNotDeprecated(ObjectId);
 
 // test mapped cursor types

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -6,7 +6,7 @@ import type { FindCursor } from '../../src/cursor/find_cursor';
 import type { Document } from 'bson';
 import { Db } from '../../src';
 import { Topology } from '../../src/sdam/topology';
-import { ObjectId } from '../../src';
+import * as MongoDBDriver from '../../src';
 
 // We wish to keep these APIs but continue to ensure they are marked as deprecated.
 expectDeprecated(Collection.prototype.insert);
@@ -16,8 +16,8 @@ expectDeprecated(Collection.prototype.count);
 expectDeprecated(AggregationCursor.prototype.geoNear);
 expectDeprecated(Topology.prototype.unref);
 expectDeprecated(Db.prototype.unref);
-// expectDeprecated(ObjectID); // not sure why tsd can't assert the deprecation
-expectNotDeprecated(ObjectId);
+expectDeprecated(MongoDBDriver.ObjectID);
+expectNotDeprecated(MongoDBDriver.ObjectId);
 
 // test mapped cursor types
 const client = new MongoClient('');

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType, expectDeprecated, expectError } from 'tsd';
+import { expectType, expectDeprecated, expectNotDeprecated, expectError } from 'tsd';
 import { MongoClient } from '../../src/mongo_client';
 import { Collection } from '../../src/collection';
 import { AggregationCursor } from '../../src/cursor/aggregation_cursor';
@@ -6,6 +6,7 @@ import type { FindCursor } from '../../src/cursor/find_cursor';
 import type { Document } from 'bson';
 import { Db } from '../../src';
 import { Topology } from '../../src/sdam/topology';
+import { ObjectId, ObjectID } from '../../src';
 
 // We wish to keep these APIs but continue to ensure they are marked as deprecated.
 expectDeprecated(Collection.prototype.insert);
@@ -15,6 +16,8 @@ expectDeprecated(Collection.prototype.count);
 expectDeprecated(AggregationCursor.prototype.geoNear);
 expectDeprecated(Topology.prototype.unref);
 expectDeprecated(Db.prototype.unref);
+expectDeprecated(ObjectID);
+expectNotDeprecated(ObjectId);
 
 // test mapped cursor types
 const client = new MongoClient('');

--- a/test/unit/bson_import.test.js
+++ b/test/unit/bson_import.test.js
@@ -87,3 +87,13 @@ describe('When importing BSON', function () {
     testTypes();
   });
 });
+
+describe('MongoDB export', () => {
+  const mongodb = require('../../src');
+  it('should include ObjectId', () =>
+    expect(mongodb).to.have.property('ObjectId').that.is.a('function'));
+  it('should include ObjectID', () =>
+    expect(mongodb).to.have.property('ObjectID').that.is.a('function'));
+  it('should have ObjectID and ObjectId equal each other', () =>
+    expect(mongodb.ObjectId).to.deep.equal(mongodb.ObjectID));
+});

--- a/test/unit/bson_import.test.js
+++ b/test/unit/bson_import.test.js
@@ -95,5 +95,5 @@ describe('MongoDB export', () => {
   it('should include ObjectID', () =>
     expect(mongodb).to.have.property('ObjectID').that.is.a('function'));
   it('should have ObjectID and ObjectId equal each other', () =>
-    expect(mongodb.ObjectId).to.deep.equal(mongodb.ObjectID));
+    expect(mongodb.ObjectId).to.equal(mongodb.ObjectID));
 });


### PR DESCRIPTION
Reintroduced the capitalized ObjectID export along with a deprecation tag.