### PR TITLE
test(NODE-3550): transactions on serverless

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1619,11 +1619,12 @@ task_groups:
           script: |
             ${PREPARE_SHELL}
             set +o xtrace
-            LOADBALANCED=ON \
-            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
-            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
-            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
-              bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
+            export LOADBALANCED="ON"
+            export SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP}
+            export SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY}
+            export SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY}
+            export PROJECT="nodeDriver"
+            bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
       - command: expansions.update
         params:
           file: serverless-expansion.yml

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -712,11 +712,12 @@ task_groups:
           script: |
             ${PREPARE_SHELL}
             set +o xtrace
-            LOADBALANCED=ON \
-            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
-            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
-            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
-              bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
+            export LOADBALANCED="ON"
+            export SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP}
+            export SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY}
+            export SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY}
+            export PROJECT="nodeDriver"
+            bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
       - command: expansions.update
         params:
           file: serverless-expansion.yml

--- a/test/functional/transactions.test.js
+++ b/test/functional/transactions.test.js
@@ -123,17 +123,8 @@ describe('Transactions Spec Legacy Tests', function () {
       name: 'withTransaction spec tests',
       specPath: path.join('transactions', 'convenient-api')
     });
-  } else {
-    // FIXME(NODE-3550): these tests should pass on serverless but currently fail
-    SKIP_TESTS.push(
-      'abortTransaction only performs a single retry',
-      'abortTransaction does not retry after Interrupted',
-      'abortTransaction does not retry after WriteConcernError Interrupted',
-      'commitTransaction does not retry error without RetryableWriteError label',
-      'commitTransaction is not retried after UnsatisfiableWriteConcern error',
-      'commitTransaction fails after Interrupted'
-    );
   }
