### PR TITLE
fix(NODE-3648): run get more ops through server selection

### DIFF
--- a/src/operations/get_more.ts
+++ b/src/operations/get_more.ts
@@ -1,0 +1,48 @@
+import type { Document, Long } from '../bson';
+import type { Callback, MongoDBNamespace } from '../utils';
+import type { Server } from '../sdam/server';
+import { Aspect, AbstractOperation, OperationOptions, defineAspects } from './operation';
+import type { ClientSession } from '../sessions';
+
+/**
+ * @public
+ * @typeParam TSchema - Unused schema definition, deprecated usage, only specify `FindOptions` with no generic
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface GetMoreOptions<TSchema extends Document = Document> extends OperationOptions {
+  /** Set the batchSize for the getMoreCommand when iterating over the query results. */
+  batchSize?: number;
+  /** You can put a $comment field on a query to make looking in the profiler logs simpler. */
+  comment?: string | Document;
+  /** Number of milliseconds to wait before aborting the query. */
+  maxTimeMS?: number;
+}
+
+/** @internal */
+export class GetMoreOperation extends AbstractOperation {
+  cursorId: Long;
+  options: GetMoreOptions;
+
+  constructor(ns: MongoDBNamespace, cursorId: Long, options: GetMoreOptions = {}) {
+    super(options);
+    this.options = options;
+    this.ns = ns;
+    this.cursorId = cursorId;
+  }
+
+  execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
+    this.server = server;
+
+    server.getMore(
+      this.ns,
+      this.cursorId,
+      {
+        ...this.options,
+        session: session
+      },
+      callback
+    );
+  }
+}
+
+defineAspects(GetMoreOperation, [Aspect.READ_OPERATION, Aspect.RETRYABLE, Aspect.CURSOR_ITERATING]);

