### PR TITLE
fix(NODE-3585): MongoClientOptions#compressors has incorrect type

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -32,7 +32,7 @@ import type { TagSet } from './sdam/server_description';
 import { Logger, LoggerLevel } from './logger';
 import { PromiseProvider } from './promise_provider';
 import { Encrypter } from './encrypter';
-import { Compressor } from './cmap/wire_protocol/compression';
+import { Compressor, CompressorName } from './cmap/wire_protocol/compression';
 
 const VALID_TXT_RECORDS = ['authSource', 'replicaSet', 'loadBalanced'];
 
@@ -612,8 +612,14 @@ export const OPTIONS = {
     target: 'compressors',
     transform({ values }) {
       const compressionList = new Set();
-      for (const compVal of values as string[]) {
-        for (const c of compVal.split(',')) {
+      for (const compVal of values as (CompressorName[] | string)[]) {
+        const compValArray = typeof compVal === 'string' ? compVal.split(',') : compVal;
+        if (!Array.isArray(compValArray)) {
+          throw new MongoInvalidArgumentError(
+            'compressors must be an array or a comma-delimited list of strings'
+          );
+        }
+        for (const c of compValArray) {
           if (Object.keys(Compressor).includes(String(c))) {
             compressionList.add(String(c));
           } else {

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -128,8 +128,8 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   connectTimeoutMS?: number;
   /** The time in milliseconds to attempt a send or receive on a socket before the attempt times out. */
   socketTimeoutMS?: number;
-  /** Comma-delimited string of compressors to enable network compression for communication between this client and a mongod/mongos instance. */
-  compressors?: CompressorName[];
+  /** An array or comma-delimited string of compressors to enable network compression for communication between this client and a mongod/mongos instance. */
+  compressors?: CompressorName[] | string;
   /** An integer that specifies the compression level if using zlib for network compression. */
   zlibCompressionLevel?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined;
   /** The maximum number of connections in the connection pool. */

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -620,7 +620,6 @@ export interface MongoOptions
       Pick<
         MongoClientOptions,
         | 'autoEncryption'
-        | 'compressors'
         | 'connectTimeoutMS'
         | 'directConnection'
         | 'driverInfo'
@@ -659,6 +658,7 @@ export interface MongoOptions
   readConcern: ReadConcern;
   loadBalanced: boolean;
   serverApi: ServerApi;
+  compressors: CompressorName[];
   writeConcern: WriteConcern;
   dbName: string;
   metadata: ClientMetadata;

--- a/test/types/community/changes_from_36.test-d.ts
+++ b/test/types/community/changes_from_36.test-d.ts
@@ -69,7 +69,7 @@ expectAssignable<((host: string, cert: PeerCertificate) => Error | undefined) | 
 // compression options have simpler specification:
 // old way: {compression: { compressors: ['zlib', 'snappy'] }}
 expectType<PropExists<MongoClientOptions, 'compression'>>(false);
-expectType<('none' | 'snappy' | 'zlib')[] | undefined>(options.compressors);
+expectType<('none' | 'snappy' | 'zlib')[] | string | undefined>(options.compressors);
 
 // Removed cursor API
 const cursor = new MongoClient('').db().aggregate();


### PR DESCRIPTION
## Description

**What changed?**
compressors now accepts an array of strings in addition to the comma-delimited string as a way of setting the option, in accordance with the documentation; the TS type has also been updated to reflect the valid inputs