### PR TITLE
fix(NODE-3648): run get more ops through server selection (4.2)

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -14,7 +14,8 @@ import { ReadPreference, ReadPreferenceLike } from '../read_preference';
 import type { Server } from '../sdam/server';
 import type { Topology } from '../sdam/topology';
 import { Readable, Transform } from 'stream';
-import type { ExecutionResult } from '../operations/execute_operation';
+import { executeOperation, ExecutionResult } from '../operations/execute_operation';
+import { GetMoreOperation } from '../operations/get_more';
 import { ReadConcern, ReadConcernLike } from '../read_concern';
 import { TODO_NODE_3286, TypedEventEmitter } from '../mongo_types';
 
@@ -610,16 +611,13 @@ export abstract class AbstractCursor<
       return;
     }
 
-    server.getMore(
-      cursorNs,
-      cursorId,
-      {
-        ...this[kOptions],
-        session: this[kSession],
-        batchSize
-      },
-      callback
-    );
+    const getMoreOperation = new GetMoreOperation(cursorNs, cursorId, server, {
+      ...this[kOptions],
+      session: this[kSession],
+      batchSize
+    });
+
+    executeOperation(this.topology, getMoreOperation, callback);
   }
 }
 

--- a/src/operations/get_more.ts
+++ b/src/operations/get_more.ts
@@ -1,0 +1,49 @@
+import type { Document, Long } from '../bson';
+import { MongoRuntimeError } from '../error';
+import type { Callback, MongoDBNamespace } from '../utils';
+import type { Server } from '../sdam/server';
+import { Aspect, AbstractOperation, OperationOptions, defineAspects } from './operation';
+import type { ClientSession } from '../sessions';
+
+/**
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface GetMoreOptions extends OperationOptions {
+  /** Set the batchSize for the getMoreCommand when iterating over the query results. */
+  batchSize?: number;
+  /** You can put a $comment field on a query to make looking in the profiler logs simpler. */
+  comment?: string | Document;
+  /** Number of milliseconds to wait before aborting the query. */
+  maxTimeMS?: number;
+}
+
+/** @internal */
+export class GetMoreOperation extends AbstractOperation {
+  cursorId: Long;
+  options: GetMoreOptions;
+  server: Server;
+
+  constructor(ns: MongoDBNamespace, cursorId: Long, server: Server, options: GetMoreOptions = {}) {
+    super(options);
+    this.options = options;
+    this.ns = ns;
+    this.cursorId = cursorId;
+    this.server = server;
+  }
+
+  /**
+   * Although there is a server already associated with the get more operation, the signature
+   * for execute passes a server so we will just use that one.
+   */
+  execute(server: Server, session: ClientSession, callback: Callback<Document>): void {
+    if (server !== this.server) {
+      return callback(
+        new MongoRuntimeError('Getmore must run on the same server operation began on')
+      );
+    }
+    server.getMore(this.ns, this.cursorId, this.options, callback);
+  }
+}
+
+defineAspects(GetMoreOperation, [Aspect.READ_OPERATION, Aspect.CURSOR_ITERATING]);

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -10,7 +10,8 @@ export const Aspect = {
   RETRYABLE: Symbol('RETRYABLE'),
   EXPLAINABLE: Symbol('EXPLAINABLE'),
   SKIP_COLLATION: Symbol('SKIP_COLLATION'),
-  CURSOR_CREATING: Symbol('CURSOR_CREATING')
+  CURSOR_CREATING: Symbol('CURSOR_CREATING'),
+  CURSOR_ITERATING: Symbol('CURSOR_ITERATING')
 } as const;
 
 /** @public */

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -32,6 +32,24 @@ export function writableServerSelector(): ServerSelector {
 }
 
 /**
+ * The purpose of this selector is to select the same server, only
+ * if it is in a state that it can have commands sent to it.
+ */
+export function sameServerSelector(description?: ServerDescription): ServerSelector {
+  return (
+    topologyDescription: TopologyDescription,
+    servers: ServerDescription[]
+  ): ServerDescription[] => {
+    if (!description) return [];
+    // Filter the servers to match the provided description only if
+    // the type is not unknown.
+    return servers.filter(sd => {
+      return sd.address === description.address && sd.type !== ServerType.Unknown;
+    });
+  };
+}
+
+/**
  * Returns a server selector that uses a read preference to select a
  * server potentially for a write on a secondary.
  */

