### PR TITLE
fix(NODE-3599): incorrect indexes return type

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1190,14 +1190,14 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
-  indexes(): Promise<Document>;
-  indexes(callback: Callback<Document>): void;
-  indexes(options: IndexInformationOptions): Promise<Document>;
-  indexes(options: IndexInformationOptions, callback: Callback<Document>): void;
+  indexes(): Promise<Document[]>;
+  indexes(callback: Callback<Document[]>): void;
+  indexes(options: IndexInformationOptions): Promise<Document[]>;
+  indexes(options: IndexInformationOptions, callback: Callback<Document[]>): void;
   indexes(
-    options?: IndexInformationOptions | Callback<Document>,
-    callback?: Callback<Document>
-  ): Promise<Document> | void {
+    options?: IndexInformationOptions | Callback<Document[]>,
+    callback?: Callback<Document[]>
+  ): Promise<Document[]> | void {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -159,7 +159,7 @@ function makeIndexSpec(indexSpec: IndexSpecification, options: any): IndexDescri
 }
 
 /** @internal */
-export class IndexesOperation extends AbstractOperation<Document> {
+export class IndexesOperation extends AbstractOperation<Document[]> {
   options: IndexInformationOptions;
   collection: Collection;
 
@@ -169,7 +169,7 @@ export class IndexesOperation extends AbstractOperation<Document> {
     this.collection = collection;
   }
 
-  execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
+  execute(server: Server, session: ClientSession, callback: Callback<Document[]>): void {
     const coll = this.collection;
     const options = this.options;
 

--- a/test/types/indexes_test-d.ts
+++ b/test/types/indexes_test-d.ts
@@ -1,0 +1,26 @@
+import { expectType } from 'tsd';
+import { MongoClient, Document, AnyError } from '../../src';
+
+const client = new MongoClient('');
+const db = client.db('test');
+const collection = db.collection('test.find');
+
+// Promise variant testing
+expectType<Promise<Document[]>>(collection.indexes());
+expectType<Promise<Document[]>>(collection.indexes({}));
+
+// Explicit check for iterable result
+for (const index of await collection.indexes()) {
+  expectType<Document>(index);
+}
+
+// Callback variant testing
+collection.indexes((err, indexes) => {
+  expectType<AnyError | undefined>(err);
+  expectType<Document[] | undefined>(indexes);
+});
+
+collection.indexes({}, (err, indexes) => {
+  expectType<AnyError | undefined>(err);
+  expectType<Document[] | undefined>(indexes);
+});


### PR DESCRIPTION
## Description

NODE-3599 `collection.indexes()` return type corrected to `Document[]`
