### PR TITLE
fix(NODE-3726): add optional option overloads of Db's createCollection function

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -226,18 +226,17 @@ export class Db {
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
-  createCollection<TSchema extends Document = Document>(name: string): Promise<Collection<TSchema>>;
+  createCollection<TSchema extends Document = Document>(
+    name: string,
+    options?: CreateCollectionOptions
+  ): Promise<Collection<TSchema>>;
   createCollection<TSchema extends Document = Document>(
     name: string,
     callback: Callback<Collection<TSchema>>
   ): void;
   createCollection<TSchema extends Document = Document>(
     name: string,
-    options: CreateCollectionOptions
-  ): Promise<Collection<TSchema>>;
-  createCollection<TSchema extends Document = Document>(
-    name: string,
-    options: CreateCollectionOptions,
+    options: CreateCollectionOptions | undefined,
     callback: Callback<Collection<TSchema>>
   ): void;
   createCollection<TSchema extends Document = Document>(

--- a/test/types/community/db/createCollection.test-d.ts
+++ b/test/types/community/db/createCollection.test-d.ts
@@ -1,0 +1,82 @@
+import { expectType } from 'tsd';
+
+import {
+  MongoClient,
+  ObjectId,
+  Collection,
+  CreateCollectionOptions,
+  AnyError,
+  Callback
+} from '../../../../src/index';
+
+const client = new MongoClient('');
+const db = client.db('test');
+
+interface SubTestSchema {
+  field1: string;
+  field2: string;
+}
+
+type FruitTypes = 'apple' | 'pear';
+
+// test with collection type
+interface TestSchema {
+  _id: ObjectId;
+  stringField: string;
+  numberField: number;
+  optionalNumberField?: number;
+  dateField: Date;
+  fruitTags: string[];
+  maybeFruitTags?: FruitTypes[];
+  readonlyFruitTags: ReadonlyArray<string>;
+  subInterfaceField: SubTestSchema;
+  subInterfaceArray: SubTestSchema[];
+}
+
+const options: CreateCollectionOptions = {};
+
+// createCollection
+
+expectType<Promise<Collection<TestSchema>>>(db.createCollection<TestSchema>('test'));
+
+expectType<Promise<Collection<TestSchema>>>(db.createCollection<TestSchema>('test', options));
+
+// ensure we can use the create collection in a promise based wrapper function
+function extendedPromiseBasedCreateCollection(
+  name: string,
+  optionalOptions?: CreateCollectionOptions
+): Promise<Collection<TestSchema>> {
+  return db.createCollection<TestSchema>(name, optionalOptions);
+}
+
+expectType<Promise<Collection<TestSchema>>>(extendedPromiseBasedCreateCollection('test'));
+
+expectType<void>(
+  db.createCollection<TestSchema>('test', (err, collection) => {
+    expectType<AnyError | undefined>(err);
+    expectType<Collection<TestSchema> | undefined>(collection);
+  })
+);
+
+expectType<void>(
+  db.createCollection<TestSchema>('test', options, (err, collection) => {
+    expectType<AnyError | undefined>(err);
+    expectType<Collection<TestSchema> | undefined>(collection);
+  })
+);
+
+// ensure we can use the create collection in a callback based wrapper function
+function extendedCallbackBasedCreateCollection(
+  name: string,
+  callback: Callback<Collection<TestSchema>>,
+  optionalOptions?: CreateCollectionOptions
+): void {
+  db.createCollection<TestSchema>(name, optionalOptions, callback);
+}
+
+expectType<void>(
+  extendedCallbackBasedCreateCollection('test', (err, collection) => {
+    expectType<AnyError | undefined>(err);
+    expectType<Collection<TestSchema> | undefined>(collection);
+  })
+);


### PR DESCRIPTION
### Description

Add support for optional options in createColelction.

#### What is changing?

This adds support for calling createCollection with optional options.
This is useful if for example a wrapper function is used.

##### Is there new documentation needed for these changes? No.

#### What is the motivation for this change?

Overloads do not allow optional options.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
