### PR TITLE
fix(NODE-3727): add overloads for BulkOperationBase's execute function

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1216,9 +1216,15 @@ export abstract class BulkOperationBase {
     return batches;
   }
 
-  /** An internal helper method. Do not invoke directly. Will be going away in the future */
+  execute(options?: BulkWriteOptions): Promise<BulkWriteResult>;
+  execute(callback: Callback<BulkWriteResult>): void;
+  execute(options: BulkWriteOptions | undefined, callback: Callback<BulkWriteResult>): void;
   execute(
-    options?: BulkWriteOptions,
+    options?: BulkWriteOptions | Callback<BulkWriteResult>,
+    callback?: Callback<BulkWriteResult>
+  ): Promise<BulkWriteResult> | void;
+  execute(
+    options?: BulkWriteOptions | Callback<BulkWriteResult>,
     callback?: Callback<BulkWriteResult>
   ): Promise<BulkWriteResult> | void {
     if (typeof options === 'function') (callback = options), (options = {});

--- a/test/types/community/bulk/bulk-operation-base.test-d.ts
+++ b/test/types/community/bulk/bulk-operation-base.test-d.ts
@@ -65,7 +65,7 @@ expectType<void>(
   })
 );
 
-// ensure we can use the create collection in a callback based wrapper function
+// ensure we can use the bulk operation execute in a callback based wrapper function
 function extendedCallbackBasedBulkExecute(
   callback: Callback<BulkWriteResult>,
   optionalOptions?: BulkWriteOptions

--- a/test/types/community/bulk/bulk-operation-base.test-d.ts
+++ b/test/types/community/bulk/bulk-operation-base.test-d.ts
@@ -1,0 +1,81 @@
+import { expectType } from 'tsd';
+
+import {
+  BulkWriteResult,
+  MongoClient,
+  BatchType,
+  UpdateStatement,
+  DeleteStatement,
+  AnyError,
+  BulkWriteOptions,
+  Callback,
+  Document
+} from '../../../../src/index';
+import { BulkOperationBase, Batch } from '../../../../src/bulk/common';
+
+const client = new MongoClient('');
+const db = client.db('test');
+const collection = db.collection('test');
+
+class TestBulkOperation extends BulkOperationBase {
+  constructor() {
+    super(collection, {}, true);
+  }
+
+  addToOperationsList(
+    batchType: BatchType,
+    document: Document | UpdateStatement | DeleteStatement
+  ): this {
+    this.s.currentBatch = new Batch<Document>(batchType, 0);
+    this.s.currentBatch.operations.push(document);
+    return this;
+  }
+}
+
+const bulkOperation = new TestBulkOperation();
+
+// execute
+
+const options: BulkWriteOptions = {};
+
+expectType<Promise<BulkWriteResult>>(bulkOperation.execute());
+
+expectType<Promise<BulkWriteResult>>(bulkOperation.execute(options));
+
+// ensure we can use the create collection in a callback based wrapper function
+function extendedPromiseBasedBulkExecute(
+  optionalOptions?: BulkWriteOptions
+): Promise<BulkWriteResult> {
+  return bulkOperation.execute(optionalOptions);
+}
+
+expectType<Promise<BulkWriteResult>>(extendedPromiseBasedBulkExecute());
+
+expectType<void>(
+  bulkOperation.execute((error, bulkWriteResult) => {
+    expectType<AnyError | undefined>(error);
+    expectType<BulkWriteResult | undefined>(bulkWriteResult);
+  })
+);
+
+expectType<void>(
+  bulkOperation.execute(options, (error, bulkWriteResult) => {
+    expectType<AnyError | undefined>(error);
+    expectType<BulkWriteResult | undefined>(bulkWriteResult);
+  })
+);
+
+// ensure we can use the create collection in a callback based wrapper function
+function extendedCallbackBasedBulkExecute(
+  callback: Callback<BulkWriteResult>,
+  optionalOptions?: BulkWriteOptions
+): void {
+  bulkOperation.execute(optionalOptions, callback);
+}
+
+expectType<void>(
+  extendedCallbackBasedBulkExecute((error, bulkWriteResult) => {
+    expectType<AnyError | undefined>(error);
+    expectType<BulkWriteResult | undefined>(bulkWriteResult);
+  })
+);

--- a/test/types/community/bulk/bulk-operation-base.test-d.ts
+++ b/test/types/community/bulk/bulk-operation-base.test-d.ts
@@ -42,7 +42,7 @@ expectType<Promise<BulkWriteResult>>(bulkOperation.execute());
 
 expectType<Promise<BulkWriteResult>>(bulkOperation.execute(options));
 
-// ensure we can use the create collection in a callback based wrapper function
+// ensure we can use the bulk operation execute in a callback based wrapper function
 function extendedPromiseBasedBulkExecute(
   optionalOptions?: BulkWriteOptions
 ): Promise<BulkWriteResult> {


### PR DESCRIPTION
### Description

Add overloads for BulkOperationBase's execute function.

#### What is changing?

This adds overloads to the execute function, to ensure void is returned if a callback is provided, 
and a promise is returned if no callback is specified.

##### Is there new documentation needed for these changes? No.

#### What is the motivation for this change?

Missing overloads.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
