### PR TITLE
fix(NODE-3895): Emit TypeScript errors when filtering on fields not in collection schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -284,6 +284,7 @@ export type {
   InferIdType,
   IntegerType,
   IsAny,
+  IsInUnion,
   Join,
   KeysOfAType,
   KeysOfOtherType,
@@ -306,6 +307,7 @@ export type {
   RootFilterOperators,
   SchemaMember,
   SetFields,
+  TypeEquals,
   UpdateFilter,
   WithId,
   WithoutId

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -91,8 +91,23 @@ export type AlternativeType<T> = T extends ReadonlyArray<infer U>
 /** @public */
 export type RegExpOrString<T> = T extends string ? BSONRegExp | RegExp | T : T;
 
+/**
+ * This is a type that allows any `$` prefixed keys and makes no assumptions
+ * about their value types. This stems from a design decision that newly added
+ * filter operators should be accepted without needing to upgrade this package.
+ *
+ * This has the unfortunate side effect of preventing type errors on unknown
+ * operator keys, so we should prefer not to extend this type whenever possible.
+ *
+ * @see https://github.com/mongodb/node-mongodb-native/pull/3115#issuecomment-1021303302
+ * @public
+ */
+export type OpenOperatorQuery = {
+  [key: `$${string}`]: unknown;
+};
+
 /** @public */
-export interface RootFilterOperators<TSchema> {
+export interface RootFilterOperators<TSchema> extends OpenOperatorQuery {
   $and?: Filter<TSchema>[];
   $nor?: Filter<TSchema>[];
   $or?: Filter<TSchema>[];

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -90,7 +90,7 @@ export type AlternativeType<T> = T extends ReadonlyArray<infer U>
 export type RegExpOrString<T> = T extends string ? BSONRegExp | RegExp | T : T;
 
 /** @public */
-export interface RootFilterOperators<TSchema> extends Document {
+export interface RootFilterOperators<TSchema> {
   $and?: Filter<TSchema>[];
   $nor?: Filter<TSchema>[];
   $or?: Filter<TSchema>[];

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -482,6 +482,24 @@ export type PropertyType<Type, Property extends string> = string extends Propert
   : unknown;
 
 /**
+ * Check if two types are exactly equal
+ *
+ * From https://github.com/microsoft/TypeScript/issues/27024#issuecomment-421529650,
+ * credit to https://github.com/mattmccutchen.
+ * @public
+ */
+// prettier-ignore
+export type TypeEquals<X, Y> =
+    (<T>() => T extends X ? 1 : 2) extends
+    (<T>() => T extends Y ? 1 : 2) ? true : false
+
+/**
+ * Check if A is a union type that includes B
+ * @public
+ */
+export type IsInUnion<A, B> = TypeEquals<Extract<A, B>, B>;
+
+/**
  * @public
  * returns tuple of strings (keys to be joined on '.') that represent every path into a schema
  * https://docs.mongodb.com/manual/tutorial/query-embedded-documents/
@@ -506,9 +524,7 @@ export type NestedPaths<Type> = Type extends
   ? {
       [Key in Extract<keyof Type, string>]: Type[Key] extends Type // type of value extends the parent
         ? [Key]
-        : // for a recursive union type, the child will never extend the parent type.
-        // but the parent will still extend the child
-        Type extends Type[Key]
+        : IsInUnion<Type[Key], Type> extends true
         ? [Key]
         : Type[Key] extends ReadonlyArray<infer ArrayType> // handling recursive types with arrays
         ? Type extends ArrayType // is the type of the parent the same as the type of the array?

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -66,7 +66,9 @@ export type WithoutId<TSchema> = Omit<TSchema, '_id'>;
 
 /** A MongoDB filter can be some portion of the schema or a set of operators @public */
 export type Filter<TSchema> =
-  | Partial<TSchema>
+  | Partial<{
+      [Property in keyof TSchema]: Condition<TSchema[Property]>;
+    }>
   | ({
       [Property in Join<NestedPaths<WithId<TSchema>>, '.'>]?: Condition<
         PropertyType<WithId<TSchema>, Property>

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -240,7 +240,7 @@ await collectionT.find({ name: { $eq: /Spot/ } }).toArray();
 await collectionT.find({ type: { $eq: 'dog' } }).toArray();
 await collectionT.find({ age: { $gt: 12, $lt: 13 } }).toArray();
 await collectionT.find({ treats: { $eq: 'kibble' } }).toArray();
-await collectionT.find({ scores: { $gte: 23 } }).toArray();
+await collectionT.find({ age: { $gte: 23 } }).toArray();
 await collectionT.find({ createdAt: { $lte: new Date() } }).toArray();
 await collectionT.find({ friends: { $ne: spot } }).toArray();
 /// it should not accept wrong queries

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -126,6 +126,11 @@ expectType<WithId<PetModel>[]>(
 expectType<WithId<PetModel>[]>(
   await collectionT.find({ name: new BSONRegExp('MrMeow', 'i') }).toArray()
 );
+
+/// it should not accept fields that are not in the schema
+type FT = Filter<PetModel>;
+expectNotType<FT>({ missing: true });
+
 /// it should not accept wrong types for string fields
 expectNotType<Filter<PetModel>>({ name: 23 });
 expectNotType<Filter<PetModel>>({ name: { suffix: 'Jr' } });
@@ -361,9 +366,11 @@ expectError(
     otherField: new ObjectId()
   })
 );
-nonObjectIdCollection.find({
-  fieldThatDoesNotExistOnSchema: new ObjectId()
-});
+expectError(
+  nonObjectIdCollection.find({
+    fieldThatDoesNotExistOnSchema: new ObjectId()
+  })
+);
 
 // we only forbid objects that "look like" object ids, so other random objects are permitted
 nonObjectIdCollection.find({

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -288,6 +288,9 @@ expectNotType<Filter<PetModel>>({ name: { $or: ['Spot', 'Bubbles'] } });
 /// it should not accept single objects for __$and, $or, $nor operator__ query
 expectNotType<Filter<PetModel>>({ $and: { name: 'Spot' } });
 
+/// it allows using unknown root operators with any value
+expectAssignable<Filter<PetModel>>({ $fakeOp: 123 });
+
 /**
  * test 'element' query operators
  */

--- a/test/types/community/collection/findX-recursive-types.test-d.ts
+++ b/test/types/community/collection/findX-recursive-types.test-d.ts
@@ -87,6 +87,7 @@ recursiveOptionalCollection.find({
  * recursive union types are supported
  */
 interface Node {
+  value?: string;
   next: Node | null;
 }
 
@@ -103,10 +104,12 @@ expectError(
 );
 
 nodeCollection.find({
-  'next.next': 'asdf'
+  'next.value': 'asdf'
 });
 
-nodeCollection.find({ 'next.next.next': 'yoohoo' });
+// type safety is lost through recursive relations; callers will
+// need to annotate queries with `ts-expect-error` comments
+expectError(nodeCollection.find({ 'next.next.value': 'yoohoo' }));
 
 /**
  * Recursive schemas with arrays are also supported
@@ -149,9 +152,11 @@ expectError(
 
 // type safety breaks after the first
 //   level of nested types
-recursiveSchemaWithArray.findOne({
-  'branches.0.directories.0.files.0.id': 'hello'
-});
+expectError(
+  recursiveSchemaWithArray.findOne({
+    'branches.0.directories.0.files.0.id': 'hello'
+  })
+);
 
 recursiveSchemaWithArray.findOne({
   branches: [

--- a/test/types/community/transaction.test-d.ts
+++ b/test/types/community/transaction.test-d.ts
@@ -8,6 +8,7 @@ const client = new MongoClient('');
 const session = client.startSession();
 
 interface Account {
+  name: string;
   balance: number;
 }
 


### PR DESCRIPTION
### Description
As a developer, I'd like the type system to catch errors I make, like trying to
query on a field that doesn't exist, or when I have made a typo in an existing
field name.

For example:

```typescript
interface Person = {
  name: string;
  age: number;
}
 

db.collection<Person>('people').find(
  { nam: 'Alice' } // should be a type error, as `nam` is not an attribute of the schema
);
```

Related JIRA: https://jira.mongodb.org/browse/NODE-3895


#### What is changing?
The TypeScript `Filter<TSchema>` definition is becoming more type safe.

Previously, querying for these fields outside the schema would pass type
checks because the `Filter<TSchema>` type included a union with
`RootFilterOperators<WithId<TSchema>>`, and `RootFilterOperators` was
defined as `extends Document`. The BSON `Document` type itself is an
object with the index property `{ [key: string]: any }`, which seemed to match
any keys present in the document that didn't have stricter rules applied.

By removing `extends Document` from that definition, we gain significant
type safety; several issues in the tests turned up. This also showed some
difficulties with the recent typing additions in #3102 - some tests started
failing with this change because the `NestedPath<>` generation was bailing
out early even on non-recursive structures (when a nested object happened
to have a subset of keys of the parent). The final commit in this series
improves how recursive unions are detected.

As one final note, folks who have started using that new recursive object
support will find that unsupported queries (those reaching through a
recursive relation) will now need to be decorated with a `@ts-expect-error`
or similar annotation. This should call attention to these queries lack of
type safety (instead of the current behavior where the filter is implicitly
cast to an `any`).


##### Is there new documentation needed for these changes?

Good question! I didn't find any very meaningful documentation about the
existing TypeScript experience of this library, but if that exists somewhere
I'd be happy to update it given a pointer to the page.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
