### PR TITLE
chore: skip flaky should recover on error during initial connect test

### DIFF
--- a/test/functional/unit-sdam/monitoring.test.js
+++ b/test/functional/unit-sdam/monitoring.test.js
@@ -48,7 +48,8 @@ describe('monitoring', function () {
     });
   });
 
-  it('should recover on error during initial connect', function (done) {
+  // TODO(NODE-3600): Unskip flaky test
+  it.skip('should recover on error during initial connect', function (done) {
     // This test should take ~1s because initial server selection fails and an immediate check
     // is requested. If the behavior of the immediate check is broken, the test will take ~10s
     // to complete. We want to ensure validation of the immediate check behavior, and therefore


### PR DESCRIPTION
NODE-3600 tracking unskip