### PR TITLE
refactor(NODE-3788): update names of offensive error codes

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -9,9 +9,11 @@ export type AnyError = MongoError | Error;
 const kErrorLabels = Symbol('errorLabels');
 
 /** @internal */
+// Abstract the offensive terminology to a constant
 const LEGACY_NOT_PRIMARY_ERROR_MESSAGE_REGEX = /not master/;
 
 /** @internal */
+// Abstract the offensive terminology to a constant
 const LEGACY_NOT_PRIMARY_OR_SECONDARY_ERROR_MESSAGE_REGEX = /not master or secondary/;
 
 /** @internal MongoDB Error Codes */

--- a/test/functional/unit-sdam/topology.test.js
+++ b/test/functional/unit-sdam/topology.test.js
@@ -227,7 +227,7 @@ describe('Topology (unit)', function () {
         if (doc.ismaster || doc.hello) {
           request.reply(Object.assign({}, mock.HELLO, { maxWireVersion: 9 }));
         } else if (doc.insert) {
-          request.reply({ ok: 0, message: 'not primary' });
+          request.reply({ ok: 0, message: 'not master' });
         } else {
           request.reply({ ok: 1 });
         }

--- a/test/functional/unit-sdam/topology.test.js
+++ b/test/functional/unit-sdam/topology.test.js
@@ -227,7 +227,7 @@ describe('Topology (unit)', function () {
         if (doc.ismaster || doc.hello) {
           request.reply(Object.assign({}, mock.HELLO, { maxWireVersion: 9 }));
         } else if (doc.insert) {
-          request.reply({ ok: 0, message: 'not master' });
+          request.reply({ ok: 0, message: 'not primary' });
         } else {
           request.reply({ ok: 1 });
         }

--- a/test/unit/error.test.js
+++ b/test/unit/error.test.js
@@ -19,6 +19,7 @@ const {
   WaitQueueTimeoutError: MongoWaitQueueTimeoutError
 } = require('../../src/cmap/errors');
 
+// Abstract the offensive terminology to a constant
 const LEGACY_NOT_PRIMARY_MESSAGE = 'not master';
 
 describe('MongoErrors', () => {


### PR DESCRIPTION
### Description

NODE-3788

#### What is changing?

- Error codes with offensive names are being renamed
- Other offensive wording in error.ts is being renamed

The tests that reference these error codes are spec tests. Updates to those tests are covered in NODE-3791.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Following the guidance documented in https://tools.ietf.org/id/draft-knodel-terminology-00.html, we will remove all oppressive and unnecessarily gendered language in driver documentation, code, tests, specs, and spec tests.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] ~~New TODOs have a related JIRA ticket~~
