### PR TITLE
refactor(NODE-3717): reorganize tests part 2

### DIFF
--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -12,10 +12,10 @@ if [ -z ${SERVERLESS_ATLAS_USER+omitted} ]; then echo "SERVERLESS_ATLAS_USER is 
 if [ -z ${SERVERLESS_ATLAS_PASSWORD+omitted} ]; then echo "SERVERLESS_ATLAS_PASSWORD is unset" && exit 1; fi
 
 npx mocha --file test/tools/runner/index.js \
-  test/functional/crud_spec.test.js \
+  test/integration/crud/crud.spec.test.js \
   test/functional/retryable_reads.test.js \
   test/functional/retryable_writes.test.js \
   test/functional/sessions.test.js \
   test/functional/transactions.test.js \
   test/functional/versioned-api.test.js \
-  test/functional/load-balancer-spec.test.js
+  test/integration/load-balancers/load_balancers.spec.test.js

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -14,7 +14,7 @@ if [ -z ${SERVERLESS_ATLAS_PASSWORD+omitted} ]; then echo "SERVERLESS_ATLAS_PASS
 npx mocha --file test/tools/runner/index.js \
   test/integration/crud/crud.spec.test.js \
   test/integration/retryable-reads/retryable_reads.spec.test.js \
-  test/functional/retryable_writes.test.js \
+  test/integration/retryable-writes/retryable_writes.spec.test.js \
   test/functional/sessions.test.js \
   test/functional/transactions.test.js \
   test/functional/versioned-api.test.js \

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -17,5 +17,5 @@ npx mocha --file test/tools/runner/index.js \
   test/integration/retryable-writes/retryable_writes.spec.test.js \
   test/functional/sessions.test.js \
   test/functional/transactions.test.js \
-  test/functional/versioned-api.test.js \
+  test/integration/versioned-api/versioned_api.spec.test.js \
   test/integration/load-balancers/load_balancers.spec.test.js

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -13,7 +13,7 @@ if [ -z ${SERVERLESS_ATLAS_PASSWORD+omitted} ]; then echo "SERVERLESS_ATLAS_PASS
 
 npx mocha --file test/tools/runner/index.js \
   test/integration/crud/crud.spec.test.js \
-  test/functional/retryable_reads.test.js \
+  test/integration/retryable-reads/retryable_reads.spec.test.js \
   test/functional/retryable_writes.test.js \
   test/functional/sessions.test.js \
   test/functional/transactions.test.js \

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -4,11 +4,10 @@ const {
   withClientV2,
   withMonitoredClient,
   setupDatabase,
-  ignoreNsNotFound
-} = require('./shared');
-const test = require('./shared').assert;
-const { MongoDriverError, MongoBatchReExecutionError } = require('../../src/error');
-const { Long, MongoBulkWriteError } = require('../../src');
+  ignoreNsNotFound,
+  assert: test
+} = require('../shared');
+const { Long, MongoBatchReExecutionError, MongoDriverError } = require('../../../src');
 const crypto = require('crypto');
 const chai = require('chai');
 const expect = chai.expect;
