### PR TITLE
fix(NODE-3344): allow setting `defaultTransactionOptions` with POJO rather than ReadConcern instance

### DIFF
--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,6 +1,6 @@
 import { ReadPreference } from './read_preference';
 import { MongoRuntimeError, MongoTransactionError } from './error';
-import { ReadConcern } from './read_concern';
+import { ReadConcern, ReadConcernLike } from './read_concern';
 import { WriteConcern } from './write_concern';
 import type { Server } from './sdam/server';
 import type { CommandOperationOptions } from './operations/command';
@@ -63,7 +63,7 @@ const COMMITTED_STATES: Set<TxnState> = new Set([
 export interface TransactionOptions extends CommandOperationOptions {
   // TODO(NODE-3344): These options use the proper class forms of these settings, it should accept the basic enum values too
   /** A default read concern for commands in this transaction */
-  readConcern?: ReadConcern;
+  readConcern?: ReadConcernLike;
   /** A default writeConcern for commands in this transaction */
   writeConcern?: WriteConcern;
   /** A default read preference for commands in this transaction */


### PR DESCRIPTION
Re: https://github.com/Automattic/mongoose/issues/10805

### Description

Right now, `startSession({ defaultTransactionOptions: { readConcern: { level: 'snapshot' } } })` fails to compile with a `Property 'toJSON' is missing in type '{ level: string; }' but required in type 'ReadConcern'.` error. This seems like something that should change.

#### What is changing?

`TransactionOptions.readConcern` is now a `ReadConcernLike`, which allows using strings or `{ level }` object.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Make `TransactionOptions` more user-friendly and line up with `Cursor#withReadConcern()` and `CollectionOptions`.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
