### PR TITLE
refactor(NODE-3273): remove undefined error param from topology open event

### DIFF
--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -182,8 +182,8 @@ export type TopologyEvents = {
   topologyOpening(event: TopologyOpeningEvent): void;
   topologyDescriptionChanged(event: TopologyDescriptionChangedEvent): void;
   error(error: Error): void;
-  /** TODO(NODE-3273) - remove error @internal */
-  open(error: undefined, topology: Topology): void;
+  /** @internal */
+  open(topology: Topology): void;
   close(): void;
   timeout(): void;
 } & Omit<ServerEvents, 'connect'> &
@@ -456,8 +456,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
           }
 
           stateTransition(this, STATE_CONNECTED);
-          // TODO(NODE-3273) - remove err
-          this.emit(Topology.OPEN, err, this);
+          this.emit(Topology.OPEN, this);
           this.emit(Topology.CONNECT, this);
 
           if (typeof callback === 'function') callback(undefined, this);
@@ -467,8 +466,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       }
 
       stateTransition(this, STATE_CONNECTED);
-      // TODO(NODE-3273) - remove err
-      this.emit(Topology.OPEN, err, this);
+      this.emit(Topology.OPEN, this);
       this.emit(Topology.CONNECT, this);
 
       if (typeof callback === 'function') callback(undefined, this);

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -72,8 +72,8 @@ describe('Connection - functional', function () {
   });
 
   it('should only pass one argument (topology and not error) for topology "open" events', function (done) {
-    var configuration = this.configuration;
-    var client = configuration.newClient({ w: 1 }, { maxPoolSize: 1 });
+    const configuration = this.configuration;
+    const client = configuration.newClient({ w: 1 }, { maxPoolSize: 1 });
 
     client.on('topologyOpening', () => {
       client.topology.on('open', (...args) => {

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -13,14 +13,25 @@ describe('Connection - functional', function () {
     return setupDatabase(this.configuration);
   });
 
-  afterEach(done => {
+  afterEach(async () => {
+    let savedError;
     if (client) {
-      client.close();
+      try {
+        await client.close();
+      } catch (err) {
+        savedError = err;
+      }
     }
     if (testClient) {
-      testClient.close();
+      try {
+        await testClient.close();
+      } catch (err) {
+        savedError = err;
+      }
     }
-    done();
+    if (savedError) {
+      throw savedError;
+    }
   });
 
   it('should correctly start monitoring for single server connection', {
@@ -41,12 +52,10 @@ describe('Connection - functional', function () {
         isMonitoring = event instanceof ServerHeartbeatStartedEvent;
       });
 
-      client
-        .connect()
-        .then(() => {
-          expect(isMonitoring);
-        })
-        .finally(done);
+      client.connect().then(() => {
+        expect(isMonitoring);
+        done();
+      });
     }
   });
 
@@ -162,7 +171,7 @@ describe('Connection - functional', function () {
       client = configuration.newClient();
 
       client.connect(
-        connectionTester(configuration, 'testConnectNoOptions', function (client) {
+        connectionTester(configuration, 'testConnectNoOptions', function () {
           done();
         })
       );
@@ -227,7 +236,7 @@ describe('Connection - functional', function () {
         testClient = configuration.newClient(opts);
 
         testClient.connect(
-          connectionTester(configuration, 'testConnectGoodAuthAsOption', function (client) {
+          connectionTester(configuration, 'testConnectGoodAuthAsOption', function () {
             done();
           })
         );

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -6,8 +6,16 @@ const { ServerHeartbeatStartedEvent, MongoClient } = require('../../src');
 const { Topology } = require('../../src/sdam/topology');
 
 describe('Connection - functional', function () {
+  let client;
+
   before(function () {
     return setupDatabase(this.configuration);
+  });
+
+  afterEach(done => {
+    if (client) {
+      client.close(done);
+    }
   });
 
   it('should correctly start monitoring for single server connection', {
@@ -73,13 +81,13 @@ describe('Connection - functional', function () {
 
   it('should only pass one argument (topology and not error) for topology "open" events', function (done) {
     const configuration = this.configuration;
-    const client = configuration.newClient({ w: 1 }, { maxPoolSize: 1 });
+    client = configuration.newClient({ w: 1 }, { maxPoolSize: 1 });
 
     client.on('topologyOpening', () => {
       client.topology.on('open', (...args) => {
-        expect(args.length).to.equal(1);
+        expect(args).to.have.lengthOf(1);
         expect(args[0]).to.be.instanceOf(Topology);
-        client.close(done);
+        done();
       });
     });
 

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -71,7 +71,7 @@ describe('Connection - functional', function () {
     }
   });
 
-  it('topology "open" event should only pass topology (and not error)', function (done) {
+  it('should only pass one argument (topology and not error) for topology "open" events', function (done) {
     var configuration = this.configuration;
     var client = configuration.newClient({ w: 1 }, { maxPoolSize: 1 });
 

--- a/test/functional/connection.test.js
+++ b/test/functional/connection.test.js
@@ -219,7 +219,7 @@ describe('Connection - functional', function () {
       const password = 'password';
 
       // First add a user.
-      const client = configuration.newClient();
+      client = configuration.newClient();
       client.connect(function (err, client) {
         expect(err).to.not.exist;
         var db = client.db(configuration.db);


### PR DESCRIPTION
### Description

[NODE-3273](https://jira.mongodb.org/browse/NODE-3273) Remove undefined error parameter from topology "open" event

#### What is changing?

The error parameter is no longer being passed on the topology "open" event

##### Is there new documentation needed for these changes?

No, this is an internal change

#### What is the motivation for this change?

The error is always undefined based on the flow of the code, so there is no need to pass it.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