+
   suitesToRun.forEach(suiteSpec => {
     describe(suiteSpec.name, function () {
       const testSuites = loadSpecTests(suiteSpec.specPath);

--- a/test/spec/transactions/legacy/error-labels.json
+++ b/test/spec/transactions/legacy/error-labels.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "description": "NotMaster errors contain transient label",
+      "description": "NotWritablePrimary errors contain transient label",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -963,12 +963,12 @@
           "failCommands": [
             "commitTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/test/spec/transactions/legacy/error-labels.yml
+++ b/test/spec/transactions/legacy/error-labels.yml
@@ -68,14 +68,14 @@ tests:
       collection:
         data: []
 
-  - description: NotMaster errors contain transient label
+  - description: NotWritablePrimary errors contain transient label
 
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 1 }
       data:
           failCommands: ["insert"]
-          errorCode: 10107  # NotMaster
+          errorCode: 10107  # NotWritablePrimary
 
     operations:
       - name: startTransaction
@@ -590,10 +590,10 @@ tests:
       mode: { times: 2 }
       data:
           failCommands: ["commitTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 91
             errmsg: Replication is being shut down
-            errorLabels: ["RetryableWriteError"]
 
     operations:
       - name: startTransaction

--- a/test/spec/transactions/legacy/mongos-recovery-token.json
+++ b/test/spec/transactions/legacy/mongos-recovery-token.json
@@ -180,12 +180,12 @@
                 "failCommands": [
                   "commitTransaction"
                 ],
+                "errorLabels": [
+                  "RetryableWriteError"
+                ],
                 "writeConcernError": {
                   "code": 91,
-                  "errmsg": "Replication is being shut down",
-                  "errorLabels": [
-                    "RetryableWriteError"
-                  ]
+                  "errmsg": "Replication is being shut down"
                 }
               }
             }
@@ -307,7 +307,8 @@
               "data": {
                 "failCommands": [
                   "commitTransaction",
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "closeConnection": true
               }

--- a/test/spec/transactions/legacy/mongos-recovery-token.yml
+++ b/test/spec/transactions/legacy/mongos-recovery-token.yml
@@ -118,10 +118,10 @@ tests:
             mode: { times: 1 }
             data:
               failCommands: ["commitTransaction"]
+              errorLabels: ["RetryableWriteError"]
               writeConcernError:
                 code: 91
                 errmsg: Replication is being shut down
-                errorLabels: ["RetryableWriteError"]
       # The client sees a retryable writeConcernError on the first
       # commitTransaction due to the fail point but it actually succeeds on the
       # server (SERVER-39346). The retry will succeed both on a new mongos and
@@ -196,7 +196,7 @@ tests:
         result:
           insertedId: 1
       # Enable the fail point only on the Mongos that session0 is pinned to.
-      # Fail isMaster to prevent the heartbeat requested directly after the
+      # Fail hello/legacy hello to prevent the heartbeat requested directly after the
       # retryable commit error from racing with server selection for the retry.
       # Note: times: 7 is slightly artbitrary but it accounts for one failed
       # commit and some SDAM heartbeats. A test runner will have multiple
@@ -210,7 +210,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 7 }
             data:
-              failCommands: ["commitTransaction", "isMaster"]
+              failCommands: ["commitTransaction", "isMaster", "hello"]
               closeConnection: true
       # The first commitTransaction sees a retryable connection error due to
       # the fail point and also fails on the server. The retry attempt on a
@@ -218,7 +218,7 @@ tests:
       # because the transaction was aborted. Note that the retry attempt should
       # not select the original mongos because that server's SDAM state is
       # reset by the connection error, heartbeatFrequencyMS is high, and
-      # subsequent isMaster heartbeats should fail.
+      # subsequent heartbeats should fail.
       - name: commitTransaction
         object: session0
         result:

--- a/test/spec/transactions/legacy/pin-mongos.json
+++ b/test/spec/transactions/legacy/pin-mongos.json
@@ -1107,7 +1107,8 @@
               "data": {
                 "failCommands": [
                   "insert",
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "closeConnection": true
               }

--- a/test/spec/transactions/legacy/pin-mongos.yml
+++ b/test/spec/transactions/legacy/pin-mongos.yml
@@ -464,7 +464,7 @@ tests:
         result:
           insertedId: 3
       # Enable the fail point only on the Mongos that session0 is pinned to.
-      # Fail isMaster to prevent the heartbeat requested directly after the
+      # Fail hello/legacy hello to prevent the heartbeat requested directly after the
       # insert error from racing with server selection for the commit.
       # Note: times: 7 is slightly artbitrary but it accounts for one failed
       # insert and some SDAM heartbeats. A test runner will have multiple
@@ -478,7 +478,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 7 }
             data:
-              failCommands: ["insert", "isMaster"]
+              failCommands: ["insert", "isMaster", "hello"]
               closeConnection: true
       - name: insertOne
         object: collection
@@ -498,7 +498,7 @@ tests:
       #
       # Note that the commit attempt should not select the original mongos
       # because that server's SDAM state is reset by the connection error,
-      # heartbeatFrequencyMS is high, and subsequent isMaster heartbeats
+      # heartbeatFrequencyMS is high, and subsequent heartbeats
       # should fail.
       - name: commitTransaction
         object: session0

--- a/test/spec/transactions/legacy/retryable-abort.json
+++ b/test/spec/transactions/legacy/retryable-abort.json
@@ -402,7 +402,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after NotMaster",
+      "description": "abortTransaction succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -506,7 +506,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after NotMasterOrSecondary",
+      "description": "abortTransaction succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -610,7 +610,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after NotMasterNoSlaveOk",
+      "description": "abortTransaction succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1556,11 +1556,11 @@
           "failCommands": [
             "abortTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 11600,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1673,11 +1673,11 @@
           "failCommands": [
             "abortTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 11602,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1790,11 +1790,11 @@
           "failCommands": [
             "abortTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 189,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1907,11 +1907,11 @@
           "failCommands": [
             "abortTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/test/spec/transactions/legacy/retryable-abort.yml
+++ b/test/spec/transactions/legacy/retryable-abort.yml
@@ -266,7 +266,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after NotMaster
+  - description: abortTransaction succeeds after NotWritablePrimary
 
     failPoint:
       configureFailPoint: failCommand
@@ -334,7 +334,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after NotMasterOrSecondary
+  - description: abortTransaction succeeds after NotPrimaryOrSecondary
 
     failPoint:
       configureFailPoint: failCommand
@@ -402,7 +402,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after NotMasterNoSlaveOk
+  - description: abortTransaction succeeds after NotPrimaryNoSecondaryOk
 
     failPoint:
       configureFailPoint: failCommand
@@ -1021,9 +1021,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["abortTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 11600
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1096,9 +1096,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["abortTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 11602
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1171,9 +1171,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["abortTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 189
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1246,9 +1246,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["abortTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 91
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:

--- a/test/spec/transactions/legacy/retryable-commit.json
+++ b/test/spec/transactions/legacy/retryable-commit.json
@@ -624,7 +624,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after NotMaster",
+      "description": "commitTransaction succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -735,7 +735,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after NotMasterOrSecondary",
+      "description": "commitTransaction succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -846,7 +846,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after NotMasterNoSlaveOk",
+      "description": "commitTransaction succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1855,11 +1855,11 @@
           "failCommands": [
             "commitTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 11600,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1977,11 +1977,11 @@
           "failCommands": [
             "commitTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 11602,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2099,11 +2099,11 @@
           "failCommands": [
             "commitTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 189,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2221,11 +2221,11 @@
           "failCommands": [
             "commitTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/test/spec/transactions/legacy/retryable-commit.yml
+++ b/test/spec/transactions/legacy/retryable-commit.yml
@@ -385,7 +385,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after NotMaster
+  - description: commitTransaction succeeds after NotWritablePrimary
 
     failPoint:
       configureFailPoint: failCommand
@@ -455,7 +455,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after NotMasterOrSecondary
+  - description: commitTransaction succeeds after NotPrimaryOrSecondary
 
     failPoint:
       configureFailPoint: failCommand
@@ -525,7 +525,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after NotMasterNoSlaveOk
+  - description: commitTransaction succeeds after NotPrimaryNoSecondaryOk
 
     failPoint:
       configureFailPoint: failCommand
@@ -1162,9 +1162,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["commitTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 11600
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1238,9 +1238,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["commitTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 11602
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1314,9 +1314,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["commitTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 189
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1390,9 +1390,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["commitTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 91
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:

--- a/test/spec/transactions/unified/mongos-unpin.json
+++ b/test/spec/transactions/unified/mongos-unpin.json
@@ -49,7 +49,7 @@
   },
   "tests": [
     {
-      "description": "unpin after TransientTransctionError error on commit",
+      "description": "unpin after TransientTransactionError error on commit",
       "runOnRequirements": [
         {
           "serverless": "forbid"
@@ -108,6 +108,24 @@
           "arguments": {
             "session": "session0"
           }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
         }
       ]
     },
@@ -142,7 +160,7 @@
       ]
     },
     {
-      "description": "unpin after TransientTransctionError error on abort",
+      "description": "unpin after non-transient error on abort",
       "runOnRequirements": [
         {
           "serverless": "forbid"
@@ -192,6 +210,91 @@
           "arguments": {
             "session": "session0"
           }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ]
+    },
+    {
+      "description": "unpin after TransientTransactionError error on abort",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "errorCode": 91
+              }
+            }
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
         }
       ]
     },

--- a/test/spec/transactions/unified/mongos-unpin.yml
+++ b/test/spec/transactions/unified/mongos-unpin.yml
@@ -33,7 +33,7 @@ _yamlAnchors:
     &lockTimeoutErrorCode 24
 
 tests:
-  - description: unpin after TransientTransctionError error on commit
+  - description: unpin after TransientTransactionError error on commit
     runOnRequirements:
         # serverless proxy doesn't append error labels to errors in transactions
         # caused by failpoints (CLOUDP-88216)
@@ -70,17 +70,22 @@ tests:
         object: testRunner
         arguments:
           session: *session0
-
-  - description: unpin on successful abort
-    operations:
+      # Cleanup the potentionally open server transaction by starting and
+      # aborting a new transaction on the same session.
       - *startTransaction
       - *insertOne
       - &abortTransaction
         name: abortTransaction
         object: *session0
+
+  - description: unpin on successful abort
+    operations:
+      - *startTransaction
+      - *insertOne
+      - *abortTransaction
       - *assertNoPinnedServer
 
-  - description: unpin after TransientTransctionError error on abort
+  - description: unpin after non-transient error on abort
     runOnRequirements:
         # serverless proxy doesn't append error labels to errors in transactions
         # caused by failpoints (CLOUDP-88216)
@@ -100,6 +105,33 @@ tests:
               errorCode: *lockTimeoutErrorCode
       - *abortTransaction
       - *assertNoPinnedServer
+      # Cleanup the potentionally open server transaction by starting and
+      # aborting a new transaction on the same session.
+      - *startTransaction
+      - *insertOne
+      - *abortTransaction
+
+  - description: unpin after TransientTransactionError error on abort
+    operations:
+      - *startTransaction
+      - *insertOne
+      - name: targetedFailPoint
+        object: testRunner
+        arguments:
+          session: *session0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ abortTransaction ]
+              errorCode: 91 # ShutdownInProgress
+      - *abortTransaction
+      - *assertNoPinnedServer
+      # Cleanup the potentionally open server transaction by starting and
+      # aborting a new transaction on the same session.
+      - *startTransaction
+      - *insertOne
+      - *abortTransaction
 
   - description: unpin when a new transaction is started
     operations:


### PR DESCRIPTION
### Description

#### What is changing?

- Unskipping transaction tests on serverless. 
- Pulls in isWritablePrimary changes to spec tests.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
