### PR TITLE
test(NODE-3606): legacy and new versions of the CSFLE library

### DIFF
--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -99,3 +99,8 @@ if [ $DRIVER_CSFLE_TEST_RESULT -ne 0 ]; then
   echo "Driver tests failed, look above for results"
   exit 1
 fi
+
+echo "Test legacy version of FLE bindings"
+rm -rf node_modules/mongodb-client-encryption
+npm install mongodb-client-encryption@"^1.2.7"
+npm run check:csfle

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -41,7 +41,7 @@ if [[ -z "${CLIENT_ENCRYPTION}" ]]; then
   unset AWS_ACCESS_KEY_ID;
   unset AWS_SECRET_ACCESS_KEY;
 else
-  npm install mongodb-client-encryption@">=1.2.6"
+  npm install mongodb-client-encryption@">=2.0.0-beta.0"
   pip install --upgrade boto3
 
   # Get access to the AWS temporary credentials:


### PR DESCRIPTION
Our "custom-csfle" has been expanded to run the 1.x version
and our normal tests will use the Node-API version.