### PR TITLE
chore(NODE-3736): fix drivers tools cloning

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -69,7 +69,7 @@ functions:
         script: >
           ${PREPARE_SHELL}
 
-          git clone --depth 1 git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+          git clone --depth 1 https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
 
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" >
           $MONGO_ORCHESTRATION_HOME/orchestration.config

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -87,7 +87,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          git clone --depth 1 git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+          git clone --depth 1 https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 
   "bootstrap mongo-orchestration":


### PR DESCRIPTION
### Description

Fixes the error "The unauthenticated git protocol on port 9418 is no longer supported." when cloning drivers tools.

#### What is changing?

Uses https now to clone the repo on evergreen

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Evergreen tasks would fail without this fix.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
