### PR TITLE
feat(NODE-3351): use hostname canonicalization 

### DIFF
--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -13,7 +13,9 @@ import { Callback, ns } from '../../utils';
 import { AuthContext, AuthProvider } from './auth_provider';
 
 type MechanismProperties = {
+  // TODO: Remove in 5.0
   gssapiCanonicalizeHostName?: boolean;
+  CANONICALIZE_HOST_NAME?: boolean;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;
 };
@@ -174,7 +176,10 @@ function performGssapiCanonicalizeHostName(
   mechanismProperties: MechanismProperties,
   callback: Callback<string>
 ): void {
-  if (!mechanismProperties.gssapiCanonicalizeHostName) return callback(undefined, host);
+  if (
+    !mechanismProperties.gssapiCanonicalizeHostName &&
+    !mechanismProperties.CANONICALIZE_HOST_NAME
+  ) return callback(undefined, host);
 
   // Attempt to resolve the host name
   dns.resolveCname(host, (err, r) => {

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -13,6 +13,8 @@ import { Callback, ns } from '../../utils';
 import { AuthContext, AuthProvider } from './auth_provider';
 
 type MechanismProperties = {
+  /** @deprecated use `CANONICALIZE_HOST_NAME` instead */
+  gssapiCanonicalizeHostName?: boolean;
   CANONICALIZE_HOST_NAME?: boolean;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -13,8 +13,6 @@ import { Callback, ns } from '../../utils';
 import { AuthContext, AuthProvider } from './auth_provider';
 
 type MechanismProperties = {
-  // TODO: Remove in 5.0
-  gssapiCanonicalizeHostName?: boolean;
   CANONICALIZE_HOST_NAME?: boolean;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;
@@ -176,10 +174,7 @@ function performGssapiCanonicalizeHostName(
   mechanismProperties: MechanismProperties,
   callback: Callback<string>
 ): void {
-  if (
-    !mechanismProperties.gssapiCanonicalizeHostName &&
-    !mechanismProperties.CANONICALIZE_HOST_NAME
-  ) return callback(undefined, host);
+  if (!mechanismProperties.CANONICALIZE_HOST_NAME) return callback(undefined, host);
 
   // Attempt to resolve the host name
   dns.resolveCname(host, (err, r) => {

--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -1,7 +1,7 @@
 // Resolves the default auth mechanism according to
-
 import type { Document } from '../../bson';
 import { MongoAPIError, MongoMissingCredentialsError } from '../../error';
+import { emitWarningOnce } from '../../utils';
 import { AUTH_MECHS_AUTH_SRC_EXTERNAL, AuthMechanism } from './providers';
 
 // https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst
@@ -90,6 +90,9 @@ export class MongoCredentials {
     }
 
     if ('gssapiCanonicalizeHostName' in this.mechanismProperties) {
+      emitWarningOnce(
+        'gssapiCanonicalizeHostName is deprecated. Please use CANONICALIZE_HOST_NAME instead.'
+      );
       this.mechanismProperties.CANONICALIZE_HOST_NAME =
         this.mechanismProperties.gssapiCanonicalizeHostName;
     }

--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -89,6 +89,11 @@ export class MongoCredentials {
       }
     }
 
+    if ('gssapiCanonicalizeHostName' in this.mechanismProperties) {
+      this.mechanismProperties.CANONICALIZE_HOST_NAME =
+        this.mechanismProperties.gssapiCanonicalizeHostName;
+    }
+
     Object.freeze(this.mechanismProperties);
     Object.freeze(this);
   }

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -69,7 +69,7 @@ describe('Kerberos', function () {
     );
     client.connect(function (err, client) {
       if (err) return done(err);
-      expect(dns.resolveCname.calledOnce);
+      expect(dns.resolveCname.calledOnce).to.be.true;
       verifyKerberosAuthentication(client, done);
     });
   });
@@ -80,7 +80,7 @@ describe('Kerberos', function () {
     );
     client.connect(function (err, client) {
       if (err) return done(err);
-      expect(dns.resolveCname.calledOnce);
+      expect(dns.resolveCname.calledOnce).to.be.true;
       verifyKerberosAuthentication(client, done);
     });
   });

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -51,12 +51,13 @@ describe('Kerberos', function () {
     });
   });
 
-  it('validate that CANONICALIZE_HOST_NAME can be passed in', async function () {
+  it('validate that CANONICALIZE_HOST_NAME can be passed in', function (done) {
     const client = new MongoClient(
       `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:true&maxPoolSize=1`
     );
-    await client.connect();
-    verifyKerberosAuthentication(client, done);
+    client.connect(function (err, client) {
+      if (err) return done(err);
+      verifyKerberosAuthentication(client, done);
     });
   });
 

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -51,8 +51,7 @@ describe('Kerberos', function () {
     });
   });
 
-  // Unskip this test when a proper setup is available - see NODE-3060
-  it.skip('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
+  it('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
     const client = new MongoClient(
       `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false,SERVICE_REALM:windows&maxPoolSize=1`
     );

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -51,7 +51,17 @@ describe('Kerberos', function () {
     });
   });
 
-  it('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
+  it('validate that CANONICALIZE_HOST_NAME can be passed in', function (done) {
+    const client = new MongoClient(
+      `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:true&maxPoolSize=1`
+    );
+    client.connect(function (err, client) {
+      expect(err).to.not.exist;
+      verifyKerberosAuthentication(client, done);
+    });
+  });
+
+  it.skip('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
     const client = new MongoClient(
       `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false,SERVICE_REALM:windows&maxPoolSize=1`
     );

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -5,6 +5,7 @@ const sinon = require('sinon');
 const dns = require('dns');
 
 const expect = chai.expect;
+chai.use(require('sinon-chai'));
 
 function verifyKerberosAuthentication(client, done) {
   client
@@ -69,7 +70,7 @@ describe('Kerberos', function () {
     );
     client.connect(function (err, client) {
       if (err) return done(err);
-      expect(dns.resolveCname.calledOnce).to.be.true;
+      expect(dns.resolveCname).to.be.calledOnce;
       verifyKerberosAuthentication(client, done);
     });
   });
@@ -80,7 +81,7 @@ describe('Kerberos', function () {
     );
     client.connect(function (err, client) {
       if (err) return done(err);
-      expect(dns.resolveCname.calledOnce).to.be.true;
+      expect(dns.resolveCname).to.be.calledOnce;
       verifyKerberosAuthentication(client, done);
     });
   });

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -51,13 +51,12 @@ describe('Kerberos', function () {
     });
   });
 
-  it('validate that CANONICALIZE_HOST_NAME can be passed in', function (done) {
+  it('validate that CANONICALIZE_HOST_NAME can be passed in', async function () {
     const client = new MongoClient(
       `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:true&maxPoolSize=1`
     );
-    client.connect(function (err, client) {
-      expect(err).to.not.exist;
-      verifyKerberosAuthentication(client, done);
+    await client.connect();
+    verifyKerberosAuthentication(client, done);
     });
   });
 

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -61,6 +61,7 @@ describe('Kerberos', function () {
     });
   });
 
+  // Unskip this test when a proper setup is available - see NODE-3060
   it.skip('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
     const client = new MongoClient(
       `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false,SERVICE_REALM:windows&maxPoolSize=1`


### PR DESCRIPTION
### Description

Sets the driver to use the proper `CANONICALIZE_HOST_NAME` option when using Kerberos.

#### What is changing?

Removes the old check of `gssapiCanonicalizeHostName` to use the proper option. This was dead code as it was not a public member of our `AuthMechanismProperties` and was not parsed by the URI.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-3351

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
