### PR TITLE
test(NODE-3543): unskip sub 3.6 lb failures

### DIFF
--- a/test/integration/load-balancers/load_balancers.spec.test.js
+++ b/test/integration/load-balancers/load_balancers.spec.test.js
@@ -8,20 +8,12 @@ const SKIP = [
   // a getMore before the killCursors even though the stream is immediately
   // closed.
   'change streams pin to a connection',
-  'errors during the initial connection hello are ignore',
-
   // NOTE: The following three tests are skipped pending a decision made on DRIVERS-1847, since
   //       pinning the connection on any getMore error is very awkward in node and likely results
   //       in sub-optimal pinning.
   'pinned connections are not returned after an network error during getMore',
   'pinned connections are not returned to the pool after a non-network error on getMore',
   'stale errors are ignored',
-  // NOTE: The driver correctly fails these 2 tests in non LB mode for server versions greater than 3.4.
-  // In versions that are 3.4 or less an error still occurs but a different one (connection closes).
-  // TODO(NODE-3543): fix the path-ing that will produce errors for older servers
-  'operations against non-load balanced clusters fail if URI contains loadBalanced=true',
-  'operations against non-load balanced clusters succeed if URI contains loadBalanced=false',
-
   'errors during the initial connection hello are ignored',
 
   ...(process.env.SERVERLESS

--- a/test/integration/load-balancers/load_balancers.spec.test.js
+++ b/test/integration/load-balancers/load_balancers.spec.test.js
@@ -6,7 +6,8 @@ const { runUnifiedSuite } = require('../../tools/unified-spec-runner/runner');
 const SKIP = [
   // Verified they use the same connection but the Node implementation executes
   // a getMore before the killCursors even though the stream is immediately
-  // closed.
+  // closed. Do not believe we need to do anything here but to leave the test
+  // skipped.
   'change streams pin to a connection',
   // NOTE: The following three tests are skipped pending a decision made on DRIVERS-1847, since
   //       pinning the connection on any getMore error is very awkward in node and likely results
@@ -14,6 +15,9 @@ const SKIP = [
   'pinned connections are not returned after an network error during getMore',
   'pinned connections are not returned to the pool after a non-network error on getMore',
   'stale errors are ignored',
+  // This test is skipped because it assumes drivers attempt connections on the first operation,
+  // but Node has a connect() method that is called before the first operation is ever run. It
+  // does not seem that we will ever get to changing this so we leave as skipped.
   'errors during the initial connection hello are ignored',
 
   ...(process.env.SERVERLESS


### PR DESCRIPTION
### Description

Unskips previously failing load balancer spec tests that used to fail for pre 3.6 servers.

#### What is changing?

Unskips previously skipped load balancer spec tests.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-3543

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
