### PR TITLE
docs(NODE-3650): Note that boolean options must now be specified as booleans in upgrade guide

### DIFF
--- a/docs/CHANGES_4.0.0.md
+++ b/docs/CHANGES_4.0.0.md
@@ -175,7 +175,7 @@ Users should use `authMechanismProperties.SERVICE_NAME` like so:
 - Or as an option: `{ authMechanismProperties: { SERVICE_NAME: 'alternateServiceName' } }`
 
 ### Non-boolean types are no longer accepted for boolean options
-Previously, the driver would accept values that could be coerced to booleans (e.g. `0` and `1`) for  boolean options (for example, `UpdateOptions.upsert`). This is longer the case; any option documented as being a boolean must be specified as a boolean value.
+Previously, the driver would accept values that could be coerced to booleans (e.g. `0` and `1`) for  boolean options (for example, `UpdateOptions.upsert`). This is no longer the case; any option documented as being a boolean must be specified as a boolean value.
 
 ### db.collection no longer accepts a callback
 


### PR DESCRIPTION
### Description
Driver 3.x would accept values such as `0` and `1` in place of booleans. We no longer accept them as of 4.0. This PR notes the change in the upgrade guide.

#### What is changing?
Added a section to the upgrade guide.

##### Is there new documentation needed for these changes?
This is documentation 🙂

#### What is the motivation for this change?
A user was confused by this behavior and posted on the community forums about it.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script (to be honest I didn't do this because I don't have a local dev environment set up, but I doubt this file gets linted 🙂)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests (N/A)
- [x] New TODOs have a related JIRA ticket (N/A)
