### PR TITLE
fix(NODE-3765): make replacement for replaceOne operations without _id

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -33,7 +33,7 @@ import type { Collection } from '../collection';
 import type { Topology } from '../sdam/topology';
 import type { CommandOperationOptions, CollationOptions } from '../operations/command';
 import type { Hint } from '../operations/operation';
-import type { Filter, OneOrMore, OptionalId, UpdateFilter } from '../mongo_types';
+import type { Filter, OneOrMore, WithoutId, OptionalId, UpdateFilter } from '../mongo_types';
 
 /** @internal */
 const kServerError = Symbol('serverError');
@@ -79,7 +79,7 @@ export interface ReplaceOneModel<TSchema extends Document = Document> {
   /** The filter to limit the replaced document. */
   filter: Filter<TSchema>;
   /** The document with which to replace the matched document. */
-  replacement: TSchema;
+  replacement: WithoutId<TSchema>;
   /** Specifies a collation. */
   collation?: CollationOptions;
   /** The index to use. If specified, then the query system will only consider plans using the hinted index. */

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -93,6 +93,7 @@ import type {
   TODO_NODE_3286,
   UpdateFilter,
   WithId,
+  WithoutId,
   OptionalId,
   Flatten
 } from './mongo_types';
@@ -459,26 +460,29 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
-  replaceOne(filter: Filter<TSchema>, replacement: TSchema): Promise<UpdateResult | Document>;
   replaceOne(
     filter: Filter<TSchema>,
-    replacement: TSchema,
+    replacement: WithoutId<TSchema>
+  ): Promise<UpdateResult | Document>;
+  replaceOne(
+    filter: Filter<TSchema>,
+    replacement: WithoutId<TSchema>,
     callback: Callback<UpdateResult | Document>
   ): void;
   replaceOne(
     filter: Filter<TSchema>,
-    replacement: TSchema,
+    replacement: WithoutId<TSchema>,
     options: ReplaceOptions
   ): Promise<UpdateResult | Document>;
   replaceOne(
     filter: Filter<TSchema>,
-    replacement: TSchema,
+    replacement: WithoutId<TSchema>,
     options: ReplaceOptions,
     callback: Callback<UpdateResult | Document>
   ): void;
   replaceOne(
     filter: Filter<TSchema>,
-    replacement: TSchema,
+    replacement: WithoutId<TSchema>,
     options?: ReplaceOptions | Callback<UpdateResult | Document>,
     callback?: Callback<UpdateResult | Document>
   ): Promise<UpdateResult | Document> | void {
@@ -1279,26 +1283,29 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
-  findOneAndReplace(filter: Filter<TSchema>, replacement: Document): Promise<ModifyResult<TSchema>>;
   findOneAndReplace(
     filter: Filter<TSchema>,
-    replacement: Document,
+    replacement: WithoutId<TSchema>
+  ): Promise<ModifyResult<TSchema>>;
+  findOneAndReplace(
+    filter: Filter<TSchema>,
+    replacement: WithoutId<TSchema>,
     callback: Callback<ModifyResult<TSchema>>
   ): void;
   findOneAndReplace(
     filter: Filter<TSchema>,
-    replacement: Document,
+    replacement: WithoutId<TSchema>,
     options: FindOneAndReplaceOptions
   ): Promise<ModifyResult<TSchema>>;
   findOneAndReplace(
     filter: Filter<TSchema>,
-    replacement: Document,
+    replacement: WithoutId<TSchema>,
     options: FindOneAndReplaceOptions,
     callback: Callback<ModifyResult<TSchema>>
   ): void;
   findOneAndReplace(
     filter: Filter<TSchema>,
-    replacement: Document,
+    replacement: WithoutId<TSchema>,
     options?: FindOneAndReplaceOptions | Callback<ModifyResult<TSchema>>,
     callback?: Callback<ModifyResult<TSchema>>
   ): Promise<ModifyResult<TSchema>> | void {

--- a/test/types/community/collection/bulkWrite.test-d.ts
+++ b/test/types/community/collection/bulkWrite.test-d.ts
@@ -181,6 +181,38 @@ collectionType.bulkWrite([
     }
   }
 ]);
+// allow a literal replacement doc without an _id
+collectionType.bulkWrite([
+  {
+    replaceOne: {
+      filter: {},
+      replacement: {
+        dateField: new Date(),
+        fruitTags: [],
+        numberField: 0,
+        readonlyFruitTags: [],
+        stringField: 'string',
+        subInterfaceArray: [],
+        subInterfaceField: { field1: '1', field2: '2' }
+      },
+      upsert: true
+    }
+  }
+]);
+// disallow a literal replacement doc with an _id
+expectError(
+  collectionType.bulkWrite([
+    {
+      replaceOne: {
+        filter: {},
+        replacement: {
+          _id: new ObjectId()
+        },
+        upsert: true
+      }
+    }
+  ])
+);
 
 expectError(
   collectionType.bulkWrite([

--- a/test/types/community/collection/replaceX.test-d.ts
+++ b/test/types/community/collection/replaceX.test-d.ts
@@ -1,0 +1,19 @@
+import { expectError } from 'tsd';
+import { MongoClient, ObjectId } from '../../../../src';
+
+// test collection.replaceX functions
+const client = new MongoClient('');
+const db = client.db('test');
+
+interface TestModel {
+  _id: ObjectId;
+  stringField: string;
+}
+
+const collection = db.collection<TestModel>('testCollection');
+
+// should accept a replacement doc without an _id
+await collection.replaceOne({}, { stringField: 'b' });
+
+// should not accept a literal replacement doc with an _id
+expectError(await collection.replaceOne({}, { _id: new ObjectId(), stringField: 'a' }));


### PR DESCRIPTION
### Description

#### What is changing?

`collection.replaceOne`, `collection.findOneAndReplace` and the `replaceOne` bulk operation now take a `WithoutId<TModel>` type for the replacement document.

##### Is there new documentation needed for these changes?

I don’t think so. It should be self-documented from the tsdoc.

#### What is the motivation for this change?

- The `_id` field is immutable, so it shouldn’t be required as it has to be the same value when passed.
- This makes `replaceOne` more in line with `insertOne`.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests