### PR TITLE
docs: Fix a typo in FindOptions doc

### DIFF
--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -36,7 +36,7 @@ export interface FindOptions<TSchema extends Document = Document> extends Comman
   timeout?: boolean;
   /** Specify if the cursor is tailable. */
   tailable?: boolean;
-  /** Specify if the cursor is a a tailable-await cursor. Requires `tailable` to be true */
+  /** Specify if the cursor is a tailable-await cursor. Requires `tailable` to be true */
   awaitData?: boolean;
   /** Set the batchSize for the getMoreCommand when iterating over the query results. */
   batchSize?: number;


### PR DESCRIPTION
### Description
Fix a typo in `src/operations/find.ts`

#### What is changing?
Delete a redundant 'a'

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
