### PR TITLE
test(NODE-3787): sync preferring error codes over messages

### DIFF
--- a/test/spec/server-discovery-and-monitoring/errors/prefer-error-code.json
+++ b/test/spec/server-discovery-and-monitoring/errors/prefer-error-code.json
@@ -52,7 +52,7 @@
       }
     },
     {
-      "description": "errmsg \"not writable primary\" gets ignored when error code exists",
+      "description": "errmsg \"not master\" gets ignored when error code exists",
       "applicationErrors": [
         {
           "address": "a:27017",
@@ -61,7 +61,7 @@
           "type": "command",
           "response": {
             "ok": 0,
-            "errmsg": "not writable primary",
+            "errmsg": "not master",
             "code": 1
           }
         }

--- a/test/spec/server-discovery-and-monitoring/errors/prefer-error-code.yml
+++ b/test/spec/server-discovery-and-monitoring/errors/prefer-error-code.yml
@@ -29,7 +29,7 @@ phases:
     logicalSessionTimeoutMinutes: null
     setName: rs
 
-- description: errmsg "not writable primary" gets ignored when error code exists
+- description: errmsg "not master" gets ignored when error code exists
   applicationErrors:
   - address: a:27017
     when: afterHandshakeCompletes
@@ -37,7 +37,7 @@ phases:
     type: command
     response:
       ok: 0
-      errmsg: "not writable primary"
+      errmsg: "not master"  # NOTE: This needs to be "not master" and not "not writable primary".
       code: 1  # Not a "not writable primary" error code.
   outcome: *outcome
 


### PR DESCRIPTION
### Description
NODE-3787
#### What is changing?

##### Is there new documentation needed for these changes?
No
#### What is the motivation for this change?

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
