### PR TITLE
feat(NODE-3728): Allow to pass `authorizedCollections` option to the `db.listCollections` method

### DIFF
--- a/src/operations/list_collections.ts
+++ b/src/operations/list_collections.ts
@@ -15,6 +15,8 @@ const LIST_COLLECTIONS_WIRE_VERSION = 3;
 export interface ListCollectionsOptions extends CommandOperationOptions {
   /** Since 4.0: If true, will only return the collection name in the response, and will omit additional info */
   nameOnly?: boolean;
+  /** Since 4.0: If true and nameOnly is true, allows a user without the required privilege (i.e. listCollections action on the database) to run the command when access control is enforced. */
+  authorizedCollections?: boolean;
   /** The batchSize for the returned command cursor or if pre 2.8 the systems batch collection */
   batchSize?: number;
 }
@@ -25,6 +27,7 @@ export class ListCollectionsOperation extends CommandOperation<string[]> {
   db: Db;
   filter: Document;
   nameOnly: boolean;
+  authorizedCollections: boolean;
   batchSize?: number;
 
   constructor(db: Db, filter: Document, options?: ListCollectionsOptions) {
@@ -34,6 +37,7 @@ export class ListCollectionsOperation extends CommandOperation<string[]> {
     this.db = db;
     this.filter = filter;
     this.nameOnly = !!this.options.nameOnly;
+    this.authorizedCollections = !!this.options.authorizedCollections;
 
     if (typeof this.options.batchSize === 'number') {
       this.batchSize = this.options.batchSize;
@@ -99,7 +103,8 @@ export class ListCollectionsOperation extends CommandOperation<string[]> {
       listCollections: 1,
       filter: this.filter,
       cursor: this.batchSize ? { batchSize: this.batchSize } : {},
-      nameOnly: this.nameOnly
+      nameOnly: this.nameOnly,
+      authorizedCollections: this.authorizedCollections
     };
   }
 }

--- a/test/unit/operations/list_collections.test.js
+++ b/test/unit/operations/list_collections.test.js
@@ -51,16 +51,12 @@ describe('ListCollectionsOperation', function () {
       });
     });
 
