### PR TITLE
feat(NODE-3692): make change stream events typing more generic

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -184,14 +184,14 @@ export interface UpdateDescription<TSchema extends Document = Document> {
 }
 
 /** @public */
-export type ChangeStreamEvents = {
+export type ChangeStreamEvents<TSchema extends Document = Document> = {
   resumeTokenChanged(token: ResumeToken): void;
-  init(response: Document): void;
-  more(response?: Document | undefined): void;
+  init(response: TSchema): void;
+  more(response?: TSchema | undefined): void;
   response(): void;
   end(): void;
   error(error: Error): void;
-  change(change: ChangeStreamDocument): void;
+  change(change: ChangeStreamDocument<TSchema>): void;
 } & AbstractCursorEvents;
 
 /**
@@ -200,7 +200,7 @@ export type ChangeStreamEvents = {
  */
 export class ChangeStream<
   TSchema extends Document = Document
-> extends TypedEventEmitter<ChangeStreamEvents> {
+> extends TypedEventEmitter<ChangeStreamEvents<TSchema>> {
   pipeline: Document[];
   options: ChangeStreamOptions;
   parent: MongoClient | Db | Collection;

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -198,9 +198,9 @@ export type ChangeStreamEvents<TSchema extends Document = Document> = {
  * Creates a new Change Stream instance. Normally created using {@link Collection#watch|Collection.watch()}.
  * @public
  */
-export class ChangeStream<
-  TSchema extends Document = Document
-> extends TypedEventEmitter<ChangeStreamEvents<TSchema>> {
+export class ChangeStream<TSchema extends Document = Document> extends TypedEventEmitter<
+  ChangeStreamEvents<TSchema>
+> {
   pipeline: Document[];
   options: ChangeStreamOptions;
   parent: MongoClient | Db | Collection;

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -21,11 +21,13 @@ expectDeprecated(MongoDBDriver.ObjectID);
 expectNotDeprecated(MongoDBDriver.ObjectId);
 
 interface TSchema extends Document {
+  name?: string;
 }
 
 // test mapped cursor types
 const client = new MongoClient('');
-const coll = client.db('test').collection('test');
+const db = client.db('test');
+const coll = db.collection('test');
 const findCursor = coll.find();
 expectType<Document | null>(await findCursor.next());
 const mappedFind = findCursor.map<number>(obj => Object.keys(obj).length);
@@ -42,7 +44,8 @@ const composedMap = mappedAgg.map<string>(x => x.toString());
 expectType<AggregationCursor<string>>(composedMap);
 expectType<string | null>(await composedMap.next());
 expectType<string[]>(await composedMap.toArray());
-const changeStream = coll.watch();
+const tschemaColl = db.collection<TSchema>('test');
+const changeStream = tschemaColl.watch();
 changeStream.on('init', doc => {
   expectType<TSchema>(doc);
 });

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -3,6 +3,7 @@ import { MongoClient } from '../../src/mongo_client';
 import { Collection } from '../../src/collection';
 import { AggregationCursor } from '../../src/cursor/aggregation_cursor';
 import type { FindCursor } from '../../src/cursor/find_cursor';
+import type { ChangeStream, ChangeStreamDocument } from '../../src/change_stream';
 import type { Document } from 'bson';
 import { Db } from '../../src';
 import { Topology } from '../../src/sdam/topology';
@@ -38,6 +39,16 @@ const composedMap = mappedAgg.map<string>(x => x.toString());
 expectType<AggregationCursor<string>>(composedMap);
 expectType<string | null>(await composedMap.next());
 expectType<string[]>(await composedMap.toArray());
+const changeStream = coll.watch();
+changeStream.on('init', (doc) => {
+  expectType<Document>(doc);
+});
+changeStream.on('more', (doc) => {
+  expectType<Document | undefined>(doc);
+});
+changeStream.on('change', (doc) => {
+  expectType<ChangeStreamDocument<Document>>(doc);
+});
 
 const builtCursor = coll.aggregate();
 // should allow string values for the out helper

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -3,7 +3,7 @@ import { MongoClient } from '../../src/mongo_client';
 import { Collection } from '../../src/collection';
 import { AggregationCursor } from '../../src/cursor/aggregation_cursor';
 import type { FindCursor } from '../../src/cursor/find_cursor';
-import type { ChangeStream, ChangeStreamDocument } from '../../src/change_stream';
+import type { ChangeStreamDocument } from '../../src/change_stream';
 import type { Document } from 'bson';
 import { Db } from '../../src';
 import { Topology } from '../../src/sdam/topology';
@@ -19,6 +19,9 @@ expectDeprecated(Topology.prototype.unref);
 expectDeprecated(Db.prototype.unref);
 expectDeprecated(MongoDBDriver.ObjectID);
 expectNotDeprecated(MongoDBDriver.ObjectId);
+
+interface TSchema extends Document {
+}
 
 // test mapped cursor types
 const client = new MongoClient('');
@@ -40,14 +43,14 @@ expectType<AggregationCursor<string>>(composedMap);
 expectType<string | null>(await composedMap.next());
 expectType<string[]>(await composedMap.toArray());
 const changeStream = coll.watch();
-changeStream.on('init', (doc) => {
-  expectType<Document>(doc);
+changeStream.on('init', doc => {
+  expectType<TSchema>(doc);
 });
-changeStream.on('more', (doc) => {
-  expectType<Document | undefined>(doc);
+changeStream.on('more', doc => {
+  expectType<TSchema | undefined>(doc);
 });
-changeStream.on('change', (doc) => {
-  expectType<ChangeStreamDocument<Document>>(doc);
+changeStream.on('change', doc => {
+  expectType<ChangeStreamDocument<TSchema>>(doc);
 });
 
 const builtCursor = coll.aggregate();

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -21,7 +21,7 @@ expectDeprecated(MongoDBDriver.ObjectID);
 expectNotDeprecated(MongoDBDriver.ObjectId);
 
 interface TSchema extends Document {
-  name?: string;
+  name: string;
 }
 
 // test mapped cursor types


### PR DESCRIPTION
Added typescript generic typing to ChangeStreamEvents

## Description

**What changed?**
The typing for `ChangeStreamEvents` was not generic, and did not contain `<TSchema>` so it was always assumed to be of type `Document`. This would affect code usage like this:
```typescript
interface MyDoc extends Document{
   name: string
}
const client = new MongoClient('');
const coll = client.db('test').collection<MyDoc>('test');
coll.watch().on('change', c => c.fullDocument) 
// c.fullDocument above is typed as Document, but should be MyDoc
```
`ChangeStreamDocument` already had generic types, so I just passed through `<TSchema>`.

I tried it out locally and the typing showed correctly in my editor.

Could someone confirm that the `init` and `more` events do indeed return the same structure as `TSchema`, as I do not know what these events are?