### PR TITLE
fix(NODE-3711): retry txn end on retryable write

### DIFF
--- a/lib/core/error.js
+++ b/lib/core/error.js
@@ -246,6 +246,10 @@ const RETRYABLE_WRITE_ERROR_CODES = new Set([
   MONGODB_ERROR_CODES.ExceededTimeLimit
 ]);
 
+function isRetryableEndTransactionError(error) {
+  return error.hasErrorLabel('RetryableWriteError');
+}
+
 function isRetryableWriteError(error) {
   if (error instanceof MongoWriteConcernError) {
     return (
@@ -347,5 +351,6 @@ module.exports = {
   isSDAMUnrecoverableError,
   isNodeShuttingDownError,
   isRetryableWriteError,
-  isNetworkErrorBeforeHandshake
+  isNetworkErrorBeforeHandshake,
+  isRetryableEndTransactionError
 };

--- a/lib/core/sessions.js
+++ b/lib/core/sessions.js
@@ -7,6 +7,7 @@ const Binary = BSON.Binary;
 const uuidV4 = require('./utils').uuidV4;
 const MongoError = require('./error').MongoError;
 const isRetryableError = require('././error').isRetryableError;
+const isRetryableEndTransactionError = require('././error').isRetryableEndTransactionError;
 const MongoNetworkError = require('./error').MongoNetworkError;
 const MongoWriteConcernError = require('./error').MongoWriteConcernError;
 const Transaction = require('./transactions').Transaction;
@@ -511,7 +512,7 @@ function endTransaction(session, commandName, callback) {
 
   // send the command
   session.topology.command('admin.$cmd', command, { session }, (err, reply) => {
-    if (err && isRetryableError(err)) {
+    if (err && isRetryableEndTransactionError(err)) {
       // SPEC-1185: apply majority write concern when retrying commitTransaction
       if (command.commitTransaction) {
         // per txns spec, must unpin session in this case

--- a/test/functional/transactions.test.js
+++ b/test/functional/transactions.test.js
@@ -131,13 +131,7 @@ describe('Transactions', function() {
 
           // Will be implemented as part of NODE-2034
           'Client side error in command starting transaction',
-          'Client side error when transaction is in progress',
-
-          // Will be implemented as part of NODE-2538
-          'abortTransaction only retries once with RetryableWriteError from server',
-          'abortTransaction does not retry without RetryableWriteError label',
-          'commitTransaction does not retry error without RetryableWriteError label',
-          'commitTransaction retries once with RetryableWriteError from server'
+          'Client side error when transaction is in progress'
         ];
 
         return SKIP_TESTS.indexOf(spec.description) === -1;

--- a/test/unit/error.test.js
+++ b/test/unit/error.test.js
@@ -2,6 +2,8 @@
 
 const expect = require('chai').expect;
 const MongoNetworkError = require('../../lib/core/error').MongoNetworkError;
+const isRetryableEndTransactionError = require('../../lib/core/error')
+  .isRetryableEndTransactionError;
 
 describe('MongoErrors', function() {
   describe('MongoNetworkError', function() {
@@ -17,6 +19,34 @@ describe('MongoErrors', function() {
 
       const errorWithoutOption = new MongoNetworkError('');
       expect(Object.getOwnPropertySymbols(errorWithoutOption).length).to.equal(0);
+    });
+  });
+
+  describe('#isRetryableEndTransactionError', function() {
+    context('when the error has a RetryableWriteError label', function() {
+      const error = new MongoNetworkError('');
+      error.addErrorLabel('RetryableWriteError');
+
+      it('returns true', function() {
+        expect(isRetryableEndTransactionError(error)).to.be.true;
+      });
+    });
+
+    context('when the error does not have a RetryableWriteError label', function() {
+      const error = new MongoNetworkError('');
+      error.addErrorLabel('InvalidLabel');
+
+      it('returns false', function() {
+        expect(isRetryableEndTransactionError(error)).to.be.false;
+      });
+    });
+
+    context('when the error does not have any label', function() {
+      const error = new MongoNetworkError('');
+
+      it('returns false', function() {
+        expect(isRetryableEndTransactionError(error)).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
### This is a backport of NODE-3711 to 3.7

### Description

The driver was retrying `commitTransaction` and `abortTransaction` but previously failing 4 spec tests that were tricking the driver to base retries on these commands on error code. The retryable writes spec defines the specific errors that are retryable, and the transactions spec states these 2 commands must adhere to that specification. The fact that an operation is retryable is stated as:

_When connected to a MongoDB instance that supports retryable writes (versions 3.6+), the driver MUST treat all errors with the RetryableWriteError label as retryable._

Note that the ticket was scoped to these two commands only, so the full gambit of retryable writes was not touched. There is a ticket to address that in NODE-3769.

#### What is changing?

This adds a new check for for if a transaction command can be retried, `isRetryableEndTransactionError`, which bases this solely on if the error contains a "RetryableWriteError" and does not look at the error code.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-3711

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