--- a/src/operations/get_more.ts
+++ b/src/operations/get_more.ts
@@ -22,17 +22,21 @@ export interface GetMoreOptions<TSchema extends Document = Document> extends Ope
 export class GetMoreOperation extends AbstractOperation {
   cursorId: Long;
   options: GetMoreOptions;
+  server: Server;
 
-  constructor(ns: MongoDBNamespace, cursorId: Long, options: GetMoreOptions = {}) {
+  constructor(ns: MongoDBNamespace, cursorId: Long, server: Server, options: GetMoreOptions = {}) {
     super(options);
     this.options = options;
     this.ns = ns;
     this.cursorId = cursorId;
+    this.server = server;
   }
 
+  /**
+   * Although there is a server already associated with the get more operation, the signature
+   * for execute passes a server so we will just use that one.
+   */
   execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
-    this.server = server;
-
     server.getMore(
       this.ns,
       this.cursorId,

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -10,7 +10,8 @@ export const Aspect = {
   RETRYABLE: Symbol('RETRYABLE'),
   EXPLAINABLE: Symbol('EXPLAINABLE'),
   SKIP_COLLATION: Symbol('SKIP_COLLATION'),
-  CURSOR_CREATING: Symbol('CURSOR_CREATING')
+  CURSOR_CREATING: Symbol('CURSOR_CREATING'),
+  CURSOR_ITERATING: Symbol('CURSOR_ITERATING')
 } as const;
 
 /** @public */

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -35,11 +35,12 @@ export function writableServerSelector(): ServerSelector {
  * The purpose of this selector is to select the same server, only
  * if it is in a state that it can have commands sent to it.
  */
-export function sameServerSelector(description: ServerDescription): ServerSelector {
+export function sameServerSelector(description?: ServerDescription): ServerSelector {
   return (
     topologyDescription: TopologyDescription,
     servers: ServerDescription[]
   ): ServerDescription[] => {
+    if (!description) return [];
     // Filter the servers to match the provided description only if
     // the type is not unknown.
     return servers.filter((s: ServerDescription) => {

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -32,6 +32,23 @@ export function writableServerSelector(): ServerSelector {
 }
 
 /**
+ * The purpose of this selector is to select the same server, only
+ * if it is in a state that it can have commands sent to it.
+ */
+export function sameServerSelector(description: ServerDescription): ServerSelector {
+  return (
+    topologyDescription: TopologyDescription,
+    servers: ServerDescription[]
+  ): ServerDescription[] => {
+    // Filter the servers to match the provided description only if
+    // the type is not unknown.
+    return servers.filter((s: ServerDescription) => {
+      return s.address === description.address && s.type !== ServerType.Unknown;
+    });
+  };
+}
+
+/**
  * Returns a server selector that uses a read preference to select a
  * server potentially for a write on a secondary.
  */

--- a/test/unit/operations/get_more.test.js
+++ b/test/unit/operations/get_more.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { expect } = require('chai');
+const { Long } = require('../../../src/bson');
+const { GetMoreOperation } = require('../../../src/operations/get_more');
+
+describe('GetMoreOperation', function () {
+  describe('#constructor', function () {
+    const ns = 'db.coll';
+    const cursorId = Long.fromNumber(1);
+    const options = { batchSize: 100, comment: 'test', maxTimeMS: 500 };
+    const operation = new GetMoreOperation(ns, cursorId, options);
+
+    it('sets the namespace', function () {
+      expect(operation.ns).to.equal(ns);
+    });
+
+    it('sets the cursorId', function () {
+      expect(operation.cursorId).to.equal(cursorId);
+    });
+
+    it('sets the options', function () {
+      expect(operation.options).to.deep.equal(options);
+    });
+  });
+});

--- a/test/unit/operations/get_more.test.js
+++ b/test/unit/operations/get_more.test.js
@@ -1,15 +1,20 @@
 'use strict';
 
+const sinon = require('sinon');
 const { expect } = require('chai');
 const { Long } = require('../../../src/bson');
 const { GetMoreOperation } = require('../../../src/operations/get_more');
+const { Server } = require('../../../src/sdam/server');
+const { ClientSession } = require('../../../src/sessions');
 
 describe('GetMoreOperation', function () {
+  const ns = 'db.coll';
+  const cursorId = Long.fromNumber(1);
+  const options = { batchSize: 100, comment: 'test', maxTimeMS: 500 };
+
   describe('#constructor', function () {
-    const ns = 'db.coll';
-    const cursorId = Long.fromNumber(1);
-    const options = { batchSize: 100, comment: 'test', maxTimeMS: 500 };
-    const operation = new GetMoreOperation(ns, cursorId, options);
+    const server = sinon.createStubInstance(Server, {});
+    const operation = new GetMoreOperation(ns, cursorId, server, options);
 
     it('sets the namespace', function () {
       expect(operation.ns).to.equal(ns);
@@ -19,8 +24,33 @@ describe('GetMoreOperation', function () {
       expect(operation.cursorId).to.equal(cursorId);
     });
 
+    it('sets the server', function () {
+      expect(operation.server).to.equal(server);
+    });
+
     it('sets the options', function () {
       expect(operation.options).to.deep.equal(options);
+    });
+  });
+
+  describe('#execute', function () {
+    const getMoreStub = sinon.stub().yields(undefined);
+    const server = sinon.createStubInstance(Server, {
+      getMore: getMoreStub
+    });
+    const session = sinon.createStubInstance(ClientSession);
+    const operation = new GetMoreOperation(ns, cursorId, server, options);
+
+    it('executes a getmore on the provided server', function (done) {
+      const callback = () => {
+        const call = getMoreStub.getCall(0);
+        expect(getMoreStub.calledOnce).to.be.true;
+        expect(call.args[0]).to.equal(ns);
+        expect(call.args[1]).to.equal(cursorId);
+        expect(call.args[2]).to.deep.equal({ ...options, session });
+        done();
+      };
+      operation.execute(server, session, callback);
     });
   });
 });

--- a/test/unit/sdam/server_selection.test.js
+++ b/test/unit/sdam/server_selection.test.js
@@ -75,6 +75,23 @@ describe('server selection', function () {
         expect(servers).to.deep.equal([primary]);
       });
     });
+
+    context('when no server description provided', function () {
+      const topologyDescription = new TopologyDescription(
+        TopologyType.ReplicaSetWithPrimary,
+        serverDescriptions,
+        'test',
+        MIN_SECONDARY_WRITE_WIRE_VERSION,
+        new ObjectId(),
+        MIN_SECONDARY_WRITE_WIRE_VERSION
+      );
+      const selector = sameServerSelector();
+      const servers = selector(topologyDescription, Array.from(serverDescriptions.values()));
+
+      it('returns an empty array', function () {
+        expect(servers).to.be.empty;
+      });
+    });
   });
 
   describe('#secondaryWritableServerSelector', function () {


### PR DESCRIPTION
### Description

Runs `getmore` command operations through server selection, selecting the same server.

#### What is changing?

A new server selector has been added, `sameServerSelector`, which takes a `ServerDescription` and returns a `ServerDescription[]`. This will always select the same server as the description provided, unless the server has transitioned into an unknown state, where it will return an empty array. In this case, server selection will force monitor checks to potentially update the server and select the same one again.

A new `GetMoreOperation` has been added in order for the cursors on `getMore` to execute this operation with server selection. The pinned server's description on the operation will be used in conjunction with the new server selector.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-3648

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
