### PR TITLE
chore: add our shared vscode settings

### DIFF
--- a/docs/editor.md
+++ b/docs/editor.md
@@ -1,12 +1,26 @@
 # Visual Studio Setup
 
 Make use of the following code workspace config to get the ideal setup for working on the driver.
+Save the contents below to a file called `node-driver.code-workspace`, somewhere outside the driver folder and modify PATH_TO_DRIVER to point to your local clone.
+
+Launch VSCode and navigate to `File > Open Workspace From File...`.
+VScode will automatically recommend a bunch of extensions defined at the bottom of this .code-workspace file.
+
+Here's a quick description of each:
+
+- `streetsidesoftware.code-spell-checker` - Spell check! who doesn't need that 😁.
+- `dbaeumer.vscode-eslint` - Runs ESLint automatically after file save, saves you the need to run the linter manually most of the time.
+- `hbenl.vscode-test-explorer` - Let's you navigate our tests, and run them through button presses.
+- `hbenl.vscode-mocha-test-adapter` - The mocha specific module to the common extension mentioned above.
+- `github.vscode-pull-request-github` - With this you can manage and make pull requests right from VSCode, even reviews can be done via the editor.
+- `eamodio.gitlens` - Gives spectacular insight into git history, has many helpful git navigation UI features.
+- `mongodb.mongodb-vscode` - Our VScode extension can be connected to your locally running MongoDB instance to help debug tests etc.
 
 ```jsonc
 {
     "folders": [
         {
-            "name": "driver",
+            "name": "node-driver",
             "path": "PATH_TO_DRIVER"
         }
     ],
@@ -54,7 +68,8 @@ Make use of the following code workspace config to get the ideal setup for worki
             "hbenl.vscode-test-explorer",
             "hbenl.vscode-mocha-test-adapter",
             "github.vscode-pull-request-github",
-            "mongodb.mongodb-vscode"
+            "mongodb.mongodb-vscode",
+            "eamodio.gitlens"
         ],
         "unwantedRecommendations": [
             "esbenp.prettier-vscode"

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -10,11 +10,11 @@ Here's a quick description of each:
 
 - `streetsidesoftware.code-spell-checker` - Spell check! who doesn't need that 😁.
 - `dbaeumer.vscode-eslint` - Runs ESLint automatically after file save, saves you the need to run the linter manually most of the time.
-- `hbenl.vscode-test-explorer` - Let's you navigate our tests, and run them through button presses.
+- `hbenl.vscode-test-explorer` - Lets you navigate our tests and run them through button presses.
 - `hbenl.vscode-mocha-test-adapter` - The mocha specific module to the common extension mentioned above.
 - `github.vscode-pull-request-github` - With this you can manage and make pull requests right from VSCode, even reviews can be done via the editor.
 - `eamodio.gitlens` - Gives spectacular insight into git history, has many helpful git navigation UI features.
-- `mongodb.mongodb-vscode` - Our VScode extension can be connected to your locally running MongoDB instance to help debug tests etc.
+- `mongodb.mongodb-vscode` - Our VScode extension can be connected to your locally running MongoDB instance (to help debug tests, etc.)
 
 ```jsonc
 {
@@ -80,9 +80,9 @@ Here's a quick description of each:
 
 ## Native Extensions
 
-I've highlighted the two non-default things with `CHANGE THIS` comments
+The two non-default things in the configuration are marked with `CHANGE THIS` comments.
 
-You need to add `node_modules/node-addon-api` to the include path to find `napi.h`. (For libmongocrypt the path might be: `bindings/node/node_modules/node-addon-api` depending on your workspace root)
+You need to add `node_modules/node-addon-api` to the include path to find `napi.h`. (For libmongocrypt the path might be: `bindings/node/node_modules/node-addon-api` depending on your workspace root).
 
 And, lastly, bump up the cpp standard to `c++14`.
 

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -1,0 +1,65 @@
+# Visual Studio Setup
+
+Make use of the following code workspace config to get the ideal setup for working on the driver.
+
+```jsonc
+{
+    "folders": [
+        {
+            "name": "driver",
+            "path": "PATH_TO_DRIVER"
+        }
+    ],
+    "settings": {
+        // Automatic Formatting settings
+        "editor.codeActionsOnSave": {
+            "source.fixAll.eslint": true
+        },
+        "[json]": {
+            "editor.formatOnSave": true
+        },
+        "[jsonc]": {
+            "editor.formatOnSave": true
+        },
+        "[javascript]": {
+            "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+        },
+        "[typescript]": {
+            "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+            "editor.codeActionsOnSave": {
+                "source.organizeImports": false
+            }
+        },
+        "files.autoSave": "onFocusChange",
+        "files.trimTrailingWhitespace": true,
+        "files.trimFinalNewlines": true,
+        "files.insertFinalNewline": true,
+        // Testing settings
+        "mochaExplorer.files": "test/unit/**/*.test.js",
+        "mochaExplorer.ui": "test/tools/runner/metadata_ui.js",
+        "mochaExplorer.envPath": null, // Useful for more advanced tests
+        // Typescript settings
+        "typescript.disableAutomaticTypeAcquisition": true,
+        "typescript.tsdk": "./node_modules/typescript/lib",
+        // Editor nice to haves
+        "editor.rulers": [
+            100
+        ],
+        "editor.renderWhitespace": "selection"
+    },
+    "extensions": {
+        "recommendations": [
+            "streetsidesoftware.code-spell-checker",
+            "dbaeumer.vscode-eslint",
+            "hbenl.vscode-test-explorer",
+            "hbenl.vscode-mocha-test-adapter",
+            "github.vscode-pull-request-github",
+            "mongodb.mongodb-vscode"
+        ],
+        "unwantedRecommendations": [
+            "esbenp.prettier-vscode"
+        ]
+    }
+}
+
+```

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -82,9 +82,9 @@ Here's a quick description of each:
 
 The two non-default things in the configuration are marked with `CHANGE THIS` comments.
 
-You need to add `node_modules/node-addon-api` to the include path to find `napi.h`. (For libmongocrypt the path might be: `bindings/node/node_modules/node-addon-api` depending on your workspace root).
-
-And, lastly, bump up the cpp standard to `c++14`.
+- You need to add `node_modules/node-addon-api` to the include path to find `napi.h`.
+  - For libmongocrypt the path might be: `bindings/node/node_modules/node-addon-api` depending on your workspace root
+- Bump up the cpp standard to whatever the relevant standard is
 
 In VSCode install `ms-vscode.cpptools` and in a `.vscode/c_cpp_properties.json` file add:
 

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -76,5 +76,37 @@ Here's a quick description of each:
         ]
     }
 }
+```
 
+## Native Extensions
+
+I've highlighted the two non-default things with `CHANGE THIS` comments
+
+You need to add `node_modules/node-addon-api` to the include path to find `napi.h`. (For libmongocrypt the path might be: `bindings/node/node_modules/node-addon-api` depending on your workspace root)
+
+And, lastly, bump up the cpp standard to `c++14`.
+
+In VSCode install `ms-vscode.cpptools` and in a `.vscode/c_cpp_properties.json` file add:
+
+```jsonc
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}",
+                "node_modules/node-addon-api" // CHANGE THIS
+            ],
+            "defines": [],
+            "macFrameworkPath": [
+                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c17",
+            "cppStandard": "c++14", // CHANGE THIS
+            "intelliSenseMode": "macos-clang-x64"
+        }
+    ],
+    "version": 4
+}
 ```


### PR DESCRIPTION
### Description

#### What is changing?

Adding some helpful onboarding related to how we use VSCode to enable our tooling.

#### What is the motivation for this change?

Helpful to new contributors!

### Double check the following

- Ran `npm run check:lint` script
- Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- Changes are covered by tests
- New TODOs have a related JIRA ticket
