### PR TITLE
docs: update Evergreen CLI example command

### DIFF
--- a/test/readme.md
+++ b/test/readme.md
@@ -109,7 +109,7 @@ Once you have the Evergreen CLI setup, you are ready to run a build. Keep in min
 
 1. Use the Evergreen `patch` command. `-y` skips the confirmation dialog. `-u` includes uncommitted changes. `-p [project name]` specifies the Evergreen project. --browse opens the patch URL in your browser.
 
-   `evergreen patch -y -u -p mongo-node-driver --browse`
+   `evergreen patch -y -u -p mongo-node-driver-next --browse`
 
 1. In your browser, select the build variants and tasks to run.
 


### PR DESCRIPTION
### Description

Update the example command to run an Evergreen build using the Evergreen CLI

#### What is changing?

Example command in the Test readme

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

I got stuck when trying to use the current command in the readme

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] ~~Changes are covered by tests~~
- [ ] ~~New TODOs have a related JIRA ticket~~
