### PR TITLE
chore: fix test importing non typescript files

### DIFF
--- a/test/unit/imports.test.ts
+++ b/test/unit/imports.test.ts
@@ -19,6 +19,10 @@ describe('importing mongodb driver', () => {
   const sourceFiles = walk(path.resolve(__dirname, '../../src'));
 
   for (const sourceFile of sourceFiles) {
+    if (!sourceFile.endsWith('.ts')) {
+      continue;
+    }
+
     const sliceFrom = sourceFile.indexOf('src');
     it(`should import ${sourceFile.slice(sliceFrom)} directly without issue`, () => {
       execSync(`./node_modules/.bin/ts-node -e "require('${sourceFile}')"`);


### PR DESCRIPTION
### Description

#### What is changing?

Only import files that end in `.ts`

#### What is the motivation for this change?

`.DS_Store` files make this test fail, so we should filter for .ts

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- New TODOs have a related JIRA ticket
