### PR TITLE
fix(NODE-3668): compile error with OptionalId on TS 4.5 beta

### DIFF
--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -38,9 +38,11 @@ export type WithId<TSchema> = EnhancedOmit<TSchema, '_id'> & { _id: InferIdType<
  * `TSchema['_id'] extends ObjectId` which translated to "Is the _id property ObjectId?"
  * we instead ask "Does ObjectId look like (have the same shape) as the _id?"
  */
-export type OptionalId<TSchema extends { _id?: any }> = ObjectId extends TSchema['_id'] // a Schema with ObjectId _id type or "any" or "indexed type" provided
-  ? EnhancedOmit<TSchema, '_id'> & { _id?: InferIdType<TSchema> } // a Schema provided but _id type is not ObjectId
-  : WithId<TSchema>; // TODO(NODE-3285): Improve type readability
+export type OptionalId<TSchema> = TSchema extends  { _id?: any }
+    ? (ObjectId extends TSchema['_id'] // a Schema with ObjectId _id type or "any" or "indexed type" provided
+        ? EnhancedOmit<TSchema, '_id'> & { _id?: InferIdType<TSchema> } // a Schema provided but _id type is not ObjectId
+        : WithId<TSchema>)
+    : WithId<TSchema>; // TODO(NODE-3285): Improve type readability
 
 /** TypeScript Omit (Exclude to be specific) does not work for objects with an "any" indexed type, and breaks discriminated unions @public */
 export type EnhancedOmit<TRecordOrUnion, KeyUnion> = string extends keyof TRecordOrUnion

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -38,11 +38,11 @@ export type WithId<TSchema> = EnhancedOmit<TSchema, '_id'> & { _id: InferIdType<
  * `TSchema['_id'] extends ObjectId` which translated to "Is the _id property ObjectId?"
  * we instead ask "Does ObjectId look like (have the same shape) as the _id?"
  */
-export type OptionalId<TSchema> = TSchema extends  { _id?: any }
-    ? (ObjectId extends TSchema['_id'] // a Schema with ObjectId _id type or "any" or "indexed type" provided
-        ? EnhancedOmit<TSchema, '_id'> & { _id?: InferIdType<TSchema> } // a Schema provided but _id type is not ObjectId
-        : WithId<TSchema>)
-    : EnhancedOmit<TSchema, '_id'> & { _id?: InferIdType<TSchema> }; // TODO(NODE-3285): Improve type readability
+export type OptionalId<TSchema> = TSchema extends { _id?: any }
+  ? ObjectId extends TSchema['_id'] // a Schema with ObjectId _id type or "any" or "indexed type" provided
+    ? EnhancedOmit<TSchema, '_id'> & { _id?: InferIdType<TSchema> } // a Schema provided but _id type is not ObjectId
+    : WithId<TSchema>
+  : EnhancedOmit<TSchema, '_id'> & { _id?: InferIdType<TSchema> }; // TODO(NODE-3285): Improve type readability
 
 /** TypeScript Omit (Exclude to be specific) does not work for objects with an "any" indexed type, and breaks discriminated unions @public */
 export type EnhancedOmit<TRecordOrUnion, KeyUnion> = string extends keyof TRecordOrUnion

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -42,7 +42,7 @@ export type OptionalId<TSchema> = TSchema extends  { _id?: any }
     ? (ObjectId extends TSchema['_id'] // a Schema with ObjectId _id type or "any" or "indexed type" provided
         ? EnhancedOmit<TSchema, '_id'> & { _id?: InferIdType<TSchema> } // a Schema provided but _id type is not ObjectId
         : WithId<TSchema>)
-    : WithId<TSchema>; // TODO(NODE-3285): Improve type readability
+    : EnhancedOmit<TSchema, '_id'> & { _id?: InferIdType<TSchema> }; // TODO(NODE-3285): Improve type readability
 
 /** TypeScript Omit (Exclude to be specific) does not work for objects with an "any" indexed type, and breaks discriminated unions @public */
 export type EnhancedOmit<TRecordOrUnion, KeyUnion> = string extends keyof TRecordOrUnion


### PR DESCRIPTION
Typescript 4.5  is better at checking certain complicated types than before. Previously, it missed an error in mongo_types.ts in the use of SetFields and OptionalId.

SetFields passes an unconstrained type parameter, TSchema, to OptionalId, which does have a constraint:

```ts
export type OptionalId<TSchema extends { _id?: any }> = ...
```

Because the type was so complex, Typescript missed this before 4.5.

Looking at the comments for OptionalId, I believe the intent is to add `_id` to *any* type, not just ones that already have an `_id` field. So I moved the constraint into a conditional type instead.

Fixes https://jira.mongodb.org/browse/NODE-3668?jql=project%20%3D%20NODE%20AND%20resolution%20%3D%20Unresolved%20AND%20text%20~%20%22typescript%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC

## Description

**What changed?**

Types in mongo_types.ts