### PR TITLE
chore(NODE-3622): bump optional-require for additional yarn berry pnp support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "optional-require": "^1.0.3",
+        "optional-require": "^1.1.8",
         "safe-buffer": "^5.1.2"
       },
       "devDependencies": {
@@ -4393,9 +4393,12 @@
       }
     },
     "node_modules/optional-require": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "dependencies": {
+        "require-at": "^1.0.6"
+      },
       "engines": {
         "node": ">=4"
       }
@@ -4963,6 +4966,14 @@
       "dependencies": {
         "es6-error": "^4.0.1"
       },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
       "engines": {
         "node": ">=4"
       }
@@ -9811,9 +9822,12 @@
       }
     },
     "optional-require": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "requires": {
+        "require-at": "^1.0.6"
+      }
     },
     "optionator": {
       "version": "0.9.1",
@@ -10259,6 +10273,11 @@
       "requires": {
         "es6-error": "^4.0.1"
       }
+    },
+    "require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bl": "^2.2.1",
     "bson": "^1.1.4",
     "denque": "^1.4.1",
-    "optional-require": "^1.0.3",
+    "optional-require": "^1.1.8",
     "safe-buffer": "^5.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

This PR upgrades optional-require to 1.1.8 for additional Yarn Berry PnP support. See https://jira.mongodb.org/browse/NODE-3622 for justification.