### PR TITLE
fix(NODE-3515): do proper opTime merging in bulk results

### DIFF
--- a/lib/bulk/common.js
+++ b/lib/bulk/common.js
@@ -455,7 +455,7 @@ function mergeBatchResults(batch, bulkResult, err, result) {
   }
 
   // The server write command specification states that lastOp is an optional
-  // mongod only field that has a type of timestamp. Across various scare specs
+  // mongod only field that has a type of timestamp. Across various scarce specs
   // where opTime is mentioned, it is an "opaque" object that can have a "ts" and
   // "t" field with Timestamp and Long as their types respectively.
   // The "lastOp" field of the bulk write result is never mentioned in the driver
@@ -465,30 +465,28 @@ function mergeBatchResults(batch, bulkResult, err, result) {
   if (result.opTime || result.lastOp) {
     let opTime = result.lastOp || result.opTime;
 
-    if (opTime) {
-      // If the opTime is a Timestamp, convert it to a consistent format to be
-      // able to compare easily. Converting to the object from a timestamp is
-      // much more straightforward than the other direction.
-      if (opTime._bsontype === 'Timestamp') {
-        opTime = { ts: opTime, t: Long.ZERO };
-      }
+    // If the opTime is a Timestamp, convert it to a consistent format to be
+    // able to compare easily. Converting to the object from a timestamp is
+    // much more straightforward than the other direction.
+    if (opTime._bsontype === 'Timestamp') {
+      opTime = { ts: opTime, t: Long.ZERO };
+    }
 
-      // If there's no lastOp, just set it.
-      if (!bulkResult.lastOp) {
+    // If there's no lastOp, just set it.
+    if (!bulkResult.lastOp) {
+      bulkResult.lastOp = opTime;
+    } else {
+      // First compare the ts values and set if the opTimeTS value is greater.
+      const lastOpTS = longOrConvert(bulkResult.lastOp.ts);
+      const opTimeTS = longOrConvert(opTime.ts);
+      if (opTimeTS.greaterThan(lastOpTS)) {
         bulkResult.lastOp = opTime;
-      } else {
-        // First compare the ts values and set if the opTimeTS value is greater.
-        const lastOpTS = longOrConvert(bulkResult.lastOp.ts);
-        const opTimeTS = longOrConvert(opTime.ts);
-        if (opTimeTS.greaterThan(lastOpTS)) {
+      } else if (opTimeTS.equals(lastOpTS)) {
+        // If the ts values are equal, then compare using the t values.
+        const lastOpT = longOrConvert(bulkResult.lastOp.t);
+        const opTimeT = longOrConvert(opTime.t);
+        if (opTimeT.greaterThan(lastOpT)) {
           bulkResult.lastOp = opTime;
-        } else if (opTimeTS.equals(lastOpTS)) {
-          // If the ts values are equal, then compare using the t values.
-          const lastOpT = longOrConvert(bulkResult.lastOp.t);
-          const opTimeT = longOrConvert(opTime.t);
-          if (opTimeT.greaterThan(lastOpT)) {
-            bulkResult.lastOp = opTime;
-          }
         }
       }
     }

--- a/test/unit/bulk_write.test.js
+++ b/test/unit/bulk_write.test.js
@@ -137,44 +137,122 @@ describe('Bulk Writes', function() {
   });
 
   describe('#mergeBatchResults', function() {
-    context('when opTime is an object', function() {
-      context('when the lastOp is a Timestamp', function() {
-        const batch = [];
-        const bulkResult = {
-          ok: 1,
-          writeErrors: [],
-          writeConcernErrors: [],
-          insertedIds: [],
-          nInserted: 0,
-          nUpserted: 0,
-          nMatched: 0,
-          nModified: 0,
-          nRemoved: 1,
-          upserted: [],
-          lastOp: {
-            ts: 7020546605669417496,
-            t: 10
-          }
-        };
-        const result = {
-          n: 8,
-          nModified: 8,
-          opTime: Timestamp.fromNumber(8020546605669417496),
-          electionId: '7fffffff0000000000000028',
-          ok: 1,
-          $clusterTime: {
-            clusterTime: '7020546605669417498',
-            signature: {
-              hash: 'AAAAAAAAAAAAAAAAAAAAAAAAAAA=',
-              keyId: 0
-            }
-          },
-          operationTime: '7020546605669417498'
-        };
+    let opTime;
+    let lastOp;
+    const bulkResult = {
+      ok: 1,
+      writeErrors: [],
+      writeConcernErrors: [],
+      insertedIds: [],
+      nInserted: 0,
+      nUpserted: 0,
+      nMatched: 0,
+      nModified: 0,
+      nRemoved: 1,
+      upserted: []
+    };
+    const result = {
+      n: 8,
+      nModified: 8,
+      electionId: '7fffffff0000000000000028',
+      ok: 1,
+      $clusterTime: {
+        clusterTime: '7020546605669417498',
+        signature: {
+          hash: 'AAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+          keyId: 0
+        }
+      },
+      operationTime: '7020546605669417498'
+    };
+    const batch = [];
 
-        it('replaces the lastOp with the properly formatted timestamp', function() {
+    context('when lastOp is an object', function() {
+      context('when the opTime is a Timestamp', function() {
+        before(function() {
+          lastOp = { ts: 7020546605669417496, t: 10 };
+          opTime = Timestamp.fromNumber(8020546605669417496);
+          bulkResult.lastOp = lastOp;
+          result.opTime = opTime;
+        });
+
+        it('replaces the lastOp with the properly formatted object', function() {
           mergeBatchResults(batch, bulkResult, null, result);
-          expect(bulkResult.lastOp.t).to.equal(Long.ZERO);
+          expect(bulkResult.lastOp).to.deep.equal({ ts: opTime, t: Long.ZERO });
+        });
+      });
+
+      context('when the opTime is an object', function() {
+        context('when the ts is greater', function() {
+          before(function() {
+            lastOp = { ts: 7020546605669417496, t: 10 };
+            opTime = { ts: 7020546605669417497, t: 10 };
+            bulkResult.lastOp = lastOp;
+            result.opTime = opTime;
+          });
+
+          it('replaces the lastOp with the new opTime', function() {
+            mergeBatchResults(batch, bulkResult, null, result);
+            expect(bulkResult.lastOp).to.deep.equal(opTime);
+          });
+        });
+
+        context('when the ts is equal', function() {
+          context('when the t is greater', function() {
+            before(function() {
+              lastOp = { ts: 7020546605669417496, t: 10 };
+              opTime = { ts: 7020546605669417496, t: 20 };
+              bulkResult.lastOp = lastOp;
+              result.opTime = opTime;
+            });
+
+            it('replaces the lastOp with the new opTime', function() {
+              mergeBatchResults(batch, bulkResult, null, result);
+              expect(bulkResult.lastOp).to.deep.equal(opTime);
+            });
+          });
+
+          context('when the t is equal', function() {
+            before(function() {
+              lastOp = { ts: 7020546605669417496, t: 10 };
+              opTime = { ts: 7020546605669417496, t: 10 };
+              bulkResult.lastOp = lastOp;
+              result.opTime = opTime;
+            });
+
+            it('does not replace the lastOp with the new opTime', function() {
+              mergeBatchResults(batch, bulkResult, null, result);
+              expect(bulkResult.lastOp).to.deep.equal(lastOp);
+            });
+          });
+
+          context('when the t is less', function() {
+            before(function() {
+              lastOp = { ts: 7020546605669417496, t: 10 };
+              opTime = { ts: 7020546605669417496, t: 5 };
+              bulkResult.lastOp = lastOp;
+              result.opTime = opTime;
+            });
+
+            it('does not replace the lastOp with the new opTime', function() {
+              mergeBatchResults(batch, bulkResult, null, result);
+              expect(bulkResult.lastOp).to.deep.equal(lastOp);
+            });
+          });
+        });
+
+        context('when the ts is less', function() {
+          before(function() {
+            lastOp = { ts: 7020546605669417496, t: 10 };
+            opTime = { ts: 7020546605669417495, t: 10 };
+            bulkResult.lastOp = lastOp;
+            result.opTime = opTime;
+          });
+
+          it('does not replace the lastOp with the new opTime', function() {
+            mergeBatchResults(batch, bulkResult, null, result);
+            expect(bulkResult.lastOp).to.deep.equal(lastOp);
+          });
         });
       });
     });


### PR DESCRIPTION
### Description

Fixes the merging of results in a bulk write inside a transaction to properly compare and set the `lastOp` value in the result.

#### What is changing?

Per various specifications, `lastOp` and `opTime` are optional fields in results that can be either a `Timestamp`, or an object with a `ts` and `t` property of `Timestamp` and `Long` respectively. In some cases they are both `Longs`. Our comparison logic on these values could get into a hot mess when trying to compare values of different types. This changes the `lastOp` value in the bulk write result to always be an object with the `ts` and `t` fields and never sets it as a `Timestamp` value anymore.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

This was reported as a bug in HELP-28460 and related to NODE-3515, although the user provided patch did not solve all potential cases.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
