### PR TITLE
docs: remove toc option, update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The official [MongoDB](https://www.mongodb.com/) driver for Node.js.
 | what          | where                                                                                                   |
 | ------------- | ------------------------------------------------------------------------------------------------------- |
 | documentation | [docs.mongodb.com/drivers/node](https://docs.mongodb.com/drivers/node)                                  |
-| api-doc       | [mongodb.github.io/node-mongodb-native/4.1/](https://mongodb.github.io/node-mongodb-native/4.1/)        |
+| api-doc       | [mongodb.github.io/node-mongodb-native/4.2/](https://mongodb.github.io/node-mongodb-native/4.2/)        |
 | npm package   | [www.npmjs.com/package/mongodb](https://www.npmjs.com/package/mongodb)                                  |
 | source        | [github.com/mongodb/node-mongodb-native](https://github.com/mongodb/node-mongodb-native)                |
 | mongodb       | [www.mongodb.com](https://www.mongodb.com)                                                              |

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,33 +2,6 @@
   "entryPoints": [
     "src/index.ts"
   ],
-  "toc": [
-    "Admin",
-    "AggregationCursor",
-    "Binary",
-    "BSONRegExp",
-    "ChangeStream",
-    "Code",
-    "Collection",
-    "Db",
-    "Decimal128",
-    "Double",
-    "FindCursor",
-    "GridFSBucket",
-    "Int32",
-    "Long",
-    "MongoClient",
-    "MongoClientOptions",
-    "MongoError",
-    "MongoNetworkError",
-    "MongoParseError",
-    "MongoServerSelectionError",
-    "MongoTimeoutError",
-    "MongoWriteConcernError",
-    "ObjectId",
-    "ReadConcern",
-    "ReadPreference",
-    "WriteConcern"
-  ],
+  "excludeTags": ["internal"],
   "out": "docs/public"
 }


### PR DESCRIPTION
### Description

#### What is changing?

typedoc no longer has the `toc` option. I've set the generator to remove internal symbols. And I've updated the link in our readme.

#### What is the motivation for this change?

correctness!

### Double check the following

- Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- Changes are covered by tests
- New TODOs have a related JIRA ticket
