### PR TITLE
fix(NODE-3609): correct listDatabases return type

### DIFF
--- a/src/operations/list_databases.ts
+++ b/src/operations/list_databases.ts
@@ -7,7 +7,12 @@ import type { Db } from '../db';
 import type { ClientSession } from '../sessions';
 
 /** @public */
-export type ListDatabasesResult = string[] | Document[];
+export interface ListDatabasesResult {
+  databases: ({ name: string; sizeOnDisk?: number; empty?: boolean } & Document)[];
+  totalSize?: number;
+  totalSizeMb?: number;
+  ok: 1 | 0;
+}
 
 /** @public */
 export interface ListDatabasesOptions extends CommandOperationOptions {

--- a/test/types/admin.test-d.ts
+++ b/test/types/admin.test-d.ts
@@ -1,0 +1,12 @@
+import { expectType } from 'tsd';
+import { Document, MongoClient } from '../../src/index';
+
+const client = new MongoClient('');
+const admin = client.db().admin();
+
+expectType<{
+  databases: ({ name: string; sizeOnDisk?: number; empty?: boolean } & Document)[];
+  totalSize?: number;
+  totalSizeMb?: number;
+  ok: 1 | 0;
+}>(await admin.listDatabases());


### PR DESCRIPTION
I took a look at the other listX() methods, we have strong type information for `listCollections()` that switches based on the nameOnly option, I figured we don't need the strict typing here but I'm open to changing that. `listIndexes()` has no type information, it returns an unannotated cursor so .toArray() will return `Promise<Document[]>`, which at least the array of objects part is correct.