### PR TITLE
feat(NODE-3793): Remove offensive language from code and tests

### DIFF
--- a/src/cmap/commands.ts
+++ b/src/cmap/commands.ts
@@ -41,8 +41,6 @@ export interface OpQueryOptions extends CommandOptions {
   ignoreUndefined?: boolean;
   maxBsonSize?: number;
   checkKeys?: boolean;
-  /**@deprecated Use secondaryOk instead */
-  slaveOk?: boolean;
   secondaryOk?: boolean;
 
   requestId?: number;
@@ -69,8 +67,6 @@ export class Query {
   checkKeys: boolean;
   batchSize: number;
   tailable: boolean;
-  /**@deprecated Use secondaryOk instead */
-  slaveOk: boolean;
   secondaryOk: boolean;
   oplogReplay: boolean;
   noCursorTimeout: boolean;
@@ -117,7 +113,6 @@ export class Query {
     // Flags
     this.tailable = false;
     this.secondaryOk = typeof options.secondaryOk === 'boolean' ? options.secondaryOk : false;
-    this.slaveOk = this.secondaryOk;
     this.oplogReplay = false;
     this.noCursorTimeout = false;
     this.awaitData = false;

--- a/src/cmap/commands.ts
+++ b/src/cmap/commands.ts
@@ -12,7 +12,7 @@ let _requestId = 0;
 
 // Query flags
 const OPTS_TAILABLE_CURSOR = 2;
-const OPTS_SLAVE = 4;
+const OPTS_SECONDARY = 4;
 const OPTS_OPLOG_REPLAY = 8;
 const OPTS_NO_CURSOR_TIMEOUT = 16;
 const OPTS_AWAIT_DATA = 32;
@@ -41,7 +41,9 @@ export interface OpQueryOptions extends CommandOptions {
   ignoreUndefined?: boolean;
   maxBsonSize?: number;
   checkKeys?: boolean;
+  /**@deprecated Use secondaryOk instead */
   slaveOk?: boolean;
+  secondaryOk?: boolean;
 
   requestId?: number;
   moreToCome?: boolean;
@@ -67,7 +69,9 @@ export class Query {
   checkKeys: boolean;
   batchSize: number;
   tailable: boolean;
+  /**@deprecated Use secondaryOk instead */
   slaveOk: boolean;
+  secondaryOk: boolean;
   oplogReplay: boolean;
   noCursorTimeout: boolean;
   awaitData: boolean;
@@ -112,7 +116,8 @@ export class Query {
 
     // Flags
     this.tailable = false;
-    this.slaveOk = typeof options.slaveOk === 'boolean' ? options.slaveOk : false;
+    this.secondaryOk = typeof options.secondaryOk === 'boolean' ? options.secondaryOk : false;
+    this.slaveOk = this.secondaryOk;
     this.oplogReplay = false;
     this.noCursorTimeout = false;
     this.awaitData = false;
@@ -146,8 +151,8 @@ export class Query {
       flags |= OPTS_TAILABLE_CURSOR;
     }
 
-    if (this.slaveOk) {
-      flags |= OPTS_SLAVE;
+    if (this.secondaryOk) {
+      flags |= OPTS_SECONDARY;
     }
 
     if (this.oplogReplay) {

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -96,7 +96,7 @@ export interface QueryOptions extends BSONSerializeOptions {
 /** @internal */
 export interface CommandOptions extends BSONSerializeOptions {
   command?: boolean;
-  slaveOk?: boolean;
+  secondaryOk?: boolean;
   /** Specify read preference if command supports it */
   readPreference?: ReadPreferenceLike;
   raw?: boolean;
@@ -427,7 +427,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
         numberToReturn: -1,
         checkKeys: false,
         // This value is not overridable
-        slaveOk: readPreference.slaveOk()
+        secondaryOk: readPreference.secondaryOk()
       },
       options
     );
@@ -472,7 +472,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       numberToReturn,
       pre32Limit: typeof limit === 'number' ? limit : undefined,
       checkKeys: false,
-      slaveOk: readPreference.slaveOk()
+      secondaryOk: readPreference.secondaryOk()
     };
 
     if (options.projection) {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -112,7 +112,11 @@ export interface CollectionOptions
   extends BSONSerializeOptions,
     WriteConcernOptions,
     LoggerOptions {
+  /**
+   * @deprecated Use secondaryOk instead
+   */
   slaveOk?: boolean;
+  secondaryOk?: boolean;
   /** Specify a read concern for the collection. (only MongoDB 3.2 or higher supported) */
   readConcern?: ReadConcernLike;
   /** The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST). */
@@ -127,7 +131,7 @@ export interface CollectionPrivate {
   namespace: MongoDBNamespace;
   readPreference?: ReadPreference;
   bsonOptions: BSONSerializeOptions;
-  slaveOk?: boolean;
+  secondaryOk?: boolean;
   collectionHint?: Hint;
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
@@ -182,7 +186,8 @@ export class Collection<TSchema extends Document = Document> {
       bsonOptions: resolveBSONOptions(options, db),
       readConcern: ReadConcern.fromOptions(options),
       writeConcern: WriteConcern.fromOptions(options),
-      slaveOk: options == null || options.slaveOk == null ? db.slaveOk : options.slaveOk
+      secondaryOk:
+        options == null || options.secondaryOk == null ? db.secondaryOk : options.secondaryOk
     };
   }
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -113,10 +113,9 @@ export interface CollectionOptions
     WriteConcernOptions,
     LoggerOptions {
   /**
-   * @deprecated Use secondaryOk instead
+   * @deprecated Use readPreference instead
    */
   slaveOk?: boolean;
-  secondaryOk?: boolean;
   /** Specify a read concern for the collection. (only MongoDB 3.2 or higher supported) */
   readConcern?: ReadConcernLike;
   /** The preferred read preference (ReadPreference.PRIMARY, ReadPreference.PRIMARY_PREFERRED, ReadPreference.SECONDARY, ReadPreference.SECONDARY_PREFERRED, ReadPreference.NEAREST). */
@@ -131,7 +130,6 @@ export interface CollectionPrivate {
   namespace: MongoDBNamespace;
   readPreference?: ReadPreference;
   bsonOptions: BSONSerializeOptions;
-  secondaryOk?: boolean;
   collectionHint?: Hint;
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
@@ -185,9 +183,7 @@ export class Collection<TSchema extends Document = Document> {
       readPreference: ReadPreference.fromOptions(options),
       bsonOptions: resolveBSONOptions(options, db),
       readConcern: ReadConcern.fromOptions(options),
-      writeConcern: WriteConcern.fromOptions(options),
-      secondaryOk:
-        options == null || options.secondaryOk == null ? db.secondaryOk : options.secondaryOk
+      writeConcern: WriteConcern.fromOptions(options)
     };
   }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -185,8 +185,18 @@ export class Db {
     return this.s.options;
   }
 
-  // slaveOk specified
+  /**
+   * slaveOk specified
+   * @deprecated Use secondaryOk instead
+   */
   get slaveOk(): boolean {
+    return this.secondaryOk;
+  }
+
+  /**
+   * Check if a secondary can be used (because the read preference is *not* set to primary)
+   */
+  get secondaryOk(): boolean {
     return this.s.readPreference?.preference !== 'primary' || false;
   }
 

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -240,7 +240,7 @@ export class ReadPreference {
     return this.secondaryOk();
   }
 
-   /**
+  /**
    * Indicates that this readPreference needs the "SecondaryOk" bit when sent over the wire
    * @see https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op-query
    */

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -232,19 +232,27 @@ export class ReadPreference {
   }
 
   /**
-   * Indicates that this readPreference needs the "slaveOk" bit when sent over the wire
-   *
+   * Indicates that this readPreference needs the "secondaryOk" bit when sent over the wire
+   * @deprecated Use secondaryOk instead
    * @see https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op-query
    */
   slaveOk(): boolean {
-    const NEEDS_SLAVEOK = new Set<string>([
+    return this.secondaryOk();
+  }
+
+   /**
+   * Indicates that this readPreference needs the "SecondaryOk" bit when sent over the wire
+   * @see https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op-query
+   */
+  secondaryOk(): boolean {
+    const NEEDS_SECONDARYOK = new Set<string>([
       ReadPreference.PRIMARY_PREFERRED,
       ReadPreference.SECONDARY,
       ReadPreference.SECONDARY_PREFERRED,
       ReadPreference.NEAREST
     ]);
 
-    return NEEDS_SLAVEOK.has(this.mode);
+    return NEEDS_SECONDARYOK.has(this.mode);
   }
 
   /**

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -11,7 +11,6 @@ const { Writable } = require('stream');
 const { ReadPreference } = require('../../src/read_preference');
 const { ServerType } = require('../../src/sdam/common');
 const { formatSort } = require('../../src/sort');
-const { FindCursor } = require('../../src/cursor/find_cursor');
 
 describe('Cursor', function () {
   before(function () {

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3752,7 +3752,7 @@ describe('Cursor', function () {
           db.s.topology,
           db.s.namespace,
           {},
-          { limit: 0, skip: 0, slaveOk: false, readPreference: 42 }
+          { limit: 0, skip: 0, secondaryOk: false, readPreference: 42 }
         );
 
         cursor.hasNext(err => {

--- a/test/functional/cursor.test.js
+++ b/test/functional/cursor.test.js
@@ -3732,38 +3732,6 @@ describe('Cursor', function () {
     }
   });
 
-  // NOTE: This is skipped because I don't think its correct or adds value. The expected error
-  //       is not an error with hasNext (from server), but rather a local TypeError which should
-  //       be caught anyway. The only solution here would be to wrap the entire top level call
-  //       in a try/catch which is not going to happen.
-  it.skip('Should propagate hasNext errors when using a callback', {
-    metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded', 'ssl', 'heap', 'wiredtiger'] }
-    },
-    test: function (done) {
-      const configuration = this.configuration;
-      var client = configuration.newClient({ w: 1 }, { maxPoolSize: 1 });
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
-
-        const db = client.db(configuration.db);
-        const cursor = new FindCursor(
-          db.s.topology,
-          db.s.namespace,
-          {},
-          { limit: 0, skip: 0, secondaryOk: false, readPreference: 42 }
-        );
-
-        cursor.hasNext(err => {
-          test.ok(err !== null);
-          test.equal(err.message, 'readPreference must be a ReadPreference instance');
-          done();
-        });
-      });
-    }
-  });
-
   it(
     'should return implicit session to pool when client-side cursor exhausts results on initial query',
     {

--- a/test/unit/db.test.ts
+++ b/test/unit/db.test.ts
@@ -8,7 +8,7 @@ describe('class Db', function () {
   const client = new MongoClient('mongodb://localhost:27017');
   const legacy_secondary_ok = 'slaveOk';
 
-  it.only('secondaryOk should be false when readPreference is Primary', function () {
+  it('secondaryOk should be false when readPreference is Primary', function () {
     const options: DbOptions = { readPreference: ReadPreference.PRIMARY };
     const mydb = new Db(client, 'mydb', options);
 
@@ -16,7 +16,7 @@ describe('class Db', function () {
     expect(mydb[legacy_secondary_ok]).to.be.false;
   });
 
-  it.only('secondaryOk should be true when readPreference is Primary Preferred', function () {
+  it('secondaryOk should be true when readPreference is Primary Preferred', function () {
     const options: DbOptions = { readPreference: ReadPreference.PRIMARY_PREFERRED };
     const mydb = new Db(client, 'mydb', options);
 
@@ -24,7 +24,7 @@ describe('class Db', function () {
     expect(mydb[legacy_secondary_ok]).to.be.true;
   });
 
-  it.only('secondaryOk should be true when readPreference is Secondary', function () {
+  it('secondaryOk should be true when readPreference is Secondary', function () {
     const options: DbOptions = { readPreference: ReadPreference.SECONDARY };
     const mydb = new Db(client, 'mydb', options);
 
@@ -32,7 +32,7 @@ describe('class Db', function () {
     expect(mydb[legacy_secondary_ok]).to.be.true;
   });
 
-  it.only('secondaryOk should be true when readPreference is Secondary Preferred', function () {
+  it('secondaryOk should be true when readPreference is Secondary Preferred', function () {
     const options: DbOptions = { readPreference: ReadPreference.SECONDARY_PREFERRED };
     const mydb = new Db(client, 'mydb', options);
 
@@ -40,7 +40,7 @@ describe('class Db', function () {
     expect(mydb[legacy_secondary_ok]).to.be.true;
   });
 
-  it.only('secondaryOk should be true when readPreference is Nearest', function () {
+  it('secondaryOk should be true when readPreference is Nearest', function () {
     const options: DbOptions = { readPreference: ReadPreference.NEAREST };
     const mydb = new Db(client, 'mydb', options);
 

--- a/test/unit/db.test.ts
+++ b/test/unit/db.test.ts
@@ -5,46 +5,49 @@ import { Db, DbOptions } from '../../src/db';
 import { ReadPreference } from '../../src/read_preference';
 
 describe('class Db', function () {
-  const client = new MongoClient('mongodb://localhost:27017');
-  const legacy_secondary_ok = 'slaveOk';
+  describe('secondaryOk', function () {
+    const client = new MongoClient('mongodb://localhost:27017');
+    const legacy_secondary_ok = 'slaveOk';
+    const secondary_ok = 'secondaryOk';
 
-  it('secondaryOk should be false when readPreference is Primary', function () {
-    const options: DbOptions = { readPreference: ReadPreference.PRIMARY };
-    const mydb = new Db(client, 'mydb', options);
+    it('should be false when readPreference is Primary', function () {
+      const options: DbOptions = { readPreference: ReadPreference.PRIMARY };
+      const mydb = new Db(client, 'mydb', options);
 
-    expect(mydb.secondaryOk).to.be.false;
-    expect(mydb[legacy_secondary_ok]).to.be.false;
-  });
+      expect(mydb).property(secondary_ok).to.be.false;
+      expect(mydb).property(legacy_secondary_ok).to.be.false;
+    });
 
-  it('secondaryOk should be true when readPreference is Primary Preferred', function () {
-    const options: DbOptions = { readPreference: ReadPreference.PRIMARY_PREFERRED };
-    const mydb = new Db(client, 'mydb', options);
+    it('should be true when readPreference is Primary Preferred', function () {
+      const options: DbOptions = { readPreference: ReadPreference.PRIMARY_PREFERRED };
+      const mydb = new Db(client, 'mydb', options);
 
-    expect(mydb.secondaryOk).to.be.true;
-    expect(mydb[legacy_secondary_ok]).to.be.true;
-  });
+      expect(mydb).property(secondary_ok).to.be.true;
+      expect(mydb).property(legacy_secondary_ok).to.be.true;
+    });
 
-  it('secondaryOk should be true when readPreference is Secondary', function () {
-    const options: DbOptions = { readPreference: ReadPreference.SECONDARY };
-    const mydb = new Db(client, 'mydb', options);
+    it('should be true when readPreference is Secondary', function () {
+      const options: DbOptions = { readPreference: ReadPreference.SECONDARY };
+      const mydb = new Db(client, 'mydb', options);
 
-    expect(mydb.secondaryOk).to.be.true;
-    expect(mydb[legacy_secondary_ok]).to.be.true;
-  });
+      expect(mydb).property(secondary_ok).to.be.true;
+      expect(mydb).property(legacy_secondary_ok).to.be.true;
+    });
 
-  it('secondaryOk should be true when readPreference is Secondary Preferred', function () {
-    const options: DbOptions = { readPreference: ReadPreference.SECONDARY_PREFERRED };
-    const mydb = new Db(client, 'mydb', options);
+    it('should be true when readPreference is Secondary Preferred', function () {
+      const options: DbOptions = { readPreference: ReadPreference.SECONDARY_PREFERRED };
+      const mydb = new Db(client, 'mydb', options);
 
-    expect(mydb.secondaryOk).to.be.true;
-    expect(mydb[legacy_secondary_ok]).to.be.true;
-  });
+      expect(mydb).property(secondary_ok).to.be.true;
+      expect(mydb).property(legacy_secondary_ok).to.be.true;
+    });
 
-  it('secondaryOk should be true when readPreference is Nearest', function () {
-    const options: DbOptions = { readPreference: ReadPreference.NEAREST };
-    const mydb = new Db(client, 'mydb', options);
+    it('should be true when readPreference is Nearest', function () {
+      const options: DbOptions = { readPreference: ReadPreference.NEAREST };
+      const mydb = new Db(client, 'mydb', options);
 
-    expect(mydb.secondaryOk).to.be.true;
-    expect(mydb[legacy_secondary_ok]).to.be.true;
+      expect(mydb).property(secondary_ok).to.be.true;
+      expect(mydb).property(legacy_secondary_ok).to.be.true;
+    });
   });
 });

--- a/test/unit/db.test.ts
+++ b/test/unit/db.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+
+import { MongoClient } from '../../src';
+import { Db, DbOptions } from '../../src/db';
+import { ReadPreference } from '../../src/read_preference';
+
+describe('Db - test secondaryOk matches readPreference', function () {
+  const client = new MongoClient('mongodb://localhost:27017');
+  const legacy_secondary_ok = 'slaveOk';
+
+  it.only('secondaryOk should be false when readPreference is Primary', function () {
+    const options: DbOptions = { readPreference: ReadPreference.PRIMARY };
+    const mydb = new Db(client, 'mydb', options);
+
+    expect(mydb.secondaryOk).to.be.false;
+    expect(mydb[legacy_secondary_ok]).to.be.false;
+  });
+
+  it.only('secondaryOk should be true when readPreference is Primary Preferred', function () {
+    const options: DbOptions = { readPreference: ReadPreference.PRIMARY_PREFERRED };
+    const mydb = new Db(client, 'mydb', options);
+
+    expect(mydb.secondaryOk).to.be.true;
+    expect(mydb[legacy_secondary_ok]).to.be.true;
+  });
+
+  it.only('secondaryOk should be true when readPreference is Secondary', function () {
+    const options: DbOptions = { readPreference: ReadPreference.SECONDARY };
+    const mydb = new Db(client, 'mydb', options);
+
+    expect(mydb.secondaryOk).to.be.true;
+    expect(mydb[legacy_secondary_ok]).to.be.true;
+  });
+
+  it.only('secondaryOk should be true when readPreference is Secondary Preferred', function () {
+    const options: DbOptions = { readPreference: ReadPreference.SECONDARY_PREFERRED };
+    const mydb = new Db(client, 'mydb', options);
+
+    expect(mydb.secondaryOk).to.be.true;
+    expect(mydb[legacy_secondary_ok]).to.be.true;
+  });
+
+  it.only('secondaryOk should be true when readPreference is Nearest', function () {
+    const options: DbOptions = { readPreference: ReadPreference.NEAREST };
+    const mydb = new Db(client, 'mydb', options);
+
+    expect(mydb.secondaryOk).to.be.true;
+    expect(mydb[legacy_secondary_ok]).to.be.true;
+  });
+});

--- a/test/unit/db.test.ts
+++ b/test/unit/db.test.ts
@@ -4,7 +4,7 @@ import { MongoClient } from '../../src';
 import { Db, DbOptions } from '../../src/db';
 import { ReadPreference } from '../../src/read_preference';
 
-describe('Db - test secondaryOk matches readPreference', function () {
+describe('class Db', function () {
   const client = new MongoClient('mongodb://localhost:27017');
   const legacy_secondary_ok = 'slaveOk';
 

--- a/test/unit/read_preference.test.ts
+++ b/test/unit/read_preference.test.ts
@@ -134,7 +134,7 @@ describe('class ReadPreference', function () {
   });
 
   describe('secondaryOk()', function () {
-    it('should be true when readPreference is Primary', function () {
+    it('should be false when readPreference is Primary', function () {
       const readPreference = ReadPreference.fromOptions({
         readPreference: PRIMARY
       });

--- a/test/unit/read_preference.test.ts
+++ b/test/unit/read_preference.test.ts
@@ -134,48 +134,44 @@ describe('class ReadPreference', function () {
   });
 
   describe('::secondaryOk', function () {
-
-  it.only('secondaryOk should be true when readPreference is Primary', function () {
+    it('secondaryOk should be true when readPreference is Primary', function () {
       const readPreference = ReadPreference.fromOptions({
-          readPreference: PRIMARY,
-        });
+        readPreference: PRIMARY
+      });
       expect(readPreference.secondaryOk()).to.equal(false);
       expect(readPreference.slaveOk()).to.equal(false);
-  });
+    });
 
-  it.only('secondaryOk should be true when readPreference is Primary Preferred', function () {
+    it('secondaryOk should be true when readPreference is Primary Preferred', function () {
       const readPreference = ReadPreference.fromOptions({
-          readPreference: PRIMARY_PREFERRED,
-        });
+        readPreference: PRIMARY_PREFERRED
+      });
       expect(readPreference.secondaryOk()).to.equal(true);
       expect(readPreference.slaveOk()).to.equal(true);
-  });
+    });
 
-  it.only('secondaryOk should be true when readPreference is Secondary', function () {
-    const readPreference = ReadPreference.fromOptions({
-          readPreference: PRIMARY_PREFERRED,
-        });
+    it('secondaryOk should be true when readPreference is Secondary', function () {
+      const readPreference = ReadPreference.fromOptions({
+        readPreference: PRIMARY_PREFERRED
+      });
       expect(readPreference.secondaryOk()).to.equal(true);
       expect(readPreference.slaveOk()).to.equal(true);
-  });
+    });
 
-  it.only('secondaryOk should be true when readPreference is Secondary Preferred', function () {
-    const readPreference = ReadPreference.fromOptions({
-          readPreference: SECONDARY_PREFERRED,
-        });
+    it('secondaryOk should be true when readPreference is Secondary Preferred', function () {
+      const readPreference = ReadPreference.fromOptions({
+        readPreference: SECONDARY_PREFERRED
+      });
       expect(readPreference.secondaryOk()).to.equal(true);
       expect(readPreference.slaveOk()).to.equal(true);
-  });
+    });
 
-  it.only('secondaryOk should be true when readPreference is Nearest', function () {
-    const readPreference = ReadPreference.fromOptions({
-          readPreference: NEAREST,
-        });
+    it('secondaryOk should be true when readPreference is Nearest', function () {
+      const readPreference = ReadPreference.fromOptions({
+        readPreference: NEAREST
+      });
       expect(readPreference.secondaryOk()).to.equal(true);
       expect(readPreference.slaveOk()).to.equal(true);
-  });
-
-
-
+    });
   });
 });

--- a/test/unit/read_preference.test.ts
+++ b/test/unit/read_preference.test.ts
@@ -4,7 +4,7 @@ import { ReadPreference } from '../../src';
 
 describe('class ReadPreference', function () {
   const maxStalenessSeconds = 1234;
-  const { PRIMARY, SECONDARY, NEAREST } = ReadPreference;
+  const { PRIMARY, PRIMARY_PREFERRED, SECONDARY, SECONDARY_PREFERRED, NEAREST } = ReadPreference;
   const TAGS = [{ loc: 'dc' }];
   describe('::constructor', function () {
     it('should accept (mode)', function () {
@@ -131,5 +131,51 @@ describe('class ReadPreference', function () {
         ReadPreference.fromOptions({ readPreference: PRIMARY, maxStalenessSeconds })
       ).to.throw('Primary read preference cannot be combined with maxStalenessSeconds');
     });
+  });
+
+  describe('::secondaryOk', function () {
+
+  it.only('secondaryOk should be true when readPreference is Primary', function () {
+      const readPreference = ReadPreference.fromOptions({
+          readPreference: PRIMARY,
+        });
+      expect(readPreference.secondaryOk()).to.equal(false);
+      expect(readPreference.slaveOk()).to.equal(false);
+  });
+
+  it.only('secondaryOk should be true when readPreference is Primary Preferred', function () {
+      const readPreference = ReadPreference.fromOptions({
+          readPreference: PRIMARY_PREFERRED,
+        });
+      expect(readPreference.secondaryOk()).to.equal(true);
+      expect(readPreference.slaveOk()).to.equal(true);
+  });
+
+  it.only('secondaryOk should be true when readPreference is Secondary', function () {
+    const readPreference = ReadPreference.fromOptions({
+          readPreference: PRIMARY_PREFERRED,
+        });
+      expect(readPreference.secondaryOk()).to.equal(true);
+      expect(readPreference.slaveOk()).to.equal(true);
+  });
+
+  it.only('secondaryOk should be true when readPreference is Secondary Preferred', function () {
+    const readPreference = ReadPreference.fromOptions({
+          readPreference: SECONDARY_PREFERRED,
+        });
+      expect(readPreference.secondaryOk()).to.equal(true);
+      expect(readPreference.slaveOk()).to.equal(true);
+  });
+
+  it.only('secondaryOk should be true when readPreference is Nearest', function () {
+    const readPreference = ReadPreference.fromOptions({
+          readPreference: NEAREST,
+        });
+      expect(readPreference.secondaryOk()).to.equal(true);
+      expect(readPreference.slaveOk()).to.equal(true);
+  });
+
+
+
   });
 });

--- a/test/unit/read_preference.test.ts
+++ b/test/unit/read_preference.test.ts
@@ -133,8 +133,8 @@ describe('class ReadPreference', function () {
     });
   });
 
-  describe('::secondaryOk', function () {
-    it('secondaryOk should be true when readPreference is Primary', function () {
+  describe('secondaryOk()', function () {
+    it('should be true when readPreference is Primary', function () {
       const readPreference = ReadPreference.fromOptions({
         readPreference: PRIMARY
       });
@@ -142,7 +142,7 @@ describe('class ReadPreference', function () {
       expect(readPreference.slaveOk()).to.equal(false);
     });
 
-    it('secondaryOk should be true when readPreference is Primary Preferred', function () {
+    it('should be true when readPreference is Primary Preferred', function () {
       const readPreference = ReadPreference.fromOptions({
         readPreference: PRIMARY_PREFERRED
       });
@@ -150,7 +150,7 @@ describe('class ReadPreference', function () {
       expect(readPreference.slaveOk()).to.equal(true);
     });
 
-    it('secondaryOk should be true when readPreference is Secondary', function () {
+    it('should be true when readPreference is Secondary', function () {
       const readPreference = ReadPreference.fromOptions({
         readPreference: PRIMARY_PREFERRED
       });
@@ -158,7 +158,7 @@ describe('class ReadPreference', function () {
       expect(readPreference.slaveOk()).to.equal(true);
     });
 
-    it('secondaryOk should be true when readPreference is Secondary Preferred', function () {
+    it('should be true when readPreference is Secondary Preferred', function () {
       const readPreference = ReadPreference.fromOptions({
         readPreference: SECONDARY_PREFERRED
       });
@@ -166,7 +166,7 @@ describe('class ReadPreference', function () {
       expect(readPreference.slaveOk()).to.equal(true);
     });
 
-    it('secondaryOk should be true when readPreference is Nearest', function () {
+    it('should be true when readPreference is Nearest', function () {
       const readPreference = ReadPreference.fromOptions({
         readPreference: NEAREST
       });

--- a/test/unit/read_preference.test.ts
+++ b/test/unit/read_preference.test.ts
@@ -138,40 +138,40 @@ describe('class ReadPreference', function () {
       const readPreference = ReadPreference.fromOptions({
         readPreference: PRIMARY
       });
-      expect(readPreference.secondaryOk()).to.equal(false);
-      expect(readPreference.slaveOk()).to.equal(false);
+      expect(readPreference.secondaryOk()).to.be.false;
+      expect(readPreference.slaveOk()).to.be.false;
     });
 
     it('should be true when readPreference is Primary Preferred', function () {
       const readPreference = ReadPreference.fromOptions({
         readPreference: PRIMARY_PREFERRED
       });
-      expect(readPreference.secondaryOk()).to.equal(true);
-      expect(readPreference.slaveOk()).to.equal(true);
+      expect(readPreference.secondaryOk()).to.be.true;
+      expect(readPreference.slaveOk()).to.be.true;
     });
 
     it('should be true when readPreference is Secondary', function () {
       const readPreference = ReadPreference.fromOptions({
-        readPreference: PRIMARY_PREFERRED
+        readPreference: SECONDARY
       });
-      expect(readPreference.secondaryOk()).to.equal(true);
-      expect(readPreference.slaveOk()).to.equal(true);
+      expect(readPreference.secondaryOk()).to.be.true;
+      expect(readPreference.slaveOk()).to.be.true;
     });
 
     it('should be true when readPreference is Secondary Preferred', function () {
       const readPreference = ReadPreference.fromOptions({
         readPreference: SECONDARY_PREFERRED
       });
-      expect(readPreference.secondaryOk()).to.equal(true);
-      expect(readPreference.slaveOk()).to.equal(true);
+      expect(readPreference.secondaryOk()).to.be.true;
+      expect(readPreference.slaveOk()).to.be.true;
     });
 
     it('should be true when readPreference is Nearest', function () {
       const readPreference = ReadPreference.fromOptions({
         readPreference: NEAREST
       });
-      expect(readPreference.secondaryOk()).to.equal(true);
-      expect(readPreference.slaveOk()).to.equal(true);
+      expect(readPreference.secondaryOk()).to.be.true;
+      expect(readPreference.slaveOk()).to.be.true;
     });
   });
 });


### PR DESCRIPTION
### Description

NODE-3793

#### What is changing?

Remove and deprecate (when removal is not possible) all references to "slaveOk" in the source code and tests. Note that spec test updates are being tracked in NODE-3791

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Following the guidance documented in tools.ietf.org/id/draft-knodel-terminology-00.html, we will remove all oppressive and unnecessarily gendered language in driver documentation, code, tests, specs, and spec tests.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests. I'm unsure and have commented below
- [x] New TODOs have a related JIRA ticket
