### PR TITLE
test(NODE-3797): Ensure RSGhost servers are not selectable

### DIFF
--- a/test/spec/server-selection/server_selection/Unknown/read/ghost.json
+++ b/test/spec/server-selection/server_selection/Unknown/read/ghost.json
@@ -1,0 +1,18 @@
+{
+  "topology_description": {
+    "type": "Unknown",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 5,
+        "type": "RSGhost"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "Nearest"
+  },
+  "suitable_servers": [],
+  "in_latency_window": []
+}

--- a/test/spec/server-selection/server_selection/Unknown/read/ghost.yml
+++ b/test/spec/server-selection/server_selection/Unknown/read/ghost.yml
@@ -1,0 +1,11 @@
+topology_description:
+  type: Unknown
+  servers:
+  - address: a:27017
+    avg_rtt_ms: 5
+    type: RSGhost
+operation: read
+read_preference:
+  mode: Nearest
+suitable_servers: []
+in_latency_window: []

--- a/test/spec/server-selection/server_selection/Unknown/write/ghost.json
+++ b/test/spec/server-selection/server_selection/Unknown/write/ghost.json
@@ -1,0 +1,18 @@
+{
+  "topology_description": {
+    "type": "Unknown",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 5,
+        "type": "RSGhost"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "Nearest"
+  },
+  "suitable_servers": [],
+  "in_latency_window": []
+}

--- a/test/spec/server-selection/server_selection/Unknown/write/ghost.yml
+++ b/test/spec/server-selection/server_selection/Unknown/write/ghost.yml
@@ -1,0 +1,11 @@
+topology_description:
+  type: Unknown
+  servers:
+  - address: a:27017
+    avg_rtt_ms: 5
+    type: RSGhost
+operation: write
+read_preference:
+  mode: Nearest
+suitable_servers: []
+in_latency_window: []

--- a/test/unit/assorted/server_selection.spec.test.js
+++ b/test/unit/assorted/server_selection.spec.test.js
@@ -49,25 +49,29 @@ describe('Server Selection (spec)', function () {
     });
   });
 
+  beforeEach(function () {
+    if (this.currentTest.title.match(/Possible/)) {
+      this.currentTest.skipReason = 'Nodejs driver does not support PossiblePrimary';
+      this.skip();
+    }
+  });
+
   after(() => {
     serverConnect.restore();
   });
 
   const specTests = collectSelectionTests(selectionSpecDir);
-  Object.keys(specTests).forEach(topologyType => {
+  for (const topologyType of Object.keys(specTests)) {
     describe(topologyType, function () {
-      Object.keys(specTests[topologyType]).forEach(subType => {
+      for (const subType of Object.keys(specTests[topologyType])) {
         describe(subType, function () {
-          specTests[topologyType][subType].forEach(test => {
-            // NOTE: node does not support PossiblePrimary
-            const maybeIt = test.name.match(/Possible/) ? it.skip : it;
-
-            maybeIt(test.name, function (done) {
+          for (const test of specTests[topologyType][subType]) {
+            it(test.name, function (done) {
               executeServerSelectionTest(test, done);
             });
-          });
+          }
         });
-      });
+      }
     });
-  });
+  }
 });


### PR DESCRIPTION
### Description

#### What is changing?

Spec test sync from here: https://github.com/mongodb/specifications/pull/1106/files

And some test code clean up.

#### What is the motivation for this change?

Compliance!

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- New TODOs have a related JIRA ticket
