### PR TITLE
chore(NODE-3715): add code coverage generation to Evergreen tasks

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -699,26 +699,20 @@ functions:
   upload coverage report:
     - command: shell.exec
       params:
-        working_dir: "src"
+        working_dir: src
         script: |
-          # Coverage combine merges (and removes) all the coverage files and
-          # generates a new .coverage file in the current directory.
-          echo $(pwd)
-          echo $(ls -a)
-
           nyc report --reporter=json
     - command: s3.put
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file:  coverage/coverage-final.json
+        local_file: coverage/coverage-final.json
         optional: true
-        # Upload the coverage report for all tasks in a single build to the same directory.
         remote_file: ${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
-        content_type: text/html
-        display_name: "Raw Coverage Report"
+        content_type: application/json
+        display_name: Raw Coverage Report
 tasks:
   - name: test-serverless
     tags:
@@ -1740,7 +1734,6 @@ pre:
   - func: fix absolute paths
   - func: make files executable
 post:
-  - func: upload coverage report
   - func: upload test results
   - func: cleanup
 ignore:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -729,7 +729,7 @@ functions:
           aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ coverage/
 
           npx nyc merge coverage/ merged-coverage/coverage.json
-          npx nyc report -t merged-coverage --reporter=lcov --report-dir output
+          npx nyc report -t merged-coverage --reporter=html --report-dir output
 
           aws s3 cp output/lcov-report s3://mciuploads/mongo-node-driver/${revision}/${version_id}//lcov-report/
 tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -696,6 +696,26 @@ functions:
     - command: attach.xunit_results
       params:
         file: src/xunit.xml
+  upload coverage report:
+    - command: shell.exec
+      params:
+        working_dir: "."
+        script: |
+          # Coverage combine merges (and removes) all the coverage files and
+          # generates a new .coverage file in the current directory.
+          npx nyc report --reporter=json
+    - command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file:  coverage/coverage-final.json
+      optional: true
+      # Upload the coverage report for all tasks in a single build to the same directory.
+      remote_file: ${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/coverage.${build_variant}.${task_name}.json
+      bucket: mciuploads
+      permissions: public-read
+      content_type: text/html
+      display_name: "Raw Coverage Report"
 tasks:
   - name: test-serverless
     tags:
@@ -1717,6 +1737,7 @@ pre:
   - func: fix absolute paths
   - func: make files executable
 post:
+  - func: upload coverage report
   - func: upload test results
   - func: cleanup
 ignore:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -703,7 +703,9 @@ functions:
         script: |
           # Coverage combine merges (and removes) all the coverage files and
           # generates a new .coverage file in the current directory.
-          npx nyc report --reporter=json
+          pwd
+
+          nyc report --reporter=json
     - command: s3.put
       params:
         aws_key: ${aws_key}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -709,7 +709,7 @@ functions:
         aws_secret: ${aws_secret}
         local_file: src/coverage/coverage-final.json
         optional: true
-        remote_file: /${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -703,7 +703,8 @@ functions:
         script: |
           # Coverage combine merges (and removes) all the coverage files and
           # generates a new .coverage file in the current directory.
-          pwd
+          echo $(pwd)
+          echo $(ls -a)
 
           nyc report --reporter=json
     - command: s3.put

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1975,11 +1975,6 @@ buildvariants:
     run_on: ubuntu1804-large
     tasks:
       - run-checks
-  - name: generate-combined-coverage
-    display_name: Generate Combined Coverage
-    run_on: ubuntu1804-large
-    tasks:
-      - download-and-merge-coverage
   - name: mongosh_integration_tests
     display_name: mongosh integration tests
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2037,7 +2037,6 @@ buildvariants:
       - run-custom-csfle-tests
       - run-custom-snappy-tests
       - run-bson-ext-test
-      - download-and-merge-coverage
   - name: ubuntu1804-test-serverless
     display_name: Serverless Test
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1724,6 +1724,14 @@ tasks:
       - func: run bson-ext test
         vars:
           NODE_LTS_NAME: erbium
+  - name: download-and-merge-coverage
+    tags: []
+    commands:
+      - func: download and merge coverage
+    depends_on:
+      - name: '*'
+        variant: '*'
+        status: '*'
 task_groups:
   - name: serverless_task_group
     setup_group_can_fail_task: true
@@ -2024,6 +2032,7 @@ buildvariants:
       - run-custom-csfle-tests
       - run-custom-snappy-tests
       - run-bson-ext-test
+      - download-and-merge-coverage
   - name: ubuntu1804-test-serverless
     display_name: Serverless Test
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1735,6 +1735,7 @@ pre:
   - func: make files executable
 post:
   - func: upload test results
+  - func: upload coverage report
   - func: cleanup
 ignore:
   - '*.md'

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -720,31 +720,16 @@ functions:
         silent: true
         working_dir: src
         script: |
+          ${PREPARE_SHELL}
           export AWS_ACCESS_KEY_ID=${aws_key}
           export AWS_SECRET_ACCESS_KEY=${aws_secret}
           # Download all the task coverage files.
-          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/ coverage/
-    - command: shell.exec
-      params:
-        working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          # Coverage combine merges (and removes) all the coverage files and
-          # generates a new .coverage file in the current directory.
-          ls -la coverage/
+          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ coverage/
+
           npx nyc merge coverage/ merged-coverage/coverage.json
           npx nyc report -t merged-coverage --reporter=lcov --report-dir output
-    - command: shell.exec
-      params:
-        silent: true
-        working_dir: src
-        script: >
-          export AWS_ACCESS_KEY_ID=${aws_key}
 
-          export AWS_SECRET_ACCESS_KEY=${aws_secret}
-
-          aws s3 cp output/lcov-report s3://mciuploads/${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/lcov-report/
-          --recursive --acl public-read --region us-east-1
+          aws s3 cp output/lcov-report s3://mciuploads/mongo-node-driver/${revision}/${version_id}//lcov-report/
 tasks:
   - name: test-serverless
     tags:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -699,7 +699,7 @@ functions:
   upload coverage report:
     - command: shell.exec
       params:
-        working_dir: "."
+        working_dir: "src"
         script: |
           # Coverage combine merges (and removes) all the coverage files and
           # generates a new .coverage file in the current directory.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -703,16 +703,13 @@ functions:
         script: |
           ${PREPARE_SHELL}
           npx nyc report --reporter=json
-
-          # debug
-          ls .nyc_output | wc -l
     - command: s3.put
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: coverage/coverage-final.json
+        local_file: src/coverage/coverage-final.json
         optional: true
-        remote_file: ${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/coverage.${build_variant}.${task_name}.json
+        remote_file: /${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1732,6 +1732,7 @@ tasks:
       - name: '*'
         variant: '*'
         status: '*'
+        patch_optional: true
 task_groups:
   - name: serverless_task_group
     setup_group_can_fail_task: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -701,7 +701,11 @@ functions:
       params:
         working_dir: src
         script: |
-          nyc report --reporter=json
+          ${PREPARE_SHELL}
+          npx nyc report --reporter=json
+
+          # debug
+          ls .nyc_output | wc -l
     - command: s3.put
       params:
         aws_key: ${aws_key}
@@ -713,6 +717,37 @@ functions:
         permissions: public-read
         content_type: application/json
         display_name: Raw Coverage Report
+  download and merge coverage:
+    - command: shell.exec
+      params:
+        silent: true
+        working_dir: src
+        script: |
+          export AWS_ACCESS_KEY_ID=${aws_key}
+          export AWS_SECRET_ACCESS_KEY=${aws_secret}
+          # Download all the task coverage files.
+          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/ coverage/
+    - command: shell.exec
+      params:
+        working_dir: src
+        script: |
+          ${PREPARE_SHELL}
+          # Coverage combine merges (and removes) all the coverage files and
+          # generates a new .coverage file in the current directory.
+          ls -la coverage/
+          npx nyc merge coverage/ merged-coverage/coverage.json
+          npx nyc report -t merged-coverage --reporter=lcov --report-dir output
+    - command: shell.exec
+      params:
+        silent: true
+        working_dir: src
+        script: >
+          export AWS_ACCESS_KEY_ID=${aws_key}
+
+          export AWS_SECRET_ACCESS_KEY=${aws_secret}
+
+          aws s3 cp output/lcov-report s3://mciuploads/${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/lcov-report/
+          --recursive --acl public-read --region us-east-1
 tasks:
   - name: test-serverless
     tags:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1999,7 +1999,8 @@ buildvariants:
   - name: generate-combined-coverage
     display_name: Generate Combined Coverage
     run_on: ubuntu1804-large
-    tasks: download and merge coverage
+    tasks:
+      - download and merge coverage
   - name: mongosh_integration_tests
     display_name: mongosh integration tests
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -705,17 +705,17 @@ functions:
           # generates a new .coverage file in the current directory.
           npx nyc report --reporter=json
     - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      local_file:  coverage/coverage-final.json
-      optional: true
-      # Upload the coverage report for all tasks in a single build to the same directory.
-      remote_file: ${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/coverage.${build_variant}.${task_name}.json
-      bucket: mciuploads
-      permissions: public-read
-      content_type: text/html
-      display_name: "Raw Coverage Report"
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file:  coverage/coverage-final.json
+        optional: true
+        # Upload the coverage report for all tasks in a single build to the same directory.
+        remote_file: ${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/coverage.${build_variant}.${task_name}.json
+        bucket: mciuploads
+        permissions: public-read
+        content_type: text/html
+        display_name: "Raw Coverage Report"
 tasks:
   - name: test-serverless
     tags:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2000,7 +2000,7 @@ buildvariants:
     display_name: Generate Combined Coverage
     run_on: ubuntu1804-large
     tasks:
-      - download and merge coverage
+      - download-and-merge-coverage
   - name: mongosh_integration_tests
     display_name: mongosh integration tests
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1996,6 +1996,10 @@ buildvariants:
     run_on: ubuntu1804-large
     tasks:
       - run-checks
+  - name: generate-combined-coverage
+    display_name: Generate Combined Coverage
+    run_on: ubuntu1804-large
+    tasks: download and merge coverage
   - name: mongosh_integration_tests
     display_name: mongosh integration tests
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -709,7 +709,7 @@ functions:
         aws_secret: ${aws_secret}
         local_file: src/coverage/coverage-final.json
         optional: true
-        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -724,6 +724,8 @@ functions:
           export AWS_ACCESS_KEY_ID=${aws_key}
           export AWS_SECRET_ACCESS_KEY=${aws_secret}
           # Download all the task coverage files.
+          # TODO NODE-3897 - finish this function.  the code below this point is untested because
+          #   aws s3 cp fails due to permissions errors
           aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ coverage/
 
           npx nyc merge coverage/ merged-coverage/coverage.json
@@ -1709,15 +1711,6 @@ tasks:
       - func: run bson-ext test
         vars:
           NODE_LTS_NAME: erbium
-  - name: download-and-merge-coverage
-    tags: []
-    commands:
-      - func: download and merge coverage
-    depends_on:
-      - name: '*'
-        variant: '*'
-        status: '*'
-        patch_optional: true
 task_groups:
   - name: serverless_task_group
     setup_group_can_fail_task: true

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -744,7 +744,7 @@ functions:
         local_file:  src/coverage/coverage-final.json
         optional: true
         # Upload the coverage report for all tasks in a single build to the same directory.
-        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -800,6 +800,7 @@ pre:
 
 post:
   - func: "upload test results"
+  - func: "upload coverage report"
   - func: "cleanup"
 
 ignore:

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -737,17 +737,14 @@ functions:
         script: |
           ${PREPARE_SHELL}
           npx nyc report --reporter=json
-
-          # debug
-          ls .nyc_output | wc -l
     - command: s3.put
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file:  coverage/coverage-final.json
+        local_file:  src/coverage/coverage-final.json
         optional: true
         # Upload the coverage report for all tasks in a single build to the same directory.
-        remote_file: ${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/coverage.${build_variant}.${task_name}.json
+        remote_file: /${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -730,6 +730,25 @@ functions:
       params:
         file: "src/xunit.xml"
 
+  "upload coverage report":
+    - command: shell.exec
+      params:
+        working_dir: "src"
+        script: |
+          nyc report --reporter=json
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file:  coverage/coverage-final.json
+        optional: true
+        # Upload the coverage report for all tasks in a single build to the same directory.
+        remote_file: ${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/coverage.${build_variant}.${task_name}.json
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/json
+        display_name: "Raw Coverage Report"
+
 tasks:
     - name: "test-serverless"
       tags: ["serverless"]

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -744,7 +744,7 @@ functions:
         local_file:  src/coverage/coverage-final.json
         optional: true
         # Upload the coverage report for all tasks in a single build to the same directory.
-        remote_file: /${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -767,7 +767,7 @@ functions:
           aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ coverage/
 
           npx nyc merge coverage/ merged-coverage/coverage.json
-          npx nyc report -t merged-coverage --reporter=lcov --report-dir output
+          npx nyc report -t merged-coverage --reporter=html --report-dir output
 
           aws s3 cp output/lcov-report s3://mciuploads/mongo-node-driver/${revision}/${version_id}//lcov-report/
 

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -756,29 +756,16 @@ functions:
         silent: true
         working_dir: "src"
         script: |
+          ${PREPARE_SHELL}
           export AWS_ACCESS_KEY_ID=${aws_key}
           export AWS_SECRET_ACCESS_KEY=${aws_secret}
           # Download all the task coverage files.
-          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/ coverage/
-    - command: shell.exec
-      params:
-        working_dir: "src"
-        script: |
-          ${PREPARE_SHELL}
-          # Coverage combine merges (and removes) all the coverage files and
-          # generates a new .coverage file in the current directory.
-          ls -la coverage/
+          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ coverage/
+
           npx nyc merge coverage/ merged-coverage/coverage.json
           npx nyc report -t merged-coverage --reporter=lcov --report-dir output
-    # Upload the resulting html coverage report.
-    - command: shell.exec
-      params:
-        silent: true
-        working_dir: "src"
-        script: |
-           export AWS_ACCESS_KEY_ID=${aws_key}
-           export AWS_SECRET_ACCESS_KEY=${aws_secret}
-           aws s3 cp output/lcov-report s3://mciuploads/${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/lcov-report/ --recursive --acl public-read --region us-east-1
+
+          aws s3 cp output/lcov-report s3://mciuploads/mongo-node-driver/${revision}/${version_id}//lcov-report/
 
 tasks:
     - name: "test-serverless"

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -744,6 +744,8 @@ functions:
         local_file:  src/coverage/coverage-final.json
         optional: true
         # Upload the coverage report for all tasks in a single build to the same directory.
+        # TODO NODE-3897 - change upload directory to mongo-node-driver-next
+        # This change will require changing the `download and merge coverage` func as well
         remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
@@ -760,6 +762,8 @@ functions:
           export AWS_ACCESS_KEY_ID=${aws_key}
           export AWS_SECRET_ACCESS_KEY=${aws_secret}
           # Download all the task coverage files.
+          # TODO NODE-3897 - finish this function.  the code below this point is untested because
+          #   aws s3 cp fails due to permissions errors
           aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ coverage/
 
           npx nyc merge coverage/ merged-coverage/coverage.json

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -735,7 +735,11 @@ functions:
       params:
         working_dir: "src"
         script: |
-          nyc report --reporter=json
+          ${PREPARE_SHELL}
+          npx nyc report --reporter=json
+
+          # debug
+          ls .nyc_output | wc -l
     - command: s3.put
       params:
         aws_key: ${aws_key}
@@ -748,6 +752,36 @@ functions:
         permissions: public-read
         content_type: application/json
         display_name: "Raw Coverage Report"
+
+  "download and merge coverage":
+    - command: shell.exec
+      params:
+        silent: true
+        working_dir: "src"
+        script: |
+          export AWS_ACCESS_KEY_ID=${aws_key}
+          export AWS_SECRET_ACCESS_KEY=${aws_secret}
+          # Download all the task coverage files.
+          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/coverage/ coverage/
+    - command: shell.exec
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          # Coverage combine merges (and removes) all the coverage files and
+          # generates a new .coverage file in the current directory.
+          ls -la coverage/
+          npx nyc merge coverage/ merged-coverage/coverage.json
+          npx nyc report -t merged-coverage --reporter=lcov --report-dir output
+    # Upload the resulting html coverage report.
+    - command: shell.exec
+      params:
+        silent: true
+        working_dir: "src"
+        script: |
+           export AWS_ACCESS_KEY_ID=${aws_key}
+           export AWS_SECRET_ACCESS_KEY=${aws_secret}
+           aws s3 cp output/lcov-report s3://mciuploads/${UPLOAD_BUCKET}/coverage/${revision}/${version_id}/lcov-report/ --recursive --acl public-read --region us-east-1
 
 tasks:
     - name: "test-serverless"

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -563,12 +563,13 @@ BUILD_VARIANTS.push({
   tasks: ['run-checks']
 });
 
-BUILD_VARIANTS.push({
-  name: 'generate-combined-coverage',
-  display_name: 'Generate Combined Coverage',
-  run_on: DEFAULT_OS,
-  tasks: ['download-and-merge-coverage']
-});
+// TODO NODE-3897
+// BUILD_VARIANTS.push({
+//   name: 'generate-combined-coverage',
+//   display_name: 'Generate Combined Coverage',
+//   run_on: DEFAULT_OS,
+//   tasks: ['download-and-merge-coverage']
+// });
 
 // singleton build variant for mongosh integration tests
 SINGLETON_TASKS.push({

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -629,6 +629,19 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
   ]
 }));
 
+oneOffFuncAsTasks.push({
+  name: 'download and merge coverage'.split(' ').join('-'),
+  tags: [],
+  commands: [
+    {
+      func: 'download and merge coverage'
+    }
+  ],
+  depends_on: [
+    { name: '*', variant: '*', status: '*' }
+  ]
+})
+
 SINGLETON_TASKS.push(...oneOffFuncAsTasks);
 
 BUILD_VARIANTS.push({

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -645,7 +645,7 @@ const coverageTask = {
     }
   ],
   depends_on: [
-    { name: '*', variant: '*', status: '*' }
+    { name: '*', variant: '*', status: '*', patch_optional: true }
   ]
 }
 

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -563,7 +563,7 @@ BUILD_VARIANTS.push({
   tasks: ['run-checks']
 });
 
-// TODO NODE-3897
+// TODO NODE-3897 - generate combined coverage report
 // BUILD_VARIANTS.push({
 //   name: 'generate-combined-coverage',
 //   display_name: 'Generate Combined Coverage',
@@ -637,6 +637,7 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
   ]
 }));
 
+// TODO NODE-3897 - generate combined coverage report
 const coverageTask = {
   name: 'download and merge coverage'.split(' ').join('-'),
   tags: [],

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -636,7 +636,7 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
   ]
 }));
 
-oneOffFuncAsTasks.push({
+const coverageTask = {
   name: 'download and merge coverage'.split(' ').join('-'),
   tags: [],
   commands: [
@@ -647,7 +647,7 @@ oneOffFuncAsTasks.push({
   depends_on: [
     { name: '*', variant: '*', status: '*' }
   ]
-})
+}
 
 SINGLETON_TASKS.push(...oneOffFuncAsTasks);
 
@@ -670,7 +670,7 @@ BUILD_VARIANTS.push({
 });
 
 const fileData = yaml.load(fs.readFileSync(`${__dirname}/config.yml.in`, 'utf8'));
-fileData.tasks = (fileData.tasks || []).concat(BASE_TASKS).concat(TASKS).concat(SINGLETON_TASKS);
+fileData.tasks = (fileData.tasks || []).concat(BASE_TASKS).concat(TASKS).concat(SINGLETON_TASKS).concat([coverageTask]);
 fileData.buildvariants = (fileData.buildvariants || []).concat(BUILD_VARIANTS);
 
 fs.writeFileSync(`${__dirname}/config.yml`, yaml.dump(fileData, { lineWidth: 120 }), 'utf8');

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -567,7 +567,7 @@ BUILD_VARIANTS.push({
   name: 'generate-combined-coverage',
   display_name: 'Generate Combined Coverage',
   run_on: DEFAULT_OS,
-  tasks: ['download and merge coverage']
+  tasks: ['download-and-merge-coverage']
 });
 
 // singleton build variant for mongosh integration tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -563,6 +563,13 @@ BUILD_VARIANTS.push({
   tasks: ['run-checks']
 });
 
+BUILD_VARIANTS.push({
+  name: 'generate-combined-coverage',
+  display_name: 'Generate Combined Coverage',
+  run_on: DEFAULT_OS,
+  tasks: 'download and merge coverage'
+});
+
 // singleton build variant for mongosh integration tests
 SINGLETON_TASKS.push({
   name: 'run-mongosh-integration-tests',

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -567,7 +567,7 @@ BUILD_VARIANTS.push({
   name: 'generate-combined-coverage',
   display_name: 'Generate Combined Coverage',
   run_on: DEFAULT_OS,
-  tasks: 'download and merge coverage'
+  tasks: ['download and merge coverage']
 });
 
 // singleton build variant for mongosh integration tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -670,7 +670,7 @@ BUILD_VARIANTS.push({
 });
 
 const fileData = yaml.load(fs.readFileSync(`${__dirname}/config.yml.in`, 'utf8'));
-fileData.tasks = (fileData.tasks || []).concat(BASE_TASKS).concat(TASKS).concat(SINGLETON_TASKS).concat([coverageTask]);
+fileData.tasks = (fileData.tasks || []).concat(BASE_TASKS).concat(TASKS).concat(SINGLETON_TASKS);
 fileData.buildvariants = (fileData.buildvariants || []).concat(BUILD_VARIANTS);
 
 fs.writeFileSync(`${__dirname}/config.yml`, yaml.dump(fileData, { lineWidth: 120 }), 'utf8');

--- a/.evergreen/run-checks.sh
+++ b/.evergreen/run-checks.sh
@@ -18,7 +18,7 @@ set -o xtrace
 ## Checks typescript, eslint, and prettier
 npm run check:lint
 
-npm run check:unit
+npx nyc npm run check:unit
 
 export TSC="./node_modules/typescript/bin/tsc"
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -8,7 +8,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       UNIFIED                 Set to enable the Unified SDAM topology for the node driver
 #       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
 #       MARCH                   Machine Architecture. Defaults to lowercase uname -m
-#       TEST_NPM_SCRIPT         Script to npm run. Defaults to "check:test"
+#       TEST_NPM_SCRIPT         Script to npm run. Defaults to "check:coverage"
 #       SKIP_DEPS               Skip installing dependencies
 #       NO_EXIT                 Don't exit early from tests that leak resources
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -8,14 +8,14 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       UNIFIED                 Set to enable the Unified SDAM topology for the node driver
 #       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
 #       MARCH                   Machine Architecture. Defaults to lowercase uname -m
-#       TEST_NPM_SCRIPT         Script to npm run. Defaults to "check:coverage"
+#       TEST_NPM_SCRIPT         Script to npm run. Defaults to "integration-coverage"
 #       SKIP_DEPS               Skip installing dependencies
 #       NO_EXIT                 Don't exit early from tests that leak resources
 
 AUTH=${AUTH:-noauth}
 UNIFIED=${UNIFIED:-}
 MONGODB_URI=${MONGODB_URI:-}
-TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-check:coverage}
+TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-check:integration-coverage}
 if [[ -z "${NO_EXIT}" ]]; then
   TEST_NPM_SCRIPT="$TEST_NPM_SCRIPT -- --exit"
 fi

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -15,7 +15,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 AUTH=${AUTH:-noauth}
 UNIFIED=${UNIFIED:-}
 MONGODB_URI=${MONGODB_URI:-}
-TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-check:test}
+TEST_NPM_SCRIPT=${TEST_NPM_SCRIPT:-check:coverage}
 if [[ -z "${NO_EXIT}" ]]; then
   TEST_NPM_SCRIPT="$TEST_NPM_SCRIPT -- --exit"
 fi

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "build:docs": "typedoc",
     "check:bench": "node test/benchmarks/driverBench",
     "check:coverage": "nyc npm run test:all",
+    "check:integration-coverage": "nyc npm run check:test",
     "check:lint": "npm run build:dts && npm run check:dts && npm run check:eslint && npm run check:tsd",
     "check:eslint": "eslint -v && eslint --max-warnings=0 --ext '.js,.ts' src test",
     "check:tsd": "tsd --version && tsd",


### PR DESCRIPTION
### Description

This PR adds code coverage generation for each build in Evergreen.

#### What is changing?

This PR does the following

- Adds a function to generate code coverage for each variant run in evergreen and upload it to s3 after each variant runs
- Adds a function (currently not used) to download all coverage reports for a patch, generate a combined coverage report and upload that to s3
- Adds a new build variant that depends on all other variants (currently commented out) to combine all coverage reports into one and upload it to s3 (calls the above function)

##### Is there new documentation needed for these changes?

Nope

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
