### PR TITLE
chore(gridfs): improve error message when overrunning file length

### DIFF
--- a/src/gridfs/download.ts
+++ b/src/gridfs/download.ts
@@ -262,7 +262,7 @@ function doRead(stream: GridFSBucketReadStream): void {
       if (bytesRemaining <= 0) {
         return stream.emit(
           GridFSBucketReadStream.ERROR,
-          new MongoGridFSChunkError(`ExtraChunk: Got unexpected n: ${doc.n}`)
+          new MongoGridFSChunkError(`ExtraChunk: Got unexpected n: ${doc.n}, expected file length ${stream.s.file.length} bytes but already read ${stream.s.bytesRead} bytes`)
         );
       }
 

--- a/src/gridfs/download.ts
+++ b/src/gridfs/download.ts
@@ -262,7 +262,9 @@ function doRead(stream: GridFSBucketReadStream): void {
       if (bytesRemaining <= 0) {
         return stream.emit(
           GridFSBucketReadStream.ERROR,
-          new MongoGridFSChunkError(`ExtraChunk: Got unexpected n: ${doc.n}, expected file length ${stream.s.file.length} bytes but already read ${stream.s.bytesRead} bytes`)
+          new MongoGridFSChunkError(
+            `ExtraChunk: Got unexpected n: ${doc.n}, expected file length ${stream.s.file.length} bytes but already read ${stream.s.bytesRead} bytes`
+          )
         );
       }
 


### PR DESCRIPTION
### Description

#### What is changing?

Improving error message for when GridFS file `length` is less than the total length of the chunks' `data`. Below script triggers this error:

```javascript
'use strict';

const mongoose = require('mongoose');
const mongodb = mongoose.mongo;

run().catch(err => console.log(err));

async function run() {
  await mongoose.connect('mongodb://localhost:27017/test');
  const client = mongoose.connection.client;
  await mongoose.connection.dropDatabase();

  const _id = new mongoose.Types.ObjectId();
  await client.db().collection('fs.files').insertOne({
    _id,
    length: 1, // <-- expecting that the file is only 1 byte...
    uploadDate: new Date(),
    chunkSize: 1
  });
  await client.db().collection('fs.chunks').insertOne({
    files_id: _id,
    n: 0,
    data: Buffer.from('h')
  });
  await client.db().collection('fs.chunks').insertOne({
    files_id: _id,
    n: 1, // <-- but there's a 2nd byte
    data: Buffer.from('i')
  });

  const bucket = new mongodb.GridFSBucket(client.db(), { bucketName: 'fs' });
  const stream = bucket.openDownloadStream(_id);

  // Throws 'MongoGridFSChunkError: ExtraChunk: Got unexpected n: 1'
  await new Promise((resolve, reject) => {
    stream.on('data', () => {});
    stream.on('end', resolve);
    stream.on('error', reject);
  });

  console.log('Done');
}
```

The error message only mentions the chunk's `n`, not the total `length`. The total `length` is what causes this error.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Error message popped up in https://github.com/Automattic/mongoose/issues/10907.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
