### PR TITLE
docs: Clarify that deprecation is a "feat" type commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ feat(NODE-xxxx)!: created new version api, removed support for old version
 This helps the team automate [HISTORY.md](HISTORY.md) generation.
 These are the commit types we make use of:
 
-- **feat:** A new feature
+- **feat:** A new feature or deprecating (not removing) an existing feature
 - **fix:** A bug fix
 - **docs:** Documentation only changes
 - **style:** Changes that do not affect the meaning of the code (e.g, formatting)


### PR DESCRIPTION
### Description

#### What is changing?

Update to the contributing guidelines to indicate that a feature deprecation is a "feat" commit type

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

I wasn't sure what commit type to use when I deprecated a feature

### Double check the following

- [ ] ~~Ran `npm run check:lint` script~~
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] ~~Changes are covered by tests~~
- [ ] ~~New TODOs have a related JIRA ticket~~
