### PR TITLE
feat(NODE-2938): add service host mechanism property

### DIFF
--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -13,7 +13,9 @@ import { Callback, ns } from '../../utils';
 import { AuthContext, AuthProvider } from './auth_provider';
 
 type MechanismProperties = {
+  // TODO: Remove in 5.0
   gssapiCanonicalizeHostName?: boolean;
+  CANONICALIZE_HOST_NAME?: boolean;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;
 };
@@ -174,7 +176,10 @@ function performGssapiCanonicalizeHostName(
   mechanismProperties: MechanismProperties,
   callback: Callback<string>
 ): void {
-  if (!mechanismProperties.gssapiCanonicalizeHostName) return callback(undefined, host);
+  if (
+    !mechanismProperties.gssapiCanonicalizeHostName &&
+    !mechanismProperties.CANONICALIZE_HOST_NAME
+  ) return callback(undefined, host);
 
   // Attempt to resolve the host name
   dns.resolveCname(host, (err, r) => {

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -13,8 +13,6 @@ import { Callback, ns } from '../../utils';
 import { AuthContext, AuthProvider } from './auth_provider';
 
 type MechanismProperties = {
-  // TODO: Remove in 5.0
-  gssapiCanonicalizeHostName?: boolean;
   CANONICALIZE_HOST_NAME?: boolean;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;
@@ -176,10 +174,7 @@ function performGssapiCanonicalizeHostName(
   mechanismProperties: MechanismProperties,
   callback: Callback<string>
 ): void {
-  if (
-    !mechanismProperties.gssapiCanonicalizeHostName &&
-    !mechanismProperties.CANONICALIZE_HOST_NAME
-  ) return callback(undefined, host);
+  if (!mechanismProperties.CANONICALIZE_HOST_NAME) return callback(undefined, host);
 
   // Attempt to resolve the host name
   dns.resolveCname(host, (err, r) => {
@@ -187,6 +182,8 @@ function performGssapiCanonicalizeHostName(
 
     // Get the first resolve host id
     if (Array.isArray(r) && r.length > 0) {
+      /* eslint no-console: 0 */
+      console.log('######################', host, r);
       return callback(undefined, r[0]);
     }
 

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -14,6 +14,7 @@ import { AuthContext, AuthProvider } from './auth_provider';
 
 type MechanismProperties = {
   CANONICALIZE_HOST_NAME?: boolean;
+  SERVICE_HOST?: string;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;
 };
@@ -70,6 +71,7 @@ export class GSSAPI extends AuthProvider {
     });
   }
 }
+
 function makeKerberosClient(authContext: AuthContext, callback: Callback<KerberosClient>): void {
   const { hostAddress } = authContext.options;
   const { credentials } = authContext;
@@ -100,7 +102,8 @@ function makeKerberosClient(authContext: AuthContext, callback: Callback<Kerbero
         Object.assign(initOptions, { user: username, password: password });
       }
 
-      let spn = `${serviceName}${process.platform === 'win32' ? '/' : '@'}${host}`;
+      const spnHost = mechanismProperties.SERVICE_HOST ?? host;
+      let spn = `${serviceName}${process.platform === 'win32' ? '/' : '@'}${spnHost}`;
       if ('SERVICE_REALM' in mechanismProperties) {
         spn = `${spn}@${mechanismProperties.SERVICE_REALM}`;
       }
@@ -182,8 +185,6 @@ function performGssapiCanonicalizeHostName(
 
     // Get the first resolve host id
     if (Array.isArray(r) && r.length > 0) {
-      /* eslint no-console: 0 */
-      console.log('######################', host, r);
       return callback(undefined, r[0]);
     }
 

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -12,8 +12,10 @@ import {
 import { Callback, ns } from '../../utils';
 import { AuthContext, AuthProvider } from './auth_provider';
 
+type CanonicalizationOptions = boolean | 'none' | 'forward' | 'forwardAndReverse';
+
 type MechanismProperties = {
-  CANONICALIZE_HOST_NAME?: boolean;
+  CANONICALIZE_HOST_NAME?: CanonicalizationOptions;
   SERVICE_HOST?: string;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;
@@ -177,14 +179,41 @@ function performGssapiCanonicalizeHostName(
   mechanismProperties: MechanismProperties,
   callback: Callback<string>
 ): void {
-  if (!mechanismProperties.CANONICALIZE_HOST_NAME) return callback(undefined, host);
+  const mode = mechanismProperties.CANONICALIZE_HOST_NAME;
+  if (!mode || mode === 'none') return callback(undefined, host);
 
+  // If forward and reverse or true
+  if (mode === true || mode === 'forwardAndReverse') {
+    // Perform the lookup of the ip address.
+    dns.lookup(host, (error, address) => {
+      // No ip found, return the error.
+      if (error) return callback(error);
+
+      // Perform a reverse ptr lookup on the ip address.
+      dns.resolvePtr(address, (err, results) => {
+        // This can error as ptr records may not exist for all ips. In this case
+        // fallback to a cname lookup as dns.lookup() does not return the
+        // cname.
+        if (err) {
+          return resolveCname(host, callback);
+        }
+        // If the ptr did not error but had no results, return the host.
+        callback(undefined, results.length > 0 ? results[0] : host);
+      });
+    });
+  }
+  // The case for forward is just to resolve the cname as dns.lookup()
+  // will not return it.
+  resolveCname(host, callback);
+}
+
+function resolveCname(host: string, callback: Callback<string>): void {
   // Attempt to resolve the host name
   dns.resolveCname(host, (err, r) => {
     if (err) return callback(err);
 
     // Get the first resolve host id
-    if (Array.isArray(r) && r.length > 0) {
+    if (r.length > 0) {
       return callback(undefined, r[0]);
     }
 

--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -27,6 +27,7 @@ function getDefaultAuthMechanism(hello?: Document): AuthMechanism {
 
 /** @public */
 export interface AuthMechanismProperties extends Document {
+  SERVICE_HOST?: string;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;
   CANONICALIZE_HOST_NAME?: boolean;

--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -25,12 +25,17 @@ function getDefaultAuthMechanism(hello?: Document): AuthMechanism {
   return AuthMechanism.MONGODB_CR;
 }
 
+const CANONICALIZATION_VALUES = [true, false, 'none', 'forward', 'forwardAndReverse'];
+
+/** @public */
+export type CanonicalizationProperties = boolean | 'none' | 'forward' | 'forwardAndReverse';
+
 /** @public */
 export interface AuthMechanismProperties extends Document {
   SERVICE_HOST?: string;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;
-  CANONICALIZE_HOST_NAME?: boolean;
+  CANONICALIZE_HOST_NAME?: CanonicalizationProperties;
   AWS_SESSION_TOKEN?: string;
 }
 
@@ -158,6 +163,11 @@ export class MongoCredentials {
       }
       // TODO(NODE-3485): Replace this with a MongoAuthValidationError
       throw new MongoAPIError(`Password not allowed for mechanism MONGODB-X509`);
+    }
+
+    const canonicalization = this.mechanismProperties.CANONICALIZE_HOST_NAME ?? false;
+    if (!CANONICALIZATION_VALUES.includes(canonicalization)) {
+      throw new MongoAPIError(`Invalid CANONICALIZE_HOST_NAME value: ${canonicalization}`);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,7 @@ export type {
 } from './change_stream';
 export type {
   AuthMechanismProperties,
+  CanonicalizationProperties,
   MongoCredentials,
   MongoCredentialsOptions
 } from './cmap/auth/mongo_credentials';

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -51,8 +51,7 @@ describe('Kerberos', function () {
     });
   });
 
-  // Unskip this test when a proper setup is available - see NODE-3060
-  it.skip('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
+  it('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
     const client = new MongoClient(
       `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false,SERVICE_REALM:windows&maxPoolSize=1`
     );

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -28,6 +28,7 @@ describe('Kerberos', function () {
     return;
   }
   let krb5Uri = process.env.MONGODB_URI;
+  const parts = krb5Uri.split('@', 2);
 
   if (!process.env.KRB5_PRINCIPAL) {
     console.error('skipping Kerberos tests, KRB5_PRINCIPAL environment variable is not defined');
@@ -39,7 +40,6 @@ describe('Kerberos', function () {
     if (process.env.LDAPTEST_PASSWORD == null) {
       throw new Error('The env parameter LDAPTEST_PASSWORD must be set');
     }
-    const parts = krb5Uri.split('@', 2);
     krb5Uri = `${parts[0]}:${process.env.LDAPTEST_PASSWORD}@${parts[1]}`;
   }
 
@@ -68,6 +68,37 @@ describe('Kerberos', function () {
     client.connect(function (err, client) {
       expect(err).to.not.exist;
       verifyKerberosAuthentication(client, done);
+    });
+  });
+
+  context('when passsing SERVICE_HOST', function () {
+    context('when the SERVICE_HOST is invalid', function () {
+      const client = new MongoClient(`${krb5Uri}&maxPoolSize=1`, {
+        authMechanismProperties: {
+          SERVICE_HOST: 'example.com'
+        }
+      });
+
+      it('fails to authenticate', function () {
+        return client.connect().catch(e => {
+          expect(e).to.exist;
+        });
+      });
+    });
+
+    context('when the SERVICE_HOST is valid', function () {
+      const client = new MongoClient(`${krb5Uri}&maxPoolSize=1`, {
+        authMechanismProperties: {
+          SERVICE_HOST: 'ldaptest.10gen.cc'
+        }
+      });
+
+      it('authenticates', function (done) {
+        client.connect(function (err, client) {
+          expect(err).to.not.exist;
+          verifyKerberosAuthentication(client, done);
+        });
+      });
     });
   });
 

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -51,7 +51,17 @@ describe('Kerberos', function () {
     });
   });
 
-  it('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
+  it('validate that CANONICALIZE_HOST_NAME can be passed in', function (done) {
+    const client = new MongoClient(
+      `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:true&maxPoolSize=1`
+    );
+    client.connect(function (err, client) {
+      expect(err).to.not.exist;
+      verifyKerberosAuthentication(client, done);
+    });
+  });
+
+  it.skip('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
     const client = new MongoClient(
       `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false,SERVICE_REALM:windows&maxPoolSize=1`
     );

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -51,13 +51,12 @@ describe('Kerberos', function () {
     });
   });
 
-  it('validate that CANONICALIZE_HOST_NAME can be passed in', function (done) {
+  it('validate that CANONICALIZE_HOST_NAME can be passed in', async function () {
     const client = new MongoClient(
       `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:true&maxPoolSize=1`
     );
-    client.connect(function (err, client) {
-      expect(err).to.not.exist;
-      verifyKerberosAuthentication(client, done);
+    await client.connect();
+    verifyKerberosAuthentication(client, done);
     });
   });
 

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -61,6 +61,7 @@ describe('Kerberos', function () {
     });
   });
 
+  // Unskip this test when a proper setup is available - see NODE-3060
   it.skip('validate that SERVICE_REALM and CANONICALIZE_HOST_NAME can be passed in', function (done) {
     const client = new MongoClient(
       `${krb5Uri}&authMechanismProperties=SERVICE_NAME:mongodb,CANONICALIZE_HOST_NAME:false,SERVICE_REALM:windows&maxPoolSize=1`

--- a/test/spec/auth/connection-string.json
+++ b/test/spec/auth/connection-string.json
@@ -80,7 +80,7 @@
     },
     {
       "description": "should accept generic mechanism property (GSSAPI)",
-      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true",
+      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com",
       "valid": true,
       "credential": {
         "username": "user@DOMAIN.COM",
@@ -89,7 +89,8 @@
         "mechanism": "GSSAPI",
         "mechanism_properties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true
+          "CANONICALIZE_HOST_NAME": true,
+          "SERVICE_HOST": "example.com"
         }
       }
     },

--- a/test/spec/auth/connection-string.json
+++ b/test/spec/auth/connection-string.json
@@ -80,7 +80,7 @@
     },
     {
       "description": "should accept generic mechanism property (GSSAPI)",
-      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com",
+      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:forward",
       "valid": true,
       "credential": {
         "username": "user@DOMAIN.COM",
@@ -89,10 +89,44 @@
         "mechanism": "GSSAPI",
         "mechanism_properties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true,
-          "SERVICE_HOST": "example.com"
+          "CANONICALIZE_HOST_NAME": "forward"
         }
       }
+    },
+    {
+      "description": "should accept forwardAndReverse hostname canonicalization (GSSAPI)",
+      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:forwardAndReverse",
+      "valid": true,
+      "credential": {
+        "username": "user@DOMAIN.COM",
+        "password": null,
+        "source": "$external",
+        "mechanism": "GSSAPI",
+        "mechanism_properties": {
+          "SERVICE_NAME": "other",
+          "CANONICALIZE_HOST_NAME": "forwardAndReverse"
+        }
+      }
+    },
+    {
+      "description": "should accept no hostname canonicalization (GSSAPI)",
+      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:none",
+      "valid": true,
+      "credential": {
+        "username": "user@DOMAIN.COM",
+        "password": null,
+        "source": "$external",
+        "mechanism": "GSSAPI",
+        "mechanism_properties": {
+          "SERVICE_NAME": "other",
+          "CANONICALIZE_HOST_NAME": "none"
+        }
+      }
+    },
+    {
+      "description": "must raise an error when the hostname canonicalization is invalid",
+      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:invalid",
+      "valid": false
     },
     {
       "description": "should accept the password (GSSAPI)",
@@ -107,6 +141,16 @@
           "SERVICE_NAME": "mongodb"
         }
       }
+    },
+    {
+      "description": "must raise an error when the authSource is empty",
+      "uri": "mongodb://user:password@localhost/foo?authSource=",
+      "valid": false
+    },
+    {
+      "description": "must raise an error when the authSource is empty without credentials",
+      "uri": "mongodb://localhost/admin?authSource=",
+      "valid": false
     },
     {
       "description": "should throw an exception if authSource is invalid (GSSAPI)",
@@ -198,6 +242,18 @@
     {
       "description": "should recognize the mechanism with no username (MONGODB-X509)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-X509",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-X509",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should recognize the mechanism with no username when auth source is explicitly specified (MONGODB-X509)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-X509&authSource=$external",
       "valid": true,
       "credential": {
         "username": null,
@@ -353,7 +409,7 @@
       "credential": null
     },
     {
-      "description": "authSource without username doesn't create credential",
+      "description": "authSource without username doesn't create credential (default mechanism)",
       "uri": "mongodb://localhost/?authSource=foo",
       "valid": true,
       "credential": null
@@ -367,6 +423,62 @@
       "description": "should throw an exception if no username/password provided (userinfo implies default mechanism)",
       "uri": "mongodb://:@localhost.com/",
       "valid": false
+    },
+    {
+      "description": "should recognise the mechanism (MONGODB-AWS)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-AWS",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-AWS",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should recognise the mechanism when auth source is explicitly specified (MONGODB-AWS)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-AWS&authSource=$external",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-AWS",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should throw an exception if username and no password (MONGODB-AWS)",
+      "uri": "mongodb://user@localhost/?authMechanism=MONGODB-AWS",
+      "valid": false,
+      "credential": null
+    },
+    {
+      "description": "should use username and password if specified (MONGODB-AWS)",
+      "uri": "mongodb://user%21%40%23%24%25%5E%26%2A%28%29_%2B:pass%21%40%23%24%25%5E%26%2A%28%29_%2B@localhost/?authMechanism=MONGODB-AWS",
+      "valid": true,
+      "credential": {
+        "username": "user!@#$%^&*()_+",
+        "password": "pass!@#$%^&*()_+",
+        "source": "$external",
+        "mechanism": "MONGODB-AWS",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should use username, password and session token if specified (MONGODB-AWS)",
+      "uri": "mongodb://user:password@localhost/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:token%21%40%23%24%25%5E%26%2A%28%29_%2B",
+      "valid": true,
+      "credential": {
+        "username": "user",
+        "password": "password",
+        "source": "$external",
+        "mechanism": "MONGODB-AWS",
+        "mechanism_properties": {
+          "AWS_SESSION_TOKEN": "token!@#$%^&*()_+"
+        }
+      }
     }
   ]
 }

--- a/test/spec/auth/connection-string.yml
+++ b/test/spec/auth/connection-string.yml
@@ -64,7 +64,7 @@ tests:
                 SERVICE_NAME: "mongodb"
     -
         description: "should accept generic mechanism property (GSSAPI)"
-        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true"
+        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com"
         valid: true
         credential:
             username: "user@DOMAIN.COM"
@@ -74,6 +74,7 @@ tests:
             mechanism_properties:
                 SERVICE_NAME: "other"
                 CANONICALIZE_HOST_NAME: true
+                SERVICE_HOST: "example.com"
     -
         description: "should accept the password (GSSAPI)"
         uri: "mongodb://user%40DOMAIN.COM:password@localhost/?authMechanism=GSSAPI&authSource=$external"

--- a/test/spec/auth/connection-string.yml
+++ b/test/spec/auth/connection-string.yml
@@ -64,7 +64,7 @@ tests:
                 SERVICE_NAME: "mongodb"
     -
         description: "should accept generic mechanism property (GSSAPI)"
-        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com"
+        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:forward"
         valid: true
         credential:
             username: "user@DOMAIN.COM"
@@ -73,8 +73,35 @@ tests:
             mechanism: "GSSAPI"
             mechanism_properties:
                 SERVICE_NAME: "other"
-                CANONICALIZE_HOST_NAME: true
-                SERVICE_HOST: "example.com"
+                CANONICALIZE_HOST_NAME: "forward"
+    -
+        description: "should accept forwardAndReverse hostname canonicalization (GSSAPI)"
+        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:forwardAndReverse"
+        valid: true
+        credential:
+            username: "user@DOMAIN.COM"
+            password: ~
+            source: "$external"
+            mechanism: "GSSAPI"
+            mechanism_properties:
+                SERVICE_NAME: "other"
+                CANONICALIZE_HOST_NAME: "forwardAndReverse"
+    -
+        description: "should accept no hostname canonicalization (GSSAPI)"
+        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:none"
+        valid: true
+        credential:
+            username: "user@DOMAIN.COM"
+            password: ~
+            source: "$external"
+            mechanism: "GSSAPI"
+            mechanism_properties:
+                SERVICE_NAME: "other"
+                CANONICALIZE_HOST_NAME: "none"
+    -
+        description: "must raise an error when the hostname canonicalization is invalid"
+        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:invalid"
+        valid: false
     -
         description: "should accept the password (GSSAPI)"
         uri: "mongodb://user%40DOMAIN.COM:password@localhost/?authMechanism=GSSAPI&authSource=$external"
@@ -86,6 +113,14 @@ tests:
             mechanism: "GSSAPI"
             mechanism_properties:
                 SERVICE_NAME: "mongodb"
+    -
+        description: "must raise an error when the authSource is empty"
+        uri: "mongodb://user:password@localhost/foo?authSource="
+        valid: false
+    -
+        description: "must raise an error when the authSource is empty without credentials"
+        uri: "mongodb://localhost/admin?authSource="
+        valid: false
     -
         description: "should throw an exception if authSource is invalid (GSSAPI)"
         uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=foo"
@@ -161,6 +196,16 @@ tests:
     -
         description: "should recognize the mechanism with no username (MONGODB-X509)"
         uri: "mongodb://localhost/?authMechanism=MONGODB-X509"
+        valid: true
+        credential:
+            username: ~
+            password: ~
+            source: "$external"
+            mechanism: "MONGODB-X509"
+            mechanism_properties: ~
+    -
+        description: "should recognize the mechanism with no username when auth source is explicitly specified (MONGODB-X509)"
+        uri: "mongodb://localhost/?authMechanism=MONGODB-X509&authSource=$external"
         valid: true
         credential:
             username: ~
@@ -289,7 +334,7 @@ tests:
         valid: true
         credential: ~
     -
-        description: "authSource without username doesn't create credential"
+        description: "authSource without username doesn't create credential (default mechanism)"
         uri: "mongodb://localhost/?authSource=foo"
         valid: true
         credential: ~
@@ -301,3 +346,49 @@ tests:
         description: "should throw an exception if no username/password provided (userinfo implies default mechanism)"
         uri: "mongodb://:@localhost.com/"
         valid: false
+    -
+        description: "should recognise the mechanism (MONGODB-AWS)"
+        uri: "mongodb://localhost/?authMechanism=MONGODB-AWS"
+        valid: true
+        credential:
+            username: ~
+            password: ~
+            source: "$external"
+            mechanism: "MONGODB-AWS"
+            mechanism_properties: ~
+    -
+        description: "should recognise the mechanism when auth source is explicitly specified (MONGODB-AWS)"
+        uri: "mongodb://localhost/?authMechanism=MONGODB-AWS&authSource=$external"
+        valid: true
+        credential:
+            username: ~
+            password: ~
+            source: "$external"
+            mechanism: "MONGODB-AWS"
+            mechanism_properties: ~
+    -
+        description: "should throw an exception if username and no password (MONGODB-AWS)"
+        uri: "mongodb://user@localhost/?authMechanism=MONGODB-AWS"
+        valid: false
+        credential: ~
+    -
+      description: "should use username and password if specified (MONGODB-AWS)"
+      uri: "mongodb://user%21%40%23%24%25%5E%26%2A%28%29_%2B:pass%21%40%23%24%25%5E%26%2A%28%29_%2B@localhost/?authMechanism=MONGODB-AWS"
+      valid: true
+      credential:
+          username: "user!@#$%^&*()_+"
+          password: "pass!@#$%^&*()_+"
+          source: "$external"
+          mechanism: "MONGODB-AWS"
+          mechanism_properties: ~
+    -
+      description: "should use username, password and session token if specified (MONGODB-AWS)"
+      uri: "mongodb://user:password@localhost/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:token%21%40%23%24%25%5E%26%2A%28%29_%2B"
+      valid: true
+      credential:
+          username: "user"
+          password: "password"
+          source: "$external"
+          mechanism: "MONGODB-AWS"
+          mechanism_properties:
+              AWS_SESSION_TOKEN: "token!@#$%^&*()_+"

--- a/test/spec/connection-string/valid-auth.json
+++ b/test/spec/connection-string/valid-auth.json
@@ -263,7 +263,7 @@
     },
     {
       "description": "Escaped username (GSSAPI)",
-      "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI",
+      "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authMechanism=GSSAPI",
       "valid": true,
       "warning": false,
       "hosts": [
@@ -282,7 +282,8 @@
         "authmechanism": "GSSAPI",
         "authmechanismproperties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true
+          "CANONICALIZE_HOST_NAME": true,
+          "SERVICE_HOST": "example.com"
         }
       }
     },

--- a/test/spec/connection-string/valid-auth.json
+++ b/test/spec/connection-string/valid-auth.json
@@ -241,6 +241,27 @@
       }
     },
     {
+      "description": "Subdelimiters in user/pass don't need escaping (MONGODB-CR)",
+      "uri": "mongodb://!$&'()*+,;=:!$&'()*+,;=@127.0.0.1/admin?authMechanism=MONGODB-CR",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "!$&'()*+,;=",
+        "password": "!$&'()*+,;=",
+        "db": "admin"
+      },
+      "options": {
+        "authmechanism": "MONGODB-CR"
+      }
+    },
+    {
       "description": "Escaped username (MONGODB-X509)",
       "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509",
       "valid": true,
@@ -263,7 +284,7 @@
     },
     {
       "description": "Escaped username (GSSAPI)",
-      "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authMechanism=GSSAPI",
+      "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:forward&authMechanism=GSSAPI",
       "valid": true,
       "warning": false,
       "hosts": [
@@ -282,8 +303,7 @@
         "authmechanism": "GSSAPI",
         "authmechanismproperties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true,
-          "SERVICE_HOST": "example.com"
+          "CANONICALIZE_HOST_NAME": "forward"
         }
       }
     },

--- a/test/spec/connection-string/valid-auth.yml
+++ b/test/spec/connection-string/valid-auth.yml
@@ -206,7 +206,7 @@ tests:
             authmechanism: "MONGODB-X509"
     -
         description: "Escaped username (GSSAPI)"
-        uri: "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI"
+        uri: "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authMechanism=GSSAPI"
         valid: true
         warning: false
         hosts:
@@ -222,7 +222,8 @@ tests:
             authmechanism: "GSSAPI"
             authmechanismproperties:
                 SERVICE_NAME: "other"
-                CANONICALIZE_HOST_NAME: true
+                CANONICALIZE_HOST_NAME: true,
+                SERVICE_HOST: "example.com"
     -
         description: "At-signs in options aren't part of the userinfo"
         uri: "mongodb://alice:secret@example.com/admin?replicaset=my@replicaset"

--- a/test/spec/connection-string/valid-auth.yml
+++ b/test/spec/connection-string/valid-auth.yml
@@ -189,6 +189,22 @@ tests:
         options:
             authmechanism: "MONGODB-CR"
     -
+        description: "Subdelimiters in user/pass don't need escaping (MONGODB-CR)"
+        uri: "mongodb://!$&'()*+,;=:!$&'()*+,;=@127.0.0.1/admin?authMechanism=MONGODB-CR"
+        valid: true
+        warning: false
+        hosts:
+            -
+                type: "ipv4"
+                host: "127.0.0.1"
+                port: ~
+        auth:
+            username: "!$&'()*+,;="
+            password: "!$&'()*+,;="
+            db: "admin"
+        options:
+            authmechanism: "MONGODB-CR"
+    -
         description: "Escaped username (MONGODB-X509)"
         uri: "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509"
         valid: true
@@ -206,7 +222,7 @@ tests:
             authmechanism: "MONGODB-X509"
     -
         description: "Escaped username (GSSAPI)"
-        uri: "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authMechanism=GSSAPI"
+        uri: "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:forward&authMechanism=GSSAPI"
         valid: true
         warning: false
         hosts:
@@ -222,8 +238,7 @@ tests:
             authmechanism: "GSSAPI"
             authmechanismproperties:
                 SERVICE_NAME: "other"
-                CANONICALIZE_HOST_NAME: true,
-                SERVICE_HOST: "example.com"
+                CANONICALIZE_HOST_NAME: "forward"
     -
         description: "At-signs in options aren't part of the userinfo"
         uri: "mongodb://alice:secret@example.com/admin?replicaset=my@replicaset"

--- a/test/spec/uri-options/auth-options.json
+++ b/test/spec/uri-options/auth-options.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "Valid auth options are parsed correctly (GSSAPI)",
-      "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external",
+      "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authSource=$external",
       "valid": true,
       "warning": false,
       "hosts": null,
@@ -11,7 +11,8 @@
         "authMechanism": "GSSAPI",
         "authMechanismProperties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true
+          "CANONICALIZE_HOST_NAME": true,
+          "SERVICE_HOST": "example.com"
         },
         "authSource": "$external"
       }

--- a/test/spec/uri-options/auth-options.json
+++ b/test/spec/uri-options/auth-options.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "Valid auth options are parsed correctly (GSSAPI)",
-      "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authSource=$external",
+      "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:forward&authSource=$external",
       "valid": true,
       "warning": false,
       "hosts": null,
@@ -11,8 +11,7 @@
         "authMechanism": "GSSAPI",
         "authMechanismProperties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true,
-          "SERVICE_HOST": "example.com"
+          "CANONICALIZE_HOST_NAME": "forward"
         },
         "authSource": "$external"
       }

--- a/test/spec/uri-options/auth-options.yml
+++ b/test/spec/uri-options/auth-options.yml
@@ -1,7 +1,7 @@
 tests:
     -
         description: "Valid auth options are parsed correctly (GSSAPI)"
-        uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external"
+        uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authSource=$external"
         valid: true
         warning: false
         hosts: ~
@@ -10,7 +10,8 @@ tests:
             authMechanism: "GSSAPI"
             authMechanismProperties:
                 SERVICE_NAME: "other"
-                CANONICALIZE_HOST_NAME: true
+                CANONICALIZE_HOST_NAME: true,
+                SERVICE_HOST: "example.com"
             authSource: "$external"
     -
         description: "Valid auth options are parsed correctly (SCRAM-SHA-1)"

--- a/test/spec/uri-options/auth-options.yml
+++ b/test/spec/uri-options/auth-options.yml
@@ -1,7 +1,7 @@
 tests:
     -
         description: "Valid auth options are parsed correctly (GSSAPI)"
-        uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authSource=$external"
+        uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:forward&authSource=$external"
         valid: true
         warning: false
         hosts: ~
@@ -10,8 +10,7 @@ tests:
             authMechanism: "GSSAPI"
             authMechanismProperties:
                 SERVICE_NAME: "other"
-                CANONICALIZE_HOST_NAME: true,
-                SERVICE_HOST: "example.com"
+                CANONICALIZE_HOST_NAME: "forward"
             authSource: "$external"
     -
         description: "Valid auth options are parsed correctly (SCRAM-SHA-1)"

--- a/test/unit/assorted/auth.spec.test.ts
+++ b/test/unit/assorted/auth.spec.test.ts
@@ -1,13 +1,16 @@
 import { loadSpecTests } from '../../spec';
 import { executeUriValidationTest } from '../../tools/uri_spec_runner';
 
+const SKIP = ['should throw an exception if username and no password (MONGODB-AWS)'];
+
 describe('Auth option spec tests', function () {
   const suites = loadSpecTests('auth');
 
   for (const suite of suites) {
     describe(suite.name, function () {
       for (const test of suite.tests) {
-        it(`${test.description}`, function () {
+        const maybeIt = SKIP.includes(test.description) ? it.skip : it;
+        maybeIt(`${test.description}`, function () {
           executeUriValidationTest(test);
         });
       }

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -77,9 +77,10 @@ describe('Connection String', function () {
 
   it('should parse `authMechanismProperties`', function () {
     const options = parseOptions(
-      'mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,SERVICE_REALM:blah,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI'
+      'mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,SERVICE_REALM:blah,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authMechanism=GSSAPI'
     );
     expect(options.credentials.mechanismProperties).to.deep.include({
+      SERVICE_HOST: 'example.com',
       SERVICE_NAME: 'other',
       SERVICE_REALM: 'blah',
       CANONICALIZE_HOST_NAME: true


### PR DESCRIPTION
### Description

Adds a `SERVICE_HOST` property to auth mechanisms for the kerberos auth case where a different host in the service principal name should be provided instead of the resolved host.

#### What is changing?

Adds a `SERVICE_HOST` property and updates the tests to include it.

This branch is rebased against https://github.com/mongodb/node-mongodb-native/pull/3122

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-2938

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
