### PR TITLE
fix(NODE-3795): unexpected No auth provider for DEFAULT defined error

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -394,6 +394,16 @@ export function parseOptions(
     }
 
     mongoOptions.credentials.validate();
+
+    // Check if the only auth related option provided was authSource, if so we can remove credentials
+    if (
+      mongoOptions.credentials.password === '' &&
+      mongoOptions.credentials.username === '' &&
+      mongoOptions.credentials.mechanism === AuthMechanism.MONGODB_DEFAULT &&
+      Object.keys(mongoOptions.credentials.mechanismProperties).length === 0
+    ) {
+      delete mongoOptions.credentials;
+    }
   }
 
   if (!mongoOptions.dbName) {

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -89,6 +89,15 @@ describe('Connection String', function () {
     expect(options.credentials.source).to.equal('$external');
   });
 
+  it('should retain user-specified authSource with no credentials for non-srv URI', function () {
+    const mockAuthSource = 'thisShouldBeAuthSource';
+    const options = parseOptions(`mongodb://localhost/?authSource=${mockAuthSource}`);
+
+    expect(options).to.have.nested.property('credentials.username', '');
+    expect(options).to.have.nested.property('credentials.mechanism', 'DEFAULT');
+    expect(options).to.have.nested.property('credentials.source', mockAuthSource);
+  });
+
   it('should parse a numeric authSource with variable width', function () {
     const options = parseOptions('mongodb://test@localhost/?authSource=0001');
     expect(options.credentials.source).to.equal('0001');
@@ -346,6 +355,8 @@ describe('Connection String', function () {
       } as MongoOptions;
 
       await resolveSRVRecordAsync(options as any);
+      expect(options).to.have.nested.property('credentials.username', '');
+      expect(options).to.have.nested.property('credentials.mechanism', 'DEFAULT');
       expect(options).to.have.nested.property('credentials.source', 'thisShouldBeAuthSource');
     });
   });

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -94,7 +94,7 @@ describe('Connection String', function () {
     expect(options.credentials.source).to.equal('$external');
   });
 
-  it('should retain user-specified authSource with no credentials', function () {
+  it('should omit credentials option when the only authSource is provided', function () {
     let options = parseOptions(`mongodb://a/?authSource=someDb`);
     expect(options).to.not.have.property('credentials');
     options = parseOptions(`mongodb+srv://a/?authSource=someDb`);

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -334,5 +334,20 @@ describe('Connection String', function () {
       expect(options).property('credentials').to.equal(credentials);
       expect(options).to.have.nested.property('credentials.source', 'admin');
     });
+
+    it('should retain specified authSource with no provided credentials', async function () {
+      makeStub('authSource=thisShouldBeAuthSource');
+      const credentials = {};
+
+      const options = {
+        credentials,
+        srvHost: 'test.mock.test.build.10gen.cc',
+        srvServiceName: 'mongodb',
+        userSpecifiedAuthSource: false
+      } as MongoOptions;
+
+      await resolveSRVRecordAsync(options as any);
+      expect(options).to.have.nested.property('credentials.source', 'thisShouldBeAuthSource');
+    });
   });
 });

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -7,10 +7,10 @@ import { MongoCredentials } from '../../src/cmap/auth/mongo_credentials';
 import { AUTH_MECHS_AUTH_SRC_EXTERNAL, AuthMechanism } from '../../src/cmap/auth/providers';
 import { parseOptions, resolveSRVRecord } from '../../src/connection_string';
 import {
+  MongoAPIError,
   MongoDriverError,
   MongoInvalidArgumentError,
-  MongoParseError,
-  MongoServerSelectionError
+  MongoParseError
 } from '../../src/error';
 import { MongoClient, MongoOptions } from '../../src/mongo_client';
 
@@ -103,7 +103,7 @@ describe('Connection String', function () {
     expect(options).to.have.nested.property('credentials.source', mockAuthSource);
   });
 
-  it('should omit credentials if the only auth related option is authSource', async () => {
+  it('should omit credentials and throw a non-MongoAPIError if the only auth related option is authSource', async () => {
     // The error we're looking to **not** see is
     // `new MongoInvalidArgumentError('No AuthProvider for ${credentials.mechanism} defined.')`
     // in `prepareHandshakeDocument` and/or `performInitialHandshake`.
@@ -122,8 +122,8 @@ describe('Connection String', function () {
       thrownError = error;
     }
 
-    // We should fail to connect, not fail to find an auth provider
-    expect(thrownError).to.be.instanceOf(MongoServerSelectionError);
+    // We should fail to connect, not fail to find an auth provider thus we should not find a MongoAPIError
+    expect(thrownError).to.not.be.instanceOf(MongoAPIError);
     expect(client.options).to.not.have.a.property('credentials');
   });
 

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -338,7 +338,6 @@ describe('Connection String', function () {
     it('should retain specified authSource with no provided credentials', async function () {
       makeStub('authSource=thisShouldBeAuthSource');
       const credentials = {};
-
       const options = {
         credentials,
         srvHost: 'test.mock.test.build.10gen.cc',

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -104,6 +104,12 @@ describe('Connection String', function () {
   });
 
   it('should omit credentials if the only auth related option is authSource', async () => {
+    // The error we're looking to **not** see is
+    // `new MongoInvalidArgumentError('No AuthProvider for ${credentials.mechanism} defined.')`
+    // in `prepareHandshakeDocument` and/or `performInitialHandshake`.
+    // Neither function is exported currently but if I did export them because of the inlined callbacks
+    // I think I would need to mock quite a bit of internals to get down to that layer.
+    // My thinking is I can lean on server selection failing for th unit tests to assert we at least don't get an error related to auth.
     const client = new MongoClient('mongodb://localhost:123/?authSource=someDb', {
       serverSelectionTimeoutMS: 500
     });

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -94,13 +94,11 @@ describe('Connection String', function () {
     expect(options.credentials.source).to.equal('$external');
   });
 
-  it('should retain user-specified authSource with no credentials for non-srv URI', function () {
-    const mockAuthSource = 'thisShouldBeAuthSource';
-    const options = parseOptions(`mongodb://localhost/?authSource=${mockAuthSource}`);
-
-    expect(options).to.have.nested.property('credentials.username', '');
-    expect(options).to.have.nested.property('credentials.mechanism', 'DEFAULT');
-    expect(options).to.have.nested.property('credentials.source', mockAuthSource);
+  it('should retain user-specified authSource with no credentials', function () {
+    let options = parseOptions(`mongodb://a/?authSource=someDb`);
+    expect(options).to.not.have.property('credentials');
+    options = parseOptions(`mongodb+srv://a/?authSource=someDb`);
+    expect(options).to.not.have.property('credentials');
   });
 
   it('should omit credentials and throw a non-MongoAPIError if the only auth related option is authSource', async () => {


### PR DESCRIPTION
### Description

Adding test case and fix for a specified authSource but no further credentials provided.
The spec states that authSource can be ignored when no other credentials are given, we have a check that is throwing in this specific scenario because we still have an empty credentials object making it down to the connection creation layer.

#### What is changing?

This PR removes the credentials from the options object in this specific scenario and tests for it.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
