### PR TITLE
feat(NODE-3083): support aggregate writes on secondaries

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -97,6 +97,7 @@ export interface CommandOptions extends BSONSerializeOptions {
   session?: ClientSession;
   documentsReturnedIn?: string;
   noResponse?: boolean;
+  omitReadPreference?: boolean;
 
   // FIXME: NODE-2802
   willRetryWrite?: boolean;

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -1,5 +1,4 @@
 import { CommandOperation, CommandOperationOptions, CollationOptions } from './command';
-import { ReadPreference } from '../read_preference';
 import { MongoInvalidArgumentError } from '../error';
 import { maxWireVersion, MongoDBNamespace } from '../utils';
 import { Aspect, defineAspects, Hint } from './operation';
@@ -65,7 +64,7 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
     }
 
     if (this.hasWriteStage) {
-      this.readPreference = ReadPreference.primary;
+      this.trySecondaryWrite = true;
     }
 
     if (this.explain && this.writeConcern) {

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -10,6 +10,7 @@ import type { Server } from '../sdam/server';
 import type { BSONSerializeOptions, Document } from '../bson';
 import type { ReadConcernLike } from './../read_concern';
 import { Explain, ExplainOptions } from '../explain';
+import { MIN_SECONDARY_WRITE_WIRE_VERSION } from '../sdam/server_selection';
 
 const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
 
@@ -124,6 +125,10 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
 
     if (this.readConcern && commandSupportsReadConcern(cmd) && !inTransaction) {
       Object.assign(cmd, { readConcern: this.readConcern });
+    }
+
+    if (this.trySecondaryWrite && serverWireVersion < MIN_SECONDARY_WRITE_WIRE_VERSION) {
+      options.omitReadPreference = true;
     }
 
     if (options.collation && serverWireVersion < SUPPORTS_WRITE_CONCERN_AND_COLLATION) {

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -49,6 +49,7 @@ export abstract class AbstractOperation<TResult = any> {
   readPreference: ReadPreference;
   server!: Server;
   bypassPinningCheck: boolean;
+  trySecondaryWrite = false;
 
   // BSON serialization options
   bsonOptions?: BSONSerializeOptions;

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -31,6 +31,7 @@ export interface OperationOptions extends BSONSerializeOptions {
 
   /** @internal Hints to `executeOperation` that this operation should not unpin on an ended transaction */
   bypassPinningCheck?: boolean;
+  omitReadPreference?: boolean;
 }
 
 /** @internal */
@@ -49,7 +50,7 @@ export abstract class AbstractOperation<TResult = any> {
   readPreference: ReadPreference;
   server!: Server;
   bypassPinningCheck: boolean;
-  trySecondaryWrite = false;
+  trySecondaryWrite: boolean;
 
   // BSON serialization options
   bsonOptions?: BSONSerializeOptions;
@@ -73,6 +74,7 @@ export abstract class AbstractOperation<TResult = any> {
 
     this.options = options;
     this.bypassPinningCheck = !!options.bypassPinningCheck;
+    this.trySecondaryWrite = false;
   }
 
   abstract execute(server: Server, session: ClientSession, callback: Callback<TResult>): void;

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -299,6 +299,14 @@ export class Server extends TypedEventEmitter<ServerEvents> {
     // Clone the options
     const finalOptions = Object.assign({}, options, { wireProtocolCommand: false });
 
+    // There are cases where we need to flag the read preference not to get sent in
+    // the command, such as pre-5.0 servers attempting to perform an aggregate write
+    // with a non-primary read preference. In this case the effective read preference
+    // (primary) is not the same as the provided and must be removed completely.
+    if (finalOptions.omitReadPreference) {
+      delete finalOptions.readPreference;
+    }
+
     // error if collation not supported
     if (collationNotSupported(this, cmd)) {
       callback(new MongoCompatibilityError(`Server ${this.name} does not support collation`));

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -43,6 +43,8 @@ export function secondaryWritableServerSelector(
   // If server version >= 5.0...
   // - If read preference is supplied, use that.
   // - If no read preference is supplied, use primary.
+  /* eslint no-console: 0 */
+  console.log('select', readPreference, wireVersion);
   if (!readPreference || (wireVersion && wireVersion < MIN_SECONDARY_WRITE_WIRE_VERSION)) {
     return readPreferenceServerSelector(ReadPreference.primary);
   }

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -43,8 +43,6 @@ export function secondaryWritableServerSelector(
   // If server version >= 5.0...
   // - If read preference is supplied, use that.
   // - If no read preference is supplied, use primary.
-  /* eslint no-console: 0 */
-  console.log('select', readPreference, wireVersion);
   if (!readPreference || (wireVersion && wireVersion < MIN_SECONDARY_WRITE_WIRE_VERSION)) {
     return readPreferenceServerSelector(ReadPreference.primary);
   }

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -43,7 +43,11 @@ export function secondaryWritableServerSelector(
   // If server version >= 5.0...
   // - If read preference is supplied, use that.
   // - If no read preference is supplied, use primary.
-  if (!readPreference || (wireVersion && wireVersion < MIN_SECONDARY_WRITE_WIRE_VERSION)) {
+  if (
+    !readPreference ||
+    !wireVersion ||
+    (wireVersion && wireVersion < MIN_SECONDARY_WRITE_WIRE_VERSION)
+  ) {
     return readPreferenceServerSelector(ReadPreference.primary);
   }
   return readPreferenceServerSelector(readPreference);

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -8,6 +8,9 @@ import type { ServerDescription, TagSet } from './server_description';
 const IDLE_WRITE_PERIOD = 10000;
 const SMALLEST_MAX_STALENESS_SECONDS = 90;
 
+//  Minimum version to try writes on secondaries.
+export const MIN_SECONDARY_WRITE_WIRE_VERSION = 13;
+
 /** @public */
 export type ServerSelector = (
   topologyDescription: TopologyDescription,
@@ -26,6 +29,24 @@ export function writableServerSelector(): ServerSelector {
       topologyDescription,
       servers.filter((s: ServerDescription) => s.isWritable)
     );
+}
+
+/**
+ * Returns a server selector that uses a read preference to select a
+ * server potentially for a write on a secondary.
+ */
+export function secondaryWritableServerSelector(
+  wireVersion?: number,
+  readPreference?: ReadPreference
+): ServerSelector {
+  // If server version < 5.0, read preference always primary.
+  // If server version >= 5.0...
+  // - If read preference is supplied, use that.
+  // - If no read preference is supplied, use primary.
+  if (!readPreference || (wireVersion && wireVersion < MIN_SECONDARY_WRITE_WIRE_VERSION)) {
+    return readPreferenceServerSelector(ReadPreference.primary);
+  }
+  return readPreferenceServerSelector(readPreference);
 }
 
 /**

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -797,6 +797,10 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
     return result;
   }
 
+  get commonWireVersion(): number | undefined {
+    return this.description.commonWireVersion;
+  }
+
   get logicalSessionTimeoutMinutes(): number | undefined {
     return this.description.logicalSessionTimeoutMinutes;
   }

--- a/test/functional/crud_spec.test.js
+++ b/test/functional/crud_spec.test.js
@@ -424,15 +424,11 @@ describe('CRUD spec v1', function () {
   }
 });
 
-// TODO: Unskip when implementing NODE-3083.
-const SKIP = ['aggregate-write-readPreference', 'db-aggregate-write-readPreference'];
-
 describe('CRUD unified', function () {
   for (const crudSpecTest of loadSpecTests('crud/unified')) {
     expect(crudSpecTest).to.exist;
     const testDescription = String(crudSpecTest.description);
-    const spec = SKIP.includes(testDescription) ? context.skip : context;
-    spec(testDescription, function () {
+    context(testDescription, function () {
       for (const test of crudSpecTest.tests) {
         it(String(test.description), {
           metadata: { sessions: { skipLeakTests: true } },

--- a/test/spec/crud/unified/aggregate-write-readPreference.json
+++ b/test/spec/crud/unified/aggregate-write-readPreference.json
@@ -1,6 +1,6 @@
 {
   "description": "aggregate-write-readPreference",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "3.6",
@@ -90,7 +90,8 @@
       "description": "Aggregate with $out includes read preference for 5.0+ server",
       "runOnRequirements": [
         {
-          "minServerVersion": "5.0"
+          "minServerVersion": "5.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -181,7 +182,8 @@
       "runOnRequirements": [
         {
           "minServerVersion": "4.2",
-          "maxServerVersion": "4.4.99"
+          "maxServerVersion": "4.4.99",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/test/spec/crud/unified/aggregate-write-readPreference.yml
+++ b/test/spec/crud/unified/aggregate-write-readPreference.yml
@@ -1,6 +1,6 @@
 description: aggregate-write-readPreference
 
-schemaVersion: '1.3'
+schemaVersion: '1.4'
 
 runOnRequirements:
   # 3.6+ non-standalone is needed to utilize $readPreference in OP_MSG
@@ -59,6 +59,7 @@ tests:
   - description: "Aggregate with $out includes read preference for 5.0+ server"
     runOnRequirements:
       - minServerVersion: "5.0"
+        serverless: "forbid"
     operations:
       - object: *collection0
         name: aggregate
@@ -91,6 +92,7 @@ tests:
       # drivers may avoid inheriting a client-level read concern for pre-4.2.
       - minServerVersion: "4.2"
         maxServerVersion: "4.4.99"
+        serverless: "forbid"
     operations:
       - object: *collection0
         name: aggregate

--- a/test/spec/crud/unified/db-aggregate-write-readPreference.json
+++ b/test/spec/crud/unified/db-aggregate-write-readPreference.json
@@ -64,7 +64,8 @@
       "description": "Database-level aggregate with $out includes read preference for 5.0+ server",
       "runOnRequirements": [
         {
-          "minServerVersion": "5.0"
+          "minServerVersion": "5.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -158,7 +159,8 @@
       "runOnRequirements": [
         {
           "minServerVersion": "4.2",
-          "maxServerVersion": "4.4.99"
+          "maxServerVersion": "4.4.99",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/test/spec/crud/unified/db-aggregate-write-readPreference.yml
+++ b/test/spec/crud/unified/db-aggregate-write-readPreference.yml
@@ -52,6 +52,7 @@ tests:
   - description: "Database-level aggregate with $out includes read preference for 5.0+ server"
     runOnRequirements:
       - minServerVersion: "5.0"
+        serverless: "forbid"
     operations:
       - object: *database0
         name: aggregate
@@ -85,6 +86,7 @@ tests:
       # drivers may avoid inheriting a client-level read concern for pre-4.2.
       - minServerVersion: "4.2"
         maxServerVersion: "4.4.99"
+        serverless: "forbid"
     operations:
       - object: *database0
         name: aggregate

--- a/test/unit/operations/aggregate.test.js
+++ b/test/unit/operations/aggregate.test.js
@@ -23,6 +23,16 @@ describe('AggregateOperation', function () {
       });
     });
 
+    context('when $out is not the last stage', function () {
+      const operation = new AggregateOperation(db, [{ $out: 'test' }, { $project: { name: 1 } }], {
+        dbName: db
+      });
+
+      it('sets trySecondaryWrite to false', function () {
+        expect(operation.trySecondaryWrite).to.be.false;
+      });
+    });
+
     context('when $merge is the last stage', function () {
       const operation = new AggregateOperation(db, [{ $merge: { into: 'test' } }], { dbName: db });
 
@@ -31,8 +41,28 @@ describe('AggregateOperation', function () {
       });
     });
 
-    context('when no writable stages', function () {
+    context('when $merge is not the last stage', function () {
+      const operation = new AggregateOperation(
+        db,
+        [{ $merge: { into: 'test' } }, { $project: { name: 1 } }],
+        { dbName: db }
+      );
+
+      it('sets trySecondaryWrite to false', function () {
+        expect(operation.trySecondaryWrite).to.be.false;
+      });
+    });
+
+    context('when no writable stages in empty pipeline', function () {
       const operation = new AggregateOperation(db, [], { dbName: db });
+
+      it('sets trySecondaryWrite to false', function () {
+        expect(operation.trySecondaryWrite).to.be.false;
+      });
+    });
+
+    context('when no writable stages', function () {
+      const operation = new AggregateOperation(db, [{ $project: { name: 1 } }], { dbName: db });
 
       it('sets trySecondaryWrite to false', function () {
         expect(operation.trySecondaryWrite).to.be.false;

--- a/test/unit/operations/aggregate.test.js
+++ b/test/unit/operations/aggregate.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { expect } = require('chai');
+const { AggregateOperation } = require('../../../src/operations/aggregate');
+
+describe('AggregateOperation', function () {
+  const db = 'test';
+
+  describe('#constructor', function () {
+    context('when out is in the options', function () {
+      const operation = new AggregateOperation(db, [], { out: 'test', dbName: db });
+
+      it('sets trySecondaryWrite to true', function () {
+        expect(operation.trySecondaryWrite).to.be.true;
+      });
+    });
+
+    context('when $out is the last stage', function () {
+      const operation = new AggregateOperation(db, [{ $out: 'test' }], { dbName: db });
+
+      it('sets trySecondaryWrite to true', function () {
+        expect(operation.trySecondaryWrite).to.be.true;
+      });
+    });
+
+    context('when $merge is the last stage', function () {
+      const operation = new AggregateOperation(db, [{ $merge: { into: 'test' } }], { dbName: db });
+
+      it('sets trySecondaryWrite to true', function () {
+        expect(operation.trySecondaryWrite).to.be.true;
+      });
+    });
+
+    context('when no writable stages', function () {
+      const operation = new AggregateOperation(db, [], { dbName: db });
+
+      it('sets trySecondaryWrite to false', function () {
+        expect(operation.trySecondaryWrite).to.be.false;
+      });
+    });
+  });
+});

--- a/test/unit/sdam/server_selection.test.js
+++ b/test/unit/sdam/server_selection.test.js
@@ -90,5 +90,22 @@ describe('ServerSelector', function () {
         });
       });
     });
+
+    context('when a common wire version is not provided', function () {
+      const topologyDescription = new TopologyDescription(
+        TopologyType.ReplicaSetWithPrimary,
+        serverDescriptions,
+        'test',
+        MIN_SECONDARY_WRITE_WIRE_VERSION,
+        new ObjectId(),
+        MIN_SECONDARY_WRITE_WIRE_VERSION
+      );
+      const selector = secondaryWritableServerSelector();
+      const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+      it('selects a primary', function () {
+        expect(server).to.deep.equal([primary]);
+      });
+    });
   });
 });

--- a/test/unit/sdam/server_selection.test.js
+++ b/test/unit/sdam/server_selection.test.js
@@ -11,7 +11,7 @@ const { ServerDescription } = require('../../../src/sdam/server_description');
 const { TopologyDescription } = require('../../../src/sdam/topology_description');
 const { TopologyType } = require('../../../src/sdam/common');
 
-describe.only('server selection', function () {
+describe('server selection', function () {
   const primary = new ServerDescription('127.0.0.1:27017', {
     setName: 'test',
     isWritablePrimary: true,

--- a/test/unit/sdam/server_selection.test.js
+++ b/test/unit/sdam/server_selection.test.js
@@ -161,7 +161,7 @@ describe('server selection', function () {
           TopologyType.Sharded,
           serverDescriptions,
           'test',
-          MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
           new ObjectId(),
           MIN_SECONDARY_WRITE_WIRE_VERSION - 1
         );
@@ -247,7 +247,7 @@ describe('server selection', function () {
           TopologyType.LoadBalanced,
           serverDescriptions,
           'test',
-          MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
           new ObjectId(),
           MIN_SECONDARY_WRITE_WIRE_VERSION - 1
         );
@@ -333,7 +333,7 @@ describe('server selection', function () {
           TopologyType.Single,
           serverDescriptions,
           'test',
-          MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
           new ObjectId(),
           MIN_SECONDARY_WRITE_WIRE_VERSION - 1
         );

--- a/test/unit/sdam/server_selection.test.js
+++ b/test/unit/sdam/server_selection.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const { expect } = require('chai');
+const { ObjectId } = require('../../../src/bson');
+const { ReadPreference } = require('../../../src/read_preference');
+const {
+  secondaryWritableServerSelector,
+  MIN_SECONDARY_WRITE_WIRE_VERSION
+} = require('../../../src/sdam/server_selection');
+const { ServerDescription } = require('../../../src/sdam/server_description');
+const { TopologyDescription } = require('../../../src/sdam/topology_description');
+const { TopologyType } = require('../../../src/sdam/common');
+
+describe('ServerSelector', function () {
+  describe('#secondaryWritableServerSelector', function () {
+    const primary = new ServerDescription('127.0.0.1:27017', {
+      setName: 'test',
+      isWritablePrimary: true,
+      ok: 1
+    });
+    const secondary = new ServerDescription('127.0.0.1:27018', {
+      setName: 'test',
+      secondary: true,
+      ok: 1
+    });
+    const serverDescriptions = new Map();
+    serverDescriptions.set('127.0.0.1:27017', primary);
+    serverDescriptions.set('127.0.0.1:27018', secondary);
+
+    context('when the common server version is >= 5.0', function () {
+      const topologyDescription = new TopologyDescription(
+        TopologyType.ReplicaSetWithPrimary,
+        serverDescriptions,
+        'test',
+        MIN_SECONDARY_WRITE_WIRE_VERSION,
+        new ObjectId(),
+        MIN_SECONDARY_WRITE_WIRE_VERSION
+      );
+
+      context('when a read preference is provided', function () {
+        const selector = secondaryWritableServerSelector(
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
+          ReadPreference.secondary
+        );
+        const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+        it('uses the provided read preference', function () {
+          expect(server).to.deep.equal([secondary]);
+        });
+      });
+
+      context('when a read preference is not provided', function () {
+        const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION);
+        const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+        it('selects a primary', function () {
+          expect(server).to.deep.equal([primary]);
+        });
+      });
+    });
+
+    context('when the common server version is < 5.0', function () {
+      const topologyDescription = new TopologyDescription(
+        TopologyType.ReplicaSetWithPrimary,
+        serverDescriptions,
+        'test',
+        MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+        new ObjectId(),
+        MIN_SECONDARY_WRITE_WIRE_VERSION - 1
+      );
+
+      context('when a read preference is provided', function () {
+        const selector = secondaryWritableServerSelector(
+          MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+          ReadPreference.secondary
+        );
+        const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+        it('selects a primary', function () {
+          expect(server).to.deep.equal([primary]);
+        });
+      });
+
+      context('when read preference is not provided', function () {
+        const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION - 1);
+        const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+        it('selects a primary', function () {
+          expect(server).to.deep.equal([primary]);
+        });
+      });
+    });
+  });
+});

--- a/test/unit/sdam/server_selection.test.js
+++ b/test/unit/sdam/server_selection.test.js
@@ -11,7 +11,7 @@ const { ServerDescription } = require('../../../src/sdam/server_description');
 const { TopologyDescription } = require('../../../src/sdam/topology_description');
 const { TopologyType } = require('../../../src/sdam/common');
 
-describe('server selection', function () {
+describe.only('server selection', function () {
   const primary = new ServerDescription('127.0.0.1:27017', {
     setName: 'test',
     isWritablePrimary: true,
@@ -75,7 +75,7 @@ describe('server selection', function () {
           TopologyType.ReplicaSetWithPrimary,
           serverDescriptions,
           'test',
-          MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
           new ObjectId(),
           MIN_SECONDARY_WRITE_WIRE_VERSION - 1
         );
@@ -111,7 +111,7 @@ describe('server selection', function () {
           new ObjectId(),
           MIN_SECONDARY_WRITE_WIRE_VERSION
         );
-        const selector = secondaryWritableServerSelector();
+        const selector = secondaryWritableServerSelector(undefined, ReadPreference.secondary);
         const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
 
         it('selects a primary', function () {

--- a/test/unit/sdam/server_selection.test.js
+++ b/test/unit/sdam/server_selection.test.js
@@ -11,78 +11,107 @@ const { ServerDescription } = require('../../../src/sdam/server_description');
 const { TopologyDescription } = require('../../../src/sdam/topology_description');
 const { TopologyType } = require('../../../src/sdam/common');
 
-describe('ServerSelector', function () {
+describe('server selection', function () {
+  const primary = new ServerDescription('127.0.0.1:27017', {
+    setName: 'test',
+    isWritablePrimary: true,
+    ok: 1
+  });
+  const secondary = new ServerDescription('127.0.0.1:27018', {
+    setName: 'test',
+    secondary: true,
+    ok: 1
+  });
+  const mongos = new ServerDescription('127.0.0.1:27019', {
+    msg: 'isdbgrid',
+    ok: 1
+  });
+  const loadBalancer = new ServerDescription('127.0.0.1:27020', { ok: 1 }, { loadBalanced: true });
+  const single = new ServerDescription('127.0.0.1:27021', {
+    isWritablePrimary: true,
+    ok: 1
+  });
+
   describe('#secondaryWritableServerSelector', function () {
-    const primary = new ServerDescription('127.0.0.1:27017', {
-      setName: 'test',
-      isWritablePrimary: true,
-      ok: 1
-    });
-    const secondary = new ServerDescription('127.0.0.1:27018', {
-      setName: 'test',
-      secondary: true,
-      ok: 1
-    });
-    const serverDescriptions = new Map();
-    serverDescriptions.set('127.0.0.1:27017', primary);
-    serverDescriptions.set('127.0.0.1:27018', secondary);
+    context('when the topology is a replica set', function () {
+      const serverDescriptions = new Map();
+      serverDescriptions.set('127.0.0.1:27017', primary);
+      serverDescriptions.set('127.0.0.1:27018', secondary);
 
-    context('when the common server version is >= 5.0', function () {
-      const topologyDescription = new TopologyDescription(
-        TopologyType.ReplicaSetWithPrimary,
-        serverDescriptions,
-        'test',
-        MIN_SECONDARY_WRITE_WIRE_VERSION,
-        new ObjectId(),
-        MIN_SECONDARY_WRITE_WIRE_VERSION
-      );
-
-      context('when a read preference is provided', function () {
-        const selector = secondaryWritableServerSelector(
+      context('when the common server version is >= 5.0', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.ReplicaSetWithPrimary,
+          serverDescriptions,
+          'test',
           MIN_SECONDARY_WRITE_WIRE_VERSION,
-          ReadPreference.secondary
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION
         );
-        const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
 
-        it('uses the provided read preference', function () {
-          expect(server).to.deep.equal([secondary]);
+        context('when a read preference is provided', function () {
+          const selector = secondaryWritableServerSelector(
+            MIN_SECONDARY_WRITE_WIRE_VERSION,
+            ReadPreference.secondary
+          );
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('uses the provided read preference', function () {
+            expect(server).to.deep.equal([secondary]);
+          });
+        });
+
+        context('when a read preference is not provided', function () {
+          const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION);
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a primary', function () {
+            expect(server).to.deep.equal([primary]);
+          });
         });
       });
 
-      context('when a read preference is not provided', function () {
-        const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION);
-        const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
-
-        it('selects a primary', function () {
-          expect(server).to.deep.equal([primary]);
-        });
-      });
-    });
-
-    context('when the common server version is < 5.0', function () {
-      const topologyDescription = new TopologyDescription(
-        TopologyType.ReplicaSetWithPrimary,
-        serverDescriptions,
-        'test',
-        MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
-        new ObjectId(),
-        MIN_SECONDARY_WRITE_WIRE_VERSION - 1
-      );
-
-      context('when a read preference is provided', function () {
-        const selector = secondaryWritableServerSelector(
+      context('when the common server version is < 5.0', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.ReplicaSetWithPrimary,
+          serverDescriptions,
+          'test',
           MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
-          ReadPreference.secondary
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION - 1
         );
-        const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
 
-        it('selects a primary', function () {
-          expect(server).to.deep.equal([primary]);
+        context('when a read preference is provided', function () {
+          const selector = secondaryWritableServerSelector(
+            MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+            ReadPreference.secondary
+          );
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a primary', function () {
+            expect(server).to.deep.equal([primary]);
+          });
+        });
+
+        context('when read preference is not provided', function () {
+          const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION - 1);
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a primary', function () {
+            expect(server).to.deep.equal([primary]);
+          });
         });
       });
 
-      context('when read preference is not provided', function () {
-        const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION - 1);
+      context('when a common wire version is not provided', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.ReplicaSetWithPrimary,
+          serverDescriptions,
+          'test',
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION
+        );
+        const selector = secondaryWritableServerSelector();
         const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
 
         it('selects a primary', function () {
@@ -91,20 +120,261 @@ describe('ServerSelector', function () {
       });
     });
 
-    context('when a common wire version is not provided', function () {
-      const topologyDescription = new TopologyDescription(
-        TopologyType.ReplicaSetWithPrimary,
-        serverDescriptions,
-        'test',
-        MIN_SECONDARY_WRITE_WIRE_VERSION,
-        new ObjectId(),
-        MIN_SECONDARY_WRITE_WIRE_VERSION
-      );
-      const selector = secondaryWritableServerSelector();
-      const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+    context('when the topology is sharded', function () {
+      const serverDescriptions = new Map();
+      serverDescriptions.set('127.0.0.1:27019', mongos);
 
-      it('selects a primary', function () {
-        expect(server).to.deep.equal([primary]);
+      context('when the common server version is >= 5.0', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.Sharded,
+          serverDescriptions,
+          'test',
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION
+        );
+
+        context('when a read preference is provided', function () {
+          const selector = secondaryWritableServerSelector(
+            MIN_SECONDARY_WRITE_WIRE_VERSION,
+            ReadPreference.secondary
+          );
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a mongos', function () {
+            expect(server).to.deep.equal([mongos]);
+          });
+        });
+
+        context('when a read preference is not provided', function () {
+          const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION);
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a mongos', function () {
+            expect(server).to.deep.equal([mongos]);
+          });
+        });
+      });
+
+      context('when the common server version is < 5.0', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.Sharded,
+          serverDescriptions,
+          'test',
+          MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION - 1
+        );
+
+        context('when a read preference is provided', function () {
+          const selector = secondaryWritableServerSelector(
+            MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+            ReadPreference.secondary
+          );
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a mongos', function () {
+            expect(server).to.deep.equal([mongos]);
+          });
+        });
+
+        context('when read preference is not provided', function () {
+          const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION - 1);
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a mongos', function () {
+            expect(server).to.deep.equal([mongos]);
+          });
+        });
+      });
+
+      context('when a common wire version is not provided', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.Sharded,
+          serverDescriptions,
+          'test',
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION
+        );
+        const selector = secondaryWritableServerSelector();
+        const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+        it('selects a mongos', function () {
+          expect(server).to.deep.equal([mongos]);
+        });
+      });
+    });
+
+    context('when the topology is load balanced', function () {
+      const serverDescriptions = new Map();
+      serverDescriptions.set('127.0.0.1:27020', loadBalancer);
+
+      context('when the common server version is >= 5.0', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.LoadBalanced,
+          serverDescriptions,
+          'test',
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION
+        );
+
+        context('when a read preference is provided', function () {
+          const selector = secondaryWritableServerSelector(
+            MIN_SECONDARY_WRITE_WIRE_VERSION,
+            ReadPreference.secondary
+          );
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a load balancer', function () {
+            expect(server).to.deep.equal([loadBalancer]);
+          });
+        });
+
+        context('when a read preference is not provided', function () {
+          const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION);
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a load balancer', function () {
+            expect(server).to.deep.equal([loadBalancer]);
+          });
+        });
+      });
+
+      context('when the common server version is < 5.0', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.LoadBalanced,
+          serverDescriptions,
+          'test',
+          MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION - 1
+        );
+
+        context('when a read preference is provided', function () {
+          const selector = secondaryWritableServerSelector(
+            MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+            ReadPreference.secondary
+          );
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a load balancer', function () {
+            expect(server).to.deep.equal([loadBalancer]);
+          });
+        });
+
+        context('when read preference is not provided', function () {
+          const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION - 1);
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a load balancer', function () {
+            expect(server).to.deep.equal([loadBalancer]);
+          });
+        });
+      });
+
+      context('when a common wire version is not provided', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.LoadBalanced,
+          serverDescriptions,
+          'test',
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION
+        );
+        const selector = secondaryWritableServerSelector();
+        const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+        it('selects a load balancer', function () {
+          expect(server).to.deep.equal([loadBalancer]);
+        });
+      });
+    });
+
+    context('when the topology is single', function () {
+      const serverDescriptions = new Map();
+      serverDescriptions.set('127.0.0.1:27020', single);
+
+      context('when the common server version is >= 5.0', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.Single,
+          serverDescriptions,
+          'test',
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION
+        );
+
+        context('when a read preference is provided', function () {
+          const selector = secondaryWritableServerSelector(
+            MIN_SECONDARY_WRITE_WIRE_VERSION,
+            ReadPreference.secondary
+          );
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a standalone', function () {
+            expect(server).to.deep.equal([single]);
+          });
+        });
+
+        context('when a read preference is not provided', function () {
+          const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION);
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a standalone', function () {
+            expect(server).to.deep.equal([single]);
+          });
+        });
+      });
+
+      context('when the common server version is < 5.0', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.Single,
+          serverDescriptions,
+          'test',
+          MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION - 1
+        );
+
+        context('when a read preference is provided', function () {
+          const selector = secondaryWritableServerSelector(
+            MIN_SECONDARY_WRITE_WIRE_VERSION - 1,
+            ReadPreference.secondary
+          );
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a standalone', function () {
+            expect(server).to.deep.equal([single]);
+          });
+        });
+
+        context('when read preference is not provided', function () {
+          const selector = secondaryWritableServerSelector(MIN_SECONDARY_WRITE_WIRE_VERSION - 1);
+          const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+          it('selects a standalone', function () {
+            expect(server).to.deep.equal([single]);
+          });
+        });
+      });
+
+      context('when a common wire version is not provided', function () {
+        const topologyDescription = new TopologyDescription(
+          TopologyType.Single,
+          serverDescriptions,
+          'test',
+          MIN_SECONDARY_WRITE_WIRE_VERSION,
+          new ObjectId(),
+          MIN_SECONDARY_WRITE_WIRE_VERSION
+        );
+        const selector = secondaryWritableServerSelector();
+        const server = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+        it('selects a standalone', function () {
+          expect(server).to.deep.equal([single]);
+        });
       });
     });
   });


### PR DESCRIPTION
### Description

Allows $merge and $out aggregate operations to execute on secondaries. The logic here is:

1. If the server version is < 5.0, these operations always execute on the primary.
2. If the server version is >= 5.0, these operations operate using the provided read preference or the primary if none is provided.

The spec specifically avoids multi-version clusters, so we can handle this at server selection by implementing our own server selection function for this case that does not need to scan twice.

Includes NODE-3684 to skip $out/$merge tests on serverless

#### What is changing?

Operations can be flagged with `trySecondaryWrite` to use the new server selector function. This function looks at the read preference and common wire version of the topology to potentially change the read preference used to select the server.

##### Is there new documentation needed for these changes?

Potentially if we want to let users know about this new feature in the node docs.

#### What is the motivation for this change?

DRIVERS-823

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
