### PR TITLE
feat(NODE-2938): add service host mechanism property

### DIFF
--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -14,6 +14,7 @@ import { AuthContext, AuthProvider } from './auth_provider';
 
 type MechanismProperties = {
   gssapiCanonicalizeHostName?: boolean;
+  SERVICE_HOST?: string;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;
 };
@@ -70,6 +71,7 @@ export class GSSAPI extends AuthProvider {
     });
   }
 }
+
 function makeKerberosClient(authContext: AuthContext, callback: Callback<KerberosClient>): void {
   const { hostAddress } = authContext.options;
   const { credentials } = authContext;
@@ -100,7 +102,8 @@ function makeKerberosClient(authContext: AuthContext, callback: Callback<Kerbero
         Object.assign(initOptions, { user: username, password: password });
       }
 
-      let spn = `${serviceName}${process.platform === 'win32' ? '/' : '@'}${host}`;
+      const spnHost = mechanismProperties.SERVICE_HOST ?? host;
+      let spn = `${serviceName}${process.platform === 'win32' ? '/' : '@'}${spnHost}`;
       if ('SERVICE_REALM' in mechanismProperties) {
         spn = `${spn}@${mechanismProperties.SERVICE_REALM}`;
       }

--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -27,6 +27,7 @@ function getDefaultAuthMechanism(hello?: Document): AuthMechanism {
 
 /** @public */
 export interface AuthMechanismProperties extends Document {
+  SERVICE_HOST?: string;
   SERVICE_NAME?: string;
   SERVICE_REALM?: string;
   CANONICALIZE_HOST_NAME?: boolean;

--- a/test/manual/kerberos.test.js
+++ b/test/manual/kerberos.test.js
@@ -28,6 +28,7 @@ describe('Kerberos', function () {
     return;
   }
   let krb5Uri = process.env.MONGODB_URI;
+  const parts = krb5Uri.split('@', 2);
 
   if (!process.env.KRB5_PRINCIPAL) {
     console.error('skipping Kerberos tests, KRB5_PRINCIPAL environment variable is not defined');
@@ -39,7 +40,6 @@ describe('Kerberos', function () {
     if (process.env.LDAPTEST_PASSWORD == null) {
       throw new Error('The env parameter LDAPTEST_PASSWORD must be set');
     }
-    const parts = krb5Uri.split('@', 2);
     krb5Uri = `${parts[0]}:${process.env.LDAPTEST_PASSWORD}@${parts[1]}`;
   }
 
@@ -59,6 +59,37 @@ describe('Kerberos', function () {
     client.connect(function (err, client) {
       expect(err).to.not.exist;
       verifyKerberosAuthentication(client, done);
+    });
+  });
+
+  context('when passsing SERVICE_HOST', function () {
+    context('when the SERVICE_HOST is invalid', function () {
+      const client = new MongoClient(`${krb5Uri}&maxPoolSize=1`, {
+        authMechanismProperties: {
+          SERVICE_HOST: 'example.com'
+        }
+      });
+
+      it('fails to authenticate', function () {
+        return client.connect().catch(e => {
+          expect(e).to.exist;
+        });
+      });
+    });
+
+    context('when the SERVICE_HOST is valid', function () {
+      const client = new MongoClient(`${krb5Uri}&maxPoolSize=1`, {
+        authMechanismProperties: {
+          SERVICE_HOST: 'ldaptest.10gen.cc'
+        }
+      });
+
+      it('authenticates', function (done) {
+        client.connect(function (err, client) {
+          expect(err).to.not.exist;
+          verifyKerberosAuthentication(client, done);
+        });
+      });
     });
   });
 

--- a/test/spec/auth/connection-string.json
+++ b/test/spec/auth/connection-string.json
@@ -80,7 +80,7 @@
     },
     {
       "description": "should accept generic mechanism property (GSSAPI)",
-      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true",
+      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com",
       "valid": true,
       "credential": {
         "username": "user@DOMAIN.COM",
@@ -89,7 +89,8 @@
         "mechanism": "GSSAPI",
         "mechanism_properties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true
+          "CANONICALIZE_HOST_NAME": true,
+          "SERVICE_HOST": "example.com"
         }
       }
     },

--- a/test/spec/auth/connection-string.yml
+++ b/test/spec/auth/connection-string.yml
@@ -64,7 +64,7 @@ tests:
                 SERVICE_NAME: "mongodb"
     -
         description: "should accept generic mechanism property (GSSAPI)"
-        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true"
+        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com"
         valid: true
         credential:
             username: "user@DOMAIN.COM"
@@ -74,6 +74,7 @@ tests:
             mechanism_properties:
                 SERVICE_NAME: "other"
                 CANONICALIZE_HOST_NAME: true
+                SERVICE_HOST: "example.com"
     -
         description: "should accept the password (GSSAPI)"
         uri: "mongodb://user%40DOMAIN.COM:password@localhost/?authMechanism=GSSAPI&authSource=$external"

--- a/test/spec/connection-string/valid-auth.json
+++ b/test/spec/connection-string/valid-auth.json
@@ -263,7 +263,7 @@
     },
     {
       "description": "Escaped username (GSSAPI)",
-      "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI",
+      "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authMechanism=GSSAPI",
       "valid": true,
       "warning": false,
       "hosts": [
@@ -282,7 +282,8 @@
         "authmechanism": "GSSAPI",
         "authmechanismproperties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true
+          "CANONICALIZE_HOST_NAME": true,
+          "SERVICE_HOST": "example.com"
         }
       }
     },

--- a/test/spec/connection-string/valid-auth.yml
+++ b/test/spec/connection-string/valid-auth.yml
@@ -206,7 +206,7 @@ tests:
             authmechanism: "MONGODB-X509"
     -
         description: "Escaped username (GSSAPI)"
-        uri: "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI"
+        uri: "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authMechanism=GSSAPI"
         valid: true
         warning: false
         hosts:
@@ -222,7 +222,8 @@ tests:
             authmechanism: "GSSAPI"
             authmechanismproperties:
                 SERVICE_NAME: "other"
-                CANONICALIZE_HOST_NAME: true
+                CANONICALIZE_HOST_NAME: true,
+                SERVICE_HOST: "example.com"
     -
         description: "At-signs in options aren't part of the userinfo"
         uri: "mongodb://alice:secret@example.com/admin?replicaset=my@replicaset"

--- a/test/spec/uri-options/auth-options.json
+++ b/test/spec/uri-options/auth-options.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "Valid auth options are parsed correctly (GSSAPI)",
-      "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external",
+      "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authSource=$external",
       "valid": true,
       "warning": false,
       "hosts": null,
@@ -11,7 +11,8 @@
         "authMechanism": "GSSAPI",
         "authMechanismProperties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true
+          "CANONICALIZE_HOST_NAME": true,
+          "SERVICE_HOST": "example.com"
         },
         "authSource": "$external"
       }

