### PR TITLE
fix(ConnectionString): missing name for getBoolean

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -385,13 +385,13 @@ export function parseOptions(
   }
 
   if (allOptions.has('tls')) {
-    if (new Set(allOptions.get('tls')?.map(getBoolean)).size !== 1) {
+    if (new Set(allOptions.get('tls')?.map(getBoolean.bind(null,'tls'))).size !== 1) {
       throw new MongoParseError('All values of tls must be the same.');
     }
   }
 
   if (allOptions.has('ssl')) {
-    if (new Set(allOptions.get('ssl')?.map(getBoolean)).size !== 1) {
+    if (new Set(allOptions.get('ssl')?.map(getBoolean.bind(null,'ssl'))).size !== 1) {
       throw new MongoParseError('All values of ssl must be the same.');
     }
   }


### PR DESCRIPTION
## Description
in follow example:
```js
const newSet = new Set(['false',false].map(getBoolean));

console.log(newSet.size === 1) // false

const newSetB = new Set(['false',false].map(getBoolean.bind(null,'tls')));

console.log(newSetB.size === 1) // true

```

the newSet would contain two values `false, true`, because `getBoolean` is checking index 0 and 1 instead of values.

this bug makes  mongodb connection is always failed.

**What changed?**

set name to getBoolean

**Are there any files to ignore?**
