### PR TITLE
fix(NODE-3767): don't delete dbName if authSource is provided

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -291,11 +291,6 @@ export function parseOptions(
     }
   }
 
-  if (urlOptions.has('authSource')) {
-    // If authSource is an explicit key in the urlOptions we need to remove the dbName
-    urlOptions.delete('dbName');
-  }
-
   const objectOptions = new CaseInsensitiveMap(
     Object.entries(options).filter(([, v]) => v != null)
   );

--- a/test/unit/connection_string.test.js
+++ b/test/unit/connection_string.test.js
@@ -99,6 +99,17 @@ describe('Connection String', function () {
     expect(options.credentials.source).to.equal('0001');
   });
 
+  it('should not remove dbName from the options if authSource is provided', function () {
+    const dbName = 'my-db-name';
+    const authSource = 'admin';
+    const options = parseOptions(
+      `mongodb://myName:myPassword@localhost:27017/${dbName}?authSource=${authSource}`
+    );
+
+    expect(options).has.property('dbName', dbName);
+    expect(options.credentials).to.have.property('source', authSource);
+  });
+
   it('should parse a replicaSet with a leading number', function () {
     const options = parseOptions('mongodb://localhost/?replicaSet=123abc');
     expect(options).to.have.property('replicaSet');

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -796,6 +796,13 @@ describe('MongoOptions', function () {
       expect(client).to.have.nested.property('options.credentials.source', 'myDb');
     });
 
+    it('in the options object', function () {
+      const client = new MongoClient('mongodb://u:p@host', { dbName: 'myDb' });
+      const db = client.db();
+      expect(db).to.have.property('databaseName', 'myDb');
+      expect(client).to.have.nested.property('options.credentials.source', 'myDb');
+    });
+
     it('in the URI as a pathname with authSource option', function () {
       const client = new MongoClient('mongodb://u:p@host/myDb?authSource=myAuthDb');
       const db = client.db();
@@ -803,8 +810,25 @@ describe('MongoOptions', function () {
       expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
     });
 
+    it('in the options object with authSource option', function () {
+      const client = new MongoClient('mongodb://u:p@host?authSource=myAuthDb', { dbName: 'myDb' });
+      const db = client.db();
+      expect(db).to.have.property('databaseName', 'myDb');
+      expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
+    });
+
     it('in the URI as a pathname with authSource option in options object', function () {
       const client = new MongoClient('mongodb://u:p@host/myDb', { authSource: 'myAuthDb' });
+      const db = client.db();
+      expect(db.databaseName).to.equal('myDb');
+      expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
+    });
+
+    it('in the options object with authSource option in options object', function () {
+      const client = new MongoClient('mongodb://u:p@host', {
+        dbName: 'myDb',
+        authSource: 'myAuthDb'
+      });
       const db = client.db();
       expect(db.databaseName).to.equal('myDb');
       expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -834,6 +834,16 @@ describe('MongoOptions', function () {
         expect(db).to.have.property('databaseName', 'myDb');
         expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
       });
+
+      it('should set the database name to dbName in options object and respect the authSource option in options object', () => {
+        const client = new MongoClient('mongodb://u:p@host/myIgnoredDb', {
+          dbName: 'myDb',
+          authSource: 'myAuthDb'
+        });
+        const db = client.db();
+        expect(db).to.have.property('databaseName', 'myDb');
+        expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
+      });
     });
   });
 });

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -788,50 +788,52 @@ describe('MongoOptions', function () {
     expect(thrownError).to.have.property('code', 'ENOTFOUND');
   });
 
