### PR TITLE
fix(NODE-3767): dont remove db name when auth source provided

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -291,11 +291,6 @@ export function parseOptions(
     }
   }
 
-  if (urlOptions.has('authSource')) {
-    // If authSource is an explicit key in the urlOptions we need to remove the dbName
-    urlOptions.delete('dbName');
-  }
-
   const objectOptions = new CaseInsensitiveMap(
     Object.entries(options).filter(([, v]) => v != null)
   );

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -788,3 +788,17 @@ describe('MongoOptions', function () {
     expect(thrownError).to.have.property('code', 'ENOTFOUND');
   });
 });
+
+describe('MongoClient', function () {
+  context('when a db is provided in the URI', function () {
+    const client = new MongoClient('mongodb://127.0.0.1:27017/dbName?authSource=admin');
+
+    context('when getting the db with no params', function () {
+      const db = client.db();
+
+      it('uses the db from the uri', function () {
+        expect(db.databaseName).to.equal('dbName');
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

Regression happened when `authSource` was provided in the URI that the driver removed the URI provided default database name.

#### What is changing?

Reverted the code block to do this introduced in 4.2.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-3767

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
