### PR TITLE
fix(NODE-3621): fixed type of documentKey property on ChangeStreamDocument

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -144,7 +144,7 @@ export interface ChangeStreamDocument<TSchema extends Document = Document> {
    * this will contain all the components of the shard key in order,
    * followed by the _id if the _id isn’t part of the shard key.
    */
-  documentKey?: InferIdType<TSchema>;
+  documentKey?: { _id: InferIdType<TSchema> };
 
   /**
    * Only present for ops of type ‘update’.


### PR DESCRIPTION
### Description

This fixes the bug described in [Jira issue NODE-3621](https://jira.mongodb.org/browse/NODE-3621). The `documentKey` property on the `ChangeStreamDocument` type is currently typed incorrectly.

I have also checked the MongoDB Realm JS code and it appears the type is [implemented correctly](https://github.com/realm/realm-js/blob/6ba56fe83d3d36e3d07b90389e48f9e9aa98fc3f/types/services.d.ts#L264) in that codebase.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