--- a/test/spec/uri-options/auth-options.yml
+++ b/test/spec/uri-options/auth-options.yml
@@ -1,7 +1,7 @@
 tests:
     -
         description: "Valid auth options are parsed correctly (GSSAPI)"
-        uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external"
+        uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authSource=$external"
         valid: true
         warning: false
         hosts: ~
@@ -10,7 +10,8 @@ tests:
             authMechanism: "GSSAPI"
             authMechanismProperties:
                 SERVICE_NAME: "other"
-                CANONICALIZE_HOST_NAME: true
+                CANONICALIZE_HOST_NAME: true,
+                SERVICE_HOST: "example.com"
             authSource: "$external"
     -
         description: "Valid auth options are parsed correctly (SCRAM-SHA-1)"

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -77,9 +77,10 @@ describe('Connection String', function () {
 
   it('should parse `authMechanismProperties`', function () {
     const options = parseOptions(
-      'mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,SERVICE_REALM:blah,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI'
+      'mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,SERVICE_REALM:blah,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authMechanism=GSSAPI'
     );
     expect(options.credentials.mechanismProperties).to.deep.include({
+      SERVICE_HOST: 'example.com',
       SERVICE_NAME: 'other',
       SERVICE_REALM: 'blah',
       CANONICALIZE_HOST_NAME: true


### PR DESCRIPTION
### Description

Adds a `SERVICE_HOST` property to auth mechanisms for the kerberos auth case where a different host in the service principal name should be provided instead of the resolved host.

#### What is changing?

Adds a `SERVICE_HOST` property and updates the tests to include it.

This branch is rebased against https://github.com/mongodb/node-mongodb-native/pull/3122

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-2938

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
