### PR TITLE
fix(NODE-3878): use legacy count operation on collection.count

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -21,7 +21,7 @@ import type {
 import type { AggregateOptions } from './operations/aggregate';
 import { BulkWriteOperation } from './operations/bulk_write';
 import type { IndexInformationOptions } from './operations/common_functions';
-import type { CountOptions } from './operations/count';
+import { CountOperation, CountOptions } from './operations/count';
 import { CountDocumentsOperation, CountDocumentsOptions } from './operations/count_documents';
 import {
   DeleteManyOperation,
@@ -1637,7 +1637,11 @@ export class Collection<TSchema extends Document = Document> {
     filter ??= {};
     return executeOperation(
       getTopology(this),
-      new CountDocumentsOperation(this as TODO_NODE_3286, filter, resolveOptions(this, options)),
+      new CountOperation(
+        MongoDBNamespace.fromString(this.namespace),
+        filter,
+        resolveOptions(this, options)
+      ),
       callback
     );
   }

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.js
@@ -35,10 +35,6 @@ describe('Client Side Encryption', function () {
   });
 
   generateTopologyTests(testSuites, testContext, spec => {
-    return (
-      !spec.description.match(/type=symbol/) &&
-      !spec.description.match(/maxWireVersion < 8/) &&
-      !spec.description.match(/Count with deterministic encryption/) // TODO(NODE-3369): Unskip
-    );
+    return !spec.description.match(/type=symbol/) && !spec.description.match(/maxWireVersion < 8/);
   });
 });

--- a/test/integration/command-monitoring/command_monitoring.spec.test.js
+++ b/test/integration/command-monitoring/command_monitoring.spec.test.js
@@ -240,7 +240,6 @@ describe('Command Monitoring spec tests', function () {
     }
 
     loadSpecTests('command-monitoring/legacy').forEach(scenario => {
-      if (scenario.name === 'command') return; // TODO(NODE-3369): remove when `count` spec tests have been fixed
       describe(scenario.name, function () {
         scenario.tests.forEach(test => {
           const requirements = { topology: ['single', 'replicaset', 'sharded'] };

--- a/test/integration/retryable-reads/retryable_reads.spec.test.js
+++ b/test/integration/retryable-reads/retryable_reads.spec.test.js
@@ -23,8 +23,6 @@ describe('Retryable Reads', function () {
       spec.description.match(/listCollections/i) ||
       spec.description.match(/listCollectionNames/i) ||
       spec.description.match(/estimatedDocumentCount/i) ||
-      // FIXME(NODE-3369): uncomment when `count` spec tests have been fixed
-      // spec.description.match(/count/i) ||
       spec.description.match(/find/i)
     );
   });

--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -88,9 +88,6 @@ const SKIP_TESTS = [
   'commitTransaction retry fails on new mongos',
   'unpin after transient error within a transaction and commit',
 
-  // TODO(NODE-3369): unskip count tests when spec tests have been updated
-  'count',
-
   // TODO(NODE-2034): Will be implemented as part of NODE-2034
   'Client side error in command starting transaction',
   'Client side error when transaction is in progress'


### PR DESCRIPTION
### Description

#### What is changing?

This PR updates `Collection.count` to use the legacy count operation.  It also unskips tests that were failing when `Collection.count` was modified to use the new count operation.

##### Is there new documentation needed for these changes?

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
