### PR TITLE
fix: stricter protocol check in connection string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bson": "^4.6.0",
         "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.2.0"
+        "mongodb-connection-string-url": "^2.3.2"
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -4413,9 +4413,9 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.2.0.tgz",
-      "integrity": "sha512-U0cDxLUrQrl7DZA828CA+o69EuWPWEJTwdMPozyd7cy/dbtncUZczMw7wRHcwMD7oKOn0NM2tF9jdf5FFVW9CA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.3.2.tgz",
+      "integrity": "sha512-2LkmS0ny7LamAyhEs2Q+zuFFxeGNSc2DaGHBevjqkoPt7bgh+67mg1sFU6awnMsdLKpdEt7zUy466K9x7RsYcQ==",
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
@@ -10076,9 +10076,9 @@
       "dev": true
     },
     "mongodb-connection-string-url": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.2.0.tgz",
-      "integrity": "sha512-U0cDxLUrQrl7DZA828CA+o69EuWPWEJTwdMPozyd7cy/dbtncUZczMw7wRHcwMD7oKOn0NM2tF9jdf5FFVW9CA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.3.2.tgz",
+      "integrity": "sha512-2LkmS0ny7LamAyhEs2Q+zuFFxeGNSc2DaGHBevjqkoPt7bgh+67mg1sFU6awnMsdLKpdEt7zUy466K9x7RsYcQ==",
       "requires": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "bson": "^4.6.0",
     "denque": "^2.0.1",
-    "mongodb-connection-string-url": "^2.2.0"
+    "mongodb-connection-string-url": "^2.3.2"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",


### PR DESCRIPTION
### Description

#### What is changing?

Updating the connection string url parser will disallow extraneous characters infront of the `mongodb://` or `mongodb+srv://` portion of a connection string.
### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- Changes are covered by tests
- New TODOs have a related JIRA ticket