-    context('when nameOnly is not provided', function () {
+    context('when no options are provided', function () {
       const operation = new ListCollectionsOperation(db, {}, { dbName: db });
 
       it('sets nameOnly to false', function () {
         expect(operation).to.have.property('nameOnly', false);
       });
-    });
-
-    context('when authorizedCollections is not provided', function () {
-      const operation = new ListCollectionsOperation(db, {}, { dbName: db });
 
       it('sets authorizedCollections to false', function () {
         expect(operation).to.have.property('authorizedCollections', false);
@@ -137,24 +133,10 @@ describe('ListCollectionsOperation', function () {
       });
     });
 
-    context('when nameOnly is not provided', function () {
+    context('when no options are provided', function () {
       const operation = new ListCollectionsOperation(db, {}, { dbName: db });
 
-      it('sets nameOnly to false', function () {
-        expect(operation.generateCommand()).to.deep.equal({
-          listCollections: 1,
-          cursor: {},
-          filter: {},
-          nameOnly: false,
-          authorizedCollections: false
-        });
-      });
-    });
-
-    context('when authorizedCollections is not provided', function () {
-      const operation = new ListCollectionsOperation(db, {}, { dbName: db });
-
-      it('sets authorizedCollections to false', function () {
+      it('sets nameOnly and authorizedCollections properties to false', function () {
         expect(operation.generateCommand()).to.deep.equal({
           listCollections: 1,
           cursor: {},

--- a/test/unit/operations/list_collections.test.js
+++ b/test/unit/operations/list_collections.test.js
@@ -12,7 +12,7 @@ describe('ListCollectionsOperation', function () {
         const operation = new ListCollectionsOperation(db, {}, { nameOnly: true, dbName: db });
 
         it('sets nameOnly to true', function () {
-          expect(operation.nameOnly).to.be.true;
+          expect(operation).to.have.property('nameOnly', true);
         });
       });
 
@@ -20,7 +20,33 @@ describe('ListCollectionsOperation', function () {
         const operation = new ListCollectionsOperation(db, {}, { nameOnly: false, dbName: db });
 
         it('sets nameOnly to false', function () {
-          expect(operation.nameOnly).to.be.false;
+          expect(operation).to.have.property('nameOnly', false);
+        });
+      });
+    });
+
+    context('when authorizedCollections is provided', function () {
+      context('when authorizedCollections is true', function () {
+        const operation = new ListCollectionsOperation(
+          db,
+          {},
+          { authorizedCollections: true, dbName: db }
+        );
+
+        it('sets authorizedCollections to true', function () {
+          expect(operation).to.have.property('authorizedCollections', true);
+        });
+      });
+
+      context('when authorizedCollections is false', function () {
+        const operation = new ListCollectionsOperation(
+          db,
+          {},
+          { authorizedCollections: false, dbName: db }
+        );
+
+        it('sets authorizedCollections to false', function () {
+          expect(operation).to.have.property('authorizedCollections', false);
         });
       });
     });
@@ -29,7 +55,15 @@ describe('ListCollectionsOperation', function () {
       const operation = new ListCollectionsOperation(db, {}, { dbName: db });
 
       it('sets nameOnly to false', function () {
-        expect(operation.nameOnly).to.be.false;
+        expect(operation).to.have.property('nameOnly', false);
+      });
+    });
+
+    context('when authorizedCollections is not provided', function () {
+      const operation = new ListCollectionsOperation(db, {}, { dbName: db });
+
+      it('sets authorizedCollections to false', function () {
+        expect(operation).to.have.property('authorizedCollections', false);
       });
     });
   });
@@ -44,7 +78,8 @@ describe('ListCollectionsOperation', function () {
             listCollections: 1,
             cursor: {},
             filter: {},
-            nameOnly: true
+            nameOnly: true,
+            authorizedCollections: false
           });
         });
       });
@@ -57,7 +92,46 @@ describe('ListCollectionsOperation', function () {
             listCollections: 1,
             cursor: {},
             filter: {},
-            nameOnly: false
+            nameOnly: false,
+            authorizedCollections: false
+          });
+        });
+      });
+    });
+
+    context('when authorizedCollections is provided', function () {
+      context('when authorizedCollections is true', function () {
+        const operation = new ListCollectionsOperation(
+          db,
+          {},
+          { authorizedCollections: true, dbName: db }
+        );
+
+        it('sets authorizedCollections to true', function () {
+          expect(operation.generateCommand()).to.deep.equal({
+            listCollections: 1,
+            cursor: {},
+            filter: {},
+            nameOnly: false,
+            authorizedCollections: true
+          });
+        });
+      });
+
+      context('when authorizedCollections is false', function () {
+        const operation = new ListCollectionsOperation(
+          db,
+          {},
+          { authorizedCollections: false, dbName: db }
+        );
+
+        it('sets authorizedCollections to false', function () {
+          expect(operation.generateCommand()).to.deep.equal({
+            listCollections: 1,
+            cursor: {},
+            filter: {},
+            nameOnly: false,
+            authorizedCollections: false
           });
         });
       });
@@ -71,7 +145,22 @@ describe('ListCollectionsOperation', function () {
           listCollections: 1,
           cursor: {},
           filter: {},
-          nameOnly: false
+          nameOnly: false,
+          authorizedCollections: false
+        });
+      });
+    });
+
+    context('when authorizedCollections is not provided', function () {
+      const operation = new ListCollectionsOperation(db, {}, { dbName: db });
+
+      it('sets authorizedCollections to false', function () {
+        expect(operation.generateCommand()).to.deep.equal({
+          listCollections: 1,
+          cursor: {},
+          filter: {},
+          nameOnly: false,
+          authorizedCollections: false
         });
       });
     });


### PR DESCRIPTION
### Description
This patch allows to pass `authorizedCollections` option when using `db.listCollections` method

#### What is changing?
`ListCollectionsOperation` class now has `authorizedCollections` defined and handled in a similar fashion to the `nameOnly` option

##### Is there new documentation needed for these changes?
Not needed (I think)

#### What is the motivation for this change?
This adds support for a `listCollections` command option that is helpful when you want to fetch a list of collections for the user that might not have enough privileges to list them otherwise. A full description can be found in [the `listCollections` command docs](https://docs.mongodb.com/manual/reference/command/listCollections/#listcollections)

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Ran `npm run test` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
