### PR TITLE
fix: remove WithId from find filter type

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -730,9 +730,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param filter - The filter predicate. If unspecified, then all documents in the collection will match the predicate
    */
   find(): FindCursor<WithId<TSchema>>;
-  find(filter: Filter<WithId<TSchema>>, options?: FindOptions): FindCursor<WithId<TSchema>>;
-  find<T>(filter: Filter<WithId<TSchema>>, options?: FindOptions): FindCursor<T>;
-  find(filter?: Filter<WithId<TSchema>>, options?: FindOptions): FindCursor<WithId<TSchema>> {
+  find(filter: Filter<TSchema>, options?: FindOptions): FindCursor<WithId<TSchema>>;
+  find<T>(filter: Filter<TSchema>, options?: FindOptions): FindCursor<T>;
+  find(filter?: Filter<TSchema>, options?: FindOptions): FindCursor<WithId<TSchema>> {
     if (arguments.length > 2) {
       throw new MongoInvalidArgumentError(
         'Method "collection.find()" accepts at most two arguments'

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -210,7 +210,7 @@ await collectionT.find({ $where: 'function() { return true }' }).toArray();
 await collectionT
   .find({
     $where: function () {
-      expectType<WithId<PetModel>>(this);
+      expectType<PetModel>(this);
       return this.name === 'MrMeow';
     }
   })


### PR DESCRIPTION
### Description

#### What is changing?

Fixes a regression in the `find()` `filter` TypeScript type.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

I believe there was a bug introduced in the #3039 PR: https://github.com/mongodb/node-mongodb-native/pull/3039/files#r752006554

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
