### PR TITLE
chore: stricten MongoClient.connect() return type

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -413,9 +413,9 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    *
    * @see docs.mongodb.org/manual/reference/connection-string/
    */
-  connect(): Promise<MongoClient>;
-  connect(callback: Callback<MongoClient>): void;
-  connect(callback?: Callback<MongoClient>): Promise<MongoClient> | void {
+  connect(): Promise<this>;
+  connect(callback: Callback<this>): void;
+  connect(callback?: Callback<this>): Promise<this> | void {
     if (callback && typeof callback !== 'function') {
       throw new MongoInvalidArgumentError('Method `connect` only accepts a callback');
     }


### PR DESCRIPTION
This method always returns the MongoClient on which it was called. 

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests (typescript is the test here)
- [x] New TODOs have a related JIRA ticket
