### PR TITLE
feat(NODE-3446): deprecate mapReduce command

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1415,6 +1415,7 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Run Map Reduce across a collection. Be aware that the inline option for out will return an array of results not a collection.
    *
+   * @deprecated collection.mapReduce is deprecated. Use the aggregation pipeline instead. Visit https://docs.mongodb.com/manual/reference/map-reduce-to-aggregation-pipeline for more information on how to translate map-reduce operations to the aggregation pipeline.
    * @param map - The mapping function.
    * @param reduce - The reduce function.
    * @param options - Optional settings for the command
@@ -1446,6 +1447,9 @@ export class Collection<TSchema extends Document = Document> {
     options?: MapReduceOptions<TKey, TValue> | Callback<Document | Document[]>,
     callback?: Callback<Document | Document[]>
   ): Promise<Document | Document[]> | void {
+    emitWarningOnce(
+      'collection.mapReduce is deprecated. Use the aggregation pipeline instead. Visit https://docs.mongodb.com/manual/reference/map-reduce-to-aggregation-pipeline for more information on how to translate map-reduce operations to the aggregation pipeline.'
+    );
     if ('function' === typeof options) (callback = options), (options = {});
     // Out must always be defined (make sure we don't break weirdly on pre 1.8+ servers)
     // TODO NODE-3339: Figure out if this is still necessary given we no longer officially support pre-1.8

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -13,6 +13,7 @@ expectDeprecated(Collection.prototype.insert);
 expectDeprecated(Collection.prototype.update);
 expectDeprecated(Collection.prototype.remove);
 expectDeprecated(Collection.prototype.count);
+expectDeprecated(Collection.prototype.mapReduce);
 expectDeprecated(AggregationCursor.prototype.geoNear);
 expectDeprecated(Topology.prototype.unref);
 expectDeprecated(Db.prototype.unref);


### PR DESCRIPTION
### Description

[NODE-3446](https://jira.mongodb.org/browse/NODE-3446)

#### What is changing?

The mapReduce command is being deprecated.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

This command predates our aggregation framework and have functionality which is superseded by the aggregate command. We do not intend to add it into the stable API and instead should deprecate it to preserve a smaller and more consistent API going forward.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
