### PR TITLE
docs: update api link to point to home page instead of specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The official [MongoDB](https://www.mongodb.com/) driver for Node.js.
 | what          | where                                                                                                   |
 | ------------- | ------------------------------------------------------------------------------------------------------- |
 | documentation | [docs.mongodb.com/drivers/node](https://docs.mongodb.com/drivers/node)                                  |
-| api-doc       | [mongodb.github.io/node-mongodb-native/4.2/](https://mongodb.github.io/node-mongodb-native/4.2/)        |
+| api-doc       | [mongodb.github.io/node-mongodb-native/](https://mongodb.github.io/node-mongodb-native/)                |
 | npm package   | [www.npmjs.com/package/mongodb](https://www.npmjs.com/package/mongodb)                                  |
 | source        | [github.com/mongodb/node-mongodb-native](https://github.com/mongodb/node-mongodb-native)                |
 | mongodb       | [www.mongodb.com](https://www.mongodb.com)                                                              |


### PR DESCRIPTION
### Description

#### What is changing?
Updating the README api docs link to point to the api doc home page

##### Is there new documentation needed for these changes?
This is docs :)

#### What is the motivation for this change?
Until we get automation in place to ensure the api docs and the links to the docs are updated at the time of the release, we run the risk of publishing packages with README api links that incorrectly point to the previous version.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [N/A] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
