### PR TITLE
fix(NODE-3467): allow object type for aggregate out helper

### DIFF
--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -121,7 +121,7 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
   }
 
   /** Add an out stage to the aggregation pipeline */
-  out($out: string): this {
+  out($out: { db: string; coll: string } | string): this {
     assertUninitialized(this);
     this[kPipeline].push({ $out });
     return this;

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -37,5 +37,11 @@ expectType<string | null>(await composedMap.next());
 expectType<string[]>(await composedMap.toArray());
 
 const builtCursor = coll.aggregate();
-expectType<AggregationCursor<Document>>(builtCursor.out('string')); // should allow string values for the out helper
-expectError(builtCursor.out(1)); // should error on non-string values
+// should allow string values for the out helper
+expectType<AggregationCursor<Document>>(builtCursor.out('collection'));
+// should also allow an object specifying db/coll (as of MongoDB 4.4)
+expectType<AggregationCursor<Document>>(builtCursor.out({ db: 'db', coll: 'collection' }));
+// should error on other object shapes
+expectError(builtCursor.out({ other: 'shape' }));
+// should error on non-object, non-string values
+expectError(builtCursor.out(1));


### PR DESCRIPTION
Corrects an oversight in #2967