### PR TITLE
test(NODE-3778): sync ADL spec test files

### DIFF
--- a/test/spec/atlas-data-lake-testing/estimatedDocumentCount.json
+++ b/test/spec/atlas-data-lake-testing/estimatedDocumentCount.json
@@ -15,8 +15,25 @@
         {
           "command_started_event": {
             "command": {
-              "count": "driverdata"
-            }
+              "aggregate": "driverdata",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "command_name": "aggregate",
+            "database_name": "test"
           }
         }
       ]

--- a/test/spec/atlas-data-lake-testing/estimatedDocumentCount.yml
+++ b/test/spec/atlas-data-lake-testing/estimatedDocumentCount.yml
@@ -13,4 +13,9 @@ tests:
       -
         command_started_event:
           command:
-            count: *collection_name
+            aggregate: *collection_name
+            pipeline:
+            - $collStats: { count: {} }
+            - $group: { _id: 1, n: { $sum: $count }}
+            command_name: aggregate
+            database_name: *database_name


### PR DESCRIPTION
### Description

#### What is changing?

ADL updated the reported wire version which changes which underlying command the driver uses for estimatedDocumentCount. Pulling in the test file changes corrects the test failure.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- New TODOs have a related JIRA ticket
