### PR TITLE
chore: fix invalid use of typeof operator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "prettier/prettier": "error",
     "tsdoc/syntax": "warn",
     "no-console": "error",
+    "valid-typeof": "error",
     "eqeqeq": [
       "error",
       "always",

--- a/src/cmap/stream_description.ts
+++ b/src/cmap/stream_description.ts
@@ -55,8 +55,8 @@ export class StreamDescription {
 
   receiveResponse(response: Document): void {
     this.type = parseServerType(response);
-    RESPONSE_FIELDS.forEach(field => {
-      if (typeof response[field] != null) {
+    for (const field of RESPONSE_FIELDS) {
+      if (response[field] != null) {
         this[field] = response[field];
       }
 
@@ -64,7 +64,7 @@ export class StreamDescription {
       if ('__nodejs_mock_server__' in response) {
         this.__nodejs_mock_server__ = response['__nodejs_mock_server__'];
       }
-    });
+    }
 
     if (response.compression) {
       this.compressor = this.compressors.filter(c => response.compression?.includes(c))[0];


### PR DESCRIPTION
### Description

#### What is changing?

Adds an eslint rule to catch my mistake. typeof x must be checked against one of the known string results.

#### What is the motivation for this change?

A superficial bug where we might have been defining properties and setting them to undefined when we intented to filter them out. 

Since this bug has no virtually no impact, I decided against a ticket and even entering it into the changelog, happy to adjust.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- ~Changes are covered by tests~
- ~New TODOs have a related JIRA ticket~