-  describe('specifying dbName', () => {
-    it('in the URI as a pathname', function () {
-      const client = new MongoClient('mongodb://u:p@host/myDb');
-      const db = client.db();
-      expect(db).to.have.property('databaseName', 'myDb');
-      expect(client).to.have.nested.property('options.credentials.source', 'myDb');
-    });
-
-    it('in the options object', function () {
-      const client = new MongoClient('mongodb://u:p@host', { dbName: 'myDb' });
-      const db = client.db();
-      expect(db).to.have.property('databaseName', 'myDb');
-      expect(client).to.have.nested.property('options.credentials.source', 'myDb');
-    });
-
-    it('in the URI as a pathname with authSource option', function () {
-      const client = new MongoClient('mongodb://u:p@host/myDb?authSource=myAuthDb');
-      const db = client.db();
-      expect(db.databaseName).to.equal('myDb');
-      expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
-    });
-
-    it('in the options object with authSource option', function () {
-      const client = new MongoClient('mongodb://u:p@host?authSource=myAuthDb', { dbName: 'myDb' });
-      const db = client.db();
-      expect(db).to.have.property('databaseName', 'myDb');
-      expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
-    });
-
-    it('in the URI as a pathname with authSource option in options object', function () {
-      const client = new MongoClient('mongodb://u:p@host/myDb', { authSource: 'myAuthDb' });
-      const db = client.db();
-      expect(db.databaseName).to.equal('myDb');
-      expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
-    });
-
-    it('in the options object with authSource option in options object', function () {
-      const client = new MongoClient('mongodb://u:p@host', {
-        dbName: 'myDb',
-        authSource: 'myAuthDb'
+  describe('dbName and authSource', () => {
+    describe('in the URI', () => {
+      it('should set the database name to the dbName in the uri', () => {
+        const client = new MongoClient('mongodb://u:p@host/myDb');
+        const db = client.db();
+        expect(db).to.have.property('databaseName', 'myDb');
+        expect(client).to.have.nested.property('options.credentials.source', 'myDb');
       });
-      const db = client.db();
-      expect(db.databaseName).to.equal('myDb');
-      expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
+      it('should set the database name to the uri pathname and respect the authSource option', () => {
+        const client = new MongoClient('mongodb://u:p@host/myDb?authSource=myAuthDb');
+        const db = client.db();
+        expect(db).to.have.property('databaseName', 'myDb');
+        expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
+      });
+      it('should set the database name to the uri pathname and respect the authSource option in options object', () => {
+        const client = new MongoClient('mongodb://u:p@host/myDb', { authSource: 'myAuthDb' });
+        const db = client.db();
+        expect(db).to.have.property('databaseName', 'myDb');
+        expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
+      });
+    });
+
+    describe('in the options object', () => {
+      it('should set the database name to the dbName in the options object', () => {
+        const client = new MongoClient('mongodb://u:p@host', { dbName: 'myDb' });
+        const db = client.db();
+        expect(db).to.have.property('databaseName', 'myDb');
+        expect(client).to.have.nested.property('options.credentials.source', 'myDb');
+      });
+      it('should set the database name to dbName and respect the authSource option', () => {
+        const client = new MongoClient('mongodb://u:p@host?authSource=myAuthDb', {
+          dbName: 'myDb'
+        });
+        const db = client.db();
+        expect(db).to.have.property('databaseName', 'myDb');
+        expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
+      });
+      it('should set the database name to dbName and respect the authSource option in options object', () => {
+        const client = new MongoClient('mongodb://u:p@host', {
+          dbName: 'myDb',
+          authSource: 'myAuthDb'
+        });
+        const db = client.db();
+        expect(db).to.have.property('databaseName', 'myDb');
+        expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
+      });
     });
   });
 });

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -787,4 +787,27 @@ describe('MongoOptions', function () {
     // Nothing wrong with the name, just DNE
     expect(thrownError).to.have.property('code', 'ENOTFOUND');
   });
+
+  describe('specifying dbName', () => {
+    it('in the URI as a pathname', function () {
+      const client = new MongoClient('mongodb://u:p@host/myDb');
+      const db = client.db();
+      expect(db).to.have.property('databaseName', 'myDb');
+      expect(client).to.have.nested.property('options.credentials.source', 'myDb');
+    });
+
+    it('in the URI as a pathname with authSource option', function () {
+      const client = new MongoClient('mongodb://u:p@host/myDb?authSource=myAuthDb');
+      const db = client.db();
+      expect(db.databaseName).to.equal('myDb');
+      expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
+    });
+
+    it('in the URI as a pathname with authSource option in options object', function () {
+      const client = new MongoClient('mongodb://u:p@host/myDb', { authSource: 'myAuthDb' });
+      const db = client.db();
+      expect(db.databaseName).to.equal('myDb');
+      expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
+    });
+  });
 });


### PR DESCRIPTION
### Description
#### What is changing?
`dbName` option is not going to be deleted when `authSource` is present in the connection string.

##### Is there new documentation needed for these changes?
I don't think there is unless this is intentional behaviour.

#### What is the motivation for this change?
I have noticed that the `dbName` option is deleted when `authSource` is being passed in the connection string since version **4.2.0** (after [this commit](https://github.com/mongodb/node-mongodb-native/pull/3031#discussion_r748391108)) but I couldn't find any documentation for this neither the [MongoDB documentation](https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authSource) nor in the [MongoDB driver documentation](https://mongodb.github.io/node-mongodb-native/4.2/classes/MongoClient.html#connect). I thought that this might be a bug since according to those documentations mentioned above, there's no colliding between `dbName` and `authSource` and currently both options are allowed. 