### PR TITLE
chore: add lint rule to prevent .only usage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,21 @@
     "es6": true
   },
   "rules": {
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "describe",
+        "property": "only"
+      },
+      {
+        "object": "it",
+        "property": "only"
+      },
+      {
+        "object": "context",
+        "property": "only"
+      }
+    ],
     "prettier/prettier": "error",
     "tsdoc/syntax": "warn",
     "no-console": "error",

--- a/test/functional/change_stream_spec.test.js
+++ b/test/functional/change_stream_spec.test.js
@@ -83,7 +83,10 @@ describe('Change Stream Spec - v1', function () {
 
       suite.tests.forEach(test => {
         const shouldSkip = test.skip || TESTS_TO_SKIP.has(test.description);
-        const itFn = shouldSkip ? it.skip : test.only ? it.only : it;
+        // There's no evidence of test.only being defined in the spec files
+        // But let's avoid removing it now to just be sure we aren't changing anything
+        // These tests will eventually be replaced by unified format versions.
+        const itFn = shouldSkip ? it.skip : test.only ? Reflect.get(it, 'only') : it;
         const metadata = generateMetadata(test);
         const testFn = generateTestFn(test);
 


### PR DESCRIPTION
### Description

#### What is changing?

Our linter will now error on (it/describe/context).only
This can just help us catch accidentally merging a .only usage

#### What is the motivation for this change?

Peace of mind

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
