### PR TITLE
fix(NODE-2370): correct a return type of hasNext()

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -310,7 +310,7 @@ export class ChangeStream<TSchema extends Document = Document> extends TypedEven
   }
 
   /** Check if there is any document still available in the Change Stream */
-  hasNext(callback?: Callback): Promise<void> | void {
+  hasNext(callback?: Callback): Promise<boolean> | void {
     setIsIterator(this);
     return maybePromise(callback, cb => {
       getCursor(this, (err, cursor) => {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -310,6 +310,8 @@ export class ChangeStream<TSchema extends Document = Document> extends TypedEven
   }
 
   /** Check if there is any document still available in the Change Stream */
+  hasNext(): Promise<boolean>;
+  hasNext(callback: Callback<boolean>): void;
   hasNext(callback?: Callback): Promise<boolean> | void {
     setIsIterator(this);
     return maybePromise(callback, cb => {


### PR DESCRIPTION
### Description

`hasNext()` returns `Promise<boolean>` instead of `Promise<void>`. The type definition is wrong.

This initial pull request fixes one instance. There are more.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
