### PR TITLE
fix(NODE-3711): retry txn end on retryable write

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -697,6 +697,10 @@ const RETRYABLE_WRITE_ERROR_CODES = new Set<number>([
   MONGODB_ERROR_CODES.ExceededTimeLimit
 ]);
 
+export function isRetryableEndTransactionError(error: MongoError): boolean {
+  return error.hasErrorLabel('RetryableWriteError');
+}
+
 export function isRetryableWriteError(error: MongoError): boolean {
   if (error instanceof MongoWriteConcernError) {
     return RETRYABLE_WRITE_ERROR_CODES.has(error.result?.code ?? error.code ?? 0);

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -8,6 +8,7 @@ import {
   MongoError,
   MongoInvalidArgumentError,
   isRetryableError,
+  isRetryableEndTransactionError,
   MongoCompatibilityError,
   MongoNetworkError,
   MongoWriteConcernError,
@@ -767,7 +768,7 @@ function endTransaction(session: ClientSession, commandName: string, callback: C
         session.unpin();
       }
 
-      if (err && isRetryableError(err as MongoError)) {
+      if (err && isRetryableEndTransactionError(err as MongoError)) {
         // SPEC-1185: apply majority write concern when retrying commitTransaction
         if (command.commitTransaction) {
           // per txns spec, must unpin session in this case

--- a/test/functional/transactions.test.js
+++ b/test/functional/transactions.test.js
@@ -111,13 +111,7 @@ const SKIP_TESTS = [
 
   // Will be implemented as part of NODE-2034
   'Client side error in command starting transaction',
-  'Client side error when transaction is in progress',
-
-  // Will be implemented as part of NODE-2538
-  'abortTransaction only retries once with RetryableWriteError from server',
-  'abortTransaction does not retry without RetryableWriteError label',
-  'commitTransaction does not retry error without RetryableWriteError label',
-  'commitTransaction retries once with RetryableWriteError from server'
+  'Client side error when transaction is in progress'
 ];
 
 describe('Transactions Spec Legacy Tests', function () {


### PR DESCRIPTION
### Description

The driver was retrying `commitTransaction` and `abortTransaction` but previously failing 4 spec tests that were tricking the driver to base retries on these commands on error code. The retryable writes spec defines the specific errors that are retryable, and the transactions spec states these 2 commands must adhere to that specification. The fact that an operation is retryable is stated as:

_When connected to a MongoDB instance that supports retryable writes (versions 3.6+), the driver MUST treat all errors with the RetryableWriteError label as retryable._

Note that the ticket was scoped to these two commands only, so the full gambit of retryable writes was not touched. There is a ticket to address that in NODE-3769.

#### What is changing?

This adds a new check for for if a transaction command can be retried, `isRetryableEndTransactionError`, which bases this solely on if the error contains a "RetryableWriteError" and does not look at the error code.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-3711

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
