### PR TITLE
feat(NODE-3692): make change stream events typing more generic

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -184,14 +184,14 @@ export interface UpdateDescription<TSchema extends Document = Document> {
 }
 
 /** @public */
-export type ChangeStreamEvents = {
+export type ChangeStreamEvents<TSchema extends Document = Document> = {
   resumeTokenChanged(token: ResumeToken): void;
-  init(response: Document): void;
-  more(response?: Document | undefined): void;
+  init(response: TSchema): void;
+  more(response?: TSchema | undefined): void;
   response(): void;
   end(): void;
   error(error: Error): void;
-  change(change: ChangeStreamDocument): void;
+  change(change: ChangeStreamDocument<TSchema>): void;
 } & AbstractCursorEvents;
 
 /**
@@ -200,7 +200,7 @@ export type ChangeStreamEvents = {
  */
 export class ChangeStream<
   TSchema extends Document = Document
-> extends TypedEventEmitter<ChangeStreamEvents> {
+> extends TypedEventEmitter<ChangeStreamEvents<TSchema>> {
   pipeline: Document[];
   options: ChangeStreamOptions;
   parent: MongoClient | Db | Collection;

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -198,9 +198,9 @@ export type ChangeStreamEvents<TSchema extends Document = Document> = {
  * Creates a new Change Stream instance. Normally created using {@link Collection#watch|Collection.watch()}.
  * @public
  */
-export class ChangeStream<
-  TSchema extends Document = Document
-> extends TypedEventEmitter<ChangeStreamEvents<TSchema>> {
+export class ChangeStream<TSchema extends Document = Document> extends TypedEventEmitter<
+  ChangeStreamEvents<TSchema>
+> {
   pipeline: Document[];
   options: ChangeStreamOptions;
   parent: MongoClient | Db | Collection;


### PR DESCRIPTION
Added typescript generic typing to ChangeStreamEvents

## Description

**What changed?**
The typing for `ChangeStreamEvents` was not generic, and did not contain `<TSchema>` so it was always assumed to be of type `Document`. This would affect code usage like this:
```typescript
interface MyDoc extends Document{
   name: string
}
const client = new MongoClient('');
const coll = client.db('test').collection<MyDoc>('test');
coll.watch().on('change', c => c.fullDocument) 
// c.fullDocument above is typed as Document, but should be MyDoc
```
`ChangeStreamDocument` already had generic types, so I just passed through `<TSchema>`.

I tried it out locally and the typing showed correctly in my editor.

Could someone confirm that the `init` and `more` events do indeed return the same structure as `TSchema`, as I do not know what these events are?