--- a/test/unit/operations/get_more.test.js
+++ b/test/unit/operations/get_more.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const sinon = require('sinon');
+const { expect } = require('chai');
+const { Long } = require('../../../src/bson');
+const { GetMoreOperation } = require('../../../src/operations/get_more');
+const { Server } = require('../../../src/sdam/server');
+const { ClientSession } = require('../../../src/sessions');
+const { ReadPreference } = require('../../../src/read_preference');
+const { Aspect } = require('../../../src/operations/operation');
+const { MongoRuntimeError } = require('../../../src/error');
+
+describe('GetMoreOperation', function () {
+  const ns = 'db.coll';
+  const cursorId = Object.freeze(Long.fromNumber(1));
+  const options = Object.freeze({
+    batchSize: 100,
+    comment: 'test',
+    maxTimeMS: 500,
+    readPreference: ReadPreference.primary
+  });
+
+  describe('#constructor', function () {
+    const server = sinon.createStubInstance(Server, {});
+    const operation = new GetMoreOperation(ns, cursorId, server, options);
+
+    it('sets the namespace', function () {
+      expect(operation.ns).to.equal(ns);
+    });
+
+    it('sets the cursorId', function () {
+      expect(operation.cursorId).to.equal(cursorId);
+    });
+
+    it('sets the server', function () {
+      expect(operation.server).to.equal(server);
+    });
+
+    it('sets the options', function () {
+      expect(operation.options).to.deep.equal(options);
+    });
+  });
+
+  describe('#execute', function () {
+    context('when the server is the same as the instance', function () {
+      const getMoreStub = sinon.stub().yields(undefined);
+      const server = sinon.createStubInstance(Server, {
+        getMore: getMoreStub
+      });
+      const session = sinon.createStubInstance(ClientSession);
+      const opts = { ...options, session };
+      const operation = new GetMoreOperation(ns, cursorId, server, opts);
+
+      it('executes a getmore on the provided server', function (done) {
+        const callback = () => {
+          const call = getMoreStub.getCall(0);
+          expect(getMoreStub.calledOnce).to.be.true;
+          expect(call.args[0]).to.equal(ns);
+          expect(call.args[1]).to.equal(cursorId);
+          expect(call.args[2]).to.deep.equal(opts);
+          done();
+        };
+        operation.execute(server, session, callback);
+      });
+    });
+
+    context('when the server is not the same as the instance', function () {
+      const getMoreStub = sinon.stub().yields(undefined);
+      const server = sinon.createStubInstance(Server, {
+        getMore: getMoreStub
+      });
+      const newServer = sinon.createStubInstance(Server, {
+        getMore: getMoreStub
+      });
+      const session = sinon.createStubInstance(ClientSession);
+      const opts = { ...options, session };
+      const operation = new GetMoreOperation(ns, cursorId, server, opts);
+
+      it('errors in the callback', function (done) {
+        const callback = error => {
+          expect(error).to.be.instanceOf(MongoRuntimeError);
+          expect(error.message).to.equal('Getmore must run on the same server operation began on');
+          done();
+        };
+        operation.execute(newServer, session, callback);
+      });
+    });
+  });
+
+  describe('#hasAspect', function () {
+    const server = sinon.createStubInstance(Server, {});
+    const operation = new GetMoreOperation(ns, cursorId, server, options);
+
+    context('when the aspect is cursor iterating', function () {
+      it('returns true', function () {
+        expect(operation.hasAspect(Aspect.CURSOR_ITERATING)).to.be.true;
+      });
+    });
+
+    context('when the aspect is read', function () {
+      it('returns true', function () {
+        expect(operation.hasAspect(Aspect.READ_OPERATION)).to.be.true;
+      });
+    });
+
+    context('when the aspect is write', function () {
+      it('returns false', function () {
+        expect(operation.hasAspect(Aspect.WRITE_OPERATION)).to.be.false;
+      });
+    });
+
+    context('when the aspect is retryable', function () {
+      it('returns false', function () {
+        expect(operation.hasAspect(Aspect.RETRYABLE)).to.be.false;
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

Runs `getmore` command operations through server selection, selecting the same server.

#### What is changing?

A new server selector has been added, `sameServerSelector`, which takes a `ServerDescription` and returns a `ServerDescription[]`. This will always select the same server as the description provided, unless the server has transitioned into an unknown state, where it will return an empty array. In this case, server selection will force monitor checks to potentially update the server and select the same one again.

A new `GetMoreOperation` has been added in order for the cursors on `getMore` to execute this operation with server selection. The pinned server's description on the operation will be used in conjunction with the new server selector.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-3648
NODE-3453
HELP-28682

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
