### PR TITLE
fix(NODE-3843): make `GridFSBucketWriteStream.prototype.end()` return `this` for compat with community nodejs types

### DIFF
--- a/src/gridfs/upload.ts
+++ b/src/gridfs/upload.ts
@@ -172,21 +172,21 @@ export class GridFSBucketWriteStream extends Writable implements NodeJS.Writable
    * @param encoding - Optional encoding for the buffer
    * @param callback - Function to call when all files and chunks have been persisted to MongoDB
    */
-  end(): void;
-  end(chunk: Buffer): void;
-  end(callback: Callback<GridFSFile | void>): void;
-  end(chunk: Buffer, callback: Callback<GridFSFile | void>): void;
-  end(chunk: Buffer, encoding: BufferEncoding): void;
+  end(): this;
+  end(chunk: Buffer): this;
+  end(callback: Callback<GridFSFile | void>): this;
+  end(chunk: Buffer, callback: Callback<GridFSFile | void>): this;
+  end(chunk: Buffer, encoding: BufferEncoding): this;
   end(
     chunk: Buffer,
     encoding: BufferEncoding | undefined,
     callback: Callback<GridFSFile | void>
-  ): void;
+  ): this;
   end(
     chunkOrCallback?: Buffer | Callback<GridFSFile | void>,
     encodingOrCallback?: BufferEncoding | Callback<GridFSFile | void>,
     callback?: Callback<GridFSFile | void>
-  ): void {
+  ): this {
     const chunk = typeof chunkOrCallback === 'function' ? undefined : chunkOrCallback;
     const encoding = typeof encodingOrCallback === 'function' ? undefined : encodingOrCallback;
     callback =
@@ -196,7 +196,7 @@ export class GridFSBucketWriteStream extends Writable implements NodeJS.Writable
         ? encodingOrCallback
         : callback;
 
-    if (checkAborted(this, callback)) return;
+    if (checkAborted(this, callback)) return this;
 
     this.state.streamEnd = true;
 
@@ -208,12 +208,14 @@ export class GridFSBucketWriteStream extends Writable implements NodeJS.Writable
 
     if (!chunk) {
       waitForIndexes(this, () => !!writeRemnant(this));
-      return;
+      return this;
     }
 
     this.write(chunk, encoding, () => {
       writeRemnant(this);
     });
+
+    return this;
   }
 }
 


### PR DESCRIPTION
### Description

Currently `GridFSBucketWriteStream.prototype.end()` returns `void`. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57473/files changed it so that `end()` now must return `this`, which means Mongoose and the Node driver are now incompatible with @types/node@17.0.6. First noticed this [here](https://github.com/Automattic/mongoose/runs/4686998575?check_suite_focus=true)

#### What is changing?

See above

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Compilation fails with @types/node@17.0.6. I took a look and it looks like this change compiles fine with @types/node@16.x as well.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
