### PR TITLE
fix: versioned api low node compat fix

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -19,10 +19,12 @@ try {
 const ServerApiVersion = Object.freeze({
   v1: '1'
 });
+const ValidServerApiVersions = Object.keys(ServerApiVersion).map(key => ServerApiVersion[key]);
 
 module.exports = {
   // Versioned API
   ServerApiVersion,
+  ValidServerApiVersions,
   // Errors
   MongoError: require('./error').MongoError,
   MongoNetworkError: require('./error').MongoNetworkError,

--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -5,7 +5,7 @@ const Db = require('./db');
 const EventEmitter = require('events').EventEmitter;
 const inherits = require('util').inherits;
 const MongoError = require('./core').MongoError;
-const ServerApiVersion = require('./core').ServerApiVersion;
+const ValidServerApiVersions = require('./core').ValidServerApiVersions;
 const deprecate = require('util').deprecate;
 const WriteConcern = require('./write_concern');
 const MongoDBNamespace = require('./utils').MongoDBNamespace;
@@ -206,16 +206,16 @@ function MongoClient(url, options) {
     const versionToValidate = serverApiToValidate && serverApiToValidate.version;
     if (!versionToValidate) {
       throw new MongoError(
-        `Invalid \`serverApi\` property; must specify a version from the following enum: ["${Object.values(
-          ServerApiVersion
-        ).join('", "')}"]`
+        `Invalid \`serverApi\` property; must specify a version from the following enum: ["${ValidServerApiVersions.join(
+          '", "'
+        )}"]`
       );
     }
-    if (!Object.values(ServerApiVersion).some(v => v === versionToValidate)) {
+    if (!ValidServerApiVersions.some(v => v === versionToValidate)) {
       throw new MongoError(
-        `Invalid server API version=${versionToValidate}; must be in the following enum: ["${Object.values(
-          ServerApiVersion
-        ).join('", "')}"]`
+        `Invalid server API version=${versionToValidate}; must be in the following enum: ["${ValidServerApiVersions.join(
+          '", "'
+        )}"]`
       );
     }
     options.serverApi = serverApiToValidate;

--- a/test/functional/unified-spec-runner/unified-utils.ts
+++ b/test/functional/unified-spec-runner/unified-utils.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import type { CollectionOrDatabaseOptions, RunOnRequirement, Document } from './schema';
 import { gte as semverGte, lte as semverLte } from 'semver';
 import { MongoClient } from '../../../index';
-import { isDeepStrictEqual } from 'util';
 import { TestConfiguration } from './runner';
 
 export async function topologySatisfies(
@@ -41,7 +40,11 @@ export async function topologySatisfies(
     if (!config.parameters) throw new Error('Configuration does not have server parameters');
     for (const [name, value] of Object.entries(r.serverParameters)) {
       if (name in config.parameters) {
-        ok &&= isDeepStrictEqual(config.parameters[name], value);
+        try {
+          expect(config.parameters[name]).to.deep.equal(value);
+        } catch (_err) {
+          ok = false;
+        }
       }
     }
   }

--- a/test/functional/versioned-api.test.js
+++ b/test/functional/versioned-api.test.js
@@ -3,12 +3,13 @@
 const expect = require('chai').expect;
 const loadSpecTests = require('../spec/index').loadSpecTests;
 const runUnifiedTest = require('./unified-spec-runner/runner').runUnifiedTest;
-const ServerApiVersion = require('../../lib/core').ServerApiVersion;
+const ValidServerApiVersions = require('../../lib/core').ValidServerApiVersions;
 
 describe('Versioned API', function() {
+  const validVersions = ValidServerApiVersions;
+
   describe('client option validation', function() {
     it('is supported as a client option when it is a valid ServerApiVersion string', function() {
-      const validVersions = Object.values(ServerApiVersion);
       expect(validVersions.length).to.be.at.least(1);
       for (const version of validVersions) {
         const client = this.configuration.newClient('mongodb://localhost/', {
@@ -21,7 +22,6 @@ describe('Versioned API', function() {
     });
 
     it('is supported as a client option when it is an object with a valid version property', function() {
-      const validVersions = Object.values(ServerApiVersion);
       expect(validVersions.length).to.be.at.least(1);
       for (const version of validVersions) {
         const client = this.configuration.newClient('mongodb://localhost/', {

--- a/test/functional/versioned-api.test.js
+++ b/test/functional/versioned-api.test.js
@@ -3,11 +3,9 @@
 const expect = require('chai').expect;
 const loadSpecTests = require('../spec/index').loadSpecTests;
 const runUnifiedTest = require('./unified-spec-runner/runner').runUnifiedTest;
-const ValidServerApiVersions = require('../../lib/core').ValidServerApiVersions;
+const validVersions = require('../../lib/core').ValidServerApiVersions;
 
 describe('Versioned API', function() {
-  const validVersions = ValidServerApiVersions;
-
   describe('client option validation', function() {
     it('is supported as a client option when it is a valid ServerApiVersion string', function() {
       expect(validVersions.length).to.be.at.least(1);


### PR DESCRIPTION
## Description

Updating versioned API not to use `Object.values` and unified runner not to use the node util for deep equality check.