@@ -19,48 +18,6 @@ const MAX_BSON_SIZE = 16777216;
 describe('Bulk', function () {
   before(function () {
     return setupDatabase(this.configuration);
-  });
-
-  describe('Write Errors', () => {
-    describe('errInfo property on insertMany', () => {
-      let client;
-
-      beforeEach(async function () {
-        client = this.configuration.newClient({ monitorCommands: true });
-        await client.connect();
-      });
-
-      afterEach(async () => {
-        if (client) {
-          await client.close();
-        }
-      });
-
-      it('should be accessible', {
-        metadata: { requires: { mongodb: '>=5.0.0' } },
-        async test() {
-          try {
-            await client.db().collection('wc_details').drop();
-          } catch {
-            // don't care
-          }
-
-          const collection = await client
-            .db()
-            .createCollection('wc_details', { validator: { x: { $type: 'string' } } });
-
-          try {
-            await collection.insertMany([{ x: /not a string/ }]);
-            expect.fail('The insert should fail the validation that x must be a string');
-          } catch (error) {
-            expect(error).to.be.instanceOf(MongoBulkWriteError);
-            expect(error).to.have.property('code', 121);
-            expect(error).to.have.property('writeErrors').that.is.an('array');
-            expect(error.writeErrors[0]).to.have.property('errInfo').that.is.an('object');
-          }
-        }
-      });
-    });
   });
 
   it('should correctly handle ordered single batch api write command error', {

--- a/test/integration/crud/crud.prose.test.js
+++ b/test/integration/crud/crud.prose.test.js
@@ -1,0 +1,43 @@
+const { expect } = require('chai');
+const { MongoBulkWriteError } = require('../../../src');
+
+describe('CRUD Prose Spec Tests', () => {
+  let client;
+
+  beforeEach(async function () {
+    client = this.configuration.newClient({ monitorCommands: true });
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    if (client) {
+      await client.close();
+    }
+  });
+
+  // Note: This test does not fully implement the described test, it's missing command monitoring assertions
+  it('2. WriteError.details exposes writeErrors[].errInfo', {
+    metadata: { requires: { mongodb: '>=5.0.0' } },
+    async test() {
+      try {
+        await client.db().collection('wc_details').drop();
+      } catch {
+        // don't care
+      }
+
+      const collection = await client
+        .db()
+        .createCollection('wc_details', { validator: { x: { $type: 'string' } } });
+
+      try {
+        await collection.insertMany([{ x: /not a string/ }]);
+        expect.fail('The insert should fail the validation that x must be a string');
+      } catch (error) {
+        expect(error).to.be.instanceOf(MongoBulkWriteError);
+        expect(error).to.have.property('code', 121);
+        expect(error).to.have.property('writeErrors').that.is.an('array');
+        expect(error.writeErrors[0]).to.have.property('errInfo').that.is.an('object');
+      }
+    }
+  });
+});

--- a/test/integration/crud/crud.spec.test.js
+++ b/test/integration/crud/crud.spec.test.js
@@ -26,7 +26,7 @@ function enforceServerVersionLimits(requires, scenario) {
 }
 
 function findScenarios() {
-  const route = [__dirname, '..', 'spec', 'crud'].concat(Array.from(arguments));
+  const route = [__dirname, '..', '..', 'spec', 'crud'].concat(Array.from(arguments));
   return fs
     .readdirSync(path.resolve.apply(path, route))
     .filter(x => x.indexOf('json') !== -1)

--- a/test/integration/crud/crud.spec.test.js
+++ b/test/integration/crud/crud.spec.test.js
@@ -6,8 +6,8 @@ const chai = require('chai');
 const expect = chai.expect;
 chai.use(require('chai-subset'));
 
-const { loadSpecTests } = require('../spec/index');
-const { runUnifiedTest } = require('../tools/unified-spec-runner/runner');
+const { loadSpecTests } = require('../../spec/index');
+const { runUnifiedTest } = require('../../tools/unified-spec-runner/runner');
 
 function enforceServerVersionLimits(requires, scenario) {
   const versionLimits = [];

--- a/test/integration/crud/crud_api.test.js
+++ b/test/integration/crud/crud_api.test.js
@@ -1,8 +1,7 @@
 'use strict';
-const test = require('./shared').assert;
+const { assert: test, setupDatabase } = require('../shared');
 const { expect } = require('chai');
-const { ReturnDocument, ObjectId } = require('../../src');
-const setupDatabase = require('./shared').setupDatabase;
+const { ReturnDocument, ObjectId } = require('../../../src');
 
 // instanceof cannot be use reliably to detect the new models in js due to scoping and new
 // contexts killing class info find/distinct/count thus cannot be overloaded without breaking

--- a/test/integration/load-balancers/load_balancers.spec.test.js
+++ b/test/integration/load-balancers/load_balancers.spec.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const path = require('path');
-const { loadSpecTests } = require('../spec/index');
-const { runUnifiedSuite } = require('../tools/unified-spec-runner/runner');
+const { loadSpecTests } = require('../../spec/index');
+const { runUnifiedSuite } = require('../../tools/unified-spec-runner/runner');
 
 const SKIP = [
   // Verified they use the same connection but the Node implementation executes

--- a/test/integration/max-staleness/max_staleness.test.js
+++ b/test/integration/max-staleness/max_staleness.test.js
@@ -1,10 +1,11 @@
 'use strict';
 const { Long } = require('bson');
 const { expect } = require('chai');
-const mock = require('../tools/mock');
-const { ReadPreference } = require('../../src');
+const mock = require('../../tools/mock');
+const { ReadPreference } = require('../../../src');
 
 const test = {};
+// TODO (NODE-3799): convert these to run against a real server
 describe('Max Staleness', function () {
   afterEach(() => mock.cleanup());
   beforeEach(() => {

--- a/test/integration/retryable-reads/retryable_reads.spec.test.js
+++ b/test/integration/retryable-reads/retryable_reads.spec.test.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const TestRunnerContext = require('./spec-runner').TestRunnerContext;
-const generateTopologyTests = require('./spec-runner').generateTopologyTests;
-const loadSpecTests = require('../spec').loadSpecTests;
+const { TestRunnerContext, generateTopologyTests } = require('../../tools/spec-runner');
+const { loadSpecTests } = require('../../spec');
 
 describe('Retryable Reads', function () {
   const testContext = new TestRunnerContext();

--- a/test/integration/retryable-writes/retryable_writes.spec.test.js
+++ b/test/integration/retryable-writes/retryable_writes.spec.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const expect = require('chai').expect;
-const loadSpecTests = require('../spec').loadSpecTests;
-const parseRunOn = require('../functional/spec-runner').parseRunOn;
+const { expect } = require('chai');
+const { loadSpecTests } = require('../../spec');
+const { parseRunOn } = require('../../tools/spec-runner');
 
 describe('Retryable Writes', function () {
   let ctx = {};

--- a/test/integration/versioned-api/versioned_api.spec.test.js
+++ b/test/integration/versioned-api/versioned_api.spec.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const { expect } = require('chai');
-const { loadSpecTests } = require('../spec/index');
-const { runUnifiedTest } = require('../tools/unified-spec-runner/runner');
+const { loadSpecTests } = require('../../spec/');
+const { runUnifiedTest } = require('../../tools/unified-spec-runner/runner');
 
 describe('Versioned API', function () {
   it('should throw an error if serverApi version is provided via the uri', {


### PR DESCRIPTION
### Description
NODE-3717

#### What is changing?
- crud and bulk tests were moved to `integration/crud`; one prose test was separated into a prose file from bulk
- max staleness test were moved to `integration/max-staleness` - they use a mock server but I think it's better to make them into proper integration tests than convert to a unit test (see my comment on this PR and new ticket)
- load balancer, retryable reads, and retryable writes tests have all been moved into a corresponding integration directory

NOTE: The changes in this PR affect the configuration for `run-serverless-tests.sh` we should double check to make sure all desired tests are still running (see my comment on that file).

##### Is there new documentation needed for these changes?
N/A

#### What is the motivation for this change?

Better test organization

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [N/A] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
