### PR TITLE
fix(NODE-3792): remove offensive language throughout the codebase

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -940,7 +940,7 @@ export abstract class BulkOperationBase {
 
     const topology = getTopology(collection);
     options = options == null ? {} : options;
-    // TODO Bring from driver information in isMaster
+    // TODO Bring from driver information in hello
     // Get the namespace for the write operations
     const namespace = collection.s.namespace;
     // Used to mark operation as executed
@@ -950,16 +950,15 @@ export abstract class BulkOperationBase {
     const currentOp = undefined;
 
     // Set max byte size
-    const isMaster = topology.lastHello();
+    const hello = topology.lastHello();
 
     // If we have autoEncryption on, batch-splitting must be done on 2mb chunks, but single documents
     // over 2mb are still allowed
     const usingAutoEncryption = !!(topology.s.options && topology.s.options.autoEncrypter);
     const maxBsonObjectSize =
-      isMaster && isMaster.maxBsonObjectSize ? isMaster.maxBsonObjectSize : 1024 * 1024 * 16;
+      hello && hello.maxBsonObjectSize ? hello.maxBsonObjectSize : 1024 * 1024 * 16;
     const maxBatchSizeBytes = usingAutoEncryption ? 1024 * 1024 * 2 : maxBsonObjectSize;
-    const maxWriteBatchSize =
-      isMaster && isMaster.maxWriteBatchSize ? isMaster.maxWriteBatchSize : 1000;
+    const maxWriteBatchSize = hello && hello.maxWriteBatchSize ? hello.maxWriteBatchSize : 1000;
 
     // Calculates the largest possible size of an Array key, represented as a BSON string
     // element. This calculation:

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -950,7 +950,7 @@ export abstract class BulkOperationBase {
     const currentOp = undefined;
 
     // Set max byte size
-    const isMaster = topology.lastIsMaster();
+    const isMaster = topology.lastHello();
 
     // If we have autoEncryption on, batch-splitting must be done on 2mb chunks, but single documents
     // over 2mb are still allowed

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -71,7 +71,7 @@ export interface ResumeOptions {
 }
 
 /**
- * Represents the logical starting point for a new or resuming {@link https://docs.mongodb.com/master/changeStreams/#change-stream-resume-token| Change Stream} on the server.
+ * Represents the logical starting point for a new or resuming {@link https://docs.mongodb.com/manual/changeStreams/#std-label-change-stream-resume| Change Stream} on the server.
  * @public
  */
 export type ResumeToken = unknown;
@@ -98,9 +98,9 @@ export interface ChangeStreamOptions extends AggregateOptions {
   fullDocument?: string;
   /** The maximum amount of time for the server to wait on new documents to satisfy a change stream query. */
   maxAwaitTimeMS?: number;
-  /** Allows you to start a changeStream after a specified event. See {@link https://docs.mongodb.com/master/changeStreams/#resumeafter-for-change-streams|ChangeStream documentation}. */
+  /** Allows you to start a changeStream after a specified event. See {@link https://docs.mongodb.com/manual/changeStreams/#resumeafter-for-change-streams|ChangeStream documentation}. */
   resumeAfter?: ResumeToken;
-  /** Similar to resumeAfter, but will allow you to start after an invalidated event. See {@link https://docs.mongodb.com/master/changeStreams/#startafter-for-change-streams|ChangeStream documentation}. */
+  /** Similar to resumeAfter, but will allow you to start after an invalidated event. See {@link https://docs.mongodb.com/manual/changeStreams/#startafter-for-change-streams|ChangeStream documentation}. */
   startAfter?: ResumeToken;
   /** Will start the changeStream after the specified operationTime. */
   startAtOperationTime?: OperationTime;

--- a/src/cmap/command_monitoring_events.ts
+++ b/src/cmap/command_monitoring_events.ts
@@ -1,4 +1,5 @@
 import type { Document, ObjectId } from '../bson';
+import { LEGACY_HELLO_COMMAND, LEGACY_HELLO_COMMAND_CAMEL_CASE } from '../constants';
 import { calculateDurationInMs, deepCopy } from '../utils';
 import { GetMore, KillCursor, Msg, WriteProtocolMessageType } from './commands';
 import type { Connection } from './connection';
@@ -161,7 +162,7 @@ const SENSITIVE_COMMANDS = new Set([
   'copydb'
 ]);
 
-const HELLO_COMMANDS = new Set(['hello', 'ismaster', 'isMaster']);
+const HELLO_COMMANDS = new Set(['hello', LEGACY_HELLO_COMMAND, LEGACY_HELLO_COMMAND_CAMEL_CASE]);
 
 // helper methods
 const extractCommandName = (commandDoc: Document) => Object.keys(commandDoc)[0];

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -6,6 +6,7 @@ import * as tls from 'tls';
 
 import type { Document } from '../bson';
 import { Int32 } from '../bson';
+import { LEGACY_HELLO_COMMAND } from '../constants';
 import {
   AnyError,
   MongoCompatibilityError,
@@ -70,15 +71,15 @@ export function connect(options: ConnectionOptions, callback: Callback<Connectio
   });
 }
 
-function checkSupportedServer(ismaster: Document, options: ConnectionOptions) {
+function checkSupportedServer(hello: Document, options: ConnectionOptions) {
   const serverVersionHighEnough =
-    ismaster &&
-    (typeof ismaster.maxWireVersion === 'number' || ismaster.maxWireVersion instanceof Int32) &&
-    ismaster.maxWireVersion >= MIN_SUPPORTED_WIRE_VERSION;
+    hello &&
+    (typeof hello.maxWireVersion === 'number' || hello.maxWireVersion instanceof Int32) &&
+    hello.maxWireVersion >= MIN_SUPPORTED_WIRE_VERSION;
   const serverVersionLowEnough =
-    ismaster &&
-    (typeof ismaster.minWireVersion === 'number' || ismaster.minWireVersion instanceof Int32) &&
-    ismaster.minWireVersion <= MAX_SUPPORTED_WIRE_VERSION;
+    hello &&
+    (typeof hello.minWireVersion === 'number' || hello.minWireVersion instanceof Int32) &&
+    hello.minWireVersion <= MAX_SUPPORTED_WIRE_VERSION;
 
   if (serverVersionHighEnough) {
     if (serverVersionLowEnough) {
@@ -86,13 +87,13 @@ function checkSupportedServer(ismaster: Document, options: ConnectionOptions) {
     }
 
     const message = `Server at ${options.hostAddress} reports minimum wire version ${JSON.stringify(
-      ismaster.minWireVersion
+      hello.minWireVersion
     )}, but this version of the Node.js Driver requires at most ${MAX_SUPPORTED_WIRE_VERSION} (MongoDB ${MAX_SUPPORTED_SERVER_VERSION})`;
     return new MongoCompatibilityError(message);
   }
 
   const message = `Server at ${options.hostAddress} reports maximum wire version ${
-    JSON.stringify(ismaster.maxWireVersion) ?? 0
+    JSON.stringify(hello.maxWireVersion) ?? 0
   }, but this version of the Node.js Driver requires at least ${MIN_SUPPORTED_WIRE_VERSION} (MongoDB ${MIN_SUPPORTED_SERVER_VERSION})`;
   return new MongoCompatibilityError(message);
 }
@@ -148,7 +149,7 @@ function performInitialHandshake(
 
       if ('isWritablePrimary' in response) {
         // Provide pre-hello-style response document.
-        response.ismaster = response.isWritablePrimary;
+        response[LEGACY_HELLO_COMMAND] = response.isWritablePrimary;
       }
 
       if (response.helloOk) {
@@ -180,7 +181,7 @@ function performInitialHandshake(
       //       handshake being done in the `Server` class. Likely, it should be
       //       relocated, or at very least restructured.
       conn.hello = response;
-      conn.lastIsMasterMS = new Date().getTime() - start;
+      conn.lastHelloMS = new Date().getTime() - start;
 
       if (!response.arbiterOnly && credentials) {
         // store the response on auth context
@@ -209,6 +210,9 @@ function performInitialHandshake(
 }
 
 export interface HandshakeDocument extends Document {
+  /**
+   * @deprecated Use hello instead
+   */
   ismaster?: boolean;
   hello?: boolean;
   helloOk?: boolean;
@@ -224,7 +228,7 @@ function prepareHandshakeDocument(authContext: AuthContext, callback: Callback<H
   const { serverApi } = authContext.connection;
 
   const handshakeDoc: HandshakeDocument = {
-    [serverApi?.version ? 'hello' : 'ismaster']: true,
+    [serverApi?.version ? 'hello' : LEGACY_HELLO_COMMAND]: true,
     helloOk: true,
     client: options.metadata || makeClientMetadata(options),
     compression: compressors,

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -147,9 +147,9 @@ function performInitialHandshake(
         return;
       }
 
-      if ('isWritablePrimary' in response) {
-        // Provide pre-hello-style response document.
-        response[LEGACY_HELLO_COMMAND] = response.isWritablePrimary;
+      if (!('isWritablePrimary' in response)) {
+        // Provide hello-style response document.
+        response.isWritablePrimary = response[LEGACY_HELLO_COMMAND];
       }
 
       if (response.helloOk) {

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -179,7 +179,7 @@ function performInitialHandshake(
       // NOTE: This is metadata attached to the connection while porting away from
       //       handshake being done in the `Server` class. Likely, it should be
       //       relocated, or at very least restructured.
-      conn.ismaster = response;
+      conn.hello = response;
       conn.lastIsMasterMS = new Date().getTime() - start;
 
       if (!response.arbiterOnly && credentials) {

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -70,7 +70,7 @@ const kClusterTime = Symbol('clusterTime');
 /** @internal */
 const kDescription = Symbol('description');
 /** @internal */
-const kIsMaster = Symbol('ismaster');
+const kHello = Symbol('hello');
 /** @internal */
 const kAutoEncrypter = Symbol('autoEncrypter');
 /** @internal */
@@ -201,7 +201,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
   /** @internal */
   [kStream]: Stream;
   /** @internal */
-  [kIsMaster]: Document;
+  [kHello]: Document;
   /** @internal */
   [kClusterTime]: Document;
 
@@ -240,7 +240,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     this[kQueue] = new Map();
     this[kMessageStream] = new MessageStream({
       ...options,
-      maxBsonMessageSize: this.ismaster?.maxBsonMessageSize
+      maxBsonMessageSize: this.hello?.maxBsonMessageSize
     });
     this[kMessageStream].on('message', messageHandler(this));
     this[kStream] = stream;
@@ -261,21 +261,21 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     return this[kDescription];
   }
 
-  get ismaster(): Document {
-    return this[kIsMaster];
+  get hello(): Document {
+    return this[kHello];
   }
 
   // the `connect` method stores the result of the handshake ismaster on the connection
-  set ismaster(response: Document) {
+  set hello(response: Document) {
     this[kDescription].receiveResponse(response);
     this[kDescription] = Object.freeze(this[kDescription]);
 
     // TODO: remove this, and only use the `StreamDescription` in the future
-    this[kIsMaster] = response;
+    this[kHello] = response;
   }
 
   get serviceId(): ObjectId | undefined {
-    return this.ismaster?.serviceId;
+    return this.hello?.serviceId;
   }
 
   get loadBalanced(): boolean {
@@ -321,7 +321,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       if (issue.isTimeout) {
         op.cb(
           new MongoNetworkTimeoutError(`connection ${this.id} to ${this.address} timed out`, {
-            beforeHandshake: this.ismaster == null
+            beforeHandshake: this.hello == null
           })
         );
       } else if (issue.isClose) {

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -185,7 +185,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
   monitorCommands: boolean;
   closed: boolean;
   destroyed: boolean;
-  lastIsMasterMS?: number;
+  lastHelloMS?: number;
   serverApi?: ServerApi;
   helloOk?: boolean;
   /** @internal */

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -265,7 +265,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     return this[kHello];
   }
 
-  // the `connect` method stores the result of the handshake ismaster on the connection
+  // the `connect` method stores the result of the handshake hello on the connection
   set hello(response: Document) {
     this[kDescription].receiveResponse(response);
     this[kDescription] = Object.freeze(this[kDescription]);

--- a/src/cmap/wire_protocol/compression.ts
+++ b/src/cmap/wire_protocol/compression.ts
@@ -1,5 +1,6 @@
 import * as zlib from 'zlib';
 
+import { LEGACY_HELLO_COMMAND } from '../../constants';
 import { PKG_VERSION, Snappy } from '../../deps';
 import { MongoDecompressionError, MongoInvalidArgumentError } from '../../error';
 import type { Callback } from '../../utils';
@@ -19,7 +20,7 @@ export type Compressor = typeof Compressor[CompressorName];
 export type CompressorName = keyof typeof Compressor;
 
 export const uncompressibleCommands = new Set([
-  'ismaster',
+  LEGACY_HELLO_COMMAND,
   'saslStart',
   'saslContinue',
   'getnonce',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -120,3 +120,9 @@ export const MONGO_CLIENT_EVENTS = Object.freeze([
  * The legacy hello command that was deprecated in MongoDB 5.0.
  */
 export const LEGACY_HELLO_COMMAND = 'ismaster';
+
+/**
+ * @internal
+ * The legacy hello command that was deprecated in MongoDB 5.0.
+ */
+export const LEGACY_HELLO_COMMAND_CAMEL_CASE = 'isMaster';

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -201,7 +201,7 @@ export interface AutoEncryptionOptions {
     /** Configuration options for using 'local' as your KMS provider */
     local?: {
       /**
-       * The KMS key used to encrypt/decrypt data keys.
+       * The master key used to encrypt/decrypt data keys.
        * A 96-byte long Buffer or base64 encoded string.
        */
       key: Buffer | string;

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -201,7 +201,7 @@ export interface AutoEncryptionOptions {
     /** Configuration options for using 'local' as your KMS provider */
     local?: {
       /**
-       * The master key used to encrypt/decrypt data keys.
+       * The KMS key used to encrypt/decrypt data keys.
        * A 96-byte long Buffer or base64 encoded string.
        */
       key: Buffer | string;

--- a/src/operations/add_user.ts
+++ b/src/operations/add_user.ts
@@ -75,7 +75,7 @@ export class AddUserOperation extends CommandOperation<Document> {
       roles = Array.isArray(options.roles) ? options.roles : [options.roles];
     }
 
-    const digestPassword = getTopology(db).lastIsMaster().maxWireVersion >= 7;
+    const digestPassword = getTopology(db).lastHello().maxWireVersion >= 7;
 
     let userPassword = password;
 

--- a/src/sdam/events.ts
+++ b/src/sdam/events.ts
@@ -123,8 +123,8 @@ export class TopologyClosedEvent {
 }
 
 /**
- * Emitted when the server monitor’s ismaster command is started - immediately before
- * the ismaster command is serialized into raw BSON and written to the socket.
+ * Emitted when the server monitor’s hello command is started - immediately before
+ * the hello command is serialized into raw BSON and written to the socket.
  *
  * @public
  * @category Event
@@ -140,7 +140,7 @@ export class ServerHeartbeatStartedEvent {
 }
 
 /**
- * Emitted when the server monitor’s ismaster succeeds.
+ * Emitted when the server monitor’s hello succeeds.
  * @public
  * @category Event
  */
@@ -161,7 +161,7 @@ export class ServerHeartbeatSucceededEvent {
 }
 
 /**
- * Emitted when the server monitor’s ismaster fails, either with an “ok: 0” or a socket exception.
+ * Emitted when the server monitor’s hello fails, either with an “ok: 0” or a socket exception.
  * @public
  * @category Event
  */

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -450,7 +450,7 @@ function measureRoundTripTime(rttPinger: RTTPinger, options: RTTPingerOptions) {
     return;
   }
 
-  connection.command(ns('admin.$cmd'), { LEGACY_HELLO_COMMAND: 1 }, undefined, err => {
+  connection.command(ns('admin.$cmd'), { [LEGACY_HELLO_COMMAND]: 1 }, undefined, err => {
     if (err) {
       rttPinger[kConnection] = undefined;
       rttPinger[kRoundTripTime] = 0;

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -317,14 +317,10 @@ function checkServer(monitor: Monitor, callback: Callback<Document>) {
       monitor[kConnection] = conn;
       monitor.emit(
         Server.SERVER_HEARTBEAT_SUCCEEDED,
-        new ServerHeartbeatSucceededEvent(
-          monitor.address,
-          calculateDurationInMs(start),
-          conn.ismaster
-        )
+        new ServerHeartbeatSucceededEvent(monitor.address, calculateDurationInMs(start), conn.hello)
       );
 
-      callback(undefined, conn.ismaster);
+      callback(undefined, conn.hello);
     }
   });
 }

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -262,9 +262,10 @@ function checkServer(monitor: Monitor, callback: Callback<Document>) {
         failureHandler(err);
         return;
       }
-      if ('isWritablePrimary' in hello) {
-        // Provide pre-hello-style response document.
-        hello[LEGACY_HELLO_COMMAND] = hello.isWritablePrimary;
+
+      if (!('isWritablePrimary' in hello)) {
+        // Provide hello-style response document.
+        hello.isWritablePrimary = hello[LEGACY_HELLO_COMMAND];
       }
 
       const rttPinger = monitor[kRTTPinger];

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -118,7 +118,7 @@ export class Server extends TypedEventEmitter<ServerEvents> {
   /** @internal */
   s: ServerPrivate;
   serverApi?: ServerApi;
-  ismaster?: Document;
+  hello?: Document;
   [kMonitor]: Monitor;
 
   /** @event */

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -1,4 +1,5 @@
 import { Document, Long, ObjectId } from '../bson';
+import { LEGACY_HELLO_COMMAND } from '../constants';
 import type { MongoError } from '../error';
 import { arrayStrictEqual, errorStrictEqual, HostAddress, now } from '../utils';
 import type { ClusterTime } from './common';
@@ -44,7 +45,7 @@ export interface ServerDescriptionOptions {
 }
 
 /**
- * The client's view of a single server, based on the most recent ismaster outcome.
+ * The client's view of a single server, based on the most recent hello outcome.
  *
  * Internal type, not meant to be directly instantiated
  * @public
@@ -81,13 +82,9 @@ export class ServerDescription {
    * @internal
    *
    * @param address - The address of the server
-   * @param ismaster - An optional ismaster response for this server
+   * @param hello - An optional hello response for this server
    */
-  constructor(
-    address: HostAddress | string,
-    ismaster?: Document,
-    options?: ServerDescriptionOptions
-  ) {
+  constructor(address: HostAddress | string, hello?: Document, options?: ServerDescriptionOptions) {
     if (typeof address === 'string') {
       this._hostAddress = new HostAddress(address);
       this.address = this._hostAddress.toString();
@@ -95,53 +92,53 @@ export class ServerDescription {
       this._hostAddress = address;
       this.address = this._hostAddress.toString();
     }
-    this.type = parseServerType(ismaster, options);
-    this.hosts = ismaster?.hosts?.map((host: string) => host.toLowerCase()) ?? [];
-    this.passives = ismaster?.passives?.map((host: string) => host.toLowerCase()) ?? [];
-    this.arbiters = ismaster?.arbiters?.map((host: string) => host.toLowerCase()) ?? [];
-    this.tags = ismaster?.tags ?? {};
-    this.minWireVersion = ismaster?.minWireVersion ?? 0;
-    this.maxWireVersion = ismaster?.maxWireVersion ?? 0;
+    this.type = parseServerType(hello, options);
+    this.hosts = hello?.hosts?.map((host: string) => host.toLowerCase()) ?? [];
+    this.passives = hello?.passives?.map((host: string) => host.toLowerCase()) ?? [];
+    this.arbiters = hello?.arbiters?.map((host: string) => host.toLowerCase()) ?? [];
+    this.tags = hello?.tags ?? {};
+    this.minWireVersion = hello?.minWireVersion ?? 0;
+    this.maxWireVersion = hello?.maxWireVersion ?? 0;
     this.roundTripTime = options?.roundTripTime ?? -1;
     this.lastUpdateTime = now();
-    this.lastWriteDate = ismaster?.lastWrite?.lastWriteDate ?? 0;
+    this.lastWriteDate = hello?.lastWrite?.lastWriteDate ?? 0;
 
     if (options?.topologyVersion) {
       this.topologyVersion = options.topologyVersion;
-    } else if (ismaster?.topologyVersion) {
-      this.topologyVersion = ismaster.topologyVersion;
+    } else if (hello?.topologyVersion) {
+      this.topologyVersion = hello.topologyVersion;
     }
 
     if (options?.error) {
       this.error = options.error;
     }
 
-    if (ismaster?.primary) {
-      this.primary = ismaster.primary;
+    if (hello?.primary) {
+      this.primary = hello.primary;
     }
 
-    if (ismaster?.me) {
-      this.me = ismaster.me.toLowerCase();
+    if (hello?.me) {
+      this.me = hello.me.toLowerCase();
     }
 
-    if (ismaster?.setName) {
-      this.setName = ismaster.setName;
+    if (hello?.setName) {
+      this.setName = hello.setName;
     }
 
-    if (ismaster?.setVersion) {
-      this.setVersion = ismaster.setVersion;
+    if (hello?.setVersion) {
+      this.setVersion = hello.setVersion;
     }
 
-    if (ismaster?.electionId) {
-      this.electionId = ismaster.electionId;
+    if (hello?.electionId) {
+      this.electionId = hello.electionId;
     }
 
-    if (ismaster?.logicalSessionTimeoutMinutes) {
-      this.logicalSessionTimeoutMinutes = ismaster.logicalSessionTimeoutMinutes;
+    if (hello?.logicalSessionTimeoutMinutes) {
+      this.logicalSessionTimeoutMinutes = hello.logicalSessionTimeoutMinutes;
     }
 
-    if (ismaster?.$clusterTime) {
-      this.$clusterTime = ismaster.$clusterTime;
+    if (hello?.$clusterTime) {
+      this.$clusterTime = hello.$clusterTime;
     }
   }
 
@@ -210,35 +207,32 @@ export class ServerDescription {
   }
 }
 
-// Parses an `ismaster` message and determines the server type
-export function parseServerType(
-  ismaster?: Document,
-  options?: ServerDescriptionOptions
-): ServerType {
+// Parses a `hello` message and determines the server type
+export function parseServerType(hello?: Document, options?: ServerDescriptionOptions): ServerType {
   if (options?.loadBalanced) {
     return ServerType.LoadBalancer;
   }
 
-  if (!ismaster || !ismaster.ok) {
+  if (!hello || !hello.ok) {
     return ServerType.Unknown;
   }
 
-  if (ismaster.isreplicaset) {
+  if (hello.isreplicaset) {
     return ServerType.RSGhost;
   }
 
-  if (ismaster.msg && ismaster.msg === 'isdbgrid') {
+  if (hello.msg && hello.msg === 'isdbgrid') {
     return ServerType.Mongos;
   }
 
-  if (ismaster.setName) {
-    if (ismaster.hidden) {
+  if (hello.setName) {
+    if (hello.hidden) {
       return ServerType.RSOther;
-    } else if (ismaster.ismaster || ismaster.isWritablePrimary) {
+    } else if (hello[LEGACY_HELLO_COMMAND] || hello.isWritablePrimary) {
       return ServerType.RSPrimary;
-    } else if (ismaster.secondary) {
+    } else if (hello.secondary) {
       return ServerType.RSSecondary;
-    } else if (ismaster.arbiterOnly) {
+    } else if (hello.arbiterOnly) {
       return ServerType.RSArbiter;
     } else {
       return ServerType.RSOther;

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -1,5 +1,4 @@
 import { Document, Long, ObjectId } from '../bson';
-import { LEGACY_HELLO_COMMAND } from '../constants';
 import type { MongoError } from '../error';
 import { arrayStrictEqual, errorStrictEqual, HostAddress, now } from '../utils';
 import type { ClusterTime } from './common';
@@ -228,7 +227,7 @@ export function parseServerType(hello?: Document, options?: ServerDescriptionOpt
   if (hello.setName) {
     if (hello.hidden) {
       return ServerType.RSOther;
-    } else if (hello[LEGACY_HELLO_COMMAND] || hello.isWritablePrimary) {
+    } else if (hello.isWritablePrimary) {
       return ServerType.RSPrimary;
     } else if (hello.secondary) {
       return ServerType.RSSecondary;

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -198,7 +198,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
   /** @internal */
   [kWaitQueue]: Denque<ServerSelectionRequest>;
   /** @internal */
-  ismaster?: Document;
+  hello?: Document;
   /** @internal */
   _type?: string;
 
@@ -403,7 +403,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
   }
 
   get capabilities(): ServerCapabilities {
-    return new ServerCapabilities(this.lastIsMaster());
+    return new ServerCapabilities(this.lastHello());
   }
 
   /** Initiate server connect */
@@ -791,10 +791,10 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
     emitWarning('`unref` is a noop and will be removed in the next major version');
   }
 
-  // NOTE: There are many places in code where we explicitly check the last isMaster
+  // NOTE: There are many places in code where we explicitly check the last hello
   //       to do feature support detection. This should be done any other way, but for
-  //       now we will just return the first isMaster seen, which should suffice.
-  lastIsMaster(): Document {
+  //       now we will just return the first hello seen, which should suffice.
+  lastHello(): Document {
     const serverDescriptions = Array.from(this.description.servers.values());
     if (serverDescriptions.length === 0) return {};
     const sd = serverDescriptions.filter(
@@ -1066,9 +1066,9 @@ export class ServerCapabilities {
   maxWireVersion: number;
   minWireVersion: number;
 
-  constructor(ismaster: Document) {
-    this.minWireVersion = ismaster.minWireVersion || 0;
-    this.maxWireVersion = ismaster.maxWireVersion || 0;
+  constructor(hello: Document) {
+    this.minWireVersion = hello.minWireVersion || 0;
+    this.maxWireVersion = hello.maxWireVersion || 0;
   }
 
   get hasAggregationCursor(): boolean {

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -106,7 +106,7 @@ export class TopologyDescription {
       }
     }
 
-    // Whenever a client updates the TopologyDescription from an ismaster response, it MUST set
+    // Whenever a client updates the TopologyDescription from a hello response, it MUST set
     // TopologyDescription.logicalSessionTimeoutMinutes to the smallest logicalSessionTimeoutMinutes
     // value among ServerDescriptions of all data-bearing server types. If any have a null
     // logicalSessionTimeoutMinutes, then TopologyDescription.logicalSessionTimeoutMinutes MUST be

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -656,14 +656,14 @@ export function maxWireVersion(topologyOrServer?: Connection | Topology | Server
       // application that a feature is avaiable that is actually not.
       return MAX_SUPPORTED_WIRE_VERSION;
     }
-    if (topologyOrServer.ismaster) {
-      return topologyOrServer.ismaster.maxWireVersion;
+    if (topologyOrServer.hello) {
+      return topologyOrServer.hello.maxWireVersion;
     }
 
-    if ('lastIsMaster' in topologyOrServer && typeof topologyOrServer.lastIsMaster === 'function') {
-      const lastIsMaster = topologyOrServer.lastIsMaster();
-      if (lastIsMaster) {
-        return lastIsMaster.maxWireVersion;
+    if ('lastHello' in topologyOrServer && typeof topologyOrServer.lastHello === 'function') {
+      const lastHello = topologyOrServer.lastHello();
+      if (lastHello) {
+        return lastHello.maxWireVersion;
       }
     }
 

--- a/test/functional/unit-sdam/server_selection/spec.test.js
+++ b/test/functional/unit-sdam/server_selection/spec.test.js
@@ -223,20 +223,13 @@ function executeServerSelectionTest(testDefinition, options, testDone) {
     { seedlist: [], hosts: [] }
   );
 
-  console.log('the seed data is');
-  console.log(seedData);
-
   const topologyOptions = {
     heartbeatFrequencyMS: testDefinition.heartbeatFrequencyMS,
     monitorFunction: () => {},
     loadBalanced: topologyDescription.type === TopologyType.LoadBalanced
   };
-  console.log('topologyOptions');
-  console.log(topologyOptions);
 
   const topology = new Topology(seedData.seedlist, topologyOptions);
-  console.log('topology');
-  console.log(topology);
   // Each test will attempt to connect by doing server selection. We want to make the first
   // call to `selectServers` call a fake, and then immediately restore the original behavior.
   let topologySelectServers = sinon
@@ -301,7 +294,6 @@ function executeServerSelectionTest(testDefinition, options, testDone) {
 
       if (err) {
         // this is another expected error case
-        console.log('THINK WE HIT A SERVER SELECTION ERROR HERE !!!!!!!!!!!');
         if (expectedServers.length === 0 && err instanceof MongoServerSelectionError) return done();
         return done(err);
       }
@@ -318,7 +310,6 @@ function executeServerSelectionTest(testDefinition, options, testDone) {
         );
 
         if (!expectedServerArray.length) {
-          console.log('No suitable servers found!!!!!!!!!!!!!!!!!!!!!');
           return done(new Error('No suitable servers found!'));
         }
 

--- a/test/functional/unit-sdam/server_selection/spec.test.js
+++ b/test/functional/unit-sdam/server_selection/spec.test.js
@@ -8,7 +8,6 @@ const { ServerDescription } = require('../../../../src/sdam/server_description')
 const { ReadPreference } = require('../../../../src/read_preference');
 const { MongoServerSelectionError } = require('../../../../src/error');
 const ServerSelectors = require('../../../../src/sdam/server_selection');
-const { LEGACY_HELLO_COMMAND } = require('../../../../src/constants');
 
 const { EJSON } = require('bson');
 
@@ -168,7 +167,7 @@ function serverDescriptionFromDefinition(definition, hosts) {
   }
 
   if (serverType === ServerType.RSPrimary) {
-    fakeHello[LEGACY_HELLO_COMMAND] = true;
+    fakeHello.isWritablePrimary = true;
   } else if (serverType === ServerType.RSSecondary) {
     fakeHello.secondary = true;
   } else if (serverType === ServerType.Mongos) {
@@ -224,13 +223,20 @@ function executeServerSelectionTest(testDefinition, options, testDone) {
     { seedlist: [], hosts: [] }
   );
 
+  console.log('the seed data is');
+  console.log(seedData);
+
   const topologyOptions = {
     heartbeatFrequencyMS: testDefinition.heartbeatFrequencyMS,
     monitorFunction: () => {},
     loadBalanced: topologyDescription.type === TopologyType.LoadBalanced
   };
+  console.log('topologyOptions');
+  console.log(topologyOptions);
 
   const topology = new Topology(seedData.seedlist, topologyOptions);
+  console.log('topology');
+  console.log(topology);
   // Each test will attempt to connect by doing server selection. We want to make the first
   // call to `selectServers` call a fake, and then immediately restore the original behavior.
   let topologySelectServers = sinon
@@ -295,6 +301,7 @@ function executeServerSelectionTest(testDefinition, options, testDone) {
 
       if (err) {
         // this is another expected error case
+        console.log('THINK WE HIT A SERVER SELECTION ERROR HERE !!!!!!!!!!!');
         if (expectedServers.length === 0 && err instanceof MongoServerSelectionError) return done();
         return done(err);
       }
@@ -311,6 +318,7 @@ function executeServerSelectionTest(testDefinition, options, testDone) {
         );
 
         if (!expectedServerArray.length) {
+          console.log('No suitable servers found!!!!!!!!!!!!!!!!!!!!!');
           return done(new Error('No suitable servers found!'));
         }
 

--- a/test/functional/unit-sdam/topology.test.js
+++ b/test/functional/unit-sdam/topology.test.js
@@ -12,6 +12,7 @@ const { TopologyDescription } = require('../../../src/sdam/topology_description'
 const { TopologyType } = require('../../../src/sdam/common');
 const { SrvPoller, SrvPollingEvent } = require('../../../src/sdam/srv_polling');
 const { getSymbolFrom } = require('../../tools/utils');
+const { LEGACY_NOT_WRITABLE_PRIMARY_ERROR_MESSAGE } = require('../../../src/error');
 
 describe('Topology (unit)', function () {
   describe('client metadata', function () {
@@ -227,7 +228,7 @@ describe('Topology (unit)', function () {
         if (isHello(doc)) {
           request.reply(Object.assign({}, mock.HELLO, { maxWireVersion: 9 }));
         } else if (doc.insert) {
-          request.reply({ ok: 0, message: 'not master' });
+          request.reply({ ok: 0, message: LEGACY_NOT_WRITABLE_PRIMARY_ERROR_MESSAGE });
         } else {
           request.reply({ ok: 1 });
         }

--- a/test/manual/socks5.test.ts
+++ b/test/manual/socks5.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import ConnectionString from 'mongodb-connection-string-url';
 
 import { MongoClient } from '../../src';
+import { LEGACY_HELLO_COMMAND } from '../../src/constants';
 import { MongoParseError } from '../../src/error';
 
 /**
@@ -271,7 +272,7 @@ describe('Socks5 Connectivity', function () {
         client.on('commandSucceeded', ev => seenCommandAddresses.add(ev.address));
 
         await client.connect();
-        await client.db('admin').command({ ismaster: 1 });
+        await client.db('admin').command({ [LEGACY_HELLO_COMMAND]: 1 });
         await client.close();
         expect([...seenCommandAddresses]).to.deep.equal(singleConnectionString.hosts);
       });

--- a/test/unit/_MISC_optional_require.test.js
+++ b/test/unit/_MISC_optional_require.test.js
@@ -67,13 +67,10 @@ describe('optionalRequire', function () {
           return this.skip();
         }
         const mdbAWS = new MongoDBAWS();
-        mdbAWS.auth(
-          new AuthContext({ [LEGACY_HELLO_COMMAND]: { maxWireVersion: 9 } }, true, null),
-          error => {
-            expect(error).to.exist;
-            expect(error.message).includes('not found');
-          }
-        );
+        mdbAWS.auth(new AuthContext({ hello: { maxWireVersion: 9 } }, true, null), error => {
+          expect(error).to.exist;
+          expect(error.message).includes('not found');
+        });
       });
     }
   });

--- a/test/unit/_MISC_optional_require.test.js
+++ b/test/unit/_MISC_optional_require.test.js
@@ -9,7 +9,6 @@ const { GSSAPI } = require('../../src/cmap/auth/gssapi');
 const { AuthContext } = require('../../src/cmap/auth/auth_provider');
 const { MongoDBAWS } = require('../../src/cmap/auth/mongodb_aws');
 const { HostAddress } = require('../../src/utils');
-const { LEGACY_HELLO_COMMAND } = require('../../src/constants');
 
 function moduleExistsSync(moduleName) {
   return existsSync(resolve(__dirname, `../../node_modules/${moduleName}`));

--- a/test/unit/cmap/connection.test.js
+++ b/test/unit/cmap/connection.test.js
@@ -7,7 +7,6 @@ const { expect } = require('chai');
 const { Socket } = require('net');
 const { ns, isHello } = require('../../../src/utils');
 const { getSymbolFrom } = require('../../tools/utils');
-const { LEGACY_HELLO_COMMAND } = require('../../../src/constants');
 
 describe('Connection - unit/cmap', function () {
   let server;

--- a/test/unit/cmap/connection.test.js
+++ b/test/unit/cmap/connection.test.js
@@ -78,7 +78,7 @@ describe('Connection - unit/cmap', function () {
     connect(options, (err, conn) => {
       expect(err).to.be.a('undefined');
       expect(conn).to.be.instanceOf(Connection);
-      expect(conn).to.have.property(LEGACY_HELLO_COMMAND).that.is.a('object');
+      expect(conn).to.have.property('hello').that.is.a('object');
 
       conn.command(ns('$admin.cmd'), { ping: 1 }, { socketTimeoutMS: 50 }, err => {
         const beforeHandshakeSymbol = getSymbolFrom(err, 'beforeHandshake', false);


### PR DESCRIPTION
### Description

Remove references to "master" throughout the codebase

#### What is changing?

- Any references to master that can be updated are updated or abstracted to a constant
- Any references to master that cannot be updated are deprecated
- Exceptions: 
   - CSFLE references to masterKey are out of scope
   - Historical documentation (e.g. history.md and changes_x.md) can remain as-is
   - References to GitHub repos with master branches
   - Spec tests are covered in NODE-3791

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Following the guidance documented in tools.ietf.org/id/draft-knodel-terminology-00.html, we will remove all oppressive and unnecessarily gendered language in driver documentation, code, tests, specs, and spec tests.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [X] Changes are covered by tests
- [X] New TODOs have a related JIRA ticket
