### PR TITLE
<fix>: _id may not be required in create operation

### DIFF
--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -50,9 +50,11 @@ export type OptionalId<TSchema> = EnhancedOmit<TSchema, '_id'> & { _id?: InferId
  * `TSchema['_id'] extends ObjectId` which translated to "Is the _id property ObjectId?"
  * we instead ask "Does ObjectId look like (have the same shape) as the _id?"
  */
-export type OptionalUnlessRequiredId<TSchema> = TSchema extends { _id: any }
-  ? TSchema
-  : OptionalId<TSchema>;
+export type OptionalUnlessRequiredId<TSchema> = TSchema extends {
+    _id: ObjectId;
+} ? OptionalId<TSchema> : TSchema extends {
+    _id: any;
+} ? TSchema : OptionalId<TSchema>;
 
 /** TypeScript Omit (Exclude to be specific) does not work for objects with an "any" indexed type, and breaks discriminated unions @public */
 export type EnhancedOmit<TRecordOrUnion, KeyUnion> = string extends keyof TRecordOrUnion


### PR DESCRIPTION
### Description

When schema includes `_id: ObjectId`, `insertOne` should not force `_id` to be a required property.

#### What is changing?

Let `_id` is still optional in `insertOne` when `_id: ObjectId` in schema

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

```ts
export interface Test {
  _id: ObjectId,
  data: string
}

db.collection<Test>('Test').insertOne({data: 'XXXX'})
```

**Expected**
Compiled successfully.

**Actual**
Got error, because missing `_id`

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
